### PR TITLE
fix(react): Add key prop to React.Fragment

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -803,7 +803,10 @@ declare namespace React {
      * </>
      * ```
      */
-    const Fragment: ExoticComponent<{ children?: ReactNode | undefined }>;
+    const Fragment: ExoticComponent<{ 
+        children?: ReactNode | undefined, 
+        key?: Key | null | undefined 
+    }>;
 
     /**
      * Lets you find common bugs in your components early during development.

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -803,9 +803,9 @@ declare namespace React {
      * </>
      * ```
      */
-    const Fragment: ExoticComponent<{ 
-        children?: ReactNode | undefined, 
-        key?: Key | null | undefined 
+    const Fragment: ExoticComponent<{
+        children?: ReactNode | undefined;
+        key?: Key | null | undefined;
     }>;
 
     /**

--- a/types/react/test/elementAttributes.tsx
+++ b/types/react/test/elementAttributes.tsx
@@ -158,3 +158,19 @@ function formActionsTest() {
         </button>
     </form>;
 }
+
+function reactFragmentTest() {
+    const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+    return (
+      <div>
+        {arr.map((item) => {
+          return (
+            <React.Fragment key={item}>
+              <div>Item: {item}</div>
+            </React.Fragment>
+          );
+        })}
+      </div>
+    );
+}

--- a/types/react/test/elementAttributes.tsx
+++ b/types/react/test/elementAttributes.tsx
@@ -163,14 +163,14 @@ function reactFragmentTest() {
     const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
     return (
-      <div>
-        {arr.map((item) => {
-          return (
-            <React.Fragment key={item}>
-              <div>Item: {item}</div>
-            </React.Fragment>
-          );
-        })}
-      </div>
+        <div>
+            {arr.map((item) => {
+                return (
+                    <React.Fragment key={item}>
+                        <div>Item: {item}</div>
+                    </React.Fragment>
+                );
+            })}
+        </div>
     );
 }

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -804,7 +804,10 @@ declare namespace React {
      * </>
      * ```
      */
-    const Fragment: ExoticComponent<{ children?: ReactNode | undefined }>;
+    const Fragment: ExoticComponent<{ 
+        children?: ReactNode | undefined, 
+        key?: Key | null | undefined 
+    }>;
 
     /**
      * Lets you find common bugs in your components early during development.

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -804,9 +804,9 @@ declare namespace React {
      * </>
      * ```
      */
-    const Fragment: ExoticComponent<{ 
-        children?: ReactNode | undefined, 
-        key?: Key | null | undefined 
+    const Fragment: ExoticComponent<{
+        children?: ReactNode | undefined;
+        key?: Key | null | undefined;
     }>;
 
     /**

--- a/types/react/ts5.0/test/elementAttributes.tsx
+++ b/types/react/ts5.0/test/elementAttributes.tsx
@@ -158,3 +158,19 @@ function formActionsTest() {
         </button>
     </form>;
 }
+
+function reactFragmentTest() {
+    const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+    return (
+      <div>
+        {arr.map((item) => {
+          return (
+            <React.Fragment key={item}>
+              <div>Item: {item}</div>
+            </React.Fragment>
+          );
+        })}
+      </div>
+    );
+}

--- a/types/react/ts5.0/test/elementAttributes.tsx
+++ b/types/react/ts5.0/test/elementAttributes.tsx
@@ -163,14 +163,14 @@ function reactFragmentTest() {
     const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
     return (
-      <div>
-        {arr.map((item) => {
-          return (
-            <React.Fragment key={item}>
-              <div>Item: {item}</div>
-            </React.Fragment>
-          );
-        })}
-      </div>
+        <div>
+            {arr.map((item) => {
+                return (
+                    <React.Fragment key={item}>
+                        <div>Item: {item}</div>
+                    </React.Fragment>
+                );
+            })}
+        </div>
     );
 }


### PR DESCRIPTION
This adds the key prop to `React.Fragment`. Without it the following code:
```
 const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];

return (
  <div>
    {arr.map((item) => {
      return (
        <Fragment key={item}>
          <div>Item: {item}</div>
        </Fragment>
      );
    })}
  </div>
);
```
will generate a compiler error:
```
Property 'key' does not exist on type 'IntrinsicAttributes & { children?: ReactNode; }'
```

The `key` is an allowed value for `React.Fragment` - https://react.dev/reference/react/Fragment

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

