### PR TITLE
[react-pivottable] Fixed export typo and missing props, better types

### DIFF
--- a/types/react-pivottable/PivotTable.d.ts
+++ b/types/react-pivottable/PivotTable.d.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { TableRenderers } from "./TableRenderers";
-import { Pivot } from "./Utilities";
+import { Pivot, PivotData } from "./Utilities";
+import { PlotParams } from "react-plotly.js";
 export interface PivotTableProps extends Pivot {
     // maybe some generic can be implemented for the last two.
     renderers?: TableRenderers;
@@ -10,6 +11,17 @@ export interface PivotTableProps extends Pivot {
      * @default "Table"
      */
     rendererName?: string;
+
+    // plotly options
+    plotlyOptions?: PlotParams["layout"];
+    plotlyConfig?: PlotParams["config"];
+    onRendererUpdate?: PlotParams["onUpdate"];
+
+    // table options
+    tableColorScaleGenerator?: (values: number[]) => (x: number) => React.CSSProperties;
+    tableOptions?: {
+        clickCallback?: (e: React.MouseEvent, value: any, filters: Record<string, string>, data: PivotData) => void;
+    };
 }
 
 export default class PivotTable extends React.PureComponent<PivotTableProps> {}

--- a/types/react-pivottable/PivotTable.d.ts
+++ b/types/react-pivottable/PivotTable.d.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
+import { PlotParams } from "react-plotly.js";
 import { TableRenderers } from "./TableRenderers";
 import { Pivot, PivotData } from "./Utilities";
-import { PlotParams } from "react-plotly.js";
 export interface PivotTableProps extends Pivot {
     // maybe some generic can be implemented for the last two.
     renderers?: TableRenderers;

--- a/types/react-pivottable/Utilities.d.ts
+++ b/types/react-pivottable/Utilities.d.ts
@@ -12,7 +12,7 @@ declare function getSort(
     attr: string,
 ): TSorterFn;
 
-declare const agregatorTemplates: unknown;
+declare const aggregatorTemplates: Record<string, (...args: any[]) => any>;
 declare const locales: object;
 declare const derivers: object;
 
@@ -104,7 +104,7 @@ declare class PivotData implements Pivot {
 
 export {
     aggregators,
-    agregatorTemplates,
+    aggregatorTemplates,
     derivers,
     getSort,
     locales,

--- a/types/react-pivottable/package.json
+++ b/types/react-pivottable/package.json
@@ -6,7 +6,8 @@
         "https://github.com/plotly/react-pivottable"
     ],
     "dependencies": {
-        "@types/react": "*"
+        "@types/react": "*",
+        "@types/react-plotly.js": "*"
     },
     "devDependencies": {
         "@types/react-pivottable": "workspace:."

--- a/types/react-pivottable/react-pivottable-tests.tsx
+++ b/types/react-pivottable/react-pivottable-tests.tsx
@@ -46,11 +46,23 @@ class MyApp extends React.Component {
     render() {
         return (
             <>
-                <PivotTableUI data={data} onChange={e => console.log(e)} />
-                <PivotTableUI data={data2} onChange={e => console.log(e)} />;
-                <PivotTableUI data={data3} onChange={e => console.log(e)} />;
+                <PivotTableUI data={data} onChange={(e) => console.log(e)} />
+                <PivotTableUI data={data2} onChange={(e) => console.log(e)} />;
+                <PivotTableUI data={data3} onChange={(e) => console.log(e)} />;
                 <PivotTable data={data} renderers={{ render01: SomeRenderer }} rendererName={"render01"} />
                 <PivotTable data={data} renderers={passDefaultRenderers} rendererName={"render01"} />
+                <PivotTable
+                    data={data}
+                    // expect plotly options can be specified
+                    plotlyOptions={{}}
+                    plotlyConfig={{}}
+                    onRendererUpdate={() => {}}
+                    // expect table options can be specified
+                    tableColorScaleGenerator={(values) => (value) => ({})}
+                    tableOptions={{
+                        clickCallback: (e, value, filters, data) => {},
+                    }}
+                />
                 <DraggableAttribute
                     addValuesToFilter={addRemValuesToFilter}
                     removeValuesFromFilter={addRemValuesToFilter}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
  - Export typo & type for `aggregatorTemplates`
    - [aggregatorTemplates](https://github.com/plotly/react-pivottable/blob/master/src/Utilities.js#L177)
  - Plotly options 
    - [PlotlyComponent](https://github.com/plotly/react-pivottable/blob/master/src/PlotlyRenderers.jsx#L112)
  - Table options
    - [tableColorScaleGenerator](https://github.com/plotly/react-pivottable/blob/master/src/TableRenderers.jsx#L298), which refers to [redColorScaleGenerator](https://github.com/plotly/react-pivottable/blob/master/src/TableRenderers.jsx#L45)
    - [tableOptions](https://github.com/plotly/react-pivottable/blob/master/src/TableRenderers.jsx#L109)


