### PR TITLE
Removed frameQuality & onFrameChange props type-defs

### DIFF
--- a/types/react-native-video/index.d.ts
+++ b/types/react-native-video/index.d.ts
@@ -185,7 +185,7 @@ export interface VideoProperties extends ViewProps {
 
     onLoadStart?(): void;
     onLoad?(data: OnLoadData): void;
-    onBuffer?(data: OnBufferData): void; 
+    onBuffer?(data: OnBufferData): void;
     onError?(error: LoadError): void;
     onProgress?(data: OnProgressData): void;
     onBandwidthUpdate?(data: OnBandwidthUpdateData): void;

--- a/types/react-native-video/index.d.ts
+++ b/types/react-native-video/index.d.ts
@@ -177,8 +177,6 @@ export interface VideoProperties extends ViewProps {
     useTextureView?: boolean | undefined;
     hideShutterView?: boolean | undefined;
     shutterColor?: string;
-    frameQuality?: number;
-    onFrameChange?: (base64ImageString: string) => void;
     allowsExternalPlayback?: boolean | undefined;
     audioOnly?: boolean | undefined;
     preventsDisplaySleepDuringVideoPlayback?: boolean | undefined;
@@ -187,7 +185,7 @@ export interface VideoProperties extends ViewProps {
 
     onLoadStart?(): void;
     onLoad?(data: OnLoadData): void;
-    onBuffer?(data: OnBufferData): void;
+    onBuffer?(data: OnBufferData): void; 
     onError?(error: LoadError): void;
     onProgress?(data: OnProgressData): void;
     onBandwidthUpdate?(data: OnBandwidthUpdateData): void;


### PR DESCRIPTION
`frameQuality` and `onFrameChange` were added in this PR (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65818)

But the PR in the `react-native-video` which adds `frameQuality` and `onFrameChange` is not merged yet. 
(https://github.com/react-native-video/react-native-video/pull/3153 , https://github.com/react-native-video/react-native-video/pull/3189)

So there are no props named `frameQuality` and `onFrameChange`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
