### PR TITLE
[react-big-calendar] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -422,9 +422,10 @@ export class DateLocalizer {
     segmentOffset: number;
 }
 
-export interface CalendarProps<TEvent extends object = Event, TResource extends object = object> {
+export interface CalendarProps<TEvent extends object = Event, TResource extends object = object>
+    extends React.RefAttributes<Calendar<TEvent, TResource>>
+{
     children?: React.ReactNode;
-    ref?: React.LegacyRef<Calendar<TEvent, TResource>> | undefined;
     localizer: DateLocalizer;
 
     date?: stringOrDate | undefined;


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.