### PR TITLE
[react-cropper] Remove usage of deprecated string refs in tests

### DIFF
--- a/types/react-cropper/react-cropper-tests.tsx
+++ b/types/react-cropper/react-cropper-tests.tsx
@@ -7,15 +7,16 @@ import Cropper from "react-cropper";
  * initializes cropper with string reference
  */
 class Demo extends React.Component {
+    cropperRef = React.createRef<Cropper>();
     crop() {
         // image in dataUrl
-        console.log((this.refs["cropper"] as any).getCroppedCanvas().toDataURL());
+        console.log(this.cropperRef.current.getCroppedCanvas().toDataURL());
     }
 
     render() {
         return (
             <Cropper
-                ref="cropper"
+                ref={this.cropperRef}
                 src="https://fengyuanchen.github.io/cropperjs/images/picture.jpg"
                 style={{ height: 400, width: "100%" }}
                 // Cropper.js options

--- a/types/react-cropper/react-cropper-tests.tsx
+++ b/types/react-cropper/react-cropper-tests.tsx
@@ -3,9 +3,6 @@ import Cropper from "react-cropper";
 // If you choose not to use import, you need to assign Cropper to default
 // var Cropper = require('react-cropper').default
 
-/**
- * initializes cropper with string reference
- */
 class Demo extends React.Component {
     cropperRef = React.createRef<Cropper>();
     crop() {


### PR DESCRIPTION
This PR removes the usage of the deprecated string refs in tests. These are unrelated to the library and are testing the `ref` prop that React implements.