### PR TITLE
[jqueryui] add `ResizableOptions.classes`, improve `ResizableOptions.aspectRatio`.

### DIFF
--- a/types/jqueryui/index.d.ts
+++ b/types/jqueryui/index.d.ts
@@ -585,9 +585,10 @@ declare namespace JQueryUI {
         animate?: boolean | undefined;
         animateDuration?: any; // number or string
         animateEasing?: string | undefined;
-        aspectRatio?: any; // boolean or number
+        aspectRatio?: number | boolean;
         autoHide?: boolean | undefined;
         cancel?: string | undefined;
+        classes: Record<ResizableThemingClass, string>,
         containment?: any; // Selector, Element or string
         delay?: number | undefined;
         disabled?: boolean | undefined;
@@ -625,6 +626,27 @@ declare namespace JQueryUI {
 
     interface Resizable extends Widget, ResizableOptions {
     }
+
+    type ResizableHandleDirection =
+        | 'n'
+        | 'e'
+        | 's'
+        | 'w'
+        | 'ne'
+        | 'se'
+        | 'sw'
+        | 'nw'
+        | 'all'
+    ;
+    type ResizableThemingClass =
+        | 'ui-resizable'
+        | 'ui-resizable-resizing'
+        | 'ui-resizable-autohide'
+        | 'ui-resizable-handle'
+        | `ui-resizable-${ResizableHandleDirection}`
+        | 'ui-resizable-ghost'
+        | 'ui-resizable-helper'
+    ;
 
     // Selectable //////////////////////////////////////////////////
 

--- a/types/jqueryui/index.d.ts
+++ b/types/jqueryui/index.d.ts
@@ -588,7 +588,7 @@ declare namespace JQueryUI {
         aspectRatio?: number | boolean;
         autoHide?: boolean | undefined;
         cancel?: string | undefined;
-        classes?: Partial<Record<ResizableThemingClass, string>>,
+        classes?: Partial<Record<ResizableThemingClass, string>>;
         containment?: any; // Selector, Element or string
         delay?: number | undefined;
         disabled?: boolean | undefined;
@@ -628,25 +628,23 @@ declare namespace JQueryUI {
     }
 
     type ResizableHandleDirection =
-        | 'n'
-        | 'e'
-        | 's'
-        | 'w'
-        | 'ne'
-        | 'se'
-        | 'sw'
-        | 'nw'
-        | 'all'
-    ;
+        | "n"
+        | "e"
+        | "s"
+        | "w"
+        | "ne"
+        | "se"
+        | "sw"
+        | "nw"
+        | "all";
     type ResizableThemingClass =
-        | 'ui-resizable'
-        | 'ui-resizable-resizing'
-        | 'ui-resizable-autohide'
-        | 'ui-resizable-handle'
+        | "ui-resizable"
+        | "ui-resizable-resizing"
+        | "ui-resizable-autohide"
+        | "ui-resizable-handle"
         | `ui-resizable-${ResizableHandleDirection}`
-        | 'ui-resizable-ghost'
-        | 'ui-resizable-helper'
-    ;
+        | "ui-resizable-ghost"
+        | "ui-resizable-helper";
 
     // Selectable //////////////////////////////////////////////////
 

--- a/types/jqueryui/index.d.ts
+++ b/types/jqueryui/index.d.ts
@@ -588,7 +588,7 @@ declare namespace JQueryUI {
         aspectRatio?: number | boolean;
         autoHide?: boolean | undefined;
         cancel?: string | undefined;
-        classes: Record<ResizableThemingClass, string>,
+        classes?: Partial<Record<ResizableThemingClass, string>>,
         containment?: any; // Selector, Element or string
         delay?: number | undefined;
         disabled?: boolean | undefined;

--- a/types/jqueryui/jqueryui-tests.ts
+++ b/types/jqueryui/jqueryui-tests.ts
@@ -301,7 +301,7 @@ function test_resizable() {
     $(".selector").resizable({ aspectRatio: true });
     $(".selector").resizable({ aspectRatio: 1.337 });
     // @ts-expect-error -- a string is not a valid aspectRatio.
-    $(".selector").resizable({ aspectRatio: 'xx' });
+    $(".selector").resizable({ aspectRatio: "xx" });
     var aspectRatio = $(".selector").resizable("option", "aspectRatio");
     $(".selector").resizable("option", "aspectRatio", true);
     $(".selector").resizable({ autoHide: true });
@@ -311,33 +311,35 @@ function test_resizable() {
     var cancel = $(".selector").resizable("option", "cancel");
     $(".selector").resizable("option", "cancel", ".cancel");
     $(".selector").resizable({ classes: {} });
-    $(".selector").resizable({ classes: {'ui-resizable': 'my-class'} });
-    $(".selector").resizable({ classes: {'ui-resizable-s': 'my-class'} });
-    $(".selector").resizable({ classes: {
-        'ui-resizable': 'my-class',
-        'ui-resizable-resizing': 'my-class',
-        'ui-resizable-autohide': 'my-class',
-        'ui-resizable-handle': 'my-class',
-        'ui-resizable-n': 'my-class',
-        'ui-resizable-e': 'my-class',
-        'ui-resizable-s': 'my-class',
-        'ui-resizable-w': 'my-class',
-        'ui-resizable-ne': 'my-class',
-        'ui-resizable-se': 'my-class',
-        'ui-resizable-sw': 'my-class',
-        'ui-resizable-nw': 'my-class',
-        'ui-resizable-all': 'my-class',
-        'ui-resizable-ghost': 'my-class',
-        'ui-resizable-helper': 'my-class',
-    } });
+    $(".selector").resizable({ classes: { "ui-resizable": "my-class" } });
+    $(".selector").resizable({ classes: { "ui-resizable-s": "my-class" } });
+    $(".selector").resizable({
+        classes: {
+            "ui-resizable": "my-class",
+            "ui-resizable-resizing": "my-class",
+            "ui-resizable-autohide": "my-class",
+            "ui-resizable-handle": "my-class",
+            "ui-resizable-n": "my-class",
+            "ui-resizable-e": "my-class",
+            "ui-resizable-s": "my-class",
+            "ui-resizable-w": "my-class",
+            "ui-resizable-ne": "my-class",
+            "ui-resizable-se": "my-class",
+            "ui-resizable-sw": "my-class",
+            "ui-resizable-nw": "my-class",
+            "ui-resizable-all": "my-class",
+            "ui-resizable-ghost": "my-class",
+            "ui-resizable-helper": "my-class",
+        },
+    });
     // @ts-expect-error -- classes is an object, not a string.
-    $(".selector").resizable({ classes: 'xx xx' });
+    $(".selector").resizable({ classes: "xx xx" });
     // @ts-expect-error -- classes is an object, not an array.
-    $(".selector").resizable({ classes: ['xx', 'xx'] });
+    $(".selector").resizable({ classes: ["xx", "xx"] });
     // @ts-expect-error -- classes only accepts the defined set of class names.
-    $(".selector").resizable({ classes: {'xx': 'my-class'} });
+    $(".selector").resizable({ classes: { "xx": "my-class" } });
     // @ts-expect-error -- classes only accepts the defined set of class names (testing the ResizableHandleDirection).
-    $(".selector").resizable({ classes: {'ui-resizable-xx': 'my-class'} });
+    $(".selector").resizable({ classes: { "ui-resizable-xx": "my-class" } });
     $(".selector").resizable({ containment: "parent" });
     var containment = $(".selector").resizable("option", "containment");
     $(".selector").resizable("option", "containment", "parent");

--- a/types/jqueryui/jqueryui-tests.ts
+++ b/types/jqueryui/jqueryui-tests.ts
@@ -299,6 +299,9 @@ function test_resizable() {
     var animateEasing = $(".selector").resizable("option", "animateEasing");
     $(".selector").resizable("option", "animateEasing", "easeOutBounce");
     $(".selector").resizable({ aspectRatio: true });
+    $(".selector").resizable({ aspectRatio: 1.337 });
+    // @ts-expect-error -- a string is not a valid aspectRatio.
+    $(".selector").resizable({ aspectRatio: 'xx' });
     var aspectRatio = $(".selector").resizable("option", "aspectRatio");
     $(".selector").resizable("option", "aspectRatio", true);
     $(".selector").resizable({ autoHide: true });
@@ -307,6 +310,34 @@ function test_resizable() {
     $(".selector").resizable({ cancel: ".cancel" });
     var cancel = $(".selector").resizable("option", "cancel");
     $(".selector").resizable("option", "cancel", ".cancel");
+    $(".selector").resizable({ classes: {} });
+    $(".selector").resizable({ classes: {'ui-resizable': 'my-class'} });
+    $(".selector").resizable({ classes: {'ui-resizable-s': 'my-class'} });
+    $(".selector").resizable({ classes: {
+        'ui-resizable': 'my-class',
+        'ui-resizable-resizing': 'my-class',
+        'ui-resizable-autohide': 'my-class',
+        'ui-resizable-handle': 'my-class',
+        'ui-resizable-n': 'my-class',
+        'ui-resizable-e': 'my-class',
+        'ui-resizable-s': 'my-class',
+        'ui-resizable-w': 'my-class',
+        'ui-resizable-ne': 'my-class',
+        'ui-resizable-se': 'my-class',
+        'ui-resizable-sw': 'my-class',
+        'ui-resizable-nw': 'my-class',
+        'ui-resizable-all': 'my-class',
+        'ui-resizable-ghost': 'my-class',
+        'ui-resizable-helper': 'my-class',
+    } });
+    // @ts-expect-error -- classes is an object, not a string.
+    $(".selector").resizable({ classes: 'xx xx' });
+    // @ts-expect-error -- classes is an object, not an array.
+    $(".selector").resizable({ classes: ['xx', 'xx'] });
+    // @ts-expect-error -- classes only accepts the defined set of class names.
+    $(".selector").resizable({ classes: {'xx': 'my-class'} });
+    // @ts-expect-error -- classes only accepts the defined set of class names (testing the ResizableHandleDirection).
+    $(".selector").resizable({ classes: {'ui-resizable-xx': 'my-class'} });
     $(".selector").resizable({ containment: "parent" });
     var containment = $(".selector").resizable("option", "containment");
     $(".selector").resizable("option", "containment", "parent");


### PR DESCRIPTION
The `classes` option was missing from `ResizableOptions`, and the `aspectRatio` option was `any`, so I defined its type to be as the documentation states: `number | boolean`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://api.jqueryui.com/resizable/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
