### PR TITLE
Add hoist-workspace-packages=false in prep for pnpm v9

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -45,6 +45,8 @@ save-workspace-protocol=false
 ignore-workspace-cycles=true
 # Don't pull symlinks up out of workspace packages.
 dedupe-direct-deps=false
+# Don't allow every package to see every other package.
+hoist-workspace-packages=false
 
 # Remove once https://github.com/pnpm/pnpm/issues/6457 is fixed
 # and we can set a hoisting limit of "workspaces" like in Yarn.


### PR DESCRIPTION
This default is changing in https://github.com/pnpm/pnpm/releases/tag/v9.0.0-alpha.1. We don't want it for DT as it makes every package visible to every other package.

(I want to test a new v9 PR, so need this change to not break it.)