### PR TITLE
[react] Move ReactDOM* tests to `react-dom`

### DIFF
--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -15,13 +15,26 @@ class TestComponent extends React.Component<{ x: string }> {
 
 describe("ReactDOM", () => {
     it("render", () => {
-        const rootElement = document.createElement("div");
-        ReactDOM.render(React.createElement("div"), rootElement);
+        const container = document.createElement("div");
+        ReactDOM.render(React.createElement("div"), container);
         ReactDOM.render(React.createElement("div"), document.createDocumentFragment());
         ReactDOM.render(React.createElement("div"), document);
 
-        const instance = ReactDOM.render(React.createElement(TestComponent), rootElement);
+        const instance = ReactDOM.render(React.createElement(TestComponent), container);
         instance.someInstanceMethod();
+
+        const element = React.createElement(TestComponent, { x: "test" });
+        const component: TestComponent = ReactDOM.render(element, container);
+        const componentNullContainer: TestComponent = ReactDOM.render(element, null);
+        const componentElementOrNull: TestComponent = ReactDOM.render(element, container);
+        class ModernComponentNoState extends React.Component<{ x: string }> {}
+        const elementNoState: React.CElement<{ x: string }, ModernComponentNoState> = React.createElement(
+            ModernComponentNoState,
+            { x: "test" },
+        );
+        const componentNoState: ModernComponentNoState = ReactDOM.render(elementNoState, container);
+        const componentNoStateElementOrNull: ModernComponentNoState = ReactDOM.render(elementNoState, container);
+        const domComponent: Element = ReactDOM.render(React.createElement("div"), container);
     });
 
     it("hydrate", () => {
@@ -40,7 +53,7 @@ describe("ReactDOM", () => {
     it("works with document fragments", () => {
         const fragment = document.createDocumentFragment();
         ReactDOM.render(React.createElement("div"), fragment);
-        ReactDOM.unmountComponentAtNode(fragment);
+        const unmounted: boolean = ReactDOM.unmountComponentAtNode(fragment);
     });
 
     it("find dom node", () => {
@@ -49,6 +62,11 @@ describe("ReactDOM", () => {
         ReactDOM.findDOMNode(rootElement);
         ReactDOM.findDOMNode(null);
         ReactDOM.findDOMNode(undefined);
+
+        const element = React.createElement(TestComponent, { x: "test" });
+        const component: TestComponent = ReactDOM.render(element, document.createElement("div"));
+        let domNode = ReactDOM.findDOMNode(component);
+        domNode = ReactDOM.findDOMNode(domNode as Element);
     });
 
     it("createPortal", () => {

--- a/types/react/package.json
+++ b/types/react/package.json
@@ -62,7 +62,6 @@
     },
     "devDependencies": {
         "@types/react": "workspace:.",
-        "@types/react-dom": "*",
         "@types/react-dom-factories": "*",
         "@types/trusted-types": "*"
     },

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -1,8 +1,6 @@
 import * as PropTypes from "prop-types";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import * as DOM from "react-dom-factories";
-import * as ReactDOMServer from "react-dom/server";
 import "trusted-types";
 
 // NOTE: forward declarations for tests
@@ -317,23 +315,9 @@ const clonedSvgElement: React.ReactSVGElement = React.cloneElement(svgElement, {
     className: "clonedVGElement",
 });
 
-// React.render
-const component: ModernComponent = ReactDOM.render(element, container);
-const componentNullContainer: ModernComponent = ReactDOM.render(element, null);
-
-const componentElementOrNull: ModernComponent = ReactDOM.render(element, container);
-const componentNoState: ModernComponentNoState = ReactDOM.render(elementNoState, container);
-const componentNoStateElementOrNull: ModernComponentNoState = ReactDOM.render(elementNoState, container);
-const domComponent: Element = ReactDOM.render(domElement, container);
-
 // Other Top-Level API
-const unmounted: boolean = ReactDOM.unmountComponentAtNode(container);
-const str: string = ReactDOMServer.renderToString(element);
-const markup: string = ReactDOMServer.renderToStaticMarkup(element);
 const notValid: boolean = React.isValidElement(props); // false
 const isValid = React.isValidElement(element); // true
-let domNode = ReactDOM.findDOMNode(component);
-domNode = ReactDOM.findDOMNode(domNode as Element);
 const fragmentType: React.ComponentType = React.Fragment;
 
 // React.Profiler
@@ -359,6 +343,8 @@ const key = element.key;
 //
 // Component API
 // --------------------------------------------------------------------------
+
+declare const component: InstanceType<typeof ModernComponent>;
 
 // modern
 const componentState: State = component.state;

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -1,8 +1,6 @@
 import * as PropTypes from "prop-types";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import * as DOM from "react-dom-factories";
-import * as ReactDOMServer from "react-dom/server";
 import "trusted-types";
 
 // NOTE: forward declarations for tests
@@ -314,23 +312,9 @@ const clonedSvgElement: React.ReactSVGElement = React.cloneElement(svgElement, {
     className: "clonedVGElement",
 });
 
-// React.render
-const component: ModernComponent = ReactDOM.render(element, container);
-const componentNullContainer: ModernComponent = ReactDOM.render(element, null);
-
-const componentElementOrNull: ModernComponent = ReactDOM.render(element, container);
-const componentNoState: ModernComponentNoState = ReactDOM.render(elementNoState, container);
-const componentNoStateElementOrNull: ModernComponentNoState = ReactDOM.render(elementNoState, container);
-const domComponent: Element = ReactDOM.render(domElement, container);
-
 // Other Top-Level API
-const unmounted: boolean = ReactDOM.unmountComponentAtNode(container);
-const str: string = ReactDOMServer.renderToString(element);
-const markup: string = ReactDOMServer.renderToStaticMarkup(element);
 const notValid: boolean = React.isValidElement(props); // false
 const isValid = React.isValidElement(element); // true
-let domNode = ReactDOM.findDOMNode(component);
-domNode = ReactDOM.findDOMNode(domNode as Element);
 const fragmentType: React.ComponentType = React.Fragment;
 
 // React.Profiler
@@ -356,6 +340,8 @@ const key = element.key;
 //
 // Component API
 // --------------------------------------------------------------------------
+
+declare const component: InstanceType<typeof ModernComponent>;
 
 // modern
 const componentState: State = component.state;


### PR DESCRIPTION
Since these were testing `react-dom` APIs, the tests should reside within that package.