### PR TITLE
[react-google-login-component] Remove usage of deprecated global React JSX namespace

### DIFF
--- a/types/react-google-login-component/react-google-login-component-tests.tsx
+++ b/types/react-google-login-component/react-google-login-component-tests.tsx
@@ -5,14 +5,14 @@ const handler = (response: GoogleLoginInfo) => {
     console.log(response.getAuthResponse().access_token);
 };
 
-const ReactGoogleLoginComponent: JSX.Element = (
+const ReactGoogleLoginComponent: React.JSX.Element = (
     <GoogleLogin
         socialId="1234567890000"
         responseHandler={handler}
     />
 );
 
-const ReactGoogleLoginComponentAllOptions: JSX.Element = (
+const ReactGoogleLoginComponentAllOptions: React.JSX.Element = (
     <GoogleLogin
         socialId="1234567890000"
         responseHandler={handler}


### PR DESCRIPTION
`JSX.*` is deprecated in favor of `React.JSX.*`