### PR TITLE
Add Missing Prop for React Native Signature Capture

### DIFF
--- a/types/react-native-signature-capture/index.d.ts
+++ b/types/react-native-signature-capture/index.d.ts
@@ -61,7 +61,7 @@ export interface SignatureCaptureProps extends ViewProps {
      *
      * @default #000000
      */
-    strokeColor?: string | undefined
+    strokeColor?: string | undefined;
 
     /**
      * Triggered when saveImage() is called, which return Base64 Encoded String and image file path.

--- a/types/react-native-signature-capture/index.d.ts
+++ b/types/react-native-signature-capture/index.d.ts
@@ -59,7 +59,7 @@ export interface SignatureCaptureProps extends ViewProps {
     /**
      * Sets the color of the signature. Defaults to black.
      *
-     * @default #000000
+     * @default "#000000"
      */
     strokeColor?: string | undefined;
 

--- a/types/react-native-signature-capture/index.d.ts
+++ b/types/react-native-signature-capture/index.d.ts
@@ -57,6 +57,13 @@ export interface SignatureCaptureProps extends ViewProps {
     maxSize?: number | undefined;
 
     /**
+     * Sets the color of the signature. Defaults to black.
+     *
+     * @default #000000
+     */
+    strokeColor?: string | undefined
+
+    /**
      * Triggered when saveImage() is called, which return Base64 Encoded String and image file path.
      *
      * @param params - the file path and encoded png

--- a/types/react-native-signature-capture/react-native-signature-capture-tests.tsx
+++ b/types/react-native-signature-capture/react-native-signature-capture-tests.tsx
@@ -22,6 +22,7 @@ class RNSignatureExample extends React.Component {
                     showNativeButtons={false}
                     showTitleLabel={false}
                     viewMode={"portrait"}
+                    strokeColor="#FFFFFF"
                 />
 
                 <View style={{ flex: 1, flexDirection: "row" }}>


### PR DESCRIPTION
This change adds the missing `strokeColor` prop for the `react-native-signature-capture` package. The prop is mentioned on the [original GitHub page for the library](https://github.com/RepairShopr/react-native-signature-capture?tab=readme-ov-file#properties) but not listed here.

Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/RepairShopr/react-native-signature-capture?tab=readme-ov-file#properties>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
