### PR TITLE
[react-elemental] Explicitly rely on `ReactElement<any>` in tests

### DIFF
--- a/types/react-elemental/react-elemental-tests.tsx
+++ b/types/react-elemental/react-elemental-tests.tsx
@@ -46,7 +46,7 @@ class App extends React.Component {
                         value="s"
                         accentColor={colors.blue}
                         style={{ display: "flex" }}
-                        radioRenderer={(option) => (
+                        radioRenderer={(option: React.ReactElement<any>) => (
                             <Spacing key={option.props.value} right>
                                 {option}
                             </Spacing>


### PR DESCRIPTION
In React 19, we'll default `element.props` to `unknown`. However, your tests rely on the old behavior of defaulting to `any`.

To reduce the size of the React 19 types PR, I'll encode this behavior now.

Feel free to adjust your tests to leverage `unknown` now in a follow-up by explicitly using `ReactElement<unknown>`.
