### PR TITLE
[react-lines-ellipsis] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/react-lines-ellipsis/lib/responsiveHOC.d.ts
+++ b/types/react-lines-ellipsis/lib/responsiveHOC.d.ts
@@ -1,5 +1,5 @@
 import { DebounceSettings } from "lodash";
-import { ComponentType, LegacyRef } from "react";
+import { ComponentType, Ref } from "react";
 import { CommonReactLinesEllipsisProps } from "..";
 
 declare function responsiveHOC(
@@ -7,6 +7,6 @@ declare function responsiveHOC(
     debounceOptions?: DebounceSettings,
 ): <P extends CommonReactLinesEllipsisProps>(
     WrappedComponent: ComponentType<P>,
-) => ComponentType<P & { innerRef?: LegacyRef<HTMLDivElement> }>;
+) => ComponentType<P & { innerRef?: Ref<HTMLDivElement> }>;
 
 export = responsiveHOC;


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.