### PR TITLE
[@types/qs] Compatibility for version 6.12.0.

### DIFF
--- a/types/qs/index.d.ts
+++ b/types/qs/index.d.ts
@@ -5,14 +5,16 @@ declare namespace QueryString {
     type defaultEncoder = (str: any, defaultEncoder?: any, charset?: string) => string;
     type defaultDecoder = (str: string, decoder?: any, charset?: string) => string;
 
-    interface IStringifyOptions {
+    type BooleanOptional = boolean | undefined;
+
+    interface IStringifyBaseOptions {
         delimiter?: string | undefined;
         strictNullHandling?: boolean | undefined;
         skipNulls?: boolean | undefined;
         encode?: boolean | undefined;
         encoder?:
-            | ((str: any, defaultEncoder: defaultEncoder, charset: string, type: "key" | "value") => string)
-            | undefined;
+          | ((str: any, defaultEncoder: defaultEncoder, charset: string, type: "key" | "value") => string)
+          | undefined;
         filter?: Array<string | number> | ((prefix: string, value: any) => any) | undefined;
         arrayFormat?: "indices" | "brackets" | "repeat" | "comma" | undefined;
         indices?: boolean | undefined;
@@ -21,22 +23,25 @@ declare namespace QueryString {
         format?: "RFC1738" | "RFC3986" | undefined;
         encodeValuesOnly?: boolean | undefined;
         addQueryPrefix?: boolean | undefined;
-        allowDots?: boolean | undefined;
         charset?: "utf-8" | "iso-8859-1" | undefined;
         charsetSentinel?: boolean | undefined;
-        encodeDotInKeys?: boolean | undefined;
     }
 
-    interface IParseOptions {
+    type IStringifyDynamicOptions<AllowDots extends BooleanOptional> = AllowDots extends true
+      ? { allowDots?: AllowDots, encodeDotInKeys?: boolean }
+      : { allowDots?: AllowDots, encodeDotInKeys?: false | undefined }
+
+    type IStringifyOptions<AllowDots extends BooleanOptional = undefined> = IStringifyBaseOptions & IStringifyDynamicOptions<AllowDots>
+
+    interface IParseBaseOptions {
         comma?: boolean | undefined;
         delimiter?: string | RegExp | undefined;
         depth?: number | false | undefined;
         decoder?:
-            | ((str: string, defaultDecoder: defaultDecoder, charset: string, type: "key" | "value") => any)
-            | undefined;
+          | ((str: string, defaultDecoder: defaultDecoder, charset: string, type: "key" | "value") => any)
+          | undefined;
         arrayLimit?: number | undefined;
         parseArrays?: boolean | undefined;
-        allowDots?: boolean | undefined;
         plainObjects?: boolean | undefined;
         allowPrototypes?: boolean | undefined;
         allowSparse?: boolean | undefined;
@@ -47,15 +52,20 @@ declare namespace QueryString {
         charsetSentinel?: boolean | undefined;
         interpretNumericEntities?: boolean | undefined;
         allowEmptyArrays?: boolean | undefined;
-        decodeDotInKeys?: boolean | undefined;
         duplicates?: 'combine' | 'first' | 'last' | undefined;
     }
+
+    type IParseDynamicOptions<AllowDots extends BooleanOptional> = AllowDots extends true
+      ? { allowDots?: AllowDots, decodeDotInKeys?: boolean }
+      : { allowDots?: AllowDots, decodeDotInKeys?: false | undefined }
+
+    type IParseOptions<AllowDots extends BooleanOptional = undefined> = IParseBaseOptions & IParseDynamicOptions<AllowDots>
 
     interface ParsedQs {
         [key: string]: undefined | string | string[] | ParsedQs | ParsedQs[];
     }
 
-    function stringify(obj: any, options?: IStringifyOptions): string;
-    function parse(str: string, options?: IParseOptions & { decoder?: never | undefined }): ParsedQs;
-    function parse(str: string | Record<string, string>, options?: IParseOptions): { [key: string]: unknown };
+    function stringify(obj: any, options?: IStringifyOptions<BooleanOptional>): string;
+    function parse(str: string, options?: IParseOptions<BooleanOptional> & { decoder?: never | undefined }): ParsedQs;
+    function parse(str: string | Record<string, string>, options?: IParseOptions<BooleanOptional>): { [key: string]: unknown };
 }

--- a/types/qs/index.d.ts
+++ b/types/qs/index.d.ts
@@ -29,7 +29,7 @@ declare namespace QueryString {
 
     type IStringifyDynamicOptions<AllowDots extends BooleanOptional> = AllowDots extends true
       ? { allowDots?: AllowDots, encodeDotInKeys?: boolean }
-      : { allowDots?: AllowDots, encodeDotInKeys?: false | undefined }
+      : { allowDots?: boolean, encodeDotInKeys?: false }
 
     type IStringifyOptions<AllowDots extends BooleanOptional = undefined> = IStringifyBaseOptions & IStringifyDynamicOptions<AllowDots>
 
@@ -57,7 +57,7 @@ declare namespace QueryString {
 
     type IParseDynamicOptions<AllowDots extends BooleanOptional> = AllowDots extends true
       ? { allowDots?: AllowDots, decodeDotInKeys?: boolean }
-      : { allowDots?: AllowDots, decodeDotInKeys?: false | undefined }
+      : { allowDots?: boolean, decodeDotInKeys?: false }
 
     type IParseOptions<AllowDots extends BooleanOptional = undefined> = IParseBaseOptions & IParseDynamicOptions<AllowDots>
 

--- a/types/qs/index.d.ts
+++ b/types/qs/index.d.ts
@@ -24,6 +24,7 @@ declare namespace QueryString {
         allowDots?: boolean | undefined;
         charset?: "utf-8" | "iso-8859-1" | undefined;
         charsetSentinel?: boolean | undefined;
+        encodeDotInKeys?: boolean | undefined;
     }
 
     interface IParseOptions {
@@ -45,6 +46,9 @@ declare namespace QueryString {
         charset?: "utf-8" | "iso-8859-1" | undefined;
         charsetSentinel?: boolean | undefined;
         interpretNumericEntities?: boolean | undefined;
+        allowEmptyArrays?: boolean | undefined;
+        decodeDotInKeys?: boolean | undefined;
+        duplicates?: 'combine' | 'first' | 'last' | undefined;
     }
 
     interface ParsedQs {

--- a/types/qs/qs-tests.ts
+++ b/types/qs/qs-tests.ts
@@ -357,6 +357,28 @@ qs.parse("a=b&c=d", { delimiter: "&" });
     assert.deepEqual(sparseArray, { a: [, "2", , "5"] });
 });
 
+(() => {
+    var withEmptyArrays = qs.parse('foo[]&bar=baz', { allowEmptyArrays: true });
+    assert.deepEqual(withEmptyArrays, { foo: [], bar: 'baz' });
+});
+
+(() => {
+    var withDots = qs.parse('name%252Eobj.first=John&name%252Eobj.last=Doe', { decodeDotInKeys: true });
+    assert.deepEqual(withDots, { 'name.obj': { first: 'John', last: 'Doe' }});
+});
+
+(() => {
+    var withDots = qs.stringify({ "name.obj": { "first": "John", "last": "Doe" } }, { allowDots: true, encodeDotInKeys: true })
+    assert.equal(withDots, 'name%252Eobj.first=John&name%252Eobj.last=Doe');
+});
+
+(() => {
+    assert.deepEqual(qs.parse('foo=bar&foo=baz'), { foo: ['bar', 'baz'] });
+    assert.deepEqual(qs.parse('foo=bar&foo=baz', { duplicates: 'combine' }), { foo: ['bar', 'baz'] });
+    assert.deepEqual(qs.parse('foo=bar&foo=baz', { duplicates: 'first' }), { foo: 'bar' });
+    assert.deepEqual(qs.parse('foo=bar&foo=baz', { duplicates: 'last' }), { foo: 'baz' });
+});
+
 declare const myQuery: { a: string; b?: string | undefined };
 const myQueryCopy: qs.ParsedQs = myQuery;
 


### PR DESCRIPTION
Qs package has been updated to version 6.12.0.
It added new functionalities with this update.
Added type support and tests for these functionalities.

**Relevant contexts;**
// duplicates
https://github.com/ljharb/qs/commit/981ce09d9cfe703db6bebdd87690878e1291c18a

// encodeDotInKeys, decodeDotInKeys
https://github.com/ljharb/qs/commit/30004b2d9bb6125a4b8624465656276796912333

// allowEmptyArrays
https://github.com/ljharb/qs/commit/f22b2bc0fa02eddc64779a328c4eaa73ede6fcf6