### PR TITLE
[cookie-parser] Add `cookies` and `signedCookies`

### DIFF
--- a/types/cookie-parser/cookie-parser-tests.ts
+++ b/types/cookie-parser/cookie-parser-tests.ts
@@ -6,6 +6,8 @@ app.use(cookieParser("optional secret string"));
 
 const req = null as any as express.Request;
 req.secret; // $ExpectType string | undefined
+req.cookies; // $ExpectType Record<string, any>
+req.signedCookies; // $ExpectType Record<string, any>
 
 let obj: object;
 let str: string;

--- a/types/cookie-parser/index.d.ts
+++ b/types/cookie-parser/index.d.ts
@@ -9,7 +9,11 @@ declare global {
              * Optionally set by cookie-parser if secret(s) are provided.  Can be used by other middleware.
              * [Declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) can be used to add your own properties.
              */
-            secret?: string;
+            secret?: string | undefined;
+            /** Parsed cookies that have not been signed */
+            cookies: Record<string, any>;
+            /** Parsed cookies that have been signed */
+            signedCookie: Record<string, any>;
         }
     }
 }

--- a/types/cookie-parser/index.d.ts
+++ b/types/cookie-parser/index.d.ts
@@ -1,20 +1,18 @@
 import * as express from "express";
 
-declare global {
-    namespace Express {
-        // Inject additional properties on express.Request
-        interface Request {
-            /**
-             * This request's secret.
-             * Optionally set by cookie-parser if secret(s) are provided.  Can be used by other middleware.
-             * [Declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) can be used to add your own properties.
-             */
-            secret?: string | undefined;
-            /** Parsed cookies that have not been signed */
-            cookies: Record<string, any>;
-            /** Parsed cookies that have been signed */
-            signedCookies: Record<string, any>;
-        }
+declare module "express" {
+    // Inject additional properties on express.Request
+    interface Request {
+        /**
+         * This request's secret.
+         * Optionally set by cookie-parser if secret(s) are provided.  Can be used by other middleware.
+         * [Declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) can be used to add your own properties.
+         */
+        secret?: string | undefined;
+        /** Parsed cookies that have not been signed */
+        cookies: Record<string, any>;
+        /** Parsed cookies that have been signed */
+        signedCookies: Record<string, any>;
     }
 }
 

--- a/types/cookie-parser/index.d.ts
+++ b/types/cookie-parser/index.d.ts
@@ -13,7 +13,7 @@ declare global {
             /** Parsed cookies that have not been signed */
             cookies: Record<string, any>;
             /** Parsed cookies that have been signed */
-            signedCookie: Record<string, any>;
+            signedCookies: Record<string, any>;
         }
     }
 }


### PR DESCRIPTION
Related discussion: #68587

Adds the missing `cookies` and `signedCookies` properties to the Express request object.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/expressjs/cookie-parser/blob/e5862bdb0c1130450a5b50bc07719becf0ab8c81/index.js#L51-L53>  
      Note that the types are `Record<string, any>` and not `Record<string, string>`. This is because a function call later on attempts to parse the cookie contents as JSON if possible, so the types can't be guaranteed

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
