### PR TITLE
[@types/oauth2orize] Open interface

### DIFF
--- a/types/oauth2orize/.eslintrc.json
+++ b/types/oauth2orize/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
-        "@definitelytyped/no-any-union": "off"
+        "@definitelytyped/no-any-union": "off",
+        "@typescript-eslint/no-empty-interface": "off"
     }
 }

--- a/types/oauth2orize/.eslintrc.json
+++ b/types/oauth2orize/.eslintrc.json
@@ -1,6 +1,6 @@
 {
     "rules": {
         "@definitelytyped/no-any-union": "off",
-        "@typescript-eslint/no-empty-interface": "off"
+        "@definitelytyped/no-unnecessary-generics": "off"
     }
 }

--- a/types/oauth2orize/.eslintrc.json
+++ b/types/oauth2orize/.eslintrc.json
@@ -1,6 +1,5 @@
 {
     "rules": {
-        "@definitelytyped/no-any-union": "off",
-        "@definitelytyped/no-unnecessary-generics": "off"
+        "@definitelytyped/no-any-union": "off"
     }
 }

--- a/types/oauth2orize/index.d.ts
+++ b/types/oauth2orize/index.d.ts
@@ -250,40 +250,40 @@ export type ExchangeDoneFunction = (
 ) => void;
 
 export class OAuth2Server {
-    grant(type: string, fn: MiddlewareFunction): OAuth2Server;
-    grant(fn: MiddlewareFunction): OAuth2Server;
+    grant(type: string, fn: MiddlewareFunction<MiddlewareRequest>): OAuth2Server;
+    grant(fn: MiddlewareFunction<MiddlewareRequest>): OAuth2Server;
 
-    exchange(type: string, fn: MiddlewareFunction): OAuth2Server;
-    exchange(fn: MiddlewareFunction): OAuth2Server;
+    exchange(type: string, fn: MiddlewareFunction<MiddlewareRequest>): OAuth2Server;
+    exchange(fn: MiddlewareFunction<MiddlewareRequest>): OAuth2Server;
 
     authorize(
         options: AuthorizeOptions,
         validate: ValidateFunctionArity5,
         immediate?: ImmediateFunction,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<MiddlewareRequest>;
     authorize(
         options: AuthorizeOptions,
         validate: ValidateFunctionArity4,
         immediate?: ImmediateFunction,
-    ): MiddlewareFunction;
-    authorize(options: AuthorizeOptions, validate: ValidateFunction, immediate?: ImmediateFunction): MiddlewareFunction;
+    ): MiddlewareFunction<MiddlewareRequest>;
+    authorize(options: AuthorizeOptions, validate: ValidateFunction, immediate?: ImmediateFunction): MiddlewareFunction<MiddlewareRequest>;
     authorize(
         options: AuthorizeOptions,
         validate: ValidateFunctionArity2,
         immediate?: ImmediateFunction,
-    ): MiddlewareFunction;
-    authorize(validate: ValidateFunctionArity5, immediate?: ImmediateFunction): MiddlewareFunction;
-    authorize(validate: ValidateFunctionArity4, immediate?: ImmediateFunction): MiddlewareFunction;
-    authorize(validate: ValidateFunction, immediate?: ImmediateFunction): MiddlewareFunction;
-    authorize(validate: ValidateFunctionArity2, immediate?: ImmediateFunction): MiddlewareFunction;
+    ): MiddlewareFunction<MiddlewareRequest>;
+    authorize(validate: ValidateFunctionArity5, immediate?: ImmediateFunction): MiddlewareFunction<MiddlewareRequest>;
+    authorize(validate: ValidateFunctionArity4, immediate?: ImmediateFunction): MiddlewareFunction<MiddlewareRequest>;
+    authorize(validate: ValidateFunction, immediate?: ImmediateFunction): MiddlewareFunction<MiddlewareRequest>;
+    authorize(validate: ValidateFunctionArity2, immediate?: ImmediateFunction): MiddlewareFunction<MiddlewareRequest>;
 
     authorization: OAuth2Server["authorize"];
 
-    decision<TReq>(options: DecisionOptions, parse: DecisionParseFunction<TReq>): MiddlewareFunction<TReq>;
-    decision<TReq>(parse: DecisionParseFunction<TReq>): MiddlewareFunction<TReq>;
-    decision<TReq>(): MiddlewareFunction<TReq>;
+    decision<TReq extends MiddlewareRequest>(options: DecisionOptions, parse: DecisionParseFunction<TReq>): MiddlewareFunction<TReq>;
+    decision<TReq extends MiddlewareRequest>(parse: DecisionParseFunction<TReq>): MiddlewareFunction<TReq>;
+    decision<TReq extends MiddlewareRequest>(): MiddlewareFunction<TReq>;
 
-    token(options?: any): MiddlewareFunction;
+    token(options?: any): MiddlewareFunction<MiddlewareRequest>;
 
     errorHandler(options?: any): MiddlewareErrorFunction;
 
@@ -307,19 +307,19 @@ export namespace grant {
         scopeSeparator?: string | undefined;
     }
 
-    function code(options: Options, issue: IssueGrantCodeFunctionArity7): MiddlewareFunction;
-    function code(options: Options, issue: IssueGrantCodeFunctionArity6): MiddlewareFunction;
-    function code(options: Options, issue: IssueGrantCodeFunction): MiddlewareFunction;
-    function code(options: Options, issue: IssueGrantCodeFunctionArity4): MiddlewareFunction;
-    function code(issue: IssueGrantCodeFunctionArity7): MiddlewareFunction;
-    function code(issue: IssueGrantCodeFunctionArity6): MiddlewareFunction;
-    function code(issue: IssueGrantCodeFunction): MiddlewareFunction;
-    function code(issue: IssueGrantCodeFunctionArity4): MiddlewareFunction;
+    function code(options: Options, issue: IssueGrantCodeFunctionArity7): MiddlewareFunction<MiddlewareRequest>;
+    function code(options: Options, issue: IssueGrantCodeFunctionArity6): MiddlewareFunction<MiddlewareRequest>;
+    function code(options: Options, issue: IssueGrantCodeFunction): MiddlewareFunction<MiddlewareRequest>;
+    function code(options: Options, issue: IssueGrantCodeFunctionArity4): MiddlewareFunction<MiddlewareRequest>;
+    function code(issue: IssueGrantCodeFunctionArity7): MiddlewareFunction<MiddlewareRequest>;
+    function code(issue: IssueGrantCodeFunctionArity6): MiddlewareFunction<MiddlewareRequest>;
+    function code(issue: IssueGrantCodeFunction): MiddlewareFunction<MiddlewareRequest>;
+    function code(issue: IssueGrantCodeFunctionArity4): MiddlewareFunction<MiddlewareRequest>;
 
-    function token(options: Options, issue: IssueGrantTokenFunctionArity5): MiddlewareFunction;
-    function token(options: Options, issue: IssueGrantTokenFunctionArity4): MiddlewareFunction;
-    function token(issue: IssueGrantTokenFunctionArity5): MiddlewareFunction;
-    function token(issue: IssueGrantTokenFunctionArity4): MiddlewareFunction;
+    function token(options: Options, issue: IssueGrantTokenFunctionArity5): MiddlewareFunction<MiddlewareRequest>;
+    function token(options: Options, issue: IssueGrantTokenFunctionArity4): MiddlewareFunction<MiddlewareRequest>;
+    function token(issue: IssueGrantTokenFunctionArity5): MiddlewareFunction<MiddlewareRequest>;
+    function token(issue: IssueGrantTokenFunctionArity4): MiddlewareFunction<MiddlewareRequest>;
 }
 
 export namespace exchange {
@@ -336,12 +336,12 @@ export namespace exchange {
         scopeSeparator?: string | undefined;
     }
 
-    function authorizationCode(options: Options, issue: IssueExchangeCodeFunctionArity6): MiddlewareFunction;
-    function authorizationCode(options: Options, issue: IssueExchangeCodeFunctionArity5): MiddlewareFunction;
-    function authorizationCode(options: Options, issue: IssueExchangeCodeFunction): MiddlewareFunction;
-    function authorizationCode(issue: IssueExchangeCodeFunctionArity6): MiddlewareFunction;
-    function authorizationCode(issue: IssueExchangeCodeFunctionArity5): MiddlewareFunction;
-    function authorizationCode(issue: IssueExchangeCodeFunction): MiddlewareFunction;
+    function authorizationCode(options: Options, issue: IssueExchangeCodeFunctionArity6): MiddlewareFunction<MiddlewareRequest>;
+    function authorizationCode(options: Options, issue: IssueExchangeCodeFunctionArity5): MiddlewareFunction<MiddlewareRequest>;
+    function authorizationCode(options: Options, issue: IssueExchangeCodeFunction): MiddlewareFunction<MiddlewareRequest>;
+    function authorizationCode(issue: IssueExchangeCodeFunctionArity6): MiddlewareFunction<MiddlewareRequest>;
+    function authorizationCode(issue: IssueExchangeCodeFunctionArity5): MiddlewareFunction<MiddlewareRequest>;
+    function authorizationCode(issue: IssueExchangeCodeFunction): MiddlewareFunction<MiddlewareRequest>;
 
     const code: typeof authorizationCode;
 
@@ -349,26 +349,26 @@ export namespace exchange {
     function clientCredentials(
         options: Options,
         issue: (client: Client, scope: string[], body: any, authInfo: any, issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<MiddlewareRequest>;
     // arity == 4; issue(client, scope, req.body, issued);
     function clientCredentials(
         options: Options,
         issue: (client: Client, scope: string[], body: any, issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<MiddlewareRequest>;
     // arity == 3; issue(client, scope, issued);
     function clientCredentials(
         options: Options,
         issue: (client: Client, scope: string[], issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<MiddlewareRequest>;
     // arity == 2; issue(client, issued);
     function clientCredentials(
         options: Options,
         issue: (client: Client, issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<MiddlewareRequest>;
     function clientCredentials(
         issue: (client: Client, scope: string[], issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
-    function clientCredentials(issue: (client: Client, issued: ExchangeDoneFunction) => void): MiddlewareFunction;
+    ): MiddlewareFunction<MiddlewareRequest>;
+    function clientCredentials(issue: (client: Client, issued: ExchangeDoneFunction) => void): MiddlewareFunction<MiddlewareRequest>;
 
     // arity == 7; issue(client, username, passwd, scope, req.body, req.authInfo, issued);
     function password(
@@ -382,7 +382,7 @@ export namespace exchange {
             authInfo: any,
             issued: ExchangeDoneFunction,
         ) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<MiddlewareRequest>;
     // arity == 6; issue(client, username, passwd, scope, req.body, issued);
     function password(
         options: Options,
@@ -394,23 +394,23 @@ export namespace exchange {
             body: any,
             issued: ExchangeDoneFunction,
         ) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<MiddlewareRequest>;
     // arity == 5; issue(client, username, passwd, scope, issued);
     function password(
         options: Options,
         issue: (client: Client, username: string, password: string, scope: string[], issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<MiddlewareRequest>;
     // arity == 4; issue(client, username, passwd, issued);
     function password(
         options: Options,
         issue: (client: Client, username: string, password: string, issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<MiddlewareRequest>;
     function password(
         issue: (client: Client, username: string, password: string, scope: string[], issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<MiddlewareRequest>;
     function password(
         issue: (client: Client, username: string, password: string, issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<MiddlewareRequest>;
 
     // arity == 6; issue(client, refreshToken, scope, req.body, req.authInfo, issued);
     function refreshToken(
@@ -423,26 +423,26 @@ export namespace exchange {
             authInfo: any,
             issued: ExchangeDoneFunction,
         ) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<MiddlewareRequest>;
     // arity == 5; issue(client, refreshToken, scope, req.body, issued);
     function refreshToken(
         options: Options,
         issue: (client: Client, refreshToken: string, scope: string[], body: any, issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<MiddlewareRequest>;
     // arity == 4; issue(client, refreshToken, scope, issued);
     function refreshToken(
         options: Options,
         issue: (client: Client, refreshToken: string, scope: string[], issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<MiddlewareRequest>;
     // arity == 3; issue(client, refreshToken, issued);
     function refreshToken(
         options: Options,
         issue: (client: Client, refreshToken: string, issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<MiddlewareRequest>;
     function refreshToken(
         issue: (client: Client, refreshToken: string, scope: string[], issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<MiddlewareRequest>;
     function refreshToken(
         issue: (client: Client, refreshToken: string, issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<MiddlewareRequest>;
 }

--- a/types/oauth2orize/index.d.ts
+++ b/types/oauth2orize/index.d.ts
@@ -18,8 +18,8 @@ declare global {
     }
 }
 
-export type Client = OAuth2orize.Client
-export type User = OAuth2orize.User
+export type Client = OAuth2orize.Client;
+export type User = OAuth2orize.User;
 
 export interface OAuth2 {
     client: Client;
@@ -128,7 +128,11 @@ export class TokenError extends OAuth2Error {
     constructor(message?: string, code?: TokenErrorCode | string, uri?: string, status?: number);
 }
 
-export type MiddlewareFunction<TReq extends MiddlewareRequest = MiddlewareRequest> = (req: TReq, res: ServerResponse, next: MiddlewareNextFunction) => void;
+export type MiddlewareFunction<TReq extends MiddlewareRequest = MiddlewareRequest> = (
+    req: TReq,
+    res: ServerResponse,
+    next: MiddlewareNextFunction,
+) => void;
 
 export type MiddlewareErrorFunction = (
     err: Error,
@@ -165,7 +169,10 @@ export type ImmediateFunction = (
     done: (err: Error | null, allow: boolean, info: any, locals: any) => void,
 ) => void;
 
-export type DecisionParseFunction<TReq extends MiddlewareRequest> = (req: TReq, done: (err: Error | null, params?: any) => void) => void;
+export type DecisionParseFunction<TReq extends MiddlewareRequest> = (
+    req: TReq,
+    done: (err: Error | null, params?: any) => void,
+) => void;
 
 export type SerializeClientFunction = (client: Client, done: SerializeClientDoneFunction) => void;
 export type SerializeClientDoneFunction = (err: Error | null, id: string) => void;
@@ -279,7 +286,10 @@ export class OAuth2Server {
 
     authorization: OAuth2Server["authorize"];
 
-    decision<TReq extends MiddlewareRequest>(options: DecisionOptions, parse: DecisionParseFunction<TReq>): MiddlewareFunction<TReq>;
+    decision<TReq extends MiddlewareRequest>(
+        options: DecisionOptions,
+        parse: DecisionParseFunction<TReq>,
+    ): MiddlewareFunction<TReq>;
     decision<TReq extends MiddlewareRequest>(parse: DecisionParseFunction<TReq>): MiddlewareFunction<TReq>;
     decision<TReq extends MiddlewareRequest>(): MiddlewareFunction<TReq>;
 
@@ -398,7 +408,13 @@ export namespace exchange {
     // arity == 5; issue(client, username, passwd, scope, issued);
     function password(
         options: Options,
-        issue: (client: Client, username: string, password: string, scope: string[], issued: ExchangeDoneFunction) => void,
+        issue: (
+            client: Client,
+            username: string,
+            password: string,
+            scope: string[],
+            issued: ExchangeDoneFunction,
+        ) => void,
     ): MiddlewareFunction;
     // arity == 4; issue(client, username, passwd, issued);
     function password(
@@ -406,7 +422,13 @@ export namespace exchange {
         issue: (client: Client, username: string, password: string, issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction;
     function password(
-        issue: (client: Client, username: string, password: string, scope: string[], issued: ExchangeDoneFunction) => void,
+        issue: (
+            client: Client,
+            username: string,
+            password: string,
+            scope: string[],
+            issued: ExchangeDoneFunction,
+        ) => void,
     ): MiddlewareFunction;
     function password(
         issue: (client: Client, username: string, password: string, issued: ExchangeDoneFunction) => void,

--- a/types/oauth2orize/index.d.ts
+++ b/types/oauth2orize/index.d.ts
@@ -128,7 +128,7 @@ export class TokenError extends OAuth2Error {
     constructor(message?: string, code?: TokenErrorCode | string, uri?: string, status?: number);
 }
 
-export type MiddlewareFunction<TReq extends MiddlewareRequest> = (req: TReq, res: ServerResponse, next: MiddlewareNextFunction) => void;
+export type MiddlewareFunction<TReq extends MiddlewareRequest = MiddlewareRequest> = (req: TReq, res: ServerResponse, next: MiddlewareNextFunction) => void;
 
 export type MiddlewareErrorFunction = (
     err: Error,
@@ -250,32 +250,32 @@ export type ExchangeDoneFunction = (
 ) => void;
 
 export class OAuth2Server {
-    grant(type: string, fn: MiddlewareFunction<MiddlewareRequest>): OAuth2Server;
-    grant(fn: MiddlewareFunction<MiddlewareRequest>): OAuth2Server;
+    grant(type: string, fn: MiddlewareFunction): OAuth2Server;
+    grant(fn: MiddlewareFunction): OAuth2Server;
 
-    exchange(type: string, fn: MiddlewareFunction<MiddlewareRequest>): OAuth2Server;
-    exchange(fn: MiddlewareFunction<MiddlewareRequest>): OAuth2Server;
+    exchange(type: string, fn: MiddlewareFunction): OAuth2Server;
+    exchange(fn: MiddlewareFunction): OAuth2Server;
 
     authorize(
         options: AuthorizeOptions,
         validate: ValidateFunctionArity5,
         immediate?: ImmediateFunction,
-    ): MiddlewareFunction<MiddlewareRequest>;
+    ): MiddlewareFunction;
     authorize(
         options: AuthorizeOptions,
         validate: ValidateFunctionArity4,
         immediate?: ImmediateFunction,
-    ): MiddlewareFunction<MiddlewareRequest>;
-    authorize(options: AuthorizeOptions, validate: ValidateFunction, immediate?: ImmediateFunction): MiddlewareFunction<MiddlewareRequest>;
+    ): MiddlewareFunction;
+    authorize(options: AuthorizeOptions, validate: ValidateFunction, immediate?: ImmediateFunction): MiddlewareFunction;
     authorize(
         options: AuthorizeOptions,
         validate: ValidateFunctionArity2,
         immediate?: ImmediateFunction,
-    ): MiddlewareFunction<MiddlewareRequest>;
-    authorize(validate: ValidateFunctionArity5, immediate?: ImmediateFunction): MiddlewareFunction<MiddlewareRequest>;
-    authorize(validate: ValidateFunctionArity4, immediate?: ImmediateFunction): MiddlewareFunction<MiddlewareRequest>;
-    authorize(validate: ValidateFunction, immediate?: ImmediateFunction): MiddlewareFunction<MiddlewareRequest>;
-    authorize(validate: ValidateFunctionArity2, immediate?: ImmediateFunction): MiddlewareFunction<MiddlewareRequest>;
+    ): MiddlewareFunction;
+    authorize(validate: ValidateFunctionArity5, immediate?: ImmediateFunction): MiddlewareFunction;
+    authorize(validate: ValidateFunctionArity4, immediate?: ImmediateFunction): MiddlewareFunction;
+    authorize(validate: ValidateFunction, immediate?: ImmediateFunction): MiddlewareFunction;
+    authorize(validate: ValidateFunctionArity2, immediate?: ImmediateFunction): MiddlewareFunction;
 
     authorization: OAuth2Server["authorize"];
 
@@ -283,7 +283,7 @@ export class OAuth2Server {
     decision<TReq extends MiddlewareRequest>(parse: DecisionParseFunction<TReq>): MiddlewareFunction<TReq>;
     decision<TReq extends MiddlewareRequest>(): MiddlewareFunction<TReq>;
 
-    token(options?: any): MiddlewareFunction<MiddlewareRequest>;
+    token(options?: any): MiddlewareFunction;
 
     errorHandler(options?: any): MiddlewareErrorFunction;
 
@@ -307,19 +307,19 @@ export namespace grant {
         scopeSeparator?: string | undefined;
     }
 
-    function code(options: Options, issue: IssueGrantCodeFunctionArity7): MiddlewareFunction<MiddlewareRequest>;
-    function code(options: Options, issue: IssueGrantCodeFunctionArity6): MiddlewareFunction<MiddlewareRequest>;
-    function code(options: Options, issue: IssueGrantCodeFunction): MiddlewareFunction<MiddlewareRequest>;
-    function code(options: Options, issue: IssueGrantCodeFunctionArity4): MiddlewareFunction<MiddlewareRequest>;
-    function code(issue: IssueGrantCodeFunctionArity7): MiddlewareFunction<MiddlewareRequest>;
-    function code(issue: IssueGrantCodeFunctionArity6): MiddlewareFunction<MiddlewareRequest>;
-    function code(issue: IssueGrantCodeFunction): MiddlewareFunction<MiddlewareRequest>;
-    function code(issue: IssueGrantCodeFunctionArity4): MiddlewareFunction<MiddlewareRequest>;
+    function code(options: Options, issue: IssueGrantCodeFunctionArity7): MiddlewareFunction;
+    function code(options: Options, issue: IssueGrantCodeFunctionArity6): MiddlewareFunction;
+    function code(options: Options, issue: IssueGrantCodeFunction): MiddlewareFunction;
+    function code(options: Options, issue: IssueGrantCodeFunctionArity4): MiddlewareFunction;
+    function code(issue: IssueGrantCodeFunctionArity7): MiddlewareFunction;
+    function code(issue: IssueGrantCodeFunctionArity6): MiddlewareFunction;
+    function code(issue: IssueGrantCodeFunction): MiddlewareFunction;
+    function code(issue: IssueGrantCodeFunctionArity4): MiddlewareFunction;
 
-    function token(options: Options, issue: IssueGrantTokenFunctionArity5): MiddlewareFunction<MiddlewareRequest>;
-    function token(options: Options, issue: IssueGrantTokenFunctionArity4): MiddlewareFunction<MiddlewareRequest>;
-    function token(issue: IssueGrantTokenFunctionArity5): MiddlewareFunction<MiddlewareRequest>;
-    function token(issue: IssueGrantTokenFunctionArity4): MiddlewareFunction<MiddlewareRequest>;
+    function token(options: Options, issue: IssueGrantTokenFunctionArity5): MiddlewareFunction;
+    function token(options: Options, issue: IssueGrantTokenFunctionArity4): MiddlewareFunction;
+    function token(issue: IssueGrantTokenFunctionArity5): MiddlewareFunction;
+    function token(issue: IssueGrantTokenFunctionArity4): MiddlewareFunction;
 }
 
 export namespace exchange {
@@ -336,12 +336,12 @@ export namespace exchange {
         scopeSeparator?: string | undefined;
     }
 
-    function authorizationCode(options: Options, issue: IssueExchangeCodeFunctionArity6): MiddlewareFunction<MiddlewareRequest>;
-    function authorizationCode(options: Options, issue: IssueExchangeCodeFunctionArity5): MiddlewareFunction<MiddlewareRequest>;
-    function authorizationCode(options: Options, issue: IssueExchangeCodeFunction): MiddlewareFunction<MiddlewareRequest>;
-    function authorizationCode(issue: IssueExchangeCodeFunctionArity6): MiddlewareFunction<MiddlewareRequest>;
-    function authorizationCode(issue: IssueExchangeCodeFunctionArity5): MiddlewareFunction<MiddlewareRequest>;
-    function authorizationCode(issue: IssueExchangeCodeFunction): MiddlewareFunction<MiddlewareRequest>;
+    function authorizationCode(options: Options, issue: IssueExchangeCodeFunctionArity6): MiddlewareFunction;
+    function authorizationCode(options: Options, issue: IssueExchangeCodeFunctionArity5): MiddlewareFunction;
+    function authorizationCode(options: Options, issue: IssueExchangeCodeFunction): MiddlewareFunction;
+    function authorizationCode(issue: IssueExchangeCodeFunctionArity6): MiddlewareFunction;
+    function authorizationCode(issue: IssueExchangeCodeFunctionArity5): MiddlewareFunction;
+    function authorizationCode(issue: IssueExchangeCodeFunction): MiddlewareFunction;
 
     const code: typeof authorizationCode;
 
@@ -349,26 +349,26 @@ export namespace exchange {
     function clientCredentials(
         options: Options,
         issue: (client: Client, scope: string[], body: any, authInfo: any, issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction<MiddlewareRequest>;
+    ): MiddlewareFunction;
     // arity == 4; issue(client, scope, req.body, issued);
     function clientCredentials(
         options: Options,
         issue: (client: Client, scope: string[], body: any, issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction<MiddlewareRequest>;
+    ): MiddlewareFunction;
     // arity == 3; issue(client, scope, issued);
     function clientCredentials(
         options: Options,
         issue: (client: Client, scope: string[], issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction<MiddlewareRequest>;
+    ): MiddlewareFunction;
     // arity == 2; issue(client, issued);
     function clientCredentials(
         options: Options,
         issue: (client: Client, issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction<MiddlewareRequest>;
+    ): MiddlewareFunction;
     function clientCredentials(
         issue: (client: Client, scope: string[], issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction<MiddlewareRequest>;
-    function clientCredentials(issue: (client: Client, issued: ExchangeDoneFunction) => void): MiddlewareFunction<MiddlewareRequest>;
+    ): MiddlewareFunction;
+    function clientCredentials(issue: (client: Client, issued: ExchangeDoneFunction) => void): MiddlewareFunction;
 
     // arity == 7; issue(client, username, passwd, scope, req.body, req.authInfo, issued);
     function password(
@@ -382,7 +382,7 @@ export namespace exchange {
             authInfo: any,
             issued: ExchangeDoneFunction,
         ) => void,
-    ): MiddlewareFunction<MiddlewareRequest>;
+    ): MiddlewareFunction;
     // arity == 6; issue(client, username, passwd, scope, req.body, issued);
     function password(
         options: Options,
@@ -394,23 +394,23 @@ export namespace exchange {
             body: any,
             issued: ExchangeDoneFunction,
         ) => void,
-    ): MiddlewareFunction<MiddlewareRequest>;
+    ): MiddlewareFunction;
     // arity == 5; issue(client, username, passwd, scope, issued);
     function password(
         options: Options,
         issue: (client: Client, username: string, password: string, scope: string[], issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction<MiddlewareRequest>;
+    ): MiddlewareFunction;
     // arity == 4; issue(client, username, passwd, issued);
     function password(
         options: Options,
         issue: (client: Client, username: string, password: string, issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction<MiddlewareRequest>;
+    ): MiddlewareFunction;
     function password(
         issue: (client: Client, username: string, password: string, scope: string[], issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction<MiddlewareRequest>;
+    ): MiddlewareFunction;
     function password(
         issue: (client: Client, username: string, password: string, issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction<MiddlewareRequest>;
+    ): MiddlewareFunction;
 
     // arity == 6; issue(client, refreshToken, scope, req.body, req.authInfo, issued);
     function refreshToken(
@@ -423,26 +423,26 @@ export namespace exchange {
             authInfo: any,
             issued: ExchangeDoneFunction,
         ) => void,
-    ): MiddlewareFunction<MiddlewareRequest>;
+    ): MiddlewareFunction;
     // arity == 5; issue(client, refreshToken, scope, req.body, issued);
     function refreshToken(
         options: Options,
         issue: (client: Client, refreshToken: string, scope: string[], body: any, issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction<MiddlewareRequest>;
+    ): MiddlewareFunction;
     // arity == 4; issue(client, refreshToken, scope, issued);
     function refreshToken(
         options: Options,
         issue: (client: Client, refreshToken: string, scope: string[], issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction<MiddlewareRequest>;
+    ): MiddlewareFunction;
     // arity == 3; issue(client, refreshToken, issued);
     function refreshToken(
         options: Options,
         issue: (client: Client, refreshToken: string, issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction<MiddlewareRequest>;
+    ): MiddlewareFunction;
     function refreshToken(
         issue: (client: Client, refreshToken: string, scope: string[], issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction<MiddlewareRequest>;
+    ): MiddlewareFunction;
     function refreshToken(
         issue: (client: Client, refreshToken: string, issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction<MiddlewareRequest>;
+    ): MiddlewareFunction;
 }

--- a/types/oauth2orize/index.d.ts
+++ b/types/oauth2orize/index.d.ts
@@ -34,6 +34,7 @@ export interface ServerOptions {
     store: any;
 }
 
+// eslint-disable-next-line @definitelytyped/no-unnecessary-generics
 export function createServer<Client = any, User = any>(options?: ServerOptions): OAuth2Server<Client, User>;
 
 export interface AuthorizeOptions {
@@ -392,24 +393,30 @@ export namespace exchange {
         scopeSeparator?: string | undefined;
     }
 
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     function authorizationCode<Client = any, User = any>(
         options: Options,
         issue: IssueExchangeCodeFunctionArity6<Client>,
     ): MiddlewareFunction<Client, User>;
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     function authorizationCode<Client = any, User = any>(
         options: Options,
         issue: IssueExchangeCodeFunctionArity5<Client>,
     ): MiddlewareFunction<Client, User>;
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     function authorizationCode<Client = any, User = any>(
         options: Options,
         issue: IssueExchangeCodeFunction<Client>,
     ): MiddlewareFunction<Client, User>;
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     function authorizationCode<Client = any, User = any>(
         issue: IssueExchangeCodeFunctionArity6<Client>,
     ): MiddlewareFunction<Client, User>;
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     function authorizationCode<Client = any, User = any>(
         issue: IssueExchangeCodeFunctionArity5<Client>,
     ): MiddlewareFunction<Client, User>;
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     function authorizationCode<Client = any, User = any>(
         issue: IssueExchangeCodeFunction<Client>,
     ): MiddlewareFunction<Client, User>;
@@ -417,33 +424,40 @@ export namespace exchange {
     const code: typeof authorizationCode;
 
     // arity == 5; issue(client, scope, req.body, req.authInfo, issued);
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     function clientCredentials<Client = any, User = any>(
         options: Options,
         issue: (client: Client, scope: string[], body: any, authInfo: any, issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction<Client, User>;
     // arity == 4; issue(client, scope, req.body, issued);
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     function clientCredentials<Client = any, User = any>(
         options: Options,
         issue: (client: Client, scope: string[], body: any, issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction<Client, User>;
     // arity == 3; issue(client, scope, issued);
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     function clientCredentials<Client = any, User = any>(
         options: Options,
         issue: (client: Client, scope: string[], issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction<Client, User>;
     // arity == 2; issue(client, issued);
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     function clientCredentials<Client = any, User = any>(
         options: Options,
         issue: (client: Client, issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction<Client, User>;
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     function clientCredentials<Client = any, User = any>(
         issue: (client: Client, scope: string[], issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction<Client, User>;
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     function clientCredentials<Client = any, User = any>(
         issue: (client: Client, issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction<Client, User>;
 
     // arity == 7; issue(client, username, passwd, scope, req.body, req.authInfo, issued);
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     function password<Client = any, User = any>(
         options: Options,
         issue: (
@@ -457,6 +471,7 @@ export namespace exchange {
         ) => void,
     ): MiddlewareFunction<Client, User>;
     // arity == 6; issue(client, username, passwd, scope, req.body, issued);
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     function password<Client = any, User = any>(
         options: Options,
         issue: (
@@ -469,6 +484,7 @@ export namespace exchange {
         ) => void,
     ): MiddlewareFunction<Client, User>;
     // arity == 5; issue(client, username, passwd, scope, issued);
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     function password<Client = any, User = any>(
         options: Options,
         issue: (
@@ -480,10 +496,12 @@ export namespace exchange {
         ) => void,
     ): MiddlewareFunction<Client, User>;
     // arity == 4; issue(client, username, passwd, issued);
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     function password<Client = any, User = any>(
         options: Options,
         issue: (client: Client, username: string, password: string, issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction<Client, User>;
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     function password<Client = any, User = any>(
         issue: (
             client: Client,
@@ -493,11 +511,13 @@ export namespace exchange {
             issued: ExchangeDoneFunction,
         ) => void,
     ): MiddlewareFunction<Client, User>;
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     function password<Client = any, User = any>(
         issue: (client: Client, username: string, password: string, issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction<Client, User>;
 
     // arity == 6; issue(client, refreshToken, scope, req.body, req.authInfo, issued);
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     function refreshToken<Client = any, User = any>(
         options: Options,
         issue: (
@@ -510,23 +530,28 @@ export namespace exchange {
         ) => void,
     ): MiddlewareFunction<Client, User>;
     // arity == 5; issue(client, refreshToken, scope, req.body, issued);
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     function refreshToken<Client = any, User = any>(
         options: Options,
         issue: (client: Client, refreshToken: string, scope: string[], body: any, issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction<Client, User>;
     // arity == 4; issue(client, refreshToken, scope, issued);
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     function refreshToken<Client = any, User = any>(
         options: Options,
         issue: (client: Client, refreshToken: string, scope: string[], issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction<Client, User>;
     // arity == 3; issue(client, refreshToken, issued);
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     function refreshToken<Client = any, User = any>(
         options: Options,
         issue: (client: Client, refreshToken: string, issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction<Client, User>;
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     function refreshToken<Client = any, User = any>(
         issue: (client: Client, refreshToken: string, scope: string[], issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction<Client, User>;
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     function refreshToken<Client = any, User = any>(
         issue: (client: Client, refreshToken: string, issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction<Client, User>;

--- a/types/oauth2orize/index.d.ts
+++ b/types/oauth2orize/index.d.ts
@@ -128,7 +128,7 @@ export class TokenError extends OAuth2Error {
     constructor(message?: string, code?: TokenErrorCode | string, uri?: string, status?: number);
 }
 
-export type MiddlewareFunction = (req: MiddlewareRequest, res: ServerResponse, next: MiddlewareNextFunction) => void;
+export type MiddlewareFunction<TReq extends MiddlewareRequest> = (req: TReq, res: ServerResponse, next: MiddlewareNextFunction) => void;
 
 export type MiddlewareErrorFunction = (
     err: Error,
@@ -165,7 +165,7 @@ export type ImmediateFunction = (
     done: (err: Error | null, allow: boolean, info: any, locals: any) => void,
 ) => void;
 
-export type DecisionParseFunction = (req: MiddlewareRequest, done: (err: Error | null, params: any) => void) => void;
+export type DecisionParseFunction<TReq extends MiddlewareRequest> = (req: TReq, done: (err: Error | null, params?: any) => void) => void;
 
 export type SerializeClientFunction = (client: Client, done: SerializeClientDoneFunction) => void;
 export type SerializeClientDoneFunction = (err: Error | null, id: string) => void;
@@ -272,9 +272,9 @@ export class OAuth2Server {
 
     authorization: OAuth2Server["authorize"];
 
-    decision(options: DecisionOptions, parse: DecisionParseFunction): MiddlewareFunction;
-    decision(parse: DecisionParseFunction): MiddlewareFunction;
-    decision(): MiddlewareFunction;
+    decision<TReq>(options: DecisionOptions, parse: DecisionParseFunction<TReq>): MiddlewareFunction<TReq>;
+    decision<TReq>(parse: DecisionParseFunction<TReq>): MiddlewareFunction<TReq>;
+    decision<TReq>(): MiddlewareFunction<TReq>;
 
     token(options?: any): MiddlewareFunction;
 

--- a/types/oauth2orize/index.d.ts
+++ b/types/oauth2orize/index.d.ts
@@ -139,7 +139,7 @@ export type MiddlewareErrorFunction = (
 
 export type MiddlewareNextFunction = (err?: Error) => void;
 
-export type ValidateDoneFunction = (err: Error | null, client?: Client | boolean, redirectURI?: string) => void;
+export type ValidateDoneFunction = (err: Error | null, client?: Client | false, redirectURI?: string) => void;
 export type ValidateFunctionArity5 = (
     clientId: string,
     redirectURI: string,

--- a/types/oauth2orize/index.d.ts
+++ b/types/oauth2orize/index.d.ts
@@ -110,7 +110,11 @@ export class TokenError extends OAuth2Error {
     constructor(message?: string, code?: TokenErrorCode | string, uri?: string, status?: number);
 }
 
-export type MiddlewareFunction<Client = any, User = any, TReq extends MiddlewareRequest<Client, User> = MiddlewareRequest<Client, User>> = (
+export type MiddlewareFunction<
+    Client = any,
+    User = any,
+    TReq extends MiddlewareRequest<Client, User> = MiddlewareRequest<Client, User>,
+> = (
     req: TReq,
     res: ServerResponse,
     next: MiddlewareNextFunction,
@@ -125,7 +129,11 @@ export type MiddlewareErrorFunction<Client = any, User = any> = (
 
 export type MiddlewareNextFunction = (err?: Error) => void;
 
-export type ValidateDoneFunction<Client = any> = (err: Error | null, client?: Client | false, redirectURI?: string) => void;
+export type ValidateDoneFunction<Client = any> = (
+    err: Error | null,
+    client?: Client | false,
+    redirectURI?: string,
+) => void;
 export type ValidateFunctionArity5<Client = any> = (
     clientId: string,
     redirectURI: string,
@@ -139,7 +147,11 @@ export type ValidateFunctionArity4<Client> = (
     scope: string[],
     validated: ValidateDoneFunction<Client>,
 ) => void;
-export type ValidateFunction<Client = any> = (clientId: string, redirectURI: string, validated: ValidateDoneFunction<Client>) => void;
+export type ValidateFunction<Client = any> = (
+    clientId: string,
+    redirectURI: string,
+    validated: ValidateDoneFunction<Client>,
+) => void;
 export type ValidateFunctionArity2<Client = any> = (areq: OAuth2Req, validated: ValidateDoneFunction<Client>) => void;
 
 export type ImmediateFunction<Client = any, User = any> = (
@@ -151,7 +163,11 @@ export type ImmediateFunction<Client = any, User = any> = (
     done: (err: Error | null, allow: boolean, info: any, locals: any) => void,
 ) => void;
 
-export type DecisionParseFunction<Client = any, User = any, TReq extends MiddlewareRequest<Client, User> = MiddlewareRequest<any, any>> = (
+export type DecisionParseFunction<
+    Client = any,
+    User = any,
+    TReq extends MiddlewareRequest<Client, User> = MiddlewareRequest<any, any>,
+> = (
     req: TReq,
     done: (err: Error | null, params?: any) => void,
 ) => void;
@@ -238,7 +254,7 @@ export type ExchangeDoneFunction = (
     params?: any,
 ) => void;
 
-export class OAuth2Server<Client = any, User = any>{
+export class OAuth2Server<Client = any, User = any> {
     grant(type: string, fn: MiddlewareFunction<Client, User>): OAuth2Server<Client, User>;
     grant(fn: MiddlewareFunction<Client, User>): OAuth2Server<Client, User>;
 
@@ -255,16 +271,32 @@ export class OAuth2Server<Client = any, User = any>{
         validate: ValidateFunctionArity4<Client>,
         immediate?: ImmediateFunction<Client, User>,
     ): MiddlewareFunction<Client, User>;
-    authorize(options: AuthorizeOptions, validate: ValidateFunction<Client>, immediate?: ImmediateFunction<Client, User>): MiddlewareFunction<Client, User>;
+    authorize(
+        options: AuthorizeOptions,
+        validate: ValidateFunction<Client>,
+        immediate?: ImmediateFunction<Client, User>,
+    ): MiddlewareFunction<Client, User>;
     authorize(
         options: AuthorizeOptions,
         validate: ValidateFunctionArity2<Client>,
         immediate?: ImmediateFunction<Client, User>,
     ): MiddlewareFunction<Client, User>;
-    authorize(validate: ValidateFunctionArity5<Client>, immediate?: ImmediateFunction<Client, User>): MiddlewareFunction<Client, User>;
-    authorize(validate: ValidateFunctionArity4<Client>, immediate?: ImmediateFunction<Client, User>): MiddlewareFunction<Client, User>;
-    authorize(validate: ValidateFunction<Client>, immediate?: ImmediateFunction<Client, User>): MiddlewareFunction<Client, User>;
-    authorize(validate: ValidateFunctionArity2<Client>, immediate?: ImmediateFunction<Client, User>): MiddlewareFunction<Client, User>;
+    authorize(
+        validate: ValidateFunctionArity5<Client>,
+        immediate?: ImmediateFunction<Client, User>,
+    ): MiddlewareFunction<Client, User>;
+    authorize(
+        validate: ValidateFunctionArity4<Client>,
+        immediate?: ImmediateFunction<Client, User>,
+    ): MiddlewareFunction<Client, User>;
+    authorize(
+        validate: ValidateFunction<Client>,
+        immediate?: ImmediateFunction<Client, User>,
+    ): MiddlewareFunction<Client, User>;
+    authorize(
+        validate: ValidateFunctionArity2<Client>,
+        immediate?: ImmediateFunction<Client, User>,
+    ): MiddlewareFunction<Client, User>;
 
     authorization: OAuth2Server<Client, User>["authorize"];
 
@@ -272,7 +304,9 @@ export class OAuth2Server<Client = any, User = any>{
         options: DecisionOptions,
         parse: DecisionParseFunction<Client, User, TReq>,
     ): MiddlewareFunction<Client, User, TReq>;
-    decision<TReq extends MiddlewareRequest<Client, User>>(parse: DecisionParseFunction<Client, User, TReq>): MiddlewareFunction<Client, User, TReq>;
+    decision<TReq extends MiddlewareRequest<Client, User>>(
+        parse: DecisionParseFunction<Client, User, TReq>,
+    ): MiddlewareFunction<Client, User, TReq>;
     decision<TReq extends MiddlewareRequest<Client, User>>(): MiddlewareFunction<Client, User, TReq>;
 
     token(options?: any): MiddlewareFunction<Client, User>;
@@ -299,19 +333,49 @@ export namespace grant {
         scopeSeparator?: string | undefined;
     }
 
-    function code<Client = any, User = any>(options: Options<Client, User>, issue: IssueGrantCodeFunctionArity7<Client, User>): MiddlewareFunction<Client, User>;
-    function code<Client = any, User = any>(options: Options<Client, User>, issue: IssueGrantCodeFunctionArity6<Client, User>): MiddlewareFunction<Client, User>;
-    function code<Client = any, User = any>(options: Options<Client, User>, issue: IssueGrantCodeFunction<Client, User>): MiddlewareFunction<Client, User>;
-    function code<Client = any, User = any>(options: Options<Client, User>, issue: IssueGrantCodeFunctionArity4<Client, User>): MiddlewareFunction<Client, User>;
-    function code<Client = any, User = any>(issue: IssueGrantCodeFunctionArity7<Client, User>): MiddlewareFunction<Client, User>;
-    function code<Client = any, User = any>(issue: IssueGrantCodeFunctionArity6<Client, User>): MiddlewareFunction<Client, User>;
-    function code<Client = any, User = any>(issue: IssueGrantCodeFunction<Client, User>): MiddlewareFunction<Client, User>;
-    function code<Client = any, User = any>(issue: IssueGrantCodeFunctionArity4<Client, User>): MiddlewareFunction<Client, User>;
+    function code<Client = any, User = any>(
+        options: Options<Client, User>,
+        issue: IssueGrantCodeFunctionArity7<Client, User>,
+    ): MiddlewareFunction<Client, User>;
+    function code<Client = any, User = any>(
+        options: Options<Client, User>,
+        issue: IssueGrantCodeFunctionArity6<Client, User>,
+    ): MiddlewareFunction<Client, User>;
+    function code<Client = any, User = any>(
+        options: Options<Client, User>,
+        issue: IssueGrantCodeFunction<Client, User>,
+    ): MiddlewareFunction<Client, User>;
+    function code<Client = any, User = any>(
+        options: Options<Client, User>,
+        issue: IssueGrantCodeFunctionArity4<Client, User>,
+    ): MiddlewareFunction<Client, User>;
+    function code<Client = any, User = any>(
+        issue: IssueGrantCodeFunctionArity7<Client, User>,
+    ): MiddlewareFunction<Client, User>;
+    function code<Client = any, User = any>(
+        issue: IssueGrantCodeFunctionArity6<Client, User>,
+    ): MiddlewareFunction<Client, User>;
+    function code<Client = any, User = any>(
+        issue: IssueGrantCodeFunction<Client, User>,
+    ): MiddlewareFunction<Client, User>;
+    function code<Client = any, User = any>(
+        issue: IssueGrantCodeFunctionArity4<Client, User>,
+    ): MiddlewareFunction<Client, User>;
 
-    function token<Client = any, User = any>(options: Options<Client, User>, issue: IssueGrantTokenFunctionArity5<Client, User>): MiddlewareFunction<Client, User>;
-    function token<Client = any, User = any>(options: Options<Client, User>, issue: IssueGrantTokenFunctionArity4<Client, User>): MiddlewareFunction<Client, User>;
-    function token<Client = any, User = any>(issue: IssueGrantTokenFunctionArity5<Client, User>): MiddlewareFunction<Client, User>;
-    function token<Client = any, User = any>(issue: IssueGrantTokenFunctionArity4<Client, User>): MiddlewareFunction<Client, User>;
+    function token<Client = any, User = any>(
+        options: Options<Client, User>,
+        issue: IssueGrantTokenFunctionArity5<Client, User>,
+    ): MiddlewareFunction<Client, User>;
+    function token<Client = any, User = any>(
+        options: Options<Client, User>,
+        issue: IssueGrantTokenFunctionArity4<Client, User>,
+    ): MiddlewareFunction<Client, User>;
+    function token<Client = any, User = any>(
+        issue: IssueGrantTokenFunctionArity5<Client, User>,
+    ): MiddlewareFunction<Client, User>;
+    function token<Client = any, User = any>(
+        issue: IssueGrantTokenFunctionArity4<Client, User>,
+    ): MiddlewareFunction<Client, User>;
 }
 
 export namespace exchange {
@@ -328,12 +392,27 @@ export namespace exchange {
         scopeSeparator?: string | undefined;
     }
 
-    function authorizationCode<Client = any, User = any>(options: Options, issue: IssueExchangeCodeFunctionArity6<Client>): MiddlewareFunction<Client, User>;
-    function authorizationCode<Client = any, User = any>(options: Options, issue: IssueExchangeCodeFunctionArity5<Client>): MiddlewareFunction<Client, User>;
-    function authorizationCode<Client = any, User = any>(options: Options, issue: IssueExchangeCodeFunction<Client>): MiddlewareFunction<Client, User>;
-    function authorizationCode<Client = any, User = any>(issue: IssueExchangeCodeFunctionArity6<Client>): MiddlewareFunction<Client, User>;
-    function authorizationCode<Client = any, User = any>(issue: IssueExchangeCodeFunctionArity5<Client>): MiddlewareFunction<Client, User>;
-    function authorizationCode<Client = any, User = any>(issue: IssueExchangeCodeFunction<Client>): MiddlewareFunction<Client, User>;
+    function authorizationCode<Client = any, User = any>(
+        options: Options,
+        issue: IssueExchangeCodeFunctionArity6<Client>,
+    ): MiddlewareFunction<Client, User>;
+    function authorizationCode<Client = any, User = any>(
+        options: Options,
+        issue: IssueExchangeCodeFunctionArity5<Client>,
+    ): MiddlewareFunction<Client, User>;
+    function authorizationCode<Client = any, User = any>(
+        options: Options,
+        issue: IssueExchangeCodeFunction<Client>,
+    ): MiddlewareFunction<Client, User>;
+    function authorizationCode<Client = any, User = any>(
+        issue: IssueExchangeCodeFunctionArity6<Client>,
+    ): MiddlewareFunction<Client, User>;
+    function authorizationCode<Client = any, User = any>(
+        issue: IssueExchangeCodeFunctionArity5<Client>,
+    ): MiddlewareFunction<Client, User>;
+    function authorizationCode<Client = any, User = any>(
+        issue: IssueExchangeCodeFunction<Client>,
+    ): MiddlewareFunction<Client, User>;
 
     const code: typeof authorizationCode;
 
@@ -360,7 +439,9 @@ export namespace exchange {
     function clientCredentials<Client = any, User = any>(
         issue: (client: Client, scope: string[], issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction<Client, User>;
-    function clientCredentials<Client = any, User = any>(issue: (client: Client, issued: ExchangeDoneFunction) => void): MiddlewareFunction<Client, User>;
+    function clientCredentials<Client = any, User = any>(
+        issue: (client: Client, issued: ExchangeDoneFunction) => void,
+    ): MiddlewareFunction<Client, User>;
 
     // arity == 7; issue(client, username, passwd, scope, req.body, req.authInfo, issued);
     function password<Client = any, User = any>(

--- a/types/oauth2orize/index.d.ts
+++ b/types/oauth2orize/index.d.ts
@@ -206,11 +206,18 @@ export type IssueGrantCodeFunctionArity4 = (
     issued: IssueGrantCodeDoneFunction,
 ) => void;
 
-export type IssueGrantTokenFunction = (
+export type IssueGrantTokenFunctionArity5 = (
     client: Client,
     user: User,
     ares: any,
-    issued: (err: Error | null, code?: string, params?: any) => void,
+    areq: any,
+    issued: (err: Error | null, code?: string | boolean, params?: any) => void,
+) => void;
+export type IssueGrantTokenFunctionArity4 = (
+    client: Client,
+    user: User,
+    ares: any,
+    issued: (err: Error | null, code?: string | boolean, params?: any) => void,
 ) => void;
 
 export type IssueExchangeCodeFunctionArity6 = (
@@ -309,8 +316,10 @@ export namespace grant {
     function code(issue: IssueGrantCodeFunction): MiddlewareFunction;
     function code(issue: IssueGrantCodeFunctionArity4): MiddlewareFunction;
 
-    function token(options: Options, issue: IssueGrantTokenFunction): MiddlewareFunction;
-    function token(issue: IssueGrantTokenFunction): MiddlewareFunction;
+    function token(options: Options, issue: IssueGrantTokenFunctionArity5): MiddlewareFunction;
+    function token(options: Options, issue: IssueGrantTokenFunctionArity4): MiddlewareFunction;
+    function token(issue: IssueGrantTokenFunctionArity5): MiddlewareFunction;
+    function token(issue: IssueGrantTokenFunctionArity4): MiddlewareFunction;
 }
 
 export namespace exchange {

--- a/types/oauth2orize/index.d.ts
+++ b/types/oauth2orize/index.d.ts
@@ -3,25 +3,7 @@
 
 import { IncomingMessage, ServerResponse } from "http";
 
-declare global {
-    namespace OAuth2orize {
-        // These open interfaces may be extended in an application-specific manner via declaration merging.
-        // See for example method-override.d.ts (https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/method-override/index.d.ts)
-        interface Client {}
-        interface User {}
-    }
-
-    namespace Express {
-        interface Request {
-            oauth2?: OAuth2 | undefined;
-        }
-    }
-}
-
-export type Client = OAuth2orize.Client;
-export type User = OAuth2orize.User;
-
-export interface OAuth2 {
+export interface OAuth2<Client = any, User = any> {
     client: Client;
     user: User;
     transactionID: string;
@@ -43,8 +25,8 @@ export interface OAuth2Info {
     scope: string;
 }
 
-export interface MiddlewareRequest extends IncomingMessage {
-    oauth2?: OAuth2 | undefined;
+export interface MiddlewareRequest<Client = any, User = any> extends IncomingMessage {
+    oauth2?: OAuth2<Client, User> | undefined;
     user?: User;
 }
 
@@ -52,7 +34,7 @@ export interface ServerOptions {
     store: any;
 }
 
-export function createServer(options?: ServerOptions): OAuth2Server;
+export function createServer<Client = any, User = any>(options?: ServerOptions): OAuth2Server<Client, User>;
 
 export interface AuthorizeOptions {
     idLength?: number | undefined;
@@ -60,10 +42,10 @@ export interface AuthorizeOptions {
 }
 
 export interface DecisionOptions {
-    cancelField: string;
-    userProperty: string;
-    sessionKey: string;
-    loadTransaction: boolean;
+    cancelField?: string;
+    userProperty?: string;
+    sessionKey?: string;
+    loadTransaction?: boolean;
 }
 
 export interface ErrorHandlerOptions {
@@ -128,39 +110,39 @@ export class TokenError extends OAuth2Error {
     constructor(message?: string, code?: TokenErrorCode | string, uri?: string, status?: number);
 }
 
-export type MiddlewareFunction<TReq extends MiddlewareRequest = MiddlewareRequest> = (
+export type MiddlewareFunction<Client = any, User = any, TReq extends MiddlewareRequest<Client, User> = MiddlewareRequest<Client, User>> = (
     req: TReq,
     res: ServerResponse,
     next: MiddlewareNextFunction,
 ) => void;
 
-export type MiddlewareErrorFunction = (
+export type MiddlewareErrorFunction<Client = any, User = any> = (
     err: Error,
-    req: MiddlewareRequest,
+    req: MiddlewareRequest<Client, User>,
     res: ServerResponse,
     next: MiddlewareNextFunction,
 ) => void;
 
 export type MiddlewareNextFunction = (err?: Error) => void;
 
-export type ValidateDoneFunction = (err: Error | null, client?: Client | false, redirectURI?: string) => void;
-export type ValidateFunctionArity5 = (
+export type ValidateDoneFunction<Client = any> = (err: Error | null, client?: Client | false, redirectURI?: string) => void;
+export type ValidateFunctionArity5<Client = any> = (
     clientId: string,
     redirectURI: string,
     scope: string[],
     type: string,
-    validated: ValidateDoneFunction,
+    validated: ValidateDoneFunction<Client>,
 ) => void;
-export type ValidateFunctionArity4 = (
+export type ValidateFunctionArity4<Client> = (
     clientId: string,
     redirectURI: string,
     scope: string[],
-    validated: ValidateDoneFunction,
+    validated: ValidateDoneFunction<Client>,
 ) => void;
-export type ValidateFunction = (clientId: string, redirectURI: string, validated: ValidateDoneFunction) => void;
-export type ValidateFunctionArity2 = (areq: OAuth2Req, validated: ValidateDoneFunction) => void;
+export type ValidateFunction<Client = any> = (clientId: string, redirectURI: string, validated: ValidateDoneFunction<Client>) => void;
+export type ValidateFunctionArity2<Client = any> = (areq: OAuth2Req, validated: ValidateDoneFunction<Client>) => void;
 
-export type ImmediateFunction = (
+export type ImmediateFunction<Client = any, User = any> = (
     client: Client,
     user: User,
     scope: string[],
@@ -169,20 +151,20 @@ export type ImmediateFunction = (
     done: (err: Error | null, allow: boolean, info: any, locals: any) => void,
 ) => void;
 
-export type DecisionParseFunction<TReq extends MiddlewareRequest> = (
+export type DecisionParseFunction<Client = any, User = any, TReq extends MiddlewareRequest<Client, User> = MiddlewareRequest<any, any>> = (
     req: TReq,
     done: (err: Error | null, params?: any) => void,
 ) => void;
 
-export type SerializeClientFunction = (client: Client, done: SerializeClientDoneFunction) => void;
+export type SerializeClientFunction<Client = any> = (client: Client, done: SerializeClientDoneFunction) => void;
 export type SerializeClientDoneFunction = (err: Error | null, id: string) => void;
 
-export type DeserializeClientFunction = (id: string, done: DeserializeClientDoneFunction) => void;
-export type DeserializeClientDoneFunction = (err: Error | null, client?: Client | boolean) => void;
+export type DeserializeClientFunction<Client = any> = (id: string, done: DeserializeClientDoneFunction<Client>) => void;
+export type DeserializeClientDoneFunction<Client = any> = (err: Error | null, client?: Client | boolean) => void;
 
 export type IssueGrantCodeDoneFunction = (err: Error | null, code?: string) => void;
 
-export type IssueGrantCodeFunctionArity7 = (
+export type IssueGrantCodeFunctionArity7<Client = any, User = any> = (
     client: Client,
     redirectUri: string,
     user: User,
@@ -191,7 +173,7 @@ export type IssueGrantCodeFunctionArity7 = (
     locals: any,
     issued: IssueGrantCodeDoneFunction,
 ) => void;
-export type IssueGrantCodeFunctionArity6 = (
+export type IssueGrantCodeFunctionArity6<Client = any, User = any> = (
     client: Client,
     redirectUri: string,
     user: User,
@@ -199,35 +181,35 @@ export type IssueGrantCodeFunctionArity6 = (
     req: OAuth2Req,
     issued: IssueGrantCodeDoneFunction,
 ) => void;
-export type IssueGrantCodeFunction = (
+export type IssueGrantCodeFunction<Client = any, User = any> = (
     client: Client,
     redirectUri: string,
     user: User,
     res: any,
     issued: IssueGrantCodeDoneFunction,
 ) => void;
-export type IssueGrantCodeFunctionArity4 = (
+export type IssueGrantCodeFunctionArity4<Client = any, User = any> = (
     client: Client,
     redirectUri: string,
     user: User,
     issued: IssueGrantCodeDoneFunction,
 ) => void;
 
-export type IssueGrantTokenFunctionArity5 = (
+export type IssueGrantTokenFunctionArity5<Client = any, User = any> = (
     client: Client,
     user: User,
     ares: any,
     areq: any,
     issued: (err: Error | null, code?: string | boolean, params?: any) => void,
 ) => void;
-export type IssueGrantTokenFunctionArity4 = (
+export type IssueGrantTokenFunctionArity4<Client = any, User = any> = (
     client: Client,
     user: User,
     ares: any,
     issued: (err: Error | null, code?: string | boolean, params?: any) => void,
 ) => void;
 
-export type IssueExchangeCodeFunctionArity6 = (
+export type IssueExchangeCodeFunctionArity6<Client = any> = (
     client: Client,
     code: string,
     redirectURI: string,
@@ -235,14 +217,14 @@ export type IssueExchangeCodeFunctionArity6 = (
     authInfo: any,
     issued: ExchangeDoneFunction,
 ) => void;
-export type IssueExchangeCodeFunctionArity5 = (
+export type IssueExchangeCodeFunctionArity5<Client = any> = (
     client: Client,
     code: string,
     redirectURI: string,
     body: Record<string, unknown>,
     issued: ExchangeDoneFunction,
 ) => void;
-export type IssueExchangeCodeFunction = (
+export type IssueExchangeCodeFunction<Client = any> = (
     client: Client,
     code: string,
     redirectURI: string,
@@ -256,58 +238,58 @@ export type ExchangeDoneFunction = (
     params?: any,
 ) => void;
 
-export class OAuth2Server {
-    grant(type: string, fn: MiddlewareFunction): OAuth2Server;
-    grant(fn: MiddlewareFunction): OAuth2Server;
+export class OAuth2Server<Client = any, User = any>{
+    grant(type: string, fn: MiddlewareFunction<Client, User>): OAuth2Server<Client, User>;
+    grant(fn: MiddlewareFunction<Client, User>): OAuth2Server<Client, User>;
 
-    exchange(type: string, fn: MiddlewareFunction): OAuth2Server;
-    exchange(fn: MiddlewareFunction): OAuth2Server;
+    exchange(type: string, fn: MiddlewareFunction<Client, User>): OAuth2Server<Client, User>;
+    exchange(fn: MiddlewareFunction<Client, User>): OAuth2Server<Client, User>;
 
     authorize(
         options: AuthorizeOptions,
-        validate: ValidateFunctionArity5,
-        immediate?: ImmediateFunction,
-    ): MiddlewareFunction;
+        validate: ValidateFunctionArity5<Client>,
+        immediate?: ImmediateFunction<Client, User>,
+    ): MiddlewareFunction<Client, User>;
     authorize(
         options: AuthorizeOptions,
-        validate: ValidateFunctionArity4,
-        immediate?: ImmediateFunction,
-    ): MiddlewareFunction;
-    authorize(options: AuthorizeOptions, validate: ValidateFunction, immediate?: ImmediateFunction): MiddlewareFunction;
+        validate: ValidateFunctionArity4<Client>,
+        immediate?: ImmediateFunction<Client, User>,
+    ): MiddlewareFunction<Client, User>;
+    authorize(options: AuthorizeOptions, validate: ValidateFunction<Client>, immediate?: ImmediateFunction<Client, User>): MiddlewareFunction<Client, User>;
     authorize(
         options: AuthorizeOptions,
-        validate: ValidateFunctionArity2,
-        immediate?: ImmediateFunction,
-    ): MiddlewareFunction;
-    authorize(validate: ValidateFunctionArity5, immediate?: ImmediateFunction): MiddlewareFunction;
-    authorize(validate: ValidateFunctionArity4, immediate?: ImmediateFunction): MiddlewareFunction;
-    authorize(validate: ValidateFunction, immediate?: ImmediateFunction): MiddlewareFunction;
-    authorize(validate: ValidateFunctionArity2, immediate?: ImmediateFunction): MiddlewareFunction;
+        validate: ValidateFunctionArity2<Client>,
+        immediate?: ImmediateFunction<Client, User>,
+    ): MiddlewareFunction<Client, User>;
+    authorize(validate: ValidateFunctionArity5<Client>, immediate?: ImmediateFunction<Client, User>): MiddlewareFunction<Client, User>;
+    authorize(validate: ValidateFunctionArity4<Client>, immediate?: ImmediateFunction<Client, User>): MiddlewareFunction<Client, User>;
+    authorize(validate: ValidateFunction<Client>, immediate?: ImmediateFunction<Client, User>): MiddlewareFunction<Client, User>;
+    authorize(validate: ValidateFunctionArity2<Client>, immediate?: ImmediateFunction<Client, User>): MiddlewareFunction<Client, User>;
 
-    authorization: OAuth2Server["authorize"];
+    authorization: OAuth2Server<Client, User>["authorize"];
 
-    decision<TReq extends MiddlewareRequest>(
+    decision<TReq extends MiddlewareRequest<Client, User>>(
         options: DecisionOptions,
-        parse: DecisionParseFunction<TReq>,
-    ): MiddlewareFunction<TReq>;
-    decision<TReq extends MiddlewareRequest>(parse: DecisionParseFunction<TReq>): MiddlewareFunction<TReq>;
-    decision<TReq extends MiddlewareRequest>(): MiddlewareFunction<TReq>;
+        parse: DecisionParseFunction<Client, User, TReq>,
+    ): MiddlewareFunction<Client, User, TReq>;
+    decision<TReq extends MiddlewareRequest<Client, User>>(parse: DecisionParseFunction<Client, User, TReq>): MiddlewareFunction<Client, User, TReq>;
+    decision<TReq extends MiddlewareRequest<Client, User>>(): MiddlewareFunction<Client, User, TReq>;
 
-    token(options?: any): MiddlewareFunction;
+    token(options?: any): MiddlewareFunction<Client, User>;
 
-    errorHandler(options?: any): MiddlewareErrorFunction;
+    errorHandler(options?: any): MiddlewareErrorFunction<Client, User>;
 
-    serializeClient(fn: SerializeClientFunction): void;
+    serializeClient(fn: SerializeClientFunction<Client>): void;
     serializeClient(client: Client, done: SerializeClientDoneFunction): void;
 
-    deserializeClient(fn: DeserializeClientFunction): void;
-    deserializeClient(obj: any, done: DeserializeClientDoneFunction): void;
+    deserializeClient(fn: DeserializeClientFunction<Client>): void;
+    deserializeClient(obj: any, done: DeserializeClientDoneFunction<Client>): void;
 }
 
 export namespace grant {
-    interface Options {
+    interface Options<Client = any, User = any> {
         modes?: {
-            query?: (txn: OAuth2, res: ServerResponse, params: Record<string, unknown>) => void;
+            query?: (txn: OAuth2<Client, User>, res: ServerResponse, params: Record<string, unknown>) => void;
         };
         // For maximum flexibility, multiple scope separators can optionally be
         // allowed.  This allows the server to accept clients that separate scope
@@ -317,19 +299,19 @@ export namespace grant {
         scopeSeparator?: string | undefined;
     }
 
-    function code(options: Options, issue: IssueGrantCodeFunctionArity7): MiddlewareFunction;
-    function code(options: Options, issue: IssueGrantCodeFunctionArity6): MiddlewareFunction;
-    function code(options: Options, issue: IssueGrantCodeFunction): MiddlewareFunction;
-    function code(options: Options, issue: IssueGrantCodeFunctionArity4): MiddlewareFunction;
-    function code(issue: IssueGrantCodeFunctionArity7): MiddlewareFunction;
-    function code(issue: IssueGrantCodeFunctionArity6): MiddlewareFunction;
-    function code(issue: IssueGrantCodeFunction): MiddlewareFunction;
-    function code(issue: IssueGrantCodeFunctionArity4): MiddlewareFunction;
+    function code<Client = any, User = any>(options: Options<Client, User>, issue: IssueGrantCodeFunctionArity7<Client, User>): MiddlewareFunction<Client, User>;
+    function code<Client = any, User = any>(options: Options<Client, User>, issue: IssueGrantCodeFunctionArity6<Client, User>): MiddlewareFunction<Client, User>;
+    function code<Client = any, User = any>(options: Options<Client, User>, issue: IssueGrantCodeFunction<Client, User>): MiddlewareFunction<Client, User>;
+    function code<Client = any, User = any>(options: Options<Client, User>, issue: IssueGrantCodeFunctionArity4<Client, User>): MiddlewareFunction<Client, User>;
+    function code<Client = any, User = any>(issue: IssueGrantCodeFunctionArity7<Client, User>): MiddlewareFunction<Client, User>;
+    function code<Client = any, User = any>(issue: IssueGrantCodeFunctionArity6<Client, User>): MiddlewareFunction<Client, User>;
+    function code<Client = any, User = any>(issue: IssueGrantCodeFunction<Client, User>): MiddlewareFunction<Client, User>;
+    function code<Client = any, User = any>(issue: IssueGrantCodeFunctionArity4<Client, User>): MiddlewareFunction<Client, User>;
 
-    function token(options: Options, issue: IssueGrantTokenFunctionArity5): MiddlewareFunction;
-    function token(options: Options, issue: IssueGrantTokenFunctionArity4): MiddlewareFunction;
-    function token(issue: IssueGrantTokenFunctionArity5): MiddlewareFunction;
-    function token(issue: IssueGrantTokenFunctionArity4): MiddlewareFunction;
+    function token<Client = any, User = any>(options: Options<Client, User>, issue: IssueGrantTokenFunctionArity5<Client, User>): MiddlewareFunction<Client, User>;
+    function token<Client = any, User = any>(options: Options<Client, User>, issue: IssueGrantTokenFunctionArity4<Client, User>): MiddlewareFunction<Client, User>;
+    function token<Client = any, User = any>(issue: IssueGrantTokenFunctionArity5<Client, User>): MiddlewareFunction<Client, User>;
+    function token<Client = any, User = any>(issue: IssueGrantTokenFunctionArity4<Client, User>): MiddlewareFunction<Client, User>;
 }
 
 export namespace exchange {
@@ -346,42 +328,42 @@ export namespace exchange {
         scopeSeparator?: string | undefined;
     }
 
-    function authorizationCode(options: Options, issue: IssueExchangeCodeFunctionArity6): MiddlewareFunction;
-    function authorizationCode(options: Options, issue: IssueExchangeCodeFunctionArity5): MiddlewareFunction;
-    function authorizationCode(options: Options, issue: IssueExchangeCodeFunction): MiddlewareFunction;
-    function authorizationCode(issue: IssueExchangeCodeFunctionArity6): MiddlewareFunction;
-    function authorizationCode(issue: IssueExchangeCodeFunctionArity5): MiddlewareFunction;
-    function authorizationCode(issue: IssueExchangeCodeFunction): MiddlewareFunction;
+    function authorizationCode<Client = any, User = any>(options: Options, issue: IssueExchangeCodeFunctionArity6<Client>): MiddlewareFunction<Client, User>;
+    function authorizationCode<Client = any, User = any>(options: Options, issue: IssueExchangeCodeFunctionArity5<Client>): MiddlewareFunction<Client, User>;
+    function authorizationCode<Client = any, User = any>(options: Options, issue: IssueExchangeCodeFunction<Client>): MiddlewareFunction<Client, User>;
+    function authorizationCode<Client = any, User = any>(issue: IssueExchangeCodeFunctionArity6<Client>): MiddlewareFunction<Client, User>;
+    function authorizationCode<Client = any, User = any>(issue: IssueExchangeCodeFunctionArity5<Client>): MiddlewareFunction<Client, User>;
+    function authorizationCode<Client = any, User = any>(issue: IssueExchangeCodeFunction<Client>): MiddlewareFunction<Client, User>;
 
     const code: typeof authorizationCode;
 
     // arity == 5; issue(client, scope, req.body, req.authInfo, issued);
-    function clientCredentials(
+    function clientCredentials<Client = any, User = any>(
         options: Options,
         issue: (client: Client, scope: string[], body: any, authInfo: any, issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<Client, User>;
     // arity == 4; issue(client, scope, req.body, issued);
-    function clientCredentials(
+    function clientCredentials<Client = any, User = any>(
         options: Options,
         issue: (client: Client, scope: string[], body: any, issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<Client, User>;
     // arity == 3; issue(client, scope, issued);
-    function clientCredentials(
+    function clientCredentials<Client = any, User = any>(
         options: Options,
         issue: (client: Client, scope: string[], issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<Client, User>;
     // arity == 2; issue(client, issued);
-    function clientCredentials(
+    function clientCredentials<Client = any, User = any>(
         options: Options,
         issue: (client: Client, issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
-    function clientCredentials(
+    ): MiddlewareFunction<Client, User>;
+    function clientCredentials<Client = any, User = any>(
         issue: (client: Client, scope: string[], issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
-    function clientCredentials(issue: (client: Client, issued: ExchangeDoneFunction) => void): MiddlewareFunction;
+    ): MiddlewareFunction<Client, User>;
+    function clientCredentials<Client = any, User = any>(issue: (client: Client, issued: ExchangeDoneFunction) => void): MiddlewareFunction<Client, User>;
 
     // arity == 7; issue(client, username, passwd, scope, req.body, req.authInfo, issued);
-    function password(
+    function password<Client = any, User = any>(
         options: Options,
         issue: (
             client: Client,
@@ -392,9 +374,9 @@ export namespace exchange {
             authInfo: any,
             issued: ExchangeDoneFunction,
         ) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<Client, User>;
     // arity == 6; issue(client, username, passwd, scope, req.body, issued);
-    function password(
+    function password<Client = any, User = any>(
         options: Options,
         issue: (
             client: Client,
@@ -404,9 +386,9 @@ export namespace exchange {
             body: any,
             issued: ExchangeDoneFunction,
         ) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<Client, User>;
     // arity == 5; issue(client, username, passwd, scope, issued);
-    function password(
+    function password<Client = any, User = any>(
         options: Options,
         issue: (
             client: Client,
@@ -415,13 +397,13 @@ export namespace exchange {
             scope: string[],
             issued: ExchangeDoneFunction,
         ) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<Client, User>;
     // arity == 4; issue(client, username, passwd, issued);
-    function password(
+    function password<Client = any, User = any>(
         options: Options,
         issue: (client: Client, username: string, password: string, issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
-    function password(
+    ): MiddlewareFunction<Client, User>;
+    function password<Client = any, User = any>(
         issue: (
             client: Client,
             username: string,
@@ -429,13 +411,13 @@ export namespace exchange {
             scope: string[],
             issued: ExchangeDoneFunction,
         ) => void,
-    ): MiddlewareFunction;
-    function password(
+    ): MiddlewareFunction<Client, User>;
+    function password<Client = any, User = any>(
         issue: (client: Client, username: string, password: string, issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<Client, User>;
 
     // arity == 6; issue(client, refreshToken, scope, req.body, req.authInfo, issued);
-    function refreshToken(
+    function refreshToken<Client = any, User = any>(
         options: Options,
         issue: (
             client: Client,
@@ -445,26 +427,26 @@ export namespace exchange {
             authInfo: any,
             issued: ExchangeDoneFunction,
         ) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<Client, User>;
     // arity == 5; issue(client, refreshToken, scope, req.body, issued);
-    function refreshToken(
+    function refreshToken<Client = any, User = any>(
         options: Options,
         issue: (client: Client, refreshToken: string, scope: string[], body: any, issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<Client, User>;
     // arity == 4; issue(client, refreshToken, scope, issued);
-    function refreshToken(
+    function refreshToken<Client = any, User = any>(
         options: Options,
         issue: (client: Client, refreshToken: string, scope: string[], issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<Client, User>;
     // arity == 3; issue(client, refreshToken, issued);
-    function refreshToken(
+    function refreshToken<Client = any, User = any>(
         options: Options,
         issue: (client: Client, refreshToken: string, issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
-    function refreshToken(
+    ): MiddlewareFunction<Client, User>;
+    function refreshToken<Client = any, User = any>(
         issue: (client: Client, refreshToken: string, scope: string[], issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
-    function refreshToken(
+    ): MiddlewareFunction<Client, User>;
+    function refreshToken<Client = any, User = any>(
         issue: (client: Client, refreshToken: string, issued: ExchangeDoneFunction) => void,
-    ): MiddlewareFunction;
+    ): MiddlewareFunction<Client, User>;
 }

--- a/types/oauth2orize/index.d.ts
+++ b/types/oauth2orize/index.d.ts
@@ -4,6 +4,13 @@
 import { IncomingMessage, ServerResponse } from "http";
 
 declare global {
+    namespace OAuth2orize {
+        // These open interfaces may be extended in an application-specific manner via declaration merging.
+        // See for example method-override.d.ts (https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/method-override/index.d.ts)
+        interface Client {}
+        interface User {}
+    }
+
     namespace Express {
         interface Request {
             oauth2?: OAuth2 | undefined;
@@ -11,9 +18,12 @@ declare global {
     }
 }
 
+export type Client = OAuth2orize.Client
+export type User = OAuth2orize.User
+
 export interface OAuth2 {
-    client: any;
-    user: any;
+    client: Client;
+    user: User;
     transactionID: string;
     redirectURI: string;
     req: OAuth2Req;
@@ -35,7 +45,7 @@ export interface OAuth2Info {
 
 export interface MiddlewareRequest extends IncomingMessage {
     oauth2?: OAuth2 | undefined;
-    user?: any;
+    user?: User;
 }
 
 export interface ServerOptions {
@@ -129,7 +139,7 @@ export type MiddlewareErrorFunction = (
 
 export type MiddlewareNextFunction = (err?: Error) => void;
 
-export type ValidateDoneFunction = (err: Error | null, client?: any, redirectURI?: string) => void;
+export type ValidateDoneFunction = (err: Error | null, client?: Client | boolean, redirectURI?: string) => void;
 export type ValidateFunctionArity5 = (
     clientId: string,
     redirectURI: string,
@@ -147,8 +157,8 @@ export type ValidateFunction = (clientId: string, redirectURI: string, validated
 export type ValidateFunctionArity2 = (areq: OAuth2Req, validated: ValidateDoneFunction) => void;
 
 export type ImmediateFunction = (
-    client: any,
-    user: any,
+    client: Client,
+    user: User,
     scope: string[],
     type: string,
     areq: any,
@@ -157,54 +167,54 @@ export type ImmediateFunction = (
 
 export type DecisionParseFunction = (req: MiddlewareRequest, done: (err: Error | null, params: any) => void) => void;
 
-export type SerializeClientFunction = (client: any, done: SerializeClientDoneFunction) => void;
+export type SerializeClientFunction = (client: Client, done: SerializeClientDoneFunction) => void;
 export type SerializeClientDoneFunction = (err: Error | null, id: string) => void;
 
 export type DeserializeClientFunction = (id: string, done: DeserializeClientDoneFunction) => void;
-export type DeserializeClientDoneFunction = (err: Error | null, client?: any | boolean) => void;
+export type DeserializeClientDoneFunction = (err: Error | null, client?: Client | boolean) => void;
 
 export type IssueGrantCodeDoneFunction = (err: Error | null, code?: string) => void;
 
 export type IssueGrantCodeFunctionArity7 = (
-    client: any,
+    client: Client,
     redirectUri: string,
-    user: any,
+    user: User,
     res: any,
     req: OAuth2Req,
     locals: any,
     issued: IssueGrantCodeDoneFunction,
 ) => void;
 export type IssueGrantCodeFunctionArity6 = (
-    client: any,
+    client: Client,
     redirectUri: string,
-    user: any,
+    user: User,
     res: any,
     req: OAuth2Req,
     issued: IssueGrantCodeDoneFunction,
 ) => void;
 export type IssueGrantCodeFunction = (
-    client: any,
+    client: Client,
     redirectUri: string,
-    user: any,
+    user: User,
     res: any,
     issued: IssueGrantCodeDoneFunction,
 ) => void;
 export type IssueGrantCodeFunctionArity4 = (
-    client: any,
+    client: Client,
     redirectUri: string,
-    user: any,
+    user: User,
     issued: IssueGrantCodeDoneFunction,
 ) => void;
 
 export type IssueGrantTokenFunction = (
-    client: any,
-    user: any,
+    client: Client,
+    user: User,
     ares: any,
     issued: (err: Error | null, code?: string, params?: any) => void,
 ) => void;
 
 export type IssueExchangeCodeFunctionArity6 = (
-    client: any,
+    client: Client,
     code: string,
     redirectURI: string,
     body: Record<string, unknown>,
@@ -212,14 +222,14 @@ export type IssueExchangeCodeFunctionArity6 = (
     issued: ExchangeDoneFunction,
 ) => void;
 export type IssueExchangeCodeFunctionArity5 = (
-    client: any,
+    client: Client,
     code: string,
     redirectURI: string,
     body: Record<string, unknown>,
     issued: ExchangeDoneFunction,
 ) => void;
 export type IssueExchangeCodeFunction = (
-    client: any,
+    client: Client,
     code: string,
     redirectURI: string,
     issued: ExchangeDoneFunction,
@@ -271,7 +281,7 @@ export class OAuth2Server {
     errorHandler(options?: any): MiddlewareErrorFunction;
 
     serializeClient(fn: SerializeClientFunction): void;
-    serializeClient(client: any, done: SerializeClientDoneFunction): void;
+    serializeClient(client: Client, done: SerializeClientDoneFunction): void;
 
     deserializeClient(fn: DeserializeClientFunction): void;
     deserializeClient(obj: any, done: DeserializeClientDoneFunction): void;
@@ -329,33 +339,33 @@ export namespace exchange {
     // arity == 5; issue(client, scope, req.body, req.authInfo, issued);
     function clientCredentials(
         options: Options,
-        issue: (client: any, scope: string[], body: any, authInfo: any, issued: ExchangeDoneFunction) => void,
+        issue: (client: Client, scope: string[], body: any, authInfo: any, issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction;
     // arity == 4; issue(client, scope, req.body, issued);
     function clientCredentials(
         options: Options,
-        issue: (client: any, scope: string[], body: any, issued: ExchangeDoneFunction) => void,
+        issue: (client: Client, scope: string[], body: any, issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction;
     // arity == 3; issue(client, scope, issued);
     function clientCredentials(
         options: Options,
-        issue: (client: any, scope: string[], issued: ExchangeDoneFunction) => void,
+        issue: (client: Client, scope: string[], issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction;
     // arity == 2; issue(client, issued);
     function clientCredentials(
         options: Options,
-        issue: (client: any, issued: ExchangeDoneFunction) => void,
+        issue: (client: Client, issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction;
     function clientCredentials(
-        issue: (client: any, scope: string[], issued: ExchangeDoneFunction) => void,
+        issue: (client: Client, scope: string[], issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction;
-    function clientCredentials(issue: (client: any, issued: ExchangeDoneFunction) => void): MiddlewareFunction;
+    function clientCredentials(issue: (client: Client, issued: ExchangeDoneFunction) => void): MiddlewareFunction;
 
     // arity == 7; issue(client, username, passwd, scope, req.body, req.authInfo, issued);
     function password(
         options: Options,
         issue: (
-            client: any,
+            client: Client,
             username: string,
             password: string,
             scope: string[],
@@ -368,7 +378,7 @@ export namespace exchange {
     function password(
         options: Options,
         issue: (
-            client: any,
+            client: Client,
             username: string,
             password: string,
             scope: string[],
@@ -379,25 +389,25 @@ export namespace exchange {
     // arity == 5; issue(client, username, passwd, scope, issued);
     function password(
         options: Options,
-        issue: (client: any, username: string, password: string, scope: string[], issued: ExchangeDoneFunction) => void,
+        issue: (client: Client, username: string, password: string, scope: string[], issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction;
     // arity == 4; issue(client, username, passwd, issued);
     function password(
         options: Options,
-        issue: (client: any, username: string, password: string, issued: ExchangeDoneFunction) => void,
+        issue: (client: Client, username: string, password: string, issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction;
     function password(
-        issue: (client: any, username: string, password: string, scope: string[], issued: ExchangeDoneFunction) => void,
+        issue: (client: Client, username: string, password: string, scope: string[], issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction;
     function password(
-        issue: (client: any, username: string, password: string, issued: ExchangeDoneFunction) => void,
+        issue: (client: Client, username: string, password: string, issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction;
 
     // arity == 6; issue(client, refreshToken, scope, req.body, req.authInfo, issued);
     function refreshToken(
         options: Options,
         issue: (
-            client: any,
+            client: Client,
             refreshToken: string,
             scope: string[],
             body: any,
@@ -408,22 +418,22 @@ export namespace exchange {
     // arity == 5; issue(client, refreshToken, scope, req.body, issued);
     function refreshToken(
         options: Options,
-        issue: (client: any, refreshToken: string, scope: string[], body: any, issued: ExchangeDoneFunction) => void,
+        issue: (client: Client, refreshToken: string, scope: string[], body: any, issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction;
     // arity == 4; issue(client, refreshToken, scope, issued);
     function refreshToken(
         options: Options,
-        issue: (client: any, refreshToken: string, scope: string[], issued: ExchangeDoneFunction) => void,
+        issue: (client: Client, refreshToken: string, scope: string[], issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction;
     // arity == 3; issue(client, refreshToken, issued);
     function refreshToken(
         options: Options,
-        issue: (client: any, refreshToken: string, issued: ExchangeDoneFunction) => void,
+        issue: (client: Client, refreshToken: string, issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction;
     function refreshToken(
-        issue: (client: any, refreshToken: string, scope: string[], issued: ExchangeDoneFunction) => void,
+        issue: (client: Client, refreshToken: string, scope: string[], issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction;
     function refreshToken(
-        issue: (client: any, refreshToken: string, issued: ExchangeDoneFunction) => void,
+        issue: (client: Client, refreshToken: string, issued: ExchangeDoneFunction) => void,
     ): MiddlewareFunction;
 }

--- a/types/oauth2orize/oauth2orize-tests.ts
+++ b/types/oauth2orize/oauth2orize-tests.ts
@@ -107,7 +107,7 @@ class Clients {
 declare global {
     namespace Express {
         interface Request {
-            oauth2: oauth2orize.OAuth2<{
+            oauth2?: oauth2orize.OAuth2<{
                 id: string;
                 redirectURI: string;
             }>;
@@ -137,6 +137,27 @@ server.authorize(
     //                        user: req.user, client: req.oauth2.client });
 });
 // );
+
+server.authorize(
+    ((clientID, redirectURI, done) => {
+        Clients.findOne(clientID, (err, client) => {
+            if (err) {
+                done(err);
+            } else if (!client) {
+                done(null, false);
+            } else if (client.redirectURI !== redirectURI) {
+                done(null, false);
+            } else {
+                done(null, client, client.redirectURI);
+            }
+        });
+    }) as oauth2orize.ValidateFunction,
+);
+((req: Express.Request, res: http.ServerResponse) => {
+    req.oauth2!.transactionID; // $ExpectType string
+    req.oauth2!.client; // $ExpectType { id: string; redirectURI: string; }
+    req.oauth2!.user; // $ExpectType any
+});
 
 server.authorize((clientID, redirectURI, scope, type, done) => {
     done; // $ExpectType ValidateDoneFunction<any>

--- a/types/oauth2orize/oauth2orize-tests.ts
+++ b/types/oauth2orize/oauth2orize-tests.ts
@@ -110,7 +110,7 @@ declare global {
             oauth2: oauth2orize.OAuth2<{
                 id: string;
                 redirectURI: string;
-            }>
+            }>;
         }
     }
 }
@@ -186,25 +186,25 @@ new oauth2orize.OAuth2Error();
 interface Client {
     id: string;
     redirectURI: string;
-};
+}
 interface User {
     id: string;
-};
+}
 const typedServer = oauth2orize.createServer<Client, User>();
 
 typedServer.grant(
     oauth2orize.grant.token(async function grantToken(
-      client,
-      user,
-      _res,
-      req,
-      done: (
-        err: Error | null,
-        token?: string | false,
-        params?: { expires_in: number }
-      ) => void
+        client,
+        user,
+        _res,
+        req,
+        done: (
+            err: Error | null,
+            token?: string | false,
+            params?: { expires_in: number },
+        ) => void,
     ) {
         client; // $ExpectType Client
         user; // $ExpectType User
-    })
+    }),
 );

--- a/types/oauth2orize/oauth2orize-tests.ts
+++ b/types/oauth2orize/oauth2orize-tests.ts
@@ -100,7 +100,17 @@ class Clients {
     static findOne(id: string, callback: (err: Error, client?: Clients) => void): void {
         callback(new Error(), {} as Clients); // tslint:disable-line no-object-literal-type-assertion
     }
+    id: string;
     redirectURI: string;
+}
+
+declare global {
+    namespace OAuth2orize {
+        interface Client {
+            id: string;
+            redirectURI: string;
+        }
+    }
 }
 
 // app.get('/dialog/authorize',

--- a/types/oauth2orize/oauth2orize-tests.ts
+++ b/types/oauth2orize/oauth2orize-tests.ts
@@ -105,10 +105,12 @@ class Clients {
 }
 
 declare global {
-    namespace OAuth2orize {
-        interface Client {
-            id: string;
-            redirectURI: string;
+    namespace Express {
+        interface Request {
+            oauth2: oauth2orize.OAuth2<{
+                id: string;
+                redirectURI: string;
+            }>
         }
     }
 }
@@ -137,17 +139,17 @@ server.authorize(
 // );
 
 server.authorize((clientID, redirectURI, scope, type, done) => {
-    done; // $ExpectType ValidateDoneFunction
+    done; // $ExpectType ValidateDoneFunction<any>
 });
 server.authorize(
     ((clientID, redirectURI, scope, done) => {
-        done; // $ExpectType ValidateDoneFunction
-    }) as oauth2orize.ValidateFunctionArity4,
+        done; // $ExpectType ValidateDoneFunction<any>
+    }) as oauth2orize.ValidateFunctionArity4<any>,
 );
 server.authorize(
     ((areq, done) => {
-        done; // $ExpectType ValidateDoneFunction
-    }) as oauth2orize.ValidateFunctionArity2,
+        done; // $ExpectType ValidateDoneFunction<any>
+    }) as oauth2orize.ValidateFunctionArity2<any>,
 );
 
 server.authorization((clientId, redirectURI, done) => {});
@@ -179,3 +181,30 @@ const tokenError = new oauth2orize.TokenError("Incorrect token", "invalid_grant"
 const code: string = tokenError.code;
 new oauth2orize.AuthorizationError("Incorrect token", "access_denied");
 new oauth2orize.OAuth2Error();
+
+// Typed server
+interface Client {
+    id: string;
+    redirectURI: string;
+};
+interface User {
+    id: string;
+};
+const typedServer = oauth2orize.createServer<Client, User>();
+
+typedServer.grant(
+    oauth2orize.grant.token(async function grantToken(
+      client,
+      user,
+      _res,
+      req,
+      done: (
+        err: Error | null,
+        token?: string | false,
+        params?: { expires_in: number }
+      ) => void
+    ) {
+        client; // $ExpectType Client
+        user; // $ExpectType User
+    })
+);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Adding an open interface like it has been done for Express.Request which allows to specify types for Client and User.
```typescript
declare global {
  namespace OAuth2orize {
    interface User extends Express.User {}
    interface Client {
      id: string;
      redirectUri: string;
    }
  }
}
```

Adding some more Arity to some functions

Infer Request Type on decision from MiddlewareFunction (can be expanded to additional functions)