### PR TITLE
[@types/k6] fix typo in Redis method name `lpush`

### DIFF
--- a/types/k6/experimental/redis.d.ts
+++ b/types/k6/experimental/redis.d.ts
@@ -238,7 +238,7 @@ export class Client {
      * @param values - values to prepend to the list
      * @returns a promise that resolves to the number of elements in the list after the prepend operation.
      */
-    lpsuh(key: string, ...values: Array<string | number | boolean>): Promise<number>;
+    lpush(key: string, ...values: Array<string | number | boolean>): Promise<number>;
 
     /**
      * Appends values to a list, creating the list if it does not already exist.

--- a/types/k6/test/redis.ts
+++ b/types/k6/test/redis.ts
@@ -217,15 +217,15 @@ redisClient.persist();
 redisClient.persist(5);
 
 //
-// Client.lpsuh
+// Client.lpush
 //
 
 // @ts-expect-error
-redisClient.lpsuh();
+redisClient.lpush();
 // @ts-expect-error
-redisClient.lpsuh(5);
+redisClient.lpush(5);
 // @ts-expect-error
-redisClient.lpsuh("key", { name: "value" });
+redisClient.lpush("key", { name: "value" });
 
 //
 // Client.rpush


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://redis.io/commands/lpush/>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

I noticed a small typo of method name in the k6 package. The correct method name should be `lpush` instead of `lpsuh` based on the following document. 

- Redis documentation: https://redis.io/commands/lpush/
- k6 documentation: https://grafana.com/docs/k6/latest/javascript-api/k6-experimental/redis/client/client-lpush/

So I've fixed the necessary corrections.

Actually, when I executed the following methods: 

```
import redis from 'k6/experimental/redis'
const client = new redis.Client('redis://localhost:6379')

client.lpsuh('mylist', 'item')
```

I encountered the following error: 

>ERRO[0001] Uncaught (in promise) TypeError: Object has no member 'lpsuh'

However, the correct method name, `lpush`, worked well when executed:

```
client.lpush('mylist', 'item')
```

Best regards,