### PR TITLE
[react-dom] add PreloadOptions.type

### DIFF
--- a/types/react-dom/canary.d.ts
+++ b/types/react-dom/canary.d.ts
@@ -67,6 +67,7 @@ declare module "." {
         imageSizes?: string | undefined;
         imageSrcSet?: string | undefined;
         integrity?: string | undefined;
+        type?: string | undefined;
         nonce?: string | undefined;
         referrerPolicy?: ReferrerPolicy | undefined;
     }

--- a/types/react-dom/test/canary-tests.tsx
+++ b/types/react-dom/test/canary-tests.tsx
@@ -7,6 +7,7 @@ function preloadTest() {
         ReactDOM.preload("foo", { as: "style", fetchPriority: "high", integrity: "sad" });
         ReactDOM.preload("bar", {
             as: "font",
+            type: "font/woff2",
             // @ts-expect-error Unknown fetch priority
             fetchPriority: "unknown",
         });


### PR DESCRIPTION
Adds the `type` option to the `react-dom` canary’s `preload(…, { type: "…" })` function, as [documented here](https://react.dev/reference/react-dom/preload#parameters) and [defined here](https://github.com/facebook/react/blob/64f354cf27a17c4e5b0dfcd908e47940cf947771/packages/react-dom/src/shared/ReactDOMTypes.js#L18).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react.dev/reference/react-dom/preload#parameters
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.