### PR TITLE
[react-tagsinput] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/react-tagsinput/index.d.ts
+++ b/types/react-tagsinput/index.d.ts
@@ -40,9 +40,8 @@ declare namespace TagsInput {
         inputElement: React.ReactElement,
     ) => React.ReactElement | number | string;
 
-    interface ReactTagsInputProps<Tag = any> {
+    interface ReactTagsInputProps<Tag = any> extends React.RefAttributes<TagsInput<Tag>> {
         children?: React.ReactNode;
-        ref?: React.LegacyRef<TagsInput<Tag>> | undefined;
         value: Tag[];
         onChange: (tags: Tag[], changed: Tag[], changedIndexes: number[]) => void;
         onChangeInput?: ((value: string) => void) | undefined;


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.