### PR TITLE
Attempt to get people to not use the issue tracker for package problems

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,8 +2,8 @@ blank_issues_enabled: false
 contact_links:
   - name: There is an issue with @types/[library]
     url: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/new?category=issues-with-a-types-package
-    about: Request a change in an existing package
+    about: Request a change in an existing package.
 
   - name: Request a new @types library
     url: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/new?category=request-a-new-types-package
-    about: Request someone more experienced create a DT module
+    about: Request someone more experienced create a DT module.

--- a/.github/ISSUE_TEMPLATE/infrastructure_issue.md
+++ b/.github/ISSUE_TEMPLATE/infrastructure_issue.md
@@ -1,10 +1,12 @@
 ---
 name: Infrastructure Issue
-about: Report a DefinitelyTyped infrastructure issue
-labels: 'infra'
+about: Report a DefinitelyTyped infrastructure issue. Do _not_ use this for package issues; please use the links below.
 ---
 
 <!-- 
+DO NOT use this template to report problems with a specific package.
+Please use https://github.com/DefinitelyTyped/DefinitelyTyped/discussions instead.
+
 Is something wrong with CI or publishing infrastructure?
 
 - Check the [Infrastructure status updates](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/44317) thread for known issues.


### PR DESCRIPTION
The discussion board is what has the bot, pings of users, etc. People still keep filing issues that nobody will ever read.