### PR TITLE
[react-scrollbar] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/react-scrollbar/index.d.ts
+++ b/types/react-scrollbar/index.d.ts
@@ -1,8 +1,7 @@
 /// <reference types="react" />
 
-interface ScrollAreaProps {
+interface ScrollAreaProps extends React.RefAttributes<ScrollArea> {
     children?: React.ReactNode;
-    ref?: React.LegacyRef<ScrollArea> | undefined;
     className?: string | undefined;
     style?: React.CSSProperties | undefined;
     speed?: number | undefined;


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.