### PR TITLE
[video-react] Ensure forwards compatible pattern for typing `ref` is used

### DIFF
--- a/types/video-react/index.d.ts
+++ b/types/video-react/index.d.ts
@@ -1,4 +1,4 @@
-import { JSX, LegacyRef } from "react";
+import { JSX, RefAttributes } from "react";
 
 export type PlayerReference = HTMLVideoElement & StaticPlayerInstanceMethods;
 
@@ -189,8 +189,7 @@ export interface PlayerActions {
     subscribeToStateChange: (listener: StateListener) => void;
 }
 
-export interface PlayerProps {
-    ref?: LegacyRef<PlayerReference> | undefined;
+export interface PlayerProps extends RefAttributes<PlayerReference> {
     /**
      * In fluid mode, it’s 100% wide all the time, the height will be
      * calculated by the video's ratio.


### PR DESCRIPTION
String refs are deprecated and will be removed in a future major release. This library was typing refs specifically against a version of React that does or doesn't support string refs. However, whether string refs are supported or not is up to the linked React version. By using `React.RefAttributes` you automatically get the right typings of the ref prop for your consumers. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68720 for full context. Part of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68751.