### PR TITLE
[webpack-bundle-analyzer] Add isInitialByEntrypoint to JSON report data

### DIFF
--- a/types/webpack-bundle-analyzer/index.d.ts
+++ b/types/webpack-bundle-analyzer/index.d.ts
@@ -133,6 +133,7 @@ export namespace BundleAnalyzerPlugin {
         inaccurateSizes?: boolean | undefined;
         id?: number | null | undefined;
         isAsset?: boolean | undefined;
+        isInitialByEntrypoint?: Record<string, boolean> | undefined;
     }
 
     /** The json report that will be produced if `analyzerMode: 'json'` */

--- a/types/webpack-bundle-analyzer/package.json
+++ b/types/webpack-bundle-analyzer/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/webpack-bundle-analyzer",
-    "version": "4.6.9999",
+    "version": "4.7.9999",
     "projects": [
         "https://github.com/webpack-contrib/webpack-bundle-analyzer"
     ],

--- a/types/webpack-bundle-analyzer/webpack-bundle-analyzer-tests.ts
+++ b/types/webpack-bundle-analyzer/webpack-bundle-analyzer-tests.ts
@@ -108,6 +108,9 @@ const report: BundleAnalyzerPlugin.JsonReport = [
                 gzipSize: 71,
             },
         ],
+        isInitialByEntrypoint: {
+            bundle: true,
+        },
     },
 ];
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/519
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
