### PR TITLE
[Xrm] Add getOptions to OptionSetControls

### DIFF
--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -3074,6 +3074,22 @@ declare namespace Xrm {
         }
 
         /**
+         * Interface for UI elements which can have their available option values read.
+         */
+        interface UiCanGetOptionsElement {
+            /**
+             * Returns an array of option objects representing valid options available for a control,
+             * including a blank option and excluding any options that have been removed from the control
+             * using removeOption.
+             *
+             * @returns The array of option objects representing valid options where each option object has the following attributes:
+             *          text: String. Label of the option.
+             *          value: Number. Enumeration value of the option.
+             */
+            getOptions(): OptionSetValue[];
+        }
+
+        /**
          * Interface for UI elements which can have the visibility value read.
          */
         interface UiCanGetVisibleElement {
@@ -3552,7 +3568,7 @@ declare namespace Xrm {
          *
          * @see {@link StandardControl}
          */
-        interface OptionSetControl extends StandardControl {
+        interface OptionSetControl extends StandardControl, UiCanGetOptionsElement {
             /**
              * Adds an option.
              *
@@ -3584,7 +3600,7 @@ declare namespace Xrm {
             removeOption(value: number): void;
         }
 
-        interface MultiSelectOptionSetControl extends StandardControl {
+        interface MultiSelectOptionSetControl extends StandardControl, UiCanGetOptionsElement {
             /**
              * Adds an option.
              *

--- a/types/xrm/xrm-tests.ts
+++ b/types/xrm/xrm-tests.ts
@@ -609,6 +609,7 @@ Xrm.Navigation.navigateTo({
     },
 );
 
+const optionSetControl = Xrm.Page.getControl<Xrm.Controls.OptionSetControl>("singlechoice");
 const multiSelectOptionSetControl = Xrm.Page.getControl<Xrm.Controls.MultiSelectOptionSetControl>("choices");
 
 // $ExpectType MultiSelectOptionSetAttribute
@@ -616,3 +617,11 @@ multiSelectOptionSetControl.getAttribute();
 
 // Demonstrates getWebResourceUrl
 const webResourceUrl = Xrm.Utility.getGlobalContext().getWebResourceUrl("sample_webResource1.js");
+
+// Demonstrates getOptions for Xrm.Controls.OptionSetControl
+// $ExpectType OptionSetValue[]
+optionSetControl.getOptions();
+
+// Demonstrates getOptions for Xrm.Controls.MultiSelectOptionSetControl
+// $ExpectType OptionSetValue[]
+multiSelectOptionSetControl.getOptions();

--- a/types/xrm/xrm-tests.ts
+++ b/types/xrm/xrm-tests.ts
@@ -609,7 +609,6 @@ Xrm.Navigation.navigateTo({
     },
 );
 
-const optionSetControl = Xrm.Page.getControl<Xrm.Controls.OptionSetControl>("singlechoice");
 const multiSelectOptionSetControl = Xrm.Page.getControl<Xrm.Controls.MultiSelectOptionSetControl>("choices");
 
 // $ExpectType MultiSelectOptionSetAttribute
@@ -617,6 +616,8 @@ multiSelectOptionSetControl.getAttribute();
 
 // Demonstrates getWebResourceUrl
 const webResourceUrl = Xrm.Utility.getGlobalContext().getWebResourceUrl("sample_webResource1.js");
+
+const optionSetControl = Xrm.Page.getControl<Xrm.Controls.OptionSetControl>("singlechoice");
 
 // Demonstrates getOptions for Xrm.Controls.OptionSetControl
 // $ExpectType OptionSetValue[]


### PR DESCRIPTION
This commit adds the getOptions method to Xrm.Controls.OptionSetControl and Xrm.Controls.MultiSelectOptionSetControl. It's definition can be found [here](https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/getoptions).

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [control.getOptions](https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/controls/getoptions)
