### PR TITLE
[tabulator-tables] Fix RowLookup, selectRow and deselectRow signatures.

### DIFF
--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -1715,7 +1715,7 @@ export type ColumnSorterParamLookupFunction = (column: ColumnComponent, dir: Sor
 
 export type ColumnLookup = ColumnComponent | ColumnDefinition | HTMLElement | string;
 
-export type RowLookup = RowComponent | HTMLElement | string | number | number[] | string[];
+export type RowLookup = RowComponent | HTMLElement | string | number;
 
 export type RowRangeLookup = "visible" | "active" | "selected" | "all";
 
@@ -2541,8 +2541,8 @@ declare class Tabulator {
      *
      * To select a specific row you can pass the any of the standard row component look up options into the first argument of the function. If you leave the argument blank you will select all rows (if you have set the selectable option to a numeric value, it will be ignored when selecting all rows). If lookup value is true you will selected all current filtered rows.
      */
-    selectRow: (lookup?: RowLookup[] | RowRangeLookup | true) => void;
-    deselectRow: (row?: RowLookup) => void;
+    selectRow: (lookup?: RowLookup[] | RowLookup | RowRangeLookup | true) => void;
+    deselectRow: (row?: RowLookup[] | RowLookup) => void;
     toggleSelectRow: (row?: RowLookup) => void;
 
     /**

--- a/types/tabulator-tables/tabulator-tables-tests.ts
+++ b/types/tabulator-tables/tabulator-tables-tests.ts
@@ -706,6 +706,14 @@ table
 
 column.updateDefinition({ title: "Updated" });
 table.selectRow("visible");
+table.selectRow(1);
+table.selectRow([1]);
+table.selectRow(table.getRow(1));
+table.selectRow([table.getRow(1)]);
+table.deselectRow(1);
+table.deselectRow([1]);
+table.deselectRow(table.getRow(1));
+table.deselectRow([table.getRow(1)]);
 table.download("csv", "data.csv", { delimiter: "." }, "visible");
 table.download("html", "data.html");
 table.download("html", "data.html", { style: true });


### PR DESCRIPTION
I wanted to change only `selectRow` to include single `RowLookup`, but then i noticed that `deselectRow` signature is also incomplete and that `RowLookup` signature is wrong.

`RowLookup` signature should not accept arrays of indexes (strings or numbers), since array variants are handled on actual methods using this type (by using `RowLookup[]`).

Thus, I updated RowLookup signature from:
`export type RowLookup = RowComponent | HTMLElement | string | number | number[] | string[];`
to
`export type RowLookup = RowComponent | HTMLElement | string | number;`

I then checked and tested all `RowLookup` usages on actual tabulator instance, these we're the problems identified:
* `selectRow`, `deselectRow` - **accepts single element and array of elements, updated their definitions.**
* `toggleSelectRow: (row?: RowLookup) => void;`  
**Signature is completely wrong, accepts only internal row object.** There is no documentation, checked tabulator source code, this is the only variant that works:  
`grid.toggleSelectRow(grid.getRow(1)._getSelf())` note the `_getSelf()` call. I think this method should not be public, but I left it there as-is.

I tested other usages as well, they now have better signature:
* `getRow: (row: RowLookup) => RowComponent;`  
Accepts single element only (`.getRow(1)` works, but `.getRow([1])` doesn't)
* `addData: (data?: Array<{}>, addToTop?: boolean, positionTarget?: RowLookup) => Promise<RowComponent[]>;`  
Accepts single element only (`.addData({Name: "bla 2"}, false, 1)` works, but `.addData({Name: "bla 2"}, false, [1])` doesn't)
* `deleteRow: (index: RowLookup | RowLookup[]) => void;`  
Accepts both variants.
* `addRow: (data?: {}, addToTop?: boolean, positionTarget?: RowLookup) => Promise<RowComponent>;`  
Accepts single element only (`.addRow({Name: "bla 3"}, false, 1)` works, but `.addRow({Name: "bla 3"}, false, [1])` doesn't)
* `updateOrAddRow: (row: RowLookup, data: {}) => Promise<RowComponent>;`  
Accepts single element only (`.updateOrAddRow(1, {Name: "bla 5"})` works - updates existing row, but `.updateOrAddRow([1], {Name: "bla 5"})` doesn't - adds new row)
* `updateRow: (row: RowLookup, data: {}) => boolean;`  
Accepts single element only (`.updateRow(1, {Name: "bla 7"})` works, but `.updateRow([1], {Name: "bla 7"})` doesn't - throws *Update Error - No matching row found*  
* `scrollToRow: (row: RowLookup, position?: ScrollToRowPosition, ifVisible?: boolean) => Promise<void>;`
Single element only, `.scrollToRow([1])` doesn't work - throws *Scroll Error - No matching row found*  
* `moveRow: (fromRow: RowLookup, toRow: RowLookup, placeAboveTarget?: boolean) => void;`
Single element only, `.moveRow([1], 2)` throws *Move Error - No matching row found*  
* `getRowPosition: (row: RowLookup, activeOnly?: boolean) => number | false;`
Single element only, `.getRowPosition([1])` returns false.
* `setPageToRow: (row: RowLookup) => Promise<void>;`
Single element only.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/68697](here)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.