### PR TITLE
twine-sugarcube: Fix ariaDisabled return type 

### DIFF
--- a/types/twine-sugarcube/extensions.d.ts
+++ b/types/twine-sugarcube/extensions.d.ts
@@ -581,7 +581,7 @@ declare global {
          * $('#so-clicky').ariaDisabled(true); // Disables the target element
          * $('#so-clicky').ariaDisabled(false); // Enables the target element
          */
-        ariaDisabled(state: boolean): boolean;
+        ariaDisabled(state: boolean): this;
         /**
          * Returns whether any of the target WAI-ARIA-compatible clickable element(s) are disabled.
          *

--- a/types/twine-sugarcube/test/extensions.ts
+++ b/types/twine-sugarcube/test/extensions.ts
@@ -92,6 +92,7 @@ s2 = String.format("{0}, {1}", 1, true);
 
 RegExp.escape(s);
 
+$(s).ariaDisabled(true) satisfies JQuery;
 $(s).wiki(s);
 $.wiki(s);
 

--- a/types/twine-sugarcube/test/extensions.ts
+++ b/types/twine-sugarcube/test/extensions.ts
@@ -92,7 +92,7 @@ s2 = String.format("{0}, {1}", 1, true);
 
 RegExp.escape(s);
 
-$(s).ariaDisabled(true) satisfies JQuery;
+const j: JQuery = $(s).ariaDisabled(true);
 $(s).wiki(s);
 $.wiki(s);
 


### PR DESCRIPTION
I changed the return type from a boolean to the current JQuery object, as described by the official documentation and the JavaScript comment

- [ x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x ] Test the change in your own code. (Compile and run.)
- [ x ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [ x ] Provide a URL to documentation or source code which provides context for the suggested changes: http://www.motoslave.net/sugarcube/2/docs/#methods-jquery-prototype-method-ariadisabled
- [ x ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.