### PR TITLE
[@types/opossum]: Add `cacheGetKey` and `cacheTransport` options

### DIFF
--- a/types/opossum/index.d.ts
+++ b/types/opossum/index.d.ts
@@ -297,7 +297,7 @@ declare namespace CircuitBreaker {
          * @param {string} key Cache key
          * @returns Response from cache
          */
-        get<T>(key: string): T | undefined;
+        get(key: string): unknown | undefined;
 
         /**
          * Set cache key with value and ttl

--- a/types/opossum/index.d.ts
+++ b/types/opossum/index.d.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from "events";
 declare class CircuitBreaker<TI extends unknown[] = unknown[], TR = unknown> extends EventEmitter {
     static isOurError(error: any): boolean;
 
-    constructor(action: (...args: TI) => Promise<TR>, options?: CircuitBreaker.Options);
+    constructor(action: (...args: TI) => Promise<TR>, options?: CircuitBreaker.Options<TI>);
 
     readonly name: string;
     readonly group: string;
@@ -113,7 +113,7 @@ declare class CircuitBreaker<TI extends unknown[] = unknown[], TR = unknown> ext
 }
 
 declare namespace CircuitBreaker {
-    interface Options {
+    interface Options<TI extends unknown[] = unknown[]> {
         /**
          * The time in milliseconds that action should be allowed to execute before timing out.
          * Timeout can be disabled by setting this to `false`.
@@ -228,6 +228,19 @@ declare namespace CircuitBreaker {
         cacheTTL?: number;
 
         /**
+         * An optional function that will be called to generate a cache key for the circuit's function.
+         * The function is passed the original `fire` arguments. If no `cacheKey` function is supplied, a JSON.stringify of the arguments will be used as the key.
+         * @default (...args) => JSON.stringify(args)
+         */
+        cacheGetKey?: ((...args: TI) => string) | undefined;
+
+        /**
+         * Transport for cache storage. By default, the cache is stored in memory.
+         * If a cacheTransport is provided, the cache will be stored there instead.
+         */
+        cacheTransport?: CacheTransport | undefined;
+
+        /**
          * Whether to enable the periodic snapshots that are emitted by the Status class.
          * Passing false will result in snapshots not being emitted
          * @default true
@@ -276,6 +289,28 @@ declare namespace CircuitBreaker {
         warmUp: boolean;
         shutdown: boolean;
         lastTimerAt: symbol;
+    }
+
+    interface CacheTransport {
+        /**
+         * Get cache value by key
+         * @param {string} key Cache key
+         * @returns Response from cache
+         */
+        get<T>(key: string): T | undefined;
+
+        /**
+         * Set cache key with value and ttl
+         * @param {string} key Cache key
+         * @param {any} value Value to cache
+         * @param {number} ttl Time to live in milliseconds
+         */
+        set(key: string, value: any, ttl: number): void;
+
+        /**
+         * Clear cache
+         */
+        flush(): void;
     }
 }
 

--- a/types/opossum/opossum-tests.ts
+++ b/types/opossum/opossum-tests.ts
@@ -23,6 +23,12 @@ breaker = new CircuitBreaker(async () => true, {
     volumeThreshold: 1,
     cache: true,
     cacheTTL: 100,
+    cacheGetKey: (...args) => JSON.stringify(args),
+    cacheTransport: {
+        get: (key) => key,
+        set: (key, value, ttl) => {},
+        flush: () => {},
+    },
     errorFilter: (err) => {
         err; // $ExpectType any
         return true;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [cacheGetKey](https://github.com/nodeshift/opossum/blob/99481d588970491bd5ead09f7fd10fdd63c7fd2f/lib/circuit.js#L91) and [cacheTransport](https://github.com/nodeshift/opossum/blob/99481d588970491bd5ead09f7fd10fdd63c7fd2f/lib/circuit.js#L96)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
