### PR TITLE
[plotly.js] allow `offset` to be `number[]`

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1404,7 +1404,7 @@ export interface PlotData {
     locations: Datum[];
     reversescale: boolean;
     colorbar: Partial<ColorBar>;
-    offset: number;
+    offset: number | number[];
     contours: Partial<{
         coloring: "fill" | "heatmap" | "lines" | "none";
         end: number;

--- a/types/plotly.js/test/index-tests.ts
+++ b/types/plotly.js/test/index-tests.ts
@@ -178,6 +178,14 @@ const graphDiv = "#test";
             marker: { line: { width: 2 } },
             offset: -0.25,
         },
+        {
+            type: "bar",
+            labels: ["Eve", "Cain", "Seth", "Enos", "Noam", "Abel", "Awan", "Enoch", "Azura"],
+            parents: ["", "Eve", "Eve", "Seth", "Seth", "Eve", "Eve", "Awan", "Eve"],
+            values: [65, 14, 12, 10, 2, 6, 6, 4, 4],
+            marker: { line: { width: 2 } },
+            offset: [-0.25, 0.25, -0.25, 0.25, -0.25, 0.25, -0.25, 0.25, -0.25],
+        },
     ];
 
     const layout = {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://plotly.com/javascript/reference/bar/#bar-offset, https://plotly.com/javascript/reference/waterfall/#waterfall-offset
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
