### PR TITLE
[mssql] Update Request properties

### DIFF
--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -326,7 +326,8 @@ export declare class Request extends events.EventEmitter {
     public verbose: boolean;
     public canceled: boolean;
     public multiple: boolean;
-    public stream: any;
+    public stream: boolean;
+    public arrayRowMode: boolean;
     public constructor(connection?: ConnectionPool);
     public constructor(transaction: Transaction);
     public constructor(preparedStatement: PreparedStatement);

--- a/types/mssql/mssql-tests.ts
+++ b/types/mssql/mssql-tests.ts
@@ -474,3 +474,13 @@ function test_request_to_readable_stream() {
     // You can optionally specify ReadableOptions.
     request.toReadableStream({ highWaterMark: 10 });
 }
+
+function test_set_request_options() {
+    const request = new sql.Request();
+    request.multiple = true;
+    request.stream = true;
+    request.arrayRowMode = true;
+
+    request.query("select 'asdf' as name, 'qwerty' as other_name, 'jkl' as name");
+    request.on('recordset', recordset => console.log(recordset));
+}

--- a/types/mssql/mssql-tests.ts
+++ b/types/mssql/mssql-tests.ts
@@ -482,5 +482,5 @@ function test_set_request_options() {
     request.arrayRowMode = true;
 
     request.query("select 'asdf' as name, 'qwerty' as other_name, 'jkl' as name");
-    request.on('recordset', recordset => console.log(recordset));
+    request.on("recordset", recordset => console.log(recordset));
 }


### PR DESCRIPTION
PR adds the missing `arrayRowMode` property to the `Request` class, as well as modifies the type for `stream` to be a boolean since it's only enabled or disabled, similar to `arrayRowMode`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/tediousjs/node-mssql/tree/v10.0.2?tab=readme-ov-file#streaming
  - https://github.com/tediousjs/node-mssql/tree/v10.0.2?tab=readme-ov-file#handling-duplicate-column-names
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
