### PR TITLE
added group attribute to wordpress inspector controls

### DIFF
--- a/types/wordpress__block-editor/components/inspector-controls.d.ts
+++ b/types/wordpress__block-editor/components/inspector-controls.d.ts
@@ -3,6 +3,7 @@ import { FC, JSX, ReactNode } from "react";
 
 declare namespace InspectorControls {
     interface Props {
+        group: string;
         children: ReactNode;
     }
 }

--- a/types/wordpress__block-editor/components/inspector-controls.d.ts
+++ b/types/wordpress__block-editor/components/inspector-controls.d.ts
@@ -3,7 +3,7 @@ import { FC, JSX, ReactNode } from "react";
 
 declare namespace InspectorControls {
     interface Props {
-        group: string;
+        group?: string;
         children: ReactNode;
     }
 }

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -219,6 +219,7 @@ be.withFontSizes("fontSize")(() => <h1>Hello World</h1>);
 // inspector-controls
 //
 <be.InspectorControls>Hello World</be.InspectorControls>;
+<be.InspectorControls group={'styles'}>Hello World</be.InspectorControls>;
 <be.InspectorControls.Slot />;
 
 //

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -219,7 +219,7 @@ be.withFontSizes("fontSize")(() => <h1>Hello World</h1>);
 // inspector-controls
 //
 <be.InspectorControls>Hello World</be.InspectorControls>;
-<be.InspectorControls group={'styles'}>Hello World</be.InspectorControls>;
+<be.InspectorControls group={"styles"}>Hello World</be.InspectorControls>;
 <be.InspectorControls.Slot />;
 
 //


### PR DESCRIPTION
Added "group" attribute to Wordpress Inspector Controls
see: https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/inspector-controls/fill.js