### PR TITLE
Only run Azure Pipelines on pushes, shallow fetch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,13 @@
-# Learn more at: https://aka.ms/yaml
+trigger:
+  - master
+
+pr: none
+
 jobs:
+  - checkout: self
+    fetchDepth: 1
+    fetchTags: false
+
   - job: npmRunTest
     pool:
       vmImage: ubuntu-latest
@@ -11,6 +19,3 @@ jobs:
       - script: |
           echo "Disabled"
         displayName: 'Do nothing'
-
-trigger:
-  - master


### PR DESCRIPTION
Everything is now on GitHub actions. I was going to delete Pipelines, but it's probably best to keep it for CG scanning, so just run it on pushes and do a shallow fetch.