### PR TITLE
[react-flexr] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/react-flexr/index.d.ts
+++ b/types/react-flexr/index.d.ts
@@ -1,9 +1,8 @@
 /// <reference types="react" />
 
 declare namespace __ReactFlexr {
-    interface GridProps {
+    interface GridProps extends React.RefAttributes<Grid> {
         children?: React.ReactNode;
-        ref?: React.LegacyRef<Grid> | undefined;
         /**
          * Vertical Align Sub Cells: top, center, bottom
          */
@@ -30,9 +29,9 @@ declare namespace __ReactFlexr {
     export class Grid extends React.Component<GridProps> {
     }
 
-    interface CellProps {
+    interface CellProps extends React.RefAttributes<Cell> {
         children?: React.ReactNode;
-        ref?: React.LegacyRef<Cell> | undefined;
+
         /**
          * Vertical Align This Cell: top, center, bottom
          */


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.