### PR TITLE
[react] Disable JSX.Element module augmentation

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -4159,7 +4159,7 @@ declare namespace React {
     // Keep in sync with JSX namespace in ./jsx-runtime.d.ts and ./jsx-dev-runtime.d.ts
     namespace JSX {
         type ElementType = GlobalJSXElementType;
-        interface Element extends GlobalJSXElement {}
+        type Element = GlobalJSXElement;
         interface ElementClass extends GlobalJSXElementClass {}
         interface ElementAttributesProperty extends GlobalJSXElementAttributesProperty {}
         interface ElementChildrenAttribute extends GlobalJSXElementChildrenAttribute {}
@@ -4232,7 +4232,7 @@ declare global {
         //  reduce the work of the type-checker.
         // TODO: Check impact of making React.ElementType<P = any> = React.JSXElementConstructor<P>
         type ElementType = string | React.JSXElementConstructor<any>;
-        interface Element extends React.ReactElement<any, any> {}
+        type Element = React.ReactElement<any, any>;
         interface ElementClass extends React.Component<any> {
             render(): React.ReactNode;
         }
@@ -4446,7 +4446,7 @@ declare global {
 // But we can't access global.JSX so we need to create these aliases instead.
 // Once the global JSX namespace will be removed we replace React.JSX with the contents of global.JSX
 type GlobalJSXElementType = JSX.ElementType;
-interface GlobalJSXElement extends JSX.Element {}
+type GlobalJSXElement = JSX.Element;
 interface GlobalJSXElementClass extends JSX.ElementClass {}
 interface GlobalJSXElementAttributesProperty extends JSX.ElementAttributesProperty {}
 interface GlobalJSXElementChildrenAttribute extends JSX.ElementChildrenAttribute {}

--- a/types/react/jsx-dev-runtime.d.ts
+++ b/types/react/jsx-dev-runtime.d.ts
@@ -3,7 +3,7 @@ export { Fragment } from "./";
 
 export namespace JSX {
     type ElementType = React.JSX.ElementType;
-    interface Element extends React.JSX.Element {}
+    type Element = React.JSX.Element;
     interface ElementClass extends React.JSX.ElementClass {}
     interface ElementAttributesProperty extends React.JSX.ElementAttributesProperty {}
     interface ElementChildrenAttribute extends React.JSX.ElementChildrenAttribute {}

--- a/types/react/jsx-runtime.d.ts
+++ b/types/react/jsx-runtime.d.ts
@@ -3,7 +3,7 @@ export { Fragment } from "./";
 
 export namespace JSX {
     type ElementType = React.JSX.ElementType;
-    interface Element extends React.JSX.Element {}
+    type Element = React.JSX.Element;
     interface ElementClass extends React.JSX.ElementClass {}
     interface ElementAttributesProperty extends React.JSX.ElementAttributesProperty {}
     interface ElementChildrenAttribute extends React.JSX.ElementChildrenAttribute {}

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -4150,8 +4150,9 @@ declare namespace React {
         componentStack: string;
     }
 
+    // Keep in sync with JSX namespace in ./jsx-runtime.d.ts and ./jsx-dev-runtime.d.ts
     namespace JSX {
-        interface Element extends GlobalJSXElement {}
+        type Element = GlobalJSXElement;
         interface ElementClass extends GlobalJSXElementClass {}
         interface ElementAttributesProperty extends GlobalJSXElementAttributesProperty {}
         interface ElementChildrenAttribute extends GlobalJSXElementChildrenAttribute {}
@@ -4212,7 +4213,7 @@ declare global {
      * @deprecated Use `React.JSX` instead of the global `JSX` namespace.
      */
     namespace JSX {
-        interface Element extends React.ReactElement<any, any> {}
+        type Element = React.ReactElement<any, any>;
         interface ElementClass extends React.Component<any> {
             render(): React.ReactNode;
         }
@@ -4425,7 +4426,7 @@ declare global {
 // React.JSX needs to point to global.JSX to keep global module augmentations intact.
 // But we can't access global.JSX so we need to create these aliases instead.
 // Once the global JSX namespace will be removed we replace React.JSX with the contents of global.JSX
-interface GlobalJSXElement extends JSX.Element {}
+type GlobalJSXElement = JSX.Element;
 interface GlobalJSXElementClass extends JSX.ElementClass {}
 interface GlobalJSXElementAttributesProperty extends JSX.ElementAttributesProperty {}
 interface GlobalJSXElementChildrenAttribute extends JSX.ElementChildrenAttribute {}

--- a/types/react/ts5.0/jsx-dev-runtime.d.ts
+++ b/types/react/ts5.0/jsx-dev-runtime.d.ts
@@ -2,7 +2,7 @@ import * as React from "./";
 export { Fragment } from "./";
 
 export namespace JSX {
-    interface Element extends React.JSX.Element {}
+    type Element = React.JSX.Element;
     interface ElementClass extends React.JSX.ElementClass {}
     interface ElementAttributesProperty extends React.JSX.ElementAttributesProperty {}
     interface ElementChildrenAttribute extends React.JSX.ElementChildrenAttribute {}

--- a/types/react/ts5.0/jsx-runtime.d.ts
+++ b/types/react/ts5.0/jsx-runtime.d.ts
@@ -2,7 +2,7 @@ import * as React from "./";
 export { Fragment } from "./";
 
 export namespace JSX {
-    interface Element extends React.JSX.Element {}
+    type Element = React.JSX.Element;
     interface ElementClass extends React.JSX.ElementClass {}
     interface ElementAttributesProperty extends React.JSX.ElementAttributesProperty {}
     interface ElementChildrenAttribute extends React.JSX.ElementChildrenAttribute {}


### PR DESCRIPTION
We want to hide away React.JSX.Element as much as possible since there really is no JSX namespace in React. It's an implementation detail of the type-checker.

However, by making JSX.Element an interface, it leaks into emitted declaration files when types for the result of JSX expression need to be inferred.

For example, `export const Component = () => <div />` will have a declaration emit of `export const Component: () => React.JSX.Element`.

By changing `JSX.Element` to a type alias, TypeScript will emit the resolved alias. In the above example, we'd get an emit of `export const Component: () => React.ReactElement<any, any>`.

This will help reduce confusion which type to use for JSX expression. We just want `React.ReactElement` which may be further reduced to `React.Element` in the future.

React's JSX namespace should really only be used for typing web components via module augmentation.

## Test plan

Motivating example:

Check the output of the ".D.TS" tab

Before:


```tsx
// component.tsx
interface ReactElement {
  type: unknown
}

declare global {
  namespace JSX {
  interface Element extends ReactElement {

  }
  interface IntrinsicElements {
    div: any
  }
}
}


export const Component = () => <div />
```

[Playground Link](https://www.typescriptlang.org/play?jsx=1#code/JYOwLgpgTgZghgYwgAgEoUWAogGwgWwnGQG8AoZZMATwAcIAuZAVxAGsQB7AdxDIF8yZACYQEOOFBQBzHJwBGcHKQrIQcQgGdaiFACkAygA0VlUJFi7kuAkTDIIAD0ghhmtBgTY8hYuVWCZuDQ8EjIAJLgUKCawAg2vmDu5JSUwsAAbkxwINQBAgVCTrScUPYInCCa9gDCnPglIHbIALzIABQAlK0AfMgAPOkZyAD0PUA)

```ts
// component.d.ts

interface ReactElement {
  type: unknown
}

declare global {
  namespace JSX {
  interface Element extends ReactElement {

  }
  interface IntrinsicElements {
    div: any
  }
}
}


export const Component = () => <div />
.JS
.D.TS
Errors
Logs
Plugins
DT
interface ReactElement {
    type: unknown;
}
declare global {
    namespace JSX {
        interface Element extends ReactElement {
        }
        interface IntrinsicElements {
            div: any;
        }
    }
}
export declare const Component: () => JSX.Element;
export {};
```

After:

```tsx
// component.tsx
```tsx
interface ReactElement {
  type: unknown
}

declare global {
  namespace JSX {
  type Element = ReactElement
  interface IntrinsicElements {
    div: any
  }
}
}


export const Component = () => <div />;
```

[Playground Link](https://www.typescriptlang.org/play?jsx=1#code/JYOwLgpgTgZghgYwgAgEoUWAogGwgWwnGQG8AoZZMATwAcIAuZAVxAGsQB7AdxDIF8yZACYQEOOFBQBzHJwBGcHKQrIQcQgGdaiFACkAygA0VlGvWS4CRMMgC8aDAmx5C4VaEixdyAJLgoUE1gBCs3ME1TSmRhYAA3JjgQalVBNKEyCAAPWk4oWwROEE1bAGFOfFyQG3tkAAoASnsAPmQAHli45AB6ZqA)

``ts
// component.d.ts
interface ReactElement {
    type: unknown;
}
declare global {
    namespace JSX {
        type Element = ReactElement;
        interface IntrinsicElements {
            div: any;
        }
    }
}
export declare const Component: () => ReactElement;
export {};
```
