### PR TITLE
[node] remove ableist language from crypto module

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -106,7 +106,7 @@ declare module "crypto" {
         const SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION: number;
         /** Attempts to use the server's preferences instead of the client's when selecting a cipher. See https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_set_options.html. */
         const SSL_OP_CIPHER_SERVER_PREFERENCE: number;
-        /** Instructs OpenSSL to use Cisco's "speshul" version of DTLS_BAD_VER. */
+        /** Instructs OpenSSL to use Cisco's version identifier of DTLS_BAD_VER. */
         const SSL_OP_CISCO_ANYCONNECT: number;
         /** Instructs OpenSSL to turn on cookie exchange. */
         const SSL_OP_COOKIE_EXCHANGE: number;

--- a/types/node/v16/crypto.d.ts
+++ b/types/node/v16/crypto.d.ts
@@ -76,7 +76,7 @@ declare module "crypto" {
         const SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION: number;
         /** Attempts to use the server's preferences instead of the client's when selecting a cipher. See https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_set_options.html. */
         const SSL_OP_CIPHER_SERVER_PREFERENCE: number;
-        /** Instructs OpenSSL to use Cisco's "speshul" version of DTLS_BAD_VER. */
+        /** Instructs OpenSSL to use Cisco's version identifier of DTLS_BAD_VER. */
         const SSL_OP_CISCO_ANYCONNECT: number;
         /** Instructs OpenSSL to turn on cookie exchange. */
         const SSL_OP_COOKIE_EXCHANGE: number;

--- a/types/node/v18/crypto.d.ts
+++ b/types/node/v18/crypto.d.ts
@@ -103,7 +103,7 @@ declare module "crypto" {
         const SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION: number;
         /** Attempts to use the server's preferences instead of the client's when selecting a cipher. See https://www.openssl.org/docs/man1.0.2/ssl/SSL_CTX_set_options.html. */
         const SSL_OP_CIPHER_SERVER_PREFERENCE: number;
-        /** Instructs OpenSSL to use Cisco's "speshul" version of DTLS_BAD_VER. */
+        /** Instructs OpenSSL to use Cisco's version identifier of DTLS_BAD_VER. */
         const SSL_OP_CISCO_ANYCONNECT: number;
         /** Instructs OpenSSL to turn on cookie exchange. */
         const SSL_OP_COOKIE_EXCHANGE: number;


### PR DESCRIPTION
I noticed some ableist language in the comment for `SSL_OP_CISCO_ANYCONNECT`. It uses the word "speshul" in a way that is not very inclusive. I've suggested a change to make it more neutral & respectful, aligning with OpenSSL's [current description](https://github.com/openssl/openssl/blob/b317583f4ad8a8e742781381fa10db5bcd072585/include/openssl/ssl.h.in#L362-L366) of `SSL_OP_CISCO_ANYCONNECT`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/openssl/openssl/blob/b317583f4ad8a8e742781381fa10db5bcd072585/include/openssl/ssl.h.in#L362-L366>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

