### PR TITLE
@ember/template: add SafeString type export to align with types shipped by ember-source itself

### DIFF
--- a/types/ember__template/ember__template-tests.ts
+++ b/types/ember__template/ember__template-tests.ts
@@ -1,5 +1,4 @@
-import { htmlSafe, isHTMLSafe } from "@ember/template";
-import { SafeString } from "@ember/template/-private/handlebars";
+import { htmlSafe, isHTMLSafe, type SafeString } from "@ember/template";
 
 const handlebarsSafeString: SafeString = htmlSafe("lorem ipsum...");
 htmlSafe("lorem ipsum..."); // $ExpectType SafeString

--- a/types/ember__template/index.d.ts
+++ b/types/ember__template/index.d.ts
@@ -1,3 +1,4 @@
 import { SafeString } from "./-private/handlebars";
 export function htmlSafe(str: string): SafeString;
 export function isHTMLSafe(str: unknown): str is SafeString;
+export { type SafeString };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/emberjs/ember.js/blob/16357a2c9bc52f4360c13c70bafc5c842c700cad/packages/%40ember/template/index.ts#L1-L3
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

Types shipped by latest version of ember-source:

```ts
declare module '@ember/template' {
  export { htmlSafe, isHTMLSafe, type SafeString } from '@ember/-internals/glimmer';
}
```

See `/types/stable/@ember/template/index.d.ts` of `ember-source@5.6.0` for reference.

The types shipped by ember-source do not have an import `@ember/template/-private/handlebars`. Some community addons (e.g. ember-intl) rely on that type export nevertheless it is explicitly marked as `-private`. This provides them an upgrade path to a stable type import.