### PR TITLE
fix(conventional-commits-parser): add option breakingHeaderPattern

### DIFF
--- a/types/conventional-commits-parser/index.d.ts
+++ b/types/conventional-commits-parser/index.d.ts
@@ -273,6 +273,14 @@ declare namespace conventionalCommitsParser {
         commentChar?: string | null | undefined;
 
         /**
+         * Breaking changes header pattern.
+         *
+         * @default
+         * undefined
+         */
+        breakingHeaderPattern?: RegExp | undefined;
+
+        /**
          * What warn function to use. For example, `console.warn.bind(console)` or
          * `grunt.log.writeln`. By default, it's a noop. If it is `true`, it will error
          * if commit cannot be parsed (strict).

--- a/types/conventional-commits-parser/package.json
+++ b/types/conventional-commits-parser/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/conventional-commits-parser",
-    "version": "5.0.0",
+    "version": "5.0.0.9999",
     "projects": [
         "https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#readme"
     ],

--- a/types/conventional-commits-parser/package.json
+++ b/types/conventional-commits-parser/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/conventional-commits-parser",
-    "version": "5.0.0.9999",
+    "version": "5.0.9999",
     "projects": [
         "https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#readme"
     ],

--- a/types/conventional-commits-parser/package.json
+++ b/types/conventional-commits-parser/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/conventional-commits-parser",
-    "version": "3.0.9999",
+    "version": "5.0.0",
     "projects": [
         "https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#readme"
     ],

--- a/types/conventional-commits-parser/ts4.9/index.d.ts
+++ b/types/conventional-commits-parser/ts4.9/index.d.ts
@@ -273,6 +273,14 @@ declare namespace conventionalCommitsParser {
         commentChar?: string | null | undefined;
 
         /**
+         * Breaking changes header pattern.
+         *
+         * @default
+         * undefined
+         */
+        breakingHeaderPattern?: RegExp | undefined;
+
+        /**
          * What warn function to use. For example, `console.warn.bind(console)` or
          * `grunt.log.writeln`. By default, it's a noop. If it is `true`, it will error
          * if commit cannot be parsed (strict).


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/conventional-changelog/conventional-changelog/pull/544
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
