### PR TITLE
splitting.js | update Splitting() return type (Result -> Result[])

### DIFF
--- a/types/splitting/index.d.ts
+++ b/types/splitting/index.d.ts
@@ -22,7 +22,7 @@ export as namespace Splitting;
  * ```
  * @see {@link <https://splitting.js.org/guide.html#basic-usage>}
  */
-declare function Splitting(options?: Splitting.Options): Splitting.Result;
+declare function Splitting(options?: Splitting.Options): Splitting.Result[];
 
 declare namespace Splitting {
     /**

--- a/types/splitting/splitting-tests.ts
+++ b/types/splitting/splitting-tests.ts
@@ -15,7 +15,7 @@ Splitting({ // $ExpectType Result[]
 // $ExpectType Result[]
 Splitting({ key: null });
 
-Splitting({ target: document.createElement("span") }) // $ExpectType Result[]
+Splitting({ target: document.createElement("span") }); // $ExpectType Result[]
 Splitting({ target: [document.createElement("span")] });  // $ExpectType Result[]
 Splitting({ target: document.querySelectorAll(".target") }); // $ExpectType Result[]
 

--- a/types/splitting/splitting-tests.ts
+++ b/types/splitting/splitting-tests.ts
@@ -4,19 +4,20 @@ import "splitting/dist/splitting-cells.css";
 
 // Base splitting function
 
-Splitting();
-Splitting({});
-Splitting({
+Splitting(); // $ExpectType Result[]
+Splitting({}); // $ExpectType Result[]
+Splitting({ // $ExpectType Result[]
     target: ".target",
     by: "chars",
     key: "foo",
 });
 
+// $ExpectType Result[]
 Splitting({ key: null });
 
-Splitting({ target: document.createElement("span") });
-Splitting({ target: [document.createElement("span")] });
-Splitting({ target: document.querySelectorAll(".target") });
+Splitting({ target: document.createElement("span") }) // $ExpectType Result[]
+Splitting({ target: [document.createElement("span")] });  // $ExpectType Result[]
+Splitting({ target: document.querySelectorAll(".target") }); // $ExpectType Result[]
 
 // HTML function
 


### PR DESCRIPTION
Splitting returns an array of type Result, not a singular Result

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://splitting.js.org/guide.html#splitting>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
