### PR TITLE
[react-bootstrap] Remove usage of deprecated string refs in tests

### DIFF
--- a/types/react-bootstrap/test/react-bootstrap-tests.tsx
+++ b/types/react-bootstrap/test/react-bootstrap-tests.tsx
@@ -1315,7 +1315,7 @@ export class ReactBootstrapTest extends Component {
                             type="text"
                             value="hello"
                             placeholder="Enter text"
-                            ref="input"
+                            ref={React.createRef<FormControl>()}
                             onChange={this.callback}
                         />
                         <FormControl.Feedback />


### PR DESCRIPTION
This PR removes the usage of the deprecated string refs in tests. These are unrelated to the library and are testing the `ref` prop that React implements.