### PR TITLE
[dns2] Update types for `DnsServer.listen()` to allow for `address` to be used

### DIFF
--- a/types/dns2/dns2-tests.ts
+++ b/types/dns2/dns2-tests.ts
@@ -135,8 +135,8 @@ serverOnAddress.on("request", (request, response, rinfo) => {
 serverOnAddress.listen({
     udp: {
         port: 5355,
-        address: '0.0.0.0'
-    }
+        address: "0.0.0.0",
+    },
 });
 
 const udpServer = new DNS.UDPServer((request, send, rinfo) => {

--- a/types/dns2/dns2-tests.ts
+++ b/types/dns2/dns2-tests.ts
@@ -97,6 +97,48 @@ serverByType.on("request", (request, response, rinfo) => {
 
 serverByType.listen({ udp: 5344 });
 
+const serverOnAddress = DNS.createServer({
+    udp: true,
+    handle: (request, send, rinfo) => {
+        const response = Packet.createResponseFromRequest(request);
+        const [question] = request.questions;
+        const { name } = question;
+        response.answers.push({
+            name,
+            type: Packet.TYPE.A,
+            class: Packet.CLASS.IN,
+            ttl: 300,
+            address: "8.8.8.8",
+        });
+        response.answers.push({
+            name,
+            type: Packet.TYPE.CNAME,
+            class: Packet.CLASS.IN,
+            ttl: 300,
+            domain: "another-name.example.com",
+        });
+        response.answers.push({
+            name,
+            type: Packet.TYPE.TXT,
+            class: Packet.CLASS.IN,
+            ttl: 60,
+            data: "dnslink=/ipfs/123abc",
+        });
+        send(response);
+    },
+});
+
+serverOnAddress.on("request", (request, response, rinfo) => {
+    console.log(request.header.id, request.questions[0]);
+});
+
+serverOnAddress.listen({
+    udp: {
+        port: 5355,
+        address: '0.0.0.0'
+    }
+});
+
 const udpServer = new DNS.UDPServer((request, send, rinfo) => {
     const response = Packet.createResponseFromRequest(request);
     send(response);

--- a/types/dns2/index.d.ts
+++ b/types/dns2/index.d.ts
@@ -84,6 +84,12 @@ declare namespace DNS {
         type: "udp4" | "udp6";
     }
 
+    interface DnsServerListenOptions {
+        udp?: ListenOptions;
+        tcp?: ListenOptions;
+        doh?: ListenOptions;
+    }
+
     type DnsHandler = (
         request: DnsRequest,
         sendResponse: (response: DnsResponse) => void,
@@ -92,6 +98,10 @@ declare namespace DNS {
 
     type PacketClass = typeof Packet.CLASS[keyof typeof Packet.CLASS];
     type PacketQuestion = keyof typeof Packet.TYPE;
+    type ListenOptions = number | {
+        port: number;
+        address: string;
+    };
 }
 
 declare class DnsServer extends EventEmitter {
@@ -101,7 +111,7 @@ declare class DnsServer extends EventEmitter {
         doh?: net.AddressInfo;
     };
 
-    listen(ports: { udp?: number; tcp?: number; doh?: number }): Promise<void>;
+    listen(options: DNS.DnsServerListenOptions): Promise<void>;
 
     close(): Promise<void>;
 }


### PR DESCRIPTION
The `listen` method on `DNSServer` is not just ports. The object is a set of options, which can be either a single port or an object containing a port and address.

See both the [JS source](https://github.com/song940/node-dns/blob/b2fdf66a1987e2597ad1b1f0948d0ac5c4acbfe2/server/dns.js#L64-L77) and the [dns2 documentation](https://github.com/song940/node-dns?tab=readme-ov-file#example-server).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test dns2`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/song940/node-dns/blob/b2fdf66a1987e2597ad1b1f0948d0ac5c4acbfe2/server/dns.js#L64-L77
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
