### PR TITLE
[react-bootstrap-table] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/react-bootstrap-table/index.d.ts
+++ b/types/react-bootstrap-table/index.d.ts
@@ -1,6 +1,6 @@
 // documentation taken from http://allenfang.github.io/react-bootstrap-table/docs.html
 
-import { Component, CSSProperties, LegacyRef, ReactElement, ReactNode, SyntheticEvent } from "react";
+import { Component, CSSProperties, ReactElement, ReactNode, Ref, RefAttributes, SyntheticEvent } from "react";
 
 /**
  * Table scroll position.
@@ -145,9 +145,8 @@ export interface RemoteObjSpec {
     pagination?: boolean | undefined;
 }
 
-export interface BootstrapTableProps {
+export interface BootstrapTableProps extends RefAttributes<BootstrapTable> {
     children?: ReactNode;
-    ref?: LegacyRef<BootstrapTable> | undefined;
     /**
      * Bootstrap version to use, values include '3' or '4'. Defaults to '3'.
      */
@@ -1176,9 +1175,8 @@ export class BootstrapTable extends Component<BootstrapTableProps> {
     reset(): void;
 }
 
-export interface TableHeaderColumnProps {
+export interface TableHeaderColumnProps extends RefAttributes<TableHeaderColumn> {
     children?: ReactNode;
-    ref?: LegacyRef<TableHeaderColumn> | undefined;
     /**
      * The field of data you want to show on column. This is used throughout react-bootstrap-table as the column field
      * name.

--- a/types/react-bootstrap-table/v2/index.d.ts
+++ b/types/react-bootstrap-table/v2/index.d.ts
@@ -3,7 +3,7 @@
 // documentation taken from http://allenfang.github.io/react-bootstrap-table/docs.html
 
 import { EventEmitter } from "events";
-import { ComponentClass, JSX, ReactElement } from "react";
+import { ComponentClass, JSX, ReactElement, RefAttributes } from "react";
 
 /**
  * Interface spec for sepcifying functionality to handle remotely
@@ -46,9 +46,8 @@ export interface RemoteObjSpec {
     pagination?: boolean | undefined;
 }
 
-export interface BootstrapTableProps {
+export interface BootstrapTableProps extends RefAttributes<BootstrapTable> {
     children?: React.ReactNode;
-    ref?: React.LegacyRef<BootstrapTable> | undefined;
 
     /**
      * Set version='4' to use bootstrap@4, else bootstrap@3 is used.
@@ -512,9 +511,8 @@ interface BootstrapTable extends ComponentClass<BootstrapTableProps> {}
 declare const BootstrapTable: BootstrapTable;
 export type DataAlignType = "left" | "center" | "right" | "start" | "end";
 
-export interface TableHeaderColumnProps {
+export interface TableHeaderColumnProps extends RefAttributes<TableHeaderColumn> {
     children?: React.ReactNode;
-    ref?: React.LegacyRef<TableHeaderColumn> | undefined;
     /**
      * The field of data you want to show on column.
      */


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.