### PR TITLE
[node] 'EventEmitter' generics cleanup

### DIFF
--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -95,24 +95,18 @@ declare module "events" {
     interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
     type EventMap<T> = Record<keyof T, any[]> | DefaultEventMap;
     type DefaultEventMap = [never];
-    const s: unique symbol;
-    type Key<K, T> = T extends DefaultEventMap ? string | symbol : K & (keyof (T & { [s]: never }));
-    type Key2<K, T> = T extends DefaultEventMap ? string | symbol : K & (keyof T);
     type AnyRest = [...args: any[]];
     type Args<K, T> = T extends DefaultEventMap ? AnyRest : (
-        K extends keyof T ? (
-                T[K] extends unknown[] ? T[K] : never
-            )
-            : never
+        K extends keyof T ? T[K] : never
     );
-
+    type Key<K, T> = T extends DefaultEventMap ? string | symbol : K | keyof T;
+    type Key2<K, T> = T extends DefaultEventMap ? string | symbol : K & keyof T;
     type Listener<K, T, F> = T extends DefaultEventMap ? F : (
         K extends keyof T ? (
                 T[K] extends unknown[] ? (...args: T[K]) => void : never
             )
             : never
     );
-
     type Listener1<K, T> = Listener<K, T, (...args: any[]) => void>;
     type Listener2<K, T> = Listener<K, T, Function>;
 

--- a/types/node/test/events_generic.ts
+++ b/types/node/test/events_generic.ts
@@ -153,11 +153,11 @@ declare const event5: "event5";
 
 {
     type Listener<K> = K extends keyof T ? (
-            T[K] extends unknown[] ? (...args: T[K]) => void : never
+            (...args: T[K]) => void
         )
         : never;
 
-    function on1<K>(event: K & keyof T, listener: Listener<K>): void {
+    function on1<K>(event: K, listener: Listener<K>): void {
         emitter.on(event, listener);
     }
 

--- a/types/node/ts4.8/events.d.ts
+++ b/types/node/ts4.8/events.d.ts
@@ -95,24 +95,18 @@ declare module "events" {
     interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
     type EventMap<T> = Record<keyof T, any[]> | DefaultEventMap;
     type DefaultEventMap = [never];
-    const s: unique symbol;
-    type Key<K, T> = T extends DefaultEventMap ? string | symbol : K & (keyof (T & { [s]: never }));
-    type Key2<K, T> = T extends DefaultEventMap ? string | symbol : K & (keyof T);
     type AnyRest = [...args: any[]];
     type Args<K, T> = T extends DefaultEventMap ? AnyRest : (
-        K extends keyof T ? (
-                T[K] extends unknown[] ? T[K] : never
-            )
-            : never
+        K extends keyof T ? T[K] : never
     );
-
+    type Key<K, T> = T extends DefaultEventMap ? string | symbol : K | keyof T;
+    type Key2<K, T> = T extends DefaultEventMap ? string | symbol : K & keyof T;
     type Listener<K, T, F> = T extends DefaultEventMap ? F : (
         K extends keyof T ? (
                 T[K] extends unknown[] ? (...args: T[K]) => void : never
             )
             : never
     );
-
     type Listener1<K, T> = Listener<K, T, (...args: any[]) => void>;
     type Listener2<K, T> = Listener<K, T, Function>;
 

--- a/types/node/ts4.8/test/events_generic.ts
+++ b/types/node/ts4.8/test/events_generic.ts
@@ -153,11 +153,11 @@ declare const event5: "event5";
 
 {
     type Listener<K> = K extends keyof T ? (
-            T[K] extends unknown[] ? (...args: T[K]) => void : never
+            (...args: T[K]) => void
         )
         : never;
 
-    function on<K>(event: K & keyof T, listener: Listener<K>): void {
+    function on<K>(event: K, listener: Listener<K>): void {
         emitter.on(event, listener);
     }
 

--- a/types/node/v16/events.d.ts
+++ b/types/node/v16/events.d.ts
@@ -61,24 +61,18 @@ declare module "events" {
     interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
     type EventMap<T> = Record<keyof T, any[]> | DefaultEventMap;
     type DefaultEventMap = [never];
-    const s: unique symbol;
-    type Key<K, T> = T extends DefaultEventMap ? string | symbol : K & (keyof (T & { [s]: never }));
-    type Key2<K, T> = T extends DefaultEventMap ? string | symbol : K & (keyof T);
     type AnyRest = [...args: any[]];
     type Args<K, T> = T extends DefaultEventMap ? AnyRest : (
-        K extends keyof T ? (
-                T[K] extends unknown[] ? T[K] : never
-            )
-            : never
+        K extends keyof T ? T[K] : never
     );
-
+    type Key<K, T> = T extends DefaultEventMap ? string | symbol : K | keyof T;
+    type Key2<K, T> = T extends DefaultEventMap ? string | symbol : K & keyof T;
     type Listener<K, T, F> = T extends DefaultEventMap ? F : (
         K extends keyof T ? (
                 T[K] extends unknown[] ? (...args: T[K]) => void : never
             )
             : never
     );
-
     type Listener1<K, T> = Listener<K, T, (...args: any[]) => void>;
     type Listener2<K, T> = Listener<K, T, Function>;
     /**

--- a/types/node/v16/test/events_generic.ts
+++ b/types/node/v16/test/events_generic.ts
@@ -153,11 +153,11 @@ declare const event5: "event5";
 
 {
     type Listener<K> = K extends keyof T ? (
-            T[K] extends unknown[] ? (...args: T[K]) => void : never
+            (...args: T[K]) => void
         )
         : never;
 
-    function on1<K>(event: K & keyof T, listener: Listener<K>): void {
+    function on1<K>(event: K, listener: Listener<K>): void {
         emitter.on(event, listener);
     }
 

--- a/types/node/v16/ts4.8/events.d.ts
+++ b/types/node/v16/ts4.8/events.d.ts
@@ -61,24 +61,18 @@ declare module "events" {
     interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
     type EventMap<T> = Record<keyof T, any[]> | DefaultEventMap;
     type DefaultEventMap = [never];
-    const s: unique symbol;
-    type Key<K, T> = T extends DefaultEventMap ? string | symbol : K & (keyof (T & { [s]: never }));
-    type Key2<K, T> = T extends DefaultEventMap ? string | symbol : K & (keyof T);
     type AnyRest = [...args: any[]];
     type Args<K, T> = T extends DefaultEventMap ? AnyRest : (
-        K extends keyof T ? (
-                T[K] extends unknown[] ? T[K] : never
-            )
-            : never
+        K extends keyof T ? T[K] : never
     );
-
+    type Key<K, T> = T extends DefaultEventMap ? string | symbol : K | keyof T;
+    type Key2<K, T> = T extends DefaultEventMap ? string | symbol : K & keyof T;
     type Listener<K, T, F> = T extends DefaultEventMap ? F : (
         K extends keyof T ? (
                 T[K] extends unknown[] ? (...args: T[K]) => void : never
             )
             : never
     );
-
     type Listener1<K, T> = Listener<K, T, (...args: any[]) => void>;
     type Listener2<K, T> = Listener<K, T, Function>;
     /**

--- a/types/node/v16/ts4.8/test/events_generic.ts
+++ b/types/node/v16/ts4.8/test/events_generic.ts
@@ -153,11 +153,11 @@ declare const event5: "event5";
 
 {
     type Listener<K> = K extends keyof T ? (
-            T[K] extends unknown[] ? (...args: T[K]) => void : never
+            (...args: T[K]) => void
         )
         : never;
 
-    function on<K>(event: K & keyof T, listener: Listener<K>): void {
+    function on<K>(event: K, listener: Listener<K>): void {
         emitter.on(event, listener);
     }
 

--- a/types/node/v18/events.d.ts
+++ b/types/node/v18/events.d.ts
@@ -98,24 +98,18 @@ declare module "events" {
     interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
     type EventMap<T> = Record<keyof T, any[]> | DefaultEventMap;
     type DefaultEventMap = [never];
-    const s: unique symbol;
-    type Key<K, T> = T extends DefaultEventMap ? string | symbol : K & (keyof (T & { [s]: never }));
-    type Key2<K, T> = T extends DefaultEventMap ? string | symbol : K & (keyof T);
     type AnyRest = [...args: any[]];
     type Args<K, T> = T extends DefaultEventMap ? AnyRest : (
-        K extends keyof T ? (
-                T[K] extends unknown[] ? T[K] : never
-            )
-            : never
+        K extends keyof T ? T[K] : never
     );
-
+    type Key<K, T> = T extends DefaultEventMap ? string | symbol : K | keyof T;
+    type Key2<K, T> = T extends DefaultEventMap ? string | symbol : K & keyof T;
     type Listener<K, T, F> = T extends DefaultEventMap ? F : (
         K extends keyof T ? (
                 T[K] extends unknown[] ? (...args: T[K]) => void : never
             )
             : never
     );
-
     type Listener1<K, T> = Listener<K, T, (...args: any[]) => void>;
     type Listener2<K, T> = Listener<K, T, Function>;
     /**

--- a/types/node/v18/test/events_generic.ts
+++ b/types/node/v18/test/events_generic.ts
@@ -153,11 +153,11 @@ declare const event5: "event5";
 
 {
     type Listener<K> = K extends keyof T ? (
-            T[K] extends unknown[] ? (...args: T[K]) => void : never
+            (...args: T[K]) => void
         )
         : never;
 
-    function on1<K>(event: K & keyof T, listener: Listener<K>): void {
+    function on1<K>(event: K, listener: Listener<K>): void {
         emitter.on(event, listener);
     }
 

--- a/types/node/v18/ts4.8/events.d.ts
+++ b/types/node/v18/ts4.8/events.d.ts
@@ -98,24 +98,18 @@ declare module "events" {
     interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
     type EventMap<T> = Record<keyof T, any[]> | DefaultEventMap;
     type DefaultEventMap = [never];
-    const s: unique symbol;
-    type Key<K, T> = T extends DefaultEventMap ? string | symbol : K & (keyof (T & { [s]: never }));
-    type Key2<K, T> = T extends DefaultEventMap ? string | symbol : K & (keyof T);
     type AnyRest = [...args: any[]];
     type Args<K, T> = T extends DefaultEventMap ? AnyRest : (
-        K extends keyof T ? (
-                T[K] extends unknown[] ? T[K] : never
-            )
-            : never
+        K extends keyof T ? T[K] : never
     );
-
+    type Key<K, T> = T extends DefaultEventMap ? string | symbol : K | keyof T;
+    type Key2<K, T> = T extends DefaultEventMap ? string | symbol : K & keyof T;
     type Listener<K, T, F> = T extends DefaultEventMap ? F : (
         K extends keyof T ? (
                 T[K] extends unknown[] ? (...args: T[K]) => void : never
             )
             : never
     );
-
     type Listener1<K, T> = Listener<K, T, (...args: any[]) => void>;
     type Listener2<K, T> = Listener<K, T, Function>;
     /**

--- a/types/node/v18/ts4.8/test/events_generic.ts
+++ b/types/node/v18/ts4.8/test/events_generic.ts
@@ -153,11 +153,11 @@ declare const event5: "event5";
 
 {
     type Listener<K> = K extends keyof T ? (
-            T[K] extends unknown[] ? (...args: T[K]) => void : never
+            (...args: T[K]) => void
         )
         : never;
 
-    function on<K>(event: K & keyof T, listener: Listener<K>): void {
+    function on<K>(event: K, listener: Listener<K>): void {
         emitter.on(event, listener);
     }
 


### PR DESCRIPTION
This is a follow-up from #68313 which cleans up some of the types.

In particular, we don't want a unique symbol which isn't exposed which in some cases can lead to irreconcilable types. Instead, a more simple "trick" to make the types work out was discovered.

---
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
