### PR TITLE
Skip trying pnpm partial install pack when react stuff is modified

### DIFF
--- a/scripts/pnpm-install.sh
+++ b/scripts/pnpm-install.sh
@@ -1,6 +1,13 @@
 #!/bin/bash -e
 
+if git diff --name-only HEAD^1 | grep -q -E 'types/(react|prop-types|scheduler)/'; then
+    echo "types/react and dependents will be installed; skipping hack"
+    pnpm install
+    exit 0
+fi
+
 if git diff --diff-filter=DR --name-only HEAD^1 | grep -q 'package.json'; then
+    echo "a package.json was removed; installing everything so dtslint-runner can run packages which now depend on npm instead"
     pnpm install
     exit 0
 fi


### PR DESCRIPTION
This script is in place mainly to work around https://github.com/pnpm/pnpm/issues/7283; pnpm fails to install some transitive dependencies in full when filtered. However, the workaround for this bug itself is buggy and sometimes OOMs. For that, this script falls back to a full install, but not after wasting a bunch of time.

Anecdotally, this seems to happen to `@types/react`. So, if we see that package (or some of its dependencies) modified, just do the full install.

This should mitigate failures like in https://github.com/DefinitelyTyped/DefinitelyTyped/actions/runs/7779859400/job/21211684676?pr=68463#step:8:1121.