### PR TITLE
Format markdown with dprint

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -35,7 +35,9 @@
         // Machine-generated files.
         "./docs/support-window.json",
         "./notNeededPackages.json",
-        "**/package-lock.json"
+        "**/package-lock.json",
+
+        "./types/**/*.md"
     ],
     "prettier": {
         "associations": [
@@ -50,6 +52,7 @@
     "plugins": [
         "https://plugins.dprint.dev/typescript-0.88.8.wasm",
         "https://plugins.dprint.dev/json-0.19.1.wasm",
+        "https://plugins.dprint.dev/markdown-0.16.3.wasm",
         "https://plugins.dprint.dev/prettier-0.32.1.json@19aa403ef0862ba8c41164e3dc6f84c0b7a66c2b11e42726b23dd25e6302ada9"
     ],
     "indentWidth": 4,

--- a/.github/ISSUE_TEMPLATE/infrastructure_issue.md
+++ b/.github/ISSUE_TEMPLATE/infrastructure_issue.md
@@ -3,7 +3,7 @@ name: Infrastructure Issue
 about: Report a DefinitelyTyped infrastructure issue. Do _not_ use this for package issues; please use the links below.
 ---
 
-<!-- 
+<!--
 DO NOT use this template to report problems with a specific package.
 Please use https://github.com/DefinitelyTyped/DefinitelyTyped/discussions instead.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,7 @@ Please fill in this template.
 Select one of these and delete the others:
 
 If adding a new definition:
+
 - [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
 - [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
 - [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
@@ -17,10 +18,12 @@ If adding a new definition:
 - [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
 
 If changing an existing definition:
+
 - [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
 - [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
 
 If removing a declaration:
+
 - [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
 - [ ] Delete the package's directory.
 - [ ] Add it to `notNeededPackages.json`.

--- a/.vscode/settings.template.json
+++ b/.vscode/settings.template.json
@@ -1,5 +1,5 @@
 {
-    "[typescript][typescriptreact][javascript][javascriptreact][json][jsonc]": {
+    "[typescript][typescriptreact][javascript][javascriptreact][json][jsonc][markdown]": {
         "editor.defaultFormatter": "dprint.dprint",
         "editor.formatOnSave": true
     }

--- a/README.es.md
+++ b/README.es.md
@@ -2,15 +2,14 @@
 
 > El repositorio de definiciones de TypeScript de alta calidad.
 
-*You can also read this README in [English](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md), [한국어](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ko.md), [Русский](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ru.md), [简体中文](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.zh-Hans.md), [Português](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.pt.md), [Italiano](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.it.md)
-and [日本語](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ja.md)!*
+_You can also read this README in [English](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md), [한국어](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ko.md), [Русский](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ru.md), [简体中文](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.zh-Hans.md), [Português](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.pt.md), [Italiano](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.it.md)
+and [日本語](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ja.md)!_
 
 Vea también el sitio web [definitelytyped.org](http://definitelytyped.org), aunque la información en este README está más actualizada.
 
 ## ¿Qué son los `declaration files`?
 
 Vea el [Manual de TypeScript](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html).
-
 
 ## ¿Cómo los obtengo?
 
@@ -43,21 +42,21 @@ o solo busca por cualquier archivo ".d.ts" en el paquete e inclúyelo manualment
 Los paquetes `@types` tienen etiquetas para las versiones de Typescript que explícitamente soportan, usualmente puedes obtener versiones más viejas de los paquetes anteriores a 2 años.
 Por ejemplo, si ejecutas `npm dist-tags @types/react`, observaras que Typescript 2.5 puede usar types para react@16.0, a su vez, Typescript 2.6 y 2.7 pueden usar types para react@16.4.
 
-|Etiqueta | Versión|
-|----|---------|
-|latest| 16.9.23|
-|ts2.0| 15.0.1|
-| ... | ... |
-|ts2.5| 16.0.36|
-|ts2.6| 16.4.7|
-|ts2.7| 16.4.7|
-| ... | ... |
+| Etiqueta | Versión |
+| -------- | ------- |
+| latest   | 16.9.23 |
+| ts2.0    | 15.0.1  |
+| ...      | ...     |
+| ts2.5    | 16.0.36 |
+| ts2.6    | 16.4.7  |
+| ts2.7    | 16.4.7  |
+| ...      | ...     |
 
 #### TypeScript 1.*
 
-* Descárguelo manualmente desde la `master` branch de este repositorio
-* [Typings](https://github.com/typings/typings)~~ (use las alternativas preferidas, typings es obsoleto)
-* ~~[NuGet](https://nuget.org/packages?q=DefinitelyTyped)~~ (use las alternativas preferidas, la publicación DT type de nuget ha sido desactivada)
+- Descárguelo manualmente desde la `master` branch de este repositorio
+- [Typings](https://github.com/typings/typings)~~ (use las alternativas preferidas, typings es obsoleto)
+- ~~[NuGet](https://nuget.org/packages?q=DefinitelyTyped)~~ (use las alternativas preferidas, la publicación DT type de nuget ha sido desactivada)
 
 Tal vez debas añadir manualmente las [referencias](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html).
 
@@ -76,7 +75,6 @@ Antes de compartir tu mejora con el mundo, úselo usted mismo.
 Para agregar nuevas funciones puedes usar el [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html).
 También puedes editar directamente los types en `node_modules/@types/foo/index.d.ts`, o copiarlos de ahí y seguir los pasos explicados a continuación.
 
-
 #### Prueba un nuevo paquete
 
 Añade a tu `tsconfig.json`:
@@ -89,11 +87,10 @@ Añade a tu `tsconfig.json`:
 (También puedes usar `src/types`.)
 Crea un `types/foo/index.d.ts` que contenga declaraciones del módulo "foo".
 Ahora deberías poder importar desde `"foo"` a tu código y te enviara a un nuevo tipo de definición.
-Entonces compila *y* ejecuta el código para asegurarte que el tipo de definición en realidad corresponde a lo que suceda en el momento de la ejecución.
+Entonces compila _y_ ejecuta el código para asegurarte que el tipo de definición en realidad corresponde a lo que suceda en el momento de la ejecución.
 Una vez que hayas probado tus definiciones con el código real, haz un [PR](#haz-un-pull-request)
 luego sigue las instrucciones para [editar un paquete existente](#editar-un-paquete-existente) o
 [crear un nuevo paquete](#crear-un-nuevo-paquete).
-
 
 ### Haz un pull request
 
@@ -101,13 +98,12 @@ Una vez que hayas probado tu paquete, podrás compartirlo en Definitely Typed.
 
 Primero, [bifurca](https://docs.github.com/es/get-started/quickstart/fork-a-repo) este repositorio, instala [node](https://nodejs.org/), y luego ejecuta el comando `npm install`.
 
-
 #### Editar un paquete existente
 
-* `cd types/<package to edit>`
-* Haz cambios. Recuerda [editar las pruebas](#my-package-teststs).
+- `cd types/<package to edit>`
+- Haz cambios. Recuerda [editar las pruebas](#my-package-teststs).
   Si realiza cambios importantes, no olvide [actualizar una versión principal](#quiero-actualizar-un-paquete-a-una-nueva-versión-principal).
-* También puede que quieras añadirle la sección "Definitions by" en el encabezado del paquete.
+- También puede que quieras añadirle la sección "Definitions by" en el encabezado del paquete.
   - Esto hará que seas notificado (a través de tu nombre de usuario en GitHub) cada vez que alguien haga un pull request o issue sobre el paquete.
   - Haz esto añadiendo tu nombre al final de la línea, así como en `// Definitions by: Alice <https://github.com/alice>, Bob <https://github.com/bob>`.
   - O si hay más personas, puede ser multiline
@@ -117,11 +113,10 @@ Primero, [bifurca](https://docs.github.com/es/get-started/quickstart/fork-a-repo
   //                 Steve <https://github.com/steve>
   //                 John <https://github.com/john>
   ```
-* [Ejecuta `npm test <package to test>`](#running-tests).
+- [Ejecuta `npm test <package to test>`](#running-tests).
 
 Cuando hagas un PR para editar un paquete existente, `dt-bot` deberá @-mencionar a los autores previos.
 Si no lo hace, puedes hacerlo en el comentario asociado con el PR.
-
 
 #### Crear un nuevo paquete
 
@@ -133,11 +128,11 @@ Si el paquete al que le estás agregando typings no es para npm, asegúrate de q
 
 Tu paquete debería tener esta estructura:
 
-| Archivo | Propósito |
-| --- | --- |
-| `index.d.ts` | Este contiene los typings del paquete. |
-| [`<my-package>-tests.ts`](#my-package-teststs) | Este contiene una muestra del código con el que se realiza la prueba de escritura. Este código *no* es ejecutable, pero sí es type-checked. |
-| [`tsconfig.json`](#tsconfigjson) | Este permite ejecutar `tsc` dentro del paquete. |
+| Archivo                                        | Propósito                                                                                                                                   |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `index.d.ts`                                   | Este contiene los typings del paquete.                                                                                                      |
+| [`<my-package>-tests.ts`](#my-package-teststs) | Este contiene una muestra del código con el que se realiza la prueba de escritura. Este código _no_ es ejecutable, pero sí es type-checked. |
+| [`tsconfig.json`](#tsconfigjson)               | Este permite ejecutar `tsc` dentro del paquete.                                                                                             |
 
 Generalas ejecutando `npm install -g dts-gen` y `dts-gen --dt --name <my-package> --template module`.
 Ve todas las opciones en [dts-gen](https://github.com/Microsoft/dts-gen).
@@ -151,6 +146,7 @@ Para un buen paquete de ejemplo, vea [base64-js](https://github.com/DefinitelyTy
 Cuando un paquete [bundles](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) sus propios tipos, estos tipos deberán ser removidos de Definitely Typed para evitar que generen confusión.
 
 Se puede remover ejecutando `pnpm run not-needed -- <typingsPackageName> <asOfVersion> [<libraryName>]`.
+
 - `<typingsPackageName>`: Este es el nombre del directorio que tienes que eliminar.
 - `<asOfVersion>`: Un stub será publicado a `@types/<typingsPackageName>` con esta versión. Debería ser más grande que cualquier versión publicada actualmente.
 - `<libraryName>`: Un nombre descriptivo de la librería, p.ej. "Angular 2" en vez de "angular2". (Si es omitido, será idéntico a `<typingsPackageName>`.)
@@ -246,21 +242,21 @@ If a file is neither tested nor referenced in `index.d.ts`, add it to a file nam
 
 #### Errores comunes
 
-* Primero, sigue el consejo del [manual](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html).
-* Formatear: Utiliza 4 espacios.
-* `function sum(nums: number[]): number`: Utiliza `ReadonlyArray` si una función no escribe a sus parámetros.
-* `interface Foo { new(): Foo; }`:
+- Primero, sigue el consejo del [manual](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html).
+- Formatear: Utiliza 4 espacios.
+- `function sum(nums: number[]): number`: Utiliza `ReadonlyArray` si una función no escribe a sus parámetros.
+- `interface Foo { new(): Foo; }`:
   Este define el tipo de objeto que esten nuevos. Probablemente quieras `declare class Foo { constructor(); }`.
-* `const Class: { new(): IClass; }`:
+- `const Class: { new(): IClass; }`:
   Prefiere usar una declaración de clase `class Class { constructor(); }` En vez de una nueva constante.
-* `getMeAT<T>(): T`:
+- `getMeAT<T>(): T`:
   Si un tipo de parámetro no aparece en los tipos de ningún parámetro, no tienes una función genérica, solo tienes un afirmación del tipo disfrazado.
   Prefiera utilizar una afirmación de tipo real, p.ej. `getMeAT() as number`.
   Un ejemplo donde un tipo de parámetro es aceptable: `function id<T>(value: T): T;`.
   Un ejemplo donde no es aceptable: `function parseJson<T>(json: string): T;`.
   Una excepción: `new Map<string, number>()` está bien.
-* Utilizando los tipos `Function` y `Object` casi nunca es una buena idea. En 99% de los casos es posible especificar un tipo más específico. Los ejemplos son `(x: number) => number` para [funciones](https://www.typescriptlang.org/docs/handbook/functions.html#function-types) y `{ x: number, y: number }` para objetos. Si no hay certeza en lo absoluto del tipo, [`any`](https://www.typescriptlang.org/docs/handbook/basic-types.html#any) es la opción correcta, no `Object`. Si el único hecho conocido sobre el tipo es que es un objecto, usa el tipo [`object`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type), no `Object` o `{ [key: string]: any }`.
-* `var foo: string | any`:
+- Utilizando los tipos `Function` y `Object` casi nunca es una buena idea. En 99% de los casos es posible especificar un tipo más específico. Los ejemplos son `(x: number) => number` para [funciones](https://www.typescriptlang.org/docs/handbook/functions.html#function-types) y `{ x: number, y: number }` para objetos. Si no hay certeza en lo absoluto del tipo, [`any`](https://www.typescriptlang.org/docs/handbook/basic-types.html#any) es la opción correcta, no `Object`. Si el único hecho conocido sobre el tipo es que es un objecto, usa el tipo [`object`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type), no `Object` o `{ [key: string]: any }`.
+- `var foo: string | any`:
   Cuando es usado `any` en un tipo de unión, el tipo resultante todavía es `any`. Así que mientras la porción `string` de este tipo de anotación puede _verse_ útil, de hecho, no ofrece ningún typechecking adicional más que un simple `any`.
   Dependiendo de la intención, una alternativa aceptable puede ser `any`, `string`, o `string | object`.
 
@@ -268,14 +264,14 @@ If a file is neither tested nor referenced in `index.d.ts`, add it to a file nam
 
 DT tiene el concepto de "Propietarios de Definiciones" que son personas que desean mantener la calidad de los tipos de un módulo en particular.
 
-* Agregarte a la lista hará que recibas notificaciones (a través de tu nombre de usuario de GitHub) cada vez que alguien haga una solicitud de extracción o informe sobre el paquete.
-* Tus revisiones de solicitudes de extracción tendrán una mayor importancia para [el bot](https://github.com/DefinitelyTyped/dt-mergebot) que mantiene este repositorio.
-* Los mantenedores de DT confían en los propietarios de las definiciones para asegurar un ecosistema estable, así que por favor, no te agregues ligeramente.
+- Agregarte a la lista hará que recibas notificaciones (a través de tu nombre de usuario de GitHub) cada vez que alguien haga una solicitud de extracción o informe sobre el paquete.
+- Tus revisiones de solicitudes de extracción tendrán una mayor importancia para [el bot](https://github.com/DefinitelyTyped/dt-mergebot) que mantiene este repositorio.
+- Los mantenedores de DT confían en los propietarios de las definiciones para asegurar un ecosistema estable, así que por favor, no te agregues ligeramente.
 
 Para agregarte como Propietario de Definiciones:
 
-* Agrega tu nombre al final de la línea, como en `// Definitions by: Alice <https://github.com/alice>, Bob <https://github.com/bob>`.
-* O si hay más personas, puede ser en varias líneas
+- Agrega tu nombre al final de la línea, como en `// Definitions by: Alice <https://github.com/alice>, Bob <https://github.com/bob>`.
+- O si hay más personas, puede ser en varias líneas
   ```typescript
   // Definitions by: Alice <https://github.com/alice>
   //                 Bob <https://github.com/bob>
@@ -289,7 +285,7 @@ Una vez a la semana, los Propietarios de Definiciones se sincronizan con el arch
 
 #### ¿Cuál es exactamente la relación entre este repositorio y los paquetes de `@types` en npm?
 
-La `master` branch es automáticamente publicada en el alcance de los  `@types` en npm gracias a los [DefinitelyTyped-tools](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher).
+La `master` branch es automáticamente publicada en el alcance de los `@types` en npm gracias a los [DefinitelyTyped-tools](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher).
 
 #### He enviado un pull request. ¿Cuánto tardará en ser merged?
 
@@ -314,7 +310,7 @@ Aquí están las [definiciones solicitadas actualmente](https://github.com/Defin
 
 #### ¿Qué pasa con las type definitions para el DOM?
 
-Si las types son parte de los estándares web, estas deberán ser contribuidas a [TSJS-lib-generator](https://github.com/Microsoft/TSJS-lib-generator) para que se hagan parte de la librería predeterminada  `lib.dom.d.ts`.
+Si las types son parte de los estándares web, estas deberán ser contribuidas a [TSJS-lib-generator](https://github.com/Microsoft/TSJS-lib-generator) para que se hagan parte de la librería predeterminada `lib.dom.d.ts`.
 
 #### Un paquete utiliza `export =`, pero prefiero utilizar las import predeterminadas. ¿Puedo cambiar `export =` por `export default`?
 
@@ -348,8 +344,8 @@ Por ejemplo [history v2 `tsconfig.json`](https://github.com/%44efinitelyTyped/De
         "baseUrl": "../../",
         "typeRoots": ["../../"],
         "paths": {
-            "history": [ "history/v2" ]
-        },
+            "history": ["history/v2"]
+        }
     },
     "files": [
         "index.d.ts",
@@ -367,9 +363,9 @@ Además, `/// <reference types=".." />` no trabajará con rutas mapeadas, así q
 
 #### ¿Cómo escribo definitions para paquetes que pueden ser usados globalmente y como un módulo?
 
-El manual de TypeScript contiene excelente [información general para escribir definiciones](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html), además [este archivo de definiciones de ejemplo](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/global-modifying-module-d-ts.html)  el cual muestra como crear una definición utilizando la sintaxis de módulo en ES6, asi como también especificando objetos que son disponibles en el alcance global. Esta técnica es demostrada prácticamente en la [definición para `big.js`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/big.js/index.d.ts), el cual es una librería que puede ser cargada globalmente a través de una etiqueta script en una página web, o importada vía require o imports estilo ES6.
+El manual de TypeScript contiene excelente [información general para escribir definiciones](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html), además [este archivo de definiciones de ejemplo](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/global-modifying-module-d-ts.html) el cual muestra como crear una definición utilizando la sintaxis de módulo en ES6, asi como también especificando objetos que son disponibles en el alcance global. Esta técnica es demostrada prácticamente en la [definición para `big.js`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/big.js/index.d.ts), el cual es una librería que puede ser cargada globalmente a través de una etiqueta script en una página web, o importada vía require o imports estilo ES6.
 
-Para probar como puede ser usada tu definición cuando se refieren globalmente o como un módulo importado, crea una carpeta `test`, y coloca dos archivos de prueba en él.  nombra uno `YourLibraryName-global.test.ts` y el otro `YourLibraryName-module.test.ts`.  El archivo de prueba _global_ debe ejercer la definición de acuerdo como va a ser usado en un script cargado en una página web donde la librería estará disponible en el alcance global - en este escenario no debes de especificar la sentencia de import. El archivo _módulo_ de prueba debe de ejercer la definición de acuerdo a como va a ser utilizado cuando sea importado (incluyendo las sentencias `import`). Si especificas una propiedad `files` en tu archivo `tsconfig.json`, asegurate de incluir ambos archivos de prueba. Un [ejemplo práctico de esto](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/big.js/test) es también disponible en la definición de `big.js`.
+Para probar como puede ser usada tu definición cuando se refieren globalmente o como un módulo importado, crea una carpeta `test`, y coloca dos archivos de prueba en él. nombra uno `YourLibraryName-global.test.ts` y el otro `YourLibraryName-module.test.ts`. El archivo de prueba _global_ debe ejercer la definición de acuerdo como va a ser usado en un script cargado en una página web donde la librería estará disponible en el alcance global - en este escenario no debes de especificar la sentencia de import. El archivo _módulo_ de prueba debe de ejercer la definición de acuerdo a como va a ser utilizado cuando sea importado (incluyendo las sentencias `import`). Si especificas una propiedad `files` en tu archivo `tsconfig.json`, asegurate de incluir ambos archivos de prueba. Un [ejemplo práctico de esto](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/big.js/test) es también disponible en la definición de `big.js`.
 
 Por favor tenga en cuenta que no es necesario para ejercer plenamente la definición en cada archivo de prueba - Es suficiente con probar solo los elementos globalmente accesibles en la prueba de archivos globales y ejercer la definición en el módulo del archivo de prueba, o viceversa.
 
@@ -382,8 +378,8 @@ Cuando `dts-gen` es utilizado como scaffold en un paquete scoped, las propiedade
 
 ```json
 {
-    "paths":{
-      "@foo/*": ["foo__*"]
+    "paths": {
+        "@foo/*": ["foo__*"]
     }
 }
 ```

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,21 +1,21 @@
 # Definitely Typed
 
-> Le référentiel des définitions de type TypeScript de *haute qualité*.
+> Le référentiel des définitions de type TypeScript de _haute qualité_.
 
-*Vous pouvez également lire ce README en [Español](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.es.md), [한국어](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ko.md), [Русский](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ru.md), [简体中文](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.zh-Hans.md), [Português](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.pt.md), [Italiano](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.it.md), [日本語](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ja.md) et [Français](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.fr.md)!*
+_Vous pouvez également lire ce README en [Español](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.es.md), [한국어](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ko.md), [Русский](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ru.md), [简体中文](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.zh-Hans.md), [Português](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.pt.md), [Italiano](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.it.md), [日本語](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ja.md) et [Français](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.fr.md)!_
 
-*Lien vers le [Manuel de l'administrateur](./docs/admin.md)*
+_Lien vers le [Manuel de l'administrateur](./docs/admin.md)_
 
 ## État actuel
 
 Cette section permet de suivre l'état de santé du référentiel et du processus de publication.
 Elle peut être utile aux contributeurs qui rencontrent des problèmes avec leurs PR et leurs paquets.
 
-* Dernière version [type-checked/linted](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint) proprement: [![Build Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.DefinitelyTyped?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=1&branchName=master)
-* Tous les paquets font l'objet d'une vérification de type et d'un marquage propre sur typescript@next: [![Build Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/Nightly%20dtslint)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=8)
-* Tous les paquets en cours de [Publication sur npm](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher) en moins d'une heure et demie : [![Publish Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.types-publisher-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=5&branchName=master)
-* [typescript-bot](https://github.com/typescript-bot) a été actif sur Definitely Typed [![Activity Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.typescript-bot-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=6&branchName=master)
-* Actuel [mise à jour de l'état de l'infrastructure](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/44317)
+- Dernière version [type-checked/linted](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint) proprement: [![Build Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.DefinitelyTyped?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=1&branchName=master)
+- Tous les paquets font l'objet d'une vérification de type et d'un marquage propre sur typescript@next: [![Build Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/Nightly%20dtslint)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=8)
+- Tous les paquets en cours de [Publication sur npm](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher) en moins d'une heure et demie : [![Publish Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.types-publisher-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=5&branchName=master)
+- [typescript-bot](https://github.com/typescript-bot) a été actif sur Definitely Typed [![Activity Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.typescript-bot-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=6&branchName=master)
+- Actuel [mise à jour de l'état de l'infrastructure](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/44317)
 
 Si quelque chose ne semble pas fonctionner, ou si l'un des éléments ci-dessus échoue, merci de nous le faire savoir dans [le canal Definitely Typed sur le serveur Discord de la Communauté TypeScript](https://discord.gg/typescript).
 
@@ -42,7 +42,7 @@ Plus d'informations dans le [manuel](https://www.typescriptlang.org/docs/handboo
 
 Pour un paquet npm "foo", les typages pour celui-ci seront à "@types/foo"..
 
-Si votre paquet a des typages spécifiés en utilisant la clé ``types`` ou ``typings`` dans son ``package.json``, le registre npm affichera que le paquet a des bindings disponibles comme ceci :
+Si votre paquet a des typages spécifiés en utilisant la clé `types` ou `typings` dans son `package.json`, le registre npm affichera que le paquet a des bindings disponibles comme ceci :
 
 ![image](https://user-images.githubusercontent.com/30049719/228748963-56fabfd1-9101-42c2-9891-b586b775b01e.png)
 
@@ -73,9 +73,9 @@ Par exemple, si vous lancez `npm dist-tags @types/react`, vous verrez que TypeSc
 
 #### TypeScript 1.*
 
-* Télécharger manuellement depuis la branche `master` de ce dépôt et les placer dans votre projet
-* ~~[Typings](https://github.com/typings/typings)~~ (utilisez les alternatives préférées, typings est déprécié)
-* ~~[NuGet](https://nuget.org/packages?q=DefinitelyTyped)~~ (utilisez les alternatives préférées, la publication des types DT de Nuget a été désactivée)
+- Télécharger manuellement depuis la branche `master` de ce dépôt et les placer dans votre projet
+- ~~[Typings](https://github.com/typings/typings)~~ (utilisez les alternatives préférées, typings est déprécié)
+- ~~[NuGet](https://nuget.org/packages?q=DefinitelyTyped)~~ (utilisez les alternatives préférées, la publication des types DT de Nuget a été désactivée)
 
 Vous pouvez avoir besoin d'ajouter le manuel [references](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html).
 
@@ -91,8 +91,8 @@ Avant de partager votre amélioration avec le monde, utilisez les types vous-mê
 
 ```ts
 declare module "libname" {
-  // Types à l'intérieur ici
-  export function helloWorldMessage(): string
+    // Types à l'intérieur ici
+    export function helloWorldMessage(): string;
 }
 ```
 
@@ -113,7 +113,7 @@ Ajoutez-le à votre `tsconfig.json` :
 
 Créez `types/foo/index.d.ts` contenant les déclarations pour le module "foo".
 Vous devriez maintenant être capable d'importer `"foo"` dans votre code et il sera dirigé vers la nouvelle définition de type.
-Ensuite, compilez *et* exécutez le code pour vous assurer que votre définition de type correspond bien à ce qui se passe à l'exécution.
+Ensuite, compilez _et_ exécutez le code pour vous assurer que votre définition de type correspond bien à ce qui se passe à l'exécution.
 
 Une fois que vous avez testé vos définitions avec du code réel, faites un [PR](#faire-une-demande-de-pull-request)
 puis suivez les instructions pour [modifier un paquet existant](#modifier-un-paquet-existant) ou
@@ -138,22 +138,22 @@ Vous pouvez cloner l'ensemble du dépôt [comme d'habitude](https://docs.github.
 
 Pour un clone plus facile à gérer qui inclut _seulement_ les paquets de type qui vous concernent, vous pouvez utiliser les fonctionnalités de git [`sparse-checkout`](https://git-scm.com/docs/git-sparse-checkout), [`--filter`](https://git-scm.com/docs/git-rev-list#Documentation/git-rev-list.txt---filterltfilter-specgt), et [`--depth`](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthltdepthgt). Cela réduira le temps de clonage et améliorera les performances de git.
 
->:warning: Ceci nécessite au minimum [git version 2.27.0](https://git-scm.com/downloads), qui est probablement plus récent que la version par défaut sur la plupart des machines. Des procédures plus complexes sont disponibles dans les versions plus anciennes, mais ne sont pas couvertes par ce guide.
+> :warning: Ceci nécessite au minimum [git version 2.27.0](https://git-scm.com/downloads), qui est probablement plus récent que la version par défaut sur la plupart des machines. Des procédures plus complexes sont disponibles dans les versions plus anciennes, mais ne sont pas couvertes par ce guide.
 
 1. `git clone --sparse --filter=blob:none --depth=1 <forkedUrl>`
-    - `--sparse` initialise le fichier sparse-checkout afin que le répertoire de travail ne contienne au départ que les fichiers situés à la racine du référentiel.
-    - `--filter=blob:none` exclura des fichiers, les récupérant uniquement en cas de besoin.
-    - `--depth=1` améliorera encore la vitesse de clonage en tronquant l'historique des livraisons, mais il peut causer des problèmes, comme le résume le tableau suivant [ici](https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/).
+   - `--sparse` initialise le fichier sparse-checkout afin que le répertoire de travail ne contienne au départ que les fichiers situés à la racine du référentiel.
+   - `--filter=blob:none` exclura des fichiers, les récupérant uniquement en cas de besoin.
+   - `--depth=1` améliorera encore la vitesse de clonage en tronquant l'historique des livraisons, mais il peut causer des problèmes, comme le résume le tableau suivant [ici](https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/).
 2. `git sparse-checkout add types/<type> types/<dependency-type> ...`
 
 </details>
 
 #### Modifier un paquet existant
 
-* `cd types/<paquet à modifier>`
-* Apporter des modifications. N'oubliez pas d' [éditer les tests](#mon-paquet-teststs).
+- `cd types/<paquet à modifier>`
+- Apporter des modifications. N'oubliez pas d' [éditer les tests](#mon-paquet-teststs).
   Si vous apportez des modifications radicales, n'oubliez pas de [mettre à jour une version majeure](#si-une-bibliothèque-est-mise-à-jour-vers-une-nouvelle-version-majeure-comportant-des-changements-importants-comment-dois-je-mettre-à-jour-son-paquet-de-déclarations-de-types-).
-* [Run `npm test <paquet-à-tester>`](#exécution-des-tests).
+- [Run `npm test <paquet-à-tester>`](#exécution-des-tests).
 
 Quand vous faites une PR pour éditer un paquet existant, `dt-bot` devrait @-mentionner les auteurs précédents.
 S'il ne le fait pas, vous pouvez le faire vous-même dans le commentaire associé à la PR.
@@ -168,12 +168,12 @@ Si le paquet pour lequel vous ajoutez des typages n'est pas sur npm, assurez-vou
 
 Votre paquet doit avoir cette structure :
 
-| Fichier          | Objectif |
-| ------------- | ------- |
-| `index.d.ts`  | Il contient les typages du paquet. |
-| [`<mon-paquet>-tests.ts`](#mon-paquet-teststs)  | Il contient un exemple de code qui teste les typages. Ce code *ne* s'exécute pas, mais il est vérifié. |
-| [`tsconfig.json`](#tsconfigjson) | Cela vous permet d'exécuter `tsc` à l'intérieur du paquet. |
-| [`.eslintrc.json`](#linter-eslintrcjson)   | (Rarement) Nécessaire uniquement pour désactiver les règles de lint écrites pour eslint. |
+| Fichier                                        | Objectif                                                                                               |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `index.d.ts`                                   | Il contient les typages du paquet.                                                                     |
+| [`<mon-paquet>-tests.ts`](#mon-paquet-teststs) | Il contient un exemple de code qui teste les typages. Ce code _ne_ s'exécute pas, mais il est vérifié. |
+| [`tsconfig.json`](#tsconfigjson)               | Cela vous permet d'exécuter `tsc` à l'intérieur du paquet.                                             |
+| [`.eslintrc.json`](#linter-eslintrcjson)       | (Rarement) Nécessaire uniquement pour désactiver les règles de lint écrites pour eslint.               |
 
 Vous pouvez les générer en lançant `npx dts-gen --dt --name <mon-paquet> --template module` si vous avez npm ≥ 5.2.0, `npm install -g dts-gen` et `dts-gen --dt --name <mon-paquet> --template module` dans le cas contraire.
 Voir toutes les options à [dts-gen](https://github.com/Microsoft/dts-gen).
@@ -189,9 +189,10 @@ Pour un bon exemple de paquet, voir [base64-js](https://github.com/DefinitelyTyp
 Lorsqu'un paquet [bundles](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) ses propres types, les types doivent être supprimés de Definitely Typed pour éviter toute confusion.
 
 Vous pouvez le supprimer en lançant `npm run not-needed -- <nomDuPaquet> <commeVersion> [<nomDeBibliothèque>]`.
-* `<nomDuPaquet>` : C'est le nom du répertoire à supprimer.
-* `<commeVersion>` : Un stub sera publié dans `@types/<nomDuPaquet>` avec cette version. Elle doit être supérieure à toute version actuellement publiée, et doit être une version de `<nomDeBibliothèque>` sur npm.
-* `<nomDeBibliothèque>` : Nom du paquet npm qui remplace Definitely Typed types. Habituellement, il est identique à `<nomDuPaquet>`, dans ce cas vous pouvez l'omettre.
+
+- `<nomDuPaquet>` : C'est le nom du répertoire à supprimer.
+- `<commeVersion>` : Un stub sera publié dans `@types/<nomDuPaquet>` avec cette version. Elle doit être supérieure à toute version actuellement publiée, et doit être une version de `<nomDeBibliothèque>` sur npm.
+- `<nomDeBibliothèque>` : Nom du paquet npm qui remplace Definitely Typed types. Habituellement, il est identique à `<nomDuPaquet>`, dans ce cas vous pouvez l'omettre.
 
 Tous les autres paquets de Definitely Typed qui référencent le paquet supprimé doivent être mis à jour pour référencer les types regroupés.
 Vous pouvez obtenir cette liste en regardant les erreurs de `npm run test-all`.
@@ -200,10 +201,10 @@ Par exemple :
 
 ```json
 {
-  "private": true,
-  "dependencies": {
-    "<libraryName>": "^2.6.0"
-  }
+    "private": true,
+    "dependencies": {
+        "<libraryName>": "^2.6.0"
+    }
 }
 ```
 
@@ -280,11 +281,14 @@ Pour plus de détails, voir le readme de [dtslint](https://github.com/Microsoft/
 
 Vous devez désactiver des règles spécifiques uniquement sur des lignes spécifiques :
 
-
 ```ts
 // eslint-disable-next-line no-const-enum
-const enum Const { One }
-const enum Enum { Two } // eslint-disable-line no-const-enum
+const enum Const {
+    One,
+}
+const enum Enum { // eslint-disable-line no-const-enum
+    Two,
+}
 ```
 
 Vous pouvez toujours désactiver les règles avec un fichier .eslintrc.json, mais vous ne devriez pas le faire dans les nouveaux paquets.
@@ -297,7 +301,7 @@ Vous pouvez éditer le fichier `tsconfig.json` pour ajouter de nouveaux fichiers
 
 ##### `esModuleInterop`/`allowSyntheticDefaultImports`
 
-TL;DR : `esModuleInterop` et `allowSyntheticDefaultImports` ne sont *pas autorisés* dans votre `tsconfig.json`.
+TL;DR : `esModuleInterop` et `allowSyntheticDefaultImports` ne sont _pas autorisés_ dans votre `tsconfig.json`.
 
 > Ces options permettent d'écrire une importation par défaut pour une exportation CJS, modélisant l'interopérabilité intégrée entre les modules CJS et ES dans Node et dans certains bundlers JS:
 >
@@ -351,27 +355,27 @@ Si un fichier n'est ni testé ni référencé dans `index.d.ts`, ajoutez-le à u
 
 #### Erreurs courantes
 
-* Tout d'abord, suivez les conseils du [manuel](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html).
-* Formatage : Utilisez 4 espaces. Prettier est installé sur ce repo, vous pouvez donc lancer `npm run prettier -- --write 'path/to/package/**/*.ts'`. [Lorsque vous utilisez des assertions](https://github.com/SamVerschueren/tsd#assertions), ajoutez l'exclusion `// prettier-ignore` pour marquer les lignes de code comme exclues du formatage :
+- Tout d'abord, suivez les conseils du [manuel](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html).
+- Formatage : Utilisez 4 espaces. Prettier est installé sur ce repo, vous pouvez donc lancer `npm run prettier -- --write 'path/to/package/**/*.ts'`. [Lorsque vous utilisez des assertions](https://github.com/SamVerschueren/tsd#assertions), ajoutez l'exclusion `// prettier-ignore` pour marquer les lignes de code comme exclues du formatage :
   ```tsx
   // prettier-ignore
   // @ts-expect-error
   const incompleteThemeColorModes: Theme = { colors: { modes: { papaya: {
   ```
-* `function sum(nums : number[]) : number` : Utilisez `ReadonlyArray` si une fonction n'écrit pas dans ses paramètres.
-* `interface Foo { new(): Foo; }`:
+- `function sum(nums : number[]) : number` : Utilisez `ReadonlyArray` si une fonction n'écrit pas dans ses paramètres.
+- `interface Foo { new(): Foo; }`:
   Cela définit un type d'objets qui peuvent être modifiés. Vous voudrez probablement `declare class Foo { constructor() ; }`.
-* `const Class: { new(): IClass; }`:
+- `const Class: { new(): IClass; }`:
   Il est préférable d'utiliser une déclaration de classe `class Class { constructor() ; }` plutôt qu'une constante modifiable.
-* `getMeAT<T>(): T`:
+- `getMeAT<T>(): T`:
   Si un paramètre de type n'apparaît dans les types d'aucun paramètre, il ne s'agit pas vraiment d'une fonction générique, mais simplement d'une assertion de type déguisée.
   Il est préférable d'utiliser une assertion de type réel, par exemple `getMeAT() as number`.
   Exemple où un paramètre de type est acceptable : `function id<T>(value : T) : T;`.
   Exemple où il n'est pas acceptable : `function parseJson<T>(json : string) : T;`.
   Exception : `new Map<string, number>()` est OK.
-* L'utilisation des types `Function` et `Object` n'est presque jamais une bonne idée. Dans 99% des cas, il est possible de spécifier un type plus spécifique. Les exemples sont `(x : number) => number` pour les [fonctions](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-type-expressions) et `{ x : number, y : number }` pour les objets. S'il n'y a aucune certitude sur le type, [`any`](https://www.typescriptlang.org/docs/handbook/basic-types.html#any) est le bon choix, pas `Object`. Si la seule chose connue à propos du type est qu'il s'agit d'un objet, utilisez le type [`object`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type), pas `Object` ou `{ [key : string] : any }`.
-* `var foo: string | any`:
-  Lorsque `any` est utilisé dans un type union, le type résultant est toujours `any`. Ainsi, bien que la partie `string` de cette annotation de type puisse _look_ utile, elle n'offre en fait aucune vérification de  type supplémentaire par rapport à l'utilisation simple de `any`.
+- L'utilisation des types `Function` et `Object` n'est presque jamais une bonne idée. Dans 99% des cas, il est possible de spécifier un type plus spécifique. Les exemples sont `(x : number) => number` pour les [fonctions](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-type-expressions) et `{ x : number, y : number }` pour les objets. S'il n'y a aucune certitude sur le type, [`any`](https://www.typescriptlang.org/docs/handbook/basic-types.html#any) est le bon choix, pas `Object`. Si la seule chose connue à propos du type est qu'il s'agit d'un objet, utilisez le type [`object`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type), pas `Object` ou `{ [key : string] : any }`.
+- `var foo: string | any`:
+  Lorsque `any` est utilisé dans un type union, le type résultant est toujours `any`. Ainsi, bien que la partie `string` de cette annotation de type puisse _look_ utile, elle n'offre en fait aucune vérification de type supplémentaire par rapport à l'utilisation simple de `any`.
   Selon l'intention, les alternatives acceptables pourraient être `any`, `string`, ou `string | object`.
 
 ### Définition des propriétaires
@@ -380,14 +384,14 @@ Si un fichier n'est ni testé ni référencé dans `index.d.ts`, ajoutez-le à u
 
 DT a le concept de "propriétaires de définition" qui sont des personnes qui veulent maintenir la qualité des types d'un module particulier.
 
-* En vous ajoutant à la liste, vous serez notifié (via votre nom d'utilisateur GitHub) chaque fois que quelqu'un fera une pull request ou posera un problème concernant le paquet.
-* Vos évaluations de PR auront une plus grande importance pour [le bot](https://github.com/DefinitelyTyped/dt-mergebot) qui maintient ce repo.
-* Les mainteneurs de DT font confiance aux propriétaires des définitions pour assurer un écosystème stable, ne vous ajoutez pas à la légère.
+- En vous ajoutant à la liste, vous serez notifié (via votre nom d'utilisateur GitHub) chaque fois que quelqu'un fera une pull request ou posera un problème concernant le paquet.
+- Vos évaluations de PR auront une plus grande importance pour [le bot](https://github.com/DefinitelyTyped/dt-mergebot) qui maintient ce repo.
+- Les mainteneurs de DT font confiance aux propriétaires des définitions pour assurer un écosystème stable, ne vous ajoutez pas à la légère.
 
 Pour vous ajouter en tant que titulaire d'une définition :
 
-* Ajouter votre nom à la fin de la ligne, comme dans l'exemple suivant `// Definitions by: Alice <https://github.com/alice>, Bob <https://github.com/bob>`.
-* Ou, s'il y a plus de personnes, il peut être multiligne
+- Ajouter votre nom à la fin de la ligne, comme dans l'exemple suivant `// Definitions by: Alice <https://github.com/alice>, Bob <https://github.com/bob>`.
+- Ou, s'il y a plus de personnes, il peut être multiligne
   ```typescript
   // Definitions by: Alice <https://github.com/alice>
   //                 Bob <https://github.com/bob>
@@ -472,6 +476,7 @@ Il s'agit d'une [réponse Stack Overflow](https://stackoverflow.com/questions/39
 
 Il est plus approprié d'importer le module en utilisant la syntaxe `import foo = require("foo");`.
 Néanmoins, si vous voulez utiliser un import par défaut comme `import foo from "foo";` vous avez deux options :
+
 - vous pouvez utiliser l'option de compilation [`--allowSyntheticDefaultImports`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-1-8.html#support-for-default-import-interop-with-systemjs) si votre module d'exécution supporte un schéma d'interopérabilité pour les modules non-ECMAScript, c'est-à-dire si les importations par défaut fonctionnent dans votre environnement (par exemple Webpack, SystemJS, esm).
 - vous pouvez utiliser l'option de compilation [`--esModuleInterop`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#support-for-import-d-from-cjs-form-commonjs-modules-with---esmoduleinterop) si vous voulez que TypeScript prenne en charge l'interopérabilité non-ECMAScript (depuis TypeScript 2.7).
 
@@ -488,7 +493,7 @@ Pour un paquet npm, `export =` est correct si `node -p 'require("foo")'` fonctio
 
 Vous devrez alors ajouter un commentaire à la dernière ligne de votre en-tête de définition (après `// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped`): `// Minimum TypeScript Version: X.Y`. Ceci définira la version minimale la plus basse supportée.
 
-Cependant, si votre projet a besoin de maintenir des types compatibles avec, disons, 3.7 et plus *en même temps* que des types compatibles avec 3.6 ou moins, vous devrez utiliser la fonctionnalité `typesVersions`.
+Cependant, si votre projet a besoin de maintenir des types compatibles avec, disons, 3.7 et plus _en même temps_ que des types compatibles avec 3.6 ou moins, vous devrez utiliser la fonctionnalité `typesVersions`.
 Vous trouverez une explication détaillée de cette fonctionnalité dans la [documentation officielle de TypeScript](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-1.html#version-selection-with-typesversions).
 
 Voici un petit exemple pour commencer :
@@ -497,26 +502,26 @@ Voici un petit exemple pour commencer :
 
    ```json
    {
-     "private": true,
-     "types": "index",
-     "typesVersions": {
-       "<=3.6": { "*": ["ts3.6/*"] }
-     }
+       "private": true,
+       "types": "index",
+       "typesVersions": {
+           "<=3.6": { "*": ["ts3.6/*"] }
+       }
    }
    ```
 
 2. Créez le sous-répertoire mentionné dans le champ `typesVersions` à l'intérieur de votre répertoire de types (`ts3.6/` dans cet exemple).
-  `ts3.6/` supportera les versions 3.6 et inférieures de TypeScript, donc copiez les types et les tests existants dans ce répertoire.
+   `ts3.6/` supportera les versions 3.6 et inférieures de TypeScript, donc copiez les types et les tests existants dans ce répertoire.
 
    Vous devrez supprimer l'en-tête de définition de `ts3.6/index.d.ts` puisque seule la racine `index.d.ts` est supposée l'avoir.
 
 3. Définissez les options `baseUrl` et `typeRoots` dans `ts3.6/tsconfig.json` avec les chemins corrects, qui devraient ressembler à ceci :
    ```json
    {
-     "compilerOptions": {
-       "baseUrl": "../../",
-       "typeRoots": ["../../"]
-     }
+       "compilerOptions": {
+           "baseUrl": "../../",
+           "typeRoots": ["../../"]
+       }
    }
    ```
 
@@ -534,7 +539,7 @@ Lorsqu'il sort du mode brouillon, nous pouvons le retirer de Definitely Typed et
 
 #### Comment les versions des paquets Definitely Typed sont-elles liées aux versions de la bibliothèque correspondante ?
 
-*REMARQUE : la discussion dans cette section suppose une certaine familiarité avec le [Semantic versioning](https://semver.org/)*.
+_REMARQUE : la discussion dans cette section suppose une certaine familiarité avec le [Semantic versioning](https://semver.org/)_.
 
 Chaque paquet Definitely Typed est versionné lorsqu'il est publié sur npm.
 L'outil [DefinitelyTyped-tools](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher) (l'outil qui publie les paquets `@types` sur npm) définira la version du paquet de déclaration en utilisant le numéro de version `major.minor` listé dans la première ligne de son fichier `index.d.ts`.
@@ -557,11 +562,11 @@ Il arrive que les versions des paquets de déclarations de type et les versions 
 Voici quelques raisons courantes, classées par ordre de gêne pour les utilisateurs d'une bibliothèque.
 Seul le dernier cas est généralement problématique.
 
-* Comme indiqué ci-dessus, la version du patch du paquet de déclaration de type n'est pas liée à la version du patch de la bibliothèque.
+- Comme indiqué ci-dessus, la version du patch du paquet de déclaration de type n'est pas liée à la version du patch de la bibliothèque.
   Cela permet à Definitely Typed de mettre à jour en toute sécurité les déclarations de types pour la même version majeure/mineure d'une bibliothèque.
-* Si vous mettez à jour un paquet pour une nouvelle fonctionnalité, n'oubliez pas de mettre à jour le numéro de version pour qu'il corresponde à la version de la bibliothèque.
+- Si vous mettez à jour un paquet pour une nouvelle fonctionnalité, n'oubliez pas de mettre à jour le numéro de version pour qu'il corresponde à la version de la bibliothèque.
   Si les utilisateurs s'assurent que les versions correspondent entre les paquets JavaScript et leurs paquets `@types` respectifs, alors `npm update` devrait fonctionner.
-* Il est fréquent que les mises à jour des paquets de déclarations de types soient en retard par rapport aux mises à jour des bibliothèques, car ce sont souvent les utilisateurs des bibliothèques, et non les mainteneurs, qui mettent à jour Definitely Typed lorsque de nouvelles fonctionnalités des bibliothèques sont publiées.
+- Il est fréquent que les mises à jour des paquets de déclarations de types soient en retard par rapport aux mises à jour des bibliothèques, car ce sont souvent les utilisateurs des bibliothèques, et non les mainteneurs, qui mettent à jour Definitely Typed lorsque de nouvelles fonctionnalités des bibliothèques sont publiées.
   Il peut donc y avoir un décalage de plusieurs jours, semaines ou même mois avant qu'un membre utile de la communauté n'envoie un PR pour mettre à jour le paquet de déclaration de type pour une nouvelle version de la bibliothèque.
   Si vous êtes affecté par cela, vous pouvez être le changement que vous voulez voir dans le monde et vous pouvez être ce membre utile de la communauté !
 
@@ -589,17 +594,17 @@ Au moment où j'écris ces lignes, le dossier [history v2 `tsconfig.json`](https
 
 ```json
 {
-  "compilerOptions": {
-    "baseUrl": "../../",
-    "typeRoots": ["../../"],
-    "paths": {
-      "history": [ "history/v2" ]
-    }
-  },
-  "files": [
-    "index.d.ts",
-    "history-tests.ts"
-  ]
+    "compilerOptions": {
+        "baseUrl": "../../",
+        "typeRoots": ["../../"],
+        "paths": {
+            "history": ["history/v2"]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "history-tests.ts"
+    ]
 }
 ```
 
@@ -613,9 +618,9 @@ De plus, `/// <reference types="..." />` ne fonctionnera pas avec la corresponda
 
 #### Comment puis-je écrire des définitions pour des paquets qui peuvent être utilisés globalement et en tant que module ?
 
-Le manuel TypeScript contient d'excellentes [informations générales sur l'écriture de définitions](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html), ainsi que [cet exemple de fichier de définition](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/global-modifying-module-d-ts.html) qui montre comment créer une définition en utilisant la syntaxe de module de style ES6, tout en spécifiant également les objets mis à la disposition de la portée globale.  Cette technique est démontrée en pratique dans la [définition de `big.js`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/big.js/index.d.ts), qui est une bibliothèque qui peut être chargée globalement via une balise script sur une page web, ou importée via require ou des importations de style ES6.
+Le manuel TypeScript contient d'excellentes [informations générales sur l'écriture de définitions](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html), ainsi que [cet exemple de fichier de définition](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/global-modifying-module-d-ts.html) qui montre comment créer une définition en utilisant la syntaxe de module de style ES6, tout en spécifiant également les objets mis à la disposition de la portée globale. Cette technique est démontrée en pratique dans la [définition de `big.js`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/big.js/index.d.ts), qui est une bibliothèque qui peut être chargée globalement via une balise script sur une page web, ou importée via require ou des importations de style ES6.
 
-Pour tester comment votre définition peut être utilisée à la fois lorsqu'elle est référencée globalement ou en tant que module importé, créez un dossier `test`, et placez-y deux fichiers de test.  Nommez l'un `VotreNomBibliothèque-global.test.ts` et l'autre `VotreNomBibliothèque-module.test.ts`.  Le fichier de test *global* doit exercer la définition de la manière dont elle serait utilisée dans un script chargé sur une page web où la bibliothèque est disponible sur la portée globale - dans ce scénario, vous ne devez pas spécifier d'instruction d'importation.  Le fichier de test *module* doit exercer la définition selon la façon dont elle serait utilisée lorsqu'elle est importée (y compris la ou les déclarations `import`).  Si vous spécifiez une propriété `files` dans votre fichier `tsconfig.json`, assurez-vous d'inclure les deux fichiers de test.  Un [exemple pratique de ceci](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/big.js/test) est aussi disponible sur la définition de `big.js`.
+Pour tester comment votre définition peut être utilisée à la fois lorsqu'elle est référencée globalement ou en tant que module importé, créez un dossier `test`, et placez-y deux fichiers de test. Nommez l'un `VotreNomBibliothèque-global.test.ts` et l'autre `VotreNomBibliothèque-module.test.ts`. Le fichier de test _global_ doit exercer la définition de la manière dont elle serait utilisée dans un script chargé sur une page web où la bibliothèque est disponible sur la portée globale - dans ce scénario, vous ne devez pas spécifier d'instruction d'importation. Le fichier de test _module_ doit exercer la définition selon la façon dont elle serait utilisée lorsqu'elle est importée (y compris la ou les déclarations `import`). Si vous spécifiez une propriété `files` dans votre fichier `tsconfig.json`, assurez-vous d'inclure les deux fichiers de test. Un [exemple pratique de ceci](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/big.js/test) est aussi disponible sur la définition de `big.js`.
 
 Il suffit de tester uniquement les éléments accessibles globalement dans le fichier de test global et d'exercer pleinement la définition dans le fichier de test du module, ou vice versa.
 
@@ -627,11 +632,11 @@ Quand `dts-gen` est utilisé pour échafauder un paquet scopé, la propriété `
 
 ```json
 {
-  "compilerOptions": {
-    "paths": {
-      "@foo/*": ["foo__*"]
+    "compilerOptions": {
+        "paths": {
+            "@foo/*": ["foo__*"]
+        }
     }
-  }
 }
 ```
 

--- a/README.it.md
+++ b/README.it.md
@@ -1,21 +1,21 @@
 # Definitely Typed
 
-> La repo per le definizioni di tipi Typescript di *alta qualità*.
+> La repo per le definizioni di tipi Typescript di _alta qualità_.
 
-*Puoi leggere questo README anche in [Spagnolo](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.es.md), [Coreano](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ko.md), [Russo](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ru.md), [Cinese](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.zh-Hans.md), [Portoghese](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.pt.md) e [Giapponese](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ja.md)!*
+_Puoi leggere questo README anche in [Spagnolo](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.es.md), [Coreano](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ko.md), [Russo](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ru.md), [Cinese](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.zh-Hans.md), [Portoghese](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.pt.md) e [Giapponese](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ja.md)!_
 
-*Link per il [manuale dell'amministratore](./docs/admin.md)*
+_Link per il [manuale dell'amministratore](./docs/admin.md)_
 
 ## Stato attuale
 
 Questa sezione tiene traccia della salute della repository e dello stato di pubblicazione.
 Può tornare utile per i contributori che stanno avendo problemi con le loro PR e package.
 
-* Ultima build [type-checked/linted](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint) pulita: [![Build Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.DefinitelyTyped?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=1&branchName=master)
-* Tutti i package sono sottoposti a controllo dei tipi e linting con typescript@next: [![Build status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/Nightly%20dtslint)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=8)
-* Tutti i package vengono [pubblicati su npm](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher) in meno di un'ora e mezza: [![Publish Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.types-publisher-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=5&branchName=master)
-* Il [bot di Typescript](https://github.com/typescript-bot) è stato attivo su Definitely Typed [![Activity Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.typescript-bot-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=6&branchName=master)
-* [Aggiornamenti dello stato dell'infrastruttura](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/44317) attuale
+- Ultima build [type-checked/linted](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint) pulita: [![Build Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.DefinitelyTyped?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=1&branchName=master)
+- Tutti i package sono sottoposti a controllo dei tipi e linting con typescript@next: [![Build status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/Nightly%20dtslint)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=8)
+- Tutti i package vengono [pubblicati su npm](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher) in meno di un'ora e mezza: [![Publish Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.types-publisher-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=5&branchName=master)
+- Il [bot di Typescript](https://github.com/typescript-bot) è stato attivo su Definitely Typed [![Activity Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.typescript-bot-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=6&branchName=master)
+- [Aggiornamenti dello stato dell'infrastruttura](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/44317) attuale
 
 Se qualcosa sembra sbagliato o una qualunque delle cose qui in alto fallisce, fatecelo sapere [sul canale di Definitely Typed nel server discord della comunità di Typescript](https://discord.gg/typescript):
 
@@ -63,7 +63,7 @@ I package `@types` hanno dei tag per indicare le specifiche versioni di TypeScri
 Ad esempio se esegui `npm dist-tags @types/react`, vedrai che TypeScript 2.5 potrà usare i tipi per react@16.0, mentre TypeScript 2.6 e 2.7 potranno usare i tipi per react@16.4:
 
 | Tag    | Versione |
-| ------ | -------  |
+| ------ | -------- |
 | ultima | 16.9.23  |
 | ts2.0  | 15.0.1   |
 | ...    | ...      |
@@ -74,9 +74,9 @@ Ad esempio se esegui `npm dist-tags @types/react`, vedrai che TypeScript 2.5 pot
 
 #### TypeScript 1.*
 
-* Scarica manualmente la branch `master` di questa repo e collocala nel tuo progetto.
-* ~~[Typings](https://github.com/typings/typings)~~ (usa altre alternative migliori, in quanto typings è deprecata)
-* ~~[NuGet](https://nuget.org/packages?q=DefinitelyTyped)~~ (usa altre alternative, in quanto la pubblicazione di tipi su nuget DT non è più possibile)
+- Scarica manualmente la branch `master` di questa repo e collocala nel tuo progetto.
+- ~~[Typings](https://github.com/typings/typings)~~ (usa altre alternative migliori, in quanto typings è deprecata)
+- ~~[NuGet](https://nuget.org/packages?q=DefinitelyTyped)~~ (usa altre alternative, in quanto la pubblicazione di tipi su nuget DT non è più possibile)
 
 Potresti dover aggiungere manualmente le [reference](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html).
 
@@ -92,8 +92,8 @@ Prima di condividere il tuo miglioramento col mondo intero, utilizza i tipi tu s
 
 ```ts
 declare module "libname" {
-  // Types inside here
-  export function helloWorldMessage(): string
+    // Types inside here
+    export function helloWorldMessage(): string;
 }
 ```
 
@@ -136,20 +136,20 @@ Ecco qui un'immagine che mostra il ciclo vitale di una pull request su Definitel
 Puoi clonare l'intera repo [come di consuetudine](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository) che però è molto grande ed include numerose cartelle di package di tipi. Ci vorrà quindi del tempo per clonarla e può essere un procedimento inutilmente lungo.
 Per clonare la repo in modo più agibile, clonando _solo_ i package per te rilevanti, pui usare le funzionalità [`sparse-checkout`](https://git-scm.com/docs/git-sparse-checkout), [`--filter`](https://git-scm.com/docs/git-rev-list#Documentation/git-rev-list.txt---filterltfilter-specgt) ed [`--depth`](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthltdepthgt) di git.
 
->:warning: Richiede almeno la [versione di git 2.27.0](https://git-scm.com/downloads), che solitamente è più recente di quelle installate di default. Per le versioni più vecchie sono disponibili procedure più complesse, che non trattiamo qui.
+> :warning: Richiede almeno la [versione di git 2.27.0](https://git-scm.com/downloads), che solitamente è più recente di quelle installate di default. Per le versioni più vecchie sono disponibili procedure più complesse, che non trattiamo qui.
 
 1. `git clone --sparse --filter=blob:none --depth=1 <forkedUrl>`
-    - `--sparse` initializes the sparse-checkout file so the working directory starts with only the files in the root of the repository.
-        - `--filter=blob:none` will exclude files, fetching them only as needed.
-        - `--depth=1` will further improve clone speed by truncating commit history, but it may cause issues as summarized [here](https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/).
-    2. `git sparse-checkout add types/<type> types/<dependency-type> ...`
+   - `--sparse` initializes the sparse-checkout file so the working directory starts with only the files in the root of the repository.
+     - `--filter=blob:none` will exclude files, fetching them only as needed.
+     - `--depth=1` will further improve clone speed by truncating commit history, but it may cause issues as summarized [here](https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/).
+   2. `git sparse-checkout add types/<type> types/<dependency-type> ...`
 
 #### Modificare un package preesistente
 
-* `cd types/<package to edit>`
-* Fai le tue modifiche. Ricorda di [testle](#mio-package-teststs).
+- `cd types/<package to edit>`
+- Fai le tue modifiche. Ricorda di [testle](#mio-package-teststs).
   Se fai modifiche essenziali, non ti dimenticare di [aggiornare il major della versione](#se-laggiornamento-di-una-libreria-comprende-modifiche-sostanziali-aggiornamento-major-come-faccio-ad-aggiornare-il-suo-pacchetto-types).
-  * [Esegui `npm test <package da testare>`](#eseguire-test).
+  - [Esegui `npm test <package da testare>`](#eseguire-test).
 
 Quando crei una pull request ad un package che esiste già, `dt-bot` dovrebbe @menzionare gli autori precedenti.
 Se non lo fa, puoi farlo direttamente tu nel commento associato alla pull request.
@@ -164,11 +164,11 @@ Se il package a cui stai aggiungendo i tipi non è su npm, assicurati che il nom
 
 Il tuo package dovrebbe avere questa struttura:
 
-| File          | Scopo |
-| ------------- | ------- |
-| `index.d.ts`  | Contiene le dichiarazioni dei tipi del package. |
-| [`<nome-package>-tests.ts`](#mio-package-teststs)  | Contiene codice di esempio con test delle dichiarazioni dei tipi. Se il codice *non* funziona anche se viene traspilato da tsc senza errori.
-| [`tsconfig.json`](#tsconfigjson) | Ti permette di eseguire `tsc` all'interno del package. |
+| File                                              | Scopo                                                                                                                                        |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `index.d.ts`                                      | Contiene le dichiarazioni dei tipi del package.                                                                                              |
+| [`<nome-package>-tests.ts`](#mio-package-teststs) | Contiene codice di esempio con test delle dichiarazioni dei tipi. Se il codice _non_ funziona anche se viene traspilato da tsc senza errori. |
+| [`tsconfig.json`](#tsconfigjson)                  | Ti permette di eseguire `tsc` all'interno del package.                                                                                       |
 
 Generali eseguento `npx dts-gen --dt --name <mio-package> --template module` se hai npm ≥ 5.2.0, altrimenti `npm install -g dts-gen` and `dts-gen --dt --name <my-package> --template module`.
 Leggi tutte le opzioni su [dts-gen](https://github.com/Microsoft/dts-gen).
@@ -184,9 +184,10 @@ Per l'esempio di un buon package, guarda [base64-js](https://github.com/Definite
 Quando un package [include](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) i suoi dichiarazioni, esse dovrebbero venire rimosse da Definitely Typed per evitare di far confusione.
 
 Puoi rimuoverli eseguendo `pnpm run not-needed -- <nome-package> <versione> [<nome-libreria>]`.
-* `<nome-package>`: È il nome della cartella da rimuovere.
-* `<versione>`: Verrà pubblicato uno stab su `@types/<nome-package>` con questa versione. Dev'essere più alto della versione attualmente pubblicata e deve essere una versione di `<ome-libreria>` su npm.
-* `<nome-libreria>`: Nome del package npm che sostituisce il package DT. Solitamente è identioc a `<nome-package>` e puoi ometterlo.
+
+- `<nome-package>`: È il nome della cartella da rimuovere.
+- `<versione>`: Verrà pubblicato uno stab su `@types/<nome-package>` con questa versione. Dev'essere più alto della versione attualmente pubblicata e deve essere una versione di `<ome-libreria>` su npm.
+- `<nome-libreria>`: Nome del package npm che sostituisce il package DT. Solitamente è identioc a `<nome-package>` e puoi ometterlo.
 
 Qualunque altro package di Definitely Typed che si riferisce ad un altro package DT eliminato dovrebbe venir aggiornato facendolo riferire ai tipi inclusi nel package stesso.
 Puoi farlo controllando gli errori che escono eseguendo `pnpm run test-all`.
@@ -195,11 +196,11 @@ Ad esempio:
 
 ```json
 {
-      "private": true,
+    "private": true,
     "dependencies": {
-          "<nome-libreria>": "^2.6.0"
-      }
-  }
+        "<nome-libreria>": "^2.6.0"
+    }
+}
 ```
 
 Quando aggiungi un `package.json` a dei package che dipendono da `<nome-libreria>`, devi aprire anche una pull request per aggiungere `<nome-libreria>` [ad allowedPackageJsonDependencies.txt su DefinitelyTyped-tools](https://github.com/microsoft/DefinitelyTyped-tools/blob/master/packages/definitions-parser/allowedPackageJsonDependencies.txt).
@@ -271,8 +272,12 @@ Dovresti disabilitare le regole solo per determinate linee:
 
 ```ts
 // eslint-disable-next-line no-const-enum
-const enum Const { One }
-const enum Enum { Two } // eslint-disable-line no-const-enum
+const enum Const {
+    One,
+}
+const enum Enum { // eslint-disable-line no-const-enum
+    Two,
+}
 ```
 
 Puoi ancora disabilitare determinate regole attraverso il file .eslintrc.json ma non dovresti nei nuovi package.
@@ -285,9 +290,9 @@ Potresti dover editare `tsconfig.json` per aggiungere nuovi file di test, per ag
 
 ##### `esModuleInterop`/`allowSyntheticDefaultImports`
 
-Riassunto: `esModuleInterop` e `allowSyntheticDefaultImports` *non sono permessi* nel tuo `tsconfig.json`.
+Riassunto: `esModuleInterop` e `allowSyntheticDefaultImports` _non sono permessi_ nel tuo `tsconfig.json`.
 
->  Queste opzioni rendono possibile lo scrivere un default import per un CJS export, andando ad alterare l'interoperabilità tra CJS ed i moduli ES in Node ed in alcuni bundler JS:
+> Queste opzioni rendono possibile lo scrivere un default import per un CJS export, andando ad alterare l'interoperabilità tra CJS ed i moduli ES in Node ed in alcuni bundler JS:
 >
 > ```tsx
 > // component.d.ts
@@ -325,30 +330,30 @@ Se un file non è nè testato nè riferito nell'`index.d.ts`, aggiungilo in un f
 
 #### Errori comuni
 
-* Inanzitutto segui i consigli nel [manuale](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html).
-* Formattazione: Usa 4 spazi. Prettier è abilitato su questa repo, quindi puoi eseguire `pnpm run prettier -- --write 'path/to/package/**/*.ts'`. [Quando usi le assertion](https://github.com/SamVerschueren/tsd#assertions), aggiungi `// prettier-ignore` per marcare le linee di codice da escludere quando si fa la formattazione:
+- Inanzitutto segui i consigli nel [manuale](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html).
+- Formattazione: Usa 4 spazi. Prettier è abilitato su questa repo, quindi puoi eseguire `pnpm run prettier -- --write 'path/to/package/**/*.ts'`. [Quando usi le assertion](https://github.com/SamVerschueren/tsd#assertions), aggiungi `// prettier-ignore` per marcare le linee di codice da escludere quando si fa la formattazione:
 
   ```tsx
-    // prettier-ignore
-    // @ts-expect-error
-    const incompleteThemeColorModes: Theme = { colors: { modes: { papaya: {
-    ```
+  // prettier-ignore
+  // @ts-expect-error
+  const incompleteThemeColorModes: Theme = { colors: { modes: { papaya: {
+  ```
 
-* `function sum(nums: number[]): number`: Usa `ReadonlyArray` se una funzione non modifica i suoi parametri.
-* `interface Foo { new(): Foo; }`:
+- `function sum(nums: number[]): number`: Usa `ReadonlyArray` se una funzione non modifica i suoi parametri.
+- `interface Foo { new(): Foo; }`:
   Definisce un tipo di oggetto su cui si può fare new. Probabilmente ciò che vuoi è `declare class Foo { constructor(); }`.
-* `const Class: { new(): IClass; }`:
+- `const Class: { new(): IClass; }`:
   Preferire sempre la dichiarazione di una classe `class Class { constructor(); }` al posto di una costante new.
-* `getMeAT<T>(): T`:
+- `getMeAT<T>(): T`:
   Se il parametro di un tipo non appare nei tipi di un parametro, ciò che vuoi non è una vera funzione generica.
-    È consigliato usare una vera asserzione di tipo, ad esempio `getMeAT() as number`.
-    Esempio dove un parametro è accettabile: `function id<T>(value: T): T;`.
-    Esempio in cui non lo è: `function parseJson<T>(json: string): T;`.
-    Eccezione: `new Map<string, number>()` va bene.
-* Usare i tipi `Function` e `Object` non è quasi mai una buona idea. Nel 99% si può specificare un tipo più preciso. Alcuni esempi sono `(x: number) => number` per le [funzioni](https://www.typescriptlang.org/docs/handbook/functions.html#function-types) e `{ x: number, y: number }` per gli oggetti. Se non si è sicuri del tipo, [`any`](https://www.typescriptlang.org/docs/handbook/basic-types.html#any) è la scelta migliore, non `Object`. Se l'unica cosa di cui si sa è che il tipo è un oggetto di qualche tipo, usa il tipo [`object`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type), non `Object` o `{ [key: string]: any }`.
-* `var foo: string | any`:
+  È consigliato usare una vera asserzione di tipo, ad esempio `getMeAT() as number`.
+  Esempio dove un parametro è accettabile: `function id<T>(value: T): T;`.
+  Esempio in cui non lo è: `function parseJson<T>(json: string): T;`.
+  Eccezione: `new Map<string, number>()` va bene.
+- Usare i tipi `Function` e `Object` non è quasi mai una buona idea. Nel 99% si può specificare un tipo più preciso. Alcuni esempi sono `(x: number) => number` per le [funzioni](https://www.typescriptlang.org/docs/handbook/functions.html#function-types) e `{ x: number, y: number }` per gli oggetti. Se non si è sicuri del tipo, [`any`](https://www.typescriptlang.org/docs/handbook/basic-types.html#any) è la scelta migliore, non `Object`. Se l'unica cosa di cui si sa è che il tipo è un oggetto di qualche tipo, usa il tipo [`object`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type), non `Object` o `{ [key: string]: any }`.
+- `var foo: string | any`:
   Quando `any` è usato in un tipo disgiuntipo, il tipo risultanto rimane `any`. Quindi mentre la porzione `string` di questo tipo potrebbe _sembrare_ utile, in realtà non offre nessuna precisazione rispetto ad un banalissimo `any`.
-    In funzione delle tue intenzioni, delle alternative accettabili sono `any`, `string` o `string | object`.
+  In funzione delle tue intenzioni, delle alternative accettabili sono `any`, `string` o `string | object`.
 
 ### Proprietari delle definizioni
 
@@ -356,20 +361,20 @@ Se un file non è nè testato nè riferito nell'`index.d.ts`, aggiungilo in un f
 
 DT ha il concetto di "Proprietari delle definizioni", che sono coloro i quali vogliono mantenere la qualità delle definizioni dei tipi di un certo modulo.
 
-* Aggiungerti da solo farà sì che tu venga notificato (tramite il tuo nome utente GitHub) ogni volta che qualcuno fa una pull request o un issue su quel package.
-* Le tue PR review avranno precedenza maggiore di quelle [dei bot](https://github.com/DefinitelyTyped/dt-mergebot) che mantengono questa repo.
-* I mantenitori di DT stanno ponendo la loro fiducia sui proprietari delle definizioni per mantenere un ecosistema stabile, quindi non aggiungerti senza sapere quello che fai.
+- Aggiungerti da solo farà sì che tu venga notificato (tramite il tuo nome utente GitHub) ogni volta che qualcuno fa una pull request o un issue su quel package.
+- Le tue PR review avranno precedenza maggiore di quelle [dei bot](https://github.com/DefinitelyTyped/dt-mergebot) che mantengono questa repo.
+- I mantenitori di DT stanno ponendo la loro fiducia sui proprietari delle definizioni per mantenere un ecosistema stabile, quindi non aggiungerti senza sapere quello che fai.
 
 Per aggiungerti come pprietario delle definizioni:
 
-* Aggiungi il tuo nome alla fine della riga, come su `// Definitions by: Alice <https://github.com/alice>, Bob <https://github.com/bob>`.
-* Se ci sono più perone, puoi separarlo in più righe:
+- Aggiungi il tuo nome alla fine della riga, come su `// Definitions by: Alice <https://github.com/alice>, Bob <https://github.com/bob>`.
+- Se ci sono più perone, puoi separarlo in più righe:
   ```typescript
-    // Definitions by: Alice <https://github.com/alice>
-    //                 Bob <https://github.com/bob>
-    //                 Steve <https://github.com/steve>
-    //                 John <https://github.com/john>
-    ```
+  // Definitions by: Alice <https://github.com/alice>
+  //                 Bob <https://github.com/bob>
+  //                 Steve <https://github.com/steve>
+  //                 John <https://github.com/john>
+  ```
 
 Una volta alla settimana i proprietari delle definizioni saranno sincronizzati nel file [.github/CODEOWNERS](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/.github/CODEOWNERS) che è la nostra fonte di verità.
 
@@ -405,7 +410,7 @@ Se noti che nessuno interagisce alla PR prova a darle un focus minore.
 Se il modulo da cui dipendi è un modulo esterno (usa `export`), utilizza `import`.
 Se il modulo da cui dipendi è un modulo d'ambiente (usa `declare module` o semplicemente dichiara le cose globali), usa `<reference types="" />`.
 
-#### Alcuni package non hanno un `tslint.json` ed ad altri mancano il `"noImplicitAny": true`, il `"noImplicitThis": true`, o  il`"strictNullChecks": true` nel `tsconfig.json`.
+#### Alcuni package non hanno un `tslint.json` ed ad altri mancano il `"noImplicitAny": true`, il `"noImplicitThis": true`, o il`"strictNullChecks": true` nel `tsconfig.json`.
 
 Questo significa che non vanno bene e noi non ce ne siamo ancora accorti. Puoi contribuire inviando una pull request che li sistemi.
 
@@ -413,7 +418,7 @@ Questo significa che non vanno bene e noi non ce ne siamo ancora accorti. Puoi c
 
 No. Abbiamo già provato ad avere una formattazione consistente dei package ma siamo arrivati ad un vicolo cieco data la mole di attività sulla repo. Noi alleghiamo delle impostazioni di formattazione attraverso i file [`.editorconfig`](.editorconfig). Questi sono esclusivamente per il tuo editor, le loro impostazioni non vanno in conflitto e non abbiamo in piano di modificarle. Né tantomeno abbiamo in piano di imporre uno stile specifico nella repository. Vogliamo tenere le barriere per le contribuzioni basse.
 
-####  Posso chiedere che venga implementata una definizione per un modulo che non le ha ancora?
+#### Posso chiedere che venga implementata una definizione per un modulo che non le ha ancora?
 
 Se un modulo che utilizzi non ha ancora delle definizioni, puoi chiedere che vengano implementate aprendo un Issue. Qui trovi le [richieste di implementazione](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/categories/request-a-new-types-package) attuali.
 
@@ -463,13 +468,13 @@ Ecco qui un breve esempio per iniziare:
 1. Aggiungi un file `package.json` alle definizioni dei tuoi package, con il contenuto seguente.
 
    ```json
-      {
-        "private": true,
-        "types": "index",
-        "typesVersions": {
-          "<=3.6": { "*": ["ts3.6/*"] }
-        }
-      }
+   {
+       "private": true,
+       "types": "index",
+       "typesVersions": {
+           "<=3.6": { "*": ["ts3.6/*"] }
+       }
+   }
    ```
 
 2. Crea la sottocartella menzionata dal campo `typesVersions` dentro la tua cartella dei tipi (che nel nostro esempio è `ts3.6/`).
@@ -480,13 +485,13 @@ Ecco qui un breve esempio per iniziare:
 3. Cambia le opzioni `baseUrl` e `typeRoots` in `ts3.6/tsconfig.json` per correggere i path, dovrebbe essere simile a:
 
    ```json
-    {
-        "compilerOptions": {
-            "baseUrl": "../../",
-            "typeRoots": ["../../"]
-        }
-    }
-    ```
+   {
+       "compilerOptions": {
+           "baseUrl": "../../",
+           "typeRoots": ["../../"]
+       }
+   }
+   ```
 
 4. Nel root del package, aggiungi le funzionalità di Typescript 3.7 che vuoi usare.
    Quando il package viene installato, Typescript 3.6 o inferiore partirà da `ts3.6/index.d.ts`, mentre Typescript 3.7 o superiore partirà da `index.d.ts`.
@@ -502,11 +507,10 @@ Quando smetterà di essere una bozza, potremo rimuoverlo da Definitely Typed e d
 
 #### Come fanno le versioni dei package Definitely Typed a coincidere con le versioni della libreria corrispondente?
 
-*NOTA: Questa sezione assume familiarità con [Versioni semantiche](https://semver.org/)*
+_NOTA: Questa sezione assume familiarità con [Versioni semantiche](https://semver.org/)_
 
 Ogni pacchetto Definitly Typed è versionato quando viene pubblicato su npm.
-Il [DefinitelyTyped-tools](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher), che è lo strumento che pubblica i pacchetti `@types` su npm) metterà la versione al pacchetto '@types` usando la versione `major.minor` scritta nella prima riga del suo file `index.d.ts`.
-Ad esempio, queste sono le prime righe delle [dichiarazioni di tipi di Node](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/node/index.d.ts) for version `10.12.x` at the time of writing:
+Il [DefinitelyTyped-tools](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher), che è lo strumento che pubblica i pacchetti `@types` su npm) metterà la versione al pacchetto '@types`usando la versione`major.minor`scritta nella prima riga del suo file`index.d.ts`. Ad esempio, queste sono le prime righe delle [dichiarazioni di tipi di Node](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1253faabf5e0d2c5470db6ea87795d7f96fef7e2/types/node/index.d.ts) for version`10.12.x` at the time of writing:
 
 ```js
 // Type definitions for Node.js 10.12
@@ -525,11 +529,11 @@ A volte le versioni delle dichiarazioni dei tipi e quelle dei pacchetti corrispo
 Qui sotto ci sono alcune delle cause più comuni, ordinate in base a quanti inconvenienti causano a chi utilizza la libreria.
 Solitamente, solo l'ultima causa da problemi.
 
-* Come messo precedentemente in evidenza, la parte patch della versione del pacchetto `@types` non è allineata con quella della libreria analoga.
+- Come messo precedentemente in evidenza, la parte patch della versione del pacchetto `@types` non è allineata con quella della libreria analoga.
   Questo permette a Definitely Typed di aggiornare in modo automatico e sicuro le dichiarazioni dei tipi di una libreria che hanno le stesse major/minor.
-* Se aggiorni un pacchetto perchè introduci una nuova funzionalità, ricordati di aggiornare la versione anche sul pacchetto `@types`.
+- Se aggiorni un pacchetto perchè introduci una nuova funzionalità, ricordati di aggiornare la versione anche sul pacchetto `@types`.
   Se gli autori dei pacchetti fanno corrispondere le versioni di JavaScript con quelle dei pacchetti `@types` analoghi, `npm update` dovrebbe funzionare alla perfezione.
-* Molto spesso capita che le versioni delle dichiaraizoni dei tipi rimangano indietro rispetto a quelle del pacchetto JavaScript, questo perchè molte volte non sono gli stessi autori dei pacchetti JavaScript
+- Molto spesso capita che le versioni delle dichiaraizoni dei tipi rimangano indietro rispetto a quelle del pacchetto JavaScript, questo perchè molte volte non sono gli stessi autori dei pacchetti JavaScript
   a farne anche le dichiarazioni dei tipi ma utenti terzi. Per questo motivo potrebbero esserci dei ritardi di giorni, settimane o perfino mesi prima che arrivi una pull request da qualche benefattore che riallinea il pacchetto `@type` con l'ultima versione JavaScript.
   Se ti ritrovi in questa situazione, puoi essere tu stesso a fare la differenza ed a risolvere il problema diventando un membro a tutti gli effetti della Community.
 
@@ -558,17 +562,17 @@ Nel momento in cui questo README è stato scritto, il [`tsconfig.json` della his
 ```json
 {
     "compilerOptions": {
-    "baseUrl": "../../",
-    "typeRoots": ["../../"],
-    "paths": {
-        "history": [ "history/v2" ]
-    }
+        "baseUrl": "../../",
+        "typeRoots": ["../../"],
+        "paths": {
+            "history": ["history/v2"]
+        }
     },
     "files": [
         "index.d.ts",
         "history-tests.ts"
     ]
-  }
+}
 ```
 
 Se ci sono pacchetti su Definitely Typed che sono incompatibili con la vesione più nuova di una libreria, dovrai mappare gli indirizzi alla vecchia versione, continuando ricorsivamente per gli altri pacchetti che dipendono da essa.
@@ -584,10 +588,9 @@ La guida di Typescript spiega benissimo [come scrivere le definizioni dei tipi](
 
 Per accertarti che le tue definizioni possono essere usate sia globalmente che come modulo importato, crea una cartella `test` e creaci dentro due file di test.
 Chiamane uno `NomeLibreria-global.test.ts` e l'altro `NomeLibreria-module.test.ts`.
-Il file di test *global* dovrebbe controllare che le definizioni funzionano bene quando la libreria è usata globalmente in una pagina web (in questo caso non devi specificare un `import`).
-Il file di test *module*, invece, controlla se le definzioni funzionano quando la libreria viene importata come un modulo.
+Il file di test _global_ dovrebbe controllare che le definizioni funzionano bene quando la libreria è usata globalmente in una pagina web (in questo caso non devi specificare un `import`).
+Il file di test _module_, invece, controlla se le definzioni funzionano quando la libreria viene importata come un modulo.
 Se aggiungi la proprietà `files` nel tuo `tsconfig.json`, assicurati di includere entrambi questi file di test. Un [esempio pratico](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/big.js/test) è disponibile nelle dichiarazioni dei tipi di `big.js`.
-
 
 #### E per quanto riguarda i pacchetti con scope?
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,20 +2,20 @@
 
 > 高品質な TypeScript の型定義用レポジトリ
 
-*この README は[英語](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md)・[スペイン語](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.es.md)・[韓国語](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ko.md)・[ロシア語](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ru.md)・[中国語](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.zh-Hans.md)・[ポルトガル語](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.pt.md)・[イタリア語](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.it.md)でも閲覧できます！*
+_この README は[英語](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md)・[スペイン語](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.es.md)・[韓国語](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ko.md)・[ロシア語](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ru.md)・[中国語](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.zh-Hans.md)・[ポルトガル語](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.pt.md)・[イタリア語](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.it.md)でも閲覧できます！_
 
-*[管理マニュアルへのリンク](./docs/admin.md)*
+_[管理マニュアルへのリンク](./docs/admin.md)_
 
 ## 現在のステータス
 
 このセクションではレポジトリと公開プロセスの稼働状況を追跡できます。
 PR やパッケージに何か不具合がある場合は、これらが役に立つかもしれません。
 
-* 直近のビルドの[型チェックと Lint](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint) が正常終了したか: [![Build Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.DefinitelyTyped?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=1&branchName=master)
-* 次バージョンの TypeScript 上で全パッケージの型チェックと Lint が正常終了したか: [![Build status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/Nightly%20dtslint)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=8)
-* 1時間以内に全パッケージが [npm に公開](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher)されているか: [![Publish Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.types-publisher-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=5&branchName=master)
-* Definitely Typed 上で [typescript-bot](https://github.com/typescript-bot) がアクティブかどうか: [![Activity Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.typescript-bot-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=6&branchName=master)
-* 現在の[運用基盤のステータス更新](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/44317)
+- 直近のビルドの[型チェックと Lint](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint) が正常終了したか: [![Build Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.DefinitelyTyped?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=1&branchName=master)
+- 次バージョンの TypeScript 上で全パッケージの型チェックと Lint が正常終了したか: [![Build status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/Nightly%20dtslint)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=8)
+- 1時間以内に全パッケージが [npm に公開](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher)されているか: [![Publish Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.types-publisher-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=5&branchName=master)
+- Definitely Typed 上で [typescript-bot](https://github.com/typescript-bot) がアクティブかどうか: [![Activity Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.typescript-bot-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=6&branchName=master)
+- 現在の[運用基盤のステータス更新](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/44317)
 
 掲載されているもので何かが正常ではなかったり、結果が失敗になっているものがある場合は、 [TypeScript コミュニティの Discord サーバーの Definitely Typed のチャンネル](https://discord.gg/typescript)までご連絡ください。
 
@@ -44,7 +44,7 @@ npm install --save-dev @types/node
 パッケージが見つからない場合は [TypeSearch](https://microsoft.github.io/TypeSearch/) で検索してください。
 
 検索しても見つからない場合は、パッケージ内に型定義が[含まれている](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html)かどうか確認してください。
-大抵は `package.json` の `"types"` フィールドや `"typings"`  フィールドに指定されています。
+大抵は `package.json` の `"types"` フィールドや `"typings"` フィールドに指定されています。
 もしくは、パッケージ内の各 ".d.ts" ファイルを確認し、 `/// <reference path="" />` を使って手動でインクルードしてください。
 
 ### Support window
@@ -70,9 +70,9 @@ npm install --save-dev @types/node
 
 #### TypeScript 1.x系
 
-* このレポジトリの `master` ブランチから手動でダウンロードして、開発しているプロジェクトに配置してください。
-* ~~[Typings](https://github.com/typings/typings)~~ （Typings は非推奨になったので、他の方式を使用すること）
-* ~~[NuGet](https://nuget.org/packages?q=DefinitelyTyped)~~ （NuGet 上の DefinitelyTyped の公開は終了したので、他の方式を使用すること）
+- このレポジトリの `master` ブランチから手動でダウンロードして、開発しているプロジェクトに配置してください。
+- ~~[Typings](https://github.com/typings/typings)~~ （Typings は非推奨になったので、他の方式を使用すること）
+- ~~[NuGet](https://nuget.org/packages?q=DefinitelyTyped)~~ （NuGet 上の DefinitelyTyped の公開は終了したので、他の方式を使用すること）
 
 手動で[リファレンス](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html)を追加する必要があります。
 
@@ -88,8 +88,8 @@ Definitely Typed は、あなたのようなユーザーによるコントリビ
 
 ```ts
 declare module "libname" {
-  // ここに型を記述
-  export function helloWorldMessage(): string
+    // ここに型を記述
+    export function helloWorldMessage(): string;
 }
 ```
 
@@ -136,19 +136,19 @@ DefinitelyTyped への大量の PR を全てセルフサービス方式で処理
 > :warning: これには最小限の[gitバージョン2.27.0](https://git-scm.com/downloads)が必要ですが、これはほとんどのマシンのデフォルトよりも新しいバージョンです。より複雑な手順が古いバージョンで利用可能ですが、このガイドではカバーされていません。
 
 1. `git clone --sparse --filter=blob:none --depth=1 <forkedUrl>`
-    - `--sparse` はスパースチェックアウトファイルを初期化し、ワーキングディレクトリがリポジトリのルートにあるファイルのみで開始されます。
-    - `--filter=blob:none` はファイルを除外し、必要に応じてそれらを取得します。
-    - `--depth=1` はコミット履歴を切り詰めることでクローン速度をさらに向上させますが、[ここでまとめられているように](https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/)問題を引き起こす可能性があります。
+   - `--sparse` はスパースチェックアウトファイルを初期化し、ワーキングディレクトリがリポジトリのルートにあるファイルのみで開始されます。
+   - `--filter=blob:none` はファイルを除外し、必要に応じてそれらを取得します。
+   - `--depth=1` はコミット履歴を切り詰めることでクローン速度をさらに向上させますが、[ここでまとめられているように](https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/)問題を引き起こす可能性があります。
 2. `git sparse-checkout add types/<type> types/<dependency-type> ...`
 
 </details>
 
 #### 既存のパッケージを編集する
 
-* `cd types/<編集したいパッケージ名>` を実行。
-* 変更を加える。[テストを編集する](#パッケージ名-teststs)のも忘れずに行う。
+- `cd types/<編集したいパッケージ名>` を実行。
+- 変更を加える。[テストを編集する](#パッケージ名-teststs)のも忘れずに行う。
   破壊的な変更を加えるときは、必ず[メジャーバージョンを更新する](#ライブラリが破壊的な変更をしてメジャーバージョンが更新されました型定義パッケージはどのように更新すればよいですか)。
-* [`npm test <テストしたいパッケージ名>` を実行](#テストの実行)。
+- [`npm test <テストしたいパッケージ名>` を実行](#テストの実行)。
 
 既存のパッケージを編集する PR を作成すると、 `dt-bot` が今までの型定義作者に@メンションを送ります。
 もしメンションが自動でつかなかった場合は、 PR のコメントにてあなたがメンションを送ってください。
@@ -163,11 +163,11 @@ npm 上にないパッケージの型定義を追加したい場合は、その�
 
 型定義パッケージは次のような構造にする必要があります:
 
-| ファイル      | 用途 |
-| ------------- | ---- |
-| `index.d.ts` | 型定義が含まれる。 |
-| [`<パッケージ名>-tests.ts`](#パッケージ名-teststs)  | 型定義をテストするサンプルコードが含まれる。このコードは実行は**されません**が、型チェックはされます。 |
-| [`tsconfig.json`](#tsconfigjson) | パッケージ内で `tsc` を実行するのに必要。 |
+| ファイル                                           | 用途                                                                                                   |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `index.d.ts`                                       | 型定義が含まれる。                                                                                     |
+| [`<パッケージ名>-tests.ts`](#パッケージ名-teststs) | 型定義をテストするサンプルコードが含まれる。このコードは実行は**されません**が、型チェックはされます。 |
+| [`tsconfig.json`](#tsconfigjson)                   | パッケージ内で `tsc` を実行するのに必要。                                                              |
 
 これらのファイルを生成するには、 npm 5.2.0 以上では `npx dts-gen --dt --name <パッケージ名> --template module` 、それより古い環境では `npm install -g dts-gen` と `dts-gen --dt --name <パッケージ名> --template module` を実行してください。
 dts-gen の全オプションは[こちら](https://github.com/Microsoft/dts-gen)で確認できます。
@@ -183,9 +183,10 @@ Definitely Typed のメンバーは常に新しい PR をチェックしてい�
 パッケージに型定義が[バンドル](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html)されている場合、混乱を避けるために Definitely Typed 側の型定義は削除します。
 
 `pnpm run not-needed -- <typingsPackageName> <asOfVersion> [<libraryName>]` を実行するとパッケージを削除できます。.
-* `<typingsPackageName>`: 削除したいディレクトリ名。
-* `<asOfVersion>`: `@types/<typingsPackageName>` に対してスタブ（stub）を公開したいバージョン。現在公開中のバージョンより新しく、かつ npm 上の `<libraryName>` のバージョンとあわせる必要があります。
-* `<libraryName>`: Definitely Typed 側の型定義の代わりとなる npm のパッケージ名。基本的に `<typingsPackageName>` と一致し、その場合は省略できます。
+
+- `<typingsPackageName>`: 削除したいディレクトリ名。
+- `<asOfVersion>`: `@types/<typingsPackageName>` に対してスタブ（stub）を公開したいバージョン。現在公開中のバージョンより新しく、かつ npm 上の `<libraryName>` のバージョンとあわせる必要があります。
+- `<libraryName>`: Definitely Typed 側の型定義の代わりとなる npm のパッケージ名。基本的に `<typingsPackageName>` と一致し、その場合は省略できます。
 
 削除されたパッケージを参照していた、他の Definitely Typed 上のパッケージは全て、ライブラリにバンドルされている型定義を参照するように更新する必要があります。
 `pnpm run test-all` を実行した際のエラーを参照することで、更新が必要なライブラリのリストが確認できます。
@@ -194,10 +195,10 @@ Definitely Typed のメンバーは常に新しい PR をチェックしてい�
 
 ```json
 {
-  "private": true,
-  "dependencies": {
-    "<libraryName>": "^2.6.0"
-  }
+    "private": true,
+    "dependencies": {
+        "<libraryName>": "^2.6.0"
+    }
 }
 ```
 
@@ -275,8 +276,12 @@ f("one");
 
 ```ts
 // eslint-disable-next-line no-const-enum
-const enum Const { One }
-const enum Enum { Two } // eslint-disable-line no-const-enum
+const enum Const {
+    One,
+}
+const enum Enum { // eslint-disable-line no-const-enum
+    Two,
+}
 ```
 
 .eslintrc.jsonを使用してルールを無効にすることはできますが、新しいパッケージでは使用しないでください。
@@ -289,7 +294,7 @@ const enum Enum { Two } // eslint-disable-line no-const-enum
 
 ##### `esModuleInterop`/`allowSyntheticDefaultImports`
 
-要約すると、`tsconfig.json` で `esModuleInterop` と `allowSyntheticDefaultImports` は *許可されていません*。
+要約すると、`tsconfig.json` で `esModuleInterop` と `allowSyntheticDefaultImports` は _許可されていません_。
 
 > これらのオプションは、CJSエクスポートのデフォルトインポートを書くことを可能にし、Nodeおよび一部のJSバンドラーにおけるCJSとESモジュールの組み込みの相互運用性をモデル化します：
 >
@@ -343,26 +348,26 @@ DefinitelyTypedのパッケージパブリッシャーは、Definitely Typedの�
 
 #### よくある間違い
 
-* まず、[ハンドブック](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)のアドバイスに従ってください。
-* フォーマット: 4つのスペースを使用してください。このリポジトリではPrettierが設定されているため、`pnpm run prettier -- --write 'path/to/package/**/*.ts'`を実行してフォーマットを適用できます。[アサーションを使用する場合](https://github.com/SamVerschueren/tsd#assertions)、フォーマットから除外するために `// prettier-ignore` を追加して、フォーマットの対象外としてマークすることができます：
+- まず、[ハンドブック](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)のアドバイスに従ってください。
+- フォーマット: 4つのスペースを使用してください。このリポジトリではPrettierが設定されているため、`pnpm run prettier -- --write 'path/to/package/**/*.ts'`を実行してフォーマットを適用できます。[アサーションを使用する場合](https://github.com/SamVerschueren/tsd#assertions)、フォーマットから除外するために `// prettier-ignore` を追加して、フォーマットの対象外としてマークすることができます：
   ```tsx
   // prettier-ignore
   // @ts-expect-error
   const incompleteThemeColorModes: Theme = { colors: { modes: { papaya: {
   ```
-* `function sum(nums: number[]): number`: パラメータを変更しない場合、`ReadonlyArray` を使用してください。
-* `interface Foo { new(): Foo; }`:
+- `function sum(nums: number[]): number`: パラメータを変更しない場合、`ReadonlyArray` を使用してください。
+- `interface Foo { new(): Foo; }`:
   これは new できるオブジェクトの型を定義しています。おそらく `declare class Foo { constructor(); }` を使用したいです。
-* `const Class: { new(): IClass; }`:
+- `const Class: { new(): IClass; }`:
   new できる定数の代わりにクラス宣言 `class Class { constructor(); }` を使用することをお勧めします。
-* `getMeAT<T>(): T`:
+- `getMeAT<T>(): T`:
   タイプパラメータがどのパラメータの型にも現れない場合、実際にはジェネリック関数ではなく、偽装された型アサーションがあります。
   実際の型アサーションを使用することをお勧めします。例: `getMeAT() as number`。
   タイプパラメータが受け入れられる例: `function id<T>(value: T): T;`。
   タイプパラメータが受け入れられない例: `function parseJson<T>(json: string): T;`。
   例外: `new Map<string, number>()` は問題ありません。
-* 型 `Function` と `Object` を使用するのはほとんどの場合良いアイデアではありません。99%の場合、より具体的な型を指定できます。関数の場合は [(x: number) => number](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-type-expressions) など、オブジェクトの場合は `{ x: number, y: number }` を指定できます。型について全く確実な情報がない場合は、[`any`](https://www.typescriptlang.org/docs/handbook/basic-types.html#any) を選択すべきです。型について唯一知られている情報が「何らかのオブジェクトである」という場合は、型 [`object`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type) を使用し、`Object` や `{ [key: string]: any }` を使用しないでください。
-* `var foo: string | any`:
+- 型 `Function` と `Object` を使用するのはほとんどの場合良いアイデアではありません。99%の場合、より具体的な型を指定できます。関数の場合は [(x: number) => number](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-type-expressions) など、オブジェクトの場合は `{ x: number, y: number }` を指定できます。型について全く確実な情報がない場合は、[`any`](https://www.typescriptlang.org/docs/handbook/basic-types.html#any) を選択すべきです。型について唯一知られている情報が「何らかのオブジェクトである」という場合は、型 [`object`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type) を使用し、`Object` や `{ [key: string]: any }` を使用しないでください。
+- `var foo: string | any`:
   `any` がユニオン型で使用される場合、結果の型は依然として `any` です。そのため、この型注釈の `string` 部分は有用に見えるかもしれませんが、実際には単に `any` を使用するよりも追加の型チェックを提供しません。
   意図に応じて、受け入れ可能な代替手段は `any`、`string`、または `string | object` などが考えられます。
 
@@ -372,14 +377,14 @@ DefinitelyTypedのパッケージパブリッシャーは、Definitely Typedの�
 
 DT には「定義オーナー」というコンセプトがあり、特定のモジュールの型の品質を維持したいと考える人々がいます。
 
-* 自分自身をリストに追加すると、誰かがそのパッケージに関するプルリクエストまたは問題を作成したときに通知を受けることができます（GitHub ユーザー名を介して）。
-* あなたのプルリクエストのレビューは、[このリポジトリを管理するボット](https://github.com/DefinitelyTyped/dt-mergebot)にとって重要度が高くなります。
-* DT メンテナーは、安定したエコシステムを確保するために、定義オーナーに信頼を置いていますので、軽率に自分を追加しないでください。
+- 自分自身をリストに追加すると、誰かがそのパッケージに関するプルリクエストまたは問題を作成したときに通知を受けることができます（GitHub ユーザー名を介して）。
+- あなたのプルリクエストのレビューは、[このリポジトリを管理するボット](https://github.com/DefinitelyTyped/dt-mergebot)にとって重要度が高くなります。
+- DT メンテナーは、安定したエコシステムを確保するために、定義オーナーに信頼を置いていますので、軽率に自分を追加しないでください。
 
 自分自身を定義オーナーとして追加するには：
 
-* 自分の名前を行の末尾に追加します。例： `// Definitions by: Alice <https://github.com/alice>, Bob <https://github.com/bob>`。
-* または、複数の人がいる場合、複数行にすることもできます。
+- 自分の名前を行の末尾に追加します。例： `// Definitions by: Alice <https://github.com/alice>, Bob <https://github.com/bob>`。
+- または、複数の人がいる場合、複数行にすることもできます。
   ```typescript
   // Definitions by: Alice <https://github.com/alice>
   //                 Bob <https://github.com/bob>
@@ -464,6 +469,7 @@ npm パッケージは数分で更新されます。もし1時間以上かかっ
 
 `import foo = require("foo");` 構文を使ってモジュールをインポートするほうが適切でしょう。
 それでもなお `import foo from "foo";` のようなデフォルトインポートを使いたい場合は、2つ選択肢があります:
+
 - モジュールの実行環境で非 ECMAScript モジュール向けの相互運用体系が整っている場合、つまりデフォルトインポートがあなたの環境（ Webpack や SystemJS 、 esm など）で動作する場合は、 [`--allowSyntheticDefaultImports` コンパイラー オプション](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-1-8.html#support-for-default-import-interop-with-systemjs)が使用できます。
 - TypeScript 側に非 ECMAScript の対応をさせたい場合は、 [`--esModuleInterop` コンパイラー オプション](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#support-for-import-d-from-cjs-form-commonjs-modules-with---esmoduleinterop)が使用できます（ TypeScript 2.7 以降）。
 
@@ -489,11 +495,11 @@ npm パッケージでは、モジュールを `node -p 'require("foo")'` でイ
 
    ```json
    {
-     "private": true,
-     "types": "index",
-     "typesVersions": {
-       "<=3.6": { "*": ["ts3.6/*"] }
-     }
+       "private": true,
+       "types": "index",
+       "typesVersions": {
+           "<=3.6": { "*": ["ts3.6/*"] }
+       }
    }
    ```
 
@@ -505,10 +511,10 @@ npm パッケージでは、モジュールを `node -p 'require("foo")'` でイ
 3. `ts3.6/tsconfig.json` の `baseUrl` ・ `typeRoots` オプションに正しいパスを指定する。次のような値になるはずです:
    ```json
    {
-     "compilerOptions": {
-       "baseUrl": "../../",
-       "typeRoots": ["../../"]
-     }
+       "compilerOptions": {
+           "baseUrl": "../../",
+           "typeRoots": ["../../"]
+       }
    }
    ```
 
@@ -526,7 +532,7 @@ npm パッケージでは、モジュールを `node -p 'require("foo")'` でイ
 
 #### Definitely Typed パッケージのバージョンと、対応するライブラリ本体のバージョンはどのように関係していますか？
 
-*注意: このセクションを読むには[セマンティック バージョニング](https://semver.org/)の知識が必要です。*
+_注意: このセクションを読むには[セマンティック バージョニング](https://semver.org/)の知識が必要です。_
 
 Definitely Typed の各パッケージは npm に公開される際にバージョン番号が付されます。
 [DefinitelyTyped-tools](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher) （`@types` パッケージを npm に公開するツール）は、パッケージの `index.d.ts` の1行目に載っている `メジャー.マイナー` バージョン番号を使って、型定義パッケージのバージョンを付けます。
@@ -549,11 +555,11 @@ Definitely Typed の各パッケージは npm に公開される際にバージ�
 考えられる原因を、ライブラリ使用者にとって不便に思う順に下記に列挙します<small>（訳注: 一番困るものが一番下）</small>。
 一番下のみが一般的に問題とされます。
 
-* 先述した通り、型定義パッケージのパッチバージョンはライブラリ本体とは無関係です。
+- 先述した通り、型定義パッケージのパッチバージョンはライブラリ本体とは無関係です。
   これにより Definitely Typed 側で、同じメジャー・マイナーバージョン用の型定義を安全に更新することができます。
-* パッケージを新機能で更新したときは、ライブラリ本体のバージョンと合うように、型定義パッケージのバージョン番号を更新してください。
+- パッケージを新機能で更新したときは、ライブラリ本体のバージョンと合うように、型定義パッケージのバージョン番号を更新してください。
   JavaScript のパッケージとそれぞれの `@types` パッケージのバージョンが一致することがユーザー側で把握されていれば、 `npm update` は基本的に正常に動作します。
-* 型定義パッケージの更新がライブラリ本体の更新から遅れることはよくあります。これは、ライブラリに新しい機能がリリースされた際に Definitely Typed を更新しているのが、メンテナーではなくライブラリ使用者である場合も多いためです。
+- 型定義パッケージの更新がライブラリ本体の更新から遅れることはよくあります。これは、ライブラリに新しい機能がリリースされた際に Definitely Typed を更新しているのが、メンテナーではなくライブラリ使用者である場合も多いためです。
   そのため、面倒見の良いコミュニティメンバーが、新しいリリース用に型定義を更新する PR を送ってくれるまで、数日、数週間、場合によって数か月かかる場合があります。
   もしこれによってお困りでしたら、「世の中に見たいと思う変化にあなたがなって」あなたがその面倒見の良いコミュニティメンバーになるのはいかがでしょうか？
 
@@ -581,17 +587,17 @@ Definitely Typed の各パッケージは npm に公開される際にバージ�
 
 ```json
 {
-  "compilerOptions": {
-    "baseUrl": "../../",
-    "typeRoots": ["../../"],
-    "paths": {
-      "history": [ "history/v2" ]
-    }
-  },
-  "files": [
-    "index.d.ts",
-    "history-tests.ts"
-  ]
+    "compilerOptions": {
+        "baseUrl": "../../",
+        "typeRoots": ["../../"],
+        "paths": {
+            "history": ["history/v2"]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "history-tests.ts"
+    ]
 }
 ```
 
@@ -607,9 +613,9 @@ Definitely Typed の各パッケージは npm に公開される際にバージ�
 
 TypeScript ハンドブックには、[型定義を書くにあたっての一般的な情報](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html)がとてもよくまとめられており、また object をグローバル スコープで使えるようにしながら ES6 方式のモジュール構文を使って型定義を作成している[型定義ファイルの例](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/global-modifying-module-d-ts.html)も掲載されています。この手法は実際に [`big.js` の型定義](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/big.js/index.d.ts)で使われています。このモジュールはウェブページでは `<script>` タグでグローバルに読み込むことができ、 `require` や ES6 方式の `import` でインポートすることもできます。
 
-型定義ファイルがグローバルにも、インポートされたモジュールとしても使用できるかをテストするには、次のようにします。まず `test` フォルダを作成し、そこに `YourLibraryName-global.test.ts` と `YourLibraryName-module.test.ts` の2つのファイルを用意します。 *global* テストファイルでは、ウェブページ上でスクリプトとして読み込まれ、ライブラリがグローバル スコープで使用可能になるようにテストします &mdash; このとき、インポート構文は使用してはいけません。 *module* テストファイルでは、 `import` 構文などを使用し、モジュールとしてインポートする方法に沿ってテストします。 `tsconfig.json` ファイル内で `files` プロパティを指定している場合は、両方をテストファイルを含めるのを忘れないでください。 `big.js` の型定義での[実際のテストファイル](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/big.js/test)も参考にしてください。
+型定義ファイルがグローバルにも、インポートされたモジュールとしても使用できるかをテストするには、次のようにします。まず `test` フォルダを作成し、そこに `YourLibraryName-global.test.ts` と `YourLibraryName-module.test.ts` の2つのファイルを用意します。 _global_ テストファイルでは、ウェブページ上でスクリプトとして読み込まれ、ライブラリがグローバル スコープで使用可能になるようにテストします &mdash; このとき、インポート構文は使用してはいけません。 _module_ テストファイルでは、 `import` 構文などを使用し、モジュールとしてインポートする方法に沿ってテストします。 `tsconfig.json` ファイル内で `files` プロパティを指定している場合は、両方をテストファイルを含めるのを忘れないでください。 `big.js` の型定義での[実際のテストファイル](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/big.js/test)も参考にしてください。
 
-両方のテストファイルで、型定義に対する完全なテストを行う必要はありません &mdash; *global* テストファイルではグローバルな要素にアクセスできるかのみをテストし、 *module* テストファイルで型定義の完全なテストを行う（またはその逆パターン）のでもかまいません。
+両方のテストファイルで、型定義に対する完全なテストを行う必要はありません &mdash; _global_ テストファイルではグローバルな要素にアクセスできるかのみをテストし、 _module_ テストファイルで型定義の完全なテストを行う（またはその逆パターン）のでもかまいません。
 
 #### スコープ付きパッケージについてはどうすればよいですか？
 
@@ -619,9 +625,9 @@ TypeScript ハンドブックには、[型定義を書くにあたっての一�
 
 ```json
 {
-  "paths": {
-    "@foo/*": ["foo__*"]
-  }
+    "paths": {
+        "@foo/*": ["foo__*"]
+    }
 }
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -2,21 +2,21 @@
 
 > 이 저장소는 고품질의 타입스크립트(TypeScript) 자료형 정의(Type definition)를 위한 저장소입니다.
 
-*이 도움말은 [영어](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md), [스페인어](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.es.md), [러시아어](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ru.md), 그리고 [중국어](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.zh-Hans.md)로도 읽으실 수 있습니다!*
+_이 도움말은 [영어](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md), [스페인어](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.es.md), [러시아어](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ru.md), 그리고 [중국어](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.zh-Hans.md)로도 읽으실 수 있습니다!_
 
 <!-- For translators: add link to README.ja.md above! -->
 
-*[관리자 설명서](./docs/admin.md) 링크*
+_[관리자 설명서](./docs/admin.md) 링크_
 
 ## 현재 상태
 
 저장소 및 퍼블리싱 과정의 상태를 표시합니다.
 기여자분들이 작성한 PR 또는 패키지에 문제가 발생했을 경우 이 표시를 보면 도움이 될 수 있습니다.
 
-* 최신 빌드가 [타입 체크/린트](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint) 과정을 깔끔하게 통과했습니다: [![Build Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.DefinitelyTyped?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=1&branchName=master)
-* 모든 패키지가 typescript@next상에서 타입 체크/린트 과정을 깔끔하게 통과합니다: [![Build status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/Nightly%20dtslint)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=8)
-* 모든 패키지가 1시간 내에 [npm에 배포](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher)되었습니다: [![Publish Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.types-publisher-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=5&branchName=master)
-* [typescript-bot](https://github.com/typescript-bot)이 Definitely Typed에서 잘 돌고 있습니다 [![Activity Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.typescript-bot-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=6&branchName=master)
+- 최신 빌드가 [타입 체크/린트](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint) 과정을 깔끔하게 통과했습니다: [![Build Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.DefinitelyTyped?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=1&branchName=master)
+- 모든 패키지가 typescript@next상에서 타입 체크/린트 과정을 깔끔하게 통과합니다: [![Build status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/Nightly%20dtslint)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=8)
+- 모든 패키지가 1시간 내에 [npm에 배포](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher)되었습니다: [![Publish Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.types-publisher-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=5&branchName=master)
+- [typescript-bot](https://github.com/typescript-bot)이 Definitely Typed에서 잘 돌고 있습니다 [![Activity Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.typescript-bot-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=6&branchName=master)
 
 상태 표시가 비정상이거나 고장 표시가 발생하면 [Definitely Typed Discord 채널](https://discord.gg/typescript)에서 이 문제를 알려주세요.
 
@@ -62,21 +62,21 @@ npm 의 "foo" 패키지에 대응되는 자료형 패키지는 "@types/foo" 입�
 `@types` 패키지 안에는 패키지가 확실하게 지원하는 TypeScript 버전이 태그로 쓰여 있으므로, 2년 지원 기간이 지난 오래된 패키지도 보통 찾아보실 수 있습니다.
 예를 들어, `npm dist-tags @types/react` 명령어를 입력하면 TypeScript 2.5는 react@16.0용 타입을, TypeScript 2.6 및 2.7은 react@16.4용 타입을 사용할 수 있는 것을 확인하실 수 있습니다:
 
-|태그 | 버전|
-|----|---------|
-|latest| 16.9.23|
-|ts2.0| 15.0.1|
-| ... | ... |
-|ts2.5| 16.0.36|
-|ts2.6| 16.4.7|
-|ts2.7| 16.4.7|
-| ... | ... |
+| 태그   | 버전    |
+| ------ | ------- |
+| latest | 16.9.23 |
+| ts2.0  | 15.0.1  |
+| ...    | ...     |
+| ts2.5  | 16.0.36 |
+| ts2.6  | 16.4.7  |
+| ts2.7  | 16.4.7  |
+| ...    | ...     |
 
 #### TypeScript 1.*
 
-* 이 저장소의 `master` 브랜치에서 직접 다운로드해 프로젝트에 삽입하기
-* ~~[Typings](https://github.com/typings/typings)를 사용하기~~ (다른 방법을 사용해주세요. typings는 더이상 추천하지 않습니다)
-* ~~[NuGet](https://nuget.org/packages?q=DefinitelyTyped) 을 사용하기~~ (다른 방법을 사용해주세요. NuGet은 더 이상 DT 자료형(Typing)을 제공하지 않습니다.)
+- 이 저장소의 `master` 브랜치에서 직접 다운로드해 프로젝트에 삽입하기
+- ~~[Typings](https://github.com/typings/typings)를 사용하기~~ (다른 방법을 사용해주세요. typings는 더이상 추천하지 않습니다)
+- ~~[NuGet](https://nuget.org/packages?q=DefinitelyTyped) 을 사용하기~~ (다른 방법을 사용해주세요. NuGet은 더 이상 DT 자료형(Typing)을 제공하지 않습니다.)
 
 위 방법을 사용할 경우 수동으로 [참조(Reference)](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html)를 추가해주어야 할 수 있습니다.
 
@@ -95,7 +95,6 @@ Definitely Typed는 여러분과 같은 많은 기여자들의 도움 덕분에 
 새로운 기능을 추가하려면 [모듈 증강(module augmentation)](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation)를 사용할 수 있습니다.
 물론 `node_modules/@types/foo/index.d.ts` 를 직접 수정하실 수도 있으며, 이 파일을 복사한 다음 아래의 과정을 따라하실 수도 있습니다.
 
-
 #### 새 패키지를 테스트하기
 
 사용하고 계신 `tsconfig.json` 에 다음 내용을 추가해주세요.
@@ -112,20 +111,18 @@ Definitely Typed는 여러분과 같은 많은 기여자들의 도움 덕분에 
 실제 코드를 통한 확인이 끝나면, [풀 리퀘스트(Pull request)](#풀-리퀘스트pull-request-만들기)를 만들어주세요.
 [이미 존재하는 패키지를 수정](#이미-존재하는-패키지를-수정하기)하거나 [새 패키지를 만들기](#새-패키지를-만들기)위한 과정들을 따라하시면 됩니다.
 
-
 ### 풀 리퀘스트(Pull request) 만들기
 
 패키지가 잘 작동하는지 확인하셨다면, Definitely Typed에 공유해주세요.
 
 우선, 이 저장소를 [포크(fork)](https://guides.github.com/activities/forking/)해 주시고, [node](https://nodejs.org/) 를 설치하신 뒤, `npm install` 명령을 실행해주세요.
 
-
 #### 이미 존재하는 패키지를 수정하기
 
-* `cd types/<package to edit>` 명령을 실행합니다.
-* 자료형(Typing) 파일들을 수정합니다. [테스트를 추가하는 것도 잊지마세요](#my-package-teststs)!
+- `cd types/<package to edit>` 명령을 실행합니다.
+- 자료형(Typing) 파일들을 수정합니다. [테스트를 추가하는 것도 잊지마세요](#my-package-teststs)!
   만약 브레이킹 체인지(Breaking change)를 만드셨다면, [메이저 버전(major version)](#패키지를-새-메이저-버전major-version에-맞게-갱신하고-싶어요)을 꼭 올려주세요.
-* 패키지 머릿주석의 "Definitions by" 부분에 여러분의 이름을 추가하실 수도 있습니다.
+- 패키지 머릿주석의 "Definitions by" 부분에 여러분의 이름을 추가하실 수도 있습니다.
   - 이름을 추가하시면 다른 사람들이 그 패키지에 대한 풀 리퀘스트(Pull request)나 이슈(Issue)를 만들 때 여러분에게 알람이 갑니다.
   - `// Definitions by: Alice <https://github.com/alice>, Bob <https://github.com/bob>` 와 같이 여러분의 이름을 줄의 맨 마지막에 추가할 수 있습니다.
   - 사람이 너무 많을 경우엔, 다음과 같이 여러 줄로 쓰실 수도 있습니다.
@@ -135,11 +132,10 @@ Definitely Typed는 여러분과 같은 많은 기여자들의 도움 덕분에 
   //                 Steve <https://github.com/steve>
   //                 John <https://github.com/john>
   ```
-* [`npm test <package to test>` 명령을 실행시키고 결과를 확인해주세요](#검증하기).
+- [`npm test <package to test>` 명령을 실행시키고 결과를 확인해주세요](#검증하기).
 
 이미 존재하는 패키지에 대한 풀 리퀘스트(Pull request)를 만들었을 경우에는, `dt-bot` 이 이전 저자들을 자동으로 호출하는지 확인해주세요.
 그렇지 않은 경우에는, 여러분이 직접 풀 리퀘스트(Pull request)와 관계있는 사람들을 호출할 수도 있습니다.
-
 
 #### 새 패키지를 만들기
 
@@ -151,11 +147,11 @@ npm 에 올라가 있지 않은 패키지를 위한 자료형(Typing) 패키지�
 
 새 자료형 패키지는 다음과 같은 구조로 구성되어있어야만 합니다.
 
-| 파일 이름 | 용도 |
-| --- | --- |
-| `index.d.ts` | 패키지를 위한 자료형(Typing)을 포함하는 파일입니다. |
+| 파일 이름                                      | 용도                                                                                                                         |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `index.d.ts`                                   | 패키지를 위한 자료형(Typing)을 포함하는 파일입니다.                                                                          |
 | [`<my-package>-tests.ts`](#my-package-teststs) | 자료형(Typing)의 테스트를 위한 파일입니다. 이 파일의 코드는 실행되지는 않지만, 자료형 검사(Type checking)를 통과해야 합니다. |
-| [`tsconfig.json`](#tsconfigjson) | `tsc` 명령을 돌릴 수 있게 해주는 파일입니다. |
+| [`tsconfig.json`](#tsconfigjson)               | `tsc` 명령을 돌릴 수 있게 해주는 파일입니다.                                                                                 |
 
 이 파일들은, npm ≥ 5.2.0 에서는 `npx dts-gen --dt --name <my-package> --template module` 명령으로,
 그 이하 경우에는 `npm install -g dts-gen` 와 `dts-gen --dt --name <my-package> --template module` 명령으로 만들 수 있습니다.
@@ -171,8 +167,9 @@ Definitely Typed 의 관리자들이 주기적으로 새로운 풀 리퀘스트(
 패키지가 스스로의 형(Type)을 [포함](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html)하게 되면, Definitely Typed 에 있는 자료형(Typing) 패키지를 삭제하는 것이 좋습니다.
 
 `pnpm run not-needed -- <typingsPackageName> <asOfVersion> [<libraryName>]` 명령어를 사용하여 자료형(Typing) 패키지를 삭제할 수 있습니다.
+
 - `<typingsPackageName>` 는 삭제할 디렉토리의 이름입니다.
-- `<asOfVersion>`  는 새 스텁(Stub) 용 `@types/<typingsPackageName>` 를 퍼블리시(Publish)할 버전입니다. 이 버전은 현재 npm 에 올라간 버전보다 더 높은 버전이어야 합니다.
+- `<asOfVersion>` 는 새 스텁(Stub) 용 `@types/<typingsPackageName>` 를 퍼블리시(Publish)할 버전입니다. 이 버전은 현재 npm 에 올라간 버전보다 더 높은 버전이어야 합니다.
 - `<libraryName>` 는 패키지의 이름을 읽기 쉽게 쓴 것입니다. 즉, "angular2" 대신에 "Angular 2" 와 같이 쓰는 것이 좋습니다. (생략했을 경우에는 `<typingsPackageName>` 와 같은 것으로 취급됩니다.)
 
 Definitely Typed 의 다른 패키지들이 삭제된 자료형(Typing) 패키지를 사용하고 있을 경우, 형(Type)을 포함하기 시작한 원래 패키지를 사용하도록 수정해야합니다. 삭제된 자료형(Typing) 패키지를 사용하는 각 Definitely Typed 패키지들의 [`package.json`](#packagejson) 파일에 `"dependencies": { "<libraryName>": "x.y.z" }` 를 추가해주시면 됩니다.
@@ -248,8 +245,12 @@ If for some reason a lint rule needs to be disabled, disable it for a specific l
 
 ```ts
 // eslint-disable-next-line no-const-enum
-const enum Const { One }
-const enum Enum { Two } // eslint-disable-line no-const-enum
+const enum Const {
+    One,
+}
+const enum Enum { // eslint-disable-line no-const-enum
+    Two,
+}
 ```
 
 You can still disable rules with an .eslintrc.json, but should not in new packages.
@@ -274,21 +275,21 @@ If a file is neither tested nor referenced in `index.d.ts`, add it to a file nam
 
 #### 많이 저지르는 실수들
 
-* 우선, [안내서(Handbook)](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)에 나와있는 내용들을 따라주세요.
-* 코드에서는 모든 곳에서 탭(Tab)을 사용하거나, 항상 4 개의 띄어쓰기를 사용해주세요.
-* `function sum(nums: number[]): number`의 경우, 만약 함수가 인자를 변경하지 않는다면 `ReadonlyArray` 를 사용해주세요.
-* `interface Foo { new(): Foo; }`의 경우,
+- 우선, [안내서(Handbook)](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)에 나와있는 내용들을 따라주세요.
+- 코드에서는 모든 곳에서 탭(Tab)을 사용하거나, 항상 4 개의 띄어쓰기를 사용해주세요.
+- `function sum(nums: number[]): number`의 경우, 만약 함수가 인자를 변경하지 않는다면 `ReadonlyArray` 를 사용해주세요.
+- `interface Foo { new(): Foo; }`의 경우,
   이런 선언은 이 형(Type)을 가진 객체(Object)에 `new` 를 사용할 수 있도록 만듭니다. 많은 경우 여러분은 `declare class Foo { constructor(); }` 를 사용하려는 것일 겁니다.
-* `const Class: { new(): IClass; }`의 경우,
+- `const Class: { new(): IClass; }`의 경우,
   `new` 를 사용할 수 있는 상수를 만드는 대신, `class Class { constructor(); }` 와 같이 클래스 선언(Class declaration)을 사용하는 게 더 좋습니다.
-* `getMeAT<T>(): T`의 경우,
+- `getMeAT<T>(): T`의 경우,
   만일 자료형 매개변수(Type parameter)가 함수의 매개변수에 등장하지 않는다면, 그런 제너릭(Generic) 함수를 사용할 필요가 없습니다.
   그 제너릭(Generic) 함수는 단순히 자료형 단언(Type assertion)을 위장시킨 것뿐입니다. 이 경우 `getMeAT() as number` 와 같이 진짜 자료형 단언(Type assertion) 을 사용하는 게 더 좋습니다.
   다음은 괜찮은 제너릭(Generic)의 예시입니다. `function id<T>(value: T): T;`.
   다음은 문제가 있는 제너릭(Generic)의 예시입니다. `function parseJson<T>(json: string): T;`.
   예외적으로, `new Map<string, number>()` 와 같은 경우는 괜찮습니다.
-* `Function` 이나 `Object` 와 같은 형(Type)을 사용하는 것은 대부분의 경우 문제를 일으킵니다. 99% 의 경우 더 구체적인 형(Type)을 사용하는게 가능합니다. [함수(Function)](https://www.typescriptlang.org/docs/handbook/functions.html#function-types) 를 위해서는 `(x: number) => number` 와 같은, 객체를 위해서는 `{ x: number, y: number }` 와 같은 형(Type)들을 사용할 수 있습니다. 형(Type)에 대한 정보가 전혀 없을 경우에는, `Object` 형(Type)이 아니라 [`any`](https://www.typescriptlang.org/docs/handbook/basic-types.html#any) 형(Type)을 사용해야 합니다. 만일 어떤 형(Type)이 객체라는 사실만 알고 있는 경우, `Object` 나 `{ [key: string]: any }` 가 아니라 [`object`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type) 를 사용해주세요.
-* `var foo: string | any`의 경우,
+- `Function` 이나 `Object` 와 같은 형(Type)을 사용하는 것은 대부분의 경우 문제를 일으킵니다. 99% 의 경우 더 구체적인 형(Type)을 사용하는게 가능합니다. [함수(Function)](https://www.typescriptlang.org/docs/handbook/functions.html#function-types) 를 위해서는 `(x: number) => number` 와 같은, 객체를 위해서는 `{ x: number, y: number }` 와 같은 형(Type)들을 사용할 수 있습니다. 형(Type)에 대한 정보가 전혀 없을 경우에는, `Object` 형(Type)이 아니라 [`any`](https://www.typescriptlang.org/docs/handbook/basic-types.html#any) 형(Type)을 사용해야 합니다. 만일 어떤 형(Type)이 객체라는 사실만 알고 있는 경우, `Object` 나 `{ [key: string]: any }` 가 아니라 [`object`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type) 를 사용해주세요.
+- `var foo: string | any`의 경우,
   `any` 가 합 자료형(Union type)의 안에서 사용될 경우, 결과 형(Type)은 언제나 `any` 가 됩니다. 따라서 형(Type)의 `string` 부분이 유용해 보인다 하더라도, 사실은 자료형 검사(Type checking)의 측면에서 `any` 와 다른 것이 없습니다.
   대신, `any`, `string`, 나 `string | object` 중 하나를 필요에 맞게 골라서 사용해주세요.
 
@@ -296,14 +297,14 @@ If a file is neither tested nor referenced in `index.d.ts`, add it to a file nam
 
 DT has the concept of "Definition Owners" which are people who want to maintain the quality of a particular module's types
 
-* Adding yourself to the list will cause you to be notified (via your GitHub username) whenever someone makes a pull request or issue about the package.
-* Your PR reviews will have a higher precedence of importance to [the bot](https://github.com/DefinitelyTyped/dt-mergebot) which maintains this repo.
-* The DT maintainers are putting trust in the definition owners to ensure a stable eco-system, please don't add yourself lightly.
+- Adding yourself to the list will cause you to be notified (via your GitHub username) whenever someone makes a pull request or issue about the package.
+- Your PR reviews will have a higher precedence of importance to [the bot](https://github.com/DefinitelyTyped/dt-mergebot) which maintains this repo.
+- The DT maintainers are putting trust in the definition owners to ensure a stable eco-system, please don't add yourself lightly.
 
 To Add yourself as a Definition Owner:
 
-* Adding your name to the end of the line, as in `// Definitions by: Alice <https://github.com/alice>, Bob <https://github.com/bob>`.
-* Or if there are more people, it can be multiline
+- Adding your name to the end of the line, as in `// Definitions by: Alice <https://github.com/alice>, Bob <https://github.com/bob>`.
+- Or if there are more people, it can be multiline
   ```typescript
   // Definitions by: Alice <https://github.com/alice>
   //                 Bob <https://github.com/bob>
@@ -377,8 +378,8 @@ npm 패키지의 경우, `node -p 'require("foo")'` 가 원하는 값이라면 `
         "baseUrl": "../../",
         "typeRoots": ["../../"],
         "paths": {
-            "history": [ "history/v2" ]
-        },
+            "history": ["history/v2"]
+        }
     },
     "files": [
         "index.d.ts",
@@ -411,8 +412,8 @@ npm 패키지의 경우, `node -p 'require("foo")'` 가 원하는 값이라면 `
 
 ```json
 {
-    "paths":{
-      "@foo/*": ["foo__*"]
+    "paths": {
+        "@foo/*": ["foo__*"]
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Definitely Typed
 
-> The repository for *high quality* TypeScript type definitions.
+> The repository for _high quality_ TypeScript type definitions.
 
-*You can also read this README in [Español](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.es.md), [한국어](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ko.md), [Русский](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ru.md), [简体中文](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.zh-Hans.md), [Português](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.pt.md), [Italiano](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.it.md), [日本語](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ja.md) and [Français](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.fr.md)!*
+_You can also read this README in [Español](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.es.md), [한국어](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ko.md), [Русский](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ru.md), [简体中文](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.zh-Hans.md), [Português](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.pt.md), [Italiano](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.it.md), [日本語](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ja.md) and [Français](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.fr.md)!_
 
-*Link to [Admin manual](./docs/admin.md)*
+_Link to [Admin manual](./docs/admin.md)_
 
 ## !!! Important! This repo has recently changed layout! !!!
 
@@ -17,13 +17,11 @@ At the very least, you may want to `git clean -fdx` the repo (or `node ./scripts
 This section tracks the health of the repository and publishing process.
 It may be helpful for contributors experiencing any issues with their PRs and packages.
 
-* Most recent build [type-checked/linted](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint) cleanly: [![Build status](https://github.com/DefinitelyTyped/DefinitelyTyped/actions/workflows/CI.yml/badge.svg?branch=master&event=push)
-](https://github.com/DefinitelyTyped/DefinitelyTyped/actions/workflows/CI.yml?query=branch%3Amaster+event%3Apush)
-* All packages are type-checking/linting cleanly on typescript@next: [![Build status](https://github.com/DefinitelyTyped/DefinitelyTyped/actions/workflows/CI.yml/badge.svg?branch=master&event=schedule)
-](https://github.com/DefinitelyTyped/DefinitelyTyped/actions/workflows/CI.yml?query=branch%3Amaster+event%3Aschedule)
-* All packages are being [published to npm](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher) in under an hour and a half: [![Publish Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.types-publisher-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=5&branchName=master)
-* [typescript-bot](https://github.com/typescript-bot) has been active on Definitely Typed [![Activity Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.typescript-bot-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=6&branchName=master)
-* Current [infrastructure status updates](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/44317)
+- Most recent build [type-checked/linted](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint) cleanly: [![Build status](https://github.com/DefinitelyTyped/DefinitelyTyped/actions/workflows/CI.yml/badge.svg?branch=master&event=push)](https://github.com/DefinitelyTyped/DefinitelyTyped/actions/workflows/CI.yml?query=branch%3Amaster+event%3Apush)
+- All packages are type-checking/linting cleanly on typescript@next: [![Build status](https://github.com/DefinitelyTyped/DefinitelyTyped/actions/workflows/CI.yml/badge.svg?branch=master&event=schedule)](https://github.com/DefinitelyTyped/DefinitelyTyped/actions/workflows/CI.yml?query=branch%3Amaster+event%3Aschedule)
+- All packages are being [published to npm](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher) in under an hour and a half: [![Publish Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.types-publisher-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=5&branchName=master)
+- [typescript-bot](https://github.com/typescript-bot) has been active on Definitely Typed [![Activity Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.typescript-bot-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=6&branchName=master)
+- Current [infrastructure status updates](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/44317)
 
 If anything here seems wrong or any of the above are failing, please let us know in [the Definitely Typed channel on the TypeScript Community Discord server](https://discord.gg/typescript).
 
@@ -56,7 +54,7 @@ See more in the [handbook](https://www.typescriptlang.org/docs/handbook/declarat
 
 For an npm package "foo", typings for it will be at "@types/foo".
 
-If your package has typings specified using the ``types`` or ``typings`` key in its ``package.json``, the npm registry will display that the package has available bindings like so:
+If your package has typings specified using the `types` or `typings` key in its `package.json`, the npm registry will display that the package has available bindings like so:
 
 ![image](https://user-images.githubusercontent.com/30049719/228748963-56fabfd1-9101-42c2-9891-b586b775b01e.png)
 
@@ -87,9 +85,9 @@ For example, if you run `npm dist-tags @types/react`, you'll see that TypeScript
 
 #### TypeScript 1.*
 
-* Manually download from the `master` branch of this repository and place them in your project
-* ~~[Typings](https://github.com/typings/typings)~~ (use preferred alternatives, typings is deprecated)
-* ~~[NuGet](https://nuget.org/packages?q=DefinitelyTyped)~~ (use preferred alternatives, nuget DT type publishing has been turned off)
+- Manually download from the `master` branch of this repository and place them in your project
+- ~~[Typings](https://github.com/typings/typings)~~ (use preferred alternatives, typings is deprecated)
+- ~~[NuGet](https://nuget.org/packages?q=DefinitelyTyped)~~ (use preferred alternatives, nuget DT type publishing has been turned off)
 
 You may need to add manual [references](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html).
 
@@ -105,8 +103,8 @@ Before you share your improvement with the world, use the types yourself by crea
 
 ```ts
 declare module "libname" {
-  // Types inside here
-  export function helloWorldMessage(): string
+    // Types inside here
+    export function helloWorldMessage(): string;
 }
 ```
 
@@ -127,7 +125,7 @@ Add to your `tsconfig.json`:
 
 Create `types/foo/index.d.ts` containing declarations for the module "foo".
 You should now be able to import from `"foo"` in your code and it will route to the new type definition.
-Then build *and* run the code to make sure your type definition actually corresponds to what happens at runtime.
+Then build _and_ run the code to make sure your type definition actually corresponds to what happens at runtime.
 
 Once you've tested your definitions with real code, make a [PR](#make-a-pull-request)
 then follow the instructions to [edit an existing package](#edit-an-existing-package) or
@@ -159,20 +157,20 @@ You can clone the entire repository [as per usual](https://docs.github.com/en/gi
 
 For a more manageable clone that includes _only_ the type packages relevant to you, you can use git's [`sparse-checkout`](https://git-scm.com/docs/git-sparse-checkout) and [`--filter`](https://git-scm.com/docs/git-rev-list#Documentation/git-rev-list.txt---filterltfilter-specgt) features. This will reduce clone time and improve git performance.
 
->:warning: This requires minimum [git version 2.27.0](https://git-scm.com/downloads), which is likely newer than the default on most machines. More complicated procedures are available in older versions, but not covered by this guide.
+> :warning: This requires minimum [git version 2.27.0](https://git-scm.com/downloads), which is likely newer than the default on most machines. More complicated procedures are available in older versions, but not covered by this guide.
 
 1. `git clone --sparse --filter=blob:none <forkedUrl>`
-    - `--sparse` initializes the sparse-checkout file so the working directory starts with only the files in the root of the repository.
-    - `--filter=blob:none` will including all commit history but exclude files, fetching them only as needed.
+   - `--sparse` initializes the sparse-checkout file so the working directory starts with only the files in the root of the repository.
+   - `--filter=blob:none` will including all commit history but exclude files, fetching them only as needed.
 2. `git sparse-checkout add types/<type> types/<dependency-type> ...`
 
 </details>
 
 #### Edit an existing package
 
-* Make changes. Remember to [edit tests](#my-package-teststs).
+- Make changes. Remember to [edit tests](#my-package-teststs).
   If you make breaking changes, do not forget to [update a major version](#if-a-library-is-updated-to-a-new-major-version-with-breaking-changes-how-should-i-update-its-type-declaration-package).
-* [Run `pnpm test <package to test>`](#running-tests).
+- [Run `pnpm test <package to test>`](#running-tests).
 
 When you make a PR to edit an existing package, `dt-bot` should @-mention previous authors.
 If it doesn't, you can do so yourself in the comment associated with the PR.
@@ -188,14 +186,14 @@ If the package you are adding typings for is not on npm, make sure the name you 
 
 Your package should have this structure:
 
-| File          | Purpose |
-| ------------- | ------- |
-| `index.d.ts`  | This contains the typings for the package. |
-| [`<my-package>-tests.ts`](#my-package-teststs)  | This contains sample code which tests the typings. This code does *not* run, but it is type-checked. |
-| [`tsconfig.json`](#tsconfigjson) | This allows you to run `tsc` within the package. |
-| [`.eslintrc.json`](#linter-eslintrcjson)   | (Rarely) Needed only to disable lint rules written for eslint. |
-| [`package.json`](#packagejson) | Contains metadata for the package, including its name, version and dependencies. |
-| [`.npmignore`](#npmignore) | Specifies which files are intended to be included in the package. |
+| File                                           | Purpose                                                                                              |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `index.d.ts`                                   | This contains the typings for the package.                                                           |
+| [`<my-package>-tests.ts`](#my-package-teststs) | This contains sample code which tests the typings. This code does _not_ run, but it is type-checked. |
+| [`tsconfig.json`](#tsconfigjson)               | This allows you to run `tsc` within the package.                                                     |
+| [`.eslintrc.json`](#linter-eslintrcjson)       | (Rarely) Needed only to disable lint rules written for eslint.                                       |
+| [`package.json`](#packagejson)                 | Contains metadata for the package, including its name, version and dependencies.                     |
+| [`.npmignore`](#npmignore)                     | Specifies which files are intended to be included in the package.                                    |
 
 Generate these by running `npx dts-gen --dt --name <my-package> --template module`.
 See all options at [dts-gen](https://github.com/Microsoft/dts-gen).
@@ -211,9 +209,10 @@ For a good example package, see [base64-js](https://github.com/DefinitelyTyped/D
 When a package [bundles](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) its own types, types should be removed from Definitely Typed to avoid confusion.
 
 You can remove it by running `pnpm run not-needed <typingsPackageName> <asOfVersion> [<libraryName>]`.
-* `<typingsPackageName>`: This is the name of the directory to delete.
-* `<asOfVersion>`: A stub will be published to `@types/<typingsPackageName>` with this version. Should be higher than any currently published version and should be a version of `<libraryName>` on npm.
-* `<libraryName>`: Name of npm package that replaces the Definitely Typed types. Usually this is identical to `<typingsPackageName>`, in which case you can omit it.
+
+- `<typingsPackageName>`: This is the name of the directory to delete.
+- `<asOfVersion>`: A stub will be published to `@types/<typingsPackageName>` with this version. Should be higher than any currently published version and should be a version of `<libraryName>` on npm.
+- `<libraryName>`: Name of npm package that replaces the Definitely Typed types. Usually this is identical to `<typingsPackageName>`, in which case you can omit it.
 
 If a package was never on Definitely Typed, it does not need to be added to `notNeededPackages.json`.
 
@@ -282,7 +281,7 @@ All problems reported by `attw` have documentation linked in the output. Some ru
 
   ```ts
   export interface Options {
-    // ...
+      // ...
   }
   export default function doSomething(options: Options): void;
   ```
@@ -291,7 +290,7 @@ All problems reported by `attw` have documentation linked in the output. Some ru
 
   ```ts
   export interface Options {
-    // ...
+      // ...
   }
   declare function doSomething(options: Options): void;
   export = doSomething;
@@ -303,9 +302,9 @@ All problems reported by `attw` have documentation linked in the output. Some ru
 
   ```ts
   declare namespace doSomething {
-    export interface Options {
-      // ...
-    }
+      export interface Options {
+          // ...
+      }
   }
   declare function doSomething(options: doSomething.Options): void;
   export = doSomething;
@@ -373,8 +372,12 @@ If for some reason a lint rule needs to be disabled, disable it for a specific l
 
 ```ts
 // eslint-disable-next-line no-const-enum
-const enum Const { One }
-const enum Enum { Two } // eslint-disable-line no-const-enum
+const enum Const {
+    One,
+}
+const enum Enum { // eslint-disable-line no-const-enum
+    Two,
+}
 ```
 
 You can still disable rules with an .eslintrc.json, but should not in new packages.
@@ -388,7 +391,7 @@ You may edit the `tsconfig.json` to add new test files, to add `"target": "es6"`
 
 ##### `esModuleInterop`/`allowSyntheticDefaultImports`
 
-TL;DR: `esModuleInterop` and `allowSyntheticDefaultImports` are *not allowed* in your `tsconfig.json`.
+TL;DR: `esModuleInterop` and `allowSyntheticDefaultImports` are _not allowed_ in your `tsconfig.json`.
 
 > These options make it possible to write a default import for a CJS export, modeling the built-in interoperability between CJS and ES modules in Node and in some JS bundlers:
 >
@@ -439,7 +442,6 @@ This file is required and should follow this template:
 }
 ```
 
-
 A `package.json` specifies _all_ dependencies, including other `@types` packages.
 
 You must add non-`@types` dependencies to [the list of allowed external dependencies](https://github.com/microsoft/DefinitelyTyped-tools/blob/master/packages/definitions-parser/allowedPackageJsonDependencies.txt).
@@ -487,22 +489,22 @@ CI will fail if this file contains the wrong contents and provide the intended v
 
 #### Common mistakes
 
-* First, follow advice from the [handbook](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html).
-* Formatting: [dprint](https://dprint.dev) is set up on this repo, so you can run `pnpm dprint fmt -- 'path/to/package/**/*.ts'`.
-  * Consider using the VS Code `.vscode/settings.template.json` (or equivalent for other editors) to format on save with the [VS Code dprint extension](https://marketplace.visualstudio.com/items?itemName=dprint.dprint)
-* `function sum(nums: number[]): number`: Use `ReadonlyArray` if a function does not write to its parameters.
-* `interface Foo { new(): Foo; }`:
+- First, follow advice from the [handbook](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html).
+- Formatting: [dprint](https://dprint.dev) is set up on this repo, so you can run `pnpm dprint fmt -- 'path/to/package/**/*.ts'`.
+  - Consider using the VS Code `.vscode/settings.template.json` (or equivalent for other editors) to format on save with the [VS Code dprint extension](https://marketplace.visualstudio.com/items?itemName=dprint.dprint)
+- `function sum(nums: number[]): number`: Use `ReadonlyArray` if a function does not write to its parameters.
+- `interface Foo { new(): Foo; }`:
   This defines a type of objects that are new-able. You probably want `declare class Foo { constructor(); }`.
-* `const Class: { new(): IClass; }`:
+- `const Class: { new(): IClass; }`:
   Prefer to use a class declaration `class Class { constructor(); }` instead of a new-able constant.
-* `getMeAT<T>(): T`:
+- `getMeAT<T>(): T`:
   If a type parameter does not appear in the types of any parameters, you don't really have a generic function, you just have a disguised type assertion.
   Prefer to use a real type assertion, e.g. `getMeAT() as number`.
   Example where a type parameter is acceptable: `function id<T>(value: T): T;`.
   Example where it is not acceptable: `function parseJson<T>(json: string): T;`.
   Exception: `new Map<string, number>()` is OK.
-* Using the types `Function` and `Object` is almost never a good idea. In 99% of cases it's possible to specify a more specific type. Examples are `(x: number) => number` for [functions](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-type-expressions) and `{ x: number, y: number }` for objects. If there is no certainty at all about the type, [`any`](https://www.typescriptlang.org/docs/handbook/basic-types.html#any) is the right choice, not `Object`. If the only known fact about the type is that it's some object, use the type [`object`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type), not `Object` or `{ [key: string]: any }`.
-* `var foo: string | any`:
+- Using the types `Function` and `Object` is almost never a good idea. In 99% of cases it's possible to specify a more specific type. Examples are `(x: number) => number` for [functions](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-type-expressions) and `{ x: number, y: number }` for objects. If there is no certainty at all about the type, [`any`](https://www.typescriptlang.org/docs/handbook/basic-types.html#any) is the right choice, not `Object`. If the only known fact about the type is that it's some object, use the type [`object`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type), not `Object` or `{ [key: string]: any }`.
+- `var foo: string | any`:
   When `any` is used in a union type, the resulting type is still `any`. So, while the `string` portion of this type annotation may _look_ useful, it in fact offers no additional typechecking over simply using `any`.
   Depending on the intention, acceptable alternatives could be `any`, `string` or `string | object`.
 
@@ -512,9 +514,9 @@ CI will fail if this file contains the wrong contents and provide the intended v
 
 DT has the concept of "Definition Owners" which are people who want to maintain the quality of a particular module's types.
 
-* Adding yourself to the list will cause you to be notified (via your GitHub username) whenever someone makes a pull request or issue about the package.
-* Your PR reviews will have a higher precedence of importance to [the bot](https://github.com/DefinitelyTyped/dt-mergebot) which maintains this repo.
-* The DT maintainers are putting trust in the definition owners to ensure a stable eco-system, please don't add yourself lightly.
+- Adding yourself to the list will cause you to be notified (via your GitHub username) whenever someone makes a pull request or issue about the package.
+- Your PR reviews will have a higher precedence of importance to [the bot](https://github.com/DefinitelyTyped/dt-mergebot) which maintains this repo.
+- The DT maintainers are putting trust in the definition owners to ensure a stable eco-system, please don't add yourself lightly.
 
 To add yourself as a Definition Owner, modify the `owners` array in `package.json`:
 
@@ -580,7 +582,7 @@ Then they are wrong and we've not noticed yet. You can help by submitting a pull
 Yes, using [dprint](https://dprint.dev).
 We recommend using a [dprint extension for your editor](https://dprint.dev/install/#editor-extensions).
 
-Alternatively, you can enable a git hook which will format your code automatically. Run `pnpm run setup-hooks`. Then, when you commit, `dprint fmt` command will be executed on changed files.  If you take advantage of [partial clone](#partial-clone), make sure to call `git sparse-checkout add .husky` to check out the git hooks before running the `setup-hooks` script.
+Alternatively, you can enable a git hook which will format your code automatically. Run `pnpm run setup-hooks`. Then, when you commit, `dprint fmt` command will be executed on changed files. If you take advantage of [partial clone](#partial-clone), make sure to call `git sparse-checkout add .husky` to check out the git hooks before running the `setup-hooks` script.
 
 Pull requests do not require correct formatting to be merged.
 Any unformatted code will be automatically reformatted after being merged.
@@ -619,6 +621,7 @@ This is a commonly cited [Stack Overflow answer](https://stackoverflow.com/quest
 
 It is more appropriate to import the module using the `import foo = require("foo");` syntax.
 Nevertheless, if you want to use a default import like `import foo from "foo";` you have two options:
+
 - you can use the [`--allowSyntheticDefaultImports` compiler option](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-1-8.html#support-for-default-import-interop-with-systemjs) if your module runtime supports an interop scheme for non-ECMAScript modules, i.e. if default imports work in your environment (e.g. Webpack, SystemJS, esm).
 - you can use the [`--esModuleInterop` compiler option](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#support-for-import-d-from-cjs-form-commonjs-modules-with---esmoduleinterop) if you want TypeScript to take care of non-ECMAScript interop (since TypeScript 2.7).
 
@@ -635,7 +638,7 @@ For an npm package, `export =` is accurate if `node -p 'require("foo")'` works t
 
 Then you will have to add a comment to the last line of your definition header (after `// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped`): `// Minimum TypeScript Version: X.Y`. This will set the lowest minimum supported version.
 
-However, if your project needs to maintain types that are compatible with, say, 3.7 and above *at the same time as* types that are compatible with 3.6 or below, you will need to use the `typesVersions` feature.
+However, if your project needs to maintain types that are compatible with, say, 3.7 and above _at the same time as_ types that are compatible with 3.6 or below, you will need to use the `typesVersions` feature.
 You can find a detailed explanation of this feature in the [official TypeScript documentation](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-1.html#version-selection-with-typesversions).
 
 Here's a short example to get you started:
@@ -644,11 +647,11 @@ Here's a short example to get you started:
 
    ```json
    {
-     "private": true,
-     "types": "index",
-     "typesVersions": {
-       "<=3.6": { "*": ["ts3.6/*"] }
-     }
+       "private": true,
+       "types": "index",
+       "typesVersions": {
+           "<=3.6": { "*": ["ts3.6/*"] }
+       }
    }
    ```
 
@@ -671,7 +674,7 @@ When it graduates draft mode, we may remove it from Definitely Typed and depreca
 
 #### How do Definitely Typed package versions relate to versions of the corresponding library?
 
-*NOTE: The discussion in this section assumes familiarity with [Semantic versioning](https://semver.org/)*
+_NOTE: The discussion in this section assumes familiarity with [Semantic versioning](https://semver.org/)_
 
 Each Definitely Typed package is versioned when published to npm.
 The [DefinitelyTyped-tools](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher) (the tool that publishes `@types` packages to npm) will set the declaration package's version by using the `major.minor.9999` version number listed in `package.json`.
@@ -681,7 +684,7 @@ For example, here are the first few lines of Node's type declarations for versio
 {
     "private": true,
     "name": "@types/node",
-    "version": "20.8.9999",
+    "version": "20.8.9999"
 }
 ```
 
@@ -694,11 +697,11 @@ Sometimes type declaration package versions and library package versions can get
 Below are a few common reasons why, in order of how much they inconvenience users of a library.
 Only the last case is typically problematic.
 
-* As noted above, the patch version of the type declaration package is unrelated to the library patch version.
+- As noted above, the patch version of the type declaration package is unrelated to the library patch version.
   This allows Definitely Typed to safely update type declarations for the same major/minor version of a library.
-* If updating a package for new functionality, don't forget to update the version number to line up with that version of the library.
+- If updating a package for new functionality, don't forget to update the version number to line up with that version of the library.
   If users make sure versions correspond between JavaScript packages and their respective `@types` packages, then `npm update` should typically just work.
-* It's common for type declaration package updates to lag behind library updates because it's often library users, not maintainers, who update Definitely Typed when new library features are released.
+- It's common for type declaration package updates to lag behind library updates because it's often library users, not maintainers, who update Definitely Typed when new library features are released.
   So, there may be a lag of days, weeks or even months before a helpful community member sends a PR to update the type declaration package for a new library release.
   If you're impacted by this, you can be the change you want to see in the world and you can be that helpful community member!
 
@@ -723,7 +726,7 @@ For example, if we are creating `types/history/v2`, its `package.json` would loo
 {
     "private": true,
     "name": "@types/history",
-    "version": "2.4.9999",
+    "version": "2.4.9999"
 }
 ```
 
@@ -751,9 +754,9 @@ When it comes to breaking changes, DT maintainers consider the popularity of the
 
 #### How do I write definitions for packages that can be used globally and as a module?
 
-The TypeScript handbook contains excellent [general information about writing definitions](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) and also [this example definition file](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/global-modifying-module-d-ts.html) which shows how to create a definition using ES6-style module syntax, while also specifying objects made available to the global scope.  This technique is demonstrated practically in the [definition for `big.js`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/big.js/index.d.ts), which is a library that can be loaded globally via script tag on a web page or imported via require or ES6-style imports.
+The TypeScript handbook contains excellent [general information about writing definitions](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) and also [this example definition file](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/global-modifying-module-d-ts.html) which shows how to create a definition using ES6-style module syntax, while also specifying objects made available to the global scope. This technique is demonstrated practically in the [definition for `big.js`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/big.js/index.d.ts), which is a library that can be loaded globally via script tag on a web page or imported via require or ES6-style imports.
 
-To test how your definition can be used both when referenced globally or as an imported module, create a `test` folder and place two test files in there.  Name one `YourLibraryName-global.test.ts` and the other `YourLibraryName-module.test.ts`.  The *global* test file should exercise the definition according to how it would be used in a script loaded on a web page where the library is available on the global scope - in this scenario you should not specify an import statement.  The *module* test file should exercise the definition according to how it would be used when imported (including the `import` statement(s)).  If you specify a `files` property in your `tsconfig.json` file, be sure to include both test files.  A [practical example of this](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/big.js/test) is also available on the `big.js` definition.
+To test how your definition can be used both when referenced globally or as an imported module, create a `test` folder and place two test files in there. Name one `YourLibraryName-global.test.ts` and the other `YourLibraryName-module.test.ts`. The _global_ test file should exercise the definition according to how it would be used in a script loaded on a web page where the library is available on the global scope - in this scenario you should not specify an import statement. The _module_ test file should exercise the definition according to how it would be used when imported (including the `import` statement(s)). If you specify a `files` property in your `tsconfig.json` file, be sure to include both test files. A [practical example of this](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/big.js/test) is also available on the `big.js` definition.
 
 Please note that it is not required to fully exercise the definition in each test file - it is sufficient to test only the globally accessible elements on the global test file and fully exercise the definition in the module test file or vice versa.
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -1,24 +1,24 @@
 # Definitely Typed
 
-> O repositório para definições de tipo do TypeScript de *alta qualidade*.
+> O repositório para definições de tipo do TypeScript de _alta qualidade_.
 
-*You can also read this README in [Español](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.es.md), [한국어](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ko.md), [Русский](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ru.md), [简体中文](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.zh-Hans.md), [English](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md), [Italiano](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.it.md)
-and [日本語](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ja.md)!*
+_You can also read this README in [Español](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.es.md), [한국어](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ko.md), [Русский](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ru.md), [简体中文](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.zh-Hans.md), [English](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md), [Italiano](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.it.md)
+and [日本語](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ja.md)!_
 
 Veja também o site [definitelytyped.org](http://definitelytyped.org), embora as informações neste README sejam mais atualizadas.
 
-*Link para o [manual do Admin](./docs/admin.md)*
+_Link para o [manual do Admin](./docs/admin.md)_
 
 ## Status atual
 
 Essa seção acompanha a saúde do respositório e o processo de publicação.
 Ela pode servir de ajuda para contribuidores que estejam passando por problemas com suas PRs e pacotes.
 
-* Build mais recente com [tipagem checada/analisada pelo linter](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint) de forma limpa: [![Build Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.DefinitelyTyped?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=1&branchName=master)
-* Todos os pacotes tem seus tipos checados/são analisadas pelo linter no typescript@next: [![Build status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/Nightly%20dtslint)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=8)
-* Todos os pacotes estão sendo [publicados no npm](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher) em menos de uma hora: [![Publish Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.types-publisher-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=5&branchName=master)
-* [typescript-bot](https://github.com/typescript-bot) esteve ativo no Definitely Typed [![Activity Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.typescript-bot-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=6&branchName=master)
-* [Atualizações do status da infraestrutura](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/44317) atual
+- Build mais recente com [tipagem checada/analisada pelo linter](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint) de forma limpa: [![Build Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.DefinitelyTyped?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=1&branchName=master)
+- Todos os pacotes tem seus tipos checados/são analisadas pelo linter no typescript@next: [![Build status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/Nightly%20dtslint)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=8)
+- Todos os pacotes estão sendo [publicados no npm](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher) em menos de uma hora: [![Publish Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.types-publisher-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=5&branchName=master)
+- [typescript-bot](https://github.com/typescript-bot) esteve ativo no Definitely Typed [![Activity Status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.typescript-bot-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=6&branchName=master)
+- [Atualizações do status da infraestrutura](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/44317) atual
 
 Se algo aqui parece estar errado, ou se algum dos itens acima está falhando, por favor fale sobre este problema no [canal do Definitely Typed no Discord](https://discord.gg/typescript).
 
@@ -63,22 +63,21 @@ ou apenas procure por qualquer arquivo ".d.ts" no pacote e manualmente inclua-os
 Pacotes `@types` têm tags para versões do TypeScript que elas explicitamente suportam, então normalmente você pode usar versões mais antigas dos pacotes que precedem o período de 2 anos.
 Por exemplo, se você executar o comando `npm dist-tags @types/react`, você verá que o TypeScript 2.5 pode usar os tipos para o react@16.0, enquanto o TypeScript 2.6 e 2.7 podem usar os tipos para o react@16.4:
 
-|Tag | Versão|
-|----|---------|
-|latest| 16.9.23|
-|ts2.0| 15.0.1|
-| ... | ... |
-|ts2.5| 16.0.36|
-|ts2.6| 16.4.7|
-|ts2.7| 16.4.7|
-| ... | ... |
-
+| Tag    | Versão  |
+| ------ | ------- |
+| latest | 16.9.23 |
+| ts2.0  | 15.0.1  |
+| ...    | ...     |
+| ts2.5  | 16.0.36 |
+| ts2.6  | 16.4.7  |
+| ts2.7  | 16.4.7  |
+| ...    | ...     |
 
 #### TypeScript 1.*
 
-* Faça download manualmente da branch `master` deste repositório e adicione-o no seu projeto
-* ~~[Typings](https://github.com/typings/typings)~~ (use alternativas aconselhadas. O typings foi descontinuado)
-* ~~[NuGet](https://nuget.org/packages?q=DefinitelyTyped)~~ (use alternativas aconselhadas. A publicação de tipos do NuGet DT foi desligada)
+- Faça download manualmente da branch `master` deste repositório e adicione-o no seu projeto
+- ~~[Typings](https://github.com/typings/typings)~~ (use alternativas aconselhadas. O typings foi descontinuado)
+- ~~[NuGet](https://nuget.org/packages?q=DefinitelyTyped)~~ (use alternativas aconselhadas. A publicação de tipos do NuGet DT foi desligada)
 
 Talvez você precise adicionar [referências](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html) manuais.
 
@@ -108,12 +107,11 @@ Adicione ao seu `tsconfig.json`:
 
 Crie o arquivo `types/foo/index.d.ts` contendo as declarações para o módulo "foo".
 Você deve conseguir fazer imports de `"foo"` em seu código e ele será redirecionado para a nova definição de tipos.
-Então faça uma build *e* execute o código para ter certeza que sua definição de tipos realmente corresponde ao que acontece em tempo de execução.
+Então faça uma build _e_ execute o código para ter certeza que sua definição de tipos realmente corresponde ao que acontece em tempo de execução.
 
 Logo após testar suas definições com um código real, faça uma [PR](#faça-uma-pull-request)
 e então siga as instruções para [editar um pacote existente](#edite-um-pacote-existente) ou
 [criar um novo pacote](#crie-um-novo-pacote).
-
 
 ### Faça uma pull request
 
@@ -121,13 +119,12 @@ Logo após testar seu pacote, você pode compartilhá-lo aqui no Definitely Type
 
 Primeiro, [faça um fork](https://guides.github.com/activities/forking/) deste respositório, instale o [node](https://nodejs.org/), e execute `npm install`.
 
-
 #### Edite um pacote existente
 
-* `cd types/meu-pacote-para-editar`
-* Faça as mudanças. Lembre de [editar os testes](#my-package-teststs).
+- `cd types/meu-pacote-para-editar`
+- Faça as mudanças. Lembre de [editar os testes](#my-package-teststs).
   Se você está fazendo mudanças que podem "quebrar" o pacote, não se esqueça de [atualizar a versão principal](#se-uma-biblioteca-for-atualizada-para-uma-nova-versão-major-com-mudanças-drásticas-como-eu-devo-atualizar-a-declaração-de-tipos).
-* [Execute `npm test nome-do-pacote`](#verificando).
+- [Execute `npm test nome-do-pacote`](#verificando).
 
 Quando você fizer uma PR para editar um pacote existente, o `dt-bot` deve mencionar (usando "@") os antigos autores.
 Se ele não o fizer, você mesmo pode fazer isso no comentário associado a PR.
@@ -142,11 +139,11 @@ Se o pacote ao qual você está adicionando tipos não está no npm, tenha certe
 
 Seu pacote deve possuir a seguinte estrutura:
 
-| Arquivo | Propósito |
-| --- | --- |
-| `index.d.ts` | Contém os tipos para o pacote. |
-| [`<my-package>-tests.ts`](#my-package-teststs) | Contém código de exemplo que testa os tipos. Esse código *não* é executado, mas seus tipos são checados. |
-| [`tsconfig.json`](#tsconfigjson) | Permite que você execute `tsc` dentro do pacote. |
+| Arquivo                                        | Propósito                                                                                                |
+| ---------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `index.d.ts`                                   | Contém os tipos para o pacote.                                                                           |
+| [`<my-package>-tests.ts`](#my-package-teststs) | Contém código de exemplo que testa os tipos. Esse código _não_ é executado, mas seus tipos são checados. |
+| [`tsconfig.json`](#tsconfigjson)               | Permite que você execute `tsc` dentro do pacote.                                                         |
 
 Gere esses arquivos executando `npx dts-gen --dt --name nome-do-seu-pacote --template module` se você possuir a versão 5.2.0 ou mais recente do npm ou `npm install -g dts-gen` e `dts-gen --dt --name nome-do-seu-pacote --template module` caso possua uma versão mais antiga.
 Veja todas as opções em [dts-gen](https://github.com/Microsoft/dts-gen).
@@ -162,6 +159,7 @@ Para ver um bom exemplo, veja o pacote [base64-js](https://github.com/Definitely
 Quando um pacote [inclui](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) seus próprios tipos, os tipos devem ser removidos do Definitely Typed para evitar confusão.
 
 Você pode removê-lo executando `pnpm run not-needed -- <typingsPackageName> <asOfVersion> [<libraryName>]`
+
 - `<typingsPackageName>`: O nome do diretório a ser deletado.
 - `<asOfVersion>`: Um esboço será publicado em `@types/<typingsPackageName>` com essa versão. Deve ser maior do que qualquer versão atualmente publicada, e deve ser uma versão de `<libraryName>` no npm.
 - `<libraryName>`: Nome do pacote no npm que substitui os tipos do Definitely Typed. Normalmente é idêntico ao `<typingsPackageName>`, e nesse caso pode ser omitido.
@@ -173,10 +171,10 @@ Por exemplo:
 
 ```json
 {
-  "private": true,
-  "dependencies": {
-    "<libraryName>": "^2.6.0"
-  }
+    "private": true,
+    "dependencies": {
+        "<libraryName>": "^2.6.0"
+    }
 }
 ```
 
@@ -217,6 +215,7 @@ Abaixo há um exemplo dessas mudanças em uma função em um arquivo `d.ts` adic
 ```
 
 `<my-package>-tests.ts`:
+
 ```diff
 import {twoslash} from "./"
 
@@ -252,8 +251,12 @@ If for some reason a lint rule needs to be disabled, disable it for a specific l
 
 ```ts
 // eslint-disable-next-line no-const-enum
-const enum Const { One }
-const enum Enum { Two } // eslint-disable-line no-const-enum
+const enum Const {
+    One,
+}
+const enum Enum { // eslint-disable-line no-const-enum
+    Two,
+}
 ```
 
 You can still disable rules with an .eslintrc.json, but should not in new packages.
@@ -284,26 +287,26 @@ Se um arquivo não for testado nem referenciado no `index.d.ts`, adicione-o em u
 
 #### Erros comuns
 
-* Primeiro, siga as instruções do [manual](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html).
-* Formatação: Use 4 espaços. O Prettier está configurado neste repositório, então você pode executar `pnpm run prettier -- --write 'path/to/package/**/*.ts'`. [Se estiver usando asserções](https://github.com/SamVerschueren/tsd#assertions), adicione a tag de exclusão `// prettier-ignore` para marcar linhas de código como exclusas da formatação:
+- Primeiro, siga as instruções do [manual](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html).
+- Formatação: Use 4 espaços. O Prettier está configurado neste repositório, então você pode executar `pnpm run prettier -- --write 'path/to/package/**/*.ts'`. [Se estiver usando asserções](https://github.com/SamVerschueren/tsd#assertions), adicione a tag de exclusão `// prettier-ignore` para marcar linhas de código como exclusas da formatação:
   ```tsx
   // prettier-ignore
   // @ts-expect-error
   const incompleteThemeColorModes: Theme = { colors: { modes: { papaya: {
   ```
-* `function sum(nums: number[]): number`: Use `ReadonlyArray` se a função não adiciona valores a seus parâmetros.
-* `interface Foo { new(): Foo; }`:
+- `function sum(nums: number[]): number`: Use `ReadonlyArray` se a função não adiciona valores a seus parâmetros.
+- `interface Foo { new(): Foo; }`:
   Isto define um tipo de objeto que pode ser instanciado utlizando o operador `new`. Você provavelmente deveria escrever `declare class Foo { constructor(); }`.
-* `const Class: { new(): IClass; }`:
+- `const Class: { new(): IClass; }`:
   Prefira usar a declaração de classe `class Class { constructor(); }` em vez de uma constante que pode ser instanciada utlizando o operador `new`.
-* `getMeAT<T>(): T`:
+- `getMeAT<T>(): T`:
   Se um parâmetro de tipo não estiver no tipo de nenhum dos parâmetros, então você não tem realmente uma função genérica, você só tem uma asserção de tipos disfarçada.
   Prefira usar uma asserção de tipos real, por exemplo `getMeAT() as number`.
   Um exemplo onde um parâmetro de tipo é aceitável: `function id<T>(value: T): T;`.
   Um exemplo onde não é aceitável: `function parseJson<T>(json: string): T;`.
   Exceção: `new Map<string, number>()` é aceitável.
-* Usar os tipos `Function` e `Object` quase nunca é uma boa ideia. Em 99% dos casos é possível especificar um tipo mais específico. Por exemplo `(x: number) => number` para [funções](https://www.typescriptlang.org/docs/handbook/functions.html#function-types) e `{ x: number, y: number }` para objetos. Se você não tem nenhuma certeza sobre o tipo, [`any`](https://www.typescriptlang.org/docs/handbook/basic-types.html#any) é a escolha correta, não `Object`. Se a única certeza sobre o tipo é que ele é algum objeto, use o tipo [`object`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type), não `Object` ou `{ [key: string]: any }`.
-* `var foo: string | any`:
+- Usar os tipos `Function` e `Object` quase nunca é uma boa ideia. Em 99% dos casos é possível especificar um tipo mais específico. Por exemplo `(x: number) => number` para [funções](https://www.typescriptlang.org/docs/handbook/functions.html#function-types) e `{ x: number, y: number }` para objetos. Se você não tem nenhuma certeza sobre o tipo, [`any`](https://www.typescriptlang.org/docs/handbook/basic-types.html#any) é a escolha correta, não `Object`. Se a única certeza sobre o tipo é que ele é algum objeto, use o tipo [`object`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type), não `Object` ou `{ [key: string]: any }`.
+- `var foo: string | any`:
   Quando `any` é usado em um tipo de união, o tipo resultante ainda é `any`. Então, enquanto a parte da anotação de tipo `string` pode _parecer_ útil, na verdade ela não oferece nenhuma verificação de tipo adicional do que simplesmente usar `any`.
   Dependendo da intenção, alternativas aceitáveis podem ser `any`, `string`, ou `string | object`.
 
@@ -311,14 +314,14 @@ Se um arquivo não for testado nem referenciado no `index.d.ts`, adicione-o em u
 
 O DT tem o coneito de "Donos de definição", que são pessoas que querem manter a qualidade dos tipos de um módulo específico
 
-* Adicionar você mesmo à lista, vai garantir que você seja notificado (pelo seu usuário do GitHub) sempre que qualquer um fizer uma pull request ou um issue sobre o pacote.
-* Suas revisões da PR terão uma precedência de importância maior para [o bot](https://github.com/DefinitelyTyped/dt-mergebot) que mantém este repositório.
-* Os mantenedores do DT estão confiando nos donos da definição para garantir um ecossistema estável, por favor não se adicione apenas por adicionar.
+- Adicionar você mesmo à lista, vai garantir que você seja notificado (pelo seu usuário do GitHub) sempre que qualquer um fizer uma pull request ou um issue sobre o pacote.
+- Suas revisões da PR terão uma precedência de importância maior para [o bot](https://github.com/DefinitelyTyped/dt-mergebot) que mantém este repositório.
+- Os mantenedores do DT estão confiando nos donos da definição para garantir um ecossistema estável, por favor não se adicione apenas por adicionar.
 
 Para se adicionar como um Dono de definição:
 
-* Adicione seu nome ao final da linha, por exemplo: `// Definitions by: Alice <https://github.com/alice>, Bob <https://github.com/bob>`.
-* Ou se há muitas pessoas, pode ser em várias linhas:
+- Adicione seu nome ao final da linha, por exemplo: `// Definitions by: Alice <https://github.com/alice>, Bob <https://github.com/bob>`.
+- Ou se há muitas pessoas, pode ser em várias linhas:
   ```typescript
   // Definitions by: Alice <https://github.com/alice>
   //                 Bob <https://github.com/bob>
@@ -378,6 +381,7 @@ Isso é recorrentemente citado nesta [resposta do Stack Overflow](https://stacko
 
 É mais apropriado importar o módulo usando a sintaxe `import foo = require("foo");`.
 Mesmo assim, se você quer usar um import padrão como `import foo from "foo";`, você tem duas opções:
+
 - você pode usar a [opção de compilador `--allowSyntheticDefaultImports`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-1-8.html#support-for-default-import-interop-with-systemjs) se o seu módulo suporta, em tempo de execução, um esquema de interop para módulos não-ECMAScript, isto é, se os imports padrão funcionam no seu ambiente (por exemplo, Webpack, SystemJS, esm).
 - você pode usar a [opção de compilador `--esModuleInterop`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#support-for-import-d-from-cjs-form-commonjs-modules-with---esmoduleinterop) se você quiser que o TypeScript tome conta dos interop não-ECMAScript (desde o TypeScript 2.7).
 
@@ -393,7 +397,7 @@ Para um pacote npm, `export =` é o certo, se `node -p 'require("foo")'` funcion
 
 Então você vai precisar adicionar este comentário na última linha do seu cabeçalho de definição (depois de `// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped`): `// Minimum TypeScript Version: 3.3`.
 
-Entretanto, se o seu projeto precisa manter tipos que são compatíveis com o 3.1 e superior *ao mesmo tempo que* tipos que são compatíveis com o 3.0 ou inferior, você vai precisar usar a feature `typesVersions`, que está disponível no TypeScript 3.1 e superior.
+Entretanto, se o seu projeto precisa manter tipos que são compatíveis com o 3.1 e superior _ao mesmo tempo que_ tipos que são compatíveis com o 3.0 ou inferior, você vai precisar usar a feature `typesVersions`, que está disponível no TypeScript 3.1 e superior.
 Você pode achar uma explicação detalhada dessa feature na [documentação oficial do TypeScript](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-1.html#version-selection-with-typesversions).
 
 Aqui vai uma explicação curta pra te ajudar:
@@ -411,9 +415,10 @@ Aqui vai uma explicação curta pra te ajudar:
 ```
 
 2. Crie o sub-diretório mencionado no campo `typesVersions` dentro do seu diretório de tipos (`ts3.1/` neste exemplo)
-e adicione os tipos e testes específicos para a nova versão do TypeScript. Você não precisa do típico cabeçalho de definição nos arquivos do diretório `ts3.1/`.
+   e adicione os tipos e testes específicos para a nova versão do TypeScript. Você não precisa do típico cabeçalho de definição nos arquivos do diretório `ts3.1/`.
 
 3. Defina as opções `baseUrl` e `typeRoots` no `ts3.1/tsconfig.json` para os caminhos corretos. Eles devem ficar semelhantes a isto:
+
 ```json
 {
     "compilerOptions": {
@@ -457,11 +462,11 @@ Algumas vezes as versões de pacotes de declaração de tipo e as versões de pa
 Abaixo estão algumas razões do porquê, por causa do quanto elas incomodam os usuários de uma biblioteca.
 Apenas o último caso é tipicamente problemático.
 
-* Como notado acima, a versão do patch do pacote de declaração de tipo não está relacionada à versão do patch da biblioteca.
+- Como notado acima, a versão do patch do pacote de declaração de tipo não está relacionada à versão do patch da biblioteca.
   Isso permite que o Definitely Typed atualize as declarações de tipo de forma segura para a mesma versão "major"/"minor" de uma biblioteca.
-* Caso esteja atualizando um pacote para uma nova funcionalidade, não se esqueça de atualizar o número da versão para alinhá-lo com aquela versão da biblioteca.
+- Caso esteja atualizando um pacote para uma nova funcionalidade, não se esqueça de atualizar o número da versão para alinhá-lo com aquela versão da biblioteca.
   Caso os usuários tenham certeza de que versões correspondam entre os pacotes JavaScript e seus respectivos pacotes `@types`, então um `npm update` deve tipicamente funcionar.
-* É comum para atualizações de um pacote de declaração de tipos ficarem atrasadas em relação às atualizações da biblioteca, porque é mais comum que os usuários das bibliotecas, não os mantenedores, atualizem o Definitely Typed quando novas features da biblioteca são lançadas.
+- É comum para atualizações de um pacote de declaração de tipos ficarem atrasadas em relação às atualizações da biblioteca, porque é mais comum que os usuários das bibliotecas, não os mantenedores, atualizem o Definitely Typed quando novas features da biblioteca são lançadas.
   Então talvez haja um atraso de alguns dias, semanas ou até mesmo meses antes de um membro solidário da comunidade mandar uma PR para atualizar o pacote de declaração de tipos para uma nova release da biblioteca. Se você estiver comovido com isso, você pode ser a mudança que você quer ver no mundo, e você pode ser esse membro solidário da comunidade!
 
 :exclamation: Se você está atualizando as declarações de tipo para uma biblioteca, sempre defina a versão `major.minor` na primeira linha do `index.d.ts` correspondendo à versão da biblioteca que você está documentando! :exclamation:
@@ -492,8 +497,8 @@ No tempo de escrita, a [history v2 `tsconfig.json`](https://github.com/%44efinit
         "baseUrl": "../../",
         "typeRoots": ["../../"],
         "paths": {
-            "history": [ "history/v2" ]
-        },
+            "history": ["history/v2"]
+        }
     },
     "files": [
         "index.d.ts",
@@ -514,7 +519,7 @@ Provisoriamente, o `browser-sync-webpack-plugin` (que depende do `browser-sync`)
 
 O manual do TypeScript contém excelentes [informações gerais sobre criar definições](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html), e também [este arquivo de definição de exemplo](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/global-modifying-module-d-ts.html) que mostra como criar uma definição usando a sintaxe de módulo no estilo ES6, enquanto também especifica os objetos que tornaram-se disponíveis ao escopo global. Essa técnica é demonstrada de forma prática na [definição da `big.js`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/big.js/index.d.ts), que é uma biblioteca que pode ser carregada globalmente via tags de script numa página da web, ou importada via require ou via imports no estilo do ES6.
 
-Para testar como sua definição pode ser usada tanto quando referenciada globalmente quanto como um módulo importável, crie uma pasta `test`, e coloque dois arquivos de teste nela. Chame um de `NomeDaSuaBiblioteca-global.test.ts` e o outro de `NomeDaSuaBiblioteca-module.test.ts`. O arquivo de teste *global* deve exercer a definição de acordo com como ele seria usado num script carregado numa página da web onde a biblioteca está disponível no escopo global - nesse cenário você não deve especificar uma declaração de importação. O arquivo de teste *module* deve exercer a definição de acordo com como ele seria usado quando importado (incluindo a(s) definição(ões) de `import`). Se Você especificar uma propriedade `files` no seu arquivo `tsconfig.json`, tenha certeza de incluir ambos os arquivos de teste. Um [exemplo prático de como fazer isso](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/big.js/test) também está disponível na definição da `big.js`.
+Para testar como sua definição pode ser usada tanto quando referenciada globalmente quanto como um módulo importável, crie uma pasta `test`, e coloque dois arquivos de teste nela. Chame um de `NomeDaSuaBiblioteca-global.test.ts` e o outro de `NomeDaSuaBiblioteca-module.test.ts`. O arquivo de teste _global_ deve exercer a definição de acordo com como ele seria usado num script carregado numa página da web onde a biblioteca está disponível no escopo global - nesse cenário você não deve especificar uma declaração de importação. O arquivo de teste _module_ deve exercer a definição de acordo com como ele seria usado quando importado (incluindo a(s) definição(ões) de `import`). Se Você especificar uma propriedade `files` no seu arquivo `tsconfig.json`, tenha certeza de incluir ambos os arquivos de teste. Um [exemplo prático de como fazer isso](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/big.js/test) também está disponível na definição da `big.js`.
 
 Por favor note que isso não é obrigatório para exercer completamente a definição em cada arquivo de teste - é suficiente para testar apenas os elementos accessíveis globalmente no arquivo de teste global e exercer a definição no arquivo de teste do módulo, ou vice versa.
 
@@ -526,8 +531,8 @@ Quando `dts-gen` for usado para montar um pacote com escopo, a propriedade `path
 
 ```json
 {
-    "paths":{
-      "@foo/*": ["foo__*"]
+    "paths": {
+        "@foo/*": ["foo__*"]
     }
 }
 ```

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,10 +13,10 @@ _Вы также можете прочитать этот README на [англ�
 Этот раздел отслеживает состояние репозитория и процесс публикации.
 Это может быть полезно для участников, испытывающих любые проблемы с PR'ами и пакетами.
 
--   Самая последняя сборка [прошла проверку-типов/линтинг](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint) полностью: [![Статус сборки](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.DefinitelyTyped?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=1&branchName=master)
--   Все пакеты проходят проверку-типов/линтинг полностью на `typescript@next`: [![Build status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/Nightly%20dtslint)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=8)
--   Все пакеты [публикуются на npm](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher) в течении часа: [![Статус публикации](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.types-publisher-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=5&branchName=master)
--   [typescript-bot](https://github.com/typescript-bot) проявляет активность на Definitely Typed [![Статус активности](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.typescript-bot-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=6&branchName=master)
+- Самая последняя сборка [прошла проверку-типов/линтинг](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint) полностью: [![Статус сборки](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.DefinitelyTyped?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=1&branchName=master)
+- Все пакеты проходят проверку-типов/линтинг полностью на `typescript@next`: [![Build status](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/Nightly%20dtslint)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=8)
+- Все пакеты [публикуются на npm](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher) в течении часа: [![Статус публикации](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.types-publisher-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=5&branchName=master)
+- [typescript-bot](https://github.com/typescript-bot) проявляет активность на Definitely Typed [![Статус активности](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.typescript-bot-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=6&branchName=master)
 
 Если что-то здесь кажется неправильным или что-либо из вышеперечисленного не работает, пожалуйста, поднимите проблему на [канале DefiniteTyped Discord](https://discord.gg/typescript).
 
@@ -71,9 +71,9 @@ npm install --save-dev @types/node
 
 ### TypeScript 1.8 и старше
 
--   [Typings](https://github.com/typings/typings)
--   ~~[NuGet](https://nuget.org/packages?q=DefinitelyTyped)~~ (используйте предпочтительные альтернативы, публикация типа nuget DT отключена)
--   Вручную загрузите из ветки `master` этого репозитория
+- [Typings](https://github.com/typings/typings)
+- ~~[NuGet](https://nuget.org/packages?q=DefinitelyTyped)~~ (используйте предпочтительные альтернативы, публикация типа nuget DT отключена)
+- Вручную загрузите из ветки `master` этого репозитория
 
 Возможно, вам придется добавить ручные [ссылки (references)](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html).
 
@@ -117,23 +117,23 @@ Definitely Typed работает только благодаря вкладу �
 
 #### Изменение существующего пакета
 
--   `cd types/<package to edit>`
--   Внесите изменения. [Не забудьте отредактировать тесты](#my-package-teststs).
-    Если вы вносите критические изменения, не забудьте [обновить основную версию](#я-хочу-обновить-пакет-новой-старшей-версии).
--   Вы также можете добавить себя в раздел "Definitions by" заголовка пакета.
+- `cd types/<package to edit>`
+- Внесите изменения. [Не забудьте отредактировать тесты](#my-package-teststs).
+  Если вы вносите критические изменения, не забудьте [обновить основную версию](#я-хочу-обновить-пакет-новой-старшей-версии).
+- Вы также можете добавить себя в раздел "Definitions by" заголовка пакета.
 
-    -   Это приведет к тому, что вы будете уведомлены (через ваше имя пользователя GitHub) о том, что кто-то делает запрос на принятие изменений (PR) или проблему с пакетом.
-    -   Сделайте это, добавив свое имя в конец строки, например `// Definitions by: Alice <https://github.com/alice>, Bob <https://github.com/bob>`.
-    -   Или, если есть больше людей, это может быть многострочным
+  - Это приведет к тому, что вы будете уведомлены (через ваше имя пользователя GitHub) о том, что кто-то делает запрос на принятие изменений (PR) или проблему с пакетом.
+  - Сделайте это, добавив свое имя в конец строки, например `// Definitions by: Alice <https://github.com/alice>, Bob <https://github.com/bob>`.
+  - Или, если есть больше людей, это может быть многострочным
 
-    ```typescript
-    // Definitions by: Alice <https://github.com/alice>
-    //                 Bob <https://github.com/bob>
-    //                 Steve <https://github.com/steve>
-    //                 John <https://github.com/john>
-    ```
+  ```typescript
+  // Definitions by: Alice <https://github.com/alice>
+  //                 Bob <https://github.com/bob>
+  //                 Steve <https://github.com/steve>
+  //                 John <https://github.com/john>
+  ```
 
--   [Запустите `npm test <package to test>`](#проверка).
+- [Запустите `npm test <package to test>`](#проверка).
 
 Когда вы создаете PR для редактирования существующего пакета, `dt-bot` должен @-уведомить
 предыдущих авторов. Если этого не произойдет, вы можете сделать это самостоятельно в комментарии, связанном с PR.
@@ -148,11 +148,11 @@ Definitely Typed работает только благодаря вкладу �
 
 Ваш пакет должен иметь такую ​​структуру:
 
-| Файл          | Назначение                                                                                           |
-| ------------- | ---------------------------------------------------------------------------------------------------- |
-| `index.d.ts`  | Содержит типизацию для пакета.                                                                       |
-| [`<my-package>-tests.ts`](#my-package-teststs)  | Содержит пример кода, который проверяет типизацию. Этот код _не_ запускается, но он проверен на тип. |
-| [`tsconfig.json`](#tsconfigjson) | Позволяет вам запускать `tsc` внутри пакета.                                      |
+| Файл                                           | Назначение                                                                                           |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `index.d.ts`                                   | Содержит типизацию для пакета.                                                                       |
+| [`<my-package>-tests.ts`](#my-package-teststs) | Содержит пример кода, который проверяет типизацию. Этот код _не_ запускается, но он проверен на тип. |
+| [`tsconfig.json`](#tsconfigjson)               | Позволяет вам запускать `tsc` внутри пакета.                                                         |
 
 Создайте их, запустив `npx dts-gen --dt --name <my-package> --template module` если у вас npm ≥ 5.2.0, `npm install -g dts-gen` и `dts-gen --dt --name <my-package> --template module` в противном случае.
 Посмотреть все варианты на [dts-gen](https://github.com/Microsoft/dts-gen).
@@ -167,9 +167,9 @@ Definitely Typed работает только благодаря вкладу �
 
 Вы можете удалить его, запустив `pnpm run not-needed -- <typingsPackageName> <asOfVersion> [<libraryName>]`.
 
--   `<typingsPackageName>`: название директории, который нужно удалить.
--   `<asOfVersion>`: заглушка будет опубликована в `@types/<typingsPackageName>` с этой версией. Должна быть выше, чем любая опубликованная на данный момент версия
--   `<libraryName>`: описательное имя библиотеки, например, "Angular 2" вместо "angular2". (Если опущено, будет идентично `<typingsPackageName>`.)
+- `<typingsPackageName>`: название директории, который нужно удалить.
+- `<asOfVersion>`: заглушка будет опубликована в `@types/<typingsPackageName>` с этой версией. Должна быть выше, чем любая опубликованная на данный момент версия
+- `<libraryName>`: описательное имя библиотеки, например, "Angular 2" вместо "angular2". (Если опущено, будет идентично `<typingsPackageName>`.)
 
 Любые другие пакеты в Definitely Typed которые ссылаются на удаленный пакет, должны быть обновлены для ссылки на связанные типы. Для этого добавьте в [`package.json`](#packagejson) ссыклу `"dependencies": { "<libraryName>": "x.y.z" }`.
 
@@ -233,7 +233,7 @@ You can [validate your changes](#проверка) with `npm test <package to te
 f(1);
 
 // @ts-expect-error
-f('one');
+f("one");
 ```
 
 Для получения дополнительной информации см. [dtslint](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint#write-tests) readme.
@@ -244,8 +244,12 @@ If for some reason a lint rule needs to be disabled, disable it for a specific l
 
 ```ts
 // eslint-disable-next-line no-const-enum
-const enum Const { One }
-const enum Enum { Two } // eslint-disable-line no-const-enum
+const enum Const {
+    One,
+}
+const enum Enum { // eslint-disable-line no-const-enum
+    Two,
+}
 ```
 
 You can still disable rules with an .eslintrc.json, but should not in new packages.
@@ -270,21 +274,21 @@ If a file is neither tested nor referenced in `index.d.ts`, add it to a file nam
 
 #### Распространенные ошибки
 
-* Сначала следуйте советам из справочника [handbook](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html).
-* Форматирование: либо используйте все табы, либо всегда используйте 4 пробела.
-* `function sum(nums: number[]): number`: используйте `ReadonlyArray` если функция не записывает свои параметры.
-* `interface Foo { new(): Foo; }`:
+- Сначала следуйте советам из справочника [handbook](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html).
+- Форматирование: либо используйте все табы, либо всегда используйте 4 пробела.
+- `function sum(nums: number[]): number`: используйте `ReadonlyArray` если функция не записывает свои параметры.
+- `interface Foo { new(): Foo; }`:
   Это определяет тип объектов, с методом `new`. Вы, вероятно, хотите объявить `declare class Foo { constructor(); }`.
-* `const Class: { new(): IClass; }`:
+- `const Class: { new(): IClass; }`:
   Предпочитайте использовать объявление класса `class Class { constructor(); }` вместо `new`.
-* `getMeAT<T>(): T`:
+- `getMeAT<T>(): T`:
   Если параметр типа не отображается в типах каких-либо параметров, у вас нет универсальной функции, а просто замаскированное утверждение типа.
   Предпочитайте использовать утверждение реального типа, например, `getMeAT() as number`.
   Пример, где допустим параметр типа: `function id<T>(value: T): T;`.
   Пример, где это недопустимо: `function parseJson<T>(json: string): T;`.
   Исключение: `new Map<string, number>()` все ОК.
-* Использование типов `Function` and `Object` почти никогда не является хорошей идеей. В 99% случаев можно указать более конкретный тип. Примеры: `(x: number) => number` для [функций](https://www.typescriptlang.org/docs/handbook/functions.html#function-types) and `{ x: number, y: number }` для объектов. Если нет никакой уверенности в типе, [`any`](https://www.typescriptlang.org/docs/handbook/basic-types.html#any) является правильным выбором, а не `Object`. Если единственным известным фактом о типе является то, что это какой-то объект, используйте тип [`object`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type), а не `Object` или `{ [key: string]: any }`.
-* `var foo: string | any`:
+- Использование типов `Function` and `Object` почти никогда не является хорошей идеей. В 99% случаев можно указать более конкретный тип. Примеры: `(x: number) => number` для [функций](https://www.typescriptlang.org/docs/handbook/functions.html#function-types) and `{ x: number, y: number }` для объектов. Если нет никакой уверенности в типе, [`any`](https://www.typescriptlang.org/docs/handbook/basic-types.html#any) является правильным выбором, а не `Object`. Если единственным известным фактом о типе является то, что это какой-то объект, используйте тип [`object`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type), а не `Object` или `{ [key: string]: any }`.
+- `var foo: string | any`:
   когда `any` используется в типе объединения, результирующий тип все еще `any`. Таким образом, хотя `string` часть аннотации этого типа может _выглядеть_ полезной, на самом деле она не предлагает никакой дополнительной проверки типов по сравнению с простым использованием `any`.
   В зависимости от намерения, приемлемыми альтернативами могут быть `any`, `string`, или `string | object`.
 
@@ -292,14 +296,14 @@ If a file is neither tested nor referenced in `index.d.ts`, add it to a file nam
 
 DT has the concept of "Definition Owners" which are people who want to maintain the quality of a particular module's types
 
-* Adding yourself to the list will cause you to be notified (via your GitHub username) whenever someone makes a pull request or issue about the package.
-* Your PR reviews will have a higher precedence of importance to [the bot](https://github.com/DefinitelyTyped/dt-mergebot) which maintains this repo.
-* The DT maintainers are putting trust in the definition owners to ensure a stable eco-system, please don't add yourself lightly.
+- Adding yourself to the list will cause you to be notified (via your GitHub username) whenever someone makes a pull request or issue about the package.
+- Your PR reviews will have a higher precedence of importance to [the bot](https://github.com/DefinitelyTyped/dt-mergebot) which maintains this repo.
+- The DT maintainers are putting trust in the definition owners to ensure a stable eco-system, please don't add yourself lightly.
 
 To Add yourself as a Definition Owner:
 
-* Adding your name to the end of the line, as in `// Definitions by: Alice <https://github.com/alice>, Bob <https://github.com/bob>`.
-* Or if there are more people, it can be multiline
+- Adding your name to the end of the line, as in `// Definitions by: Alice <https://github.com/alice>, Bob <https://github.com/bob>`.
+- Or if there are more people, it can be multiline
   ```typescript
   // Definitions by: Alice <https://github.com/alice>
   //                 Bob <https://github.com/bob>

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -1,10 +1,10 @@
 # Definitely Typed
 
-> 提供*高质量* TypeScript 类型定义的仓库。
+> 提供_高质量_ TypeScript 类型定义的仓库。
 
-*你也可以阅读此 README 文件的[英语](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md)、[西班牙语](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.es.md)、[韩语](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ko.md)、[俄罗斯语](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ru.md)、[葡萄牙语](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.pt.md)、[意大利语](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.it.md)或[日语](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ja.md)版本！*
+_你也可以阅读此 README 文件的[英语](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md)、[西班牙语](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.es.md)、[韩语](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ko.md)、[俄罗斯语](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ru.md)、[葡萄牙语](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.pt.md)、[意大利语](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.it.md)或[日语](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.ja.md)版本！_
 
-*[管理员手册](./docs/admin.md)*
+_[管理员手册](./docs/admin.md)_
 
 ## ！！！重要提示！此仓库最近已更改布局！！！！
 
@@ -16,11 +16,11 @@ Definitely Typed 最近已转为正确的 `pnpm` monorepo(包含多项目或模�
 
 此章节跟踪了当前仓库及发布流程的健康状况。如果贡献者的 PR 和软件包遇到任何问题，此处的内容可能有帮助。
 
-* 最新构建全部通过[类型检查/Lint](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint)：[![构建状态](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.DefinitelyTyped?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=1&branchName=master)
-* 所有软件包在 typescript@next 版本中全部通过类型检查/Lint：[![构建状态](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/Nightly%20dtslint)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=8)
-* 所有软件包都在一个半小时内[发布至 npm](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher): [![发布状态](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.types-publisher-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=5&branchName=master)
-* [typescript-bot](https://github.com/typescript-bot) 在 Definitely Typed 上处于活动状态：[![活动状态](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.typescript-bot-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=6&branchName=master)
-* [基础设施更新现状](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/44317)
+- 最新构建全部通过[类型检查/Lint](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint)：[![构建状态](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.DefinitelyTyped?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=1&branchName=master)
+- 所有软件包在 typescript@next 版本中全部通过类型检查/Lint：[![构建状态](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/Nightly%20dtslint)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=8)
+- 所有软件包都在一个半小时内[发布至 npm](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher): [![发布状态](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.types-publisher-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=5&branchName=master)
+- [typescript-bot](https://github.com/typescript-bot) 在 Definitely Typed 上处于活动状态：[![活动状态](https://dev.azure.com/definitelytyped/DefinitelyTyped/_apis/build/status/DefinitelyTyped.typescript-bot-watchdog?branchName=master)](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/latest?definitionId=6&branchName=master)
+- [基础设施更新现状](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/44317)
 
 如果此处有任何错误或上述任何操作失败，请在 [TypeScript 社群 Discord 服务器中的 Definitely Typed 频道](https://discord.gg/typescript)提出。
 
@@ -47,7 +47,7 @@ npm install --save-dev @types/node
 
 例如，若 npm 软件包名为“foo”，其类型声明的包名应为“@types/foo”。
 
-如果你的软件包使用 ``package.json`` 中的 ``types`` 或 ``typings`` 关键字指定了类型，那么 npm 注册表就会像这样显示该软件包有可用的绑定：
+如果你的软件包使用 `package.json` 中的 `types` 或 `typings` 关键字指定了类型，那么 npm 注册表就会像这样显示该软件包有可用的绑定：
 
 ![image](https://user-images.githubusercontent.com/30049719/228748963-56fabfd1-9101-42c2-9891-b586b775b01e.png)
 
@@ -78,9 +78,9 @@ Definitely Typed 仅在发布时间小于 2 年的 TypeScript 版本上测试软
 
 #### TypeScript 1.*
 
-* 从本仓库的 `master` 分支手动下载并将其放入你的项目中；
-* ~~[Typings](https://github.com/typings/typings)；~~ (请使用首选替代方案，typings 已经被弃用)
-* ~~[NuGet](https://nuget.org/packages?q=DefinitelyTyped)。~~ (请使用首选替代方案，NuGet DT 类型发布已关闭)
+- 从本仓库的 `master` 分支手动下载并将其放入你的项目中；
+- ~~[Typings](https://github.com/typings/typings)；~~ (请使用首选替代方案，typings 已经被弃用)
+- ~~[NuGet](https://nuget.org/packages?q=DefinitelyTyped)。~~ (请使用首选替代方案，NuGet DT 类型发布已关闭)
 
 你可能需要手动添加[引用](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html)。
 
@@ -96,8 +96,8 @@ Definitely Typed 因来自阁下及众多用户的贡献而发光发热！
 
 ```ts
 declare module "libname" {
-  // 类型放置于此处
-  export function helloWorldMessage(): string
+    // 类型放置于此处
+    export function helloWorldMessage(): string;
 }
 ```
 
@@ -132,7 +132,6 @@ declare module "libname" {
 如果你只想安装部分内容，可以运行 `pnpm install -w --filter "{./types/foo}..."` 以安装 `@types/foo` 及其所有依赖项。
 如果你需要运行依赖于 `@types/foo` 的包的测试，可以运行 `pnpm install -w --filter "...{./types/foo}..."` 来引入所有相关的测试包。
 
-
 > [!NOTE]
 > 如果你使用的是 Windows，你可能会发现 `git clean` 不会移除 `node_modules` 目录，或者在尝试移除时挂起。如果你需要移除 `node_modules`，你可以运行 `pnpm clean-node-modules` 来重置仓库。
 
@@ -149,21 +148,21 @@ declare module "libname" {
 
 你可以使用 git 的 [`sparse-checkout`](https://git-scm.com/docs/git-sparse-checkout)，[`--filter`](https://git-scm.com/docs/git-rev-list#Documentation/git-rev-list.txt---filterltfilter-specgt)，和 [`--depth`](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthltdepthgt) 功能。这样，仓库克隆只会包含相关的类型软件包，更便于管理、减少了克隆时间且提高了 git 的性能。
 
->:warning: 该特性需要 [git 版本 2.27.0 或更高](https://git-scm.com/downloads)，而大多数设备上的默认版本通常要低于此。旧版本的 git 可以通过更复杂的流程实现类似功能，但本文不涉及。
+> :warning: 该特性需要 [git 版本 2.27.0 或更高](https://git-scm.com/downloads)，而大多数设备上的默认版本通常要低于此。旧版本的 git 可以通过更复杂的流程实现类似功能，但本文不涉及。
 
 1. `git clone --sparse --filter=blob:none --depth=1 <forkedUrl>`
-    - `--sparse` 将初始化 sparse-checkout 文件，首次克隆的只有仓库根目录的文件。
-    - `--filter=blob:none` 将排除文件，只在需要时获取它们。
-    - `--depth=1` 可以通过截断提交历史来进一步提高克隆速度，不过它可能会导致一些问题，详情请见[此链接](https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/)。
+   - `--sparse` 将初始化 sparse-checkout 文件，首次克隆的只有仓库根目录的文件。
+   - `--filter=blob:none` 将排除文件，只在需要时获取它们。
+   - `--depth=1` 可以通过截断提交历史来进一步提高克隆速度，不过它可能会导致一些问题，详情请见[此链接](https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/)。
 2. `git sparse-checkout add types/<type> types/<dependency-type> ...`
 
 </details>
 
 #### 编辑现有软件包
 
-* 作出修改之后，[请记得编辑测试](#my-package-teststs)。
+- 作出修改之后，[请记得编辑测试](#my-package-teststs)。
   如果你作出了破坏性更改，请不要忘记[更新主版本](#如果一个软件包做了重大的修改而更新了主版本我应该如何更新它的类型声明包)。
-* [运行 `pnpm test <package to test>`](#运行测试)。
+- [运行 `pnpm test <package to test>`](#运行测试)。
 
 当你对现有的软件包发起 PR 的时候，`dt-bot` 应该会通知先前的作者。
 如果没有，你可在与 PR 关联的评论中手动 @ 作者。
@@ -178,15 +177,14 @@ declare module "libname" {
 
 你的软件包应该具有这样的结构：
 
-| 文件名 | 目的 |
-| --- | --- |
-| `index.d.ts` | 此文件包含软件包的类型声明。 |
+| 文件名                                         | 目的                                                                     |
+| ---------------------------------------------- | ------------------------------------------------------------------------ |
+| `index.d.ts`                                   | 此文件包含软件包的类型声明。                                             |
 | [`<my-package>-tests.ts`](#my-package-teststs) | 此文件包含测试类型声明的示例代码，其**不会**运行，但是它会通过类型检查。 |
-| [`tsconfig.json`](#tsconfigjson) | 此文件允许你在软件包中运行 `tsc`。 |
-| [`.eslintrc.json`](#linter-eslintrcjson)   | （极少使用）仅在需要禁用 ESLint 规则时使用。 |
-| [`package.json`](#packagejson) | 包含该包的元数据(metadata)，包括其名称、版本和依赖关系。       |
-| [`.npmignore`](#npmignore)    | 指定哪些文件应包含在包中。                  |
-
+| [`tsconfig.json`](#tsconfigjson)               | 此文件允许你在软件包中运行 `tsc`。                                       |
+| [`.eslintrc.json`](#linter-eslintrcjson)       | （极少使用）仅在需要禁用 ESLint 规则时使用。                             |
+| [`package.json`](#packagejson)                 | 包含该包的元数据(metadata)，包括其名称、版本和依赖关系。                 |
+| [`.npmignore`](#npmignore)                     | 指定哪些文件应包含在包中。                                               |
 
 通过运行 `npx dts-gen --dt --name <my-package> --template module` 来生成这些文件。
 可以在 [dts-gen](https://github.com/Microsoft/dts-gen) 查看所有的选项。
@@ -202,9 +200,10 @@ Definitely Typed 的成员会定期查看新的 PR，但是请留意，当 PR �
 当一个软件包[捆绑](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html)了自己的类型时，应该从 Definitely Typed 中删除相应的类型以避免混淆。
 
 你可以运行以下命令来删除它： `pnpm run not-needed -- <typingsPackageName> <asOfVersion> [<libraryName>]`。
-* `<typingsPackageName>`：这是你要删除的目录名字。
-* `<asOfVersion>`：一个含有废弃信息的软件包的新版本将会发布到 `@types/<typingsPackageName>`。此选项指定新版本的版本号，其应该高于当前发布的任何版本，并且应该是 npm 上的 `<libraryName>` 版本。
-* `<libraryName>`：替换 Definitely Typed 中类型的 npm 的包名。与 `<typingsPackageName>` 相同时可省略此项。
+
+- `<typingsPackageName>`：这是你要删除的目录名字。
+- `<asOfVersion>`：一个含有废弃信息的软件包的新版本将会发布到 `@types/<typingsPackageName>`。此选项指定新版本的版本号，其应该高于当前发布的任何版本，并且应该是 npm 上的 `<libraryName>` 版本。
+- `<libraryName>`：替换 Definitely Typed 中类型的 npm 的包名。与 `<typingsPackageName>` 相同时可省略此项。
 
 如果这个软件包从未发布到 Definitely Typed 过，则不需要将其添加到 `notNeededPackages.json`。
 
@@ -278,8 +277,12 @@ f("one");
 
 ```ts
 // eslint-disable-next-line no-const-enum
-const enum Const { One }
-const enum Enum { Two } // eslint-disable-line no-const-enum
+const enum Const {
+    One,
+}
+const enum Enum { // eslint-disable-line no-const-enum
+    Two,
+}
 ```
 
 你仍可以在 `.eslintrc.json` 中禁用规则，但在新增软件包中不应这么做。
@@ -360,7 +363,6 @@ const enum Enum { Two } // eslint-disable-line no-const-enum
 
 如果软件包在 `package.json` 中包含了 `export` 导出，这么做仍旧适用。
 
-
 #### `.npmignore`
 
 此文件定义了应该包含在每个 `@types` 包中的文件。它必须采用特定的形式。对于仓库中只有一个版本的包：
@@ -392,23 +394,23 @@ const enum Enum { Two } // eslint-disable-line no-const-enum
 
 #### 常见错误
 
-* 首先，请遵循[手册](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)的建议。
-* 格式化：此仓库已设置 [dprint](https://dprint.dev)，因此你可以运行 `pnpm dprint fmt -- 'path/to/package/**/*.ts'`。
-  * 考虑使用 VS Code 的 `.vscode/settings.template.json`（或其他编辑器的等效文件），通过 [VS Code dprint 扩展](https://marketplace.visualstudio.com/items?itemName=dprint.dprint) 在保存时进行格式化。
-* `function sum(nums: number[]): number`: 如果函数没有修改传入的参数，请使用 `ReadonlyArray`。
-* `interface Foo { new(): Foo; }`:
+- 首先，请遵循[手册](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html)的建议。
+- 格式化：此仓库已设置 [dprint](https://dprint.dev)，因此你可以运行 `pnpm dprint fmt -- 'path/to/package/**/*.ts'`。
+  - 考虑使用 VS Code 的 `.vscode/settings.template.json`（或其他编辑器的等效文件），通过 [VS Code dprint 扩展](https://marketplace.visualstudio.com/items?itemName=dprint.dprint) 在保存时进行格式化。
+- `function sum(nums: number[]): number`: 如果函数没有修改传入的参数，请使用 `ReadonlyArray`。
+- `interface Foo { new(): Foo; }`:
   以上代码定义了一个可以实例化的接口（对象），你可能想要的是 `declare class Foo { constructor(); }`。
-* `const Class: { new(): IClass; }`:
+- `const Class: { new(): IClass; }`:
   更推荐使用类声明 `class Class { constructor(); }`，而不是可实例化的常量。
-* `getMeAT<T>(): T`:
+- `getMeAT<T>(): T`:
   如果类型参数没有在函数的参数列表中出现，那么其仅仅是变相的类型断言。
   这种情况下，并不需要使用泛型，建议你使用真正的类型断言，类似这样：`getMeAT() as number`。
   可接受的类型参数示例：`function id<T>(value: T): T;`。
   不可接受的类型参数示例：`function parseJson<T>(json: string): T;`。
   例外：`new Map<string, number>()` 是可以接受的。
-* 使用 `Function` 和 `Object` 类型基本上属于下下策。在 99% 的情况下，你都可以将其替换为更精确的类型。例如，如果使用 `(x: number) => number` 表示 [函数(Function)](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-type-expressions)；使用 `{ x: number, y: number }` 表示 `Object`。对于完全无法确定的类型，应使用 [`any`](https://www.typescriptlang.org/docs/handbook/basic-types.html#any) 而不是 `Object`。如果仅知道某个类型为某种对象，请使用 [`object`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type)，而不是 `Object` 或 `{ [key: string]: any }`。
-* `var foo: string | any`:
- 在联合类型中使用 `any` 将导致最终结果始终为 `any`。因此，即便类型中的 `string` 部分*看起来*很有用，但实际上在类型检查方面与 `any` 并无区别。根据你的实际目的，请考虑选择 `any`、`string`，或 `string | object`。
+- 使用 `Function` 和 `Object` 类型基本上属于下下策。在 99% 的情况下，你都可以将其替换为更精确的类型。例如，如果使用 `(x: number) => number` 表示 [函数(Function)](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-type-expressions)；使用 `{ x: number, y: number }` 表示 `Object`。对于完全无法确定的类型，应使用 [`any`](https://www.typescriptlang.org/docs/handbook/basic-types.html#any) 而不是 `Object`。如果仅知道某个类型为某种对象，请使用 [`object`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type)，而不是 `Object` 或 `{ [key: string]: any }`。
+- `var foo: string | any`:
+  在联合类型中使用 `any` 将导致最终结果始终为 `any`。因此，即便类型中的 `string` 部分*看起来*很有用，但实际上在类型检查方面与 `any` 并无区别。根据你的实际目的，请考虑选择 `any`、`string`，或 `string | object`。
 
 ### 类型定义所有者
 
@@ -416,9 +418,9 @@ const enum Enum { Two } // eslint-disable-line no-const-enum
 
 Definitely Typed 有“类型定义所有者”的概念——即愿意维护特定模块类型声明的人。
 
-* 如果你将自己添加到了列表中，当他人发起关于此软件包的 PR 或 issue 时，你将会收到通知（通过你的 GitHub 用户名）。
-* 对于维护本仓库的[机器人](https://github.com/DefinitelyTyped/dt-mergebot)而言，你的 PR 审核将会具有更高优先级以及重要性。
-* 为维护稳定的社区环境，DT 维护者对类型定义所有者给予了较高的信任，因此将你自己添加为所有者时，请三思而后行。
+- 如果你将自己添加到了列表中，当他人发起关于此软件包的 PR 或 issue 时，你将会收到通知（通过你的 GitHub 用户名）。
+- 对于维护本仓库的[机器人](https://github.com/DefinitelyTyped/dt-mergebot)而言，你的 PR 审核将会具有更高优先级以及重要性。
+- 为维护稳定的社区环境，DT 维护者对类型定义所有者给予了较高的信任，因此将你自己添加为所有者时，请三思而后行。
 
 若要将你自己添加为类型定义所有者，编辑 `package.json` 中的 `owners` 数组：
 
@@ -494,7 +496,7 @@ npm 软件包应该会在几分钟内更新。如果已经超过了一小时，�
 
 #### DOM 的类型定义应该包含于此吗？
 
-如果类型是 Web 标准的一部分，它们应该贡献给  [TypeScript-DOM-lib-generator](https://github.com/Microsoft/TypeScript-DOM-lib-generator)，以便其成为默认 `lib.dom.d.ts` 的一部分。
+如果类型是 Web 标准的一部分，它们应该贡献给 [TypeScript-DOM-lib-generator](https://github.com/Microsoft/TypeScript-DOM-lib-generator)，以便其成为默认 `lib.dom.d.ts` 的一部分。
 
 #### 没有匹配软件包的类型定义怎么办?
 
@@ -504,8 +506,7 @@ npm 软件包应该会在几分钟内更新。如果已经超过了一小时，�
 当 `foo` 未安装时，也不要指望写出 `import type { ... } from "foo"`。
 
 这不同于为浏览器专用 Javascript 库提供类型，也不同于为整个环境（如 node、bun 等）提供类型。
-在那种情况下，要么隐式地解析类型，要么使用  `/// <references types="foo" />` 来解析。
-
+在那种情况下，要么隐式地解析类型，要么使用 `/// <references types="foo" />` 来解析。
 
 #### 如果一个软件包导出的不是模块对象，为了能使用 ES6 风格的导入语法，我应该向软件包中添加一个空命名空间吗？
 
@@ -519,6 +520,7 @@ npm 软件包应该会在几分钟内更新。如果已经超过了一小时，�
 
 使用 `import foo = require("foo");` 语法导入模块更合适。
 但如果你欲使用如 `import foo from "foo";` 这样的默认导入，有两个选择：
+
 - 你可以使用 [`--allowSyntheticDefaultImports` 编译器选项](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-1-8.html#support-for-default-import-interop-with-systemjs) ，如果你的模块运行时环境支持与非 ECMAScript 模块的互操作，即默认导入在你的环境中能正常工作（例如 Webpack、SystemJS、esm）。
 - 你可以使用 [`--esModuleInterop` 编译器选项](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#support-for-import-d-from-cjs-form-commonjs-modules-with---esmoduleinterop)，如果你想使用 TypeScript 处理非 ECMAScript 模块的互操作（自 TypeScript 2.7 版本开始）。
 
@@ -542,15 +544,15 @@ npm 软件包应该会在几分钟内更新。如果已经超过了一小时，�
 
 1. 你需要在 `package.json` 中添加 `typesVersions`：
 
-    ```json
-    {
-        "private": true,
-        "types": "index",
-        "typesVersions": {
-            "<=3.6": { "*": ["ts3.6/*"] }
-        }
-    }
-    ```
+   ```json
+   {
+       "private": true,
+       "types": "index",
+       "typesVersions": {
+           "<=3.6": { "*": ["ts3.6/*"] }
+       }
+   }
+   ```
 
 2. 在你的类型目录中创建在 `typesVersions` 字段中提到的子目录（在本例中为 `ts3.6/`），其中包含支持 TypeScript 3.6 及以下版本的类型声明。接着，请复制现有的类型声明和测试文件至该目录。
 
@@ -570,7 +572,7 @@ npm 软件包应该会在几分钟内更新。如果已经超过了一小时，�
 
 #### Definitely Typed 软件包的版本好与相应库的版本号有什么关系？
 
-*注意：本节中的讨论假定你熟悉[语义化版本（Semantic Versioning）](https://semver.org/lang/zh-CN/)*
+_注意：本节中的讨论假定你熟悉[语义化版本（Semantic Versioning）](https://semver.org/lang/zh-CN/)_
 
 每个 Definitely Typed 软件包在发布到 npm 时都会标注版本。
 [DefinitelyTyped-tools](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher) (将 `@types` 软件包发布到 npm 的工具) 将使用在 `package.json` 中列出的 `major.minor.9999` 版本号来设置声明包的版本。
@@ -580,7 +582,7 @@ npm 软件包应该会在几分钟内更新。如果已经超过了一小时，�
 {
     "private": true,
     "name": "@types/node",
-    "version": "20.8.9999",
+    "version": "20.8.9999"
 }
 ```
 
@@ -593,9 +595,9 @@ npm 软件包应该会在几分钟内更新。如果已经超过了一小时，�
 以下是一些常见的原因，按照给库的用户带来不便的程度排序。
 只有最后一种情况通常是有问题的。
 
-* 如上所示，类型定义包的补丁版本与库包的补丁版本是无关的。这允许 Definitely Typed 安全地更新同一主/次版本的类型声明。
-* 如果要更新类型声明包以获取新功能，请务必更新版本号以与该版本的库保持一致。如果用户能确保 JavaScript 软件包与其各自的 `@types` 软件包之间的版本一一对应，那么 `npm update` 通常就可以正常使用。
-* 类型声明包的更新滞后于库的更新是很常见的，这通常是因为当库的新功能发布时，通常是库的用户来更新 Definitely Typed，而不是维护者。因此，在愿意帮忙的社区成员发送 PR 以更新库的新版本对应的类型声明包之前，可能会有几天、几周甚至几个月的滞后。如果你深受此影响，你不妨亲自动手作出喜闻乐见的贡献，成为乐于助人的社区成员！
+- 如上所示，类型定义包的补丁版本与库包的补丁版本是无关的。这允许 Definitely Typed 安全地更新同一主/次版本的类型声明。
+- 如果要更新类型声明包以获取新功能，请务必更新版本号以与该版本的库保持一致。如果用户能确保 JavaScript 软件包与其各自的 `@types` 软件包之间的版本一一对应，那么 `npm update` 通常就可以正常使用。
+- 类型声明包的更新滞后于库的更新是很常见的，这通常是因为当库的新功能发布时，通常是库的用户来更新 Definitely Typed，而不是维护者。因此，在愿意帮忙的社区成员发送 PR 以更新库的新版本对应的类型声明包之前，可能会有几天、几周甚至几个月的滞后。如果你深受此影响，你不妨亲自动手作出喜闻乐见的贡献，成为乐于助人的社区成员！
 
 :exclamation: 如果你想更新库的类型声明，请记住始终要在 `index.d.ts` 文件的第一行设置 `major.minor` 的版本号以匹配你正在描述的库版本！ :exclamation:
 
@@ -618,7 +620,7 @@ npm 软件包应该会在几分钟内更新。如果已经超过了一小时，�
 {
     "private": true,
     "name": "@types/history",
-    "version": "2.4.9999",
+    "version": "2.4.9999"
 }
 ```
 

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -15,7 +15,6 @@ of how well the changes fit the rest of the type definitions and if it could bre
 With the impact understood, your job is to delegate to the people who actually know how to review the code: users
 of the library who have agreed to look after the types.
 
-
 ### Looking at a PR
 
 For a [quick TLDR overview, you can read these slides](https://docs.google.com/presentation/d/1Q4xfZSY7d9yHhtxSyb-DE85fTXB38RyF3nnyVyvenwc/edit#slide=id.p).
@@ -25,7 +24,6 @@ Some key concepts:
 - Popular packages can break more installs, and will need more time and focus
 - There are a handful of authors who have shipped a lot of high-quality contributions who you can happily delegate to
 
-
 ##### Project board columns
 
 - `Needs Maintainer Action`: PRs that cannot be dismissed with a blessing
@@ -34,28 +32,27 @@ Some key concepts:
 - `Waiting for Author to Merge`: All good, and the owner can self-merge their PR
 - `Needs Author Action`, `Recently Merged`, `Waiting for Code Reviews`: Self describing
 
-
 ##### "Blessing" a PR
 
 You can control the life-cycle of PRs via "blessings", which are implicit operations done without providing a review that can be misinterpreted as an expert review.
 
 > TL;DR:
-> * To dismiss a PR in "Needs Maintainer Review", move it to "Waiting for Code Reviews".
-> * To dismiss a PR in "Needs Maintainer Action", move it to "Waiting for Author to Merge".
-> * To undo either of these, move them to any other column.
+>
+> - To dismiss a PR in "Needs Maintainer Review", move it to "Waiting for Code Reviews".
+> - To dismiss a PR in "Needs Maintainer Action", move it to "Waiting for Author to Merge".
+> - To undo either of these, move them to any other column.
 
-* If a PR requires a *maintainer review*, you can fulfill this requirement by a "review-blessing": you do that by moving the PR to the `Waiting for Code Reviews` column (using the drop-down in the "Projects" section on the right).
+- If a PR requires a _maintainer review_, you can fulfill this requirement by a "review-blessing": you do that by moving the PR to the `Waiting for Code Reviews` column (using the drop-down in the "Projects" section on the right).
   This is especially relevant in cases where a maintainer review is needed because of a technical requirement like no tests, suspicious config edits etc.: in such cases you can review-bless the PR in case the config edit is fine, the change is small or doesn't modify types etc.
   Note that it only dismisses the maintainer review requirement, so the PR will continue the usual flow, and will wait for approvals as needed.
 
-* If a PR requires a *maintainer action*, you can move it to the `Waiting for Author to Merge` column to "merge-bless" it: make the bot offer the author to self-merge.
+- If a PR requires a _maintainer action_, you can move it to the `Waiting for Author to Merge` column to "merge-bless" it: make the bot offer the author to self-merge.
   This is particularly useful in cases where a PR author is unsure about something, and is trying to solicit review from owners or library authors: it makes it possible to defer the decision when to merge to the author, instead of starting an "are you ready" discussion.
 
-You can use either of these blessings in other cases too, the above are just the common use cases.  A review-blessing is only good to satisfy a maintainer review requirement (so other reviews will be needed), and a merge-blessing will usually make a PR self-mergeable, but it will still wait until a PR is unconflicted and the CI is green.
+You can use either of these blessings in other cases too, the above are just the common use cases. A review-blessing is only good to satisfy a maintainer review requirement (so other reviews will be needed), and a merge-blessing will usually make a PR self-mergeable, but it will still wait until a PR is unconflicted and the CI is green.
 
 Like a review, both kinds of blessings will be dismissed if the PR is updated.
 You can also undo a blessing by moving a PR to any other column.
-
 
 ##### Amending an existing Definitely Typed Package
 
@@ -86,8 +83,8 @@ Constraints which you should consider:
   ```ts
   // Cannot have `export default` in the dts
   module.exports = {
-    thing: () => "hello world"
-  }
+      thing: () => "hello world",
+  };
   ```
 
   vs
@@ -95,18 +92,16 @@ Constraints which you should consider:
   ```ts
   // Can import via `export default`
   module.exports.default = {
-    thing: () => "hello world"
-  }
+      thing: () => "hello world",
+  };
   ```
 
   `react-*` packages get a pass on this.
   Their `tsconfig.json` should never have `esModuleInterop: true`, which would hide the above issue.
 
-
 ##### New Definitely Typed Package
 
 - Is the author also a maintainer of the library? If so, they could use [`--declaration` and `--allowJs`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#--declaration-and---allowjs) in TypeScript to generate their types.
-
 
 ### Useful Repos and Links
 


### PR DESCRIPTION
This enables dprint formatting for markdown files, except those in types. Maybe we should also format the other markdown files, but I don't think it matters.

Closes #68581