### PR TITLE
[react-datagrid] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/react-datagrid/index.d.ts
+++ b/types/react-datagrid/index.d.ts
@@ -5,9 +5,8 @@ import DataGrid = ReactDataGrid.DataGrid;
 export = DataGrid;
 
 declare namespace ReactDataGrid {
-    interface DataGridProps {
+    interface DataGridProps extends React.RefAttributes<DataGrid> {
         children?: React.ReactNode;
-        ref?: React.LegacyRef<DataGrid> | undefined;
 
         /**
          * Array/String/Function/Promise - for local data, an array of object


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.