### PR TITLE
[react] Deprecate types that are related to the `prop-types` package

### DIFF
--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -50,6 +50,17 @@ export interface Requireable<T> extends Validator<T | undefined | null> {
 
 export type ValidationMap<T> = { [K in keyof T]?: Validator<T[K]> };
 
+/**
+ * Like {@link ValidationMap} but treats `undefined`, `null` and optional properties the same.
+ * This type is only added as a migration path in React 19 where this type was removed from React.
+ * Runtime and compile time types would mismatch since you could see `undefined` at runtime when your types don't expect this type.
+ */
+export type WeakValidationMap<T> = {
+    [K in keyof T]?: null extends T[K] ? Validator<T[K] | null | undefined>
+        : undefined extends T[K] ? Validator<T[K] | null | undefined>
+        : Validator<T[K]>;
+};
+
 export type InferType<V> = V extends Validator<infer T> ? T : any;
 export type InferProps<V> =
     & InferPropsInner<Pick<V, RequiredKeys<V>>>

--- a/types/prop-types/prop-types-tests.ts
+++ b/types/prop-types/prop-types-tests.ts
@@ -89,6 +89,17 @@ const propTypes: PropTypesMap = {
     component: PropTypes.elementType.isRequired,
 };
 
+const strongIncorrectPropTypes: PropTypes.ValidationMap<{ foo: number | null }> = {
+    // @ts-expect-error
+    foo: PropTypes.number,
+};
+const strongCorrectPropTypes: PropTypes.ValidationMap<{ foo: number | null | undefined }> = {
+    foo: PropTypes.number,
+};
+const weakPropTypes: PropTypes.WeakValidationMap<{ foo: number | null }> = {
+    foo: PropTypes.number,
+};
+
 // JS checking
 const propTypesWithoutAnnotation = {
     any: PropTypes.any,

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -4069,18 +4069,33 @@ declare namespace React {
     // React.PropTypes
     // ----------------------------------------------------------------------
 
+    /**
+     * @deprecated Use `Validator` from the ´prop-types` instead.
+     */
     type Validator<T> = PropTypes.Validator<T>;
 
+    /**
+     * @deprecated Use `Requireable` from the ´prop-types` instead.
+     */
     type Requireable<T> = PropTypes.Requireable<T>;
 
+    /**
+     * @deprecated Use `ValidationMap` from the ´prop-types` instead.
+     */
     type ValidationMap<T> = PropTypes.ValidationMap<T>;
 
+    /**
+     * @deprecated Use `WeakValidationMap` from the ´prop-types` instead.
+     */
     type WeakValidationMap<T> = {
         [K in keyof T]?: null extends T[K] ? Validator<T[K] | null | undefined>
             : undefined extends T[K] ? Validator<T[K] | null | undefined>
             : Validator<T[K]>;
     };
 
+    /**
+     * @deprecated Use `PropTypes.*` where `PropTypes` comes from `import * as PropTypes from 'prop-types'` instead.
+     */
     interface ReactPropTypes {
         any: typeof PropTypes.any;
         array: typeof PropTypes.array;

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -4070,18 +4070,33 @@ declare namespace React {
     // React.PropTypes
     // ----------------------------------------------------------------------
 
+    /**
+     * @deprecated Use `Validator` from the ´prop-types` instead.
+     */
     type Validator<T> = PropTypes.Validator<T>;
 
+    /**
+     * @deprecated Use `Requireable` from the ´prop-types` instead.
+     */
     type Requireable<T> = PropTypes.Requireable<T>;
 
+    /**
+     * @deprecated Use `ValidationMap` from the ´prop-types` instead.
+     */
     type ValidationMap<T> = PropTypes.ValidationMap<T>;
 
+    /**
+     * @deprecated Use `WeakValidationMap` from the ´prop-types` instead.
+     */
     type WeakValidationMap<T> = {
         [K in keyof T]?: null extends T[K] ? Validator<T[K] | null | undefined>
             : undefined extends T[K] ? Validator<T[K] | null | undefined>
             : Validator<T[K]>;
     };
 
+    /**
+     * @deprecated Use `PropTypes.*` where `PropTypes` comes from `import * as PropTypes from 'prop-types'` instead.
+     */
     interface ReactPropTypes {
         any: typeof PropTypes.any;
         array: typeof PropTypes.array;


### PR DESCRIPTION
React 19 will ignore `.propTypes` which means we no longer have any use for the types related to that.

Turns out that we don't even need most of the related types since these are just aliases to `prop-types` types. So if you use runtime validation with `prop-types` and TypeScript, you can continue using the relevant types from `prop-types` instead of `react`.

To ease migration, I ported the `WeakValidationMap` type which was introduced in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/31280.

The following types are deprecated:
- `WeakValidationMap`
- `ValidationMap`
- `Requireable`
- `Validator`
- `ReactPropTypes`

To keep using these types, the following diff is required (can be handled with the [`deprecated-react-prop-types-types` codemod](https://github.com/eps1lon/types-react-codemod#deprecated-prop-types-types)):

```diff
+import * as PropTypes from 'prop-types'

-React.WeakValidationMap;
+PropTypes.WeakValidationMap;

-React.ValidationMap;
+PropTypes.ValidationMap;

-React.Requireable;
+PropTypes.Requireable;

-React.Validator;
+PropTypes.Validator;
```

`ReactPropTypes` is deprecated without removal. You should pick the relevant validators from `PropTypes` instead.

Migration away from the deprecated types within DT is illustrated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69011 which I'll split out into one PR per package.