### PR TITLE
[react-imageloader] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/react-imageloader/index.d.ts
+++ b/types/react-imageloader/index.d.ts
@@ -1,9 +1,8 @@
 /// <reference types="react" />
 
 declare module "react-imageloader" {
-    interface ImageLoaderProps {
+    interface ImageLoaderProps extends React.RefAttributes<ImageLoader> {
         children?: React.ReactNode;
-        ref?: React.LegacyRef<ImageLoader> | undefined;
         /** An optional class name for the wrapper component. */
         className?: string | undefined;
 


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.