### PR TITLE
[@types/highland] Fix types to allow `AsyncIterator` and `AsyncIterable` when creating a stream

### DIFF
--- a/types/highland/highland-tests.ts
+++ b/types/highland/highland-tests.ts
@@ -115,6 +115,9 @@ var barStreamThen: PromiseLike<Highland.Stream<Bar>>;
 var fooIterable: Iterable<Foo>;
 var fooIterator: Iterator<Foo>;
 
+var fooAsyncIterable: AsyncIterable<Foo>;
+var fooAsyncIterator: AsyncIterator<Foo>;
+
 var maybeFooStream: Highland.Stream<Foo | undefined>;
 
 var isBaz: (obj: Foo) => obj is Baz;
@@ -186,6 +189,9 @@ fooArrStream = _(fooArrThen);
 
 fooStream = _(fooIterable);
 fooStream = _(fooIterator);
+
+fooStream = _(fooAsyncIterable);
+fooStream = _(fooAsyncIterator);
 
 // $ExpectType Stream<Stream<Foo>>
 _([fooStream]);

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -136,6 +136,9 @@ interface HighlandStatic {
     <R>(source: Iterable<R>): Highland.Stream<R>;
     <R>(source: Iterator<R>): Highland.Stream<R>;
 
+    <R>(source: AsyncIterable<R>): Highland.Stream<R>;
+    <R>(source: AsyncIterator<R>): Highland.Stream<R>;
+
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // UTILS
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -109,6 +109,17 @@ interface HighlandStatic {
      * i.e., contains a method that returns an object that conforms to the iterator protocol. The stream will use the
      * iterator defined in the `Symbol.iterator` property of the iterable object to generate emitted values.
      *
+     * **Asynchronous Iterator -** Accepts an iterator produced by an ES8 [async generator function](https://github.com/tc39/proposal-async-iteration#async-generator-functions),
+     * yields all the values from the iterator by resolving its `next()` method and terminates when the
+     * iterator's done value returns true. If the iterator's `next()` method throws or rejects, the exception will be emitted as an error,
+     * and the stream will be ended with no further calls to `next()`.
+     *
+     * **Asynchronous Iterable -** Accepts an object with a `Symbol.asyncIterator`
+     * property that conforms to the [async iteration
+     * spec](https://github.com/tc39/proposal-async-iteration#async-iterators-and-async-iterables).
+     * The constructor will create a async iterator and use it to generator emitted
+     * values.
+     *
      * @id _(source)
      * @section Stream Objects
      * @name _(source)

--- a/types/highland/tsconfig.json
+++ b/types/highland/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "node16",
         "lib": [
-            "es6"
+            "es6",
+            "es2018"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Doc comment: https://github.com/caolan/highland/blob/3516a5105c02dffdc10c330ddb5ce7d1eff5ba65/lib/index.js#L129-L138
  - Stream creation: https://github.com/caolan/highland/blob/3516a5105c02dffdc10c330ddb5ce7d1eff5ba65/lib/index.js#L290-L293
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
  - `2.13.5` is the latest released Highland version, so I cannot bump the types version beyond `2.13.9999`
