### PR TITLE
[react-bootstrap-typeahead] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/react-bootstrap-typeahead/index.d.ts
+++ b/types/react-bootstrap-typeahead/index.d.ts
@@ -64,7 +64,7 @@ export interface InputContainerPropsSingle<T extends TypeaheadModel> extends Inp
     autoComplete: string;
     disabled: boolean;
     inputClassName: string;
-    inputRef: React.LegacyRef<HTMLInputElement>;
+    inputRef: React.Ref<HTMLInputElement>;
     onBlur: (e: React.SyntheticEvent) => void;
     onChange: (selected: T[]) => void;
     onClick: (e: React.SyntheticEvent<HTMLInputElement>) => void;
@@ -424,7 +424,7 @@ export const Loader: React.FunctionComponent<LoaderProps>;
 --------------------------------------------------------------------------- */
 export interface AutosizeInputProps extends Pick<React.InputHTMLAttributes<HTMLInputElement>, "className" | "style"> {
     inputClassName?: string | undefined;
-    inputRef?: React.LegacyRef<HTMLInputElement> | undefined;
+    inputRef?: React.Ref<HTMLInputElement> | undefined;
     inputStyle?: React.CSSProperties | undefined;
     style: React.CSSProperties;
 }
@@ -440,7 +440,7 @@ export interface MenuProps {
     className?: string | undefined;
     emptyLabel?: React.ReactNode | undefined;
     id: string;
-    innerRef?: React.LegacyRef<HTMLUListElement> | undefined;
+    innerRef?: React.Ref<HTMLUListElement> | undefined;
     inputHeight?: number | undefined;
     maxHeight?: string | undefined;
     style?: React.CSSProperties | undefined;


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.