### PR TITLE
[react] Add useActionState

### DIFF
--- a/types/react-dom/test/canary-tests.tsx
+++ b/types/react-dom/test/canary-tests.tsx
@@ -124,6 +124,7 @@ function Status() {
     }
 }
 
+// Keep in sync with React.useActionState tests
 function formTest() {
     function Page1() {
         async function action(state: number) {

--- a/types/react/canary.d.ts
+++ b/types/react/canary.d.ts
@@ -102,10 +102,10 @@ declare module "." {
         (callback: () => Promise<VoidOrUndefinedOnly>): void;
     }
 
-    function useOptimistic<State>(
+    export function useOptimistic<State>(
         passthrough: State,
     ): [State, (action: State | ((pendingState: State) => State)) => void];
-    function useOptimistic<State, Action>(
+    export function useOptimistic<State, Action>(
         passthrough: State,
         reducer: (state: State, action: Action) => State,
     ): [State, (action: Action) => void];
@@ -113,4 +113,15 @@ declare module "." {
     interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES {
         cleanup: () => VoidOrUndefinedOnly;
     }
+
+    export function useActionState<State>(
+        action: (state: Awaited<State>) => State | Promise<State>,
+        initialState: Awaited<State>,
+        permalink?: string,
+    ): [state: Awaited<State>, dispatch: () => void, isPending: boolean];
+    export function useActionState<State, Payload>(
+        action: (state: Awaited<State>, payload: Payload) => State | Promise<State>,
+        initialState: Awaited<State>,
+        permalink?: string,
+    ): [state: Awaited<State>, dispatch: (payload: Payload) => void, isPending: boolean];
 }

--- a/types/react/test/canary.tsx
+++ b/types/react/test/canary.tsx
@@ -202,3 +202,125 @@ function Optimistic() {
         };
     }}
 />;
+
+const useActionState = React.useActionState;
+function formTest() {
+    function usePage1() {
+        async function action(state: number) {
+            return state + 1;
+        }
+
+        const [
+            // $ExpectType number
+            state,
+            dispatch,
+            // $ExpectType boolean
+            isPending,
+        ] = useActionState(action, 1);
+
+        function actionExpectingPromiseState(state: Promise<number>) {
+            return state.then((s) => s + 1);
+        }
+
+        useActionState(
+            // @ts-expect-error
+            actionExpectingPromiseState,
+            Promise.resolve(1),
+        );
+        useActionState(
+            action,
+            // @ts-expect-error
+            Promise.resolve(1),
+        );
+        // $ExpectType number
+        useActionState<Promise<number>>(action, 1)[0];
+
+        useActionState(
+            async (
+                prevState: // only needed in TypeScript 4.9
+                    // 5.0 infers `number` whereas 4.9 infers `0`
+                    number,
+            ) => prevState + 1,
+            0,
+        )[0];
+        // $ExpectType number
+        useActionState(
+            async (prevState) => prevState + 1,
+            // @ts-expect-error
+            Promise.resolve(0),
+        )[0];
+
+        const [
+            state2,
+            action2,
+            // $ExpectType boolean
+            isPending2,
+        ] = useActionState(
+            async (state: React.ReactNode, payload: FormData): Promise<React.ReactNode> => {
+                return state;
+            },
+            (
+                <button>
+                    New Project
+                </button>
+            ),
+        );
+
+        return function handleClick() {
+            dispatch();
+        };
+        return (
+            <button
+                onClick={() => {
+                    dispatch();
+                }}
+            >
+                count: {state}
+            </button>
+        );
+    }
+
+    function usePage2() {
+        async function action(state: number) {
+            return state + 1;
+        }
+
+        const [
+            // $ExpectType number
+            state,
+            dispatch,
+        ] = useActionState(action, 1, "/permalink");
+
+        return dispatch;
+    }
+
+    function usePage3() {
+        function actionSync(state: number, type: "increment" | "decrement") {
+            return state + (type === "increment" ? 1 : -1);
+        }
+
+        const [
+            // $ExpectType number
+            state,
+            dispatch,
+        ] = useActionState(actionSync, 1, "/permalink");
+        return function handleClick() {
+            dispatch("decrement");
+        };
+    }
+
+    function usePage4() {
+        async function action(state: number, type: "increment" | "decrement") {
+            return state + (type === "increment" ? 1 : -1);
+        }
+
+        const [
+            // $ExpectType number
+            state,
+            dispatch,
+        ] = useActionState(action, 1, "/permalink");
+        return function handleClick() {
+            dispatch("decrement");
+        };
+    }
+}

--- a/types/react/test/canary.tsx
+++ b/types/react/test/canary.tsx
@@ -204,8 +204,9 @@ function Optimistic() {
 />;
 
 const useActionState = React.useActionState;
+// Keep in sync with ReactDOM.useFormState tests
 function formTest() {
-    function usePage1() {
+    function Page1() {
         async function action(state: number) {
             return state + 1;
         }
@@ -266,9 +267,6 @@ function formTest() {
             ),
         );
 
-        return function handleClick() {
-            dispatch();
-        };
         return (
             <button
                 onClick={() => {
@@ -280,7 +278,7 @@ function formTest() {
         );
     }
 
-    function usePage2() {
+    function Page2() {
         async function action(state: number) {
             return state + 1;
         }
@@ -290,11 +288,15 @@ function formTest() {
             state,
             dispatch,
         ] = useActionState(action, 1, "/permalink");
-
-        return dispatch;
+        return (
+            <form action={dispatch}>
+                <span>Count: {state}</span>
+                <input type="text" name="incrementAmount" defaultValue="5" />
+            </form>
+        );
     }
 
-    function usePage3() {
+    function Page3() {
         function actionSync(state: number, type: "increment" | "decrement") {
             return state + (type === "increment" ? 1 : -1);
         }
@@ -304,12 +306,18 @@ function formTest() {
             state,
             dispatch,
         ] = useActionState(actionSync, 1, "/permalink");
-        return function handleClick() {
-            dispatch("decrement");
-        };
+        return (
+            <button
+                onClick={() => {
+                    dispatch("decrement");
+                }}
+            >
+                count: {state}
+            </button>
+        );
     }
 
-    function usePage4() {
+    function Page4() {
         async function action(state: number, type: "increment" | "decrement") {
             return state + (type === "increment" ? 1 : -1);
         }
@@ -319,8 +327,14 @@ function formTest() {
             state,
             dispatch,
         ] = useActionState(action, 1, "/permalink");
-        return function handleClick() {
-            dispatch("decrement");
-        };
+        return (
+            <button
+                onClick={() => {
+                    dispatch("decrement");
+                }}
+            >
+                count: {state}
+            </button>
+        );
     }
 }

--- a/types/react/ts5.0/canary.d.ts
+++ b/types/react/ts5.0/canary.d.ts
@@ -102,10 +102,10 @@ declare module "." {
         (callback: () => Promise<VoidOrUndefinedOnly>): void;
     }
 
-    function useOptimistic<State>(
+    export function useOptimistic<State>(
         passthrough: State,
     ): [State, (action: State | ((pendingState: State) => State)) => void];
-    function useOptimistic<State, Action>(
+    export function useOptimistic<State, Action>(
         passthrough: State,
         reducer: (state: State, action: Action) => State,
     ): [State, (action: Action) => void];
@@ -113,4 +113,15 @@ declare module "." {
     interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES {
         cleanup: () => VoidOrUndefinedOnly;
     }
+
+    export function useActionState<State>(
+        action: (state: Awaited<State>) => State | Promise<State>,
+        initialState: Awaited<State>,
+        permalink?: string,
+    ): [state: Awaited<State>, dispatch: () => void, isPending: boolean];
+    export function useActionState<State, Payload>(
+        action: (state: Awaited<State>, payload: Payload) => State | Promise<State>,
+        initialState: Awaited<State>,
+        permalink?: string,
+    ): [state: Awaited<State>, dispatch: (payload: Payload) => void, isPending: boolean];
 }

--- a/types/react/ts5.0/test/canary.tsx
+++ b/types/react/ts5.0/test/canary.tsx
@@ -202,3 +202,125 @@ function Optimistic() {
         };
     }}
 />;
+
+const useActionState = React.useActionState;
+function formTest() {
+    function usePage1() {
+        async function action(state: number) {
+            return state + 1;
+        }
+
+        const [
+            // $ExpectType number
+            state,
+            dispatch,
+            // $ExpectType boolean
+            isPending,
+        ] = useActionState(action, 1);
+
+        function actionExpectingPromiseState(state: Promise<number>) {
+            return state.then((s) => s + 1);
+        }
+
+        useActionState(
+            // @ts-expect-error
+            actionExpectingPromiseState,
+            Promise.resolve(1),
+        );
+        useActionState(
+            action,
+            // @ts-expect-error
+            Promise.resolve(1),
+        );
+        // $ExpectType number
+        useActionState<Promise<number>>(action, 1)[0];
+
+        useActionState(
+            async (
+                prevState: // only needed in TypeScript 4.9
+                    // 5.0 infers `number` whereas 4.9 infers `0`
+                    number,
+            ) => prevState + 1,
+            0,
+        )[0];
+        // $ExpectType number
+        useActionState(
+            async (prevState) => prevState + 1,
+            // @ts-expect-error
+            Promise.resolve(0),
+        )[0];
+
+        const [
+            state2,
+            action2,
+            // $ExpectType boolean
+            isPending2,
+        ] = useActionState(
+            async (state: React.ReactNode, payload: FormData): Promise<React.ReactNode> => {
+                return state;
+            },
+            (
+                <button>
+                    New Project
+                </button>
+            ),
+        );
+
+        return function handleClick() {
+            dispatch();
+        };
+        return (
+            <button
+                onClick={() => {
+                    dispatch();
+                }}
+            >
+                count: {state}
+            </button>
+        );
+    }
+
+    function usePage2() {
+        async function action(state: number) {
+            return state + 1;
+        }
+
+        const [
+            // $ExpectType number
+            state,
+            dispatch,
+        ] = useActionState(action, 1, "/permalink");
+
+        return dispatch;
+    }
+
+    function usePage3() {
+        function actionSync(state: number, type: "increment" | "decrement") {
+            return state + (type === "increment" ? 1 : -1);
+        }
+
+        const [
+            // $ExpectType number
+            state,
+            dispatch,
+        ] = useActionState(actionSync, 1, "/permalink");
+        return function handleClick() {
+            dispatch("decrement");
+        };
+    }
+
+    function usePage4() {
+        async function action(state: number, type: "increment" | "decrement") {
+            return state + (type === "increment" ? 1 : -1);
+        }
+
+        const [
+            // $ExpectType number
+            state,
+            dispatch,
+        ] = useActionState(action, 1, "/permalink");
+        return function handleClick() {
+            dispatch("decrement");
+        };
+    }
+}

--- a/types/react/ts5.0/test/canary.tsx
+++ b/types/react/ts5.0/test/canary.tsx
@@ -204,8 +204,9 @@ function Optimistic() {
 />;
 
 const useActionState = React.useActionState;
+// Keep in sync with ReactDOM.useFormState tests
 function formTest() {
-    function usePage1() {
+    function Page1() {
         async function action(state: number) {
             return state + 1;
         }
@@ -266,9 +267,6 @@ function formTest() {
             ),
         );
 
-        return function handleClick() {
-            dispatch();
-        };
         return (
             <button
                 onClick={() => {
@@ -280,7 +278,7 @@ function formTest() {
         );
     }
 
-    function usePage2() {
+    function Page2() {
         async function action(state: number) {
             return state + 1;
         }
@@ -290,11 +288,15 @@ function formTest() {
             state,
             dispatch,
         ] = useActionState(action, 1, "/permalink");
-
-        return dispatch;
+        return (
+            <form action={dispatch}>
+                <span>Count: {state}</span>
+                <input type="text" name="incrementAmount" defaultValue="5" />
+            </form>
+        );
     }
 
-    function usePage3() {
+    function Page3() {
         function actionSync(state: number, type: "increment" | "decrement") {
             return state + (type === "increment" ? 1 : -1);
         }
@@ -304,12 +306,18 @@ function formTest() {
             state,
             dispatch,
         ] = useActionState(actionSync, 1, "/permalink");
-        return function handleClick() {
-            dispatch("decrement");
-        };
+        return (
+            <button
+                onClick={() => {
+                    dispatch("decrement");
+                }}
+            >
+                count: {state}
+            </button>
+        );
     }
 
-    function usePage4() {
+    function Page4() {
         async function action(state: number, type: "increment" | "decrement") {
             return state + (type === "increment" ? 1 : -1);
         }
@@ -319,8 +327,14 @@ function formTest() {
             state,
             dispatch,
         ] = useActionState(action, 1, "/permalink");
-        return function handleClick() {
-            dispatch("decrement");
-        };
+        return (
+            <button
+                onClick={() => {
+                    dispatch("decrement");
+                }}
+            >
+                count: {state}
+            </button>
+        );
     }
 }


### PR DESCRIPTION
Types for https://github.com/facebook/react/pull/28491

Just c&p type definitions from `useFormState`. Tests are adjusted to not use DOM stuff. When `useFormState` is removed, the tests will just check that the returned action from `useActionState` can be used as form actions.