### PR TITLE
[reactcss] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/reactcss/index.d.ts
+++ b/types/reactcss/index.d.ts
@@ -1,8 +1,7 @@
 import * as React from "react";
 
-interface LoopableProps {
+interface LoopableProps extends React.RefAttributes<any> {
     children?: React.ReactNode;
-    ref?: React.LegacyRef<any> | undefined;
     "nth-child": number;
     "first-child"?: boolean | undefined;
     "last-child"?: boolean | undefined;
@@ -10,9 +9,8 @@ interface LoopableProps {
     odd?: boolean | undefined;
 }
 
-interface HoverProps<T> {
+interface HoverProps<T> extends React.RefAttributes<T> {
     children?: React.ReactNode;
-    ref?: React.LegacyRef<T> | undefined;
     hover?: boolean | undefined;
 }
 


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.