### PR TITLE
[react-tagcloud] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/react-tagcloud/index.d.ts
+++ b/types/react-tagcloud/index.d.ts
@@ -2,9 +2,8 @@ import * as React from "react";
 
 export class TagCloud extends React.Component<TagCloudProps> {}
 
-export interface TagCloudProps {
+export interface TagCloudProps extends React.RefAttributes<void> {
     children?: React.ReactNode | undefined;
-    ref?: React.LegacyRef<void> | undefined;
     className?: string | undefined;
     /** Array of objects that represent tags */
     tags: Tag[];


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.