### PR TITLE
[@uswds/uswds]: Fix inaccurate typings for optional elements, add new components

### DIFF
--- a/types/uswds__uswds/js/_usa-password/index.d.ts
+++ b/types/uswds__uswds/js/_usa-password/index.d.ts
@@ -1,6 +1,6 @@
 interface Password {
-    on(el: HTMLElement): void;
-    off(el: HTMLElement): void;
+    on(el?: HTMLElement): void;
+    off(el?: HTMLElement): void;
 }
 
 declare const password: Password;

--- a/types/uswds__uswds/js/index.d.ts
+++ b/types/uswds__uswds/js/index.d.ts
@@ -1,6 +1,7 @@
 import password from "./_usa-password";
 import accordion from "./usa-accordion";
 import banner from "./usa-banner";
+import button from "./usa-button";
 import characterCount from "./usa-character-count";
 import comboBox from "./usa-combo-box";
 import datePicker from "./usa-date-picker";
@@ -13,6 +14,7 @@ import inputMask from "./usa-input-mask";
 import inputPrefixSuffix from "./usa-input-prefix-suffix";
 import languageSelector from "./usa-language-selector";
 import modal from "./usa-modal";
+import range from "./usa-range";
 import search from "./usa-search";
 import skipnav from "./usa-skipnav";
 import table from "./usa-table";
@@ -23,6 +25,7 @@ import validator from "./usa-validation";
 export {
     accordion,
     banner,
+    button,
     characterCount,
     comboBox,
     datePicker,
@@ -36,6 +39,7 @@ export {
     modal,
     navigation,
     password,
+    range,
     search,
     skipnav,
     table,

--- a/types/uswds__uswds/js/usa-accordion/index.d.ts
+++ b/types/uswds__uswds/js/usa-accordion/index.d.ts
@@ -1,9 +1,9 @@
 interface Accordion {
     ACCORDION: string;
     BUTTON: string;
-    init(root: HTMLElement | Document): void;
-    on(el: HTMLElement): void;
-    off(el: HTMLElement): void;
+    init(root?: HTMLElement | Document): void;
+    on(el?: HTMLElement): void;
+    off(el?: HTMLElement): void;
     show(button: HTMLButtonElement): boolean;
     hide(button: HTMLButtonElement): boolean;
     /**

--- a/types/uswds__uswds/js/usa-banner/index.d.ts
+++ b/types/uswds__uswds/js/usa-banner/index.d.ts
@@ -1,6 +1,6 @@
 interface Banner {
-    on(el: HTMLElement): void;
-    off(el: HTMLElement): void;
+    on(el?: HTMLElement): void;
+    off(el?: HTMLElement): void;
 }
 
 declare const banner: Banner;

--- a/types/uswds__uswds/js/usa-button/index.d.ts
+++ b/types/uswds__uswds/js/usa-button/index.d.ts
@@ -1,0 +1,8 @@
+interface Button {
+  on(el?: HTMLElement): void;
+  off(el?: HTMLElement): void;
+}
+
+declare const button: Button;
+
+export default button;

--- a/types/uswds__uswds/js/usa-button/index.d.ts
+++ b/types/uswds__uswds/js/usa-button/index.d.ts
@@ -1,6 +1,6 @@
 interface Button {
-  on(el?: HTMLElement): void;
-  off(el?: HTMLElement): void;
+    on(el?: HTMLElement): void;
+    off(el?: HTMLElement): void;
 }
 
 declare const button: Button;

--- a/types/uswds__uswds/js/usa-character-count/index.d.ts
+++ b/types/uswds__uswds/js/usa-character-count/index.d.ts
@@ -1,12 +1,12 @@
 interface CharacterCount {
-    init(root: HTMLElement | Document): void;
+    init(root?: HTMLElement | Document): void;
     MESSAGE_INVALID_CLASS: string;
     VALIDATION_MESSAGE: string;
     STATUS_MESSAGE_CLASS: string;
     STATUS_MESSAGE_SR_ONLY_CLASS: string;
     DEFAULT_STATUS_LABEL: string;
-    on(el: HTMLElement): void;
-    off(el: HTMLElement): void;
+    on(el?: HTMLElement): void;
+    off(el?: HTMLElement): void;
     /**
      * Create and append status messages for visual and screen readers
      */

--- a/types/uswds__uswds/js/usa-combo-box/index.d.ts
+++ b/types/uswds__uswds/js/usa-combo-box/index.d.ts
@@ -13,10 +13,10 @@ interface ComboBoxContext {
 }
 
 interface ComboBox {
-    init(root: HTMLElement | Document): void;
+    init(root?: HTMLElement | Document): void;
     COMBO_BOX_CLASS: string;
-    on(el: HTMLElement): void;
-    off(el: HTMLElement): void;
+    on(el?: HTMLElement): void;
+    off(el?: HTMLElement): void;
     /**
      * Get an object of elements belonging directly to the given
      * combo box component.

--- a/types/uswds__uswds/js/usa-date-picker/index.d.ts
+++ b/types/uswds__uswds/js/usa-date-picker/index.d.ts
@@ -14,9 +14,9 @@ interface DatePickerContext {
 }
 
 interface DatePicker {
-    init(root: HTMLElement | Document): void;
-    on(el: HTMLElement): void;
-    off(el: HTMLElement): void;
+    init(root?: HTMLElement | Document): void;
+    on(el?: HTMLElement): void;
+    off(el?: HTMLElement): void;
     /**
      * Get an object of the properties and elements belonging directly to the given
      * date picker component.

--- a/types/uswds__uswds/js/usa-date-range-picker/index.d.ts
+++ b/types/uswds__uswds/js/usa-date-range-picker/index.d.ts
@@ -1,7 +1,7 @@
 interface DateRangePicker {
-    init(root: HTMLElement | Document): void;
-    on(el: HTMLElement): void;
-    off(el: HTMLElement): void;
+    init(root?: HTMLElement | Document): void;
+    on(el?: HTMLElement): void;
+    off(el?: HTMLElement): void;
 }
 
 declare const dateRangePicker: DateRangePicker;

--- a/types/uswds__uswds/js/usa-file-input/index.d.ts
+++ b/types/uswds__uswds/js/usa-file-input/index.d.ts
@@ -4,10 +4,10 @@ interface FileInputContext {
 }
 
 interface FileInput {
-    init(root: HTMLElement | Document): void;
-    teardown(root: HTMLElement | Document): void;
-    on(el: HTMLElement): void;
-    off(el: HTMLElement): void;
+    init(root?: HTMLElement | Document): void;
+    teardown(root?: HTMLElement | Document): void;
+    on(el?: HTMLElement): void;
+    off(el?: HTMLElement): void;
     /**
      * Get an object of the properties and elements belonging directly to the given
      * file input component.

--- a/types/uswds__uswds/js/usa-footer/index.d.ts
+++ b/types/uswds__uswds/js/usa-footer/index.d.ts
@@ -2,8 +2,8 @@ interface Footer {
     HIDE_MAX_WIDTH: number;
     init(): void;
     teardown(): void;
-    on(el: HTMLElement): void;
-    off(el: HTMLElement): void;
+    on(el?: HTMLElement): void;
+    off(el?: HTMLElement): void;
 }
 
 declare const footer: Footer;

--- a/types/uswds__uswds/js/usa-header/index.d.ts
+++ b/types/uswds__uswds/js/usa-header/index.d.ts
@@ -1,9 +1,9 @@
 interface Navigation {
     focusTrap: null;
-    init(root: HTMLElement | Document): void;
+    init(root?: HTMLElement | Document): void;
     teardown(): void;
-    on(el: HTMLElement): void;
-    off(el: HTMLElement): void;
+    on(el?: HTMLElement): void;
+    off(el?: HTMLElement): void;
     toggleNav(active: boolean): boolean;
 }
 

--- a/types/uswds__uswds/js/usa-in-page-navigation/index.d.ts
+++ b/types/uswds__uswds/js/usa-in-page-navigation/index.d.ts
@@ -1,7 +1,7 @@
 interface InPageNavigation {
-    init(root: HTMLElement | Document): void;
-    on(root: HTMLElement | Document): void;
-    off(root: HTMLElement | Document): void;
+    init(root?: HTMLElement | Document): void;
+    on(root?: HTMLElement | Document): void;
+    off(root?: HTMLElement | Document): void;
 }
 
 declare const inPageNavigation: InPageNavigation;

--- a/types/uswds__uswds/js/usa-input-mask/index.d.ts
+++ b/types/uswds__uswds/js/usa-input-mask/index.d.ts
@@ -1,7 +1,7 @@
 interface InputMask {
-    init(root: HTMLElement | Document): void;
-    on(root: HTMLElement | Document): void;
-    off(root: HTMLElement | Document): void;
+    init(root?: HTMLElement | Document): void;
+    on(root?: HTMLElement | Document): void;
+    off(root?: HTMLElement | Document): void;
 }
 
 declare const inputMask: InputMask;

--- a/types/uswds__uswds/js/usa-input-prefix-suffix/index.d.ts
+++ b/types/uswds__uswds/js/usa-input-prefix-suffix/index.d.ts
@@ -1,7 +1,7 @@
 interface InputPrefixSuffix {
-    init(root: HTMLElement | Document): void;
-    on(el: HTMLElement): void;
-    off(el: HTMLElement): void;
+    init(root?: HTMLElement | Document): void;
+    on(el?: HTMLElement): void;
+    off(el?: HTMLElement): void;
 }
 
 declare const inputPrefixSuffix: InputPrefixSuffix;

--- a/types/uswds__uswds/js/usa-language-selector/index.d.ts
+++ b/types/uswds__uswds/js/usa-language-selector/index.d.ts
@@ -1,9 +1,9 @@
 interface LanguageSelector {
     focusTrap: null;
-    init(root: HTMLElement | Document): void;
+    init(root?: HTMLElement | Document): void;
     teardown(): void;
-    on(root: HTMLElement | Document): void;
-    off(root: HTMLElement | Document): void;
+    on(root?: HTMLElement | Document): void;
+    off(root?: HTMLElement | Document): void;
 }
 
 declare const languageSelector: LanguageSelector;

--- a/types/uswds__uswds/js/usa-modal/index.d.ts
+++ b/types/uswds__uswds/js/usa-modal/index.d.ts
@@ -1,9 +1,9 @@
 interface Modal {
     focusTrap: null;
-    init(root: HTMLElement | Document): void;
-    teardown(root: HTMLElement | Document): void;
-    on(root: HTMLElement | Document): void;
-    off(root: HTMLElement | Document): void;
+    init(root?: HTMLElement | Document): void;
+    teardown(root?: HTMLElement | Document): void;
+    on(root?: HTMLElement | Document): void;
+    off(root?: HTMLElement | Document): void;
     /**
      *  Toggle the visibility of a modal window
      */

--- a/types/uswds__uswds/js/usa-range/index.d.ts
+++ b/types/uswds__uswds/js/usa-range/index.d.ts
@@ -1,0 +1,10 @@
+interface Range {
+  on(el?: HTMLElement): void;
+  off(el?: HTMLElement): void;
+  init(root?: HTMLElement): void;
+  updateCallout(targetRange: HTMLInputElement): void;
+}
+
+declare const range: Range;
+
+export default range;

--- a/types/uswds__uswds/js/usa-range/index.d.ts
+++ b/types/uswds__uswds/js/usa-range/index.d.ts
@@ -1,8 +1,8 @@
 interface Range {
-  on(el?: HTMLElement): void;
-  off(el?: HTMLElement): void;
-  init(root?: HTMLElement): void;
-  updateCallout(targetRange: HTMLInputElement): void;
+    on(el?: HTMLElement): void;
+    off(el?: HTMLElement): void;
+    init(root?: HTMLElement): void;
+    updateCallout(targetRange: HTMLInputElement): void;
 }
 
 declare const range: Range;

--- a/types/uswds__uswds/js/usa-search/index.d.ts
+++ b/types/uswds__uswds/js/usa-search/index.d.ts
@@ -1,8 +1,8 @@
 interface Search {
-    init(target: HTMLElement | Document): void;
+    init(target?: HTMLElement | Document): void;
     teardown(): void;
-    on(el: HTMLElement): void;
-    off(el: HTMLElement): void;
+    on(el?: HTMLElement): void;
+    off(el?: HTMLElement): void;
 }
 
 declare const search: Search;

--- a/types/uswds__uswds/js/usa-skipnav/index.d.ts
+++ b/types/uswds__uswds/js/usa-skipnav/index.d.ts
@@ -1,6 +1,6 @@
 interface Skipnav {
-    on(el: HTMLElement): void;
-    off(el: HTMLElement): void;
+    on(el?: HTMLElement): void;
+    off(el?: HTMLElement): void;
 }
 
 declare const skipnav: Skipnav;

--- a/types/uswds__uswds/js/usa-table/index.d.ts
+++ b/types/uswds__uswds/js/usa-table/index.d.ts
@@ -2,9 +2,9 @@ interface Table {
     TABLE: string;
     SORTABLE_HEADER: string;
     SORT_BUTTON: string;
-    init(root: HTMLElement | Document): void;
-    on(el: HTMLElement): void;
-    off(el: HTMLElement): void;
+    init(root?: HTMLElement | Document): void;
+    on(el?: HTMLElement): void;
+    off(el?: HTMLElement): void;
 }
 
 declare const table: Table;

--- a/types/uswds__uswds/js/usa-time-picker/index.d.ts
+++ b/types/uswds__uswds/js/usa-time-picker/index.d.ts
@@ -5,9 +5,9 @@ interface TimePicker {
         hourQueryFilter: string;
         minuteQueryFilter: string;
     };
-    init(root: HTMLElement | Document): void;
-    on(el: HTMLElement): void;
-    off(el: HTMLElement): void;
+    init(root?: HTMLElement | Document): void;
+    on(el?: HTMLElement): void;
+    off(el?: HTMLElement): void;
 }
 
 declare const timePicker: TimePicker;

--- a/types/uswds__uswds/js/usa-tooltip/index.d.ts
+++ b/types/uswds__uswds/js/usa-tooltip/index.d.ts
@@ -6,9 +6,9 @@ interface TooltipContext {
 }
 
 interface Tooltip {
-    init(root: HTMLElement | Document): void;
-    on(el: HTMLElement): void;
-    off(el: HTMLElement): void;
+    init(root?: HTMLElement | Document): void;
+    on(el?: HTMLElement): void;
+    off(el?: HTMLElement): void;
     /**
      * Setup the tooltip component
      */

--- a/types/uswds__uswds/js/usa-tooltip/index.d.ts
+++ b/types/uswds__uswds/js/usa-tooltip/index.d.ts
@@ -1,3 +1,5 @@
+type TooltipPosition = 'top' | 'right' | 'bottom' | 'left';
+
 interface TooltipContext {
     tooltipBody: HTMLSpanElement;
     position: string;
@@ -19,14 +21,14 @@ interface Tooltip {
         wrapper: HTMLSpanElement;
     };
     getTooltipElements(trigger: Element): {
-        trigger: Element;
+        trigger: HTMLElement;
         wrapper: HTMLElement;
         body: HTMLElement;
     };
     /**
      * Shows the tooltip
      */
-    show(tooltipTrigger: HTMLElement): void;
+    show(tooltipBody: HTMLElement, tooltipTrigger: HTMLElement, position: TooltipPosition): void;
     /**
      * Removes all the properties to show and position the tooltip,
      * and resets the tooltip position to the original intention

--- a/types/uswds__uswds/js/usa-tooltip/index.d.ts
+++ b/types/uswds__uswds/js/usa-tooltip/index.d.ts
@@ -1,4 +1,4 @@
-type TooltipPosition = 'top' | 'right' | 'bottom' | 'left';
+type TooltipPosition = "top" | "right" | "bottom" | "left";
 
 interface TooltipContext {
     tooltipBody: HTMLSpanElement;

--- a/types/uswds__uswds/js/usa-validation/index.d.ts
+++ b/types/uswds__uswds/js/usa-validation/index.d.ts
@@ -1,7 +1,7 @@
 interface Validator {
-    init(root: HTMLElement | Document): void;
-    on(el: HTMLElement): void;
-    off(el: HTMLElement): void;
+    init(root?: HTMLElement | Document): void;
+    on(el?: HTMLElement): void;
+    off(el?: HTMLElement): void;
 }
 
 declare const validator: Validator;

--- a/types/uswds__uswds/package.json
+++ b/types/uswds__uswds/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/uswds__uswds",
-    "version": "3.3.9999",
+    "version": "3.7.9999",
     "projects": [
         "https://github.com/uswds/uswds"
     ],

--- a/types/uswds__uswds/package.json
+++ b/types/uswds__uswds/package.json
@@ -12,6 +12,10 @@
         {
             "name": "Morgan Spencer",
             "githubUsername": "morganmspencer"
+        },
+        {
+            "name": "Andrew Duthie",
+            "githubUsername": "aduth"
         }
     ]
 }

--- a/types/uswds__uswds/uswds__uswds-tests.ts
+++ b/types/uswds__uswds/uswds__uswds-tests.ts
@@ -29,8 +29,11 @@ const input = document.createElement("input");
 // Accordion
 accordion.ACCORDION; // $ExpectType string
 accordion.BUTTON; // $ExpectType string
+accordion.init(); // $ExpectType void
 accordion.init(element); // $ExpectType void
+accordion.on(); // $ExpectType void
 accordion.on(element); // $ExpectType void
+accordion.off(); // $ExpectType void
 accordion.off(element); // $ExpectType void
 accordion.show(button); // $ExpectType boolean
 accordion.hide(button); // $ExpectType boolean
@@ -39,7 +42,9 @@ accordion.toggle(button, true); // $ExpectType boolean
 accordion.getButtons(element); // $ExpectType HTMLButtonElement[]
 
 // Banner
+banner.on(); // $ExpectType void
 banner.on(element); // $ExpectType void
+banner.off(); // $ExpectType void
 banner.off(element); // $ExpectType void
 
 // Character Count
@@ -48,17 +53,23 @@ characterCount.MESSAGE_INVALID_CLASS; // $ExpectType string
 characterCount.STATUS_MESSAGE_CLASS; // $ExpectType string
 characterCount.STATUS_MESSAGE_SR_ONLY_CLASS; // $ExpectType string
 characterCount.VALIDATION_MESSAGE; // $ExpectType string
+characterCount.init(); // $ExpectType void
 characterCount.init(element); // $ExpectType void
+characterCount.on(); // $ExpectType void
 characterCount.on(element); // $ExpectType void
+characterCount.off(); // $ExpectType void
 characterCount.off(element); // $ExpectType void
 characterCount.createStatusMessages(element); // $ExpectType void
 characterCount.getCountMessage(2, 25); // $ExpectType string
 characterCount.updateCountMessage(input); // $ExpectType void
 
 // Combo Box
+comboBox.init(); // $ExpectType void
 comboBox.init(element); // $ExpectType void
 comboBox.COMBO_BOX_CLASS; // $ExpectType string
+comboBox.on(); // $ExpectType void
 comboBox.on(element); // $ExpectType void
+comboBox.off(); // $ExpectType void
 comboBox.off(element); // $ExpectType void
 /*
 $ExpectType {
@@ -84,8 +95,11 @@ comboBox.displayList(input); // $ExpectType void
 comboBox.hideList(input); // $ExpectType void
 
 // Date Picker
+datePicker.init(); // $ExpectType void
 datePicker.init(element); // $ExpectType void
+datePicker.on(); // $ExpectType void
 datePicker.on(element); // $ExpectType void
+datePicker.off(); // $ExpectType void
 datePicker.off(element); // $ExpectType void
 /*
 $ExpectType {
@@ -113,14 +127,21 @@ datePicker.renderCalendar(element, new Date()); // $ExpectType HTMLElement
 datePicker.updateCalendarIfVisible(element); // $ExpectType void
 
 // Date Range Picker
+dateRangePicker.init(); // $ExpectType void
 dateRangePicker.init(element); // $ExpectType void
+dateRangePicker.on(); // $ExpectType void
 dateRangePicker.on(element); // $ExpectType void
+dateRangePicker.off(); // $ExpectType void
 dateRangePicker.off(element); // $ExpectType void
 
 // File Input
+fileInput.init(); // $ExpectType void
 fileInput.init(element); // $ExpectType void
+fileInput.teardown(); // $ExpectType void
 fileInput.teardown(element); // $ExpectType void
+fileInput.on(); // $ExpectType void
 fileInput.on(element); // $ExpectType void
+fileInput.off(); // $ExpectType void
 fileInput.off(element); // $ExpectType void
 /*
 $ExpectType {
@@ -140,63 +161,91 @@ footer.off(element); // $ExpectType void
 footer.teardown(); // $ExpectType void
 
 // In Page Navigation
+inPageNavigation.init(); // $ExpectType void
 inPageNavigation.init(element); // $ExpectType void
+inPageNavigation.on(); // $ExpectType void
 inPageNavigation.on(element); // $ExpectType void
+inPageNavigation.off(); // $ExpectType void
 inPageNavigation.off(element); // $ExpectType void
 
 // Input Mask
+inputMask.init(); // $ExpectType void
 inputMask.init(element); // $ExpectType void
+inputMask.on(); // $ExpectType void
 inputMask.on(element); // $ExpectType void
+inputMask.off(); // $ExpectType void
 inputMask.off(element); // $ExpectType void
 
 // Input Prefix Suffix
+inputPrefixSuffix.init(); // $ExpectType void
 inputPrefixSuffix.init(element); // $ExpectType void
+inputPrefixSuffix.on(); // $ExpectType void
 inputPrefixSuffix.on(element); // $ExpectType void
+inputPrefixSuffix.off(); // $ExpectType void
 inputPrefixSuffix.off(element); // $ExpectType void
 
 // Language Selector
 languageSelector.focusTrap; // $ExpectType null
 languageSelector.init(element); // $ExpectType void
 languageSelector.teardown(); // $ExpectType void
+languageSelector.on(); // $ExpectType void
 languageSelector.on(element); // $ExpectType void
+languageSelector.off(); // $ExpectType void
 languageSelector.off(element); // $ExpectType void
 
 // Modal
 modal.focusTrap; // $ExpectType null
+modal.init(); // $ExpectType void
 modal.init(element); // $ExpectType void
+modal.teardown(); // $ExpectType void
 modal.teardown(element); // $ExpectType void
+modal.on(); // $ExpectType void
 modal.on(element); // $ExpectType void
+modal.off(); // $ExpectType void
 modal.off(element); // $ExpectType void
 modal.toggleModal(new KeyboardEvent("keydown")); // $ExpectType boolean
 
 // Navigation
 navigation.focusTrap; // $ExpectType null
+navigation.init(); // $ExpectType void
 navigation.init(element); // $ExpectType void
+navigation.on(); // $ExpectType void
 navigation.on(element); // $ExpectType void
+navigation.off(); // $ExpectType void
 navigation.off(element); // $ExpectType void
 navigation.teardown(); // $ExpectType void
 navigation.toggleNav(true); // $ExpectType boolean
 
 // Password
+password.on(); // $ExpectType void
 password.on(element); // $ExpectType void
+password.off(); // $ExpectType void
 password.off(element); // $ExpectType void
 
 // Search
+search.init(); // $ExpectType void
 search.init(element); // $ExpectType void
+search.on(); // $ExpectType void
 search.on(element); // $ExpectType void
+search.off(); // $ExpectType void
 search.off(element); // $ExpectType void
 search.teardown(); // $ExpectType void
 
 // Skipnav
+skipnav.on(); // $ExpectType void
 skipnav.on(element); // $ExpectType void
+skipnav.off(); // $ExpectType void
 skipnav.off(element); // $ExpectType void
 
 // Table
 table.TABLE; // $ExpectType string
 table.SORTABLE_HEADER; // $ExpectType string
 table.SORT_BUTTON; // $ExpectType string
+table.init(); // $ExpectType void
 table.init(element); // $ExpectType void
+table.on(); // $ExpectType void
 table.on(element); // $ExpectType void
+table.off(); // $ExpectType void
 table.off(element); // $ExpectType void
 
 // Time Picker
@@ -209,13 +258,19 @@ $ExpectType {
 }
 */
 timePicker.FILTER_DATASET;
+timePicker.init(); // $ExpectType void
 timePicker.init(element); // $ExpectType void
+timePicker.on(); // $ExpectType void
 timePicker.on(element); // $ExpectType void
+timePicker.off(); // $ExpectType void
 timePicker.off(element); // $ExpectType void
 
 // Tooltip
+tooltip.init(); // $ExpectType void
 tooltip.init(element); // $ExpectType void
+tooltip.on(); // $ExpectType void
 tooltip.on(element); // $ExpectType void
+tooltip.off(); // $ExpectType void
 tooltip.off(element); // $ExpectType void
 tooltip.show(element); // $ExpectType void
 tooltip.hide(element); // $ExpectType void
@@ -238,6 +293,9 @@ $ExpectType {
 tooltip.getTooltipElements(element);
 
 // Validator
+validator.init(); // $ExpectType void
 validator.init(element); // $ExpectType void
+validator.on(); // $ExpectType void
 validator.on(element); // $ExpectType void
+validator.off(); // $ExpectType void
 validator.off(element); // $ExpectType void

--- a/types/uswds__uswds/uswds__uswds-tests.ts
+++ b/types/uswds__uswds/uswds__uswds-tests.ts
@@ -272,7 +272,7 @@ tooltip.on(); // $ExpectType void
 tooltip.on(element); // $ExpectType void
 tooltip.off(); // $ExpectType void
 tooltip.off(element); // $ExpectType void
-tooltip.show(element); // $ExpectType void
+tooltip.show(element, element, 'left'); // $ExpectType void
 tooltip.hide(element); // $ExpectType void
 /*
 $ExpectType {
@@ -285,7 +285,7 @@ $ExpectType {
 tooltip.setup(element);
 /*
 $ExpectType {
-    trigger: Element;
+    trigger: HTMLElement;
     wrapper: HTMLElement;
     body: HTMLElement;
 }

--- a/types/uswds__uswds/uswds__uswds-tests.ts
+++ b/types/uswds__uswds/uswds__uswds-tests.ts
@@ -14,8 +14,8 @@ import {
     languageSelector,
     modal,
     navigation,
-    range,
     password,
+    range,
     search,
     skipnav,
     table,
@@ -289,7 +289,7 @@ tooltip.on(); // $ExpectType void
 tooltip.on(element); // $ExpectType void
 tooltip.off(); // $ExpectType void
 tooltip.off(element); // $ExpectType void
-tooltip.show(element, element, 'left'); // $ExpectType void
+tooltip.show(element, element, "left"); // $ExpectType void
 tooltip.hide(element); // $ExpectType void
 /*
 $ExpectType {

--- a/types/uswds__uswds/uswds__uswds-tests.ts
+++ b/types/uswds__uswds/uswds__uswds-tests.ts
@@ -1,6 +1,7 @@
 import {
     accordion,
     banner,
+    button,
     characterCount,
     comboBox,
     datePicker,
@@ -13,6 +14,7 @@ import {
     languageSelector,
     modal,
     navigation,
+    range,
     password,
     search,
     skipnav,
@@ -23,7 +25,7 @@ import {
 } from "@uswds/uswds/js";
 
 const element = document.createElement("div");
-const button = document.createElement("button");
+const buttonElement = document.createElement("button");
 const input = document.createElement("input");
 
 // Accordion
@@ -35,10 +37,10 @@ accordion.on(); // $ExpectType void
 accordion.on(element); // $ExpectType void
 accordion.off(); // $ExpectType void
 accordion.off(element); // $ExpectType void
-accordion.show(button); // $ExpectType boolean
-accordion.hide(button); // $ExpectType boolean
-accordion.toggle(button); // $ExpectType boolean
-accordion.toggle(button, true); // $ExpectType boolean
+accordion.show(buttonElement); // $ExpectType boolean
+accordion.hide(buttonElement); // $ExpectType boolean
+accordion.toggle(buttonElement); // $ExpectType boolean
+accordion.toggle(buttonElement, true); // $ExpectType boolean
 accordion.getButtons(element); // $ExpectType HTMLButtonElement[]
 
 // Banner
@@ -46,6 +48,12 @@ banner.on(); // $ExpectType void
 banner.on(element); // $ExpectType void
 banner.off(); // $ExpectType void
 banner.off(element); // $ExpectType void
+
+// Button
+button.on(); // $ExpectType void
+button.on(element); // $ExpectType void
+button.off(); // $ExpectType void
+button.off(element); // $ExpectType void
 
 // Character Count
 characterCount.DEFAULT_STATUS_LABEL; // $ExpectType string
@@ -121,7 +129,7 @@ datePicker.getDatePickerContext(element);
 datePicker.disable(input); // $ExpectType void
 datePicker.enable(input); // $ExpectType void
 datePicker.isDateInputInvalid(input); // $ExpectType boolean
-datePicker.setCalendarValue(button, "2022-01-01"); // $ExpectType void
+datePicker.setCalendarValue(buttonElement, "2022-01-01"); // $ExpectType void
 datePicker.validateDateInput(element); // $ExpectType void
 datePicker.renderCalendar(element, new Date()); // $ExpectType HTMLElement
 datePicker.updateCalendarIfVisible(element); // $ExpectType void
@@ -221,6 +229,15 @@ password.on(); // $ExpectType void
 password.on(element); // $ExpectType void
 password.off(); // $ExpectType void
 password.off(element); // $ExpectType void
+
+// Range
+range.on(); // $ExpectType void
+range.on(element); // $ExpectType void
+range.off(); // $ExpectType void
+range.off(element); // $ExpectType void
+range.init(); // $ExpectType void
+range.init(element); // $ExpectType void
+range.updateCallout(input); // $ExpectType void
 
 // Search
 search.init(); // $ExpectType void


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   - [Optional target for `on` and `off`](https://github.com/uswds/uswds/blob/4ec68cecfe1288fa510f3d54c97323e68812dc35/packages/uswds-core/src/js/utils/behavior.js#L12)
   - [Optional target for `init` and `teardown` uses `selectOrMatches`, documented as "If not provided, defaults to the document"](https://github.com/uswds/uswds/blob/4ec68cecfe1288fa510f3d54c97323e68812dc35/packages/uswds-core/src/js/utils/select-or-matches.js#L15-L16)
   - [`tooltip.show` receives 3 arguments](https://github.com/uswds/uswds/blob/4ec68cecfe1288fa510f3d54c97323e68812dc35/packages/usa-tooltip/src/index.js#L33)
   - [New `button` component](https://github.com/uswds/uswds/blob/4ec68cecfe1288fa510f3d54c97323e68812dc35/packages/usa-button/src/index.js), added in [v3.5.0](https://github.com/uswds/uswds/releases/tag/v3.5.0) (https://github.com/uswds/uswds/pull/4385)
   - [New `range` component](https://github.com/uswds/uswds/blob/4ec68cecfe1288fa510f3d54c97323e68812dc35/packages/usa-range/src/index.js), added in [v3.7.0](https://github.com/uswds/uswds/releases/tag/v3.7.0) (https://github.com/uswds/uswds/pull/5472)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
   - Updated to from `3.3.9999` to `3.7.9999`
