### PR TITLE
[mongoose-delete] Update mongoose dependency support v8

### DIFF
--- a/types/mongoose-delete/index.d.ts
+++ b/types/mongoose-delete/index.d.ts
@@ -8,7 +8,6 @@ declare namespace MongooseDelete {
         (this: THIS, err: any, doc: T): void;
     }
     type overridableMethods =
-        | "count"
         | "countDocuments"
         | "find"
         | "findOne"
@@ -20,10 +19,6 @@ declare namespace MongooseDelete {
     interface SoftDeleteModel<T extends Omit<mongoose.Document, "delete">, QueryHelpers = {}>
         extends mongoose.Model<T, QueryHelpers>
     {
-        /** Count only deleted documents */
-        countDeleted: this["count"];
-        /** Count all documents including deleted */
-        countWithDeleted: this["count"];
         /** Count only deleted documents */
         countDocumentsDeleted: this["countDocuments"];
         /** Count all documents including deleted */

--- a/types/mongoose-delete/mongoose-delete-tests.ts
+++ b/types/mongoose-delete/mongoose-delete-tests.ts
@@ -14,14 +14,14 @@ PetSchema.plugin(MongooseDelete, { overrideMethods: true });
 
 // Overide only specific methods
 PetSchema.plugin(MongooseDelete, {
-    overrideMethods: ["count", "find", "findOne", "findOneAndUpdate", "update"],
+    overrideMethods: ["find", "findOne", "findOneAndUpdate", "update"],
 });
 // or
 PetSchema.plugin(MongooseDelete, {
-    overrideMethods: ["count", "countDocuments", "find"],
+    overrideMethods: ["countDocuments", "find"],
 });
 // @ts-expect-error (unrecognized method names are disallowed)
-PetSchema.plugin(MongooseDelete, { overrideMethods: ["count", "find", "errorXyz"] });
+PetSchema.plugin(MongooseDelete, { overrideMethods: ["find", "errorXyz"] });
 
 PetSchema.plugin(MongooseDelete, { overrideMethods: "all", deletedAt: true });
 PetSchema.plugin(MongooseDelete, { overrideMethods: "all", deletedBy: true });
@@ -86,8 +86,6 @@ type deletedType = PetDocument["deleted"];
 type deletedAtType = PetDocument["deletedAt"];
 
 // Additional Methods for overrides
-Pet.countDeleted({ age: 10 });
-Pet.countWithDeleted({ age: 10 });
 Pet.countDocumentsDeleted({ age: 10 });
 Pet.countDocumentsWithDeleted({ age: 10 });
 Pet.findDeleted({ age: 10 });

--- a/types/mongoose-delete/package.json
+++ b/types/mongoose-delete/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "mongoose": "^5.11 || ^6 || ^7"
+        "mongoose": "^5.11 || ^6 || ^7 || ^8"
     },
     "devDependencies": {
         "@types/mongoose-delete": "workspace:."

--- a/types/mongoose-delete/package.json
+++ b/types/mongoose-delete/package.json
@@ -16,6 +16,10 @@
         {
             "name": "Mochamad Arifin",
             "githubUsername": "ndunks"
+        },
+        {
+            "name": "Alex Brazier",
+            "githubUsername": "alexbrazier"
         }
     ]
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://github.com/dsanel/mongoose-delete/commit/0d68bdb82e77290ba16bd9ce54a8e609c0cd7fd4)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Add support for mongoose v8 and remove the long time deprecated `count` methods.
Added myself as an owner as I have made multiple updates to the package type definitions in the past.

