### PR TITLE
[react-cropper] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/react-cropper/index.d.ts
+++ b/types/react-cropper/index.d.ts
@@ -3,8 +3,9 @@ import * as React from "react";
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 
-interface ReactCropperProps extends Cropper.Options, Omit<React.HTMLProps<HTMLImageElement>, "data" | "ref"> {
-    ref?: React.LegacyRef<ReactCropper> | undefined;
+interface ReactCropperProps
+    extends Cropper.Options, Omit<React.HTMLProps<HTMLImageElement>, "data" | "ref">, React.RefAttributes<ReactCropper>
+{
 }
 
 interface ReactCropper extends Cropper {} // eslint-disable-line @typescript-eslint/no-empty-interface


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.