### PR TITLE
[react] Replace DOM tests with `createElement`

### DIFF
--- a/types/react-dom-factories/react-dom-factories-tests.ts
+++ b/types/react-dom-factories/react-dom-factories-tests.ts
@@ -1,5 +1,94 @@
 import * as DOM from "react-dom-factories";
 
-// tiny sampling of factories
-DOM.a({}, "a");
-DOM.div({}, DOM.span({}, DOM.b()), DOM.ul({}, DOM.li({}, "test")));
+// NOTE: forward declarations for tests
+declare var console: Console;
+interface Console {
+    log(...args: any[]): void;
+}
+
+// These are all taken from the tests for the React types.
+// They're only kept in case they were actually testing some exotic behavior of react-dom-factories.
+// Feel free to remove if they no longer make sense.
+function testsFromReact(htmlAttr: React.HTMLProps<HTMLElement>) {
+    // tiny sampling of factories
+    DOM.a({}, "a");
+    DOM.div({}, DOM.span({}, DOM.b()), DOM.ul({}, DOM.li({}, "test")));
+
+    DOM.div(
+        null,
+        DOM.input({
+            ref: input => {
+                // $ExpectType HTMLInputElement | null
+                input;
+            },
+            value: "foo",
+        }),
+        DOM.input({
+            onChange: event => console.log(event.target),
+        }),
+    );
+
+    [DOM.h1({ key: "1" }, "1"), DOM.h1({ key: "2" }, "2")];
+
+    DOM.div(null, 2);
+    DOM.div(null, undefined);
+
+    let domNodeRef: Element | null;
+    DOM.div({ ref: "domRef" });
+    // type of node should be inferred
+    DOM.div({ ref: node => domNodeRef = node });
+
+    let inputNodeRef: HTMLInputElement | null;
+    DOM.input({ ref: node => inputNodeRef = node as HTMLInputElement });
+
+    DOM.span(null);
+
+    DOM.div(htmlAttr);
+    DOM.span(htmlAttr);
+    DOM.input(htmlAttr);
+
+    DOM.svg(
+        {
+            viewBox: "0 0 48 48",
+            xmlns: "http://www.w3.org/2000/svg",
+        },
+        DOM.rect({
+            className: "foobar",
+            id: "foo",
+            color: "black",
+            x: 22,
+            y: 10,
+            width: 4,
+            height: 28,
+            strokeDasharray: "30%",
+            strokeDashoffset: "20%",
+        }),
+        DOM.rect({
+            x: 10,
+            y: 22,
+            width: 28,
+            height: 4,
+            strokeDasharray: 30,
+            strokeDashoffset: 20,
+        }),
+        DOM.path({
+            d: "M0,0V3H3V0ZM1,1V2H2V1Z",
+            fill: "#999999",
+            fillRule: "evenodd",
+        }),
+    );
+
+    DOM.textarea({
+        value: "test",
+        onChange: e => {
+            const target: HTMLTextAreaElement = e.target;
+        },
+    });
+
+    DOM.input({
+        onChange: event => {
+            // `event.target` is guaranteed to be HTMLInputElement
+            const target: HTMLInputElement = event.target;
+        },
+    });
+}

--- a/types/react/package.json
+++ b/types/react/package.json
@@ -62,7 +62,6 @@
     },
     "devDependencies": {
         "@types/react": "workspace:.",
-        "@types/react-dom-factories": "*",
         "@types/trusted-types": "*"
     },
     "owners": [

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -1,6 +1,5 @@
 import * as PropTypes from "prop-types";
 import * as React from "react";
-import * as DOM from "react-dom-factories";
 import "trusted-types";
 
 // NOTE: forward declarations for tests
@@ -162,13 +161,14 @@ class ModernComponent extends React.Component<Props, State, Snapshot>
     private _input: HTMLInputElement | null;
 
     render() {
-        return DOM.div(
+        return React.createElement(
+            "div",
             null,
-            DOM.input({
+            React.createElement("input", {
                 ref: input => this._input = input,
                 value: this.state.inputValue ? this.state.inputValue : undefined,
             }),
-            DOM.input({
+            React.createElement("input", {
                 onChange: event => console.log(event.target),
             }),
         );
@@ -185,7 +185,10 @@ class ModernComponent extends React.Component<Props, State, Snapshot>
 
 class ModernComponentArrayRender extends React.Component<Props> {
     render() {
-        return [DOM.h1({ key: "1" }, "1"), DOM.h1({ key: "2" }, "2")];
+        return [
+            React.createElement("h1", { key: "1" }, "1"),
+            React.createElement("h1", { key: "2" }, "2"),
+        ];
     }
 }
 
@@ -197,7 +200,7 @@ interface SCProps {
 }
 
 function FunctionComponent(props: SCProps) {
-    return props.foo ? DOM.div(null, props.foo) : null;
+    return props.foo ? React.createElement("div", null, props.foo) : null;
 }
 
 // tslint:disable-next-line:no-namespace
@@ -208,7 +211,7 @@ namespace FunctionComponent {
 
 const FunctionComponent2: React.FunctionComponent<SCProps> =
     // props is contextually typed
-    props => DOM.div(null, props.foo);
+    props => React.createElement("div", null, props.foo);
 FunctionComponent2.displayName = "FunctionComponent2";
 FunctionComponent2.defaultProps = {
     foo: 42,
@@ -378,12 +381,12 @@ RefComponent.create({ ref: c => componentRef = c });
 componentRef.refMethod();
 
 let domNodeRef: Element | null;
-DOM.div({ ref: "domRef" });
+React.createElement("div", { ref: "domRef" });
 // type of node should be inferred
-DOM.div({ ref: node => domNodeRef = node });
+React.createElement("div", { ref: node => domNodeRef = node });
 
 let inputNodeRef: HTMLInputElement | null;
-DOM.input({ ref: node => inputNodeRef = node as HTMLInputElement });
+React.createElement("input", { ref: node => inputNodeRef = node as HTMLInputElement });
 
 interface ForwardingRefComponentProps {
     hello: string;
@@ -463,7 +466,7 @@ type LazyComponentAsRef = React.ElementRef<typeof LazyComponent>; // $ExpectType
 // Attributes
 // --------------------------------------------------------------------------
 
-const children: any[] = ["Hello world", [null], DOM.span(null)];
+const children: any[] = ["Hello world", [null], React.createElement("span")];
 const divStyle: React.CSSProperties = { // CSSProperties
     flex: "1 1 main-size",
     backgroundImage: "url('hello.png')",
@@ -512,16 +515,17 @@ const htmlAttr: React.HTMLProps<HTMLElement> = {
     "aria-label": "test",
     "aria-relevant": "additions removals",
 };
-DOM.div(htmlAttr);
-DOM.span(htmlAttr);
-DOM.input(htmlAttr);
+React.createElement("div", htmlAttr);
+React.createElement("span", htmlAttr);
+React.createElement("input", htmlAttr);
 
-DOM.svg(
+React.createElement(
+    "svg",
     {
         viewBox: "0 0 48 48",
         xmlns: "http://www.w3.org/2000/svg",
     },
-    DOM.rect({
+    React.createElement("rect", {
         className: "foobar",
         id: "foo",
         color: "black",
@@ -532,7 +536,7 @@ DOM.svg(
         strokeDasharray: "30%",
         strokeDashoffset: "20%",
     }),
-    DOM.rect({
+    React.createElement("rect", {
         x: 10,
         y: 22,
         width: 28,
@@ -540,7 +544,7 @@ DOM.svg(
         strokeDasharray: 30,
         strokeDashoffset: 20,
     }),
-    DOM.path({
+    React.createElement("path", {
         d: "M0,0V3H3V0ZM1,1V2H2V1Z",
         fill: "#999999",
         fillRule: "evenodd",
@@ -556,8 +560,8 @@ const trustedTypesHTMLAttr: React.HTMLProps<HTMLElement> = {
         __html: trustedHtml,
     },
 };
-DOM.div(trustedTypesHTMLAttr);
-DOM.span(trustedTypesHTMLAttr);
+React.createElement("div", trustedTypesHTMLAttr);
+React.createElement("span", trustedTypesHTMLAttr);
 
 //
 // React.Children
@@ -568,7 +572,7 @@ const childrenArray: Array<React.ReactElement<{ p: number }>> = children;
 const mappedChildrenArrayWithKnownChildren: number[] = React.Children.map(childrenArray, child => child.props.p);
 React.Children.forEach(children, child => {});
 const nChildren: number = React.Children.count(children);
-let onlyChild: React.ReactElement = React.Children.only(DOM.div()); // ok
+let onlyChild: React.ReactElement = React.Children.only(React.createElement("div")); // ok
 onlyChild = React.Children.only([null, [[["Hallo"], true]], false]); // error
 const childrenToArray: Array<Exclude<React.ReactNode, boolean | null | undefined>> = React.Children.toArray(children);
 
@@ -621,7 +625,7 @@ class SyntheticEventTargetValue extends React.Component<{}, { value: string }> {
         this.state = { value: "a" };
     }
     render() {
-        return DOM.textarea({
+        return React.createElement("textarea", {
             value: this.state.value,
             onChange: e => {
                 const target: HTMLTextAreaElement = e.target;
@@ -630,7 +634,7 @@ class SyntheticEventTargetValue extends React.Component<{}, { value: string }> {
     }
 }
 
-DOM.input({
+React.createElement("input", {
     onChange: event => {
         // `event.target` is guaranteed to be HTMLInputElement
         const target: HTMLInputElement = event.target;

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -1,6 +1,5 @@
 import * as PropTypes from "prop-types";
 import * as React from "react";
-import * as DOM from "react-dom-factories";
 import "trusted-types";
 
 // NOTE: forward declarations for tests
@@ -162,13 +161,14 @@ class ModernComponent extends React.Component<Props, State, Snapshot>
     private _input: HTMLInputElement | null;
 
     render() {
-        return DOM.div(
+        return React.createElement(
+            "div",
             null,
-            DOM.input({
+            React.createElement("input", {
                 ref: input => this._input = input,
                 value: this.state.inputValue ? this.state.inputValue : undefined,
             }),
-            DOM.input({
+            React.createElement("input", {
                 onChange: event => console.log(event.target),
             }),
         );
@@ -185,7 +185,10 @@ class ModernComponent extends React.Component<Props, State, Snapshot>
 
 class ModernComponentArrayRender extends React.Component<Props> {
     render() {
-        return [DOM.h1({ key: "1" }, "1"), DOM.h1({ key: "2" }, "2")];
+        return [
+            React.createElement("h1", { key: "1" }, "1"),
+            React.createElement("h1", { key: "2" }, "2"),
+        ];
     }
 }
 
@@ -197,7 +200,7 @@ interface SCProps {
 }
 
 function FunctionComponent(props: SCProps) {
-    return props.foo ? DOM.div(null, props.foo) : null;
+    return props.foo ? React.createElement("div", null, props.foo) : null;
 }
 
 // tslint:disable-next-line:no-namespace
@@ -208,7 +211,7 @@ namespace FunctionComponent {
 
 const FunctionComponent2: React.FunctionComponent<SCProps> =
     // props is contextually typed
-    props => DOM.div(null, props.foo);
+    props => React.createElement("div", null, props.foo);
 FunctionComponent2.displayName = "FunctionComponent2";
 FunctionComponent2.defaultProps = {
     foo: 42,
@@ -381,12 +384,12 @@ RefComponent.create({ ref: c => componentRef = c });
 componentRef.refMethod();
 
 let domNodeRef: Element | null;
-DOM.div({ ref: "domRef" });
+React.createElement("div", { ref: "domRef" });
 // type of node should be inferred
-DOM.div({ ref: node => domNodeRef = node });
+React.createElement("div", { ref: node => domNodeRef = node });
 
 let inputNodeRef: HTMLInputElement | null;
-DOM.input({ ref: node => inputNodeRef = node as HTMLInputElement });
+React.createElement("input", { ref: node => inputNodeRef = node as HTMLInputElement });
 
 interface ForwardingRefComponentProps {
     hello: string;
@@ -466,7 +469,7 @@ type LazyComponentAsRef = React.ElementRef<typeof LazyComponent>; // $ExpectType
 // Attributes
 // --------------------------------------------------------------------------
 
-const children: any[] = ["Hello world", [null], DOM.span(null)];
+const children: any[] = ["Hello world", [null], React.createElement("span", null)];
 const divStyle: React.CSSProperties = { // CSSProperties
     flex: "1 1 main-size",
     backgroundImage: "url('hello.png')",
@@ -515,16 +518,17 @@ const htmlAttr: React.HTMLProps<HTMLElement> = {
     "aria-label": "test",
     "aria-relevant": "additions removals",
 };
-DOM.div(htmlAttr);
-DOM.span(htmlAttr);
-DOM.input(htmlAttr);
+React.createElement("div", htmlAttr);
+React.createElement("span", htmlAttr);
+React.createElement("input", htmlAttr);
 
-DOM.svg(
+React.createElement(
+    "svg",
     {
         viewBox: "0 0 48 48",
         xmlns: "http://www.w3.org/2000/svg",
     },
-    DOM.rect({
+    React.createElement("rect", {
         className: "foobar",
         id: "foo",
         color: "black",
@@ -535,7 +539,7 @@ DOM.svg(
         strokeDasharray: "30%",
         strokeDashoffset: "20%",
     }),
-    DOM.rect({
+    React.createElement("rect", {
         x: 10,
         y: 22,
         width: 28,
@@ -543,7 +547,7 @@ DOM.svg(
         strokeDasharray: 30,
         strokeDashoffset: 20,
     }),
-    DOM.path({
+    React.createElement("path", {
         d: "M0,0V3H3V0ZM1,1V2H2V1Z",
         fill: "#999999",
         fillRule: "evenodd",
@@ -559,8 +563,8 @@ const trustedTypesHTMLAttr: React.HTMLProps<HTMLElement> = {
         __html: trustedHtml,
     },
 };
-DOM.div(trustedTypesHTMLAttr);
-DOM.span(trustedTypesHTMLAttr);
+React.createElement("div", trustedTypesHTMLAttr);
+React.createElement("span", trustedTypesHTMLAttr);
 
 //
 // React.Children
@@ -571,7 +575,7 @@ const childrenArray: Array<React.ReactElement<{ p: number }>> = children;
 const mappedChildrenArrayWithKnownChildren: number[] = React.Children.map(childrenArray, child => child.props.p);
 React.Children.forEach(children, child => {});
 const nChildren: number = React.Children.count(children);
-let onlyChild: React.ReactElement = React.Children.only(DOM.div()); // ok
+let onlyChild: React.ReactElement = React.Children.only(React.createElement("div")); // ok
 onlyChild = React.Children.only([null, [[["Hallo"], true]], false]); // error
 const childrenToArray: Array<Exclude<React.ReactNode, boolean | null | undefined>> = React.Children.toArray(children);
 
@@ -624,7 +628,7 @@ class SyntheticEventTargetValue extends React.Component<{}, { value: string }> {
         this.state = { value: "a" };
     }
     render() {
-        return DOM.textarea({
+        return React.createElement("textarea", {
             value: this.state.value,
             onChange: e => {
                 const target: HTMLTextAreaElement = e.target;
@@ -633,7 +637,7 @@ class SyntheticEventTargetValue extends React.Component<{}, { value: string }> {
     }
 }
 
-DOM.input({
+React.createElement("input", {
     onChange: event => {
         // `event.target` is guaranteed to be HTMLInputElement
         const target: HTMLInputElement = event.target;


### PR DESCRIPTION
The DOM tests were copied into `react-dom-factories` since these were testing `react-dom-factories` APIs.
    
Most of the tests don't really look like they're doing much
    so I made it clear that they can be removed once they cause problems. For now I just kept them for test coverage.
    
The replacemenet in React was basically just a `.replace(/DOM.(\w+)\(/g, "React.createElement('$1', ")`