### PR TITLE
[@types/node]: ability to set numeric value of URLSearchParams

### DIFF
--- a/types/node/test/url.ts
+++ b/types/node/test/url.ts
@@ -183,12 +183,12 @@ import * as url from "node:url";
 }
 
 {
-    const searchParams = new url.URLSearchParams()
-    searchParams.append("string", "foo")
-    searchParams.set("number", 42)
-    assert.equal(searchParams.get("string"), "foo")
-    assert.equal(searchParams.get("number"), "42")
-    assert.ok(searchParams.has('number', 42))
+    const searchParams = new url.URLSearchParams();
+    searchParams.append("string", "foo");
+    searchParams.set("number", 42);
+    assert.equal(searchParams.get("string"), "foo");
+    assert.equal(searchParams.get("number"), "42");
+    assert.ok(searchParams.has("number", 42));
 }
 
 {

--- a/types/node/test/url.ts
+++ b/types/node/test/url.ts
@@ -163,21 +163,32 @@ import * as url from "node:url";
 {
     const searchParams = new url.URLSearchParams({
         user: "abc",
-        query: ["first", "second"] as readonly string[],
+        query: ["first", "second", 3, 4],
     });
 
-    assert.equal(searchParams.toString(), "user=abc&query=first%2Csecond");
-    assert.deepEqual(searchParams.getAll("query"), ["first,second"]);
+    assert.equal(searchParams.toString(), "user=abc&query=first%2Csecond%2C3%2C4");
+    assert.deepEqual(searchParams.getAll("query"), ["first,second,3,4"]);
 }
 
 {
     // Using an array
-    const params = new url.URLSearchParams([
+    const searchParams = new url.URLSearchParams([
         ["user", "abc"],
         ["query", "first"],
         ["query", "second"],
-    ] as ReadonlyArray<[string, string]>);
-    assert.equal(params.toString(), "user=abc&query=first&query=second");
+        ["query", "3"],
+        ["query", "4"],
+    ]);
+    assert.equal(searchParams.toString(), "user=abc&query=first&query=second&query=3&query=4");
+}
+
+{
+    const searchParams = new url.URLSearchParams()
+    searchParams.append("string", "foo")
+    searchParams.set("number", 42)
+    assert.equal(searchParams.get("string"), "foo")
+    assert.equal(searchParams.get("number"), "42")
+    assert.ok(searchParams.has('number', 42))
 }
 
 {

--- a/types/node/url.d.ts
+++ b/types/node/url.d.ts
@@ -781,21 +781,21 @@ declare module "url" {
             init?:
                 | URLSearchParams
                 | string
-                | Record<string, string | readonly string[]>
-                | Iterable<[string, string]>
-                | ReadonlyArray<[string, string]>,
+                | Record<string, string | number | ReadonlyArray<string | number>>
+                | Iterable<[string, string | number]>
+                | ReadonlyArray<[string, string | number]>
         );
         /**
          * Append a new name-value pair to the query string.
          */
-        append(name: string, value: string): void;
+        append(name: string, value: string | number): void;
         /**
          * If `value` is provided, removes all name-value pairs
          * where name is `name` and value is `value`.
          *
          * If `value` is not provided, removes all name-value pairs whose name is `name`.
          */
-        delete(name: string, value?: string): void;
+        delete(name: string, value?: string | number): void;
         /**
          * Returns an ES6 `Iterator` over each of the name-value pairs in the query.
          * Each item of the iterator is a JavaScript `Array`. The first item of the `Array` is the `name`, the second item of the `Array` is the `value`.
@@ -842,7 +842,7 @@ declare module "url" {
          * If `value` is not provided, returns `true` if there is at least one name-value
          * pair whose name is `name`.
          */
-        has(name: string, value?: string): boolean;
+        has(name: string, value?: string | number): boolean;
         /**
          * Returns an ES6 `Iterator` over the names of each name-value pair.
          *
@@ -876,7 +876,7 @@ declare module "url" {
          * // Prints foo=def&#x26;abc=def&#x26;xyz=opq
          * ```
          */
-        set(name: string, value: string): void;
+        set(name: string, value: string | number): void;
         /**
          * The total number of parameter entries.
          * @since v19.8.0

--- a/types/node/url.d.ts
+++ b/types/node/url.d.ts
@@ -783,7 +783,7 @@ declare module "url" {
                 | string
                 | Record<string, string | number | ReadonlyArray<string | number>>
                 | Iterable<[string, string | number]>
-                | ReadonlyArray<[string, string | number]>
+                | ReadonlyArray<[string, string | number]>,
         );
         /**
          * Append a new name-value pair to the query string.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

This doesn't seem to be in the spec, but platforms allow you to set a numeric value.
All I've found on this topic is [this discussion](https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1568).