### PR TITLE
fix(aws-lambda): mark as non-npm and remove from `attr.json`

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -134,7 +134,6 @@
         "auth0.widget",
         "awesome-notifications",
         "aws-cloudfront-function",
-        "aws-lambda",
         "aws-sdk2-types",
         "aws-synthetics-puppeteer",
         "axios-cancel",

--- a/types/aws-lambda/package.json
+++ b/types/aws-lambda/package.json
@@ -2,6 +2,8 @@
     "private": true,
     "name": "@types/aws-lambda",
     "version": "8.10.9999",
+    "nonNpm": "conflict",
+    "nonNpmDescription": "AWS Lambda",
     "projects": [
         "http://docs.aws.amazon.com/lambda"
     ],


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] ~Test the change in your own code. (Compile and run.)~
- [x] ~[Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/awspilot/cli-lambda-deploy/issues/7#issuecomment-1732368393
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
---

From my reading this is the correct thing to do - this package provides types for the AWS Lambda _service_ rather than the [`aws-lambda`](https://www.npmjs.com/package/aws-lambda) npm package; so it should not compared to that package and not considered published on NPM.
