### PR TITLE
[react-redux] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -1738,7 +1738,7 @@ function testRef() {
     <ConnectedForwardedFunctionalComponent ref={(ref: number) => {}}></ConnectedForwardedFunctionalComponent>;
 
     // Should be able to use all refs including legacy string
-    const classLegacyRef: React.LegacyRef<ClassComponent> | undefined = undefined;
+    const classLegacyRef: React.RefAttributes<ClassComponent>["ref"] = undefined;
     <ConnectedClassComponent ref={classLegacyRef}></ConnectedClassComponent>;
     <ConnectedClassComponent ref={React.createRef<ClassComponent>()}></ConnectedClassComponent>;
     <ConnectedClassComponent ref={(ref: ClassComponent | null) => {}}></ConnectedClassComponent>;


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.