### PR TITLE
[@types/mpv-script] Update types for `mp.add_key_binding`

### DIFF
--- a/types/mpv-script/index.d.ts
+++ b/types/mpv-script/index.d.ts
@@ -1,15 +1,6 @@
 declare namespace mp {
     type LogLevel = "fatal" | "error" | "warn" | "info" | "v" | "debug" | "trace";
 
-    interface AddKeyBindingFlags {
-        repeatable?: boolean | undefined;
-        complex?: boolean | undefined;
-        event?: "down" | "repeat" | "up" | "press" | undefined;
-        is_mouse?: boolean | undefined;
-        key_name?: string | undefined;
-        key_text?: string | undefined;
-    }
-
     interface OSDOverlay {
         data: string;
         res_x: number;
@@ -93,6 +84,25 @@ declare namespace mp {
         stderr: string;
     }
 
+    interface UncomplexKeyBindingFlags {
+        repeatable?: boolean;
+        complex?: false;
+    }
+
+    interface ComplexKeyBindingFlags {
+        // Setting `repeatable` to `true` when `complex` is `true` doesn't make sense
+        // See also: https://github.com/mpv-player/mpv/pull/13452
+        repeatable?: false;
+        complex: true;
+    }
+
+    interface UserInputCommand {
+        event: "down" | "repeat" | "up" | "press";
+        is_mouse: boolean;
+        key_name?: string | undefined;
+        key_text?: string | undefined;
+    }
+
     function command(command: string): true | undefined;
 
     function commandv(...args: readonly string[]): true | undefined;
@@ -143,9 +153,61 @@ declare namespace mp {
 
     function get_time(): number;
 
-    function add_key_binding(key: string, name?: string, fn?: () => void, flags?: AddKeyBindingFlags): void;
+    /**
+     * @deprecated Passing the `fn` argument in place of the `name` is not recommended and is handled for compatibility only
+     */
+    function add_key_binding(key: string | undefined, fn: () => void, flags?: UncomplexKeyBindingFlags): void;
 
-    function add_forced_key_binding(key: string, name?: string, fn?: () => void, flags?: AddKeyBindingFlags): void;
+    /**
+     * @deprecated Passing the `fn` argument in place of the `name` is not recommended and is handled for compatibility only
+     */
+    function add_key_binding(
+        key: string | undefined,
+        fn: (table: UserInputCommand) => void,
+        flags: ComplexKeyBindingFlags,
+    ): void;
+
+    function add_key_binding(
+        key: string | undefined,
+        name: string | undefined,
+        fn: () => void,
+        flags?: UncomplexKeyBindingFlags,
+    ): void;
+
+    function add_key_binding(
+        key: string | undefined,
+        name: string | undefined,
+        fn: (table: UserInputCommand) => void,
+        flags: ComplexKeyBindingFlags,
+    ): void;
+
+    /**
+     * @deprecated Passing the `fn` argument in place of the `name` is not recommended and is handled for compatibility only
+     */
+    function add_forced_key_binding(key: string | undefined, fn: () => void, flags?: UncomplexKeyBindingFlags): void;
+
+    /**
+     * @deprecated Passing the `fn` argument in place of the `name` is not recommended and is handled for compatibility only
+     */
+    function add_forced_key_binding(
+        key: string | undefined,
+        fn: (table: UserInputCommand) => void,
+        flags: ComplexKeyBindingFlags,
+    ): void;
+
+    function add_forced_key_binding(
+        key: string | undefined,
+        name: string | undefined,
+        fn: () => void,
+        flags?: UncomplexKeyBindingFlags,
+    ): void;
+
+    function add_forced_key_binding(
+        key: string | undefined,
+        name: string | undefined,
+        fn: (table: UserInputCommand) => void,
+        flags: ComplexKeyBindingFlags,
+    ): void;
 
     function remove_key_binding(name: string): void;
 

--- a/types/mpv-script/mpv-script-tests.ts
+++ b/types/mpv-script/mpv-script-tests.ts
@@ -110,6 +110,70 @@ mp.observe_property("test", "none", (name, value) => {});
 // @ts-expect-error
 mp.observe_property("test", undefined, (name, value) => {});
 
+// The test is not completed because there are about 2*2*2*3*((1/3)*1+(2/3)*(1+1*3))=72 cases
+// Choice 1 (Forced): 2 cases (forced or not forced)
+// Choice 2 (Key): 2 cases (`string` or `undefined`)
+// Choice 3 (Name): 2 cases (specified or not specified)
+// Choice 4 (Complex): 3 cases (`true`, `false`, or not specified)
+// Choice 5 (Flags): 2 cases (specified or not specified)
+// Choice 6 (Repeatable): 3 cases (`true`, `false`, or not specified), but only exist when the flags is specified
+// $ExpectType void
+mp.add_key_binding(
+    "Ctrl+a",
+    "uncomplex_repeatable",
+    () => {
+        dump("uncomplex, repeatable");
+    },
+    { repeatable: true },
+);
+
+// $ExpectType void
+mp.add_key_binding(
+    "Ctrl+b",
+    "uncomplex_non_repeatable0",
+    () => {
+        dump("uncomplex, non-repeatable0");
+    },
+    { repeatable: false },
+);
+
+// $ExpectType void
+mp.add_key_binding(
+    "Ctrl+c",
+    "uncomplex_non_repeatable1",
+    () => {
+        dump("uncomplex, non-repeatable1");
+    },
+    {},
+);
+
+// $ExpectType void
+mp.add_key_binding("Ctrl+d", "uncomplex_non_repeatable2", () => {
+    dump("uncomplex, non-repeatable2");
+});
+
+// $ExpectType void
+mp.add_key_binding(
+    "Ctrl+e",
+    "complex",
+    (table: mp.UserInputCommand) => {
+        dump("complex");
+        dump("   ", table);
+    },
+    { complex: true },
+);
+
+// @ts-expect-error
+mp.add_key_binding(
+    "Ctrl+f",
+    "complex_nonsence",
+    (table: mp.UserInputCommand) => {
+        dump("complex, nonsense");
+        dump("   ", table);
+    },
+    { complex: true, repeatable: true }, // see also the comment for `ComplexKeyBindingFlags`
+);
+
 // $ExpectType OSDSize | undefined
 const osd_size = mp.get_osd_size();
 if (osd_size) {

--- a/types/mpv-script/mpv-script-tests.ts
+++ b/types/mpv-script/mpv-script-tests.ts
@@ -50,7 +50,7 @@ mp.command_native({ name: "echo", args: ["echo", "test"], capture_stdout: true, 
 // @ts-expect-error
 mp.command_native({});
 
-// command_native 13: wrong options with `def`
+// command_native 14: wrong options with `def`
 // @ts-expect-error
 mp.command_native({}, "def");
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <[DOCS/man/lua.rst](https://github.com/mpv-player/mpv/blob/master/DOCS/man/lua.rst?plain=1#L286), [player/command.c](https://github.com/mpv-player/mpv/blob/master/player/command.c#L6120-L6126), [player/javascript/defaults.js①](https://github.com/mpv-player/mpv/blob/master/player/javascript/defaults.js#L784), [player/javascript/defaults.js②](https://github.com/mpv-player/mpv/blob/master/player/javascript/defaults.js#L249), [player/javascript/defaults.js③](https://github.com/mpv-player/mpv/blob/master/player/javascript/defaults.js#L290-L334)>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

### Changes

1. Updated the `mp.add_key_binding` function signatures to support both simple and complex key bindings. This includes the addition of new interface definitions (`UncomplexKeyBindingFlags`, `ComplexKeyBindingFlags`, and `UserInputCommand`) to provide better type support.
2. Deprecated passing the `fn` argument in place of the `name` for compatibility reasons.
3. Fixed a typo in a comment in `mpv-script-tests.ts`.

<details>
<summary>Additional runtime tests</summary>

```javascript
function assert(condition: boolean, message?: string): void {
    if (!condition) {
        throw new Error(message !== void 0 ? message : "Assertion failed");
    } else {
        return;
    }
}

function isBoolean(value: unknown): boolean {
    return typeof value === "boolean";
}

function requireUnion<T1, T2 extends boolean = true>(
    value: T1,
    types: unknown[],
    isLiteral: T2,
    message?: string,
): T1 {
    const check = isLiteral
        ? (type: unknown) => value === type
        : (type: unknown) => typeof value === type;
    assert(types.some(check), message);
    return value;
}

function requireLiteralUnion<T>(
    value: T,
    types: unknown[],
    message?: string,
): T {
    return requireUnion(
        value,
        types,
        true,
        message === void 0
            ? `value '${value}' is not any literal type in ${JSON.stringify(types)}`
            : message,
    );
}

function requireTypedUnion<T>(value: T, types: unknown[], message?: string): T {
    return requireUnion(
        value,
        types,
        false,
        message === void 0
            ? `value '${value}' is not any type in '${JSON.stringify(types)}'`
            : message,
    );
}

const Cases = {
    testUnnamedUncomplex0(): void {
        mp.add_key_binding("Ctrl+a", () => {
            dump("00_0: unamed, uncomplex");
        });
    },

    testUnnamedUncomplex1(): void {
        mp.add_key_binding(void 0, () => {
            dump("00_1: unamed, uncomplex");
        });
    },

    testUnnamedUncomplex2(): void {
        mp.add_key_binding(
            "Ctrl+b",
            () => {
                dump("00_2: unamed, uncomplex");
            },
            {},
        );
    },

    testUnnamedUncomplex3(): void {
        mp.add_key_binding(
            "Ctrl+c",
            () => {
                dump("00_3: unamed, uncomplex");
            },
            {},
        );
    },

    testUnnamedComplex(): void {
        mp.add_key_binding(
            "Ctrl+d",
            (table) => {
                dump("01: unamed, complex");
                dump(
                    "   ",
                    requireLiteralUnion(table.event, [
                        "down",
                        "repeat",
                        "up",
                        "press",
                    ]),
                );
                dump("   ", table);
                assert(isBoolean(table.is_mouse));
                requireTypedUnion(table.key_name, ["undefined", "string"]);
                assert(!("key_text" in table) || table.key_text === void 0);
            },
            { complex: true },
        );
    },

    testNamedUncomplex(): void {
        mp.add_key_binding(
            "Ctrl+e",
            "MyBinding10",
            () => {
                dump("10: named, uncomplex");
            },
            { repeatable: true },
        );
    },

    testNamedComplex(): void {
        mp.add_key_binding(
            "Ctrl+f",
            "MyBinding11",
            (table) => {
                dump("11: named, complex");
                dump(
                    "   ",
                    requireLiteralUnion(table.event, [
                        "down",
                        "repeat",
                        "up",
                        "press",
                    ]),
                );
                dump("   ", table);
                assert(isBoolean(table.is_mouse));
                requireTypedUnion(table.key_name, ["undefined", "string"]);
                assert(!("key_text" in table) || table.key_text === void 0);
            },
            { complex: true },
        );
    },
};

function main(): void {
    Cases.testUnnamedUncomplex0();
    Cases.testUnnamedUncomplex1();
    Cases.testUnnamedUncomplex2();
    Cases.testUnnamedUncomplex3();
    Cases.testUnnamedComplex();
    Cases.testNamedUncomplex();
    Cases.testNamedComplex();
}

mp.register_event("file-loaded", main);
```
</details>