### PR TITLE
[xrm] fix Xrm.Navigation.openFile

### DIFF
--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -5241,6 +5241,17 @@ declare namespace Xrm {
             text: string;
         }
 
+        /**
+         * An object describing whether to open or save the file
+         */
+        interface OpenFileOptions {
+            /**
+             * If you do not specify this parameter, by default 1 (open) is passed.
+             * This parameter is only supported on Unified Interface
+             */
+            openMode?: XrmEnum.OpenFileOptions
+        }
+
         interface DialogSizeOptions {
             /**
              * Height of the alert dialog in pixels.
@@ -5615,7 +5626,7 @@ declare namespace Xrm {
         /**
          * Opens a file.
          */
-        openFile(file: Navigation.FileDetails, openFileOptions?: XrmEnum.OpenFileOptions): void;
+        openFile(file: Navigation.FileDetails, openFileOptions?: Navigation.OpenFileOptions): void;
 
         /**
          * Opens an entity form or a quick create form.

--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -5249,7 +5249,7 @@ declare namespace Xrm {
              * If you do not specify this parameter, by default 1 (open) is passed.
              * This parameter is only supported on Unified Interface
              */
-            openMode?: XrmEnum.OpenFileOptions
+            openMode?: XrmEnum.OpenFileOptions;
         }
 
         interface DialogSizeOptions {

--- a/types/xrm/xrm-tests.ts
+++ b/types/xrm/xrm-tests.ts
@@ -626,3 +626,12 @@ optionSetControl.getOptions();
 // Demonstrates getOptions for Xrm.Controls.MultiSelectOptionSetControl
 // $ExpectType OptionSetValue[]
 multiSelectOptionSetControl.getOptions();
+
+const openFileSave = Xrm.Navigation.openFile({
+    fileContent: "",
+    fileName: "test.txt",
+    fileSize: 0,
+    mimeType: "text/plain",
+}, {
+    openMode: XrmEnum.OpenFileOptions.Save,
+});


### PR DESCRIPTION
parameter `openFileOptions` must have property `openMode` (and not directly enum value)

docs:
- https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/xrm-navigation/openfile

Mentioned  in https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/68991

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Xrm.Navigation.openFile](https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/xrm-navigation/openfile)
