### PR TITLE
:memo: alpinejs improves JSDoc 

### DIFF
--- a/types/alpinejs/alpinejs-tests.ts
+++ b/types/alpinejs/alpinejs-tests.ts
@@ -79,10 +79,10 @@ import Alpine, {
     // Alpine.setReactivityEngine
     // $ExpectType void
     Alpine.setReactivityEngine({
-        reactive: val => val,
-        effect: cb => 1,
+        reactive: (val) => val,
+        effect: (cb) => 1,
         release: (id: number) => undefined,
-        raw: val => val,
+        raw: (val) => val,
     });
 }
 
@@ -115,7 +115,7 @@ import Alpine, {
         }) as DirectiveCallback,
         (el, { expression, modifiers }, { evaluate }) => {
             // do something
-        },
+        }
     );
     Alpine.directive("trap", directiveHandler);
 }
@@ -168,17 +168,18 @@ import Alpine, {
     // inspired by
     // https://github.com/alpinejs/alpine/blob/8d4f1266b25a550d9bd777b8aeb632a6857e89d1/packages/alpinejs/src/directives/x-bind.js
 
-    const startingWith = (s: string, r: string) =>
-    <T>(attribute: {
-        name: string;
-        value: T;
-    }): {
-        name: string;
-        value: T;
-    } => ({
-        name: attribute.name.replace(s, r),
-        value: attribute.value,
-    });
+    const startingWith =
+        (s: string, r: string) =>
+        <T>(attribute: {
+            name: string;
+            value: T;
+        }): {
+            name: string;
+            value: T;
+        } => ({
+            name: attribute.name.replace(s, r),
+            value: attribute.value,
+        });
     const into = (i: string) => i;
 
     // $ExpectType void
@@ -195,7 +196,7 @@ import Alpine, {
     // $resultType (resultCallback: (result: unknown) => void) => void
     const getThingToLog = Alpine.evaluateLater(el, expression);
 
-    getThingToLog(thingToLog => {
+    getThingToLog((thingToLog) => {
         console.log(thingToLog);
     });
 }
@@ -204,12 +205,13 @@ import Alpine, {
     // Alpine.setEvaluator
     // inspired by
     // https://github.com/alpinejs/alpine/blob/b46c41fa240cd8af2dcaa29fb60fb1db0389c95a/packages/alpinejs/src/index.js
-    const justExpressionEvaluator = <T>( // eslint-disable-line @definitelytyped/no-unnecessary-generics
-        el: ElementWithXAttributes,
-        expression?: string | (() => T),
-    ) =>
-    (resultCallback: (result: T) => void) =>
-        resultCallback(typeof expression === "function" ? expression() : Alpine.evaluate<T>(el, expression ?? ""));
+    const justExpressionEvaluator =
+        <T>( // eslint-disable-line @definitelytyped/no-unnecessary-generics
+            el: ElementWithXAttributes,
+            expression?: string | (() => T)
+        ) =>
+        (resultCallback: (result: T) => void) =>
+            resultCallback(typeof expression === "function" ? expression() : Alpine.evaluate<T>(el, expression ?? ""));
 
     Alpine.setEvaluator(justExpressionEvaluator);
 }
@@ -249,11 +251,15 @@ import Alpine, {
     Alpine.interceptor;
 
     // This uses the generics as older versions of TypeScript don't properly infer the argument types
-    Alpine.data<{
-        intercepted: InterceptorObject<"foo">;
-        init(): void;
-        hello: "world";
-    }, [hello: "world"]>("user", (hello: "world") => ({ // checks argument support
+    Alpine.data<
+        {
+            intercepted: InterceptorObject<"foo">;
+            init(): void;
+            hello: "world";
+        },
+        [hello: "world"]
+    >("user", (hello: "world") => ({
+        // checks argument support
         intercepted: Alpine.interceptor((initialValue: "foo") => initialValue)("foo"),
         init() {
             // $ExpectType "foo"
@@ -286,7 +292,7 @@ import Alpine, {
                 storage = target;
                 return func;
             };
-        },
+        }
     );
 }
 
@@ -309,7 +315,7 @@ import Alpine, {
             end: { height: "200px" },
         },
         () => (transitioning = true),
-        () => (transitioning = false),
+        () => (transitioning = false)
     );
 }
 
@@ -362,7 +368,7 @@ import Alpine, {
         cleanup;
     });
 
-    ((el: Node, { value, modifiers, expression }: DirectiveData, { Alpine, effect, cleanup }: DirectiveUtilities) => {
+    (el: Node, { value, modifiers, expression }: DirectiveData, { Alpine, effect, cleanup }: DirectiveUtilities) => {
         // $ExpectType Node
         el;
         // $ExpectType string
@@ -377,7 +383,7 @@ import Alpine, {
         effect;
         // $ExpectType (callback: () => void) => void
         cleanup;
-    });
+    };
 }
 
 {
@@ -436,7 +442,7 @@ import Alpine, {
 
     const shallowWalker = (
         el: ElementWithXAttributes,
-        callback: (el: ElementWithXAttributes, skip: () => void) => void,
+        callback: (el: ElementWithXAttributes, skip: () => void) => void
     ) => {
         // do walking
     };
@@ -534,6 +540,9 @@ import Alpine, {
     // $ExpectType void
     Alpine.store("darkModeState", false);
 
+    // $ExpectType boolean
+    Alpine.store("darkModeState");
+
     // $ExpectType void
     Alpine.store("tabs", {
         current: "first",
@@ -546,6 +555,9 @@ import Alpine, {
     Alpine.store("untypedKey", {
         foo: "bar",
     });
+
+    // $ExpectType unknown
+    Alpine.store("untypedKey");
 }
 
 {
@@ -705,8 +717,8 @@ import Alpine, {
                 "user",
                 (
                     // $ExpectType { id: number; name: string; }
-                    newValue,
-                ) => {},
+                    newValue
+                ) => {}
             );
         },
     }));
@@ -730,8 +742,8 @@ import Alpine, {
                         // $ExpectType { id: number; name: string; }
                         newValue,
                         // $ExpectType { id: number; name: string; }
-                        oldValue,
-                    ) => {},
+                        oldValue
+                    ) => {}
                 );
 
                 // $ExpectType void
@@ -739,11 +751,11 @@ import Alpine, {
                     "user.id",
                     (
                         // $ExpectType any
-                        newValue,
-                    ) => {},
+                        newValue
+                    ) => {}
                 );
             },
-        }),
+        })
     );
 }
 

--- a/types/alpinejs/alpinejs-tests.ts
+++ b/types/alpinejs/alpinejs-tests.ts
@@ -115,7 +115,7 @@ import Alpine, {
         }) as DirectiveCallback,
         (el, { expression, modifiers }, { evaluate }) => {
             // do something
-        }
+        },
     );
     Alpine.directive("trap", directiveHandler);
 }
@@ -168,18 +168,17 @@ import Alpine, {
     // inspired by
     // https://github.com/alpinejs/alpine/blob/8d4f1266b25a550d9bd777b8aeb632a6857e89d1/packages/alpinejs/src/directives/x-bind.js
 
-    const startingWith =
-        (s: string, r: string) =>
-        <T>(attribute: {
-            name: string;
-            value: T;
-        }): {
-            name: string;
-            value: T;
-        } => ({
-            name: attribute.name.replace(s, r),
-            value: attribute.value,
-        });
+    const startingWith = (s: string, r: string) =>
+    <T>(attribute: {
+        name: string;
+        value: T;
+    }): {
+        name: string;
+        value: T;
+    } => ({
+        name: attribute.name.replace(s, r),
+        value: attribute.value,
+    });
     const into = (i: string) => i;
 
     // $ExpectType void
@@ -205,13 +204,12 @@ import Alpine, {
     // Alpine.setEvaluator
     // inspired by
     // https://github.com/alpinejs/alpine/blob/b46c41fa240cd8af2dcaa29fb60fb1db0389c95a/packages/alpinejs/src/index.js
-    const justExpressionEvaluator =
-        <T>( // eslint-disable-line @definitelytyped/no-unnecessary-generics
-            el: ElementWithXAttributes,
-            expression?: string | (() => T)
-        ) =>
-        (resultCallback: (result: T) => void) =>
-            resultCallback(typeof expression === "function" ? expression() : Alpine.evaluate<T>(el, expression ?? ""));
+    const justExpressionEvaluator = <T>( // eslint-disable-line @definitelytyped/no-unnecessary-generics
+        el: ElementWithXAttributes,
+        expression?: string | (() => T),
+    ) =>
+    (resultCallback: (result: T) => void) =>
+        resultCallback(typeof expression === "function" ? expression() : Alpine.evaluate<T>(el, expression ?? ""));
 
     Alpine.setEvaluator(justExpressionEvaluator);
 }
@@ -292,7 +290,7 @@ import Alpine, {
                 storage = target;
                 return func;
             };
-        }
+        },
     );
 }
 
@@ -315,7 +313,7 @@ import Alpine, {
             end: { height: "200px" },
         },
         () => (transitioning = true),
-        () => (transitioning = false)
+        () => (transitioning = false),
     );
 }
 
@@ -368,7 +366,7 @@ import Alpine, {
         cleanup;
     });
 
-    (el: Node, { value, modifiers, expression }: DirectiveData, { Alpine, effect, cleanup }: DirectiveUtilities) => {
+    ((el: Node, { value, modifiers, expression }: DirectiveData, { Alpine, effect, cleanup }: DirectiveUtilities) => {
         // $ExpectType Node
         el;
         // $ExpectType string
@@ -383,7 +381,7 @@ import Alpine, {
         effect;
         // $ExpectType (callback: () => void) => void
         cleanup;
-    };
+    });
 }
 
 {
@@ -442,7 +440,7 @@ import Alpine, {
 
     const shallowWalker = (
         el: ElementWithXAttributes,
-        callback: (el: ElementWithXAttributes, skip: () => void) => void
+        callback: (el: ElementWithXAttributes, skip: () => void) => void,
     ) => {
         // do walking
     };
@@ -717,8 +715,8 @@ import Alpine, {
                 "user",
                 (
                     // $ExpectType { id: number; name: string; }
-                    newValue
-                ) => {}
+                    newValue,
+                ) => {},
             );
         },
     }));
@@ -742,8 +740,8 @@ import Alpine, {
                         // $ExpectType { id: number; name: string; }
                         newValue,
                         // $ExpectType { id: number; name: string; }
-                        oldValue
-                    ) => {}
+                        oldValue,
+                    ) => {},
                 );
 
                 // $ExpectType void
@@ -751,11 +749,11 @@ import Alpine, {
                     "user.id",
                     (
                         // $ExpectType any
-                        newValue
-                    ) => {}
+                        newValue,
+                    ) => {},
                 );
             },
-        })
+        }),
     );
 }
 

--- a/types/alpinejs/index.d.ts
+++ b/types/alpinejs/index.d.ts
@@ -232,7 +232,7 @@ export interface Alpine {
     /**
      * Releases an effect from reactive to dependency changes
      *
-     * @param {ReactiveEffect} effect returned from `Alpine.effect`
+     * @param {ReactiveEffect} effect returned from {@link Alpine.effect}
      */
     readonly release: (effect: ReactiveEffect) => void;
     /**
@@ -271,7 +271,7 @@ export interface Alpine {
     disableEffectScheduling: (callback: () => void) => void;
     /**
      * Starts observing the Alpine component tree for mutations
-     * Used internally in `Alpine.start`
+     * Used internally in {@link Alpine.start}
      */
     startObservingMutations: () => void;
     /**
@@ -461,16 +461,16 @@ export interface Alpine {
      */
     destroyTree: (root: ElementWithXAttributes) => void;
     /**
-     * @private
      * Helper function for building data interceptor objects
-     * @param callback
+     * @internal
+     * @param callback to run on Interception
      * @param mutator to further mutate the Interceptor
      * @returns Interceptor Function
      */
     interceptor: interceptor;
     /**
-     * @private
      * Runs a series of transitions on an element
+     * @internal
      * @param el to apply transitions to
      * @param setFunction that applies the state
      * @param State Object with keys for start, during, and end
@@ -578,7 +578,7 @@ export interface Alpine {
     evaluate: <T_9>(el: Node, expression: string | (() => T_9), extras?: {}) => T_9;
     /**
      * Initializes the Alpine tree rooted at a particular element
-     * Used internally in `Alpine.start` and to initialize cloned templates
+     * Used internally in {@link Alpine.start} and to initialize cloned templates
      * @param el to initialize as the root
      * @param walker callback to assist in walking the tree
      * @param intercept initialization of elements
@@ -636,17 +636,17 @@ export interface Alpine {
      */
     start: () => void;
     /**
-     * @private
-     * @deprecated
      * Clones the Alpine context of an element to another element
+     * @internal
+     * @deprecated use {@link Alpine.cloneNode} instead
      * @param oldEl element to clone from
      * @param newEl element to clone to
      * @returns
      */
     clone: (oldEl: ElementWithXAttributes, newEl: ElementWithXAttributes) => void;
     /**
-     * @private
      * Clones the Alpine context of an element to another element
+     * @internal
      * @param from element to clone from
      * @param to element to clone to
      */

--- a/types/alpinejs/index.d.ts
+++ b/types/alpinejs/index.d.ts
@@ -144,11 +144,14 @@ export type AlpineComponent<T> = T & XDataContext & ThisType<InferInterceptors<T
 
 interface XDataContext {
     /**
-     * Will be executed before Alpine initializes the rest of the component.
+     * Will be executed immediately upon Alpine initializing the component.
+     * This will run before `x-init` directives on even the root element.
+     * Interceptors ($persist, etc) will be initialized before this.
      */
     init?(): void;
     /**
-     * Will be executed when the component is destroyed.
+     * Will be executed upon destruction/unmount of the component tree.
+     * This will run intermingled with other cleanup operations.
      */
     destroy?(): void;
 }
@@ -159,48 +162,55 @@ export interface Stores {
 
 export interface Magics<T> {
     /**
-     * Access to current Alpine data.
+     * Provides access to the element's current Alpine scope
+     * This is a flattened Proxy object over the datastack
+     * Use to avoid errors from accessing undefined properties
      */
     $data: InferInterceptors<T>;
     /**
      * Dispatches a CustomEvent on the current DOM node.
-     * Event automatically bubbles up.
+     * Event automatically bubbles up the DOM tree.
      *
      * @param event the event name
-     * @param detail an event-dependent value associated with the event, the value is then available to the handler using the CustomEvent.detail property
+     * @param detail an event-dependent value associated with the event
      */
     $dispatch: (event: string, detail?: any) => void;
     /**
-     * Retrieve the current DOM node.
+     * The current HTMLElement that triggered this expression.
      */
     $el: HTMLElement;
     /**
-     * Generate an element's ID and ensure that it won't conflict with other IDs of the same name on the same page.
+     * Generate a unique ID within the current `x-id` scope.
+     * Name is required to allow reuse in related contexts.
      *
      * @param name the name of the id
      * @param key suffix on the end of the generated ID, usually helpful for the purpose of identifying id in a loop
      */
     $id: (name: string, key?: number | string | null) => string;
     /**
-     * Execute a given expression AFTER Alpine has made its reactive DOM updates.
+     * Triggers callback at the beginning of the next event loop.
+     * Use to evaluate AFTER Alpine has made reactive DOM updates.
      *
-     * @param callback a callback that will be fired after Alpine finishes updating the DOM
+     * @param callback a callback that will be fired on next tick
      */
     $nextTick: (callback?: () => void) => Promise<void>;
     /**
-     * Retrieve DOM elements marked with x-ref inside the component.
+     * Record of DOM elements marked with `x-ref` inside the component.
      */
     $refs: Record<string, HTMLElement>;
     /**
-     * Accesses the root element of the current component context.
+     * The root element of the current component context.
+     * Roots are typically defined by `x-data` directive.
      */
     $root: ElementWithXAttributes;
     /**
-     * Access registered global Alpine stores.
+     * Record of global reactive Alpine stores.
      */
     $store: Stores;
     /**
-     * Fire the given callback when the value in the property is changed.
+     * Evaluate the given callback when the property is changed.
+     * Deeply watches for changes on object and array types.
+     * Property can be a dot notated nested property.
      *
      * @param property the component property
      * @param callback a callback that will fire when a given property is changed

--- a/types/alpinejs/index.d.ts
+++ b/types/alpinejs/index.d.ts
@@ -27,10 +27,7 @@ export interface XAttributes {
     _x_currentIfEl: ElementWithXAttributes;
     _x_undoIf: () => void;
     _x_removeModelListeners: Record<string, () => void>;
-    _x_model: {
-        get: () => unknown;
-        set: (value: unknown) => void;
-    };
+    _x_model: GetterSetter<unknown>;
     _x_forceModelUpdate: (value: unknown) => void;
     _x_forwardEvents: string[];
     _x_doHide: () => void;
@@ -230,6 +227,11 @@ export interface ReactiveEffect<T = any> {
     raw: () => T;
 }
 
+type GetterSetter<T> = {
+    get(): T;
+    set(value: T): void;
+};
+
 export interface Alpine {
     /**
      * Wraps an object in a reactive proxy that can track access
@@ -266,29 +268,29 @@ export interface Alpine {
      * Handles all deferred mutation entries
      * Resumes immediate handling of mutations
      */
-    flushAndStopDeferringMutations: () => void;
+    flushAndStopDeferringMutations(): void;
     /**
      * Prevents `evaluate` from automatically calling functions
      * returned by the expression
      *
      * @param callback
      */
-    dontAutoEvaluateFunctions: (callback: () => void) => void;
+    dontAutoEvaluateFunctions(callback: () => void): void;
     /**
      * Disables the scheduling of triggered Effects
      * @param callback
      */
-    disableEffectScheduling: (callback: () => void) => void;
+    disableEffectScheduling(callback: () => void): void;
     /**
      * Starts observing the Alpine component tree for mutations
      * Used internally in {@link Alpine.start}
      */
-    startObservingMutations: () => void;
+    startObservingMutations(): void;
     /**
      * Stops observing the Alpine component tree for mutations
      * Used internally to control handling of cloned templates
      */
-    stopObservingMutations: () => void;
+    stopObservingMutations(): void;
     /**
      * Sets the reactivity engine for Alpine
      * @param engine
@@ -306,13 +308,13 @@ export interface Alpine {
      * @param name
      * @param callback
      */
-    onAttributeRemoved: (el: ElementWithXAttributes, name: string, callback: () => void) => void;
+    onAttributeRemoved(el: ElementWithXAttributes, name: string, callback: () => void): void;
     /**
      * Registers a listener for when any attribute is added to any element
      * @param callback
      * @returns
      */
-    onAttributesAdded: (callback: AttrMutationCallback) => void;
+    onAttributesAdded(callback: AttrMutationCallback): void;
     /**
      * Retrieves the list of Contexts that build the Alpine Context for the element
      * from most local to least
@@ -326,29 +328,29 @@ export interface Alpine {
      * @param fallback will run when cloning (optional)
      * @returns wrapped function
      */
-    skipDuringClone: <T extends (...args: Parameters<T>) => ReturnType<T>>(callback: T, fallback?: T) => T;
+    skipDuringClone<T extends (...args: Parameters<T>) => ReturnType<T>>(callback: T, fallback?: T): T;
     /**
      * Returns a conditional function that will only execute
      * during the cloning of an element
      * @param callback will run when cloning
      * @returns wrapped function
      */
-    onlyDuringClone: (callback: DirectiveCallback) => DirectiveCallback;
+    onlyDuringClone(callback: DirectiveCallback): DirectiveCallback;
     /**
      * Adds a root selector from which Alpine builds an Alpine Tree
      * @param selectorCallback
      */
-    addRootSelector: (selectorCallback: () => string) => void;
+    addRootSelector(selectorCallback: () => string): void;
     /**
      * Adds an init selector where Alpine will evaluate the element without a context
      * @param selectorCallback
      */
-    addInitSelector: (selectorCallback: () => string) => void;
+    addInitSelector(selectorCallback: () => string): void;
     /**
      * Registers a callback to pre-process elements being cloned
      * @param callback
      */
-    interceptClone: (callback: (from: ElementWithXAttributes, to: ElementWithXAttributes) => void) => void;
+    interceptClone(callback: (from: ElementWithXAttributes, to: ElementWithXAttributes) => void): void;
     /**
      * Adds an Record to the Element's data stack
      * It does not make the object reactive if it isn't already
@@ -366,7 +368,7 @@ export interface Alpine {
      * Begins deferring mutation handling to allow for a set of changes to be made
      * call `flushAndStopDeferringMutations` to resume handling
      */
-    deferMutations: () => void;
+    deferMutations(): void;
     /**
      * Registers a callback to preprocess attributes/directives before they are evaluated
      * Allows transforming custom syntaxes into known directives
@@ -398,7 +400,7 @@ export interface Alpine {
      * Call the `skip` function to prevent the element from being initialized
      * @param callback
      */
-    interceptInit: (callback: WalkerCallback) => void;
+    interceptInit(callback: WalkerCallback): void;
     /**
      * Registers an evaluator to be used
      * Used internally by Alpine CSP to use a CSP safe evaluator
@@ -443,7 +445,7 @@ export interface Alpine {
      * @param callback
      * @returns {Node}
      */
-    findClosest: (el: Element, callback: (el: ElementWithXAttributes) => boolean) => Element;
+    findClosest(el: Element, callback: (el: ElementWithXAttributes) => boolean): Element;
     /**
      * Registers a callback to run when any element is removed from the DOM
      * @param callback to run when an element is removed removed
@@ -469,7 +471,7 @@ export interface Alpine {
      * Used to cleanup removed elements or disable Alpine
      * @param root
      */
-    destroyTree: (root: ElementWithXAttributes) => void;
+    destroyTree(root: ElementWithXAttributes): void;
     /**
      * Helper function for building data interceptor objects
      * @internal
@@ -483,11 +485,11 @@ export interface Alpine {
      * @internal
      * @param el to apply transitions to
      * @param setFunction that applies the state
-     * @param State Object with keys for start, during, and end
+     * @param states Object with keys for start, during, and end
      * @param before callback to run before transitions
      * @param after callback to run after transitions
      */
-    transition: (
+    transition(
         el: ElementWithXAttributes,
         setFunction:
             | ((
@@ -495,18 +497,14 @@ export interface Alpine {
                   value: string | boolean | Record<string, boolean> | (() => string | boolean | Record<string, boolean>)
               ) => () => void)
             | ((el: ElementWithXAttributes, value: string | Partial<CSSStyleDeclaration>) => () => void),
-        {
-            during,
-            start,
-            end,
-        }: Partial<{
+        states: Partial<{
             start: string | Partial<CSSStyleDeclaration>;
             during: string | Partial<CSSStyleDeclaration>;
             end: string | Partial<CSSStyleDeclaration>;
         }>,
         before?: () => void,
         after?: () => void
-    ) => void;
+    ): void;
     /**
      * Sets styles to an element, from a string or object
      * Provides a function to undo the changes
@@ -514,69 +512,56 @@ export interface Alpine {
      * @param {string | CSSStyleDeclaration} styles
      * @returns undo function
      */
-    setStyles: (el: ElementWithXAttributes, styles: string | Partial<CSSStyleDeclaration>) => () => void;
+    setStyles(el: ElementWithXAttributes, styles: string | Partial<CSSStyleDeclaration>): () => void;
     /**
      * Runs an operation without having Alpine react to changes in the DOM caused by the function
      * Useful for making a set of changes to the DOM and manually handling initialization
      * @param callback that mutates the DOM
      */
-    mutateDom: <T_5>(callback: () => T_5) => T_5;
+    mutateDom<T_5>(callback: () => T_5): T_5;
     /**
      * Registers a new directive that can be used in markup (ex. `x-directive`)
      * @param name of directive (without the `x-` prefix)
      * @param callback to handle the directive
      */
-    directive: (
+    directive(
         name: string,
         callback: DirectiveCallback
-    ) => {
+    ): {
         before(directive: string): void;
     };
     /**
-     * Entangles two objects
-     * Creates a reactive effect that bidirectionally bings the getters and setters on each object
+     * Entangles two values, through getter/setter pairs.
+     * When one value changes, the other is updated.
+     * On entanglement, the outer is pushed onto the inner
      *
      * @param outer getter and setter pair
      * @param inner getter and setter pair
      */
-    entangle: <T_6>(
-        {
-            get: outerGet,
-            set: outerSet,
-        }: {
-            get: () => T_6;
-            set: (value: T_6) => void;
-        },
-        {
-            get: innerGet,
-            set: innerSet,
-        }: {
-            get: () => T_6;
-            set: (value: T_6) => void;
-        }
-    ) => () => void;
+    entangle<T_6>(outer: GetterSetter<T_6>, inner: GetterSetter<T_6>): () => void;
     /**
-     * Provides a throttled version of the passed in function
-     * Can be called multiple times and only executes once per specified time
+     * Provides a throttled version of the passed in function.
+     * Throttled Function can be called multiple times
+     * and only executes once per specified limit.
      *
      * @param func to apply throttle to
      * @param limit time in ms
      * @returns throttled function
      */
-    throttle: <T_7 extends (...args: Parameters<T_7>) => void>(
+    throttle<T_7 extends (...args: Parameters<T_7>) => void>(
         func: T_7,
         limit?: number
-    ) => (...args: Parameters<T_7>) => void;
+    ): (...args: Parameters<T_7>) => void;
     /**
-     * Provides a debounced version of the passed in function
-     * Can be called multiple times and only executes after specified delay
-     * since last call
+     * Provides a debounced version of the passed in function.
+     * Can be called multiple times and only executes
+     * only after specified delay since last call
      *
      * @param func to apply debounce to
      * @param wait time in ms
      * @returns debounced function
      */
-    debounce: <T_8 extends (...args: Parameters<T_8>) => void>(func: T_8, wait?: number) => T_8;
+    debounce<T_8 extends (...args: Parameters<T_8>) => void>(func: T_8, wait?: number): T_8;
     /**
      * Evaluates a string expression within the Alpine context of a particular Node
      *
@@ -585,7 +570,7 @@ export interface Alpine {
      * @param extras additional values to expose to the expression
      * @returns whatever the expression returns
      */
-    evaluate: <T_9>(el: Node, expression: string | (() => T_9), extras?: {}) => T_9;
+    evaluate<T_9>(el: Node, expression: string | (() => T_9), extras?: {}): T_9;
     /**
      * Initializes the Alpine tree rooted at a particular element
      * Used internally in {@link Alpine.start} and to initialize cloned templates
@@ -593,17 +578,17 @@ export interface Alpine {
      * @param walker callback to assist in walking the tree
      * @param intercept initialization of elements
      */
-    initTree: (
+    initTree(
         el: ElementWithXAttributes,
         walker?: (el: ElementWithXAttributes, callback: WalkerCallback) => any,
         intercept?: WalkerCallback
-    ) => void;
+    ): void;
     /**
      * Waits until after a frame is painted to continue execution
      * @param callback to run at the start of the next frame
      * @returns Promise that resolves on the next frame
      */
-    nextTick: (callback?: () => void) => Promise<unknown>;
+    nextTick(callback?: () => void): Promise<unknown>;
     /**
      * Applies the current Alpine Prefix to a string
      * Default prefix is `x-`
@@ -611,23 +596,23 @@ export interface Alpine {
      * @param subject to prefix
      * @returns prefixed subject
      */
-    prefixed: (subject?: string) => string;
+    prefixed(subject?: string): string;
     /**
      * Changes the prefix Alpine uses to identify directives
      * Commonly, `data-x` is used to make the directives in spec
      * @param newPrefix to use
      */
-    prefix: (newPrefix: string) => void;
+    prefix(newPrefix: string): void;
     /**
      * Registers Plugins onto Alpine
      */
-    plugin: (callbacks: PluginCallback | PluginCallback[]) => void;
+    plugin(callbacks: PluginCallback | PluginCallback[]): void;
     /**
      * Registers a magic accessible at $name in Alpine contexts
      * @param name name of Magic
      * @param callback Method that builds the magic's value
      */
-    magic: (name: string, callback: (el: ElementWithXAttributes, options: MagicUtilities) => unknown) => void;
+    magic(name: string, callback: (el: ElementWithXAttributes, options: MagicUtilities) => unknown): void;
     /**
      * Registers a global reactive store to a name
      * Store is made Reactive if not already
@@ -644,7 +629,7 @@ export interface Alpine {
     /**
      * Starts Alpine on the current document
      */
-    start: () => void;
+    start(): void;
     /**
      * Clones the Alpine context of an element to another element
      * @internal
@@ -653,14 +638,14 @@ export interface Alpine {
      * @param newEl element to clone to
      * @returns
      */
-    clone: (oldEl: ElementWithXAttributes, newEl: ElementWithXAttributes) => void;
+    clone(oldEl: ElementWithXAttributes, newEl: ElementWithXAttributes): void;
     /**
      * Clones the Alpine context of an element to another element
      * @internal
      * @param from element to clone from
      * @param to element to clone to
      */
-    cloneNode: (from: ElementWithXAttributes, to: ElementWithXAttributes) => void;
+    cloneNode(from: ElementWithXAttributes, to: ElementWithXAttributes): void;
     /**
      * Gets current binding or value of a prop from an element
      * Similar to `extractProp` but does not access inline bindings
@@ -669,21 +654,21 @@ export interface Alpine {
      * @param fallback value if not present
      * @returns value of attribute
      */
-    bound: (el: ElementWithXAttributes, name: string, fallback?: unknown) => unknown;
+    bound(el: ElementWithXAttributes, name: string, fallback?: unknown): unknown;
     /**
      * Gets the data context of a particular Node
      * This is a "flattened" object of all the scopes that element is within
      * @param node Element inside an Alpine Component
      * @returns Object
      */
-    $data: (node: ElementWithXAttributes) => {};
+    $data(node: ElementWithXAttributes): {};
     /**
      * Walks the DOM tree from the provided root element
      * Runs the callback on each element
      * @param el to start walking from
      * @param callback to run on found elements
      */
-    walk: (el: ElementWithXAttributes, callback: WalkerCallback) => any;
+    walk(el: ElementWithXAttributes, callback: WalkerCallback): any;
     /**
      * Registers a component constructor a name referenceable inside `x-data` expressions
      *
@@ -691,10 +676,11 @@ export interface Alpine {
      * @param callback Data context constructor function
      */
     // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-    data: <T extends { [key in keyof T]: T[key] }, A extends unknown[]>(
+    data<T extends { [key in keyof T]: T[key] }, A extends unknown[]>(
         name: string,
         callback: (...args: A) => AlpineComponent<T> // Needed generic to properly autotype objects
-    ) => void;
+    ): void;
+
     /**
      * Binds directives and attributes to an element
      * @param element to bind

--- a/types/alpinejs/index.d.ts
+++ b/types/alpinejs/index.d.ts
@@ -227,10 +227,10 @@ export interface ReactiveEffect<T = any> {
     raw: () => T;
 }
 
-type GetterSetter<T> = {
+interface GetterSetter<T> {
     get(): T;
     set(value: T): void;
-};
+}
 
 export interface Alpine {
     /**

--- a/types/alpinejs/index.d.ts
+++ b/types/alpinejs/index.d.ts
@@ -36,7 +36,7 @@ export interface XAttributes {
         el: ElementWithXAttributes,
         val: boolean,
         show: () => void,
-        hide: () => void
+        hide: () => void,
     ) => void;
     _x_teleport: ElementWithXAttributes;
     _x_transition: Transitions;
@@ -82,7 +82,7 @@ export type AttrMutationCallback = (
     attrs: Array<{
         name: string;
         value: string;
-    }>
+    }>,
 ) => void;
 
 export interface DirectiveData {
@@ -101,13 +101,11 @@ export interface InterceptorObject<T> {
     initialize: (data: Record<string, unknown>, path: string, key: string) => T;
 }
 
-type InferInterceptor<T> = T extends InterceptorObject<infer U>
-    ? U
-    : keyof T extends never
-    ? T
+type InferInterceptor<T> = T extends InterceptorObject<infer U> ? U
+    : keyof T extends never ? T
     : {
-          [K in keyof T]: InferInterceptor<T[K]>;
-      };
+        [K in keyof T]: InferInterceptor<T[K]>;
+    };
 
 export type InferInterceptors<T> = {
     [K in keyof T]: InferInterceptor<T[K]>;
@@ -115,7 +113,7 @@ export type InferInterceptors<T> = {
 
 type interceptor = <T>(
     callback: InterceptorCallback<T>,
-    mutateObj?: (obj: InterceptorObject<T>) => void
+    mutateObj?: (obj: InterceptorObject<T>) => void,
 ) => (initialValue: T) => InterceptorObject<T>;
 
 export interface DirectiveUtilities {
@@ -214,7 +212,7 @@ export interface Magics<T> {
      */
     $watch: <K extends keyof T | string, V extends K extends keyof T ? T[K] : any>(
         property: K,
-        callback: (newValue: V, oldValue: V) => void
+        callback: (newValue: V, oldValue: V) => void,
     ) => void;
 }
 
@@ -362,7 +360,7 @@ export interface Alpine {
     addScopeToNode: (
         node: Element,
         data: Record<string, unknown>,
-        referenceNode?: ElementWithXAttributes
+        referenceNode?: ElementWithXAttributes,
     ) => () => void;
     /**
      * Begins deferring mutation handling to allow for a set of changes to be made
@@ -379,7 +377,7 @@ export interface Alpine {
         callback: (attribute: { name: string; value: string | (() => unknown) }) => {
             name: string;
             value: string | (() => unknown);
-        }
+        },
     ) => void;
     /**
      * Provides a function that can be called to evaluate an expression
@@ -387,13 +385,13 @@ export interface Alpine {
      */
     evaluateLater: <T_1>(
         el: Element,
-        expression?: string | (() => T_1)
+        expression?: string | (() => T_1),
     ) => (
         callback?: (value: T_1) => void,
         extras?: {
             scope?: object;
             params?: unknown[];
-        }
+        },
     ) => void;
     /**
      * Registers a callback to preprocess elements before they are initialized
@@ -409,14 +407,14 @@ export interface Alpine {
     setEvaluator: (
         newEvaluator: <T_2>(
             el: ElementWithXAttributes,
-            expression?: string | (() => T_2)
+            expression?: string | (() => T_2),
         ) => (
             callback: (value: T_2) => void,
             extras?: {
                 scope?: object;
                 params?: unknown[];
-            }
-        ) => void
+            },
+        ) => void,
     ) => void;
     /**
      * "Flattens" an array of objects into a single Proxy object
@@ -437,7 +435,7 @@ export interface Alpine {
         el: ElementWithXAttributes,
         name: string,
         fallback: T_3 | (() => T_3),
-        extract?: boolean
+        extract?: boolean,
     ) => unknown;
     /**
      * Finds closest Node that satisfies the provided test function
@@ -493,9 +491,9 @@ export interface Alpine {
         el: ElementWithXAttributes,
         setFunction:
             | ((
-                  el: ElementWithXAttributes,
-                  value: string | boolean | Record<string, boolean> | (() => string | boolean | Record<string, boolean>)
-              ) => () => void)
+                el: ElementWithXAttributes,
+                value: string | boolean | Record<string, boolean> | (() => string | boolean | Record<string, boolean>),
+            ) => () => void)
             | ((el: ElementWithXAttributes, value: string | Partial<CSSStyleDeclaration>) => () => void),
         states: Partial<{
             start: string | Partial<CSSStyleDeclaration>;
@@ -503,7 +501,7 @@ export interface Alpine {
             end: string | Partial<CSSStyleDeclaration>;
         }>,
         before?: () => void,
-        after?: () => void
+        after?: () => void,
     ): void;
     /**
      * Sets styles to an element, from a string or object
@@ -526,7 +524,7 @@ export interface Alpine {
      */
     directive(
         name: string,
-        callback: DirectiveCallback
+        callback: DirectiveCallback,
     ): {
         before(directive: string): void;
     };
@@ -550,7 +548,7 @@ export interface Alpine {
      */
     throttle<T_7 extends (...args: Parameters<T_7>) => void>(
         func: T_7,
-        limit?: number
+        limit?: number,
     ): (...args: Parameters<T_7>) => void;
     /**
      * Provides a debounced version of the passed in function.
@@ -581,7 +579,7 @@ export interface Alpine {
     initTree(
         el: ElementWithXAttributes,
         walker?: (el: ElementWithXAttributes, callback: WalkerCallback) => any,
-        intercept?: WalkerCallback
+        intercept?: WalkerCallback,
     ): void;
     /**
      * Waits until after a frame is painted to continue execution
@@ -678,7 +676,7 @@ export interface Alpine {
     // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     data<T extends { [key in keyof T]: T[key] }, A extends unknown[]>(
         name: string,
-        callback: (...args: A) => AlpineComponent<T> // Needed generic to properly autotype objects
+        callback: (...args: A) => AlpineComponent<T>, // Needed generic to properly autotype objects
     ): void;
 
     /**


### PR DESCRIPTION
This primarily adds/improves the JSDoc on exposed methods. Uses overloading on a few methods.

This also adds declarations on the `Alpine` object for minor API additions.

This does not (should not?) actually change the definitions of anything that was valid before.