### PR TITLE
update popper* props to use floating-ui types

### DIFF
--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -1,7 +1,6 @@
-import * as Popper from "@popperjs/core";
+import { UseFloatingOptions } from "@floating-ui/react";
 import { Locale } from "date-fns";
 import * as React from "react";
-import { Modifier, StrictModifierNames } from "react-popper";
 
 export interface CalendarContainerProps {
     className?: string | undefined;
@@ -40,7 +39,6 @@ export interface ReactDatePickerCustomHeaderProps {
 }
 
 export interface ReactDatePickerProps<
-    CustomModifierNames extends string = never,
     WithRange extends boolean | undefined = undefined,
 > {
     adjustDateOnChange?: boolean | undefined;
@@ -136,9 +134,9 @@ export interface ReactDatePickerProps<
     placeholderText?: string | undefined;
     popperClassName?: string | undefined;
     popperContainer?(props: { children: React.ReactNode[] }): React.ReactNode;
-    popperModifiers?: ReadonlyArray<Modifier<StrictModifierNames | CustomModifierNames>> | undefined;
-    popperPlacement?: Popper.Placement | undefined;
-    popperProps?: {} | undefined;
+    popperModifiers?: UseFloatingOptions["middleware"] | undefined;
+    popperPlacement?: UseFloatingOptions["placement"] | undefined;
+    popperProps?: Partial<UseFloatingOptions> | undefined;
     preventOpenOnFocus?: boolean | undefined;
     previousMonthAriaLabel?: string | undefined;
     previousMonthButtonLabel?: string | React.ReactNode | undefined;
@@ -201,9 +199,8 @@ export interface ReactDatePickerProps<
 }
 
 export class ReactDatePicker<
-    CustomModifierNames extends string = never,
     WithRange extends boolean | undefined = undefined,
-> extends React.Component<ReactDatePickerProps<CustomModifierNames, WithRange>> {
+> extends React.Component<ReactDatePickerProps<WithRange>> {
     readonly setBlur: () => void;
     readonly setFocus: () => void;
     readonly setOpen: (open: boolean, skipSetBlur?: boolean) => void;

--- a/types/react-datepicker/package.json
+++ b/types/react-datepicker/package.json
@@ -6,10 +6,10 @@
         "https://github.com/Hacker0x01/react-datepicker"
     ],
     "dependencies": {
+        "@floating-ui/react": "^0.26.9",
         "@popperjs/core": "^2.9.2",
         "@types/react": "*",
-        "date-fns": "^2.0.1",
-        "react-popper": "^2.2.5"
+        "date-fns": "^3.3.1"
     },
     "devDependencies": {
         "@types/react-datepicker": "workspace:."

--- a/types/react-datepicker/react-datepicker-tests.tsx
+++ b/types/react-datepicker/react-datepicker-tests.tsx
@@ -1,4 +1,6 @@
-import enUS from "date-fns/locale/en-US";
+import { detectOverflow, offset } from "@floating-ui/react";
+import { enGB } from "date-fns/locale/en-GB";
+import { enUS } from "date-fns/locale/en-US";
 import * as React from "react";
 import DatePicker, {
     CalendarContainer,
@@ -6,20 +8,8 @@ import DatePicker, {
     ReactDatePickerProps,
     registerLocale,
 } from "react-datepicker";
-import { Modifier } from "react-popper";
 
-registerLocale("en-GB", { options: { weekStartsOn: 1 } });
-
-const topLogger: Modifier<"topLogger"> = {
-    name: "topLogger",
-    enabled: true,
-    phase: "main",
-    fn({ state }) {
-        if (state.placement === "top") {
-            console.log("Popper is on the top");
-        }
-    },
-};
+registerLocale("en-GB", { ...enGB, options: { weekStartsOn: 1 } });
 
 <DatePicker
     adjustDateOnChange
@@ -109,23 +99,23 @@ const topLogger: Modifier<"topLogger"> = {
     popperClassName=""
     popperContainer={props => <div />}
     popperModifiers={[
+        offset({
+            mainAxis: 5,
+            alignmentAxis: 10,
+        }),
         {
-            name: "offset",
-            options: {
-                offset: [5, 10],
-            },
-        },
-        {
-            name: "preventOverflow",
-            options: {
-                rootBoundary: "viewport",
-                tether: false,
-                altAxis: true,
+            name: "detectOverflow",
+            async fn(state) {
+                const overflow = await detectOverflow(state);
+                return {};
             },
         },
     ]}
     popperPlacement="bottom-start"
-    popperProps={{}}
+    popperProps={{
+        nodeId: "nodeId",
+        open: true,
+    }}
     preventOpenOnFocus
     previousMonthAriaLabel=""
     previousMonthButtonLabel=""
@@ -134,7 +124,7 @@ const topLogger: Modifier<"topLogger"> = {
     readOnly
     ref={instance => {
         if (instance !== null) {
-            // $ExpectType ReactDatePicker<"offset" | "preventOverflow", true>
+            // $ExpectType ReactDatePicker<true>
             instance;
         }
     }}
@@ -231,12 +221,6 @@ function handleRef(ref: DatePicker | null) {
 const props: ReactDatePickerProps = {
     onChange: () => {},
 };
-
-<DatePicker<"topLogger">
-    onChange={() => {}}
-    popperModifiers={[{ name: "arrow", options: { padding: 5 } }, topLogger]}
-    ref={(instance: DatePicker<"topLogger"> | null) => {}}
-/>;
 
 const DatePickerCustomHeader = ({
     monthDate,


### PR DESCRIPTION
react-datepicker moved from react-popper to floating-ui in [5.0.0](https://github.com/Hacker0x01/react-datepicker/releases/tag/v5.0.0).

Related props are updated to use types from the new package.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Hacker0x01/react-datepicker/releases/tag/v5.0.0
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. (not sure if it's still needed as I haven't seen the version number being updated in any of the previous commits)
