### PR TITLE
[react-datagrid] Remove usage of deprecated string refs in tests

### DIFF
--- a/types/react-datagrid/react-datagrid-tests.tsx
+++ b/types/react-datagrid/react-datagrid-tests.tsx
@@ -24,7 +24,7 @@ export namespace X {
             return (
                 <ReactDataGrid
                     key={0}
-                    ref="dlgBasic"
+                    ref={React.createRef()}
                     idProperty="id"
                     dataSource={data}
                     columns={columns}
@@ -39,7 +39,7 @@ class ExampleFull extends React.Component {
         return (
             <ReactDataGrid
                 key={1}
-                ref="dlgFull"
+                ref={React.createRef()}
                 idProperty="id"
                 dataSource={data}
                 columns={columns}


### PR DESCRIPTION
This PR removes the usage of the deprecated string refs in tests. These are unrelated to the library and are testing the `ref` prop that React implements.