### PR TITLE
[react-native-form] Remove usage of deprecated string refs in tests

### DIFF
--- a/types/react-native-form/index.d.ts
+++ b/types/react-native-form/index.d.ts
@@ -9,7 +9,6 @@ export interface FormProps extends ViewProps {
             valueProp: string;
         };
     } | undefined;
-    ref: string;
 }
 
 export default class Form extends Component<FormProps> {}

--- a/types/react-native-form/react-native-form-tests.tsx
+++ b/types/react-native-form/react-native-form-tests.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import Form from "react-native-form";
 
 function FormView() {
-    return <Form ref="form"></Form>;
+    return <Form ref={React.createRef()}></Form>;
 }
 
 const customFields = {
@@ -14,9 +14,9 @@ const customFields = {
 };
 
 function FormViewWithCustomField() {
-    return <Form ref="form" customFields={customFields}></Form>;
+    return <Form ref={React.createRef()} customFields={customFields}></Form>;
 }
 
 function FormViewWithViewProps() {
-    return <Form ref="form" style={{ flex: 1 }}></Form>;
+    return <Form ref={React.createRef()} style={{ flex: 1 }}></Form>;
 }


### PR DESCRIPTION
This PR removes the usage of the deprecated string refs in tests. These are unrelated to the library and are testing the `ref` prop that React implements.