### PR TITLE
[busboy] Add `stream.truncated` property

### DIFF
--- a/types/busboy/busboy-tests.ts
+++ b/types/busboy/busboy-tests.ts
@@ -21,7 +21,7 @@ const bb = busboy({
 
 bb.addListener("file", (name, stream, info) => {
     name; // $ExpectType string
-    stream; // $ExpectType Readable
+    stream; // $ExpectType Readable & { truncated?: boolean }
     info; // $ExpectType FileInfo
 });
 bb.addListener("field", (name, value, info) => {
@@ -54,7 +54,7 @@ bb.on(Symbol("foo"), foo => {
 
 bb.on("file", (name, stream, info) => {
     name; // $ExpectType string
-    stream; // $ExpectType Readable
+    stream; // $ExpectType Readable & { truncated?: boolean }
     info; // $ExpectType FileInfo
 });
 bb.on("field", (name, value, info) => {
@@ -87,7 +87,7 @@ bb.on(Symbol("foo"), foo => {
 
 bb.once("file", (name, stream, info) => {
     name; // $ExpectType string
-    stream; // $ExpectType Readable
+    stream; // $ExpectType Readable & { truncated?: boolean }
     info; // $ExpectType FileInfo
 });
 bb.once("field", (name, value, info) => {
@@ -120,7 +120,7 @@ bb.once(Symbol("foo"), foo => {
 
 bb.removeListener("file", (name, stream, info) => {
     name; // $ExpectType string
-    stream; // $ExpectType Readable
+    stream; // $ExpectType Readable & { truncated?: boolean }
     info; // $ExpectType FileInfo
 });
 bb.removeListener("field", (name, value, info) => {
@@ -153,7 +153,7 @@ bb.removeListener(Symbol("foo"), foo => {
 
 bb.off("file", (name, stream, info) => {
     name; // $ExpectType string
-    stream; // $ExpectType Readable
+    stream; // $ExpectType Readable & { truncated?: boolean }
     info; // $ExpectType FileInfo
 });
 bb.off("field", (name, value, info) => {
@@ -186,7 +186,7 @@ bb.off(Symbol("foo"), foo => {
 
 bb.prependListener("file", (name, stream, info) => {
     name; // $ExpectType string
-    stream; // $ExpectType Readable
+    stream; // $ExpectType Readable & { truncated?: boolean }
     info; // $ExpectType FileInfo
 });
 bb.prependListener("field", (name, value, info) => {
@@ -219,7 +219,7 @@ bb.prependListener(Symbol("foo"), foo => {
 
 bb.prependOnceListener("file", (name, stream, info) => {
     name; // $ExpectType string
-    stream; // $ExpectType Readable
+    stream; // $ExpectType Readable & { truncated?: boolean }
     info; // $ExpectType FileInfo
 });
 bb.prependOnceListener("field", (name, value, info) => {

--- a/types/busboy/busboy-tests.ts
+++ b/types/busboy/busboy-tests.ts
@@ -21,7 +21,7 @@ const bb = busboy({
 
 bb.addListener("file", (name, stream, info) => {
     name; // $ExpectType string
-    stream; // $ExpectType Readable & { truncated?: boolean }
+    stream; // $ExpectType Readable & { truncated?: boolean | undefined; }
     info; // $ExpectType FileInfo
 });
 bb.addListener("field", (name, value, info) => {
@@ -54,7 +54,7 @@ bb.on(Symbol("foo"), foo => {
 
 bb.on("file", (name, stream, info) => {
     name; // $ExpectType string
-    stream; // $ExpectType Readable & { truncated?: boolean }
+    stream; // $ExpectType Readable & { truncated?: boolean | undefined; }
     info; // $ExpectType FileInfo
 });
 bb.on("field", (name, value, info) => {
@@ -87,7 +87,7 @@ bb.on(Symbol("foo"), foo => {
 
 bb.once("file", (name, stream, info) => {
     name; // $ExpectType string
-    stream; // $ExpectType Readable & { truncated?: boolean }
+    stream; // $ExpectType Readable & { truncated?: boolean | undefined; }
     info; // $ExpectType FileInfo
 });
 bb.once("field", (name, value, info) => {
@@ -120,7 +120,7 @@ bb.once(Symbol("foo"), foo => {
 
 bb.removeListener("file", (name, stream, info) => {
     name; // $ExpectType string
-    stream; // $ExpectType Readable & { truncated?: boolean }
+    stream; // $ExpectType Readable & { truncated?: boolean | undefined; }
     info; // $ExpectType FileInfo
 });
 bb.removeListener("field", (name, value, info) => {
@@ -153,7 +153,7 @@ bb.removeListener(Symbol("foo"), foo => {
 
 bb.off("file", (name, stream, info) => {
     name; // $ExpectType string
-    stream; // $ExpectType Readable & { truncated?: boolean }
+    stream; // $ExpectType Readable & { truncated?: boolean | undefined; }
     info; // $ExpectType FileInfo
 });
 bb.off("field", (name, value, info) => {
@@ -186,7 +186,7 @@ bb.off(Symbol("foo"), foo => {
 
 bb.prependListener("file", (name, stream, info) => {
     name; // $ExpectType string
-    stream; // $ExpectType Readable & { truncated?: boolean }
+    stream; // $ExpectType Readable & { truncated?: boolean | undefined; }
     info; // $ExpectType FileInfo
 });
 bb.prependListener("field", (name, value, info) => {
@@ -219,7 +219,7 @@ bb.prependListener(Symbol("foo"), foo => {
 
 bb.prependOnceListener("file", (name, stream, info) => {
     name; // $ExpectType string
-    stream; // $ExpectType Readable & { truncated?: boolean }
+    stream; // $ExpectType Readable & { truncated?: boolean | undefined; }
     info; // $ExpectType FileInfo
 });
 bb.prependOnceListener("field", (name, value, info) => {

--- a/types/busboy/index.d.ts
+++ b/types/busboy/index.d.ts
@@ -155,7 +155,7 @@ declare namespace busboy {
          * @param listener.transferEncoding Contains the 'Content-Transfer-Encoding' value for the file stream.
          * @param listener.mimeType Contains the 'Content-Type' value for the file stream.
          */
-        file: (name: string, stream: Readable, info: FileInfo) => void;
+        file: (name: string, stream: Readable & { truncated?: boolean }, info: FileInfo) => void;
 
         /**
          * Emitted for each new non-file field found.


### PR DESCRIPTION
The documentation above the modified mentions the existence of this property.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. **I skipped this because it’s a small change. Please bear with me 😅**
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request). **I used GitHub’s editing interface because it’s a small change. Please bear with me 😅**
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests). **I skipped this because I was using GitHub’s editing interface. It’s a small change and I trust the CI server to catch issues if they arise. Please bear with me 😅**

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/6c31c706695910736af0ee24a5724f3837bfcd9a/types/busboy/index.d.ts#L152-L153
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. **Does not apply.**

