### PR TITLE
[pretty-quick] remove devDep on mri

### DIFF
--- a/types/pretty-quick/package.json
+++ b/types/pretty-quick/package.json
@@ -9,7 +9,6 @@
         "@types/prettier": "^2.0.0"
     },
     "devDependencies": {
-        "@types/mri": "*",
         "@types/pretty-quick": "workspace:."
     },
     "owners": [

--- a/types/pretty-quick/pretty-quick-tests.ts
+++ b/types/pretty-quick/pretty-quick-tests.ts
@@ -1,10 +1,6 @@
-import mri = require("mri");
 import prettyQuick = require("pretty-quick");
 
-declare const args: mri.Argv;
-
 const prettyQuickResult = prettyQuick("./cwd", {
-    ...args,
     onFoundSinceRevision: (scm, revision) => {
         scm; // $ExpectType string
         revision; // $ExpectType string
@@ -30,6 +26,8 @@ const prettyQuickResult = prettyQuick("./cwd", {
     onExamineFile: file => {
         file; // $ExpectType string
     },
+
+    otherProp: "otherProp",
 });
 
 {


### PR DESCRIPTION
This broke after mri was removed; we can't determine when that happens, apparently.

In any case, it's a devDep. All it was testing was the index signature, so I just added some other prop.