### PR TITLE
[react-list] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/react-list/index.d.ts
+++ b/types/react-list/index.d.ts
@@ -6,9 +6,8 @@ type ItemSizeEstimator = (index: number, cache: {}) => number;
 type ItemSizeGetter = (index: number) => number;
 type ScrollParentGetter = () => JSX.Element;
 
-interface ReactListProps {
+interface ReactListProps extends React.RefAttributes<ReactList> {
     children?: React.ReactNode;
-    ref?: React.LegacyRef<ReactList> | undefined;
     axis?: "x" | "y" | undefined;
     initialIndex?: number | undefined;
     itemRenderer?: ItemRenderer | undefined;


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.