### PR TITLE
[@types/css-tree] Add formattedMessage to SyntaxParseError

### DIFF
--- a/types/css-tree/css-tree-tests.ts
+++ b/types/css-tree/css-tree-tests.ts
@@ -713,8 +713,8 @@ csstree.parse(".a { ::: invalid css ::: }", {
     onParseError(error, fallbackNode) {
         error; // $ExpectType SyntaxParseError
         fallbackNode; // $ExpectType CssNode
-    }
-})
+    },
+});
 
 csstree.ident.decode("foo"); // $ExpectType string
 csstree.ident.encode("foo"); // $ExpectType string

--- a/types/css-tree/css-tree-tests.ts
+++ b/types/css-tree/css-tree-tests.ts
@@ -709,6 +709,13 @@ csstree.parse(".selector { /* comment */ }", {
     },
 });
 
+csstree.parse(".a { ::: invalid css ::: }", {
+    onParseError(error, fallbackNode) {
+        error; // $ExpectType SyntaxParseError
+        fallbackNode; // $ExpectType CssNode
+    }
+})
+
 csstree.ident.decode("foo"); // $ExpectType string
 csstree.ident.encode("foo"); // $ExpectType string
 csstree.string.decode("foo"); // $ExpectType string

--- a/types/css-tree/index.d.ts
+++ b/types/css-tree/index.d.ts
@@ -492,6 +492,7 @@ export interface SyntaxParseError extends SyntaxError {
     input: string;
     offset: number;
     rawMessage: string;
+    formattedMessage: string;
 }
 
 export interface ParseOptions {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Documentation: https://github.com/csstree/csstree/blob/master/docs/parsing.md
  - Source code: https://github.com/csstree/csstree/blob/master/lib/parser/SyntaxError.js#L61
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
