### PR TITLE
[react-flags-select] Remove usage of deprecated string refs in tests

### DIFF
--- a/types/react-flags-select/react-flags-select-tests.tsx
+++ b/types/react-flags-select/react-flags-select-tests.tsx
@@ -64,7 +64,7 @@ export class ReactFlagsSelectTest extends React.Component {
                     onSelect={this.onSelectFlag}
                 />
                 <ReactFlagsSelect
-                    ref="userFlag"
+                    ref={React.createRef()}
                     defaultCountry="FR"
                 />
             </div>


### PR DESCRIPTION
This PR removes the usage of the deprecated string refs in tests. These are unrelated to the library and are testing the `ref` prop that React implements.