### PR TITLE
Add gulp/grunt interfaces for @types/google-closure-compiler

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -953,7 +953,6 @@
         "google-ads-scripts",
         "google-adwords-scripts",
         "google-apps-script-oauth2",
-        "google-closure-compiler",
         "google-cloud__datastore",
         "google-drive-realtime-api",
         "google-earth",

--- a/types/google-closure-compiler/google-closure-compiler-tests.ts
+++ b/types/google-closure-compiler/google-closure-compiler-tests.ts
@@ -1,4 +1,5 @@
 import * as GoogleClosureCompiler from "google-closure-compiler";
+import grunt from "grunt";
 
 // See
 //   https://github.com/chadkillingsworth/closure-compiler-npm#plugin-authors-and-native-node-usage
@@ -33,3 +34,86 @@ let optionsFormats: GoogleClosureCompiler.CompileOptions = {
     js_output_file: "out.js",
     debug: true,
 };
+
+// Gulp plugin examples from
+//   https://github.com/google/closure-compiler-npm/blob/master/packages/google-closure-compiler/docs/gulp.md
+
+const gulpCompiler = GoogleClosureCompiler.gulp({
+    extraArguments: ["-Xms2048m"],
+});
+
+// $ExpectType CompilationStream
+gulpCompiler({
+    compilation_level: "SIMPLE",
+    warning_level: "VERBOSE",
+    language_in: "ECMASCRIPT6_STRICT",
+    language_out: "ECMASCRIPT5_STRICT",
+    output_wrapper: "(function(){\n%output%\n}).call(this)",
+    js_output_file: "output.min.js",
+}, {
+    platform: ["native", "java", "javascript"],
+});
+
+gulpCompiler({
+    js: "./src/js/**.js",
+    externs: GoogleClosureCompiler.compiler.CONTRIB_PATH + "/externs/jquery-1.9.js",
+    compilation_level: "SIMPLE",
+    warning_level: "VERBOSE",
+    language_in: "ECMASCRIPT6_STRICT",
+    language_out: "ECMASCRIPT5_STRICT",
+    output_wrapper: "(function(){\n%output%\n}).call(this)",
+    js_output_file: "output.min.js",
+})
+    .src() // needed to force the plugin to run without gulp.src
+    .pipe(null!);
+
+// Grunt plugin examples from
+//   https://github.com/google/closure-compiler-npm/blob/master/packages/google-closure-compiler/docs/grunt.md
+
+// with options...
+GoogleClosureCompiler.grunt(grunt, {
+    platform: ["native", "java", "javascript"],
+    extraArguments: ["-Xms2048m"],
+    max_parallel_compilations: require("os").cpus().length,
+});
+// or without options
+GoogleClosureCompiler.grunt(grunt);
+
+// but make sure to pass the grunt instance
+// @ts-expect-error
+GoogleClosureCompiler.grunt(console);
+
+grunt.initConfig({
+    "closure-compiler": {
+        my_target: {
+            files: {
+                "dest/output.min.js": ["src/js/**/*.js"],
+            },
+            options: {
+                compilation_level: "SIMPLE",
+                language_in: "ECMASCRIPT5_STRICT",
+                create_source_map: "dest/output.min.js.map",
+                output_wrapper: "(function(){\n%output%\n}).call(this)\n//# sourceMappingURL=output.min.js.map",
+            },
+        },
+    },
+});
+
+grunt.initConfig({
+    "closure-compiler": {
+        my_target: {
+            files: {
+                "dest/output.min.js": ["src/js/**/*.js"],
+            },
+            options: {
+                js: "/node_modules/google-closure-library/**.js",
+                externs: GoogleClosureCompiler.compiler.CONTRIB_PATH + "/externs/jquery-1.9.js",
+                compilation_level: "SIMPLE",
+                manage_closure_dependencies: true,
+                language_in: "ECMASCRIPT5_STRICT",
+                create_source_map: "dest/output.min.js.map",
+                output_wrapper: "(function(){\n%output%\n}).call(this)\n//# sourceMappingURL=output.min.js.map",
+            },
+        },
+    },
+});

--- a/types/google-closure-compiler/index.d.ts
+++ b/types/google-closure-compiler/index.d.ts
@@ -33,3 +33,58 @@ export var compiler: {
     COMPILER_PATH: string;
     CONTRIB_PATH: string;
 };
+
+interface GulpInitOptions {
+    extraArguments?: string[];
+}
+type LogFunction = (message: string) => void;
+interface GulpPluginOptions {
+    streamMode?: string;
+    logger?: LogFunction | { warn: LogFunction };
+    pluginName?: string;
+    requireStreamInput?: boolean;
+    platform?: string | string[];
+}
+type Transform = import("stream").Transform;
+interface CompilationStream extends Transform {
+    platform: string;
+    src(): this;
+}
+export function gulp(
+    initOptions?: GulpInitOptions,
+): (opts: CompileOptions, pluginOpts?: GulpPluginOptions) => CompilationStream;
+
+// Creating PartialIGrunt as a sparse replica of import("grunt").IGrunt, because there's no reason to add the
+// full grunt types package as a hard dependency of google-closure-compiler. The actual IGrunt will find its
+// way into these type definitions when it is passed in as a generic parameter to the grunt() function below,
+// and that will ensure that type-safety is maintained even in the face of a Grunt API change.
+interface PartialIGrunt {
+    registerMultiTask(
+        taskName: string,
+        taskDescription: string,
+        taskFunction: (this: any, ...args: any[]) => void,
+    ): void;
+    file: {
+        write(filepath: string, contents: string | Buffer): void;
+    };
+    log: {
+        ok(msg: string): any;
+        warn(msg: string): any;
+    };
+    fail: {
+        warn(error: string): void;
+    };
+}
+type GruntTaskFunction<IGrunt extends PartialIGrunt> = Parameters<IGrunt["registerMultiTask"]>[2];
+type GruntPluginOptions = string[] | {
+    platform?: string | string[];
+    extraArguments?: string[];
+    max_parallel_compilations?: number;
+    /** @deprecated */
+    compile_in_batches?: number;
+};
+
+export function grunt<IGrunt extends PartialIGrunt>(
+    grunt: IGrunt,
+    pluginOptions?: GruntPluginOptions,
+): GruntTaskFunction<IGrunt>;

--- a/types/google-closure-compiler/package.json
+++ b/types/google-closure-compiler/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/google-closure-compiler",
-    "version": "0.0.9999",
+    "version": "20231112.0.9999",
     "projects": [
         "https://github.com/chadkillingsworth/closure-compiler-npm"
     ],
@@ -9,6 +9,7 @@
         "@types/node": "*"
     },
     "devDependencies": {
+        "@types/grunt": "*",
         "@types/google-closure-compiler": "workspace:."
     },
     "owners": [

--- a/types/google-closure-compiler/package.json
+++ b/types/google-closure-compiler/package.json
@@ -14,7 +14,7 @@
     },
     "owners": [
         {
-            "name": "Evan Martin (http://neugierig.org)",
+            "name": "Evan Martin",
             "githubUsername": "evmar"
         },
         {

--- a/types/google-closure-compiler/package.json
+++ b/types/google-closure-compiler/package.json
@@ -15,7 +15,12 @@
     "owners": [
         {
             "name": "Evan Martin",
+            "githubUsername": "evmar",
             "url": "http://neugierig.org"
+        },
+        {
+            "name": "Danielle Church",
+            "githubUsername": "dmchurch"
         }
     ]
 }

--- a/types/google-closure-compiler/package.json
+++ b/types/google-closure-compiler/package.json
@@ -14,9 +14,8 @@
     },
     "owners": [
         {
-            "name": "Evan Martin",
-            "githubUsername": "evmar",
-            "url": "http://neugierig.org"
+            "name": "Evan Martin (http://neugierig.org)",
+            "githubUsername": "evmar"
         },
         {
             "name": "Danielle Church",


### PR DESCRIPTION
The google-closure-compiler definition files are missing the bundled gulp/grunt plugins, this adds them. The only thing that might be unusual about this PR is that I've added the grunt type definitions as a `devDependency` rather than a `dependency`, since I wrote the definitions in a way that doesn't directly reference the grunt types. Standard checklist follows:

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/google/closure-compiler-npm/blob/master/packages/google-closure-compiler/docs/gulp.md and https://github.com/google/closure-compiler-npm/blob/master/packages/google-closure-compiler/docs/grunt.md
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
