### PR TITLE
[rc-tooltip] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/rc-tooltip/index.d.ts
+++ b/types/rc-tooltip/index.d.ts
@@ -18,9 +18,8 @@ declare namespace RCTooltip {
         | "leftTop"
         | "leftBottom";
 
-    export interface Props {
+    export interface Props extends React.RefAttributes<any> {
         children?: React.ReactNode;
-        ref?: React.LegacyRef<any> | undefined;
         overlayClassName?: string | undefined;
         trigger?: Trigger[] | undefined;
         mouseEnterDelay?: number | undefined;


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.