### PR TITLE
Remove dependencies on three's ambient namespace

### DIFF
--- a/types/aframe/index.d.ts
+++ b/types/aframe/index.d.ts
@@ -69,7 +69,7 @@ export interface Component<T extends object = any, S extends System = System> {
     play(): void;
     remove(): void;
     tick?(time: number, timeDelta: number): void;
-    tock?(time: number, timeDelta: number, camera: THREE.Camera): void;
+    tock?(time: number, timeDelta: number, camera: three.Camera): void;
     update(oldData: T): void;
     updateSchema?(): void;
 
@@ -116,8 +116,8 @@ export interface Entity<C = ObjectMap<Component>> extends ANode {
     components: C & DefaultComponents;
     hasLoaded: boolean;
     isPlaying: boolean;
-    object3D: THREE.Object3D;
-    object3DMap: ObjectMap<THREE.Object3D>;
+    object3D: three.Object3D;
+    object3DMap: ObjectMap<three.Object3D>;
     sceneEl?: Scene | undefined;
 
     destroy(): void;
@@ -128,12 +128,12 @@ export interface Entity<C = ObjectMap<Component>> extends ANode {
      */
     getComputedAttribute(attr: string): Component;
     getDOMAttribute(attr: string): any;
-    getObject3D(type: string): THREE.Object3D;
-    getOrCreateObject3D(type: string, construct: any): THREE.Object3D;
+    getObject3D(type: string): three.Object3D;
+    getOrCreateObject3D(type: string, construct: any): three.Object3D;
     is(stateName: string): boolean;
     pause(): void;
     play(): void;
-    setObject3D(type: string, obj: THREE.Object3D): void;
+    setObject3D(type: string, obj: three.Object3D): void;
     removeAttribute(attr: string, property?: string): void;
     removeObject3D(type: string): void;
     removeState(stateName: string): void;
@@ -234,13 +234,13 @@ export type SceneEvents = "enter-vr" | "exit-vr" | "loaded" | "renderstart";
 
 export interface Scene extends Entity {
     behaviors: Behavior[];
-    camera: THREE.Camera;
+    camera: three.Camera;
     canvas: HTMLCanvasElement;
     isMobile: boolean;
-    object3D: THREE.Scene;
-    renderer: THREE.WebGLRenderer;
+    object3D: three.Scene;
+    renderer: three.WebGLRenderer;
     renderStarted: boolean;
-    effect?: any; // THREE.VREffect
+    effect?: any; // three.VREffect
     systems: ObjectMap<System>;
     time: number;
 
@@ -267,7 +267,7 @@ export interface Shader {
     name: string;
     data: object;
     schema: Schema<this["data"]>;
-    material: THREE.Material;
+    material: three.Material;
     vertexShader: string;
     fragmentShader: string;
 
@@ -334,7 +334,7 @@ export interface Utils {
         isLandscape(): boolean;
         isBrowserEnvironment(): boolean;
         isNodeEnvironment(): boolean;
-        PolyfillControls(object3D: THREE.Object3D): void;
+        PolyfillControls(object3D: three.Object3D): void;
     };
     styleParser: {
         parse(value: string): object;
@@ -433,7 +433,7 @@ export const scenes: AFrame["scenes"];
 export const schema: AFrame["schema"];
 export const shaders: AFrame["shaders"];
 export const systems: AFrame["systems"];
-export const THREE: AFrame["THREE"];
+export import THREE = three;
 export const ANIME: AFrame["ANIME"];
 export const utils: AFrame["utils"];
 export const version: AFrame["version"];

--- a/types/itowns/src/Core/Prefab/Globe/GlobeLayer.d.ts
+++ b/types/itowns/src/Core/Prefab/Globe/GlobeLayer.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import Layer from "../../../Layer/Layer";
 
 export type GlobeLayerOptions = any;

--- a/types/itowns/src/Core/Prefab/Planar/PlanarLayer.d.ts
+++ b/types/itowns/src/Core/Prefab/Planar/PlanarLayer.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import Layer from "../../../Layer/Layer";
 
 export type PlanarLayerOptions = any;

--- a/types/itowns/src/Layer/GeometryLayer.d.ts
+++ b/types/itowns/src/Layer/GeometryLayer.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import View from "../Core/View";
 import Layer, { LayerOptions } from "./Layer";
 

--- a/types/itowns/src/Layer/PointCloudLayer.d.ts
+++ b/types/itowns/src/Layer/PointCloudLayer.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import { PNTS_MODE } from "../Renderer/PointsMaterial";
 import GeometryLayer, { GeometryLayerOptions } from "./GeometryLayer";
 

--- a/types/itowns/src/Layer/TiledGeometryLayer.d.ts
+++ b/types/itowns/src/Layer/TiledGeometryLayer.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import GeometryLayer from "./GeometryLayer";
 import Layer from "./Layer";
 // import { InfoTiledGeometryLayer } from "./InfoLayer";

--- a/types/itowns/src/Source/EntwinePointTileSource.d.ts
+++ b/types/itowns/src/Source/EntwinePointTileSource.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import Extent from "../Core/Geographic/Extent";
 import Source, { SourceOptions } from "./Source";
 

--- a/types/itowns/src/Source/PotreeSource.d.ts
+++ b/types/itowns/src/Source/PotreeSource.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import Extent from "../Core/Geographic/Extent";
 import Source, { SourceOptions } from "./Source";
 

--- a/types/itowns/test/3DTilesBasic.ts
+++ b/types/itowns/test/3DTilesBasic.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import * as itowns from "itowns";
 import { OpenSM } from "./jsonLayers";
 

--- a/types/openjscad/package.json
+++ b/types/openjscad/package.json
@@ -8,7 +8,7 @@
         "https://github.com/joostn/OpenJsCad"
     ],
     "dependencies": {
-        "@types/three": "*"
+        "@types/three": "^0.81.1"
     },
     "devDependencies": {
         "@types/openjscad": "workspace:."

--- a/types/three-nebula/src/behaviour/Behaviour.d.ts
+++ b/types/three-nebula/src/behaviour/Behaviour.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import Particle from "../core/Particle";
 import type { EasingFunction } from "../ease";
 import { Emitter } from "../emitter";

--- a/types/three-nebula/src/behaviour/Color.d.ts
+++ b/types/three-nebula/src/behaviour/Color.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import Particle from "../core/Particle";
 import { EasingFunction } from "../ease";
 import { JSONObject } from "../initializer/Rate";

--- a/types/three-nebula/src/core/System.d.ts
+++ b/types/three-nebula/src/core/System.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import { POOL_MAX } from "../constants";
 import { Emitter } from "../emitter";
 import EventDispatcher from "../events/EventDispatcher";

--- a/types/three-nebula/src/core/three/Matrix4.d.ts
+++ b/types/three-nebula/src/core/three/Matrix4.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import { Euler } from "./Euler.js";
 import { Quaternion } from "./Quaternion.js";
 import { Vector3 } from "./Vector3.js";

--- a/types/three-nebula/src/core/three/Vector3.d.ts
+++ b/types/three-nebula/src/core/three/Vector3.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import { Euler } from "./Euler.js";
 import { Matrix4 } from "./Matrix4.js";
 import { Quaternion } from "./Quaternion.js";

--- a/types/three-nebula/src/emitter/FollowEmitter.d.ts
+++ b/types/three-nebula/src/emitter/FollowEmitter.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import Emitter from "./Emitter";
 
 export default class FollowEmitter extends Emitter {

--- a/types/three-nebula/src/initializer/BodySprite.d.ts
+++ b/types/three-nebula/src/initializer/BodySprite.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import Particle from "../core/Particle";
 import Initializer from "./Initializer";
 import { JSONObject } from "./Rate";

--- a/types/three-nebula/src/initializer/InitializerUtil.d.ts
+++ b/types/three-nebula/src/initializer/InitializerUtil.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import Particle from "../core/Particle";
 import { Emitter } from "../emitter";
 import Initializer from "./Initializer";

--- a/types/three-nebula/src/initializer/Texture.d.ts
+++ b/types/three-nebula/src/initializer/Texture.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import { Three } from "../../src/core/three";
 import Particle from "../core/Particle";
 import { DEFAULT_MATERIAL_PROPERTIES } from "./constants";

--- a/types/three-nebula/src/renderer/GPURenderer/Desktop/index.d.ts
+++ b/types/three-nebula/src/renderer/GPURenderer/Desktop/index.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import { Particle, Pool, System } from "../../../core";
 import { Three } from "../../../core/three";
 import BaseRenderer from "../../BaseRenderer";

--- a/types/three-nebula/src/renderer/GPURenderer/Mobile/index.d.ts
+++ b/types/three-nebula/src/renderer/GPURenderer/Mobile/index.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import { Particle, Pool } from "../../../core";
 import { Three } from "../../../core/three";
 import BaseRenderer from "../../BaseRenderer";

--- a/types/three-nebula/src/renderer/GPURenderer/common/ParticleBuffer/index.d.ts
+++ b/types/three-nebula/src/renderer/GPURenderer/common/ParticleBuffer/index.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import { Three } from "../../../../core/three";
 import { DEFAULT_MAX_PARTICLES } from "./constants";
 /**

--- a/types/three-nebula/src/renderer/GPURenderer/common/TextureAtlas/index.d.ts
+++ b/types/three-nebula/src/renderer/GPURenderer/common/TextureAtlas/index.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import { RENDERER_TYPE_GPU_DESKTOP, RENDERER_TYPE_GPU_MOBILE } from "../../../types";
 /**
  * Dynamic texture atlas for performant support of systems with multiple emitters and textures.

--- a/types/three-nebula/src/renderer/GPURenderer/common/stores/Target.d.ts
+++ b/types/three-nebula/src/renderer/GPURenderer/common/stores/Target.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import { Three } from "../../../../core/three";
 /**
  * Simple class that stores the particle's "target" or "next" state.

--- a/types/three-nebula/src/renderer/GPURenderer/index.d.ts
+++ b/types/three-nebula/src/renderer/GPURenderer/index.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import { Three } from "../../core/three";
 import BaseRenderer from "../BaseRenderer";
 import { DEFAULT_RENDERER_OPTIONS } from "./common/constants";

--- a/types/three-nebula/src/renderer/MeshRenderer.d.ts
+++ b/types/three-nebula/src/renderer/MeshRenderer.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import { Particle, Pool } from "../core";
 import { Three } from "../core/three";
 import BaseRenderer from "./BaseRenderer";

--- a/types/three-nebula/src/renderer/SpriteRenderer.d.ts
+++ b/types/three-nebula/src/renderer/SpriteRenderer.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import { Particle } from "../core";
 import { Three } from "../core/three";
 import MeshRenderer from "./MeshRenderer";

--- a/types/three-nebula/src/utils/THREEUtil.d.ts
+++ b/types/three-nebula/src/utils/THREEUtil.d.ts
@@ -1,3 +1,5 @@
+import * as THREE from "three";
+
 export namespace THREEUtil {
     function toScreenPos(pos: THREE.Vector3, camera: THREE.Camera, canvas: HTMLCanvasElement): THREE.Vector3;
 

--- a/types/three-nebula/src/zone/MeshZone.d.ts
+++ b/types/three-nebula/src/zone/MeshZone.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import type { Vector3D } from "../math";
 import type Zone from "./Zone";
 

--- a/types/three-nebula/src/zone/ScreenZone.d.ts
+++ b/types/three-nebula/src/zone/ScreenZone.d.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 import type Particle from "../core/Particle";
 import type Zone from "./Zone";
 

--- a/types/three/build/three.d.cts
+++ b/types/three/build/three.d.cts
@@ -1,2 +1,1 @@
 export * from "../src/Three.js";
-export as namespace THREE;

--- a/types/three/build/three.module.d.ts
+++ b/types/three/build/three.module.d.ts
@@ -1,2 +1,1 @@
 export * from "../src/Three.js";
-export as namespace THREE;

--- a/types/three/build/three.module.min.d.ts
+++ b/types/three/build/three.module.min.d.ts
@@ -1,2 +1,1 @@
 export * from "../src/Three.js";
-export as namespace THREE;

--- a/types/three/index.d.ts
+++ b/types/three/index.d.ts
@@ -4,5 +4,3 @@
 // and released in the @types/three npm package.
 
 export * from "./src/Three";
-
-export as namespace THREE;


### PR DESCRIPTION
We are planning to remove three's ambient namespace since three.js no longer builds a UMD bundle [as of r161](https://github.com/mrdoob/three.js/wiki/Migration-Guide#r160--r161). This PR fixes the packages on DT that depend on three's ambient namespace (in most cases by just making sure THREE is imported). The ambient namespace will be removed in the next major version (to avoid making the breaking change in a patch).

For openjscad, I pinned @types/three to an earlier version since [openjscad is deprecated](https://github.com/joostn/OpenJsCad?tab=readme-ov-file#deprecated) and the latest version of three it depended on [was r70](https://github.com/joostn/OpenJsCad/blob/gh-pages/lib/three.min.js). We do not have types for r70, so I set the types to `@types/three@0.81.1` as the closest thing.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
