### PR TITLE
[tar] add brotli and preservePaths options with minor cleanup

### DIFF
--- a/types/tar/index.d.ts
+++ b/types/tar/index.d.ts
@@ -22,13 +22,6 @@ export interface HeaderProperties {
     devmin?: number | undefined;
 }
 
-export interface ExtractOptions {
-    type?: string | undefined;
-    Directory?: boolean | undefined;
-    path?: string | undefined;
-    strip?: number | undefined;
-}
-
 export interface ParseStream extends NodeJS.ReadWriteStream {
     position: number;
 
@@ -241,6 +234,11 @@ export interface PackOptions {
      */
     gzip?: boolean | zlib.ZlibOptions;
     /**
+     * Set to any truthy value to create a brotli-compressed archive,
+     * or an object with settings for zlib.BrotliCompress()
+     */
+    brotli?: boolean | zlib.BrotliOptions;
+    /**
      * A function that gets called with (path, stat) for each entry being added.
      * Return true to add the entry to the archive, or false to omit it.
      */
@@ -423,6 +421,12 @@ export interface CreateOptions {
     z?: boolean | zlib.ZlibOptions | undefined;
 
     /**
+     * Set to any truthy value to create a brotli-compressed archive,
+     * or an object with settings for zlib.BrotliCompress()
+     */
+    brotli?: boolean | zlib.BrotliOptions | undefined;
+
+    /**
      * A function that gets called with (path, stat) for each entry being
      * added. Return true to add the entry to the archive, or false to omit it.
      */
@@ -544,6 +548,20 @@ export interface ExtractOptions {
      * Alias for keep.
      */
     "keep-existing"?: boolean | undefined;
+
+    /**
+     * Allow absolute paths, paths containing .., and extracting
+     * through symbolic links. By default, / is stripped from
+     * absolute paths, .. paths are not extracted, and any file
+     * whose location would be modified by a symbolic link is not
+     * extracted.
+     */
+    preservePaths?: boolean | undefined;
+
+    /**
+     * Alias for presevePaths.
+     */
+    P?: boolean | undefined;
 
     /**
      * Unlink files before creating them. Without this option, tar overwrites
@@ -729,12 +747,6 @@ export interface ReplaceOptions {
      * A path portion to prefix onto the entries in the archive.
      */
     prefix?: string | undefined;
-
-    /**
-     * Set to any truthy value to create a gzipped archive,
-     * or an object with settings for zlib.Gzip()
-     */
-    gzip?: boolean | zlib.ZlibOptions | undefined;
 
     /**
      * A function that gets called with (path, stat) for each entry being

--- a/types/tar/tar-tests.ts
+++ b/types/tar/tar-tests.ts
@@ -136,6 +136,42 @@ tar.t({
     onentry: (entry) => console.log(entry.path, "was", entry.size),
 });
 
+tar.c(
+    {
+        gzip: true,
+        preservePaths: true,
+    },
+    ["some", "files", "and", "folders"],
+).pipe(fs.createWriteStream("my-tarball.tgz"));
+
+tar.x(
+    {
+        file: "my-tarball.tgz",
+        preservePaths: true,
+    },
+).then(() => undefined);
+
+tar.c(
+    {
+        brotli: true,
+        file: "my-tarball.tbr",
+    },
+    ["some", "files", "and", "folders"],
+).then(() => undefined);
+
+tar.c(
+    {
+        brotli: {
+            flush: 1,
+            finishFlush: 2,
+            chunkSize: 32 * 1024,
+            maxOutputLength: 1073741823,
+        },
+        file: "my-tarball.tbr",
+    },
+    ["some", "files", "and", "folders"],
+).then(() => undefined);
+
 fs.createReadStream("my-tarball.tgz")
     .pipe(tar.t())
     .on("entry", entry => console.log(entry.size));


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/isaacs/node-tar
  - https://github.com/isaacs/node-tar/pull/391
  - https://github.com/isaacs/node-tar/pull/403
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
