### PR TITLE
feat: strongly type upperFirst w/ TS Capitalize

### DIFF
--- a/types/lodash/common/string.d.ts
+++ b/types/lodash/common/string.d.ts
@@ -744,7 +744,7 @@ declare module "../index" {
          * @param string The string to convert.
          * @return Returns the converted string.
          */
-        upperFirst(string?: string): string;
+        upperFirst<T extends string = string>(string?: T): Capitalize<T>;
     }
     interface LoDashImplicitWrapper<TValue> {
         /**

--- a/types/lodash/fp.d.ts
+++ b/types/lodash/fp.d.ts
@@ -4479,7 +4479,7 @@ declare namespace _ {
     type LodashUpdateWith1x13<T> = (path: lodash.PropertyPath) => T;
     type LodashUpdateWith1x14<T> = (customizer: lodash.SetWithCustomizer<T>) => T;
     type LodashUpperCase = (string: string) => string;
-    type LodashUpperFirst = (string: string) => string;
+    type LodashUpperFirst<T extends string = string> = (string: T) => Capitalize<T>;
     interface LodashValues {
         <T>(object: lodash.Dictionary<T> | lodash.NumericDictionary<T> | lodash.List<T> | null | undefined): T[];
         <T extends object>(object: T | null | undefined): Array<T[keyof T]>;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -6786,10 +6786,10 @@ fp.now(); // $ExpectType number
 
 // _.upperFirst
 {
-    _.upperFirst("fred, barney, &amp; pebbles"); // $ExpectType string
+    _.upperFirst("fred, barney, &amp; pebbles"); // $ExpectType "Fred, barney, &amp; pebbles"
     _("fred, barney, &amp; pebbles").upperFirst(); // $ExpectType string
     _.chain("fred, barney, &amp; pebbles").upperFirst(); // $ExpectType StringChain
-    fp.upperFirst("fred, barney, &amp; pebbles"); // $ExpectType string
+    fp.upperFirst("fred, barney, &amp; pebbles"); // $ExpectType "Fred, barney, &amp; pebbles"
 }
 
 // _.words


### PR DESCRIPTION
Currently `upperFirst` only returns a string, not leveraging the power of `Capitalize`.

```js
upperFirst(string?: string): string;
````

could become:

```js
upperFirst<S extends string>(string?: S): Capitalize<S>;
```

See also: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/68489 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [file](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68635#issue-2135057770)

