### PR TITLE
chore: [jsonwebtoken] remove undefined in SignOptions.expiresIn type

### DIFF
--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -40,7 +40,7 @@ export interface SignOptions {
     algorithm?: Algorithm | undefined;
     keyid?: string | undefined;
     /** expressed in seconds or a string describing a time span [zeit/ms](https://github.com/zeit/ms.js).  Eg: 60, "2 days", "10h", "7d" */
-    expiresIn?: string | number | undefined;
+    expiresIn?: string | number;
     /** expressed in seconds or a string describing a time span [zeit/ms](https://github.com/zeit/ms.js).  Eg: 60, "2 days", "10h", "7d" */
     notBefore?: string | number | undefined;
     audience?: string | string[] | undefined;

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -52,10 +52,10 @@ secretKey = createSecretKey("shhhhh", "utf-8");
 token = jwt.sign(testObject, secretKey);
 
 // sign with expiresIn
-token = jwt.sign({ foo: "bar" }, "shhhhh", { expiresIn: '1d' })
-token = jwt.sign({ foo: "bar" }, "shhhhh", { expiresIn: 10 })
+token = jwt.sign({ foo: "bar" }, "shhhhh", { expiresIn: "1d" });
+token = jwt.sign({ foo: "bar" }, "shhhhh", { expiresIn: 10 });
 // @ts-expect-error
-token = jwt.sign({ foo: "bar" }, "shhhhh", { expiresIn: undefined })
+token = jwt.sign({ foo: "bar" }, "shhhhh", { expiresIn: undefined });
 
 // sign with insecure key size
 token = jwt.sign({ foo: "bar" }, "shhhhh", { algorithm: "RS256", allowInsecureKeySizes: true });

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -51,6 +51,12 @@ token = jwt.sign(testObject, { key: privKey, passphrase: "keypwd" }, { algorithm
 secretKey = createSecretKey("shhhhh", "utf-8");
 token = jwt.sign(testObject, secretKey);
 
+// sign with expiresIn
+token = jwt.sign({ foo: "bar" }, "shhhhh", { expiresIn: '1d' })
+token = jwt.sign({ foo: "bar" }, "shhhhh", { expiresIn: 10 })
+// @ts-expect-error
+token = jwt.sign({ foo: "bar" }, "shhhhh", { expiresIn: undefined })
+
 // sign with insecure key size
 token = jwt.sign({ foo: "bar" }, "shhhhh", { algorithm: "RS256", allowInsecureKeySizes: true });
 

--- a/types/jsonwebtoken/tsconfig.json
+++ b/types/jsonwebtoken/tsconfig.json
@@ -10,7 +10,8 @@
         "strictFunctionTypes": true,
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "exactOptionalPropertyTypes": true
     },
     "files": [
         "index.d.ts",


### PR DESCRIPTION
📓 After release [8.0.0](https://github.com/auth0/node-jsonwebtoken/compare/v7.4.3...v8.0.0), `SignOptions.expiresIn` throw an error when given `undefined`.

```ts
expiresIn: { isValid: function(value) { return isInteger(value) || isString(value); }, message: '"expiresIn" should be a number of seconds or string representing a timespan' },
```
🗒️ Source: https://github.com/auth0/node-jsonwebtoken/blob/f3138506fe7fb9383a709e97c12e96148f0c7d7b/sign.js#L14

📝 https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54322#discussion_r1480596340


- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.