### PR TITLE
[react] Handle state hook of type Function

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1773,7 +1773,7 @@ declare namespace React {
      * }
      * ```
      */
-    type SetStateAction<S> = S | ((prevState: S) => S);
+    type SetStateAction<S> = S extends Function ? ((prevState: S) => S) : S | ((prevState: S) => S);
 
     /**
      * A function that can be used to update the state of a {@link useState}
@@ -1819,7 +1819,7 @@ declare namespace React {
      * @version 16.8.0
      * @see {@link https://react.dev/reference/react/useState}
      */
-    function useState<S>(initialState: S | (() => S)): [S, Dispatch<SetStateAction<S>>];
+    function useState<S>(initialState: S extends Function ? () => S : S | (() => S)): [S, Dispatch<SetStateAction<S>>];
     // convenience overload when first argument is omitted
     /**
      * Returns a stateful value, and a function to update it.


### PR DESCRIPTION
## Tasks

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Updating state based on the previous state](https://react.dev/reference/react/useState#updating-state-based-on-the-previous-state)

## Description

The `useState` hook allows for both a value and a callback as a parameter to set the initial and the next value. It, however, cannot correctly understand when a _callback itself_ is to be set a state, so a `() => ...` has to be added to prevent the "callback as a value" to be executed. I had a local issue where `useState<() => void>(() => {})` was incorrectly interpreted to result in `() => void`, where in reality it would be `undefined`:

<img width="571" alt="Screenshot 2024-03-06 at 11 17 01" src="https://github.com/DefinitelyTyped/DefinitelyTyped/assets/5251376/930dee64-b435-42aa-b01a-cee532f1a5f4">
