### PR TITLE
[tabulator-tables] Fix parameter order error issue.

### DIFF
--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -798,7 +798,7 @@ export type RowContextMenuSignature =
 
 export type GroupContextMenuSignature =
     | Array<MenuObject<GroupComponent> | MenuSeparator>
-    | ((component: GroupComponent, e: MouseEvent) => MenuObject<GroupComponent> | false | any[]);
+    | ((e: MouseEvent, component: GroupComponent) => MenuObject<GroupComponent> | false | any[]);
 
 export interface MenuObject<T extends RowComponent | CellComponent | ColumnComponent | GroupComponent> {
     label: string | HTMLElement | ((component: T) => string | HTMLElement);

--- a/types/tabulator-tables/tabulator-tables-tests.ts
+++ b/types/tabulator-tables/tabulator-tables-tests.ts
@@ -1469,3 +1469,11 @@ table = new Tabulator("#testDownloadCallbacks", {
         return data;
     },
 });
+
+// Test groupClickMenu parameter type
+table = new Tabulator("#TestGroupClickMenu", {
+    groupClickMenu(e, component) {
+        component.toggle();
+        return false;
+    },
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

```javascript=
const table = new Tabulator('#Table', {
  // ...
  groupClickMenu(component, ev) {
    console.log('group.click.menu', {
      component,
      ev,
    });
    component.toggle();
  },
  // ...
});
```
The browser console clearly shows that the parameter type order is reversed, the error was resolved after modifying the parameter order.

![image](https://github.com/DefinitelyTyped/DefinitelyTyped/assets/30082521/14d69530-1dd1-4872-aeed-1f44641d0b3f)

