### PR TITLE
[react-data-grid] Remove usage of deprecated string refs in tests

### DIFF
--- a/types/react-data-grid/react-data-grid-tests.tsx
+++ b/types/react-data-grid/react-data-grid-tests.tsx
@@ -244,6 +244,7 @@ var columns: Array<ReactDataGrid.Column<typeof counties>> = [
 ];
 
 class Example extends React.Component<any, any> {
+    gridRef = React.createRef<ReactDataGrid<Array<{ id: number; title: string }>>>();
     getInitialState() {
         var fakeRows = createRows(2000);
         return { rows: fakeRows };
@@ -255,7 +256,7 @@ class Example extends React.Component<any, any> {
             onClick: (ev: React.SyntheticEvent<any>, args: { idx: number; rowIdx: number }) => {
                 var idx = args.idx;
                 var rowIdx = args.rowIdx;
-                (this.refs.grid as ReactDataGrid<{}>).openCellEditor(rowIdx, idx);
+                (this.gridRef.current!).openCellEditor(rowIdx, idx);
             },
         };
 
@@ -330,7 +331,7 @@ class Example extends React.Component<any, any> {
         let selectedRows = ["id1", "id2"];
         return (
             <ReactDataGrid
-                ref="grid"
+                ref={this.gridRef}
                 enableCellSelect={true}
                 enableDragAndDrop={true}
                 columns={this.getColumns()}

--- a/types/react-data-grid/v1/react-data-grid-tests.tsx
+++ b/types/react-data-grid/v1/react-data-grid-tests.tsx
@@ -190,6 +190,7 @@ var columns: ReactDataGrid.Column[] = [
 ];
 
 class Example extends React.Component<any, any> {
+    gridRef = React.createRef<ReactDataGrid>();
     getInitialState() {
         var fakeRows = createRows(2000);
         return { rows: fakeRows };
@@ -201,7 +202,7 @@ class Example extends React.Component<any, any> {
             onClick: (ev: React.SyntheticEvent<any>, args: { idx: number; rowIdx: number }) => {
                 var idx = args.idx;
                 var rowIdx = args.rowIdx;
-                this.refs.grid as ReactDataGrid;
+                this.gridRef!;
             },
         };
 
@@ -258,7 +259,7 @@ class Example extends React.Component<any, any> {
         let selectedRows = ["id1", "id2"];
         return (
             <ReactDataGrid
-                ref="grid"
+                ref={this.gridRef}
                 enableCellSelect={true}
                 columns={this.getColumns()}
                 rowGetter={this.getRowAt}

--- a/types/react-data-grid/v2/react-data-grid-tests.tsx
+++ b/types/react-data-grid/v2/react-data-grid-tests.tsx
@@ -244,6 +244,7 @@ var columns: ReactDataGrid.Column[] = [
 ];
 
 class Example extends React.Component<any, any> {
+    gridRef = React.createRef<ReactDataGrid>();
     getInitialState() {
         var fakeRows = createRows(2000);
         return { rows: fakeRows };
@@ -255,7 +256,7 @@ class Example extends React.Component<any, any> {
             onClick: (ev: React.SyntheticEvent<any>, args: { idx: number; rowIdx: number }) => {
                 var idx = args.idx;
                 var rowIdx = args.rowIdx;
-                (this.refs.grid as ReactDataGrid).openCellEditor(rowIdx, idx);
+                this.gridRef.current.openCellEditor(rowIdx, idx);
             },
         };
 
@@ -333,7 +334,7 @@ class Example extends React.Component<any, any> {
         let selectedRows = ["id1", "id2"];
         return (
             <ReactDataGrid
-                ref="grid"
+                ref={this.gridRef}
                 enableCellSelect={true}
                 enableDragAndDrop={true}
                 columns={this.getColumns()}


### PR DESCRIPTION
This PR removes the usage of the deprecated string refs in tests. These are unrelated to the library and are testing the `ref` prop that React implements.