### PR TITLE
fix(backbone): do not import `underscore` as namespace

### DIFF
--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -3,7 +3,7 @@
 export = Backbone;
 export as namespace Backbone;
 
-import * as _ from "underscore";
+import _ from "underscore";
 
 declare namespace Backbone {
     type _Omit<T, K> = Pick<T, Exclude<keyof T, K>>;

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -1,9 +1,8 @@
 /// <reference types="jquery" />
+/// <reference types="underscore" />
 
 export = Backbone;
 export as namespace Backbone;
-
-import _ = require("underscore");
 
 declare namespace Backbone {
     type _Omit<T, K> = Pick<T, Exclude<keyof T, K>>;

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -3,7 +3,7 @@
 export = Backbone;
 export as namespace Backbone;
 
-import _ from "underscore";
+import _ = require("underscore");
 
 declare namespace Backbone {
     type _Omit<T, K> = Pick<T, Exclude<keyof T, K>>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/9ba7e7e63794245c5217a4cc0f07b4b9a5741820/types/underscore/index.d.mts#L144-L145
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If using some `moduleResolution` config that reads `exports` (such as `bundler`), then doing `import 'underscore'` will give the ESM file, which only re-exports the helpers needed (such as `ListIterator` and `MemoIterator`) in the default export.

<img width="1340" alt="image" src="https://github.com/DefinitelyTyped/DefinitelyTyped/assets/1404810/64b51eb0-8069-4ef3-8f81-c4d063f93247">

I'm not sure how to add a test - `tsconfig.json` needs to be changed to reproduce, at which point there's no need for new tests as the current ones will fail