### PR TITLE
dygraphs: Add access to the built in Tickers so they can be used in custom tickers

### DIFF
--- a/types/dygraphs/index.d.ts
+++ b/types/dygraphs/index.d.ts
@@ -1587,6 +1587,11 @@ export default class Dygraph {
      */
     ready(callback: (g: Dygraph) => any): void;
 
+    // built-in tickers
+    static numericLinearTicks:dygraphs.Ticker;
+    static numericTicks:dygraphs.Ticker;
+    static dateTicker:dygraphs.Ticker;
+
     // Tick granularities (passed to ticker).
     static SECONDLY: number;
     static TWO_SECONDLY: number;

--- a/types/dygraphs/index.d.ts
+++ b/types/dygraphs/index.d.ts
@@ -1588,9 +1588,9 @@ export default class Dygraph {
     ready(callback: (g: Dygraph) => any): void;
 
     // built-in tickers
-    static numericLinearTicks:dygraphs.Ticker;
-    static numericTicks:dygraphs.Ticker;
-    static dateTicker:dygraphs.Ticker;
+    static numericLinearTicks: dygraphs.Ticker;
+    static numericTicks: dygraphs.Ticker;
+    static dateTicker: dygraphs.Ticker;
 
     // Tick granularities (passed to ticker).
     static SECONDLY: number;


### PR DESCRIPTION
Changing an existing definition:

Changing to give access to the built in Tickers so they can be used in custom tickers as per lines 3547-3549 in:
[https://github.com/danvk/dygraphs/blame/v2.2.1/src/dygraph.js](https://github.com/danvk/dygraphs/blame/v2.2.1/src/dygraph.js)
[These lines were added 9 years ago](https://github.com/danvk/dygraphs/commit/2b66af4f76dcd72d22f5844cb7684f3cb79fde42) 

[As per the documentation it is recommended to use the built in tickers's to help when making a custom ticker](https://dygraphs.com/options.html#ticker)