### PR TITLE
fix(randomstring): autocomplete charset value

### DIFF
--- a/types/randomstring/index.d.ts
+++ b/types/randomstring/index.d.ts
@@ -6,7 +6,7 @@ declare namespace Randomstring {
         | "hex"
         | "binary"
         | "octal"
-        | string;
+        | string & {};
     type Capitalization = "lowercase" | "uppercase";
     interface GenerateOptions {
         length?: number | undefined;

--- a/types/randomstring/randomstring-tests.ts
+++ b/types/randomstring/randomstring-tests.ts
@@ -20,4 +20,4 @@ randomstring.generate({
     capitalization: "uppercase",
 });
 
-randomstring.generate({ charset: 'abcdef' })
+randomstring.generate({ charset: "abcdef" });

--- a/types/randomstring/randomstring-tests.ts
+++ b/types/randomstring/randomstring-tests.ts
@@ -19,3 +19,5 @@ randomstring.generate({
     charset: "octal",
     capitalization: "uppercase",
 });
+
+randomstring.generate({ charset: 'abcdef' })


### PR DESCRIPTION
As per the documentation:

https://github.com/klughammer/node-randomstring?tab=readme-ov-file#api

This PR fixes the autocomplete for the `charset` property of the `generate` function, by intersecting string with never.
This fix still allows a string as a value.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.