### PR TITLE
[OvenPlayer] Fix volumeChanged eventData fields

### DIFF
--- a/types/ovenplayer/index.d.ts
+++ b/types/ovenplayer/index.d.ts
@@ -302,7 +302,12 @@ interface OvenPlayerEvents {
     /** New volume percentage (0-100) */
     mute: number;
     /** New volume percentage (0-100) */
-    volumeChanged: number;
+    volumeChanged: {
+        /** New volume percentage (0-100) */
+        volume: number;
+        /** True if the volume is muted, false otherwise. */
+        mute: boolean;
+    };
     /** index of the new playlist index */
     playlistChanged: number;
     /** index of the new quality level in the getSources() array */

--- a/types/ovenplayer/ovenplayer-tests.ts
+++ b/types/ovenplayer/ovenplayer-tests.ts
@@ -171,6 +171,13 @@ player.on("ready", () => {});
 // once (evnetName: 'stateChanged', callback: (eventData: OvenPlayerEvents['stateChanged']) => void): void;
 player.once("stateChanged", data => {});
 
+player.on("volumeChanged", data => {
+    // $ExpectType number
+    data.volume;
+    // $ExpectType boolean
+    data.mute;
+});
+
 // off(eventName: keyof OvenPlayerEvents): void;
 player.off("ready");
 


### PR DESCRIPTION
The eventData for volumeChanged is documented incorrectly. The [website](https://airensoft.gitbook.io/ovenplayer/api-reference/events#on-volumechanged) says it is just a number, but actually it is an object with fields volume and muted.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.


