### PR TITLE
#68869 Fix @types/pg types enforce users to define query config values as array of any

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -7,6 +7,8 @@ import { NoticeMessage } from "pg-protocol/dist/messages";
 
 import { ConnectionOptions } from "tls";
 
+export type QueryConfigValues<T> = T extends Array<infer U> ? (U extends never ? never : T) : never
+
 export interface ClientConfig {
     user?: string | undefined;
     database?: string | undefined;
@@ -49,10 +51,10 @@ export interface PoolConfig extends ClientConfig {
     maxUses?: number | undefined;
 }
 
-export interface QueryConfig<I extends any[] = any[]> {
+export interface QueryConfig<I = any[]> {
     name?: string | undefined;
     text: string;
-    values?: I | undefined;
+    values?: QueryConfigValues<I>;
     types?: CustomTypesConfig | undefined;
 }
 
@@ -64,7 +66,7 @@ export interface Submittable {
     submit: (connection: Connection) => void;
 }
 
-export interface QueryArrayConfig<I extends any[] = any[]> extends QueryConfig<I> {
+export interface QueryArrayConfig<I = any[]> extends QueryConfig<I> {
     rowMode: "array";
 }
 
@@ -181,28 +183,28 @@ export class Pool extends events.EventEmitter {
 
     query<T extends Submittable>(queryStream: T): T;
     // tslint:disable:no-unnecessary-generics
-    query<R extends any[] = any[], I extends any[] = any[]>(
+    query<R extends any[] = any[], I = any[]>(
         queryConfig: QueryArrayConfig<I>,
-        values?: I,
+        values?: QueryConfigValues<I>,
     ): Promise<QueryArrayResult<R>>;
-    query<R extends QueryResultRow = any, I extends any[] = any[]>(
+    query<R extends QueryResultRow = any, I = any[]>(
         queryConfig: QueryConfig<I>,
     ): Promise<QueryResult<R>>;
-    query<R extends QueryResultRow = any, I extends any[] = any[]>(
+    query<R extends QueryResultRow = any, I  = any[]>(
         queryTextOrConfig: string | QueryConfig<I>,
-        values?: I,
+        values?: QueryConfigValues<I>,
     ): Promise<QueryResult<R>>;
-    query<R extends any[] = any[], I extends any[] = any[]>(
+    query<R extends any[] = any[], I  = any[]>(
         queryConfig: QueryArrayConfig<I>,
         callback: (err: Error, result: QueryArrayResult<R>) => void,
     ): void;
-    query<R extends QueryResultRow = any, I extends any[] = any[]>(
+    query<R extends QueryResultRow = any, I  = any[]>(
         queryTextOrConfig: string | QueryConfig<I>,
         callback: (err: Error, result: QueryResult<R>) => void,
     ): void;
-    query<R extends QueryResultRow = any, I extends any[] = any[]>(
+    query<R extends QueryResultRow = any, I = any[]>(
         queryText: string,
-        values: I,
+        values: QueryConfigValues<I>,
         callback: (err: Error, result: QueryResult<R>) => void,
     ): void;
     // tslint:enable:no-unnecessary-generics
@@ -219,28 +221,28 @@ export class ClientBase extends events.EventEmitter {
 
     query<T extends Submittable>(queryStream: T): T;
     // tslint:disable:no-unnecessary-generics
-    query<R extends any[] = any[], I extends any[] = any[]>(
+    query<R extends any[] = any[], I = any[]>(
         queryConfig: QueryArrayConfig<I>,
-        values?: I,
+        values?: QueryConfigValues<I>,
     ): Promise<QueryArrayResult<R>>;
-    query<R extends QueryResultRow = any, I extends any[] = any[]>(
+    query<R extends QueryResultRow = any, I = any>(
         queryConfig: QueryConfig<I>,
     ): Promise<QueryResult<R>>;
-    query<R extends QueryResultRow = any, I extends any[] = any[]>(
+    query<R extends QueryResultRow = any, I = any[]>(
         queryTextOrConfig: string | QueryConfig<I>,
-        values?: I,
+        values?: QueryConfigValues<I>,
     ): Promise<QueryResult<R>>;
-    query<R extends any[] = any[], I extends any[] = any[]>(
+    query<R extends any[] = any[], I = any[]>(
         queryConfig: QueryArrayConfig<I>,
         callback: (err: Error, result: QueryArrayResult<R>) => void,
     ): void;
-    query<R extends QueryResultRow = any, I extends any[] = any[]>(
+    query<R extends QueryResultRow = any, I = any[]>(
         queryTextOrConfig: string | QueryConfig<I>,
         callback: (err: Error, result: QueryResult<R>) => void,
     ): void;
-    query<R extends QueryResultRow = any, I extends any[] = any[]>(
+    query<R extends QueryResultRow = any, I = any[]>(
         queryText: string,
-        values: any[],
+        values: QueryConfigValues<I>,
         callback: (err: Error, result: QueryResult<R>) => void,
     ): void;
     // tslint:enable:no-unnecessary-generics
@@ -285,7 +287,7 @@ export interface PoolClient extends ClientBase {
 export class Query<R extends QueryResultRow = any, I extends any[] = any> extends events.EventEmitter
     implements Submittable
 {
-    constructor(queryTextOrConfig?: string | QueryConfig<I>, values?: I);
+    constructor(queryTextOrConfig?: string | QueryConfig<I>, values?: QueryConfigValues<I>);
     submit: (connection: Connection) => void;
     on(event: "row", listener: (row: R, result?: ResultBuilder<R>) => void): this;
     on(event: "error", listener: (err: Error) => void): this;

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -116,7 +116,7 @@ client
         console.error(e.stack);
     });
 
-const queryArrMode: QueryArrayConfig = {
+const queryArrMode: QueryArrayConfig<[string]> = {
     name: "get-name-array",
     text: "SELECT $1::text",
     values: ["brianc"],
@@ -150,7 +150,7 @@ const customTypes: CustomTypesConfig = {
     getTypeParser: () => () => "aCustomTypeParser!",
 };
 
-const queryCustomTypes = {
+const queryCustomTypes: pg.QueryConfig<[string]> = {
     name: "get-name",
     text: "SELECT $1::text",
     values: ["brianc"],


### PR DESCRIPTION
Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/68869. 

With this solution you don't have to extend `any[]`. 

```
import { Client, ClientConfig, QueryConfig, QueryResult, QueryResultRow } from "pg";

export class DatabaseConnector {
  private client: Client;

  constructor(config: ClientConfig) {
    this.client = new Client(config);
  }

  public async connect(): Promise<void> {
    await this.client.connect();
  }

  public async end(): Promise<void> {
    await this.client.end();
  }

  public async query<T extends QueryResultRow, I>(
    queryConfig: QueryConfig<I>,
  ): Promise<QueryResult<T>> {
    return this.client.query<T, I>(queryConfig);
  }
}
```

After instantiation you can use it with array type. 

```
connector.query<ResultRow, string[]>({
  text: "SELECT * FROM users WHERE id = $1",
  values: ["f18b9bb3-4d0a-46b0-b4d9-cd82759e4901"],
});
```

With tuple type.

```
connector.query<ResultRow, [string]>({
  text: "SELECT * FROM users WHERE id = $1",
  values: ["f18b9bb3-4d0a-46b0-b4d9-cd82759e4901"],
});
```

You get the expected type errors.

```
connector.query<ResultRow, [number]>({
  text: "SELECT * FROM users WHERE id = $1",
  values: ["f18b9bb3-4d0a-46b0-b4d9-cd82759e4901"],
});

// Type 'string' is not assignable to type 'number'.ts(2322)
```

And you can only use array or tuple types.

```
connector.query<ResultRow, [number]>({
  text: "SELECT * FROM users WHERE id = $1",
  values: ["f18b9bb3-4d0a-46b0-b4d9-cd82759e4901"],
});

// Type 'string' is not assignable to type 'undefined'.ts(2322)
```

