### PR TITLE
[react-timeago] Remove usage of deprecated global React JSX namespace

### DIFF
--- a/types/react-timeago/react-timeago-tests.tsx
+++ b/types/react-timeago/react-timeago-tests.tsx
@@ -56,7 +56,7 @@ const ReactTimeagoCustomComponent: React.JSX.Element = (
 
 const CustomJSXElement = ({ myProp }: { myProp: string }) => <div>{myProp}</div>;
 
-const ReactTimeagoCustomJSXElement: JSX.Element = (
+const ReactTimeagoCustomJSXElement: React.JSX.Element = (
     <ReactTimeago
         date={new Date()}
         component={CustomJSXElement}


### PR DESCRIPTION
`JSX.*` is deprecated in favor of `React.JSX.*`
