### PR TITLE
[@types/splunk-logging] Remove extraneous dependency of request

### DIFF
--- a/types/splunk-bunyan-logger/splunk-bunyan-logger-tests.ts
+++ b/types/splunk-bunyan-logger/splunk-bunyan-logger-tests.ts
@@ -8,8 +8,6 @@ const config = {
 };
 
 const splunkStream = createStream(config);
-// Enable SSL certificate validation
-splunkStream.stream.logger.requestOptions.strictSSL = true;
 
 splunkStream.on("error", (err, context) => {
     // Handle errors here

--- a/types/splunk-logging/index.d.ts
+++ b/types/splunk-logging/index.d.ts
@@ -1,5 +1,3 @@
-import { CoreOptions as RequestOptions } from "request";
-
 export interface Config {
     token: string;
     name?: string | undefined;
@@ -35,7 +33,6 @@ export type EventFormatter = (message: any, severity: string) => any;
 export class Logger {
     error: (error: Error, context: SendContext) => void;
     eventFormatter: EventFormatter;
-    requestOptions: RequestOptions;
     readonly serializedContextQueue: any[];
 
     constructor(config: Config);

--- a/types/splunk-logging/package.json
+++ b/types/splunk-logging/package.json
@@ -5,9 +5,6 @@
     "projects": [
         "http://dev.splunk.com"
     ],
-    "dependencies": {
-        "@types/request": "*"
-    },
     "devDependencies": {
         "@types/splunk-logging": "workspace:."
     },

--- a/types/splunk-logging/splunk-logging-tests.ts
+++ b/types/splunk-logging/splunk-logging-tests.ts
@@ -6,7 +6,6 @@ const config = {
 };
 
 const logger = new Logger(config);
-logger.requestOptions.strictSSL = true;
 logger.eventFormatter = (msg, sev) => ({});
 logger.error = (err, context) => {
     context.message;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://github.com/splunk/splunk-javascript-logging/commit/376f1eca513d867a776a34b1228cdb995b59bb4d#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L35)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

The `request` dependency has long been removed from `splunk-logging` but it's still marked as a dependency in `@types` which is causing warnings with dependabot.