### PR TITLE
[atlassian-connect-js] Add overloads for AP.resize and AP.history.getState

### DIFF
--- a/types/atlassian-connect-js/atlassian-connect-js-tests.ts
+++ b/types/atlassian-connect-js/atlassian-connect-js-tests.ts
@@ -111,6 +111,10 @@ AP.history.back(); // $ExpectType void
 AP.history.forward(); // $ExpectType void
 AP.history.go(-2); // $ExpectType void
 AP.history.getState(); // $ExpectType string
+AP.history.getState("all", (state) => console.log(state)); // $ExpectType void
+AP.history.getState("hash", (state) => console.log(state)); // $ExpectType void
+AP.history.getState(undefined, (state) => console.log(state)); // $ExpectType void
+AP.history.getState("all", (state) => console.log(state)); // $ExpectType void
 AP.history.pushState(1); // $ExpectType void
 AP.history.pushState("page2"); // $ExpectType void
 AP.history.pushState({ state: "state" }, "title", "https://example.com"); // $ExpectType void

--- a/types/atlassian-connect-js/atlassian-connect-js-tests.ts
+++ b/types/atlassian-connect-js/atlassian-connect-js-tests.ts
@@ -2,6 +2,7 @@ AP.defineGlobal({}); // $ExpectType void
 AP.defineModule("module", {}); // $ExpectType void
 AP.getLocation(location => console.log(location)); // $ExpectType void
 AP.resize("10px", "10px"); // $ExpectType void
+AP.resize(); // $ExpectType void
 AP.sizeToParent(true); // $ExpectType void
 AP.hideFooter(true); // $ExpectType void
 AP.addRequestMarshal(); // $ExpectType void

--- a/types/atlassian-connect-js/index.d.ts
+++ b/types/atlassian-connect-js/index.d.ts
@@ -502,6 +502,8 @@ declare namespace AP {
      * The dialog is opened over the entire window, rather than within the iframe itself.
      */
     namespace dialog {
+        type DialogSizes = "small" | "medium" | "large" | "x-large" | "maximum" | "fullscreen";
+
         interface DialogOptions {
             /**
              * The module key of a dialog, or the key of a page or web-item that you want to open as a dialog.
@@ -510,8 +512,9 @@ declare namespace AP {
 
             /**
              * Opens the dialog at a preset size: small, medium, large, x-large or fullscreen (with chrome).
+             * Sizes are defined in https://developer.atlassian.com/cloud/confluence/modules/dialog/ and replace the width and height options.
              */
-            size?: "small" | "medium" | "large" | "x-large" | "fullscreen" | undefined;
+            size?: DialogSizes | Uppercase<DialogSizes> | undefined;
 
             /**
              * if size is not set, define the width as a percentage (append a % to the number) or pixels.

--- a/types/atlassian-connect-js/index.d.ts
+++ b/types/atlassian-connect-js/index.d.ts
@@ -854,6 +854,19 @@ declare namespace AP {
         function getState(): string;
 
         /**
+         * Retrieves the current state of the history stack and returns the value. The returned value is the same as what was set with the pushState method.
+         * @param type Type of requested value (optional). Valid values are undefined, "hash" and "all".
+         * @param callback Asynchronous callback (optional) if retrieving state during page load.
+         */
+        function getState(type: "hash" | undefined, callback: (state: string) => void): void;
+        function getState(type: "all", callback: (state: {
+            key: string;
+            hash: string;
+            title: string;
+            href: string;
+        }) => void): void;
+
+        /**
          * Updates the location's anchor with the specified value and pushes the given data onto the session history. Does not invoke popState callback.
          * @param newState
          * @param title

--- a/types/atlassian-connect-js/index.d.ts
+++ b/types/atlassian-connect-js/index.d.ts
@@ -83,6 +83,16 @@ declare namespace AP {
     function resize(width: string, height: string): void;
 
     /**
+     * Undocumented: Resize the iframe according to content.
+     *
+     * Only content within an element with the class `ac-content` will be resized automatically.
+     * Content without this identifier is sized according to the `body` element, and will dynamically grow, but not shrink.
+     *
+     * Note that this method cannot be used in dialogs.
+     */
+    function resize(): void;
+
+    /**
      * Resize the iframe, so that it takes the entire page. Add-on may define to hide the footer using data-options.
      *
      * Note that this method is only available for general page modules.

--- a/types/atlassian-connect-js/index.d.ts
+++ b/types/atlassian-connect-js/index.d.ts
@@ -872,12 +872,15 @@ declare namespace AP {
          * @param callback Asynchronous callback (optional) if retrieving state during page load.
          */
         function getState(type: "hash" | undefined, callback: (state: string) => void): void;
-        function getState(type: "all", callback: (state: {
-            key: string;
-            hash: string;
-            title: string;
-            href: string;
-        }) => void): void;
+        function getState(
+            type: "all",
+            callback: (state: {
+                key: string;
+                hash: string;
+                title: string;
+                href: string;
+            }) => void,
+        ): void;
 
         /**
          * Updates the location's anchor with the specified value and pushes the given data onto the session history. Does not invoke popState callback.


### PR DESCRIPTION
AP.resize with no parameters is not documented anywhere, but we use it in our codebase and it works great (in dynamic content macros for instance).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [History API](https://developer.atlassian.com/cloud/confluence/jsapi/history/)
  - [Dialog sizes](https://developer.atlassian.com/cloud/confluence/modules/dialog/)
