### PR TITLE
Fix artifact name in new sharded GHA workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Upload suggestions
         uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         with:
-          name: suggestions_${{ matrix.id }}_${{ matrix.shardCount }}
+          name: suggestions_${{ matrix.shardId }}_${{ matrix.shardCount }}
           if-no-files-found: ignore
           path: ${{ steps.suggestions-dir.outputs.path }}
           retention-days: 1


### PR DESCRIPTION
Noticed this oops while working on another change.