### PR TITLE
Revert "[@types/react] fix: remove onPointerEnterCapture & onPointerLeaveCapture (#68984)"

### DIFF
--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -1522,8 +1522,16 @@ declare namespace React {
         onPointerCancel?: PointerEventHandler<T> | undefined;
         onPointerCancelCapture?: PointerEventHandler<T> | undefined;
         onPointerEnter?: PointerEventHandler<T> | undefined;
+        /**
+         * @deprecated This event handler was always ignored by React. It was added by mistake to the types.
+         */
+        // Removing this breaks too many libraries to be worth it.
         onPointerEnterCapture?: PointerEventHandler<T> | undefined;
         onPointerLeave?: PointerEventHandler<T> | undefined;
+        /**
+         * @deprecated This event handler was always ignored by React. It was added by mistake to the types.
+         */
+        // Removing this breaks too many libraries to be worth it.
         onPointerLeaveCapture?: PointerEventHandler<T> | undefined;
         onPointerOver?: PointerEventHandler<T> | undefined;
         onPointerOverCapture?: PointerEventHandler<T> | undefined;

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -1522,7 +1522,9 @@ declare namespace React {
         onPointerCancel?: PointerEventHandler<T> | undefined;
         onPointerCancelCapture?: PointerEventHandler<T> | undefined;
         onPointerEnter?: PointerEventHandler<T> | undefined;
+        onPointerEnterCapture?: PointerEventHandler<T> | undefined;
         onPointerLeave?: PointerEventHandler<T> | undefined;
+        onPointerLeaveCapture?: PointerEventHandler<T> | undefined;
         onPointerOver?: PointerEventHandler<T> | undefined;
         onPointerOverCapture?: PointerEventHandler<T> | undefined;
         onPointerOut?: PointerEventHandler<T> | undefined;

--- a/types/react/v17/index.d.ts
+++ b/types/react/v17/index.d.ts
@@ -1522,8 +1522,16 @@ declare namespace React {
         onPointerCancel?: PointerEventHandler<T> | undefined;
         onPointerCancelCapture?: PointerEventHandler<T> | undefined;
         onPointerEnter?: PointerEventHandler<T> | undefined;
+        /**
+         * @deprecated This event handler was always ignored by React. It was added by mistake to the types.
+         */
+        // Removing this breaks too many libraries to be worth it.
         onPointerEnterCapture?: PointerEventHandler<T> | undefined;
         onPointerLeave?: PointerEventHandler<T> | undefined;
+        /**
+         * @deprecated This event handler was always ignored by React. It was added by mistake to the types.
+         */
+        // Removing this breaks too many libraries to be worth it.
         onPointerLeaveCapture?: PointerEventHandler<T> | undefined;
         onPointerOver?: PointerEventHandler<T> | undefined;
         onPointerOverCapture?: PointerEventHandler<T> | undefined;

--- a/types/react/v17/index.d.ts
+++ b/types/react/v17/index.d.ts
@@ -1522,7 +1522,9 @@ declare namespace React {
         onPointerCancel?: PointerEventHandler<T> | undefined;
         onPointerCancelCapture?: PointerEventHandler<T> | undefined;
         onPointerEnter?: PointerEventHandler<T> | undefined;
+        onPointerEnterCapture?: PointerEventHandler<T> | undefined;
         onPointerLeave?: PointerEventHandler<T> | undefined;
+        onPointerLeaveCapture?: PointerEventHandler<T> | undefined;
         onPointerOver?: PointerEventHandler<T> | undefined;
         onPointerOverCapture?: PointerEventHandler<T> | undefined;
         onPointerOut?: PointerEventHandler<T> | undefined;


### PR DESCRIPTION
This reverts commit 73b5985432df63aa8724c9bfe257c5f3dbbebfcd for older versions in favor of a deprecation notice. It breaks too much of the ecosystem to be worth it. Backports should be reserved for critical bug fixes e.g. a behavior change of TypeScript.

Closes https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69006