### PR TITLE
fix(rdfjs/fetch): preserve return dataset type

### DIFF
--- a/types/rdfjs__fetch-lite/Factory.d.ts
+++ b/types/rdfjs__fetch-lite/Factory.d.ts
@@ -1,5 +1,7 @@
-import { BaseQuad, DatasetCore, Quad, Stream } from "@rdfjs/types";
+import { BaseQuad, DatasetCore, DatasetCoreFactory, Quad, Stream } from "@rdfjs/types";
 import { FormatsInit } from "./index.js";
+
+type ExtractDataset<This> = This extends DatasetCoreFactory ? ReturnType<This["dataset"]> : never;
 
 interface RdfFetchResponse<
     D extends DatasetCore<OutQuad, InQuad>,
@@ -11,7 +13,11 @@ interface RdfFetchResponse<
 }
 
 interface Fetch {
-    (url: Parameters<typeof fetch>[0], options?: FormatsInit): Promise<RdfFetchResponse<DatasetCore>>;
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+    <D extends DatasetCore = ExtractDataset<this>>(
+        url: Parameters<typeof fetch>[0],
+        options?: FormatsInit,
+    ): Promise<RdfFetchResponse<D>>;
     config(key: string, value: unknown): void;
     Headers: Headers;
 }

--- a/types/rdfjs__fetch-lite/rdfjs__fetch-lite-tests.ts
+++ b/types/rdfjs__fetch-lite/rdfjs__fetch-lite-tests.ts
@@ -63,7 +63,7 @@ async function environmentRawFetch(): Promise<Stream> {
 interface TestDataset extends DatasetCore {
     foo: "bar";
 }
-async function environmentDatasetFetch(): Promise<DatasetCore> {
+async function environmentDatasetFetch(): Promise<TestDataset> {
     class DatasetFactory {
         dataset(): TestDataset {
             return <any> {};


### PR DESCRIPTION
When using `rdf.fetch().dataset` of custom RDF/JS Environment, the returned type should match that of the `rdf.dataset()`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
