### PR TITLE
[node] adds missing ReadableStream.from constructor

### DIFF
--- a/types/node/stream/web.d.ts
+++ b/types/node/stream/web.d.ts
@@ -156,6 +156,7 @@ declare module "stream/web" {
     }
     const ReadableStream: {
         prototype: ReadableStream;
+        from<T>(iterable: Iterable<T> | AsyncIterable<T>): ReadableStream<T>;
         new(underlyingSource: UnderlyingByteSource, strategy?: QueuingStrategy<Uint8Array>): ReadableStream<Uint8Array>;
         new<R = any>(underlyingSource?: UnderlyingSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
     };

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -688,7 +688,6 @@ async function testReadableStream() {
         value;
     }
 
-
     // ERROR: 538:31  await-promise  Invalid 'for-await-of' of a non-AsyncIterable value.
     // for await (const value of stream) {
     //     // $ExpectType number

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -20,7 +20,7 @@ import { stdout } from "node:process";
 import { arrayBuffer, blob, buffer, json, text } from "node:stream/consumers";
 import { pipeline as pipelinePromise } from "node:stream/promises";
 import { ReadableStream, TransformStream, WritableStream } from "node:stream/web";
-import { setInterval as every } from "node:timers/promises";
+import { setInterval as every, setTimeout as wait } from "node:timers/promises";
 import { MessageChannel as NodeMC } from "node:worker_threads";
 
 // Simplified constructors
@@ -668,6 +668,26 @@ async function testReadableStream() {
         // $ExpectType number
         value;
     }
+
+    const streamFromIterable = ReadableStream.from([1, 2, 3, 4]);
+    for await (const value of streamFromIterable) {
+        // $ExpectType number
+        value;
+    }
+
+    const streamFromAsyncIterable = ReadableStream.from({
+        async *[Symbol.asyncIterator]() {
+            for (let i = 0; i < 10; i++) {
+                await wait(100);
+                yield i;
+            }
+        },
+    });
+    for await (const value of streamFromAsyncIterable) {
+        // $ExpectType number
+        value;
+    }
+
 
     // ERROR: 538:31  await-promise  Invalid 'for-await-of' of a non-AsyncIterable value.
     // for await (const value of stream) {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [nodejs documentation (since v20.6.0)](https://nodejs.org/docs/latest-v20.x/api/webstreams.html#readablestreamfromiterable)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

