### PR TITLE
[ember] Make Transition.to nullable

### DIFF
--- a/types/ember__routing/test/router-service.ts
+++ b/types/ember__routing/test/router-service.ts
@@ -79,13 +79,13 @@ transition.promise;
 // @ts-expect-error
 transition.promise = "promise";
 
-// $ExpectType RouteInfo | RouteInfoWithAttributes
+// $ExpectType RouteInfo | RouteInfoWithAttributes | null
 transition.to;
 // @ts-expect-error
 transition.to = "to";
 
 // $ExpectType unknown
-transition.to.metadata;
+transition.to?.metadata;
 // @ts-expect-error
 transition.to.metadata = "foo";
 

--- a/types/ember__routing/test/router.ts
+++ b/types/ember__routing/test/router.ts
@@ -55,14 +55,16 @@ const RouterServiceConsumer = Service.extend({
         router
             .on("routeWillChange", transition => {
                 const to = transition.to;
-                to.child; // $ExpectType RouteInfo | null
-                to.localName; // $ExpectType string
-                to.name; // $ExpectType string
-                to.paramNames; // $ExpectType string[]
-                to.params.foo; // $ExpectType string | undefined
-                to.parent; // $ExpectType RouteInfo | null
-                to.queryParams.foo; // $ExpectType string | undefined
-                to.find(info => info.name === "foo"); // $ExpectType RouteInfo | undefined
+                if (to) {
+                    to.child; // $ExpectType RouteInfo | null
+                    to.localName; // $ExpectType string
+                    to.name; // $ExpectType string
+                    to.paramNames; // $ExpectType string[]
+                    to.params.foo; // $ExpectType string | undefined
+                    to.parent; // $ExpectType RouteInfo | null
+                    to.queryParams.foo; // $ExpectType string | undefined
+                    to.find(info => info.name === "foo"); // $ExpectType RouteInfo | undefined
+                }
             })
             .on("routeDidChange", transition => {
                 const from = transition.from;

--- a/types/ember__routing/transition.d.ts
+++ b/types/ember__routing/transition.d.ts
@@ -35,7 +35,7 @@ export default interface Transition<T = unknown> extends Partial<Promise<T>> {
      * This property is a `RouteInfo` object that represents where the router is transitioning to.
      * It's important to note that a `RouteInfo` is a linked list and this property is simply the leafmost route.
      */
-    readonly to: RouteInfo | RouteInfoWithAttributes;
+    readonly to: RouteInfo | RouteInfoWithAttributes | null;
     /**
      * The targetName is the route name of the destination route.
      */


### PR DESCRIPTION
Looking at the Ember source code it's possible that `Transition.to` is `null`, as far back as v3.28

https://github.com/emberjs/ember.js/blob/v3.28.12/packages/%40ember/-internals/routing/lib/system/transition.ts#L137-L144

It's not mentioned in the documentation..

https://api.emberjs.com/ember/3.28/classes/Transition/properties/to?anchor=to

..but I've run into a few instance where it has occured

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
