### PR TITLE
[defect] export AllReservedOperationsInterface to avoid TS4023 in projects

### DIFF
--- a/types/json-logic-js/index.d.ts
+++ b/types/json-logic-js/index.d.ts
@@ -70,7 +70,7 @@ export type ReservedOperations =
  */
 export type AdditionalOperation = Partial<Record<ReservedOperations, never>> & { [k: string]: any };
 
-interface AllReservedOperationsInterface<AddOps extends AdditionalOperation = never> {
+export interface AllReservedOperationsInterface<AddOps extends AdditionalOperation = never> {
     var: RulesLogic<AddOps> | [RulesLogic<AddOps>] | [RulesLogic<AddOps>, any] | [RulesLogic<AddOps>, any];
     missing: RulesLogic<AddOps> | any[];
     missing_some: [RulesLogic<AddOps>, RulesLogic<AddOps> | any[]];


### PR DESCRIPTION
Since typescript 5.4.2, this exception appears in all the projects that import any type that Pick in AllReservedOperationsInterface (JsonLogicInString for example)

```
error TS4023: Exported variable 'isJsonLogicInString' has or is using name 'AllReservedOperationsInterface' from external module "node_modules/@types/json-logic-js/index" but cannot be named.
```

AllReservedOperationsInterface is implicitly used by the other and its declaration must be now exported  

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
