### PR TITLE
[@types/react-datepicker] fix: remove named export

### DIFF
--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -198,7 +198,7 @@ export interface ReactDatePickerProps<WithRange extends boolean | undefined = un
     yearItemNumber?: number | undefined;
 }
 
-export class ReactDatePicker<WithRange extends boolean | undefined = undefined> extends React.Component<
+declare class ReactDatePicker<WithRange extends boolean | undefined = undefined> extends React.Component<
     ReactDatePickerProps<WithRange>
 > {
     readonly setBlur: () => void;

--- a/types/react-datepicker/react-datepicker-tests.tsx
+++ b/types/react-datepicker/react-datepicker-tests.tsx
@@ -3,6 +3,8 @@ import { enGB } from "date-fns/locale/en-GB";
 import { enUS } from "date-fns/locale/en-US";
 import * as React from "react";
 import DatePicker, {
+    // @ts-expect-error The library is not exporting the component as a named export
+    ReactDatePicker as _MissingNamedExport, 
     CalendarContainer,
     ReactDatePickerCustomHeaderProps,
     ReactDatePickerProps,

--- a/types/react-datepicker/react-datepicker-tests.tsx
+++ b/types/react-datepicker/react-datepicker-tests.tsx
@@ -3,9 +3,9 @@ import { enGB } from "date-fns/locale/en-GB";
 import { enUS } from "date-fns/locale/en-US";
 import * as React from "react";
 import DatePicker, {
-    // @ts-expect-error The library is not exporting the component as a named export
-    ReactDatePicker as _MissingNamedExport, 
     CalendarContainer,
+    // @ts-expect-error The library is not exporting the component as a named export
+    ReactDatePicker as _MissingNamedExport,
     ReactDatePickerCustomHeaderProps,
     ReactDatePickerProps,
     registerLocale,


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Hacker0x01/react-datepicker/blob/main/src/index.jsx#L79
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

The library does not export the component as a named export, only as a default. It is currently possible to import the component (`ReactDatePicker`) as a named export though, which breaks everything. This PR fixes it.