### PR TITLE
[react-flex] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/react-flex/index.d.ts
+++ b/types/react-flex/index.d.ts
@@ -58,17 +58,15 @@ export interface CommonFlexProps {
     display?: string | undefined;
 }
 
-export interface FlexProps extends CommonFlexProps {
+export interface FlexProps extends CommonFlexProps, React.RefAttributes<Flex> {
     children?: React.ReactNode;
-    ref?: React.LegacyRef<Flex> | undefined;
 }
 
 export class Flex extends React.Component<FlexProps> {
 }
 
-export interface ItemProps extends CommonFlexProps {
+export interface ItemProps extends CommonFlexProps, React.RefAttributes<Item> {
     children?: React.ReactNode;
-    ref?: React.LegacyRef<Flex> | undefined;
     /**
      * A number/string from 0 to 24 for `flex-grow`. Most of the times, using `flex` is just enough.
      */


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.