### PR TITLE
Fix depency version in `dockerode-compose`

### DIFF
--- a/types/dockerode-compose/package.json
+++ b/types/dockerode-compose/package.json
@@ -6,7 +6,7 @@
         "https://github.com/apocas/dockerode-compose#readme"
     ],
     "dependencies": {
-        "@types/dockerode": "^3.3.9999"
+        "@types/dockerode": "*"
     },
     "devDependencies": {
         "@types/dockerode-compose": "workspace:."


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Hello,

I have made a mistake by specifying the wrong version of another @types/... dependency. Instead of the star (`*`) version, I have previously added the version of the dependent package as it was in the repository.
  
[Here](https://github.com/DefinitelyTyped/DefinitelyTyped?tab=readme-ov-file#packagejsonl) is the reference how to specify the versions correctly.

This PR fixes my previous issue.

Thank you in advance

Kind regards

Sharknoon