### PR TITLE
Fix GHA nightly run matrixes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,7 @@ on:
   schedule:
     # 12PM UTC -> 4AM Pacific
     - cron: '0 12 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -42,8 +43,12 @@ jobs:
 
       - id: matrix
         run: |
-          TEST_COUNT=$(pnpm ls --depth -1 --parseable --filter '...@types/**[HEAD^1]' | wc -)
-          MATRIX=$(node ./scripts/get-ci-matrix $TEST_COUNT)
+          if [ "${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}" == "true" ]; then
+            TESTS=all
+          else
+            TESTS=$(pnpm ls --depth -1 --parseable --filter '...@types/**[HEAD^1]' | wc -)
+          fi
+          MATRIX=$(node ./scripts/get-ci-matrix $TESTS)
           echo $MATRIX
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
@@ -90,19 +95,19 @@ jobs:
 
       - run: ./scripts/pnpm-install.sh
         name: pnpm install (filtered)
-        if: ${{ github.event_name != 'schedule' }}
+        if: ${{ !(github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
 
       - run: pnpm install
         name: pnpm install
-        if: ${{ github.event_name == 'schedule' }}
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
       - run: pnpm ls
 
       - run: pnpm run test-all --diffBase HEAD^1 --shardCount ${{ matrix.shardCount }} --shardId ${{ matrix.shardId }}
-        if: ${{ github.event_name != 'schedule' }}
+        if: ${{ !(github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
 
       - run: pnpm dtslint-runner --path . --selection all --onlyTestTsNext --shardCount ${{ matrix.shardCount }} --shardId ${{ matrix.shardId }}
-        if: ${{ github.event_name == 'schedule' }}
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
       - name: Get suggestions dir
         id: suggestions-dir

--- a/scripts/get-ci-matrix.js
+++ b/scripts/get-ci-matrix.js
@@ -1,13 +1,21 @@
-const testCount = Number.parseInt(process.argv[2]);
+const arg = process.argv[2];
 
-const testsPerJob = 250;
-const maxJobs = 8;
+let shardCount;
 
-// Attempt to spawn as many jobs as needed to have only 250 tests per job,
-// up to 8 concurrent jobs.
-let shardCount = Math.ceil(testCount / testsPerJob);
-shardCount = Math.min(shardCount, maxJobs);
-shardCount = Math.max(shardCount, 1);
+if (arg === "all") {
+    shardCount = 16;
+} else {
+    const testCount = Number.parseInt(arg);
+
+    const testsPerJob = 250;
+    const maxJobs = 8;
+
+    // Attempt to spawn as many jobs as needed to have only 250 tests per job,
+    // up to 8 concurrent jobs.
+    shardCount = Math.ceil(testCount / testsPerJob);
+    shardCount = Math.min(shardCount, maxJobs);
+    shardCount = Math.max(shardCount, 1);
+}
 
 const include = [];
 

--- a/scripts/get-ci-matrix.js
+++ b/scripts/get-ci-matrix.js
@@ -1,14 +1,14 @@
 const arg = process.argv[2];
 
+const maxJobs = 8;
+
 let shardCount;
 
 if (arg === "all") {
-    shardCount = 16;
+    shardCount = maxJobs;
 } else {
     const testCount = Number.parseInt(arg);
-
     const testsPerJob = 250;
-    const maxJobs = 8;
 
     // Attempt to spawn as many jobs as needed to have only 250 tests per job,
     // up to 8 concurrent jobs.


### PR DESCRIPTION
Nightly runs were still using a comparison with `HEAD^1` to choose the shard size. This meant that the number of shards was sensitive to the most recent change, which wasn't my intent.

Instead, on scheduled runs (or workflow dispatch for manual runs), just use a fixed count.