### PR TITLE
infinitescroll: fix type of checkLastPage

### DIFF
--- a/types/infinite-scroll/index.d.ts
+++ b/types/infinite-scroll/index.d.ts
@@ -24,7 +24,7 @@ declare namespace InfiniteScroll {
          * `last` event will be triggered when last page is reached
          * @default true
          */
-        checkLastPage?: boolean | undefined;
+        checkLastPage?: boolean | string | undefined;
         /**
          * Sets the Response body interface method,
          * on the response returned from fetch request

--- a/types/infinite-scroll/infinite-scroll-tests.ts
+++ b/types/infinite-scroll/infinite-scroll-tests.ts
@@ -27,6 +27,17 @@ infScrollJQuery("getAbsolutePath");
 infScroll.option({ path: "/page/{{#}}" });
 infScrollJQuery("option", { path: "/page/{{#}}" });
 
+// Check the `checkLastPage` option, which can take either a boolean
+// or a string.
+infScroll.option({ checkLastPage: true });
+infScrollJQuery("option", { checkLastPage: true });
+infScroll.option({ checkLastPage: ".nextpage" });
+infScrollJQuery("option", { checkLastPage: ".nextpage" });
+// @ts-expect-error
+infScroll.option({ checkLastPage: 5 });
+// @ts-expect-error
+infScrollJQuery("option", { checkLastPage: 5 });
+
 infScroll.destroy();
 infScrollJQuery("destroy");
 


### PR DESCRIPTION
Per https://github.com/metafizzy/infinite-scroll?tab=readme-ov-file#options, the `checkLastPage` option can take a string, if the `path` is not set.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code - yes.
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change - change is trivial.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/metafizzy/infinite-scroll?tab=readme-ov-file#options