### PR TITLE
[react-native-scrollable-tab-view] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/react-native-scrollable-tab-view/index.d.ts
+++ b/types/react-native-scrollable-tab-view/index.d.ts
@@ -1,9 +1,8 @@
 import * as React from "react";
 import { Animated, LayoutChangeEvent, ScrollViewProps, StyleProp, TextStyle, ViewStyle } from "react-native";
 
-export interface ScrollableTabViewProperties {
+export interface ScrollableTabViewProperties extends React.RefAttributes<ScrollableTabView> {
     children?: React.ReactNode;
-    ref?: React.LegacyRef<ScrollableTabView> | undefined;
     /**
      * accept 1 argument props and should return a component
      * to use as the tab bar. The component has goToPage, tabs, activeTab and ref added to the props,


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.