### PR TITLE
[@types/dockerode] Add dict filter to list methods

### DIFF
--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -274,6 +274,15 @@ docker.listImages({
     return images.map(image => docker.getImage(image.Id));
 });
 
+docker.listImages({
+    all: true,
+    filters: { "dangling": ["true"] },
+    digests: true,
+    abortSignal: new AbortController().signal,
+}).then(images => {
+    return images.map(image => docker.getImage(image.Id));
+});
+
 docker.buildImage("archive.tar", { t: "imageName" }, (err, response) => {
     // NOOP
 });

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -465,8 +465,9 @@ declare namespace Dockerode {
         abortSignal?: AbortSignal;
         /**
          * Filters to process on the prune list, encoded as JSON (a `map[string][]string`).
+         * A dictionary of key/value list is also accepted.
          */
-        filters?: string;
+        filters?: string | { [key: string]: string[] };
     }
 
     interface VolumeRemoveOptions {
@@ -647,8 +648,9 @@ declare namespace Dockerode {
     interface NetworkListOptions {
         /**
          * JSON encoded value of the filters (a `map[string][]string`) to process on the networks list.
+         * A dictionary of key/value list is also accepted.
          */
-        filters?: string;
+        filters?: string | { [key: string]: string[] };
         abortSignal?: AbortSignal;
     }
 
@@ -670,9 +672,9 @@ declare namespace Dockerode {
     interface VolumeListOptions {
         abortSignal?: AbortSignal;
         /**
-         * A JSON encoded value of the filters (a map[string][]string) to process on the images list.
+         * A JSON encoded value of the filters (a map[string][]string) to process on the volume list.
          */
-        filters?: string;
+        filters?: string | { [key: string]: string[] };
         /**
          * Show digest information as a RepoDigests field on each image.
          * @default false
@@ -1559,8 +1561,9 @@ declare namespace Dockerode {
         size?: boolean;
         /**
          * Filters to process on the container list, encoded as JSON (a map[string][]string).
+         * A dictionary of key/value list is also accepted.
          */
-        filters?: string;
+        filters?: string | { [key: string]: string[] };
     }
 
     interface ServiceListOptions {
@@ -1825,7 +1828,7 @@ declare namespace Dockerode {
 
     interface ListImagesOptions {
         all?: boolean | undefined;
-        filters?: string | undefined;
+        filters?: string | { [key: string]: string[] } | undefined;
         digests?: boolean | undefined;
         abortSignal?: AbortSignal;
     }


### PR DESCRIPTION
Allows to use `{[key: string]: string[]}` as input to the `filters` property in list methods. Previously, only `string` was supported, however, dockerode supports both.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/apocas/dockerode/blob/0a1e34cd0d30d492fe2c6078ae73e2002a698b5a/examples/listContainers.js#L27-L33
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.