### PR TITLE
Revert "Put `asserts` on various `assert*` functions in chai."

### DIFF
--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -1465,8 +1465,6 @@ class CrashyObject {
     }
 }
 
-declare function foobar<T>(): T;
-
 suite("assert", () => {
     test("assert", () => {
         const foo = "bar" as string;
@@ -1539,10 +1537,6 @@ suite("assert", () => {
         assert.instanceOf(new Foo(), Foo);
         assert.instanceOf(5, Foo);
         assert.instanceOf(new CrashyObject(), CrashyObject);
-
-        const value = foobar<Foo | null>();
-        assert.instanceOf(value, Foo);
-        const fooValue: Foo = value;
     });
 
     test("notInstanceOf", () => {
@@ -1662,37 +1656,21 @@ suite("assert", () => {
     test("isNull", () => {
         assert.isNull(null);
         assert.isNull(undefined);
-
-        const value = foobar<string | null>();
-        assert.isNull(value);
-        const nullValue: null = value;
     });
 
     test("isNotNull", () => {
         assert.isNotNull(undefined);
         assert.isNotNull(null);
-
-        const value = foobar<number | null>();
-        assert.isNotNull(value);
-        const numberValue: number = value;
     });
 
     test("isUndefined", () => {
         assert.isUndefined(undefined);
         assert.isUndefined(null);
-
-        const value = foobar<undefined | number>();
-        assert.isUndefined(value);
-        const undefinedValue: undefined = value;
     });
 
     test("isDefined", () => {
         assert.isDefined(null);
         assert.isDefined(undefined);
-
-        const value = foobar<undefined | number>();
-        assert.isDefined(value);
-        const definedValue: number = value;
     });
 
     test("isNaN", () => {
@@ -1759,20 +1737,12 @@ suite("assert", () => {
         assert.isBoolean(true);
         assert.isBoolean(false);
         assert.isBoolean("1");
-
-        const value = foobar<boolean | string>();
-        assert.isBoolean(value);
-        const booleanValue: boolean = value;
     });
 
     test("isNotBoolean", () => {
         assert.isNotBoolean("true");
         assert.isNotBoolean(true);
         assert.isNotBoolean(false);
-
-        const value = foobar<boolean | string>();
-        assert.isNotBoolean(value);
-        const stringValue: string = value;
     });
 
     test("include", () => {

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -9,10 +9,6 @@ declare namespace Chai {
         exists: boolean;
     }
 
-    interface Constructor<T> {
-        new(...args: any[]): T;
-    }
-
     interface ErrorConstructor {
         new(...args: any[]): Error;
     }
@@ -599,10 +595,11 @@ declare namespace Chai {
         /**
          * Asserts that value is null.
          *
+         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isNull(value: unknown, message?: string): asserts value is null;
+        isNull<T>(value: T, message?: string): void;
 
         /**
          * Asserts that value is not null.
@@ -611,7 +608,7 @@ declare namespace Chai {
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isNotNull<T>(value: T, message?: string): asserts value is Exclude<T, null>;
+        isNotNull<T>(value: T, message?: string): void;
 
         /**
          * Asserts that value is NaN.
@@ -656,7 +653,7 @@ declare namespace Chai {
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isUndefined<T>(value: T | undefined, message?: string): asserts value is undefined;
+        isUndefined<T>(value: T, message?: string): void;
 
         /**
          * Asserts that value is not undefined.
@@ -665,7 +662,7 @@ declare namespace Chai {
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isDefined<T>(value: T, message?: string): asserts value is Exclude<T, undefined>;
+        isDefined<T>(value: T, message?: string): void;
 
         /**
          * Asserts that value is a function.
@@ -773,10 +770,11 @@ declare namespace Chai {
         /**
          * Asserts that value is a boolean.
          *
+         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isBoolean(value: unknown, message?: string): asserts value is boolean;
+        isBoolean<T>(value: T, message?: string): void;
 
         /**
          * Asserts that value is not a boolean.
@@ -785,7 +783,7 @@ declare namespace Chai {
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isNotBoolean<T>(value: T, message?: string): asserts value is Exclude<T, boolean>;
+        isNotBoolean<T>(value: T, message?: string): void;
 
         /**
          * Asserts that value's type is name, as determined by Object.prototype.toString.
@@ -810,12 +808,12 @@ declare namespace Chai {
         /**
          * Asserts that value is an instance of constructor.
          *
-         * T   Expected type of value.
+         * T   Type of value.
          * @param value   Actual value.
          * @param constructor   Potential expected contructor of value.
          * @param message   Message to display on error.
          */
-        instanceOf<T>(value: unknown, constructor: Constructor<T>, message?: string): asserts value is T;
+        instanceOf<T>(value: T, constructor: Function, message?: string): void;
 
         /**
          * Asserts that value is not an instance of constructor.


### PR DESCRIPTION
Reverts DefinitelyTyped/DefinitelyTyped#68780

This seems to lead to some unhappiness because of current TypeScript limitations ("Assertions require every name in the call target to be declared with an explicit type annotation."). I'll try to prepare a subset of these changes and send another PR instead.