### PR TITLE
[@types/pg] fix broken link to Pool documentation

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -157,7 +157,7 @@ export class Connection extends events.EventEmitter {
 }
 
 /**
- * {@link https://node-postgres.com/api/pool}
+ * {@link https://node-postgres.com/apis/pool}
  */
 export class Pool extends events.EventEmitter {
     /**

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -205,7 +205,7 @@ const customCustomTypeOverrides = new TypeOverrides(customTypes);
 customTypeOverrides.setTypeParser(types.builtins.INT8, BigInt);
 
 // pg.Pool
-// https://node-postgres.com/api/pool
+// https://node-postgres.com/apis/pool
 
 // no params ctor
 const poolParameterlessCtor = new Pool();


### PR DESCRIPTION
The link to the documentation for Pool should be https://node-postgres.com/apis/pool instead of https://node-postgres.com/api/pool (which yields a 404)

This link was broken when the docs for node-postgres were added to the node-postgres monorepo in https://github.com/brianc/node-postgres/pull/2823, which replaced [the old gatsby docs site](https://github.com/brianc/node-postgres-docs). The new documentation has an an `apis` directory for this route that succeeds the the old `api` directory.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/brianc/node-postgres/pull/2823
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
