### PR TITLE
[jsdom-screenshot] add missing options to GenerateImageOptions

### DIFF
--- a/types/jsdom-screenshot/index.d.ts
+++ b/types/jsdom-screenshot/index.d.ts
@@ -1,4 +1,4 @@
-import { LaunchOptions, Page, ScreenshotOptions, Viewport } from "puppeteer";
+import { LaunchOptions, Page, ScreenshotOptions, Viewport, Request } from "puppeteer";
 
 export interface GenerateImageOptions {
     launch?: LaunchOptions | undefined;
@@ -7,7 +7,7 @@ export interface GenerateImageOptions {
     debug?: boolean | undefined;
     waitUntilNetworkIdle?: boolean | undefined;
     viewport?: Viewport | undefined;
-    intercept?: VoidFunction | undefined;
+    intercept?: ((request: Request) => void) | undefined;
 }
 
 export function debug(element?: Element | Document): void;

--- a/types/jsdom-screenshot/index.d.ts
+++ b/types/jsdom-screenshot/index.d.ts
@@ -1,4 +1,4 @@
-import { LaunchOptions, Page, ScreenshotOptions, Viewport, Request } from "puppeteer";
+import { LaunchOptions, Page, Request, ScreenshotOptions, Viewport } from "puppeteer";
 
 export interface GenerateImageOptions {
     launch?: LaunchOptions | undefined;

--- a/types/jsdom-screenshot/index.d.ts
+++ b/types/jsdom-screenshot/index.d.ts
@@ -8,6 +8,7 @@ export interface GenerateImageOptions {
     waitUntilNetworkIdle?: boolean | undefined;
     viewport?: Viewport | undefined;
     intercept?: ((request: Request) => void) | undefined;
+    targetSelector?: string;
 }
 
 export function debug(element?: Element | Document): void;

--- a/types/jsdom-screenshot/jsdom-screenshot-tests.ts
+++ b/types/jsdom-screenshot/jsdom-screenshot-tests.ts
@@ -5,6 +5,10 @@ generateImage({
     launch: { args: ["--no-sandbox"] },
 });
 
+generateImage({
+    intercept: (request) => request.continue(),
+});
+
 setDefaultOptions({
     debug: true,
 });

--- a/types/jsdom-screenshot/package.json
+++ b/types/jsdom-screenshot/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/jsdom-screenshot",
-    "version": "3.3.9999",
+    "version": "4.0.9999",
     "projects": [
         "https://github.com/dferber90/jsdom-screenshot"
     ],

--- a/types/jsdom-screenshot/package.json
+++ b/types/jsdom-screenshot/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/jsdom-screenshot",
-    "version": "3.2.9999",
+    "version": "3.3.9999",
     "projects": [
         "https://github.com/dferber90/jsdom-screenshot"
     ],


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/jsdom-screenshot#-optionsintercept-

---

`VoidFunction` appears to be an incorrect type for `intercept`.

The [documentation](https://www.npmjs.com/package/jsdom-screenshot#-optionsintercept-) lists the following code sample:

```js
generateImage({
  intercept: request => {
    if (request.url().endsWith(".png") || request.url().endsWith(".jpg")) {
      // Blocks some images.
      request.abort();
    } else if (request.url().endsWith("/some-big-library.css")) {
      // Fake a response
      request.respond({
        status: 200,
        contentType: "text/css",
        body: "html, body { background: red }"
      });
    } else {
      // Call request.continue() for requests which should not be intercepted
      request.continue();
    }
  }
});
```

Logging the request object reveals the correct type to be puppeteer's `Request`. This is confirmed in the [source code](https://github.com/dferber90/jsdom-screenshot/blob/ed8d8b18206735195d930c3e8b6bd37a862964ca/generateImage.js#L70).

---

Additionally, the option `targetSelector` appears to be missing, despite being present in the [documentation](https://www.npmjs.com/package/jsdom-screenshot#-optionstargetselector-) and [source code](https://github.com/dferber90/jsdom-screenshot/blob/ed8d8b18206735195d930c3e8b6bd37a862964ca/generateImage.js#L85).

This PR adds both missing types.