### PR TITLE
Put `asserts` on various `assert*` functions in chai.

### DIFF
--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -1465,6 +1465,8 @@ class CrashyObject {
     }
 }
 
+declare function foobar<T>(): T;
+
 suite("assert", () => {
     test("assert", () => {
         const foo = "bar" as string;
@@ -1537,6 +1539,10 @@ suite("assert", () => {
         assert.instanceOf(new Foo(), Foo);
         assert.instanceOf(5, Foo);
         assert.instanceOf(new CrashyObject(), CrashyObject);
+
+        const value = foobar<Foo | null>();
+        assert.instanceOf(value, Foo);
+        const fooValue: Foo = value;
     });
 
     test("notInstanceOf", () => {
@@ -1656,21 +1662,37 @@ suite("assert", () => {
     test("isNull", () => {
         assert.isNull(null);
         assert.isNull(undefined);
+
+        const value = foobar<string | null>();
+        assert.isNull(value);
+        const nullValue: null = value;
     });
 
     test("isNotNull", () => {
         assert.isNotNull(undefined);
         assert.isNotNull(null);
+
+        const value = foobar<number | null>();
+        assert.isNotNull(value);
+        const numberValue: number = value;
     });
 
     test("isUndefined", () => {
         assert.isUndefined(undefined);
         assert.isUndefined(null);
+
+        const value = foobar<undefined | number>();
+        assert.isUndefined(value);
+        const undefinedValue: undefined = value;
     });
 
     test("isDefined", () => {
         assert.isDefined(null);
         assert.isDefined(undefined);
+
+        const value = foobar<undefined | number>();
+        assert.isDefined(value);
+        const definedValue: number = value;
     });
 
     test("isNaN", () => {
@@ -1737,12 +1759,20 @@ suite("assert", () => {
         assert.isBoolean(true);
         assert.isBoolean(false);
         assert.isBoolean("1");
+
+        const value = foobar<boolean | string>();
+        assert.isBoolean(value);
+        const booleanValue: boolean = value;
     });
 
     test("isNotBoolean", () => {
         assert.isNotBoolean("true");
         assert.isNotBoolean(true);
         assert.isNotBoolean(false);
+
+        const value = foobar<boolean | string>();
+        assert.isNotBoolean(value);
+        const stringValue: string = value;
     });
 
     test("include", () => {

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -9,6 +9,10 @@ declare namespace Chai {
         exists: boolean;
     }
 
+    interface Constructor<T> {
+        new(...args: any[]): T;
+    }
+
     interface ErrorConstructor {
         new(...args: any[]): Error;
     }
@@ -595,11 +599,10 @@ declare namespace Chai {
         /**
          * Asserts that value is null.
          *
-         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isNull<T>(value: T, message?: string): void;
+        isNull(value: unknown, message?: string): asserts value is null;
 
         /**
          * Asserts that value is not null.
@@ -608,7 +611,7 @@ declare namespace Chai {
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isNotNull<T>(value: T, message?: string): void;
+        isNotNull<T>(value: T, message?: string): asserts value is Exclude<T, null>;
 
         /**
          * Asserts that value is NaN.
@@ -653,7 +656,7 @@ declare namespace Chai {
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isUndefined<T>(value: T, message?: string): void;
+        isUndefined<T>(value: T | undefined, message?: string): asserts value is undefined;
 
         /**
          * Asserts that value is not undefined.
@@ -662,7 +665,7 @@ declare namespace Chai {
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isDefined<T>(value: T, message?: string): void;
+        isDefined<T>(value: T, message?: string): asserts value is Exclude<T, undefined>;
 
         /**
          * Asserts that value is a function.
@@ -770,11 +773,10 @@ declare namespace Chai {
         /**
          * Asserts that value is a boolean.
          *
-         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isBoolean<T>(value: T, message?: string): void;
+        isBoolean(value: unknown, message?: string): asserts value is boolean;
 
         /**
          * Asserts that value is not a boolean.
@@ -783,7 +785,7 @@ declare namespace Chai {
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isNotBoolean<T>(value: T, message?: string): void;
+        isNotBoolean<T>(value: T, message?: string): asserts value is Exclude<T, boolean>;
 
         /**
          * Asserts that value's type is name, as determined by Object.prototype.toString.
@@ -808,12 +810,12 @@ declare namespace Chai {
         /**
          * Asserts that value is an instance of constructor.
          *
-         * T   Type of value.
+         * T   Expected type of value.
          * @param value   Actual value.
          * @param constructor   Potential expected contructor of value.
          * @param message   Message to display on error.
          */
-        instanceOf<T>(value: T, constructor: Function, message?: string): void;
+        instanceOf<T>(value: unknown, constructor: Constructor<T>, message?: string): asserts value is T;
 
         /**
          * Asserts that value is not an instance of constructor.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.chaijs.com/api/assert/

Why?

I'm testing the waters here to see how folks feel about these changes. We're using chai quite extensively in Chrome DevTools and the fact that `assert` functions don't play well with control flow based type narrowing is quite annoying (and we even ended up wrapping the `assert`s into otherwise useless helpers). We believe this should be solved here.