### PR TITLE
@wordpress/block-editor: add missing `templateLock` option

### DIFF
--- a/types/wordpress__block-editor/components/inner-blocks.d.ts
+++ b/types/wordpress__block-editor/components/inner-blocks.d.ts
@@ -29,11 +29,13 @@ declare namespace InnerBlocks {
         /**
          * Template locking allows locking the `InnerBlocks` area for the current template.
          *
+         * - `'contentOnly'` — prevents all operations. Additionally, the block types that don't have content are hidden from the list view and can't gain focus within the block list. Unlike the other lock types, this is not overrideable by children.
          * - `'all'` — prevents all operations. It is not possible to insert new blocks. Move existing blocks or delete them.
          * - `'insert'` — prevents inserting or removing blocks, but allows moving existing ones.
          * - `false` — prevents locking from being applied to an `InnerBlocks` area even if a parent block contains locking.
          *
          * If locking is not set in an `InnerBlocks` area: the locking of the parent `InnerBlocks` area is used.
+         * Note that contentOnly can't be overridden: it's present, the templateLock value of any children is ignored.
          *
          * If the block is a top level block: the locking of the Custom Post Type is used.
          */

--- a/types/wordpress__block-editor/index.d.ts
+++ b/types/wordpress__block-editor/index.d.ts
@@ -20,7 +20,7 @@ export const store: BlockEditorStoreDescriptor;
 
 export type EditorBlockMode = "html" | "visual";
 export type EditorMode = "text" | "visual";
-export type EditorTemplateLock = "all" | "insert" | false;
+export type EditorTemplateLock = "contentOnly" | "all" | "insert" | false;
 
 export interface EditorBaseSetting {
     name: string;

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -202,6 +202,7 @@ be.withFontSizes("fontSize")(() => <h1>Hello World</h1>);
 <be.InnerBlocks renderAppender={be.InnerBlocks.ButtonBlockAppender} />;
 <be.InnerBlocks.Content />;
 <be.InnerBlocks.DefaultBlockAppender />;
+<be.InnerBlocks templateLock="all" />;
 
 //
 // inserter


### PR DESCRIPTION
Added `contentOnly` option: https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/inner-blocks/README.md#templatelock
