### PR TITLE
`qs` sort schema

### DIFF
--- a/types/qs/index.d.ts
+++ b/types/qs/index.d.ts
@@ -16,7 +16,7 @@ declare namespace QueryString {
         filter?: Array<string | number> | ((prefix: string, value: any) => any) | undefined;
         arrayFormat?: "indices" | "brackets" | "repeat" | "comma" | undefined;
         indices?: boolean | undefined;
-        sort?: ((a: any, b: any) => number) | undefined;
+        sort?: ((a: string, b: string) => number) | undefined;
         serializeDate?: ((d: Date) => string) | undefined;
         format?: "RFC1738" | "RFC3986" | undefined;
         encodeValuesOnly?: boolean | undefined;


### PR DESCRIPTION
`sort` function is used only to compare strings, returned from `Object.keys` calls.

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - https://github.com/ljharb/qs/blob/main/lib/stringify.js#L287-L293
    - https://github.com/ljharb/qs/blob/main/lib/stringify.js#L147-L148
