### PR TITLE
[react-bootstrap] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/react-bootstrap/lib/BreadcrumbItem.d.ts
+++ b/types/react-bootstrap/lib/BreadcrumbItem.d.ts
@@ -1,9 +1,8 @@
 import * as React from "react";
 
 declare namespace BreadcrumbItem {
-    export interface BreadcrumbItemProps {
+    export interface BreadcrumbItemProps extends React.RefAttributes<BreadcrumbItem> {
         children?: React.ReactNode;
-        ref?: React.LegacyRef<BreadcrumbItem> | undefined;
         active?: boolean | undefined;
         href?: string | undefined;
         title?: React.ReactNode | undefined;

--- a/types/react-bootstrap/lib/OverlayTrigger.d.ts
+++ b/types/react-bootstrap/lib/OverlayTrigger.d.ts
@@ -1,9 +1,8 @@
 import * as React from "react";
 
 declare namespace OverlayTrigger {
-    export interface OverlayTriggerProps {
+    export interface OverlayTriggerProps extends React.RefAttributes<OverlayTrigger> {
         children?: React.ReactNode;
-        ref?: React.LegacyRef<OverlayTrigger> | undefined;
         // Required
         overlay: any; // TODO: Add more specific type
 


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.