### PR TITLE
Remove redundant explicit TS minimums

### DIFF
--- a/types/agnostic-http-error-handler/package.json
+++ b/types/agnostic-http-error-handler/package.json
@@ -5,7 +5,6 @@
     "projects": [
         "https://github.com/jkyberneees/http-error-handler#readme"
     ],
-    "minimumTypeScriptVersion": "4.7",
     "devDependencies": {
         "@types/agnostic-http-error-handler": "workspace:.",
         "@types/express": "*"

--- a/types/alpinejs/package.json
+++ b/types/alpinejs/package.json
@@ -5,7 +5,6 @@
     "projects": [
         "https://github.com/alpinejs/alpine"
     ],
-    "minimumTypeScriptVersion": "4.6",
     "devDependencies": {
         "@types/alpinejs": "workspace:."
     },

--- a/types/alpinejs__anchor/package.json
+++ b/types/alpinejs__anchor/package.json
@@ -5,7 +5,6 @@
     "projects": [
         "https://alpinejs.dev/plugins/anchor"
     ],
-    "minimumTypeScriptVersion": "4.6",
     "dependencies": {
         "@types/alpinejs": "*"
     },

--- a/types/alpinejs__collapse/package.json
+++ b/types/alpinejs__collapse/package.json
@@ -5,7 +5,6 @@
     "projects": [
         "https://github.com/alpinejs/alpine"
     ],
-    "minimumTypeScriptVersion": "4.6",
     "dependencies": {
         "@types/alpinejs": "*"
     },

--- a/types/alpinejs__focus/package.json
+++ b/types/alpinejs__focus/package.json
@@ -5,7 +5,6 @@
     "projects": [
         "https://github.com/alpinejs/alpine"
     ],
-    "minimumTypeScriptVersion": "4.6",
     "dependencies": {
         "@types/alpinejs": "*"
     },

--- a/types/alpinejs__intersect/package.json
+++ b/types/alpinejs__intersect/package.json
@@ -5,7 +5,6 @@
     "projects": [
         "https://github.com/alpinejs/alpine"
     ],
-    "minimumTypeScriptVersion": "4.6",
     "dependencies": {
         "@types/alpinejs": "*"
     },

--- a/types/alpinejs__mask/package.json
+++ b/types/alpinejs__mask/package.json
@@ -5,7 +5,6 @@
     "projects": [
         "https://github.com/alpinejs/alpine"
     ],
-    "minimumTypeScriptVersion": "4.6",
     "dependencies": {
         "@types/alpinejs": "*"
     },

--- a/types/alpinejs__morph/package.json
+++ b/types/alpinejs__morph/package.json
@@ -5,7 +5,6 @@
     "projects": [
         "https://github.com/alpinejs/alpine"
     ],
-    "minimumTypeScriptVersion": "4.6",
     "dependencies": {
         "@types/alpinejs": "*"
     },

--- a/types/alpinejs__persist/package.json
+++ b/types/alpinejs__persist/package.json
@@ -5,7 +5,6 @@
     "projects": [
         "https://github.com/alpinejs/alpine"
     ],
-    "minimumTypeScriptVersion": "4.6",
     "dependencies": {
         "@types/alpinejs": "*"
     },

--- a/types/cadviewer/package.json
+++ b/types/cadviewer/package.json
@@ -5,7 +5,6 @@
     "projects": [
         "https://github.com/CADViewer/cadviewer-testapp-react-01"
     ],
-    "minimumTypeScriptVersion": "4.7",
     "devDependencies": {
         "@types/cadviewer": "workspace:."
     },

--- a/types/can-autoplay/package.json
+++ b/types/can-autoplay/package.json
@@ -5,7 +5,6 @@
     "projects": [
         "https://github.com/video-dev/can-autoplay"
     ],
-    "minimumTypeScriptVersion": "4.6",
     "devDependencies": {
         "@types/can-autoplay": "workspace:."
     },

--- a/types/dcp-client/package.json
+++ b/types/dcp-client/package.json
@@ -5,7 +5,6 @@
     "projects": [
         "https://github.com/Distributed-Compute-Labs/dcp-client"
     ],
-    "minimumTypeScriptVersion": "4.7",
     "devDependencies": {
         "@types/dcp-client": "workspace:."
     },

--- a/types/express-healthcheck/package.json
+++ b/types/express-healthcheck/package.json
@@ -5,7 +5,6 @@
     "projects": [
         "https://github.com/lennym/express-healthcheck"
     ],
-    "minimumTypeScriptVersion": "4.7",
     "dependencies": {
         "@types/express": "*"
     },

--- a/types/gulp-run/package.json
+++ b/types/gulp-run/package.json
@@ -5,7 +5,6 @@
     "projects": [
         "https://github.com/MrBoolean/gulp-run"
     ],
-    "minimumTypeScriptVersion": "4.6",
     "dependencies": {
         "@types/node": "*",
         "@types/vinyl": "*"

--- a/types/jsrsasign/package.json
+++ b/types/jsrsasign/package.json
@@ -5,7 +5,6 @@
     "projects": [
         "https://github.com/kjur/jsrsasign"
     ],
-    "minimumTypeScriptVersion": "4.6",
     "devDependencies": {
         "@types/jsrsasign": "workspace:."
     },

--- a/types/keycloak-connect-roles/package.json
+++ b/types/keycloak-connect-roles/package.json
@@ -5,7 +5,6 @@
     "projects": [
         "https://github.com/osvaldo2627/keycloak-connect-roles#readme"
     ],
-    "minimumTypeScriptVersion": "4.7",
     "dependencies": {
         "@types/express": "*"
     },

--- a/types/node-red-node-test-helper/package.json
+++ b/types/node-red-node-test-helper/package.json
@@ -5,7 +5,6 @@
     "projects": [
         "https://github.com/node-red/node-red-node-test-helper#readme"
     ],
-    "minimumTypeScriptVersion": "4.7",
     "dependencies": {
         "@types/node-red": "*",
         "@types/node-red__runtime": "*",

--- a/types/node-red/package.json
+++ b/types/node-red/package.json
@@ -6,7 +6,6 @@
         "https://github.com/node-red/node-red/tree/master/packages/node_modules/node-red",
         "https://nodered.org/"
     ],
-    "minimumTypeScriptVersion": "4.7",
     "dependencies": {
         "@types/express": "*",
         "@types/node-red__editor-api": "*",

--- a/types/node-red__editor-api/package.json
+++ b/types/node-red__editor-api/package.json
@@ -6,7 +6,6 @@
         "https://github.com/node-red/node-red/tree/master/packages/node_modules/%40node-red/editor-api",
         "https://nodered.org/"
     ],
-    "minimumTypeScriptVersion": "4.7",
     "dependencies": {
         "@types/express": "*",
         "@types/node-red__runtime": "*"

--- a/types/node-red__editor-client/package.json
+++ b/types/node-red__editor-client/package.json
@@ -6,7 +6,6 @@
         "https://github.com/node-red/node-red/tree/master/packages/node_modules/%40node-red/editor-client",
         "https://nodered.org/"
     ],
-    "minimumTypeScriptVersion": "4.7",
     "dependencies": {
         "@types/ace": "*",
         "@types/jquery": "*",

--- a/types/node-red__registry/package.json
+++ b/types/node-red__registry/package.json
@@ -6,7 +6,6 @@
         "https://github.com/node-red/node-red/tree/master/packages/node_modules/%40node-red/registry",
         "https://nodered.org/"
     ],
-    "minimumTypeScriptVersion": "4.7",
     "dependencies": {
         "@types/express": "*",
         "@types/node-red__runtime": "*",

--- a/types/node-red__runtime/package.json
+++ b/types/node-red__runtime/package.json
@@ -6,7 +6,6 @@
         "https://github.com/node-red/node-red/tree/master/packages/node_modules/%40node-red/runtime",
         "https://nodered.org/"
     ],
-    "minimumTypeScriptVersion": "4.7",
     "dependencies": {
         "@types/cors": "*",
         "@types/express": "*",

--- a/types/node-red__util/package.json
+++ b/types/node-red__util/package.json
@@ -6,7 +6,6 @@
         "https://github.com/node-red/node-red/tree/master/packages/node_modules/%40node-red/util",
         "https://nodered.org/"
     ],
-    "minimumTypeScriptVersion": "4.7",
     "dependencies": {
         "@types/node-red__registry": "*",
         "@types/node-red__runtime": "*",

--- a/types/react-scroll-to-bottom/package.json
+++ b/types/react-scroll-to-bottom/package.json
@@ -5,7 +5,6 @@
     "projects": [
         "https://github.com/compulim/react-scroll-to-bottom"
     ],
-    "minimumTypeScriptVersion": "4.6",
     "dependencies": {
         "@types/react": "*"
     },

--- a/types/rollup-plugin-generate-package-json/package.json
+++ b/types/rollup-plugin-generate-package-json/package.json
@@ -5,7 +5,6 @@
     "projects": [
         "https://github.com/vladshcherbin/rollup-plugin-generate-package-json"
     ],
-    "minimumTypeScriptVersion": "4.7",
     "dependencies": {
         "rollup": ">=1.0.0"
     },

--- a/types/screeps/package.json
+++ b/types/screeps/package.json
@@ -5,7 +5,6 @@
     "projects": [
         "https://github.com/screeps/screeps"
     ],
-    "minimumTypeScriptVersion": "4.6",
     "devDependencies": {
         "@types/screeps": "workspace:."
     },

--- a/types/scriptable-ios/package.json
+++ b/types/scriptable-ios/package.json
@@ -7,7 +7,6 @@
     "projects": [
         "https://scriptable.app/"
     ],
-    "minimumTypeScriptVersion": "4.7",
     "devDependencies": {
         "@types/scriptable-ios": "workspace:."
     },

--- a/types/statuses/package.json
+++ b/types/statuses/package.json
@@ -5,7 +5,6 @@
     "projects": [
         "https://github.com/jshttp/statuses"
     ],
-    "minimumTypeScriptVersion": "4.7",
     "devDependencies": {
         "@types/statuses": "workspace:."
     },

--- a/types/terraformer__wkt/package.json
+++ b/types/terraformer__wkt/package.json
@@ -5,7 +5,6 @@
     "projects": [
         "https://github.com/terraformer-js/terraformer/tree/main/packages/wkt"
     ],
-    "minimumTypeScriptVersion": "4.7",
     "dependencies": {
         "@types/geojson": "*"
     },

--- a/types/treeverse/package.json
+++ b/types/treeverse/package.json
@@ -5,7 +5,6 @@
     "projects": [
         "https://github.com/npm/treeverse#readme"
     ],
-    "minimumTypeScriptVersion": "4.7",
     "devDependencies": {
         "@types/treeverse": "workspace:."
     },

--- a/types/wicg-file-system-access/package.json
+++ b/types/wicg-file-system-access/package.json
@@ -8,7 +8,6 @@
         "https://github.com/WICG/file-system-access"
     ],
     "types": "index",
-    "minimumTypeScriptVersion": "4.6",
     "typesVersions": {
         "<=5.0": {
             "*": [

--- a/types/wicg-web-app-launch/package.json
+++ b/types/wicg-web-app-launch/package.json
@@ -7,7 +7,6 @@
     "projects": [
         "https://github.com/WICG/web-app-launch"
     ],
-    "minimumTypeScriptVersion": "4.7",
     "devDependencies": {
         "@types/wicg-web-app-launch": "workspace:."
     },

--- a/types/zingchart/package.json
+++ b/types/zingchart/package.json
@@ -5,7 +5,6 @@
     "projects": [
         "https://github.com/zingchart"
     ],
-    "minimumTypeScriptVersion": "4.7",
     "devDependencies": {
         "@types/zingchart": "workspace:."
     },


### PR DESCRIPTION
TypeScript 4.7 is now the minimum version supported on DT; these explicit minimums can be removed.