### PR TITLE
[@types/eslint] Add rule definitions and update 

### DIFF
--- a/types/eslint/rules/best-practices.d.ts
+++ b/types/eslint/rules/best-practices.d.ts
@@ -201,6 +201,14 @@ export interface BestPractices extends Linter.RulesRecord {
         | Linter.RuleEntry<["smart" | "allow-null"]>;
 
     /**
+     * Require grouped accessor pairs in object literals and classes.
+     *
+     * @since 6.7.0
+     * @see https://eslint.org/docs/latest/rules/grouped-accessor-pairs
+     */
+    "grouped-accessor-pairs": Linter.RuleEntry<["anyOrder" | "getBeforeSet" | "setBeforeGet"]>;
+
+    /**
      * Rule to require `for-in` loops to include an `if` statement.
      *
      * @since 0.0.6

--- a/types/eslint/rules/best-practices.d.ts
+++ b/types/eslint/rules/best-practices.d.ts
@@ -823,6 +823,17 @@ export interface BestPractices extends Linter.RulesRecord {
     "no-unused-labels": Linter.RuleEntry<[]>;
 
     /**
+     * Disallow useless backreferences in regular expressions
+     *
+     * @remarks
+     * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
+     *
+     * @since 7.0.0-alpha.0
+     * @see https://eslint.org/docs/latest/rules/no-useless-backreference
+     */
+    "no-useless-backreference": Linter.RuleEntry<[]>;
+
+    /**
      * Rule to disallow unnecessary calls to `.call()` and `.apply()`.
      *
      * @since 1.0.0-rc-1

--- a/types/eslint/rules/best-practices.d.ts
+++ b/types/eslint/rules/best-practices.d.ts
@@ -439,6 +439,10 @@ export interface BestPractices extends Linter.RulesRecord {
                  */
                 string: boolean;
                 /**
+                 * @default false
+                 */
+                disallowTemplateShorthand: boolean;
+                /**
                  * @default []
                  */
                 allow: Array<"~" | "!!" | "+" | "*">;

--- a/types/eslint/rules/best-practices.d.ts
+++ b/types/eslint/rules/best-practices.d.ts
@@ -467,6 +467,17 @@ export interface BestPractices extends Linter.RulesRecord {
     "no-implied-eval": Linter.RuleEntry<[]>;
 
     /**
+     * Disallow assigning to imported bindings.
+     *
+     * @remarks
+     * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
+     *
+     * @since 6.4.0
+     * @see https://eslint.org/docs/latest/rules/no-import-assign
+     */
+    "no-import-assign": Linter.RuleEntry<[]>;
+
+    /**
      * Rule to disallow `this` keywords outside of classes or class-like objects.
      *
      * @since 1.0.0-rc-2

--- a/types/eslint/rules/best-practices.d.ts
+++ b/types/eslint/rules/best-practices.d.ts
@@ -139,6 +139,22 @@ export interface BestPractices extends Linter.RulesRecord {
     >;
 
     /**
+     * Rule to enforce default clauses in switch statements to be last
+     *
+     * @since 7.0.0
+     * @see https://eslint.org/docs/latest/rules/default-case-last
+     */
+    "default-case-last": Linter.RuleEntry<[]>;
+
+    /**
+     * Enforce default parameters to be last
+     *
+     * @since 6.4.0
+     * @see https://eslint.org/docs/latest/rules/default-param-last
+     */
+    "default-param-last": Linter.RuleEntry<[]>;
+
+    /**
      * Rule to enforce consistent newlines before and after dots.
      *
      * @since 0.21.0

--- a/types/eslint/rules/best-practices.d.ts
+++ b/types/eslint/rules/best-practices.d.ts
@@ -953,6 +953,23 @@ export interface BestPractices extends Linter.RulesRecord {
     >;
 
     /**
+     * Disallow use of the `RegExp` constructor in favor of regular expression literals.
+     *
+     * @since 6.4.0
+     * @see https://eslint.org/docs/latest/rules/prefer-regex-literals
+     */
+    "prefer-regex-literals": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                disallowRedundantWrapping: boolean;
+            }>,
+        ]
+    >;
+
+    /**
      * Rule to enforce the consistent use of the radix argument when using `parseInt()`.
      *
      * @since 0.0.7

--- a/types/eslint/rules/best-practices.d.ts
+++ b/types/eslint/rules/best-practices.d.ts
@@ -902,6 +902,14 @@ export interface BestPractices extends Linter.RulesRecord {
     "prefer-named-capture-group": Linter.RuleEntry<[]>;
 
     /**
+     * Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`.
+     *
+     * @since 3.5.0
+     * @see https://eslint.org/docs/rules/prefer-object-has-own
+     */
+    "prefer-object-has-own": Linter.RuleEntry<[]>;
+
+    /**
      * Rule to require using Error objects as Promise rejection reasons.
      *
      * @since 3.14.0

--- a/types/eslint/rules/best-practices.d.ts
+++ b/types/eslint/rules/best-practices.d.ts
@@ -607,6 +607,14 @@ export interface BestPractices extends Linter.RulesRecord {
     "no-new-wrappers": Linter.RuleEntry<[]>;
 
     /**
+     * Disallow `\\8` and `\\9` escape sequences in string literals.
+     *
+     * @since 7.14.0
+     * @see https://eslint.org/docs/rules/no-nonoctal-decimal-escape
+     */
+    "no-nonoctal-decimal-escape": Linter.RuleEntry<[]>;
+
+    /**
      * Rule to disallow octal literals.
      *
      * @remarks

--- a/types/eslint/rules/ecmascript-6.d.ts
+++ b/types/eslint/rules/ecmascript-6.d.ts
@@ -107,6 +107,26 @@ export interface ECMAScript6 extends Linter.RulesRecord {
     >;
 
     /**
+     * Require or disallow logical assignment operator shorthand.
+     *
+     * @since 8.24.0
+     * @see https://eslint.org/docs/rules/logical-assignment-operators
+     */
+    "logical-assignment-operators": Linter.RuleEntry<
+        [
+            'never'
+        ] | [
+            'always',
+            Partial<{
+                /**
+                 * @default false
+                 */
+                enforceForIfStatements: boolean;
+            }>,
+        ]
+    >;
+
+    /**
      * Rule to disallow reassigning class members.
      *
      * @remarks

--- a/types/eslint/rules/ecmascript-6.d.ts
+++ b/types/eslint/rules/ecmascript-6.d.ts
@@ -406,6 +406,14 @@ export interface ECMAScript6 extends Linter.RulesRecord {
     >;
 
     /**
+     * Disallow the use of `Math.pow` in favor of the `**` operator.
+     *
+     * @since 6.7.0
+     * @see https://eslint.org/docs/latest/rules/prefer-exponentiation-operator
+     */
+    "prefer-exponentiation-operator": Linter.RuleEntry<[]>;
+
+    /**
      * Rule to disallow `parseInt()` and `Number.parseInt()` in favor of binary, octal, and hexadecimal literals.
      *
      * @since 3.5.0

--- a/types/eslint/rules/ecmascript-6.d.ts
+++ b/types/eslint/rules/ecmascript-6.d.ts
@@ -112,19 +112,19 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * @since 8.24.0
      * @see https://eslint.org/docs/rules/logical-assignment-operators
      */
-    "logical-assignment-operators": Linter.RuleEntry<
-        [
-            'never'
-        ] | [
-            'always',
-            Partial<{
-                /**
-                 * @default false
-                 */
-                enforceForIfStatements: boolean;
-            }>,
-        ]
-    >;
+    "logical-assignment-operators":
+        | Linter.RuleEntry<
+            [
+                "always",
+                Partial<{
+                    /**
+                     * @default false
+                     */
+                    enforceForIfStatements: boolean;
+                }>,
+            ]
+        >
+        | Linter.RuleEntry<["never"]>;
 
     /**
      * Rule to disallow reassigning class members.

--- a/types/eslint/rules/ecmascript-6.d.ts
+++ b/types/eslint/rules/ecmascript-6.d.ts
@@ -180,9 +180,9 @@ export interface ECMAScript6 extends Linter.RulesRecord {
      * Rule to disallow duplicate module imports.
      *
      * @since 2.5.0
-     * @see https://eslint.org/docs/rules/no-duplicate-import
+     * @see https://eslint.org/docs/rules/no-duplicate-imports
      */
-    "no-duplicate-import": Linter.RuleEntry<
+    "no-duplicate-imports": Linter.RuleEntry<
         [
             Partial<{
                 /**

--- a/types/eslint/rules/possible-errors.d.ts
+++ b/types/eslint/rules/possible-errors.d.ts
@@ -467,6 +467,26 @@ export interface PossibleErrors extends Linter.RulesRecord {
     "no-unsafe-negation": Linter.RuleEntry<[]>;
 
     /**
+     * Disallow use of optional chaining in contexts where the `undefined` value is not allowed.
+     *
+     * @remarks
+     * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
+     *
+     * @since 7.15.0
+     * @see https://eslint.org/docs/rules/no-unsafe-optional-chaining
+     */
+    "no-unsafe-optional-chaining": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default false
+                 */
+                disallowArithmeticOperators: boolean;
+            }>,
+        ]
+    >;
+
+    /**
      * Rule to disallow assignments that can lead to race conditions due to usage of `await` or `yield`.
      *
      * @remarks

--- a/types/eslint/rules/possible-errors.d.ts
+++ b/types/eslint/rules/possible-errors.d.ts
@@ -141,6 +141,17 @@ export interface PossibleErrors extends Linter.RulesRecord {
     "no-dupe-args": Linter.RuleEntry<[]>;
 
     /**
+     * Disallow duplicate conditions in if-else-if chains.
+     *
+     * @remarks
+     * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
+     *
+     * @since 6.7.0
+     * @see https://eslint.org/docs/rules/no-dupe-else-if
+     */
+    "no-dupe-else-if": Linter.RuleEntry<[]>;
+
+    /**
      * Rule to disallow duplicate keys in object literals.
      *
      * @remarks

--- a/types/eslint/rules/possible-errors.d.ts
+++ b/types/eslint/rules/possible-errors.d.ts
@@ -461,7 +461,16 @@ export interface PossibleErrors extends Linter.RulesRecord {
      * @since 7.3.0
      * @see https://eslint.org/docs/latest/rules/no-unreachable-loop
      */
-    "no-unreachable-loop": Linter.RuleEntry<[]>;
+    "no-unreachable-loop": Linter.RuleEntry<
+        [
+            Partial<{
+                /**
+                 * @default []
+                 */
+                ignore: "WhileStatement" | "DoWhileStatement" | "ForStatement" | "ForInStatement" | "ForOfStatement";
+            }>,
+        ]
+    >;
 
     /**
      * Rule to disallow control flow statements in `finally` blocks.

--- a/types/eslint/rules/possible-errors.d.ts
+++ b/types/eslint/rules/possible-errors.d.ts
@@ -31,13 +31,6 @@ export interface PossibleErrors extends Linter.RulesRecord {
             }>,
         ]
     >;
-    /**
-     * Rule to enforce default clauses in switch statements to be last
-     *
-     * @since 7.0.0
-     * @see https://eslint.org/docs/latest/rules/default-case-last
-     */
-    "default-case-last": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow using an async function as a `Promise` executor.

--- a/types/eslint/rules/possible-errors.d.ts
+++ b/types/eslint/rules/possible-errors.d.ts
@@ -456,6 +456,14 @@ export interface PossibleErrors extends Linter.RulesRecord {
     "no-unreachable": Linter.RuleEntry<[]>;
 
     /**
+     * Disallow loops with a body that allows only one iteration.
+     *
+     * @since 7.3.0
+     * @see https://eslint.org/docs/latest/rules/no-unreachable-loop
+     */
+    "no-unreachable-loop": Linter.RuleEntry<[]>;
+
+    /**
      * Rule to disallow control flow statements in `finally` blocks.
      *
      * @remarks

--- a/types/eslint/rules/possible-errors.d.ts
+++ b/types/eslint/rules/possible-errors.d.ts
@@ -31,6 +31,13 @@ export interface PossibleErrors extends Linter.RulesRecord {
             }>,
         ]
     >;
+    /**
+     * Rule to enforce default clauses in switch statements to be last
+     *
+     * @since 7.0.0
+     * @see https://eslint.org/docs/latest/rules/default-case-last
+     */
+    "default-case-last": Linter.RuleEntry<[]>;
 
     /**
      * Rule to disallow using an async function as a `Promise` executor.

--- a/types/eslint/rules/possible-errors.d.ts
+++ b/types/eslint/rules/possible-errors.d.ts
@@ -345,6 +345,17 @@ export interface PossibleErrors extends Linter.RulesRecord {
     >;
 
     /**
+     * Disallow literal numbers that lose precision.
+     *
+     * @remarks
+     * Recommended by ESLint, the rule was enabled in `eslint:recommended`.
+     *
+     * @since 7.1.0
+     * @see https://eslint.org/docs/latest/rules/no-loss-of-precision
+     */
+    "no-loss-of-precision": Linter.RuleEntry<[]>;
+
+    /**
      * Rule to disallow characters which are made with multiple code points in character class syntax.
      *
      * @remarks


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Add rules:
[default-case-last](https://github.com/eslint/eslint/blob/main/lib/rules/default-case-last.js)
[default-param-last](https://github.com/eslint/eslint/blob/main/lib/rules/default-param-last.js)
[grouped-accessor-pairs](https://github.com/eslint/eslint/blob/main/lib/rules/grouped-accessor-pairs.js)
[no-import-assign](https://github.com/eslint/eslint/blob/main/lib/rules/no-import-assign.js)
[no-nonoctal-decimal-escape](https://github.com/eslint/eslint/blob/main/lib/rules/no-nonoctal-decimal-escape.js)
[no-useless-backreference](https://github.com/eslint/eslint/blob/main/lib/rules/no-useless-backreference.js)
[prefer-regex-literals](https://github.com/eslint/eslint/blob/main/lib/rules/prefer-regex-literals.js)
[logical-assignment-operators](https://github.com/eslint/eslint/blob/main/lib/rules/logical-assignment-operators.js)
[prefer-exponentiation-operator](https://github.com/eslint/eslint/blob/main/lib/rules/prefer-exponentiation-operator.js)
[no-dupe-else-if](https://github.com/eslint/eslint/blob/main/lib/rules/no-dupe-else-if.js)
[no-loss-of-precision](https://github.com/eslint/eslint/blob/main/lib/rules/no-loss-of-precision.js)
[no-unreachable-loop](https://github.com/eslint/eslint/blob/main/lib/rules/no-unreachable-loop.js)
[no-unsafe-optional-chaining](https://github.com/eslint/eslint/blob/main/lib/rules/no-unsafe-optional-chaining.js)

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Modify rules:
[update no-implicit-coercion option](https://github.com/eslint/eslint/blob/main/lib/rules/no-implicit-coercion.js)
[rename no-duplicate-import to no-duplicate-imports](https://github.com/eslint/eslint/blob/main/lib/rules/no-duplicate-imports.js)


