### PR TITLE
Refractor: Adding missing language file for log

### DIFF
--- a/types/refractor/lang/log.d.ts
+++ b/types/refractor/lang/log.d.ts
@@ -1,0 +1,3 @@
+import { RefractorSyntax } from "../core";
+declare const lang: RefractorSyntax;
+export = lang;


### PR DESCRIPTION
log was missing from the type definitions despite being in the package both in 3.x and 4.x versions

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/wooorm/refractor/blob/main/lang/log.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
