### PR TITLE
feat: relax TermMap#has and TermMap#get

### DIFF
--- a/types/rdfjs__term-map/index.d.ts
+++ b/types/rdfjs__term-map/index.d.ts
@@ -2,4 +2,6 @@ import { Term } from "@rdfjs/types";
 
 export default class TermMap<T extends Term = Term, V = any> extends Map<T, V> {
     constructor(entries?: Array<[Term, V]>);
+    get(term: Term): V | undefined;
+    has(term: Term): boolean;
 }

--- a/types/rdfjs__term-map/rdfjs__term-map-tests.ts
+++ b/types/rdfjs__term-map/rdfjs__term-map-tests.ts
@@ -24,3 +24,21 @@ let fromFactory: Map<NamedNode, number> = factory.termMap();
 fromFactory = factory.termMap([
     [named, 5],
 ]);
+
+function testHas() {
+    const map = new TermMap<NamedNode, string>([
+        [named, "foo"],
+    ]);
+
+    const hasNamed: boolean = map.has(named);
+    const hasOther: boolean = map.has(blank);
+}
+
+function testGet() {
+    const map = new TermMap<NamedNode, string>([
+        [named, "foo"],
+    ]);
+
+    const gotNamed: string | undefined = map.get(named);
+    const gotOther: string | undefined = map.get(blank);
+}


### PR DESCRIPTION
Analogous to #68445, allows any `Term` argument when calling `has` and `get` of a `TermMap` typed to a narrower subclass

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
