### PR TITLE
SlickGrid Column Editor and Editor Factory should return the type to compile correctly.

### DIFF
--- a/types/slickgrid/index.d.ts
+++ b/types/slickgrid/index.d.ts
@@ -476,7 +476,7 @@ declare namespace Slick {
     }
 
     export interface EditorFactory {
-        getEditor<T extends SlickData>(column: Column<T>): Editors.Editor<T>;
+        getEditor<T extends SlickData>(column: Column<T>): new (args: Editors.EditorOptions<T>) => Editors.Editor<T>;
     }
 
     export interface FormatterFactory<T extends SlickData> {

--- a/types/slickgrid/index.d.ts
+++ b/types/slickgrid/index.d.ts
@@ -396,7 +396,7 @@ declare namespace Slick {
         /**
          * The editor for cell edits {TextEditor, IntegerEditor, DateEditor...} See slick.editors.js
          */
-        editor?: any; // typeof Editors.Editor<T>;
+        editor?: new (args: Editors.EditorOptions<T>) => Editors.Editor<T>; // typeof Editors.Editor<T>;
 
         /**
          * The property name in the data object to pull content from. (This is assumed to be on the root of the data object.)


### PR DESCRIPTION
changed Types Editor or any to new (args: EditorOptions<T>) => Editors.Editor<T> so it could be compiled with strong reference.