### PR TITLE
chromecast-caf-sender / CastOptions: Added `androidReceiverCompatible` property

### DIFF
--- a/types/chromecast-caf-sender/index.d.ts
+++ b/types/chromecast-caf-sender/index.d.ts
@@ -80,6 +80,7 @@ declare namespace cast.framework {
     }
 
     interface CastOptions {
+        androidReceiverCompatible?: boolean | undefined;
         autoJoinPolicy: chrome.cast.AutoJoinPolicy;
         language?: string | undefined;
         receiverApplicationId?: string | undefined;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/cast/docs/reference/web_sender/cast.framework.CastOptions
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
