### PR TITLE
Document nonNpm=conflict in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Once you have all your changes ready, use `pnpm run test-all` to see how your ch
 
 ##### @arethetypeswrong/cli (`attw`) checks
 
-dtslint includes module format and `package.json` configuration checks from [@arethetypeswrong/cli](https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/packages/cli). The checks run only if a SemVer-major-compatible implementation package can be found on npm to compare against the DefinitelyTyped package. (DefinitelyTyped packages marked as `"nonNpm": true` in their `package.json` are skipped.)
+dtslint includes module format and `package.json` configuration checks from [@arethetypeswrong/cli](https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/packages/cli). The checks run only if a SemVer-major-compatible implementation package can be found on npm to compare against the DefinitelyTyped package. (DefinitelyTyped packages marked as `nonNpm` in their `package.json` are skipped.)
 
 Many packages currently fail the `attw` checks and need to be fixed. To allow us to make incremental progress, failed `attw` checks do not fail the `dtslint` run when the package is listed in `failingPackages` in [`attw.json`](./attw.json), but they will still be reported in the `pnpm test my-package` output. If you fix the package, remove it from `failingPackages` so that `attw` checks can start failing `dtslint` runs.
 
@@ -317,6 +317,9 @@ If you need help fixing a problem, please ask in the DefinitelyTyped channel on 
 If you are adding typings for an npm package, create a directory with the same name.
 If the package you are adding typings for is not on npm, set `"nonNpm": true` in the `package.json`, and make sure the name you choose for it does not conflict with the name of a package on npm.
 (You can use `npm info <my-package>` to check for the existence of the `<my-package>` package.)
+
+In rare occasions, `nonNpm` may be set to `"conflict"`, which incidates that there is a package on npm with the same name, but the types intentionally conflict with that package.
+This can be true for packages which define an environment like `@types/node` or for dummy packages like `aws-lambda`. Avoid using `"conflict"` where possible.
 
 #### `<my-package>-tests.ts`
 


### PR DESCRIPTION
Let me know if I should say more (or less).