### PR TITLE
React Element Type Definition - Add Type Definition for element `set`

### DIFF
--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -140,6 +140,7 @@ interface SVGPolygonElement extends SVGElement {}
 interface SVGPolylineElement extends SVGElement {}
 interface SVGRadialGradientElement extends SVGElement {}
 interface SVGRectElement extends SVGElement {}
+interface SVGSetElement extends SVGElement {}
 interface SVGStopElement extends SVGElement {}
 interface SVGSwitchElement extends SVGElement {}
 interface SVGSymbolElement extends SVGElement {}

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -4322,6 +4322,7 @@ declare global {
             polyline: React.SVGProps<SVGPolylineElement>;
             radialGradient: React.SVGProps<SVGRadialGradientElement>;
             rect: React.SVGProps<SVGRectElement>;
+            set: React.SVGProps<SVGSetElement>;
             stop: React.SVGProps<SVGStopElement>;
             switch: React.SVGProps<SVGSwitchElement>;
             symbol: React.SVGProps<SVGSymbolElement>;

--- a/types/react/ts5.0/global.d.ts
+++ b/types/react/ts5.0/global.d.ts
@@ -140,6 +140,7 @@ interface SVGPolygonElement extends SVGElement {}
 interface SVGPolylineElement extends SVGElement {}
 interface SVGRadialGradientElement extends SVGElement {}
 interface SVGRectElement extends SVGElement {}
+interface SVGSetElement extends SVGElement {}
 interface SVGStopElement extends SVGElement {}
 interface SVGSwitchElement extends SVGElement {}
 interface SVGSymbolElement extends SVGElement {}

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -4305,6 +4305,7 @@ declare global {
             polyline: React.SVGProps<SVGPolylineElement>;
             radialGradient: React.SVGProps<SVGRadialGradientElement>;
             rect: React.SVGProps<SVGRectElement>;
+            set: React.SVGProps<SVGSetElement>;
             stop: React.SVGProps<SVGStopElement>;
             switch: React.SVGProps<SVGSwitchElement>;
             symbol: React.SVGProps<SVGSymbolElement>;


### PR DESCRIPTION
Added type definition for `set` element in svg.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

