### PR TITLE
chrome/chrome-cast: Mark as optional, fields documented as nullable in Media and MediaInfo

### DIFF
--- a/types/chrome/chrome-cast/index.d.ts
+++ b/types/chrome/chrome-cast/index.d.ts
@@ -843,10 +843,10 @@ declare namespace chrome.cast.media {
         streamType: chrome.cast.media.StreamType;
         contentType: string;
         metadata: any;
-        duration?: number;
-        tracks?: chrome.cast.media.Track[];
-        textTrackStyle?: chrome.cast.media.TextTrackStyle;
-        customData?: Object;
+        duration?: number | null;
+        tracks?: chrome.cast.media.Track[] | null;
+        textTrackStyle?: chrome.cast.media.TextTrackStyle | null;
+        customData?: Object | null;
     }
 
     export class Media {
@@ -857,18 +857,18 @@ declare namespace chrome.cast.media {
          */
         constructor(sessionId: string, mediaSessionId: number);
 
-        activeTrackIds?: number[];
-        currentItemId?: number;
-        customData?: Object;
+        activeTrackIds?: number[] | null;
+        currentItemId?: number | null;
+        customData?: Object | null;
         idleReason: chrome.cast.media.IdleReason | null;
-        items?: chrome.cast.media.QueueItem[];
+        items?: chrome.cast.media.QueueItem[] | null;
         liveSeekableRange?: chrome.cast.media.LiveSeekableRange | undefined;
-        loadingItemId?: number;
-        media?: chrome.cast.media.MediaInfo;
+        loadingItemId?: number | null;
+        media?: chrome.cast.media.MediaInfo | null;
         mediaSessionId: number;
         playbackRate: number;
         playerState: chrome.cast.media.PlayerState;
-        preloadedItemId?: number;
+        preloadedItemId?: number | null;
         repeatMode: chrome.cast.media.RepeatMode;
         sessionId: string;
         supportedMediaCommands: chrome.cast.media.MediaCommand[];

--- a/types/chrome/chrome-cast/index.d.ts
+++ b/types/chrome/chrome-cast/index.d.ts
@@ -843,10 +843,10 @@ declare namespace chrome.cast.media {
         streamType: chrome.cast.media.StreamType;
         contentType: string;
         metadata: any;
-        duration: number;
-        tracks: chrome.cast.media.Track[];
-        textTrackStyle: chrome.cast.media.TextTrackStyle;
-        customData: Object;
+        duration?: number;
+        tracks?: chrome.cast.media.Track[];
+        textTrackStyle?: chrome.cast.media.TextTrackStyle;
+        customData?: Object;
     }
 
     export class Media {
@@ -857,18 +857,18 @@ declare namespace chrome.cast.media {
          */
         constructor(sessionId: string, mediaSessionId: number);
 
-        activeTrackIds: number[];
-        currentItemId: number;
-        customData: Object;
+        activeTrackIds?: number[];
+        currentItemId?: number;
+        customData?: Object;
         idleReason: chrome.cast.media.IdleReason | null;
-        items: chrome.cast.media.QueueItem[];
+        items?: chrome.cast.media.QueueItem[];
         liveSeekableRange?: chrome.cast.media.LiveSeekableRange | undefined;
-        loadingItemId: number;
-        media: chrome.cast.media.MediaInfo;
+        loadingItemId?: number;
+        media?: chrome.cast.media.MediaInfo;
         mediaSessionId: number;
         playbackRate: number;
         playerState: chrome.cast.media.PlayerState;
-        preloadedItemId: number;
+        preloadedItemId?: number;
         repeatMode: chrome.cast.media.RepeatMode;
         sessionId: string;
         supportedMediaCommands: chrome.cast.media.MediaCommand[];


### PR DESCRIPTION
According to the official documentation (linked below), many fields are actually nullable. I found this out the hard way, getting thousands of "Cannot read properties of undefined" errors reported to Sentry.

https://developers.google.com/cast/docs/reference/web_sender/chrome.cast.media.Media
https://developers.google.com/cast/docs/reference/web_sender/chrome.cast.media.MediaInfo

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
