### PR TITLE
[npm:@types/iyzipay] Small Namespace Variable Names' Update

### DIFF
--- a/types/iyzipay/index.d.ts
+++ b/types/iyzipay/index.d.ts
@@ -1573,19 +1573,19 @@ declare class Iyzipay {
 }
 
 declare namespace Iyzipay {
-    const Locale: Ilocale;
-    const PaymentGroup: IpaymentGroup;
-    const BasketItemType: IbasketItemType;
-    const PaymentChannel: IpaymentChannel;
-    const SubMerchantType: IsubMerchantType;
-    const Currency: Icurrency;
-    const ApmType: IapmType;
-    const RefundReason: IrefundReason;
-    const PlanPaymentType: IplanPaymentType;
-    const SubscriptionPricingPlanInterval: IsubscriptionPricingPlanInterval;
-    const SubscriptionUpgradePeriod: IsubscriptionUpgradePeriod;
-    const SubscriptionStatus: IsubscriptionStatus;
-    const SubscriptionInitialStatus: IsubscriptionInitialStatus;
+    const LOCALE: Ilocale;
+    const PAYMENT_GROUP: IpaymentGroup;
+    const BASKET_ITEM_TYPE: IbasketItemType;
+    const PAYMENT_CHANNEL: IpaymentChannel;
+    const SUB_MERCHANT_TYPE: IsubMerchantType;
+    const CURRENCY: Icurrency;
+    const APM_TYPE: IapmType;
+    const REFUND_REASON: IrefundReason;
+    const PLAN_PAYMENT_TYPE: IplanPaymentType;
+    const SUBSCRIPTION_PRICING_PLAN_INTERVAL: IsubscriptionPricingPlanInterval;
+    const SUBSCRIPTION_UPGRADE_PERIOD: IsubscriptionUpgradePeriod;
+    const SUBSCRIPTION_STATUS: IsubscriptionStatus;
+    const SUBSCRIPTION_INITIAL_STATUS: IsubscriptionInitialStatus;
 }
 
 export = Iyzipay;

--- a/types/iyzipay/iyzipay-tests.ts
+++ b/types/iyzipay/iyzipay-tests.ts
@@ -6,4 +6,6 @@ const iyzipay = new Iyzipay({
     uri: "https://sandbox-api.iyzipay.com",
 });
 
-iyzipay.apiTest.retrieve({}, (err, result) => {});
+iyzipay.apiTest.retrieve({}, (err, result) => { });
+Iyzipay.LOCALE.TR;
+Iyzipay.PAYMENT_GROUP.PRODUCT;

--- a/types/iyzipay/package.json
+++ b/types/iyzipay/package.json
@@ -5,9 +5,6 @@
     "projects": [
         "https://github.com/iyzico/iyzipay-node"
     ],
-    "dependencies": {
-        "@types/node": "*"
-    },
     "devDependencies": {
         "@types/iyzipay": "workspace:."
     },


### PR DESCRIPTION
I am the owner of this declaration package. This package is currently released.

- [X] I made a small mistake regarding **namespace** elements of class Iyzipay. There was a naming error ( Locale ->LOCALE ) (I was using ChatGpt to handle eslint naming-convention errors. I didn't realize it manipulated this part. I have checked the remaining parts, everything is okay after this )

- [X] I have removed @types/node, it should be unnecessary

Old version variable names:
```typescript
const Locale: Ilocale;
const PaymentGroup: IpaymentGroup;
const BasketItemType: IbasketItemType;
const PaymentChannel: IpaymentChannel;
const SubMerchantType: IsubMerchantType;
const Currency: Icurrency;
const ApmType: IapmType;
const RefundReason: IrefundReason;
const PlanPaymentType: IplanPaymentType;
const SubscriptionPricingPlanInterval: IsubscriptionPricingPlanInterval;
const SubscriptionUpgradePeriod: IsubscriptionUpgradePeriod;
const SubscriptionStatus: IsubscriptionStatus;
const SubscriptionInitialStatus: IsubscriptionInitialStatus;
```

New variable names:
```typescript
const LOCALE: Ilocale;
const PAYMENT_GROUP: IpaymentGroup;
const BASKET_ITEM_TYPE: IbasketItemType;
const PAYMENT_CHANNEL: IpaymentChannel;
const SUB_MERCHANT_TYPE: IsubMerchantType;
const CURRENCY: Icurrency;
const APM_TYPE: IapmType;
const REFUND_REASON: IrefundReason;
const PLAN_PAYMENT_TYPE: IplanPaymentType;
const SUBSCRIPTION_PRICING_PLAN_INTERVAL: IsubscriptionPricingPlanInterval;
const SUBSCRIPTION_UPGRADE_PERIOD: IsubscriptionUpgradePeriod;
const SUBSCRIPTION_STATUS: IsubscriptionStatus;
const SUBSCRIPTION_INITIAL_STATUS: IsubscriptionInitialStatus;
```

Thanks