### PR TITLE
Update dependabot config to match TS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: /
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: daily
+      interval: 'weekly'
+    groups:
+      github-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
This copies the dependabot config from the TypeScript repo, which only sends PRs weekly and groups them together for easier review.

(I also want to add CODEOWNERS for some of the infra files but that can come later.)