### PR TITLE
Fix/k6 browser 1.3.0 type definitions

### DIFF
--- a/types/k6/experimental/browser.d.ts
+++ b/types/k6/experimental/browser.d.ts
@@ -3370,7 +3370,7 @@ export interface Page {
      * To wait for an element on the page, use locator.waitFor([options]).
      * @param selector A selector to query for.
      */
-    $(selector: string): ElementHandle;
+    $(selector: string): ElementHandle | null;
 
     /**
      * **NOTE** Use locator-based page.locator(selector[, options]) instead.

--- a/types/k6/experimental/browser.d.ts
+++ b/types/k6/experimental/browser.d.ts
@@ -1170,7 +1170,10 @@ export interface ElementHandle extends JSHandle {
      * @param selector A selector to query for.
      * @param options Wait options.
      */
-    waitForSelector(selector: string, options?: { state?: ElementState } & StrictnessOptions & TimeoutOptions): ElementHandle;
+    waitForSelector(
+        selector: string,
+        options?: { state?: ElementState } & StrictnessOptions & TimeoutOptions,
+    ): ElementHandle;
 }
 
 /**

--- a/types/k6/experimental/browser.d.ts
+++ b/types/k6/experimental/browser.d.ts
@@ -1170,7 +1170,7 @@ export interface ElementHandle extends JSHandle {
      * @param selector A selector to query for.
      * @param options Wait options.
      */
-    waitForSelector(selector: string, options?: { state?: ElementState } & StrictnessOptions & TimeoutOptions): void;
+    waitForSelector(selector: string, options?: { state?: ElementState } & StrictnessOptions & TimeoutOptions): ElementHandle;
 }
 
 /**

--- a/types/k6/test/browser.ts
+++ b/types/k6/test/browser.ts
@@ -1475,13 +1475,13 @@ elementHandle.waitForElementState("visible", { timeout: 10000 });
 
 // @ts-expect-error
 elementHandle.waitForSelector();
-// $ExpectType void
+// $ExpectType ElementHandle
 elementHandle.waitForSelector("div");
-// $ExpectType void
+// $ExpectType ElementHandle
 elementHandle.waitForSelector("div", { timeout: 10000 });
-// $ExpectType void
+// $ExpectType ElementHandle
 elementHandle.waitForSelector("div", { state: "attached" });
-// $ExpectType void
+// $ExpectType ElementHandle
 elementHandle.waitForSelector("div", { strict: true });
 
 //

--- a/types/k6/test/browser.ts
+++ b/types/k6/test/browser.ts
@@ -788,7 +788,7 @@ page.workers();
 
 // @ts-expect-error
 page.$();
-// $ExpectType ElementHandle
+// $ExpectType ElementHandle | null
 page.$(selector);
 
 // @ts-expect-error
@@ -1273,7 +1273,7 @@ response.then(r => r?.url());
 // ElementHandle
 //
 
-const elementHandle = page.$(selector);
+const elementHandle = page.waitForSelector(selector);
 
 // @ts-expect-error
 elementHandle.$();


### PR DESCRIPTION
Fixing the type definitions for some APIs which were incorrect.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
