### PR TITLE
[vscode] disable @typescript-eslint/array-type

### DIFF
--- a/types/vscode/.eslintrc.json
+++ b/types/vscode/.eslintrc.json
@@ -7,6 +7,7 @@
         "@definitelytyped/no-single-declare-module": "off",
         "@typescript-eslint/ban-types": "off",
         "@typescript-eslint/no-empty-interface": "off",
-        "@typescript-eslint/no-invalid-void-type": "off"
+        "@typescript-eslint/no-invalid-void-type": "off",
+        "@typescript-eslint/array-type": "off"
     }
 }


### PR DESCRIPTION
#68425 was merged with failing lints. This code is generated, so just disable the lint rule.