### PR TITLE
[react-portal] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/react-portal/v3/index.d.ts
+++ b/types/react-portal/v3/index.d.ts
@@ -1,8 +1,7 @@
 import * as React from "react";
 
-interface CallBackProps {
+interface CallBackProps extends React.RefAttributes<any> {
     children?: React.ReactNode;
-    ref?: React.LegacyRef<any> | undefined;
     closePortal(): void;
 }
 


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.