### PR TITLE
[loadable__component] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/loadable__component/index.d.ts
+++ b/types/loadable__component/index.d.ts
@@ -48,8 +48,9 @@ export type LoadableComponent<Props> =
     & React.ComponentType<Props & ExtraComponentProps>
     & LoadableComponentMethods<Props>;
 
-export interface ExtraClassComponentProps<Component extends React.ComponentClass> extends ExtraComponentProps {
-    ref?: React.LegacyRef<InstanceType<Component>> | undefined;
+export interface ExtraClassComponentProps<Component extends React.ComponentClass>
+    extends ExtraComponentProps, React.RefAttributes<InstanceType<Component>>
+{
 }
 
 export type LoadableClassComponent<Component extends React.ComponentClass> =


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.