### PR TITLE
AlpineJS: Add optional arg types to Binding functions

### DIFF
--- a/types/alpinejs/alpinejs-tests.ts
+++ b/types/alpinejs/alpinejs-tests.ts
@@ -630,6 +630,24 @@ import Alpine, {
     }));
 
     // $ExpectType void
+    Alpine.bind('#my-el', () => ({
+      'x-show': 'true',
+      '@mouseenter'() {
+      },
+      '@mouseleave'(e: MouseEvent) {
+      }
+    }));
+
+    // $ExpectType void
+    Alpine.bind(null as unknown as HTMLElement, () => ({
+      'x-show': 'true',
+      '@mouseenter'() {
+      },
+      '@mouseleave'(e: MouseEvent) {
+      }
+    }));
+
+    // $ExpectType void
     Alpine.data("user", () => ({
         user: { id: 1, name: "John Doe" },
 

--- a/types/alpinejs/alpinejs-tests.ts
+++ b/types/alpinejs/alpinejs-tests.ts
@@ -630,21 +630,21 @@ import Alpine, {
     }));
 
     // $ExpectType void
-    Alpine.bind('#my-el', () => ({
-      'x-show': 'true',
-      '@mouseenter'() {
-      },
-      '@mouseleave'(e: MouseEvent) {
-      }
+    Alpine.bind("#my-el", () => ({
+        "x-show": "true",
+        "@mouseenter"() {
+        },
+        "@mouseleave"(e: MouseEvent) {
+        },
     }));
 
     // $ExpectType void
     Alpine.bind(null as unknown as HTMLElement, () => ({
-      'x-show': 'true',
-      '@mouseenter'() {
-      },
-      '@mouseleave'(e: MouseEvent) {
-      }
+        "x-show": "true",
+        "@mouseenter"() {
+        },
+        "@mouseleave"(e: MouseEvent) {
+        },
     }));
 
     // $ExpectType void

--- a/types/alpinejs/alpinejs-tests.ts
+++ b/types/alpinejs/alpinejs-tests.ts
@@ -648,6 +648,11 @@ import Alpine, {
         "@custom-event"(e: string) {},
         // does not require event
         "@keydown"() {},
+        // infers Event type
+        "@keyup"(e) {
+            // $ExpectType KeyboardEvent
+            e;
+        },
     }));
 
     // @ts-expect-error: does not allow incorrect event types

--- a/types/alpinejs/alpinejs-tests.ts
+++ b/types/alpinejs/alpinejs-tests.ts
@@ -632,19 +632,27 @@ import Alpine, {
     // $ExpectType void
     Alpine.bind("#my-el", () => ({
         "x-show": "true",
-        "@mouseenter"() {
-        },
-        "@mouseleave"(e: MouseEvent) {
-        },
+        "@mouseenter"() {},
+        "@mouseleave"(e: MouseEvent) {},
     }));
 
     // $ExpectType void
-    Alpine.bind(null as unknown as HTMLElement, () => ({
+    Alpine.bind(document.createElement("div") as HTMLElement, () => ({
         "x-show": "true",
-        "@mouseenter"() {
-        },
-        "@mouseleave"(e: MouseEvent) {
-        },
+        // allows typed events for x-on and @ bindings
+        "x-on:keydown"(e: KeyboardEvent) {},
+        "@mouseleave"(e: MouseEvent) {},
+        // allows higher event types
+        "@click"(e: Event) {},
+        // does not limit events on custom events
+        "@custom-event"(e: string) {},
+        // does not require event
+        "@keydown"() {},
+    }));
+
+    // @ts-expect-error: does not allow incorrect event types
+    Alpine.bind(document.createElement("div") as HTMLElement, () => ({
+        "x-on:keydown"(e: MouseEvent) {},
     }));
 
     // $ExpectType void

--- a/types/alpinejs/index.d.ts
+++ b/types/alpinejs/index.d.ts
@@ -75,7 +75,7 @@ interface Binding {
 }
 
 export interface Bindings {
-    [key: string]: string | (() => unknown);
+    [key: string]: string | ((...args: any[]) => unknown);
 }
 
 export type AttrMutationCallback = (

--- a/types/alpinejs/index.d.ts
+++ b/types/alpinejs/index.d.ts
@@ -3,7 +3,7 @@ export type ElementWithXAttributes<T extends Element = HTMLElement> = withXAttri
 export type withXAttributes<T extends Element> = T & Partial<XAttributes>;
 
 export interface XAttributes {
-    _x_virtualDirectives: Bindings;
+    _x_virtualDirectives: Bindings<{}>;
     _x_ids: Record<string, number>;
     _x_effects: Set<() => void>;
     _x_runEffects: () => void;
@@ -74,9 +74,11 @@ interface Binding {
     extract: boolean;
 }
 
-export interface Bindings {
-    [key: string]: string | ((...args: any[]) => unknown);
-}
+export type Bindings<T> = {
+    [key in keyof T]: key extends `${"x-on:" | "@"}${infer K extends keyof HTMLElementEventMap}`
+        ? string | ((e: HTMLElementEventMap[K]) => void)
+        : string | ((...args: any[]) => void);
+};
 
 export type AttrMutationCallback = (
     el: ElementWithXAttributes,
@@ -476,7 +478,14 @@ export interface Alpine {
         name: string,
         callback: (...args: A) => AlpineComponent<T>, // Needed generic to properly autotype objects
     ) => void;
-    bind: (name: string | ElementWithXAttributes, bindings: Bindings | ((...args: unknown[]) => Bindings)) => void;
+    /**
+     * Binds directives and attributes to an element
+     */
+    bind<T extends Bindings<T>>(element: HTMLElement, bindings: T | (() => T)): void;
+    /**
+     * Registers a named binding group to be exposed to `x-bind` directive expressions
+     */
+    bind<T extends Bindings<T>>(name: string, bindings: T | ((...args: unknown[]) => T)): void;
 }
 
 declare const Alpine: Alpine;


### PR DESCRIPTION
Currently, the function typings for `Bindings` values do not allow arguments:

<img width="799" alt="image" src="https://github.com/DefinitelyTyped/DefinitelyTyped/assets/64985/fa5dcce9-3d41-4724-9562-cd55b3deec6f">

This PR adds support for any number of arguments of any type
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [ ] ~~Provide a URL to documentation or source code which provides context for the suggested changes~~ _Am not quite sure where in the code to point you to but I can tell you from trying it this is the correct behaviour_
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`~~ 