### PR TITLE
Add parse_intermixed_args and parse_known_intermixed_args to argparse

### DIFF
--- a/types/argparse/argparse-tests.ts
+++ b/types/argparse/argparse-tests.ts
@@ -339,16 +339,14 @@ booleanOptionalActionExample.parse_args(["--no-foo"]);
 console.dir(args);
 console.log("-----------");
 
-
 const intermixedArgsExample = new ArgumentParser();
-intermixedArgsExample.add_argument('--foo')
-intermixedArgsExample.add_argument('cmd')
-intermixedArgsExample.add_argument('rest', {nargs: '*', type:"int"})
-args = intermixedArgsExample.parse_intermixed_args('doit 1 --foo bar 2 3'.split(' '))
-console.dir(args)
+intermixedArgsExample.add_argument("--foo");
+intermixedArgsExample.add_argument("cmd");
+intermixedArgsExample.add_argument("rest", { nargs: "*", type: "int" });
+args = intermixedArgsExample.parse_intermixed_args("doit 1 --foo bar 2 3".split(" "));
+console.dir(args);
 console.log("-----------");
-let [ns, remaining] = intermixedArgsExample.parse_known_intermixed_args('doit 1 --unknown --foo bar 2 3'.split(' '))
-console.dir(ns)
-console.log(remaining)
+let [ns, remaining] = intermixedArgsExample.parse_known_intermixed_args("doit 1 --unknown --foo bar 2 3".split(" "));
+console.dir(ns);
+console.log(remaining);
 console.log("-----------");
-

--- a/types/argparse/argparse-tests.ts
+++ b/types/argparse/argparse-tests.ts
@@ -338,3 +338,17 @@ console.log("-----------");
 booleanOptionalActionExample.parse_args(["--no-foo"]);
 console.dir(args);
 console.log("-----------");
+
+
+const intermixedArgsExample = new ArgumentParser();
+intermixedArgsExample.add_argument('--foo')
+intermixedArgsExample.add_argument('cmd')
+intermixedArgsExample.add_argument('rest', {nargs: '*', type:"int"})
+args = intermixedArgsExample.parse_intermixed_args('doit 1 --foo bar 2 3'.split(' '))
+console.dir(args)
+console.log("-----------");
+let [ns, remaining] = intermixedArgsExample.parse_known_intermixed_args('doit 1 --unknown --foo bar 2 3'.split(' '))
+console.dir(ns)
+console.log(remaining)
+console.log("-----------");
+

--- a/types/argparse/index.d.ts
+++ b/types/argparse/index.d.ts
@@ -2,11 +2,13 @@ export class ArgumentParser extends ArgumentGroup {
     constructor(options?: ArgumentParserOptions);
     add_subparsers(options?: SubparserOptions): SubParser;
     parse_args(args?: string[], ns?: Namespace | object): any;
+    parse_intermixed_args(args?: string[], ns?: Namespace | object): any;
     print_usage(): void;
     print_help(): void;
     format_usage(): string;
     format_help(): string;
     parse_known_args(args?: string[], ns?: Namespace | object): any[];
+    parse_known_intermixed_args(args?: string[], ns?: Namespace | object): any[];
     convert_arg_line_to_args(argLine: string): string[];
     exit(status: number, message: string): void;
     error(err: string | Error): void;


### PR DESCRIPTION
ArgumentParser class from argparse
`parse_intermixed_args` and `parse_known_intermixed_args` were missing from the ArgumentParser type definition though they exist on the class

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.parse_intermixed_args  
This npm package is a direct port of the python library, and I have tested that these functions exist in the npm version too.
