### PR TITLE
[passport-discord] Fix existing and add missing profile types

### DIFF
--- a/types/passport-discord/index.d.ts
+++ b/types/passport-discord/index.d.ts
@@ -84,20 +84,28 @@ declare namespace Strategy {
     interface Profile extends passport.Profile {
         provider: "discord";
         username: string;
-        global_name: string;
+        global_name: string | null;
         locale: string;
         mfa_enabled: boolean;
         flags: number;
+        public_flags: number;
         banner: string | null;
         accent_color: number | null;
         avatar: string | null;
-        avatar_decoration_data: string | null;
+        avatar_decoration_data: AvatarDecorationData | null;
         discriminator: string;
         verified: boolean;
+        /** @see {@link https://discord.com/developers/docs/resources/user#user-object-premium-types} */
+        premium_type: 0 | 1 | 2 | 3;
         fetchedAt: string;
         email?: string | undefined; // requires "email" scope
         connections?: ConnectionInfo[] | undefined; // requires "connection" scope
         guilds?: GuildInfo[] | undefined; // requires "guilds" scope
+    }
+
+    interface AvatarDecorationData {
+        sku_id: string;
+        asset: string;
     }
 
     interface ConnectionInfo {

--- a/types/passport-discord/package.json
+++ b/types/passport-discord/package.json
@@ -17,6 +17,10 @@
         {
             "name": "Gonthier Renaud",
             "githubUsername": "kzay"
+        },
+        {
+            "name": "Almeida",
+            "githubUsername": "almeidx"
         }
     ]
 }

--- a/types/passport-discord/passport-discord-tests.ts
+++ b/types/passport-discord/passport-discord-tests.ts
@@ -39,3 +39,10 @@ passport.use(
         },
     ),
 );
+
+declare const profile: discord.Profile;
+
+profile.avatar_decoration_data; // $ExpectType AvatarDecorationData | null
+profile.public_flags; // $ExpectType number
+profile.global_name; // $ExpectType string | null
+profile.premium_type; // $ExpectType 0 | 1 | 2 | 3


### PR DESCRIPTION
#68349 added incorrect types for `global_name` and `avatar_decoration_data` (the latter has not been officially documented). I've corrected these types to what they are currently. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - <https://discord.com/developers/docs/resources/user#user-object-user-structure>
  - `avatar_decoration_data`: <https://github.com/discord/discord-api-docs/pull/6464>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

