### PR TITLE
feat: relax TermSet#has

### DIFF
--- a/types/rdfjs__term-set/index.d.ts
+++ b/types/rdfjs__term-set/index.d.ts
@@ -1,4 +1,5 @@
 import { Term } from "@rdfjs/types";
 
 export default class TermSet<T extends Term = Term> extends Set<T> {
+    has(term: Term): boolean;
 }

--- a/types/rdfjs__term-set/rdfjs__term-set-tests.ts
+++ b/types/rdfjs__term-set/rdfjs__term-set-tests.ts
@@ -1,11 +1,18 @@
 import TermSet from "@rdfjs/term-set";
 import Factory from "@rdfjs/term-set/Factory";
-import { Term } from "@rdfjs/types";
+import { NamedNode, Term } from "@rdfjs/types";
 
 const type1: Term = <any> {};
 const type2: Term = <any> {};
+const namedNode: NamedNode = <any> {};
 
 const set: Set<Term> = new TermSet([type1, type2]);
 
 const exports: ["termSet"] = Factory.exports;
 const fromFactory: Set<Term> = new Factory().termSet([type1, type2]);
+
+function testHas() {
+    const set = new TermSet<NamedNode>();
+    const hasTerm: boolean = set.has(type1);
+    const hasNamedNode: boolean = set.has(namedNode);
+}


### PR DESCRIPTION
I never understood why `TermSet` did not allow any `Term` as argument to `has`. It will return false when the term is not found anyway. No reason to enforce additional type checks beforehand

I could argue even for `has(arg: unknown)` but let's not go there

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

