### PR TITLE
refactor!(types/opossum): change to single class parameter

### DIFF
--- a/types/opossum/index.d.ts
+++ b/types/opossum/index.d.ts
@@ -2,9 +2,9 @@
 import { EventEmitter } from "events";
 
 declare class CircuitBreaker<
-  T extends (...args: readonly never[]) => Promise<unknown> = (
-    ...args: readonly unknown[]
-  ) => Promise<unknown>,
+    T extends (...args: readonly never[]) => Promise<unknown> = (
+        ...args: readonly unknown[]
+    ) => Promise<unknown>,
 > extends EventEmitter {
     static isOurError(error: any): boolean;
 
@@ -74,10 +74,10 @@ declare class CircuitBreaker<
      * It will always be preceded by a `failure` event, and `breaker.fire` returns a rejected Promise.
      */
     fallback(
-      func:
-        | T
-        | ((...args: Parameters<T>) => Awaited<ReturnType<T>>)
-        | CircuitBreaker<T>,
+        func:
+            | T
+            | ((...args: Parameters<T>) => Awaited<ReturnType<T>>)
+            | CircuitBreaker<T>,
     ): this;
 
     /**
@@ -114,15 +114,15 @@ declare class CircuitBreaker<
     on(event: "reject", listener: (err: Error) => void): this;
     on(event: "timeout", listener: (err: Error) => void): this;
     on(
-      event: "success",
-      listener: (result: Awaited<ReturnType<T>>, latencyMs: number) => void,
+        event: "success",
+        listener: (result: Awaited<ReturnType<T>>, latencyMs: number) => void,
     ): this;
     on(event: "semaphoreLocked", listener: (err: Error) => void): this;
     on(event: "healthCheckFailed", listener: (err: Error) => void): this;
     on(event: "fallback", listener: (result: unknown, err: Error) => void): this;
     on(
-      event: "failure",
-      listener: (err: Error, latencyMs: number, args: Parameters<T>) => void,
+        event: "failure",
+        listener: (err: Error, latencyMs: number, args: Parameters<T>) => void,
     ): this;
     /* tslint:enable:unified-signatures */
 }

--- a/types/opossum/opossum-tests.ts
+++ b/types/opossum/opossum-tests.ts
@@ -2,53 +2,54 @@ import * as fs from "fs";
 import * as CircuitBreaker from "opossum";
 import { promisify } from "util";
 
-let breaker: CircuitBreaker;
 const callbackNoArgs = async () => console.log("foo");
 
 CircuitBreaker.isOurError(new Error()); // $ExpectType boolean
 
-breaker = new CircuitBreaker(async () => true, {
-    timeout: 1000,
-    maxFailures: 50,
-    resetTimeout: 10,
-    rollingCountTimeout: 500,
-    rollingCountBuckets: 20,
-    name: "test",
-    group: "group",
-    rollingPercentilesEnabled: true,
-    capacity: 1,
-    errorThresholdPercentage: 1,
-    enabled: true,
-    allowWarmUp: true,
-    volumeThreshold: 1,
-    cache: true,
-    cacheTTL: 100,
-    errorFilter: (err) => {
-        err; // $ExpectType any
-        return true;
-    },
-});
+{
+    const breaker = new CircuitBreaker(async () => true, {
+        timeout: 1000,
+        maxFailures: 50,
+        resetTimeout: 10,
+        rollingCountTimeout: 500,
+        rollingCountBuckets: 20,
+        name: "test",
+        group: "group",
+        rollingPercentilesEnabled: true,
+        capacity: 1,
+        errorThresholdPercentage: 1,
+        enabled: true,
+        allowWarmUp: true,
+        volumeThreshold: 1,
+        cache: true,
+        cacheTTL: 100,
+        errorFilter: (err) => {
+            err; // $ExpectType any
+            return true;
+        },
+    });
 
-breaker.name; // $ExpectType string
-breaker.group; // $ExpectType string
-breaker.enabled; // $ExpectType boolean
-breaker.pendingClose; // $ExpectType boolean
-breaker.closed; // $ExpectType boolean
-breaker.opened; // $ExpectType boolean
-breaker.halfOpen; // $ExpectType boolean
-breaker.warmUp; // $ExpectType boolean
-breaker.isShutdown; // $ExpectType boolean
-breaker.volumeThreshold; // $ExpectType number
-breaker.status.stats.latencyMean; // $ExpectType number
-breaker.stats.latencyTimes; // $ExpectType number[]
+    breaker.name; // $ExpectType string
+    breaker.group; // $ExpectType string
+    breaker.enabled; // $ExpectType boolean
+    breaker.pendingClose; // $ExpectType boolean
+    breaker.closed; // $ExpectType boolean
+    breaker.opened; // $ExpectType boolean
+    breaker.halfOpen; // $ExpectType boolean
+    breaker.warmUp; // $ExpectType boolean
+    breaker.isShutdown; // $ExpectType boolean
+    breaker.volumeThreshold; // $ExpectType number
+    breaker.status.stats.latencyMean; // $ExpectType number
+    breaker.stats.latencyTimes; // $ExpectType number[]
 
-breaker.clearCache(); // $ExpectType void
-breaker.open(); // $ExpectType void
-breaker.close(); // $ExpectType void
-breaker.disable(); // $ExpectType void
-breaker.enable(); // $ExpectType void
-breaker.shutdown(); // $ExpectType void
-breaker.toJSON(); // $ExpectType { state: State; status: Stats; }
+    breaker.clearCache(); // $ExpectType void
+    breaker.open(); // $ExpectType void
+    breaker.close(); // $ExpectType void
+    breaker.disable(); // $ExpectType void
+    breaker.enable(); // $ExpectType void
+    breaker.shutdown(); // $ExpectType void
+    breaker.toJSON(); // $ExpectType { state: State; status: Stats; }
+}
 
 // Check the generic types pass down correctly from constructor to `fire` and events.
 const action = async (foo: string, bar: number) => {
@@ -71,9 +72,9 @@ typedBreaker.on("fire", ([foo, bar]) => {
 // https://nodeshift.github.io/opossum/index.html.
 
 function asyncFunctionThatCouldFail(x: any, y: any) {
-    return new Promise((resolve, reject) => {
+    return new Promise<string>((resolve, reject) => {
         // Do something, maybe on the network or a disk
-        resolve([x, y]);
+        resolve("x y");
     });
 }
 
@@ -84,71 +85,80 @@ const options: CircuitBreaker.Options = {
 };
 options.enableSnapshots; // $ExpectType boolean | undefined
 options.rotateBucketController; // $ExpectType EventEmitter<DefaultEventMap> | undefined
-breaker = new CircuitBreaker(asyncFunctionThatCouldFail, options);
 
-breaker
-    .fire("foo")
-    .then(console.log)
-    .catch(console.error);
+{
+    const breaker = new CircuitBreaker(asyncFunctionThatCouldFail, options);
 
-breaker = new CircuitBreaker(asyncFunctionThatCouldFail, options);
-// if asyncFunctionThatCouldFail starts to fail, firing the breaker
-// will trigger our fallback function
-breaker.fallback(() => "Sorry, out of service right now");
-breaker.on("fallback", result => console.log(result));
+    breaker
+        .fire("foo", "bar")
+        .then(console.log)
+        .catch(console.error);
+}
+{
+    const breaker = new CircuitBreaker(asyncFunctionThatCouldFail, options);
+    // if asyncFunctionThatCouldFail starts to fail, firing the breaker
+    // will trigger our fallback function
+    breaker.fallback(() => "Sorry, out of service right now");
+    breaker.fallback(() => Promise.resolve("Sorry, out of service right now"));
+    breaker.on("fallback", result => console.log(result));
+}
+{
+    const breaker = new CircuitBreaker(callbackNoArgs, options);
 
-breaker = new CircuitBreaker(callbackNoArgs, options);
+    breaker.fallback(callbackNoArgs);
 
-breaker.fallback(callbackNoArgs);
-
-breaker.on("success", result => console.log(result));
-breaker.on("timeout", callbackNoArgs);
-breaker.on("reject", callbackNoArgs);
-breaker.on("open", callbackNoArgs);
-breaker.on("halfOpen", callbackNoArgs);
-breaker.on("close", callbackNoArgs);
-breaker.on("fallback", data => console.log(data));
+    breaker.on("success", result => console.log(result));
+    breaker.on("timeout", callbackNoArgs);
+    breaker.on("reject", callbackNoArgs);
+    breaker.on("open", callbackNoArgs);
+    breaker.on("halfOpen", callbackNoArgs);
+    breaker.on("close", callbackNoArgs);
+    breaker.on("fallback", data => console.log(data));
+}
 
 const readFile = promisify(fs.readFile);
-breaker = new CircuitBreaker(readFile, options);
+{
+    const breaker = new CircuitBreaker(readFile, options);
 
-breaker
-    .fire("./package.json", "utf-8")
-    .then(console.log)
-    .catch(console.error);
-
-breaker = new CircuitBreaker(readFile, {});
-
-// Creates a 1 second window consisting of ten time slices,
-// each 100ms long.
-const circuit = new CircuitBreaker(readFile, {
-    rollingCountBuckets: 10,
-    rollingCountTimeout: 1000,
-});
-
-// get the cumulative statistics for the last second
-const theStats: CircuitBreaker.Stats = breaker.status.stats;
-
-// get the array of 10, 1 second time slices for the last second
-const window: CircuitBreaker.Window = breaker.status.window;
-window[0].fires; // $ExpectType number
-
-// you can deactivate timeout
-const noTimeoutOptions: CircuitBreaker.Options = {
-    timeout: false, // false value deactivate timeout
-};
-
-// you can call with a provided this arg
-const context = { test: "test" as const };
-async function proxyFn(this: typeof context, ...args: number[]) {
-    return {
-        args,
-        thisArg: this.test,
-    };
+    breaker
+        .fire("./package.json", "utf-8")
+        .then(console.log)
+        .catch(console.error);
 }
-const args: number[] = [1, 2, 3];
-const callBreaker = new CircuitBreaker(proxyFn, options);
-callBreaker.call(context, ...args).then((result) => {
-    result.args; // $ExpectType number[]
-    result.thisArg; // $ExpectType "test"
-});
+() => {
+    const breaker = new CircuitBreaker(readFile, {});
+
+    // Creates a 1 second window consisting of ten time slices,
+    // each 100ms long.
+    const circuit = new CircuitBreaker(readFile, {
+        rollingCountBuckets: 10,
+        rollingCountTimeout: 1000,
+    });
+
+    // get the cumulative statistics for the last second
+    const theStats: CircuitBreaker.Stats = breaker.status.stats;
+
+    // get the array of 10, 1 second time slices for the last second
+    const window: CircuitBreaker.Window = breaker.status.window;
+    window[0].fires; // $ExpectType number
+
+    // you can deactivate timeout
+    const noTimeoutOptions: CircuitBreaker.Options = {
+        timeout: false, // false value deactivate timeout
+    };
+
+    // you can call with a provided this arg
+    const context = { test: "test" as const };
+    async function proxyFn(this: typeof context, ...args: number[]) {
+        return {
+            args,
+            thisArg: this.test,
+        };
+    }
+    const args: number[] = [1, 2, 3];
+    const callBreaker = new CircuitBreaker(proxyFn, options);
+    callBreaker.call(context, ...args).then((result) => {
+        result.args; // $ExpectType number[]
+        result.thisArg; // $ExpectType "test"
+    });
+}

--- a/types/opossum/opossum-tests.ts
+++ b/types/opossum/opossum-tests.ts
@@ -125,7 +125,7 @@ const readFile = promisify(fs.readFile);
         .then(console.log)
         .catch(console.error);
 }
-() => {
+(() => {
     const breaker = new CircuitBreaker(readFile, {});
 
     // Creates a 1 second window consisting of ten time slices,
@@ -161,4 +161,4 @@ const readFile = promisify(fs.readFile);
         result.args; // $ExpectType number[]
         result.thisArg; // $ExpectType "test"
     });
-}
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

Change based on this issue: https://github.com/nodeshift/opossum/issues/846

The package version is currently `8.1.9999`, so I assume there's a different versioning scheme in use. Please feel free to make the major bump accordingly.