### PR TITLE
[aws-lambda] add types for CloudWatch alarm events

### DIFF
--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -12,6 +12,7 @@ export * from "./trigger/cdk-custom-resource";
 export * from "./trigger/cloudformation-custom-resource";
 export * from "./trigger/cloudfront-request";
 export * from "./trigger/cloudfront-response";
+export * from "./trigger/cloudwatch-alarm";
 export * from "./trigger/cloudwatch-events";
 export * from "./trigger/cloudwatch-logs";
 export * from "./trigger/codebuild-cloudwatch-state";

--- a/types/aws-lambda/test/cloudwatch-tests.ts
+++ b/types/aws-lambda/test/cloudwatch-tests.ts
@@ -1,6 +1,12 @@
 /// <reference types="node" />
 
-import { CloudWatchLogsDecodedData, CloudWatchLogsHandler, CloudWatchLogsLogEvent, ScheduledHandler } from "aws-lambda";
+import {
+    CloudWatchAlarmHandler,
+    CloudWatchLogsDecodedData,
+    CloudWatchLogsHandler,
+    CloudWatchLogsLogEvent,
+    ScheduledHandler,
+} from "aws-lambda";
 
 import { gunzipSync } from "zlib";
 
@@ -41,4 +47,63 @@ const scheduledHandler: ScheduledHandler = async (event, context, callback) => {
 
 const scheduledHandlerWithDetails: ScheduledHandler<{ status: string }> = async (event, context, callback) => {
     const eventDetail: { status: string } = event.detail;
+};
+
+const alarmHandler: CloudWatchAlarmHandler = async (event, context, callback) => {
+    str = event.source;
+    str = event.alarmArn;
+    str = event.accountId;
+    str = event.time;
+    str = event.region;
+
+    const alarmData = event.alarmData;
+    str = alarmData.alarmName;
+
+    const state = alarmData.state;
+    str = state.value;
+    str = state.reason;
+    str = state.timestamp;
+    strOrUndefined = state.reasonData;
+    strOrUndefined = state.actionsSuppressedBy;
+    strOrUndefined = state.actionsSuppressedReason;
+
+    const previousState = alarmData.previousState;
+    str = previousState.value;
+    str = previousState.reason;
+    str = previousState.timestamp;
+    strOrUndefined = previousState.reasonData;
+    strOrUndefined = previousState.actionsSuppressedBy;
+    strOrUndefined = previousState.actionsSuppressedReason;
+
+    const configuration = alarmData.configuration;
+    strOrUndefined = configuration.description;
+
+    if ("metrics" in configuration) {
+        const metric = configuration.metrics[0];
+        str = metric.id;
+        bool = metric.returnData;
+
+        if ("metricStat" in metric) {
+            const metricStat = metric.metricStat;
+            num = metricStat.period;
+            str = metricStat.stat;
+            strOrUndefined = metricStat.unit;
+            str = metricStat.metric.namespace;
+            str = metricStat.metric.name;
+            if (metricStat.metric.dimensions) {
+                str = metricStat.metric.dimensions[str];
+            }
+        } else {
+            str = metric.expression;
+            str = metric.label;
+        }
+    } else {
+        str = configuration.alarmRule;
+        strOrUndefined = configuration.actionsSuppressor;
+        numOrUndefined = configuration.actionsSuppressorWaitPeriod;
+        numOrUndefined = configuration.actionsSuppressorExtensionPeriod;
+    }
+
+    callback();
+    callback(new Error());
 };

--- a/types/aws-lambda/trigger/cloudwatch-alarm.d.ts
+++ b/types/aws-lambda/trigger/cloudwatch-alarm.d.ts
@@ -1,0 +1,69 @@
+import { Handler } from "../handler";
+
+export interface CloudWatchAlarmState {
+    value: string;
+    reason: string;
+    timestamp: string;
+    reasonData?: string;
+    actionsSuppressedBy?: string;
+    actionsSuppressedReason?: string;
+}
+
+export interface CloudWatchMetric {
+    namespace: string;
+    name: string;
+    dimensions?: Record<string, string>;
+}
+
+export interface CloudWatchMetricStat {
+    metric: CloudWatchMetric;
+    period: number;
+    stat: string;
+    unit?: string;
+}
+
+export interface CloudWatchAlarmMetric {
+    id: string;
+    metricStat: CloudWatchMetricStat;
+    returnData: boolean;
+}
+
+export interface CloudWatchAlarmExpression {
+    id: string;
+    expression: string;
+    label: string;
+    returnData: boolean;
+}
+
+export type CloudWatchAlarmMetricDataQuery = CloudWatchAlarmMetric | CloudWatchAlarmExpression;
+
+export interface CloudWatchAlarmConfiguration {
+    metrics: CloudWatchAlarmMetricDataQuery[];
+    description?: string;
+}
+
+export interface CloudWatchAlarmCompositeConfiguration {
+    alarmRule: string;
+    description?: string;
+    actionsSuppressor?: string;
+    actionsSuppressorWaitPeriod?: number;
+    actionsSuppressorExtensionPeriod?: number;
+}
+
+export interface CloudWatchAlarmData {
+    alarmName: string;
+    state: CloudWatchAlarmState;
+    previousState: CloudWatchAlarmState;
+    configuration: CloudWatchAlarmConfiguration | CloudWatchAlarmCompositeConfiguration;
+}
+
+export interface CloudWatchAlarmEvent {
+    source: string;
+    alarmArn: string;
+    accountId: string;
+    time: string;
+    region: string;
+    alarmData: CloudWatchAlarmData;
+}
+
+export type CloudWatchAlarmHandler = Handler<CloudWatchAlarmEvent, void>;

--- a/types/aws-lambda/trigger/cloudwatch-alarm.d.ts
+++ b/types/aws-lambda/trigger/cloudwatch-alarm.d.ts
@@ -1,5 +1,16 @@
 import { Handler } from "../handler";
 
+export type CloudWatchAlarmHandler = Handler<CloudWatchAlarmEvent, void>;
+
+export interface CloudWatchAlarmEvent {
+    source: string;
+    alarmArn: string;
+    accountId: string;
+    time: string;
+    region: string;
+    alarmData: CloudWatchAlarmData;
+}
+
 export interface CloudWatchAlarmState {
     value: string;
     reason: string;
@@ -56,14 +67,3 @@ export interface CloudWatchAlarmData {
     previousState: CloudWatchAlarmState;
     configuration: CloudWatchAlarmConfiguration | CloudWatchAlarmCompositeConfiguration;
 }
-
-export interface CloudWatchAlarmEvent {
-    source: string;
-    alarmArn: string;
-    accountId: string;
-    time: string;
-    region: string;
-    alarmData: CloudWatchAlarmData;
-}
-
-export type CloudWatchAlarmHandler = Handler<CloudWatchAlarmEvent, void>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://aws.amazon.com/about-aws/whats-new/2023/12/amazon-cloudwatch-alarms-lambda-change-action/ https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-actions
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Note: I didn't find a complete schema for these events in the AWS docs so these types are based on the examples included in the AWS docs and the results of me testing various alarms. 