### PR TITLE
[react] Enable Awaited<ReactNode> in experimental release channels

### DIFF
--- a/types/react-dom/test/canary-tests.tsx
+++ b/types/react-dom/test/canary-tests.tsx
@@ -1,4 +1,5 @@
 /// <reference types="../canary"/>
+import React = require("react");
 import ReactDOM = require("react-dom");
 import ReactDOMClient = require("react-dom/client");
 
@@ -165,6 +166,17 @@ function formTest() {
             // @ts-expect-error
             Promise.resolve(0),
         )[0];
+
+        useFormState(
+            async (state: React.ReactNode, payload: FormData): Promise<React.ReactNode> => {
+                return state;
+            },
+            (
+                <button>
+                    New Project
+                </button>
+            ),
+        );
 
         return (
             <button

--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -42,10 +42,22 @@ declare const UNDEFINED_VOID_ONLY: unique symbol;
 type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 
 declare module "." {
-    // Need an interface to not cause ReactNode to be a self-referential type.
-    interface PromiseLikeOfReactNode extends PromiseLike<ReactNode> {}
+    /**
+     * @internal Use `Awaited<ReactNode>` instead
+     */
+    // Helper type to enable `Awaited<ReactNode>`.
+    // Must be a copy of the non-thenables of `ReactNode`.
+    type AwaitedReactNode =
+        | ReactElement
+        | string
+        | number
+        | Iterable<AwaitedReactNode>
+        | ReactPortal
+        | boolean
+        | null
+        | undefined;
     interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES {
-        promises: PromiseLikeOfReactNode;
+        promises: Promise<AwaitedReactNode>;
     }
 
     export interface SuspenseProps {

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -465,6 +465,7 @@ declare namespace React {
      * <Component customElement={<div>hello</div>} />
      * ```
      */
+    // non-thenables need to be kept in sync with AwaitedReactNode
     type ReactNode =
         | ReactElement
         | string

--- a/types/react/test/experimental.tsx
+++ b/types/react/test/experimental.tsx
@@ -84,6 +84,10 @@ function useEvent() {
     // @ts-expect-error plain objects are not allowed
     <div>{{ dave: true }}</div>;
     <div>{Promise.resolve("React")}</div>;
+
+    const asyncTests = async function asyncTests() {
+        const node: Awaited<React.ReactNode> = await Promise.resolve("React");
+    };
 }
 
 function elementTypeTests() {

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -710,6 +710,11 @@ class RenderChildren extends React.Component<{ children?: React.ReactNode }> {
     const plainObject: React.ReactNode = { dave: true };
     // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
     const promise: React.ReactNode = Promise.resolve("React");
+
+    const asyncTests = async function asyncTests() {
+        // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
+        const node: Awaited<React.ReactNode> = await Promise.resolve("React");
+    };
 }
 
 const Memoized1 = React.memo(function Foo(props: { foo: string }) {

--- a/types/react/ts5.0/experimental.d.ts
+++ b/types/react/ts5.0/experimental.d.ts
@@ -42,10 +42,22 @@ declare const UNDEFINED_VOID_ONLY: unique symbol;
 type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 
 declare module "." {
-    // Need an interface to not cause ReactNode to be a self-referential type.
-    interface PromiseLikeOfReactNode extends PromiseLike<ReactNode> {}
+    /**
+     * @internal Use `Awaited<ReactNode>` instead
+     */
+    // Helper type to enable `Awaited<ReactNode>`.
+    // Must be a copy of the non-thenables of `ReactNode`.
+    type AwaitedReactNode =
+        | ReactElement
+        | string
+        | number
+        | Iterable<AwaitedReactNode>
+        | ReactPortal
+        | boolean
+        | null
+        | undefined;
     interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES {
-        promises: PromiseLikeOfReactNode;
+        promises: Promise<AwaitedReactNode>;
     }
 
     export interface SuspenseProps {

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -466,6 +466,7 @@ declare namespace React {
      * <Component customElement={<div>hello</div>} />
      * ```
      */
+    // non-thenables need to be kept in sync with AwaitedReactNode
     type ReactNode =
         | ReactElement
         | string

--- a/types/react/ts5.0/test/experimental.tsx
+++ b/types/react/ts5.0/test/experimental.tsx
@@ -84,6 +84,10 @@ function useEvent() {
     // @ts-expect-error plain objects are not allowed
     <div>{{ dave: true }}</div>;
     <div>{Promise.resolve("React")}</div>;
+
+    const asyncTests = async function asyncTests() {
+        const node: Awaited<React.ReactNode> = await Promise.resolve("React");
+    };
 }
 
 function elementTypeTests() {

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -713,6 +713,11 @@ class RenderChildren extends React.Component<{ children?: React.ReactNode }> {
     const plainObject: React.ReactNode = { dave: true };
     // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
     const promise: React.ReactNode = Promise.resolve("React");
+
+    const asyncTests = async function asyncTests() {
+        // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
+        const node: Awaited<React.ReactNode> = await Promise.resolve("React");
+    };
 }
 
 const Memoized1 = React.memo(function Foo(props: { foo: string }) {


### PR DESCRIPTION
Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/68909

`type T = string | Promise<T>` is rejected for a reason. The previous trick by using interface just masked the problem until you `Awaited<T>` and got `TS2589: Type instantiation is excessively deep and possibly infinite.`