### PR TITLE
[@types/oracledb] Fix fetchAsBuffer and fetchAsString types

### DIFF
--- a/types/oracledb/index.d.ts
+++ b/types/oracledb/index.d.ts
@@ -538,7 +538,7 @@ declare namespace OracleDB {
      *
      * @since 1.13
      */
-    let fetchAsBuffer: number[];
+    let fetchAsBuffer: Array<typeof BLOB>;
     /**
      * An array of node-oracledb types. The valid types are oracledb.DATE, oracledb.NUMBER, oracledb.BUFFER, and oracledb.CLOB.
      * When any column having one of the specified types is queried with execute() or queryStream(), the column data is returned as a string instead of the default representation.
@@ -555,7 +555,7 @@ declare namespace OracleDB {
      *
      * For non-CLOB types, the conversion to string is handled by Oracle client libraries and is often referred to as defining the fetch type.
      */
-    let fetchAsString: number[];
+    let fetchAsString: Array<typeof DATE | typeof NUMBER | typeof BUFFER | typeof CLOB>;
     /**
      * The maximum number of rows that are fetched by a query with connection.execute() when not using a ResultSet.
      * Rows beyond this limit are not fetched from the database. A value of 0 means there is no limit.

--- a/types/oracledb/oracledb-tests.ts
+++ b/types/oracledb/oracledb-tests.ts
@@ -677,7 +677,18 @@ export const v5point1Tests = (): void => {
     defaultOracledb.dbObjectAsPojo = true;
 };
 
-export const testFetchAsTypeTests = (): void => {
+export const fetchAsBufferTests = (): void => {
     defaultOracledb.fetchAsBuffer = [oracledb.BLOB];
+    // @ts-expect-error
+    defaultOracledb.fetchAsBuffer = [{}];
+    // @ts-expect-error
+    defaultOracledb.fetchAsBuffer = [oracledb.DATE];
+};
+
+export const fetchAsStringTests = (): void => {
     defaultOracledb.fetchAsString = [oracledb.DATE, oracledb.NUMBER, oracledb.BUFFER, oracledb.CLOB];
+    // @ts-expect-error
+    defaultOracledb.fetchAsString = [{}];
+    // @ts-expect-error
+    defaultOracledb.fetchAsString = [oracledb.STRING];
 };

--- a/types/oracledb/oracledb-tests.ts
+++ b/types/oracledb/oracledb-tests.ts
@@ -51,7 +51,7 @@ const testBreak = (connection: oracledb.Connection): Promise<void> =>
         setTimeout((): void => {
             console.log("Testing connection.execute()...");
 
-            connection.break().then((): void => { });
+            connection.break().then((): void => {});
         }, 1000);
     });
 

--- a/types/oracledb/oracledb-tests.ts
+++ b/types/oracledb/oracledb-tests.ts
@@ -51,7 +51,7 @@ const testBreak = (connection: oracledb.Connection): Promise<void> =>
         setTimeout((): void => {
             console.log("Testing connection.execute()...");
 
-            connection.break().then((): void => {});
+            connection.break().then((): void => { });
         }, 1000);
     });
 
@@ -675,4 +675,9 @@ export const v5Tests = async (): Promise<void> => {
 export const v5point1Tests = (): void => {
     console.log(defaultOracledb.DB_TYPE_JSON);
     defaultOracledb.dbObjectAsPojo = true;
+};
+
+export const testFetchAsTypeTests = (): void => {
+    defaultOracledb.fetchAsBuffer = [oracledb.BLOB];
+    defaultOracledb.fetchAsString = [oracledb.DATE, oracledb.NUMBER, oracledb.BUFFER, oracledb.CLOB];
 };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
  - https://node-oracledb.readthedocs.io/en/latest/api_manual/oracledb.html#oracledb.fetchAsBuffer
  - https://node-oracledb.readthedocs.io/en/latest/api_manual/oracledb.html#oracledb.fetchAsString
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
  - no new version, just a bug fix

