### PR TITLE
[draft-js] Ensure forwards compatibility with React without legacy context

### DIFF
--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -505,7 +505,7 @@ declare namespace Draft {
                 ) => void;
                 component:
                     | React.Component
-                    | typeof React.Component
+                    | React.ComponentClass<any>
                     | ((props: DraftDecoratorComponentProps & P) => React.ReactNode);
                 props?: P | undefined;
             }


### PR DESCRIPTION
Legacy context is deprecated and therefore libraries should work with `React.Component` with a single constructor signature.

However, `MyComponent extends typeof React.Component` will not be true in this world. You'd have to check against `typeof React.Component<any>`. However, that syntax is not only supported in later versions of TypeScript in `extends` position. But we can use `ComponentClass<any>` instead here.

Related: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68768