### PR TITLE
[node] Add `flush` option to `writeFile` in `fs/promises`

### DIFF
--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -10,13 +10,10 @@
  */
 declare module "fs/promises" {
     import { Abortable } from "node:events";
-    import { Stream } from "node:stream";
-    import { ReadableStream } from "node:stream/web";
     import {
         BigIntStats,
         BigIntStatsFs,
         BufferEncodingOption,
-        constants as fsConstants,
         CopyOptions,
         Dir,
         Dirent,
@@ -39,8 +36,11 @@ declare module "fs/promises" {
         WatchOptions,
         WriteStream,
         WriteVResult,
+        constants as fsConstants,
     } from "node:fs";
     import { Interface as ReadlineInterface } from "node:readline";
+    import { Stream } from "node:stream";
+    import { ReadableStream } from "node:stream/web";
     interface FileChangeInfo<T extends string | Buffer> {
         eventType: WatchEventType;
         filename: T | null;
@@ -1008,6 +1008,11 @@ declare module "fs/promises" {
             | (ObjectEncodingOptions & {
                 mode?: Mode | undefined;
                 flag?: OpenMode | undefined;
+                /**
+                 * If all data is successfully written to the file, and `flush`
+                 * is `true`, `filehandle.sync()` is used to flush the data. 
+                 * @default false  
+                 */
                 flush?: boolean;
             } & Abortable)
             | BufferEncoding

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -1008,6 +1008,7 @@ declare module "fs/promises" {
             | (ObjectEncodingOptions & {
                 mode?: Mode | undefined;
                 flag?: OpenMode | undefined;
+                flush?: boolean;
             } & Abortable)
             | BufferEncoding
             | null,

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -14,6 +14,7 @@ declare module "fs/promises" {
         BigIntStats,
         BigIntStatsFs,
         BufferEncodingOption,
+        constants as fsConstants,
         CopyOptions,
         Dir,
         Dirent,
@@ -36,7 +37,6 @@ declare module "fs/promises" {
         WatchOptions,
         WriteStream,
         WriteVResult,
-        constants as fsConstants,
     } from "node:fs";
     import { Interface as ReadlineInterface } from "node:readline";
     import { Stream } from "node:stream";
@@ -1010,8 +1010,8 @@ declare module "fs/promises" {
                 flag?: OpenMode | undefined;
                 /**
                  * If all data is successfully written to the file, and `flush`
-                 * is `true`, `filehandle.sync()` is used to flush the data. 
-                 * @default false  
+                 * is `true`, `filehandle.sync()` is used to flush the data.
+                 * @default false
                  */
                 flush?: boolean;
             } & Abortable)

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -10,6 +10,8 @@
  */
 declare module "fs/promises" {
     import { Abortable } from "node:events";
+    import { Stream } from "node:stream";
+    import { ReadableStream } from "node:stream/web";
     import {
         BigIntStats,
         BigIntStatsFs,
@@ -39,8 +41,6 @@ declare module "fs/promises" {
         WriteVResult,
     } from "node:fs";
     import { Interface as ReadlineInterface } from "node:readline";
-    import { Stream } from "node:stream";
-    import { ReadableStream } from "node:stream/web";
     interface FileChangeInfo<T extends string | Buffer> {
         eventType: WatchEventType;
         filename: T | null;

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -1013,7 +1013,7 @@ declare module "fs/promises" {
                  * is `true`, `filehandle.sync()` is used to flush the data.
                  * @default false
                  */
-                flush?: boolean;
+                flush?: boolean | undefined;
             } & Abortable)
             | BufferEncoding
             | null,

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -582,7 +582,7 @@ async function testPromisify() {
         }(),
     );
     await writeFileAsync("test", process.stdin);
-    await writeFileAsync("test", "test", { flush: true })
+    await writeFileAsync("test", "test", { flush: true });
 });
 
 {

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -582,6 +582,7 @@ async function testPromisify() {
         }(),
     );
     await writeFileAsync("test", process.stdin);
+    await writeFileAsync("test", "test", { flush: true })
 });
 
 {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v20.x/api/fs.html#fspromiseswritefilefile-data-options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.