### PR TITLE
[react-input-autosize] Remove usage of deprecated string refs in tests

### DIFF
--- a/types/react-input-autosize/react-input-autosize-tests.tsx
+++ b/types/react-input-autosize/react-input-autosize-tests.tsx
@@ -21,7 +21,7 @@ class Test extends React.Component<AutosizeInputProps> {
                 defaultValue="hello"
                 value="goodbye"
                 minWidth="400"
-                ref="auto"
+                ref={React.createRef<AutosizeInput & HTMLInputElement>()}
                 inputRef={this.inputRef}
                 id="testInput"
                 placeholder="Testing 1, 2, 3"


### PR DESCRIPTION
This PR removes the usage of the deprecated string refs in tests. These are unrelated to the library and are testing the `ref` prop that React implements.