### PR TITLE
[react-onclickoutside] Ensure forwards compatibility with React without legacy context

### DIFF
--- a/types/react-onclickoutside/index.d.ts
+++ b/types/react-onclickoutside/index.d.ts
@@ -40,7 +40,7 @@ export interface WrapperClass<P, C> {
 export interface WrapperInstance<P, C>
     extends React.Component<OnClickOutProps<React.JSX.LibraryManagedAttributes<C, P>>>
 {
-    getInstance(): C extends typeof React.Component ? InstanceType<C> : never;
+    getInstance(): C extends React.ComponentClass<any> ? InstanceType<C> : never;
 }
 
 type PropsOf<T> = T extends (


### PR DESCRIPTION
Legacy context is deprecated and therefore libraries should work with `React.Component` with a single constructor signatur.

However, `MyComponent extends typeof React.Component` will not be true in this world. You'd have to check against `typeof React.Component<any>`. However, that syntax is not only supported in later versions of TypeScript in `extends` position. But we can use `ComponentClass<any>` instead here.