### PR TITLE
Update types for yauzl-promise to add AsyncIterable support

### DIFF
--- a/types/yauzl-promise/index.d.ts
+++ b/types/yauzl-promise/index.d.ts
@@ -8,7 +8,7 @@ import { Entry as BaseEntry, Options, RandomAccessReader, ZipFileOptions } from 
 
 // This class is not directly compatible with @types/yauzl 's ZipFile as this library changes the function signatures
 // Therefore, it is replaced, albeit with a significant portion
-export class ZipFile extends EventEmitter {
+export class ZipFile extends EventEmitter implements AsyncIterable<Entry> {
     // This chunk taken directly from @types/yauzl
     autoClose: boolean;
     comment: string;
@@ -41,6 +41,7 @@ export class ZipFile extends EventEmitter {
     readEntries(numEntries?: number): Promise<Entry[]>;
     walkEntries(callback: (entry: Entry) => Promise<void> | void, numEntries?: number): Promise<void>;
     openReadStream(entry: Entry, options?: ZipFileOptions): Promise<Readable>;
+    [Symbol.asyncIterator](): AsyncIterator<Entry>;
 }
 
 export class Entry extends BaseEntry {

--- a/types/yauzl-promise/yauzl-promise-tests.ts
+++ b/types/yauzl-promise/yauzl-promise-tests.ts
@@ -46,4 +46,9 @@ async function test() {
     await zip.walkEntries(async (entry: yauzl.Entry) => {
         console.log("foo");
     }, 1);
+
+    {
+        let entry: yauzl.Entry;
+        for await (entry of zip) {}
+    }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test yauzl-promise`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/overlookmotel/yauzl-promise/blob/e52bdeda0fd1f0bf2292f13d7f89208e17607170/lib/zip.js#L1104-L1116
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.~