### PR TITLE
[react-blessed] Remove usage of deprecated string refs in tests

### DIFF
--- a/types/react-blessed/react-blessed-tests.tsx
+++ b/types/react-blessed/react-blessed-tests.tsx
@@ -221,7 +221,7 @@ const boxRef = React.createRef<ReactBlessed.BoxElement>();
 const newContextRef = React.createRef<NewContext>();
 <NewContext ref={newContextRef} />;
 
-<NewContext ref="string" />;
+<NewContext ref={React.createRef<NewContext>()} />;
 
 const ForwardNewContext = React.forwardRef((_props: {}, ref?: React.Ref<NewContext>) => <NewContext ref={ref} />);
 <ForwardNewContext ref={newContextRef} />;


### PR DESCRIPTION
This PR removes the usage of the deprecated string refs in tests. These are unrelated to the library and are testing the `ref` prop that React implements.