### PR TITLE
Add type definitions for the React jsx runtime

### DIFF
--- a/types/react/jsx-dev-runtime.d.ts
+++ b/types/react/jsx-dev-runtime.d.ts
@@ -17,17 +17,17 @@ export interface JSXSource {
     /**
      * The source file where the element originates from.
      */
-    fileName?: string;
+    fileName?: string | undefined;
 
     /**
      * The line number where the element was created.
      */
-    lineNumber?: number;
+    lineNumber?: number | undefined;
 
     /**
      * The column number where the element was created.
      */
-    columnNumber?: number;
+    columnNumber?: number | undefined;
 }
 
 /**

--- a/types/react/jsx-dev-runtime.d.ts
+++ b/types/react/jsx-dev-runtime.d.ts
@@ -1,4 +1,5 @@
 import * as React from "./";
+export { Fragment } from "./";
 
 export namespace JSX {
     type ElementType = React.JSX.ElementType;
@@ -11,3 +12,34 @@ export namespace JSX {
     interface IntrinsicClassAttributes<T> extends React.JSX.IntrinsicClassAttributes<T> {}
     interface IntrinsicElements extends React.JSX.IntrinsicElements {}
 }
+
+export interface JSXSource {
+    /**
+     * The source file where the element originates from.
+     */
+    fileName?: string;
+
+    /**
+     * The line number where the element was created.
+     */
+    lineNumber?: number;
+
+    /**
+     * The column number where the element was created.
+     */
+    columnNumber?: number;
+}
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsxDEV(
+    type: React.ElementType,
+    props: unknown,
+    key: React.Key | undefined,
+    isStatic: boolean,
+    source?: JSXSource,
+    self?: unknown,
+): React.ReactElement;

--- a/types/react/jsx-runtime.d.ts
+++ b/types/react/jsx-runtime.d.ts
@@ -1,4 +1,5 @@
 import * as React from "./";
+export { Fragment } from "./";
 
 export namespace JSX {
     type ElementType = React.JSX.ElementType;
@@ -11,3 +12,25 @@ export namespace JSX {
     interface IntrinsicClassAttributes<T> extends React.JSX.IntrinsicClassAttributes<T> {}
     interface IntrinsicElements extends React.JSX.IntrinsicElements {}
 }
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsx(
+    type: React.ElementType,
+    props: unknown,
+    key?: React.Key,
+): React.ReactElement;
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsxs(
+    type: React.ElementType,
+    props: unknown,
+    key?: React.Key,
+): React.ReactElement;

--- a/types/react/ts5.0/jsx-dev-runtime.d.ts
+++ b/types/react/ts5.0/jsx-dev-runtime.d.ts
@@ -16,17 +16,17 @@ export interface JSXSource {
     /**
      * The source file where the element originates from.
      */
-    fileName?: string;
+    fileName?: string | undefined;
 
     /**
      * The line number where the element was created.
      */
-    lineNumber?: number;
+    lineNumber?: number | undefined;
 
     /**
      * The column number where the element was created.
      */
-    columnNumber?: number;
+    columnNumber?: number | undefined;
 }
 
 /**

--- a/types/react/ts5.0/jsx-dev-runtime.d.ts
+++ b/types/react/ts5.0/jsx-dev-runtime.d.ts
@@ -1,4 +1,5 @@
 import * as React from "./";
+export { Fragment } from "./";
 
 export namespace JSX {
     interface Element extends React.JSX.Element {}
@@ -10,3 +11,34 @@ export namespace JSX {
     interface IntrinsicClassAttributes<T> extends React.JSX.IntrinsicClassAttributes<T> {}
     interface IntrinsicElements extends React.JSX.IntrinsicElements {}
 }
+
+export interface JSXSource {
+    /**
+     * The source file where the element originates from.
+     */
+    fileName?: string;
+
+    /**
+     * The line number where the element was created.
+     */
+    lineNumber?: number;
+
+    /**
+     * The column number where the element was created.
+     */
+    columnNumber?: number;
+}
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsxDEV(
+    type: React.ElementType,
+    props: unknown,
+    key: React.Key | undefined,
+    isStatic: boolean,
+    source?: JSXSource,
+    self?: unknown,
+): React.ReactElement;

--- a/types/react/ts5.0/jsx-runtime.d.ts
+++ b/types/react/ts5.0/jsx-runtime.d.ts
@@ -1,4 +1,5 @@
 import * as React from "./";
+export { Fragment } from "./";
 
 export namespace JSX {
     interface Element extends React.JSX.Element {}
@@ -10,3 +11,25 @@ export namespace JSX {
     interface IntrinsicClassAttributes<T> extends React.JSX.IntrinsicClassAttributes<T> {}
     interface IntrinsicElements extends React.JSX.IntrinsicElements {}
 }
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsx(
+    type: React.ElementType,
+    props: unknown,
+    key?: React.Key,
+): React.ReactElement;
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsxs(
+    type: React.ElementType,
+    props: unknown,
+    key?: React.Key,
+): React.ReactElement;

--- a/types/react/ts5.0/tsconfig.json
+++ b/types/react/ts5.0/tsconfig.json
@@ -1,6 +1,8 @@
 {
     "files": [
         "index.d.ts",
+        "jsx-dev-runtime.d.ts",
+        "jsx-runtime.d.ts",
         "test/index.ts",
         "test/tsx.tsx",
         "test/cssProperties.tsx",

--- a/types/react/tsconfig.json
+++ b/types/react/tsconfig.json
@@ -1,6 +1,8 @@
 {
     "files": [
         "index.d.ts",
+        "jsx-dev-runtime.d.ts",
+        "jsx-runtime.d.ts",
         "test/index.ts",
         "test/tsx.tsx",
         "test/cssProperties.tsx",

--- a/types/react/v15/jsx-dev-runtime.d.ts
+++ b/types/react/v15/jsx-dev-runtime.d.ts
@@ -1,2 +1,33 @@
 // Expose `JSX` namespace in `global` namespace
-import "./";
+import * as React from "./";
+
+export interface JSXSource {
+    /**
+     * The source file where the element originates from.
+     */
+    fileName?: string;
+
+    /**
+     * The line number where the element was created.
+     */
+    lineNumber?: number;
+
+    /**
+     * The column number where the element was created.
+     */
+    columnNumber?: number;
+}
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsxDEV(
+    type: React.ElementType,
+    props: unknown,
+    key: React.Key | undefined,
+    isStatic: boolean,
+    source?: JSXSource,
+    self?: unknown,
+): React.ReactElement;

--- a/types/react/v15/jsx-dev-runtime.d.ts
+++ b/types/react/v15/jsx-dev-runtime.d.ts
@@ -5,17 +5,17 @@ export interface JSXSource {
     /**
      * The source file where the element originates from.
      */
-    fileName?: string;
+    fileName?: string | undefined;
 
     /**
      * The line number where the element was created.
      */
-    lineNumber?: number;
+    lineNumber?: number | undefined;
 
     /**
      * The column number where the element was created.
      */
-    columnNumber?: number;
+    columnNumber?: number | undefined;
 }
 
 /**

--- a/types/react/v15/jsx-runtime.d.ts
+++ b/types/react/v15/jsx-runtime.d.ts
@@ -1,2 +1,24 @@
 // Expose `JSX` namespace in `global` namespace
-import "./";
+import * as React from "./";
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsx(
+    type: React.ElementType,
+    props: unknown,
+    key?: React.Key,
+): React.ReactElement;
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsxs(
+    type: React.ElementType,
+    props: unknown,
+    key?: React.Key,
+): React.ReactElement;

--- a/types/react/v15/tsconfig.json
+++ b/types/react/v15/tsconfig.json
@@ -1,6 +1,8 @@
 {
     "files": [
         "index.d.ts",
+        "jsx-dev-runtime.d.ts",
+        "jsx-runtime.d.ts",
         "test/index.ts",
         "test/tsx.tsx",
         "test/cssProperties.tsx"

--- a/types/react/v16/jsx-dev-runtime.d.ts
+++ b/types/react/v16/jsx-dev-runtime.d.ts
@@ -6,17 +6,17 @@ export interface JSXSource {
     /**
      * The source file where the element originates from.
      */
-    fileName?: string;
+    fileName?: string | undefined;
 
     /**
      * The line number where the element was created.
      */
-    lineNumber?: number;
+    lineNumber?: number | undefined;
 
     /**
      * The column number where the element was created.
      */
-    columnNumber?: number;
+    columnNumber?: number | undefined;
 }
 
 /**

--- a/types/react/v16/jsx-dev-runtime.d.ts
+++ b/types/react/v16/jsx-dev-runtime.d.ts
@@ -1,2 +1,34 @@
 // Expose `JSX` namespace in `global` namespace
-import "./";
+import * as React from "./";
+export { Fragment } from "./";
+
+export interface JSXSource {
+    /**
+     * The source file where the element originates from.
+     */
+    fileName?: string;
+
+    /**
+     * The line number where the element was created.
+     */
+    lineNumber?: number;
+
+    /**
+     * The column number where the element was created.
+     */
+    columnNumber?: number;
+}
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsxDEV(
+    type: React.ElementType,
+    props: unknown,
+    key: React.Key | undefined,
+    isStatic: boolean,
+    source?: JSXSource,
+    self?: unknown,
+): React.ReactElement;

--- a/types/react/v16/jsx-runtime.d.ts
+++ b/types/react/v16/jsx-runtime.d.ts
@@ -1,2 +1,25 @@
 // Expose `JSX` namespace in `global` namespace
-import "./";
+import * as React from "./";
+export { Fragment } from "./";
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsx(
+    type: React.ElementType,
+    props: unknown,
+    key?: React.Key,
+): React.ReactElement;
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsxs(
+    type: React.ElementType,
+    props: unknown,
+    key?: React.Key,
+): React.ReactElement;

--- a/types/react/v16/tsconfig.json
+++ b/types/react/v16/tsconfig.json
@@ -1,6 +1,8 @@
 {
     "files": [
         "index.d.ts",
+        "jsx-dev-runtime.d.ts",
+        "jsx-runtime.d.ts",
         "test/index.ts",
         "test/tsx.tsx",
         "test/cssProperties.tsx",

--- a/types/react/v17/jsx-dev-runtime.d.ts
+++ b/types/react/v17/jsx-dev-runtime.d.ts
@@ -6,17 +6,17 @@ export interface JSXSource {
     /**
      * The source file where the element originates from.
      */
-    fileName?: string;
+    fileName?: string | undefined;
 
     /**
      * The line number where the element was created.
      */
-    lineNumber?: number;
+    lineNumber?: number | undefined;
 
     /**
      * The column number where the element was created.
      */
-    columnNumber?: number;
+    columnNumber?: number | undefined;
 }
 
 /**

--- a/types/react/v17/jsx-dev-runtime.d.ts
+++ b/types/react/v17/jsx-dev-runtime.d.ts
@@ -1,2 +1,34 @@
 // Expose `JSX` namespace in `global` namespace
-import "./";
+import * as React from "./";
+export { Fragment } from "./";
+
+export interface JSXSource {
+    /**
+     * The source file where the element originates from.
+     */
+    fileName?: string;
+
+    /**
+     * The line number where the element was created.
+     */
+    lineNumber?: number;
+
+    /**
+     * The column number where the element was created.
+     */
+    columnNumber?: number;
+}
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsxDEV(
+    type: React.ElementType,
+    props: unknown,
+    key: React.Key | undefined,
+    isStatic: boolean,
+    source?: JSXSource,
+    self?: unknown,
+): React.ReactElement;

--- a/types/react/v17/jsx-runtime.d.ts
+++ b/types/react/v17/jsx-runtime.d.ts
@@ -1,2 +1,25 @@
 // Expose `JSX` namespace in `global` namespace
-import "./";
+import * as React from "./";
+export { Fragment } from "./";
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsx(
+    type: React.ElementType,
+    props: unknown,
+    key?: React.Key,
+): React.ReactElement;
+
+/**
+ * Create a React element.
+ *
+ * You should not use this function directly. Use JSX and a transpiler instead.
+ */
+export function jsxs(
+    type: React.ElementType,
+    props: unknown,
+    key?: React.Key,
+): React.ReactElement;

--- a/types/react/v17/tsconfig.json
+++ b/types/react/v17/tsconfig.json
@@ -1,6 +1,8 @@
 {
     "files": [
         "index.d.ts",
+        "jsx-dev-runtime.d.ts",
+        "jsx-runtime.d.ts",
         "test/index.ts",
         "test/tsx.tsx",
         "test/cssProperties.tsx",


### PR DESCRIPTION
Although one typically shouldn’t use this directly, there are some legitimate use cases for it. For example, with [MDX on demand](https://mdxjs.com/guides/mdx-on-demand/#quick-example) or [`hast-util-to-jsx-runtime`](https://github.com/syntax-tree/hast-util-to-jsx-runtime).

There was some previous discussion in #64661. This was blocked because of how TypeScript 5.1 would change how JSX works. However, the way it changed doesn’t actually affect these types.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://mdxjs.com/guides/mdx-on-demand/#quick-example
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

