### PR TITLE
Added `NestingSelector` type in `csstree`

### DIFF
--- a/types/css-tree/css-tree-tests.ts
+++ b/types/css-tree/css-tree-tests.ts
@@ -367,6 +367,9 @@ switch (ast.type) {
     case "MediaQueryList":
         ast.children; // $ExpectType List<CssNode>
         break;
+    
+    case "NestingSelector":
+        break;
 
     case "Nth":
         ast.nth; // $ExpectType AnPlusB | Identifier

--- a/types/css-tree/index.d.ts
+++ b/types/css-tree/index.d.ts
@@ -255,6 +255,10 @@ export interface MediaQueryListPlain extends CssNodeCommon {
     children: CssNodePlain[];
 }
 
+export interface NestingSelector extends CssNodeCommon {
+    type: "NestingSelector";
+}
+
 export interface Nth extends CssNodeCommon {
     type: "Nth";
     nth: AnPlusB | Identifier;
@@ -426,6 +430,7 @@ export type CssNode =
     | MediaFeature
     | MediaQuery
     | MediaQueryList
+    | NestingSelector
     | Nth
     | NumberNode
     | Operator


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: Changelog: https://github.com/csstree/csstree/blob/ba6dfd8bb0e33055c05f13803d04825d98dd2d8d/CHANGELOG.md?plain=1#L69
File: https://github.com/csstree/csstree/blob/master/lib/syntax/node/NestingSelector.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
