### PR TITLE
[aws-lambda] CloudFrontS3Origin.region not on authType none.

### DIFF
--- a/types/aws-lambda/common/cloudfront.d.ts
+++ b/types/aws-lambda/common/cloudfront.d.ts
@@ -27,11 +27,24 @@ export interface CloudFrontCustomOrigin {
     sslProtocols: string[];
 }
 
-export interface CloudFrontS3Origin {
+export type CloudFrontS3Origin =
+    | CloudFrontS3OriginAuthMethodNone
+    | CloudFrontS3OriginAuthMethodOriginAccessIdentity;
+
+export interface CloudFrontS3OriginBase {
     authMethod: "origin-access-identity" | "none";
     customHeaders: CloudFrontHeaders;
     domainName: string;
     path: string;
+}
+
+export interface CloudFrontS3OriginAuthMethodNone extends CloudFrontS3OriginBase {
+    authMethod: "none";
+    region?: never;
+}
+
+export interface CloudFrontS3OriginAuthMethodOriginAccessIdentity extends CloudFrontS3OriginBase {
+    authMethod: "origin-access-identity";
     region: string;
 }
 

--- a/types/aws-lambda/test/cloudfront-tests.ts
+++ b/types/aws-lambda/test/cloudfront-tests.ts
@@ -31,8 +31,25 @@ const requestHandler: CloudFrontRequestHandler = async (event, context, cb) => {
         customHeaders: {},
         domainName: "example.com",
         path: "/",
+    };
+    s3Origin = {
+        authMethod: "origin-access-identity",
+        customHeaders: {},
+        domainName: "example.com",
+        path: "/",
         region: "us-east-1",
     };
+
+    if (request.origin?.s3?.authMethod === "none") {
+        str = request.origin.s3.path;
+        // @ts-expect-error
+        str = request.origin.s3.region;
+    }
+
+    if (request.origin?.s3?.authMethod === "origin-access-identity") {
+        str = request.origin.s3.path;
+        str = request.origin.s3.region;
+    }
 
     if (request.origin && request.origin.custom) {
         request.origin.custom.domainName;


### PR DESCRIPTION
Apparently, region is only available when authType is `"origin-access-identity"`, not `"none"`.

Did my best to preserve backwards compatibility for people who are not affected by this behavior: if you have any errors, try using `CloudFrontS3OriginBase` instead of `CloudFrontS3Origin` to get a simple interface without the `region` property.

Fixes #68844

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See #68844
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
