### PR TITLE
Increase sharding to 12 shards, at least 100 packages per shard

### DIFF
--- a/scripts/get-ci-matrix.js
+++ b/scripts/get-ci-matrix.js
@@ -1,6 +1,6 @@
 const arg = process.argv[2];
 
-const maxJobs = 8;
+const maxJobs = 12;
 
 let shardCount;
 
@@ -8,10 +8,9 @@ if (arg === "all") {
     shardCount = maxJobs;
 } else {
     const testCount = Number.parseInt(arg);
-    const testsPerJob = 250;
+    const testsPerJob = 100;
 
-    // Attempt to spawn as many jobs as needed to have only 250 tests per job,
-    // up to 8 concurrent jobs.
+    // Attempt to spawn as many jobs as needed to have at least `testsPerJob` tests per job.
     shardCount = Math.ceil(testCount / testsPerJob);
     shardCount = Math.min(shardCount, maxJobs);
     shardCount = Math.max(shardCount, 1);


### PR DESCRIPTION
A change to `@types/node` PR tests about 2500 packages, and a change to `@types/react` tests about 800 packages. Right now, we give each 8 and 4 shards, respectively. This will increase that to 12 and 8.

Most PRs don't touch more than a couple packages and will still get one shard.