### PR TITLE
[superagent]: Remove dependency on dom Request

### DIFF
--- a/types/promisify-supertest/tsconfig.json
+++ b/types/promisify-supertest/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "dom"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/simple-cw-node/tsconfig.json
+++ b/types/simple-cw-node/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "dom"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/superagent-bunyan/tsconfig.json
+++ b/types/superagent-bunyan/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "dom"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/superagent-no-cache/tsconfig.json
+++ b/types/superagent-no-cache/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "dom"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/superagent-prefix/tsconfig.json
+++ b/types/superagent-prefix/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "dom"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/superagent/lib/node/http2wrapper.d.ts
+++ b/types/superagent/lib/node/http2wrapper.d.ts
@@ -1,21 +1,20 @@
 /// <reference types="node" />
 
-import * as tls from "tls";
-import * as net from "net";
 import * as http2 from "http2";
+import * as net from "net";
 import { Stream } from "stream";
+import * as tls from "tls";
 
 export {};
 
 declare namespace http2wrapper {
-
     interface CreateUnixConnectionOptions extends http2.ClientSessionOptions, http2.SecureClientSessionOptions {
         socketPath: string;
     }
 
     type MappedHeaders = http2.IncomingHttpHeaders & http2.IncomingHttpStatusHeader & {
-        'set-cookie'?: string[];
-    }
+        "set-cookie"?: string[];
+    };
 
     class Request extends Stream {
         constructor(protocol: "http:" | "https:", options: Http2Options);

--- a/types/superagent/lib/node/http2wrapper.d.ts
+++ b/types/superagent/lib/node/http2wrapper.d.ts
@@ -1,0 +1,50 @@
+/// <reference types="node" />
+
+import * as tls from "tls";
+import * as net from "net";
+import * as http2 from "http2";
+import { Stream } from "stream";
+
+export {};
+
+declare namespace http2wrapper {
+
+    interface CreateUnixConnectionOptions extends http2.ClientSessionOptions, http2.SecureClientSessionOptions {
+        socketPath: string;
+    }
+
+    type MappedHeaders = http2.IncomingHttpHeaders & http2.IncomingHttpStatusHeader & {
+        'set-cookie'?: string[];
+    }
+
+    class Request extends Stream {
+        constructor(protocol: "http:" | "https:", options: Http2Options);
+
+        createUnixConnection(authority: any, options: CreateUnixConnectionOptions): net.Socket | tls.TLSSocket;
+        setNoDelay(bool: boolean): void;
+        getFrame(): http2.ClientHttp2Stream;
+        mapToHttpHeader(headers: http2.IncomingHttpHeaders & http2.IncomingHttpStatusHeader): MappedHeaders;
+        mapToHttp2Header(headers: MappedHeaders): Record<string, string | undefined>;
+        setHeader(name: string, value: string): void;
+        getHeader(name: string): string | string[] | undefined;
+        write(chunk: any, encoding: BufferEncoding): boolean;
+        end(data: any): void;
+        abort(data: any): void;
+    }
+
+    interface Http2Options {
+        port?: number;
+        host?: string;
+        method: string;
+        path: string;
+        socketPath?: string;
+    }
+
+    interface Http2Wrapper {
+        request(options: Http2Options): Request;
+    }
+}
+
+export type Request = http2wrapper.Request;
+
+export function setProtocol(protocol: "http:" | "https:"): http2wrapper.Http2Wrapper;

--- a/types/superagent/lib/node/index.d.ts
+++ b/types/superagent/lib/node/index.d.ts
@@ -10,8 +10,8 @@ import { ReadStream } from "fs";
 import { LookupFunction } from "net";
 import RequestBase = require("../request-base");
 import ResponseBase = require("./response");
-import { Request as Http2Request } from './http2wrapper';
 import { AgentOptions as SAgentOptions, CBHandler, URLType } from "../../types";
+import { Request as Http2Request } from "./http2wrapper";
 
 type HttpMethod<Req extends request.Request> =
     | ((url: URLType, callback?: CBHandler) => Req)

--- a/types/superagent/lib/node/index.d.ts
+++ b/types/superagent/lib/node/index.d.ts
@@ -2,7 +2,6 @@ import * as http from "http";
 import * as http2 from "http2";
 import * as https from "https";
 import { Stream } from "stream";
-import { UrlObject } from "url";
 import methods = require("methods");
 
 import SAgent = require("./agent");
@@ -11,22 +10,25 @@ import { ReadStream } from "fs";
 import { LookupFunction } from "net";
 import RequestBase = require("../request-base");
 import ResponseBase = require("./response");
-import { AgentOptions as SAgentOptions, CBHandler } from "../../types";
+import { Request as Http2Request } from './http2wrapper';
+import { AgentOptions as SAgentOptions, CBHandler, URLType } from "../../types";
 
 type HttpMethod<Req extends request.Request> =
-    | ((url: string, callback?: CBHandler) => Req)
-    | ((url: string, data?: string | Record<string, any>, callback?: CBHandler) => Req);
+    | ((url: URLType, callback?: CBHandler) => Req)
+    | ((url: URLType, data?: string | Record<string, any>, callback?: CBHandler) => Req);
 
 type RequestMethods<Req extends request.Request> = {
     [key in (typeof methods[number]) | "del"]: HttpMethod<Req>;
 };
 
 declare class SARequest extends Stream implements RequestBase {
-    constructor(method: string, url: string | URL | UrlObject);
+    constructor(method: string, url: URLType);
 
     method: string;
     url: string;
     cookies: string;
+    req: http.ClientRequest | Http2Request;
+    res: http.IncomingMessage | (http2.IncomingHttpHeaders & http2.IncomingHttpStatusHeader);
 
     [Symbol.toStringTag]: string;
 
@@ -140,8 +142,9 @@ declare namespace request {
     type SuperAgent<Req extends Request = Request> = RequestMethods<Req> & Stream;
 
     interface SuperAgentStatic<Req extends Request = Request> extends SuperAgent<Req> {
-        (url: string): Request;
-        (method: string, url: string): Request;
+        (url: URLType): Request;
+        (method: string, url: URLType): Request;
+        (url: URLType, cb: CBHandler): void;
 
         Request: typeof SARequest;
         Response: typeof ResponseBase;

--- a/types/superagent/lib/node/response.d.ts
+++ b/types/superagent/lib/node/response.d.ts
@@ -1,7 +1,6 @@
-/// <reference types="node" />
-
-import { IncomingMessage } from "http";
+import { IncomingMessage, } from "http";
 import { Stream } from "stream";
+import { Request } from "./index";
 
 interface HTTPError extends Error {
     status: number;
@@ -9,6 +8,7 @@ interface HTTPError extends Error {
     method: string;
     path: string;
 }
+
 declare class Response extends Stream implements Pick<IncomingMessage, "setEncoding"> {
     constructor(request: Request);
 

--- a/types/superagent/lib/node/response.d.ts
+++ b/types/superagent/lib/node/response.d.ts
@@ -1,4 +1,4 @@
-import { IncomingMessage, } from "http";
+import { IncomingMessage } from "http";
 import { Stream } from "stream";
 import { Request } from "./index";
 

--- a/types/superagent/lib/node/response.d.ts
+++ b/types/superagent/lib/node/response.d.ts
@@ -31,7 +31,7 @@ declare class Response extends Stream implements Pick<IncomingMessage, "setEncod
     notFound: boolean;
     ok: boolean;
     redirect: boolean;
-    request: InstanceType<typeof Request>;
+    request: Request;
     serverError: boolean;
     status: number;
     statusCode: number;

--- a/types/superagent/superagent-tests.ts
+++ b/types/superagent/superagent-tests.ts
@@ -337,13 +337,23 @@ request
 
 // Test that the "Plugin" type from "use" provides a SuperAgentRequest rather than a Request,
 // which has additional properties.
-const echoPlugin = (request: request.SuperAgentRequest) => {
+let echoPlugin: request.Plugin = (request) => {
     req.url = "" + req.url;
     req.cookies = "" + req.cookies;
     if (req.method) {
         req.url = "/echo";
     }
 };
+
+if (1) {
+    echoPlugin = (request: request.SuperAgentRequest) => {
+        req.url = "" + req.url;
+        req.cookies = "" + req.cookies;
+        if (req.method) {
+            req.url = "/echo";
+        }
+    };
+}
 
 request.get("/echo").use(echoPlugin).end();
 

--- a/types/superagent/test.ts
+++ b/types/superagent/test.ts
@@ -1,3 +1,0 @@
-import Agent = require("./lib/agent-base");
-
-const asAgent = new Agent();

--- a/types/superagent/types.d.ts
+++ b/types/superagent/types.d.ts
@@ -1,5 +1,5 @@
 import Response = require("./lib/node/response");
-import {UrlObject} from "url";
+import { UrlObject } from "url";
 
 export interface AgentOptions {
     ca?: any;

--- a/types/superagent/types.d.ts
+++ b/types/superagent/types.d.ts
@@ -1,4 +1,5 @@
 import Response = require("./lib/node/response");
+import {UrlObject} from "url";
 
 export interface AgentOptions {
     ca?: any;
@@ -9,3 +10,5 @@ export interface AgentOptions {
 }
 
 export type CBHandler = (err: any, res: Response) => void;
+
+export type URLType = string | URL | UrlObject;

--- a/types/supertest-as-promised/tsconfig.json
+++ b/types/supertest-as-promised/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "dom"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/supertest/tsconfig.json
+++ b/types/supertest/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "dom"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [N/A] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [N/A] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Using the `dom` `Request` type was a bug.  This adds the http2wrapper and makes all references to Request local to the package, reflecting the `superagent` library.

Closes #68398 
