### PR TITLE
[react-instantsearch-core] Explicitly rely on `ReactElement<any>` in tests

### DIFF
--- a/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
+++ b/types/react-instantsearch-core/react-instantsearch-core-tests.tsx
@@ -709,7 +709,7 @@ import { Hits, RefinementList } from "react-instantsearch-dom";
 });
 
 (() => {
-    function getAttribute(component: React.ReactElement | number | string): string | undefined {
+    function getAttribute(component: React.ReactElement<any> | number | string): string | undefined {
         if (typeof component !== "object") {
             return undefined;
         }


### PR DESCRIPTION

In React 19, we'll default `element.props` to `unknown` which used to be `any`. However, your tests rely on the old behavior of defaulting to `any`.

To reduce the size of the React 19 types PR, I'll encode this behavior now.

Feel free to adjust your tests to leverage `unknown` now in a follow-up by explicitly using `ReactElement<unknown>`.
