### PR TITLE
[@types/next-pwa] Move some dependencies to peerDependencies

### DIFF
--- a/types/next-pwa/package.json
+++ b/types/next-pwa/package.json
@@ -9,12 +9,16 @@
     "dependencies": {
         "@types/node": "*",
         "@types/react": "*",
-        "@types/react-dom": "*",
-        "next": "^12.2.5 || ^13.0.0",
-        "workbox-build": "^6.5.4"
+        "@types/react-dom": "*"
     },
     "devDependencies": {
-        "@types/next-pwa": "workspace:."
+        "@types/next-pwa": "workspace:.",
+        "next": "^12.2.5 || ^13.0.0 || ^14.0.0",
+        "workbox-build": "^6.5.4"
+    },
+    "peerDependencies": {
+        "next": "^12.2.5 || ^13.0.0 || ^14.0.0",
+        "workbox-build": "^6.5.4"        
     },
     "owners": [
         {


### PR DESCRIPTION
This PR moves `next` and `workbox-build` from `dependencies` to `peerDependencies`. The origin `next-pwa` package puts `next` in the `peerDependencies` ([link](https://unpkg.com/next-pwa@5.6.0/package.json)) so `@types/next-pwa` should too. 

This PR also allows `next` version 14. The origin `next-pwa` requires `"next": ">=9.0.0"` so this change should be valid. 

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://unpkg.com/next-pwa@5.6.0/package.json
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
