### PR TITLE
Clean up multiple tsconfigs caught by new errors

### DIFF
--- a/types/ali-app/tsconfig.json
+++ b/types/ali-app/tsconfig.json
@@ -17,8 +17,5 @@
     "files": [
         "index.d.ts",
         "ali-app-tests.ts"
-    ],
-    "exclude": [
-        ".prettierrc"
     ]
 }

--- a/types/bun/tsconfig.json
+++ b/types/bun/tsconfig.json
@@ -9,5 +9,9 @@
         "types": [],
         "noUnusedLocals": true,
         "noEmit": true
-    }
+    },
+    "files": [
+        "index.d.ts",
+        "bun-tests.ts"
+    ]
 }

--- a/types/clearbladejs-client/tsconfig.json
+++ b/types/clearbladejs-client/tsconfig.json
@@ -16,9 +16,5 @@
     "files": [
         "index.d.ts",
         "clearbladejs-client-tests.ts"
-    ],
-    "exclude": [
-        "**/clearbladejs-node/*",
-        "**/clearbladejs-server/*"
     ]
 }

--- a/types/clearbladejs-node/tsconfig.json
+++ b/types/clearbladejs-node/tsconfig.json
@@ -16,9 +16,5 @@
     "files": [
         "index.d.ts",
         "clearbladejs-node-tests.ts"
-    ],
-    "exclude": [
-        "**/clearbladejs-client/*",
-        "**/clearbladejs-server/*"
     ]
 }

--- a/types/clearbladejs-server/tsconfig.json
+++ b/types/clearbladejs-server/tsconfig.json
@@ -16,9 +16,5 @@
     "files": [
         "index.d.ts",
         "clearbladejs-server-tests.ts"
-    ],
-    "exclude": [
-        "**/clearbladejs-client/*",
-        "**/clearbladejs-node/*"
     ]
 }

--- a/types/connect-mongodb-session/tsconfig.json
+++ b/types/connect-mongodb-session/tsconfig.json
@@ -15,8 +15,5 @@
     "files": [
         "connect-mongodb-session-tests.ts",
         "index.d.ts"
-    ],
-    "exclude": [
-        "node_modules"
     ]
 }

--- a/types/iframe-resizer/tsconfig.json
+++ b/types/iframe-resizer/tsconfig.json
@@ -13,9 +13,6 @@
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
-    "exclude": [
-        "node_modules"
-    ],
     "files": [
         "index.d.ts",
         "iframe-resizer-tests.ts"

--- a/types/ion-rangeslider/tsconfig.json
+++ b/types/ion-rangeslider/tsconfig.json
@@ -16,9 +16,5 @@
     "files": [
         "index.d.ts",
         "ion-rangeslider-tests.ts"
-    ],
-    "exclude": [
-        "util/**/*",
-        ".gitignore"
     ]
 }

--- a/types/sawtooth-sdk/tsconfig.json
+++ b/types/sawtooth-sdk/tsconfig.json
@@ -16,8 +16,5 @@
         "index.d.ts",
         "test/signing-tests.ts",
         "test/processor-tests.ts"
-    ],
-    "exclude": [
-        "protobuf/index.d.ts"
     ]
 }

--- a/types/stream-to-blob/tsconfig.json
+++ b/types/stream-to-blob/tsconfig.json
@@ -13,7 +13,7 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
-        "./index.d.ts",
-        "./stream-to-blob-tests.ts"
+        "index.d.ts",
+        "stream-to-blob-tests.ts"
     ]
 }

--- a/types/udp-discovery/tsconfig.json
+++ b/types/udp-discovery/tsconfig.json
@@ -16,8 +16,5 @@
     "files": [
         "index.d.ts",
         "udp-discovery-tests.ts"
-    ],
-    "exclude": [
-        "node_modules"
     ]
 }

--- a/types/weixin-app/tsconfig.json
+++ b/types/weixin-app/tsconfig.json
@@ -17,8 +17,5 @@
     "files": [
         "index.d.ts",
         "weixin-app-tests.ts"
-    ],
-    "exclude": [
-        ".prettierrc"
     ]
 }


### PR DESCRIPTION
There are still quite literally 800 other packages which fail for not having tests, but these few can be fixed immediately.

`types/stream-to-blob/tsconfig.json` really shouldn't fail; dt-tools should allow `./index.d.ts` too, but it's easy to fix.