### PR TITLE
feat(sanitize-html): update types to 2.11 with nonBooleanAttributes

### DIFF
--- a/types/sanitize-html/index.d.ts
+++ b/types/sanitize-html/index.d.ts
@@ -32,6 +32,7 @@ declare namespace sanitize {
         disallowedTagsMode: DisallowedTagsModes;
         enforceHtmlBoundary: boolean;
         selfClosing: string[];
+        nonBooleanAttributes: string[];
     }
 
     // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -76,6 +77,7 @@ declare namespace sanitize {
          * @default true
          */
         enforceHtmlBoundary?: boolean | undefined;
+        nonBooleanAttributes?: string[];
     }
 
     const defaults: IDefaults;

--- a/types/sanitize-html/package.json
+++ b/types/sanitize-html/package.json
@@ -51,6 +51,10 @@
         {
             "name": "Alex Rantos",
             "githubUsername": "alex-rantos"
+        },
+        {
+            "name": "Dylan Armstrong",
+            "githubUsername": "dylanarmstrong"
         }
     ]
 }

--- a/types/sanitize-html/package.json
+++ b/types/sanitize-html/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/sanitize-html",
-    "version": "2.9.9999",
+    "version": "2.11.9999",
     "projects": [
         "https://github.com/punkave/sanitize-html"
     ],

--- a/types/sanitize-html/sanitize-html-tests.ts
+++ b/types/sanitize-html/sanitize-html-tests.ts
@@ -44,7 +44,7 @@ const options: IOptions = {
     enforceHtmlBoundary: true,
     allowedScriptDomains: ["test.com"],
     allowedScriptHostnames: ["test.com"],
-    nonBooleanAttributes: ['href'],
+    nonBooleanAttributes: ["href"],
 };
 
 sanitize.defaults.allowedAttributes; // $ExpectType Record<string, AllowedAttribute[]>

--- a/types/sanitize-html/sanitize-html-tests.ts
+++ b/types/sanitize-html/sanitize-html-tests.ts
@@ -44,6 +44,7 @@ const options: IOptions = {
     enforceHtmlBoundary: true,
     allowedScriptDomains: ["test.com"],
     allowedScriptHostnames: ["test.com"],
+    nonBooleanAttributes: ['href'],
 };
 
 sanitize.defaults.allowedAttributes; // $ExpectType Record<string, AllowedAttribute[]>
@@ -55,6 +56,7 @@ sanitize.defaults.allowProtocolRelative; // $ExpectType boolean
 sanitize.defaults.disallowedTagsMode; // $ExpectType DisallowedTagsModes
 sanitize.defaults.enforceHtmlBoundary; // $ExpectType boolean
 sanitize.defaults.selfClosing; // $ExpectType string[]
+sanitize.defaults.nonBooleanAttributes; // $ExpectType string[]
 
 sanitize.options.allowedClasses; // $ExpectType { [index: string]: boolean | (string | RegExp)[]; } | undefined
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/apostrophecms/sanitize-html/blob/main/CHANGELOG.md
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes:
The only user facing change since 2.9 types has been the addition of `nonBooleanAttributes`