### PR TITLE
[rebass__grid] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/rebass__grid/index.d.ts
+++ b/types/rebass__grid/index.d.ts
@@ -5,9 +5,8 @@ export {};
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 
-export interface BaseProps {
+export interface BaseProps extends React.RefAttributes<any> {
     children?: React.ReactNode;
-    ref?: React.LegacyRef<any> | undefined;
     as?: React.ElementType | undefined;
 }
 


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.