### PR TITLE
[use-double-click] Use modern typings for refs

### DIFF
--- a/types/use-double-click/index.d.ts
+++ b/types/use-double-click/index.d.ts
@@ -1,8 +1,9 @@
-import { MouseEvent, MutableRefObject, RefObject } from "react";
+import { MouseEvent, RefObject } from "react";
 
+// eslint-disable-next-line @definitelytyped/no-unnecessary-generics -- Backwards compatibility. Can be removed in a Major release.
 declare function useDoubleClick<T = unknown>(options: {
     /** Dom node to watch for double clicks */
-    ref: RefObject<T> | MutableRefObject<T>;
+    ref: RefObject<T | null>;
     /** The amount of time (in milliseconds) to wait before differentiating a single from a double click. Defaults to 300. */
     latency?: number | undefined;
     /** A callback function for single click events */


### PR DESCRIPTION
In React 19, ref objects will only be typed through `RefObject`. We won't try to guess if it's mutable or not and every ref will be mutable by default because that's how `useRef` works.

We can encode this today with `RefObject<T | null>`.
