### PR TITLE
Update tr46 from v3 to v5

### DIFF
--- a/types/tr46/index.d.ts
+++ b/types/tr46/index.d.ts
@@ -25,24 +25,26 @@ export interface Options {
      */
     checkJoiners?: boolean | undefined;
     /**
+     * When set to `true`, invalid Punycode strings within the input will be allowed.
+     * @default false
+     */
+    ignoreInvalidPunycode?: boolean | undefined;
+    /**
+     * When set to `true`, uses transitional (compatibility) processing of the deviation characters.
+     * @default false
+     */
+    transitionalProcessing?: boolean | undefined;
+    /**
      * When set to `true`, input will be validated according to [STD3 Rules](http://unicode.org/reports/tr46/#STD3_Rules).
      * @default false
      */
     useSTD3ASCIIRules?: boolean | undefined;
+}
+
+export interface ToASCIIOptions extends Options {
     /**
      * When set to `true`, the length of each DNS label within the input will be checked for validation.
      * @default false
      */
     verifyDNSLength?: boolean | undefined;
 }
-
-export interface ToASCIIOptions extends Options {
-    /**
-     * When set to `"transitional"`, symbols within the input will be validated according to the older
-     * IDNA2003 protocol. When set to `"nontransitional"`, the current IDNA2008 protocol will be used.
-     * @default 'nontransitional'
-     */
-    processingOption?: ProcessingOption | undefined;
-}
-
-export type ProcessingOption = "nontransitional" | "transitional";

--- a/types/tr46/package.json
+++ b/types/tr46/package.json
@@ -12,10 +12,6 @@
         {
             "name": "BendingBender",
             "githubUsername": "BendingBender"
-        },
-        {
-            "name": "Manabu Niseki",
-            "githubUsername": "ninoseki"
         }
     ]
 }

--- a/types/tr46/package.json
+++ b/types/tr46/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/tr46",
-    "version": "3.0.9999",
+    "version": "5.0.9999",
     "projects": [
         "https://github.com/jsdom/tr46"
     ],
@@ -12,6 +12,10 @@
         {
             "name": "BendingBender",
             "githubUsername": "BendingBender"
+        },
+        {
+            "name": "Manabu Niseki",
+            "githubUsername": "ninoseki"
         }
     ]
 }

--- a/types/tr46/tr46-tests.ts
+++ b/types/tr46/tr46-tests.ts
@@ -1,7 +1,6 @@
-import { Options, ProcessingOption, toASCII, ToASCIIOptions, toUnicode } from "tr46";
+import { Options, toASCII, ToASCIIOptions, toUnicode } from "tr46";
 
 // test type exports
-type PO = ProcessingOption;
 type O = Options;
 type TAO = ToASCIIOptions;
 
@@ -9,10 +8,8 @@ toASCII("foo.bar"); // $ExpectType string
 toASCII("foo.bar", { checkBidi: true }); // $ExpectType string
 toASCII("foo.bar", { checkHyphens: true }); // $ExpectType string
 toASCII("foo.bar", { checkJoiners: true }); // $ExpectType string
-toASCII("foo.bar", { processingOption: "nontransitional" }); // $ExpectType string
-toASCII("foo.bar", { processingOption: "transitional" }); // $ExpectType string
-// @ts-expect-error
-toASCII("foo.bar", { processingOption: "foo" });
+toASCII("foo.bar", { ignoreInvalidPunycode: true }); // $ExpectType string
+toASCII("foo.bar", { transitionalProcessing: true }); // $ExpectType string
 toASCII("foo.bar", { useSTD3ASCIIRules: true }); // $ExpectType string
 toASCII("foo.bar", { verifyDNSLength: true }); // $ExpectType string
 // @ts-expect-error
@@ -22,9 +19,10 @@ toUnicode("foo.bar"); // $ExpectType string
 toUnicode("foo.bar", { checkBidi: true }); // $ExpectType string
 toUnicode("foo.bar", { checkHyphens: true }); // $ExpectType string
 toUnicode("foo.bar", { checkJoiners: true }); // $ExpectType string
-// @ts-expect-error
-toUnicode("foo.bar", { processingOption: "nontransitional" });
+toUnicode("foo.bar", { ignoreInvalidPunycode: true }); // $ExpectType string
+toUnicode("foo.bar", { transitionalProcessing: true }); // $ExpectType string
 toUnicode("foo.bar", { useSTD3ASCIIRules: true }); // $ExpectType string
-toUnicode("foo.bar", { verifyDNSLength: true }); // $ExpectType string
+// @ts-expect-error
+toUnicode("foo.bar", { verifyDNSLength: true });
 // @ts-expect-error
 toUnicode("foo.bar", { foo: true });


### PR DESCRIPTION
This PR updates the definition for `tr46` from v3 to v5.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jsdom/tr46 (https://github.com/jsdom/tr46/releases/tag/v5.0.0)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
