### PR TITLE
[@types/mpv-script] Update types for `mp.command_native`

### DIFF
--- a/types/mpv-script/index.d.ts
+++ b/types/mpv-script/index.d.ts
@@ -35,11 +35,83 @@ declare namespace mp {
         is_dir: boolean;
     }
 
+    interface BaseCommandOpts {
+        args: string[];
+        playback_only?: boolean;
+        capture_size?: number;
+        detach?: boolean;
+        env?: string[];
+        stdin_data?: string;
+        passthrough_stdin?: boolean;
+    }
+
+    interface UnnamedCommandOpts extends BaseCommandOpts {
+        capture_stdout?: boolean;
+        capture_stderr?: boolean;
+    }
+
+    interface UncapturedNamedCommandOpts extends BaseCommandOpts {
+        name: string;
+        capture_stdout?: false;
+        capture_stderr?: false;
+    }
+
+    interface NamedCommandOptsWithStdout extends BaseCommandOpts {
+        name: string;
+        capture_stdout: true;
+        capture_stderr?: false;
+    }
+
+    interface NamedCommandOptsWithStderr extends BaseCommandOpts {
+        name: string;
+        capture_stderr: true;
+        capture_stdout?: false;
+    }
+
+    interface CapturedNamedOptsCommand extends BaseCommandOpts {
+        name: string;
+        capture_stdout: true;
+        capture_stderr: true;
+    }
+
+    interface UncapturedProcess {
+        status: number;
+        error_string: "" | "killed" | "init";
+        killed_by_us: boolean;
+    }
+
+    interface ProcessWithStdout extends UncapturedProcess {
+        stdout: string;
+    }
+
+    interface ProcessWithStderr extends UncapturedProcess {
+        stderr: string;
+    }
+
+    interface CapturedProcess extends UncapturedProcess {
+        stdout: string;
+        stderr: string;
+    }
+
     function command(command: string): true | undefined;
 
     function commandv(...args: readonly string[]): true | undefined;
 
-    function command_native(table: unknown, def?: unknown): unknown;
+    function command_native(table: [string, ...unknown[]]): null | undefined; // `undefined` on error
+
+    function command_native<T>(table: [string, ...unknown[]], def: T): null | T; // `T` on error
+
+    function command_native(table: UnnamedCommandOpts): undefined;
+
+    function command_native<T>(table: UnnamedCommandOpts, def: T): T;
+
+    function command_native(table: UncapturedNamedCommandOpts, def?: unknown): UncapturedProcess;
+
+    function command_native(table: NamedCommandOptsWithStdout, def?: unknown): ProcessWithStdout;
+
+    function command_native(table: NamedCommandOptsWithStderr, def?: unknown): ProcessWithStderr;
+
+    function command_native(table: CapturedNamedOptsCommand, def?: unknown): CapturedProcess;
 
     function command_native_async(
         table: unknown,

--- a/types/mpv-script/mpv-script-tests.ts
+++ b/types/mpv-script/mpv-script-tests.ts
@@ -1,3 +1,59 @@
+// command_native 1: Array parameter without `def`, expecting null when not occurring error or undefine on error
+// $ExpectType null | undefined
+mp.command_native(["print-text", "test"]);
+
+// command_native 2: Array parameter with `def`, expecting null when not occurring error or `typeof def` on error
+// $ExpectType null | "def"
+mp.command_native(["print-text", "test"], "def");
+
+// command_native 3: UnnamedCommandOpts without `def`, expecting undefined
+// $ExpectType undefined
+mp.command_native({ args: ["echo", "test"] });
+
+// command_native 4: UnnamedCommandOpts with `def`, expecting `def` type
+// $ExpectType "def"
+mp.command_native({ args: ["echo", "test"] }, "def");
+
+// command_native 5: UncapturedNamedCommandOpts without `def`, expecting UncapturedProcess return type
+// $ExpectType UncapturedProcess
+mp.command_native({ name: "echo", args: ["echo", "test"] });
+
+// command_native 6: UncapturedNamedCommandOpts with `def`, expecting UncapturedProcess return type
+// $ExpectType UncapturedProcess
+mp.command_native({ name: "echo", args: ["echo", "test"] }, "def");
+
+// command_native 7: NamedCommandOptsWithStdout without `def`, expecting ProcessWithStdout return type
+// $ExpectType ProcessWithStdout
+mp.command_native({ name: "echo", args: ["echo", "test"], capture_stdout: true });
+
+// command_native 8: NamedCommandOptsWithStdout with `def`, expecting ProcessWithStdout return type
+// $ExpectType ProcessWithStdout
+mp.command_native({ name: "echo", args: ["echo", "test"], capture_stdout: true }, "def");
+
+// command_native 9: NamedCommandOptsWithStderr without `def`, expecting ProcessWithStderr return type
+// $ExpectType ProcessWithStderr
+mp.command_native({ name: "echo", args: ["echo", "test"], capture_stderr: true });
+
+// command_native 10: NamedCommandOptsWithStderr with `def`, expecting ProcessWithStderr return type
+// $ExpectType ProcessWithStderr
+mp.command_native({ name: "echo", args: ["echo", "test"], capture_stderr: true }, "def");
+
+// command_native 11: CapturedNamedCommandOpts without `def`, expecting CapturedProcess return type
+// $ExpectType CapturedProcess
+mp.command_native({ name: "echo", args: ["echo", "test"], capture_stdout: true, capture_stderr: true });
+
+// command_native 12: CapturedNamedCommandOpts with `def`, expecting CapturedProcess return type
+// $ExpectType CapturedProcess
+mp.command_native({ name: "echo", args: ["echo", "test"], capture_stdout: true, capture_stderr: true }, "def");
+
+// command_native 13: wrong options without `def`
+// @ts-expect-error
+mp.command_native({});
+
+// command_native 13: wrong options with `def`
+// @ts-expect-error
+mp.command_native({}, "def");
+
 // result from command_native_async can be passed to abort_async_command
 const res = mp.command_native_async([], () => {});
 mp.abort_async_command(res);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [man/mpv.1#subprocess](https://man.archlinux.org/man/mpv.1#subprocess), [man/mpv.1#mp.command_native(table](https://man.archlinux.org/man/mpv.1#mp.command_native%28table)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

## Key Enhancements:

- **Specific Type Definitions**: Detailed interfaces for command options and return types, replacing generic `unknown` types.
- **Comprehensive Use Cases Covered**: The update includes types for commands with and without `name` attribute, and various configurations for capturing command output.
- **Runtime Test Code Included**: For validating the accuracy of the type updates, runtime test code is provided as below. These tests ensure compatibility and correctness, reflecting real usage scenarios.

<details>
<summary>Additional tests</summary>

```typescript
function assert(condition: boolean, message?: string): void {
    if (!condition) {
        throw new Error(message !== void 0 ? message : "Assertion failed");
    } else {
        return;
    }
}

function isObject(variable: any): boolean {
    return typeof variable === "object" && variable !== null;
}

function isUndefined(variable: any): boolean {
    return variable === void 0;
}

function isNull(variable: any): boolean {
    return variable === null;
}

// Naming: 0 means false, 1 means true,
// three continuous number represents the state of `named`, with `def` parameter, occurring error
const testCommandNative = {
    case000_array(): void {
        dump("unnamed, no def, no error: array");
        const result = mp.command_native(["print-text", "test"]);
        dump(result);
        assert(
            isNull(result),
            "function with array parameter should return `null` when not occurring error",
        );
    },

    case010_array(): void {
        dump("unnamed, def, no error: array");
        const result = mp.command_native(["print-text", "test"], "def");
        dump(result);
        assert(
            isNull(result),
            "function with array parameter should return `null` when not occurring error",
        );
    },

    case001_array(): void {
        dump("unnamed, no def, error: array");
        const result = mp.command_native(["print-text", "test", "invalid"]);
        dump(result);
        assert(
            isUndefined(result),
            "function with array parameter should return `def` on error, `def` defaults to `undefined`",
        );
    },

    case011_array(): void {
        dump("unnamed, def, error: array");
        const result = mp.command_native(
            ["print-text", "test", "invalid"],
            "def",
        );
        dump(result);
        assert(
            result === "def",
            "function with array parameter should return `def` on error",
        );
    },

    case000_object(): void {
        dump("unnamed, no def, no error: table");
        const result = mp.command_native({ args: ["ls"] });
        dump(result);
        assert(
            isUndefined(result),
            "function with unnamed object parameter should always return `def` which defaults to `undefined`",
        );
    },

    case001_object(): void {
        dump("unnamed, no def, error: table");
        const result = mp.command_native({ args: ["ls", "invalid"] });
        dump(result);
        assert(
            isUndefined(result),
            "function with unnamed object parameter should always return `def` which defaults to `undefined`",
        );
    },

    case010_object(): void {
        dump("unnamed, def, no error: table");
        const result = mp.command_native({ args: ["ls"] }, "def");
        dump(result);
        assert(
            result === "def",
            "function with unnamed object parameter should always return `def`",
        );
    },

    case011_object(): void {
        dump("unnamed, def, error: table");
        const result = mp.command_native({ args: ["ls", "invalid"] }, "def");
        dump(result);
        assert(
            result === "def",
            "function with unnamed object parameter should always return `def`",
        );
    },

    case100(): void {
        dump("named, no def, no error");
        const result = mp.command_native({ args: ["ls"], name: "subprocess" });
        dump(result);
        assert(
            isObject(result),
            "function with named object parameter should always return an object",
        );
    },

    case110(): void {
        dump("named, def, no error");
        const result = mp.command_native(
            { args: ["ls"], name: "subprocess" },
            "def",
        );
        dump(result);
        assert(
            isObject(result),
            "function with named object parameter should always return an object",
        );
    },

    case101(): void {
        dump("named, no def, error");
        const result = mp.command_native({
            args: ["ls", "invalid"],
            name: "subprocess",
            capture_stderr: true,
        });
        dump(result);
        assert(
            isObject(result),
            "function with named object parameter should always return an object",
        );
    },

    case111(): void {
        dump("named, def, error");
        const result = mp.command_native(
            {
                args: ["ls", "invalid"],
                name: "subprocess",
                capture_stderr: true,
            },
            "def",
        );
        dump(result);
        assert(
            isObject(result),
            "function with named object parameter should always return an object",
        );
    },
};

function main() {
    // `command_native` with array parameter always returns `null` or `def` on error, `def` defaults to `undefined`
    testCommandNative.case000_array(); //null
    testCommandNative.case010_array(); //null
    testCommandNative.case001_array(); //undefined (with error printed)
    testCommandNative.case011_array(); //def (with error printed)

    // `command_native` with unnamed object parameter always returns `def`, `def` defaults to `undefined`
    testCommandNative.case000_object(); //undefined
    testCommandNative.case001_object(); //undefined (error disappears)
    testCommandNative.case010_object(); //def
    testCommandNative.case011_object(); //def (error disappears)

    // `command_native` with named object parameter always returns an object regardless of the occurrence of `def`
    testCommandNative.case100(); //object
    testCommandNative.case110(); //object
    testCommandNative.case101(); //object (error is captured)
    testCommandNative.case111(); //object (error is captured)
}

mp.register_event("file-loaded", main);
```
</details>