### PR TITLE
[@types/selenium-webdriver] Remove deprecated headless methods

### DIFF
--- a/types/selenium-webdriver/chrome.d.ts
+++ b/types/selenium-webdriver/chrome.d.ts
@@ -77,17 +77,6 @@ export class Options extends webdriver.Capabilities {
     debuggerAddress(address: string): Options;
 
     /**
-     * Configures the chromedriver to start Chrome in headless mode.
-     *
-     * > __NOTE:__ Resizing the browser window in headless mode is only supported
-     * > in Chrome 60. Users are encouraged to set an initial window size with
-     * > the {@link #windowSize windowSize({width, height})} option.
-     *
-     * @return {!Options} A self reference.
-     */
-    headless(): Options;
-
-    /**
      * Sets the initial window size.
      *
      * @param {{width: number, height: number}} size The desired window size.

--- a/types/selenium-webdriver/edge.d.ts
+++ b/types/selenium-webdriver/edge.d.ts
@@ -61,17 +61,6 @@ export class Options extends webdriver.Capabilities {
     addArguments(...var_args: string[]): Options;
 
     /**
-     * Configures the edgedriver to start Edge in headless mode.
-     *
-     * > __NOTE:__ Resizing the browser window in headless mode is only supported
-     * > in Edge 60. Users are encouraged to set an initial window size with
-     * > the {@link #windowSize windowSize({width, height})} option.
-     *
-     * @return {!Options} A self reference.
-     */
-    headless(): Options;
-
-    /**
      * Sets the initial window size.
      *
      * @param {{width: number, height: number}} size The desired window size.

--- a/types/selenium-webdriver/firefox.d.ts
+++ b/types/selenium-webdriver/firefox.d.ts
@@ -33,8 +33,7 @@ export class Options extends webdriver.Capabilities {
     addExtensions(...paths: string[]): Options;
 
     /**
-     * Sets the initial window size when running in
-     * {@linkplain #headless headless} mode.
+     * Sets the initial window size.
      *
      * @param {{width: number, height: number}} size The desired window size.
      * @return {!Options} A self reference.
@@ -77,12 +76,6 @@ export class Options extends webdriver.Capabilities {
      * @see https://github.com/mozilla/geckodriver
      */
     useGeckoDriver(enable: boolean): Options;
-
-    /**
-     * Configures the geckodriver to start Firefox in headless mode.
-     * @return {!Options} A self reference.
-     */
-    headless(): Options;
 }
 
 /**

--- a/types/selenium-webdriver/test/chrome.ts
+++ b/types/selenium-webdriver/test/chrome.ts
@@ -38,7 +38,6 @@ function TestChromeOptions() {
     options = options.setChromeLogFile("logfile");
     options = options.setLocalState("state");
     options = options.androidActivity("com.example.Activity");
-    options = options.headless();
     options = options.androidDeviceSerial("emulator-5554");
     options = options.androidChrome();
     options = options.androidPackage("com.android.chrome");

--- a/types/selenium-webdriver/test/edge.ts
+++ b/types/selenium-webdriver/test/edge.ts
@@ -22,7 +22,6 @@ function TestEdgeOptions() {
     options = options.setEdgeLogFile("logfile");
     options = options.setLocalState("state");
     options = options.androidActivity("com.example.Activity");
-    options = options.headless();
     options = options.androidDeviceSerial("emulator-5554");
     options = options.androidEdge();
     options = options.androidPackage("com.android.edge");

--- a/types/selenium-webdriver/test/firefox.ts
+++ b/types/selenium-webdriver/test/firefox.ts
@@ -23,7 +23,6 @@ function TestFirefoxOptions() {
     options = options.setBinary("binary");
     options = options.setProfile("profile");
     options = options.setProxy({ proxyType: "proxy" });
-    options = options.headless();
     options = options.addArguments("argument");
     options = options.addExtensions("/dev/null");
     options = options.setPreference("key", "value");


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - https://github.com/SeleniumHQ/selenium/commit/5a97adf9864a346fdd8914cdb1b601c05dd837ac#diff-612a21f82da509d9e115847454336aa2a5ddd7679e98d50736214366937973ed
    - https://github.com/SeleniumHQ/selenium/blob/b9a95a32a2897b3d939ec96e6083ef3b812f75e6/javascript/node/selenium-webdriver/CHANGES.md?plain=1#L21
    - https://www.selenium.dev/blog/2023/headless-is-going-away/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

