### PR TITLE
[react-native-snap-carousel] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/react-native-snap-carousel/index.d.ts
+++ b/types/react-native-snap-carousel/index.d.ts
@@ -294,9 +294,8 @@ export interface ParallaxImageProps extends ImageProps, AdditionalParallaxProps 
 
 export type ParallaxImageStatic = React.ComponentClass<ParallaxImageProps>;
 
-export type ParallaxImageProperties = ParallaxImageProps & {
+export type ParallaxImageProperties = ParallaxImageProps & React.RefAttributes<ParallaxImageStatic> & {
     children?: React.ReactNode;
-    ref?: React.LegacyRef<ParallaxImageStatic> | undefined;
 };
 
 export class ParallaxImage extends React.Component<ParallaxImageProperties> {}
@@ -400,9 +399,8 @@ export interface PaginationProps {
 
 export type PaginationStatic = React.ComponentClass<PaginationProps>;
 
-export type PaginationProperties = PaginationProps & {
+export type PaginationProperties = PaginationProps & React.RefAttributes<PaginationStatic> & {
     children?: React.ReactNode;
-    ref?: React.LegacyRef<PaginationStatic> | undefined;
 };
 
 export class Pagination extends React.Component<PaginationProperties> {}


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.