### PR TITLE
[react-bytesize-icons] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/react-bytesize-icons/index.d.ts
+++ b/types/react-bytesize-icons/index.d.ts
@@ -2,9 +2,8 @@ import * as React from "react";
 
 export type StrokeLinejoin = "round" | "bevel" | "miter" | "inherit";
 export type StrokeLinecap = "round" | "butt" | "square" | "inherit";
-interface BytesizeBaseIconsProps {
+interface BytesizeBaseIconsProps extends React.RefAttributes<any> {
     children?: React.ReactNode;
-    ref?: React.LegacyRef<any> | undefined;
     width?: number | undefined;
     height?: number | undefined;
     color?: string | undefined;


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.