### PR TITLE
[react-infinite] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/react-infinite/index.d.ts
+++ b/types/react-infinite/index.d.ts
@@ -6,9 +6,8 @@ export = Infinite;
 export as namespace Infinite;
 
 declare namespace Infinite {
-    interface InfiniteProps {
+    interface InfiniteProps extends React.RefAttributes<Infinite> {
         children?: React.ReactNode;
-        ref?: React.LegacyRef<Infinite> | undefined;
         elementHeight: number | number[];
         containerHeight?: number | undefined;
         preloadBatchSize?: number | Object | undefined;


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.