### PR TITLE
[aws-synthetics-puppeteer] Replaced deprecated @types/puppeteer

### DIFF
--- a/types/aws-synthetics-puppeteer/aws-synthetics-puppeteer-tests.ts
+++ b/types/aws-synthetics-puppeteer/aws-synthetics-puppeteer-tests.ts
@@ -3,6 +3,7 @@ import * as synthetics from "Synthetics";
 export const handler = async () => {
     const page = synthetics.getPage();
     await page.goto("https://example.com");
+    await page.waitForFrame("https://example.com");
     await page.screenshot({ path: "/tmp/example.png" });
 };
 

--- a/types/aws-synthetics-puppeteer/package.json
+++ b/types/aws-synthetics-puppeteer/package.json
@@ -9,7 +9,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "@types/puppeteer": "^5.4.0",
+        "puppeteer-core": "21.11.0",
         "aws-xray-sdk-core": "=3.3.1"
     },
     "devDependencies": {

--- a/types/aws-synthetics-puppeteer/src/Synthetics.d.ts
+++ b/types/aws-synthetics-puppeteer/src/Synthetics.d.ts
@@ -222,7 +222,7 @@ declare module "Synthetics" {
             launchTime?: number,
         ): string;
     }
-    import * as localPuppeteer from "puppeteer";
+    import * as localPuppeteer from "puppeteer-core";
     import * as RequestResponseLogHelper_1 from "RequestResponseLogHelper";
     import RequestResponseLogHelper = RequestResponseLogHelper_1.RequestResponseLogHelper;
     import * as SyntheticsMetricEmitter_1 from "SyntheticsMetricEmitter";


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - deprecated `@types/puppeteer`: https://www.npmjs.com/package/@types/puppeteer
  - current Synthetics runtime using `Puppeteer-core version 21.9.0`: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Library_nodejs_puppeteer.html#CloudWatch_Synthetics_runtimeversion-nodejs-puppeteer-7.0
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
