### PR TITLE
[@uswds/uswds]: Synchronize exports across entrypoints, bump to 3.8.0

### DIFF
--- a/types/uswds__uswds/index.d.ts
+++ b/types/uswds__uswds/index.d.ts
@@ -1,6 +1,7 @@
 import {
     accordion,
     banner,
+    button,
     characterCount,
     comboBox,
     datePicker,
@@ -14,6 +15,7 @@ import {
     modal,
     navigation,
     password,
+    range,
     search,
     skipnav,
     table,
@@ -25,6 +27,7 @@ import {
 export {
     accordion,
     banner,
+    button,
     characterCount,
     comboBox,
     datePicker,
@@ -38,6 +41,7 @@ export {
     modal,
     navigation,
     password,
+    range,
     search,
     skipnav,
     table,

--- a/types/uswds__uswds/package.json
+++ b/types/uswds__uswds/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/uswds__uswds",
-    "version": "3.7.9999",
+    "version": "3.8.9999",
     "projects": [
         "https://github.com/uswds/uswds"
     ],

--- a/types/uswds__uswds/src/js/components/index.d.ts
+++ b/types/uswds__uswds/src/js/components/index.d.ts
@@ -1,6 +1,7 @@
 import {
     accordion,
     banner,
+    button,
     characterCount,
     comboBox,
     datePicker,
@@ -14,6 +15,7 @@ import {
     modal,
     navigation,
     password,
+    range,
     search,
     skipnav,
     table,
@@ -25,6 +27,7 @@ import {
 export {
     accordion,
     banner,
+    button,
     characterCount,
     comboBox,
     datePicker,
@@ -38,6 +41,7 @@ export {
     modal,
     navigation,
     password,
+    range,
     search,
     skipnav,
     table,

--- a/types/uswds__uswds/uswds__uswds-tests.ts
+++ b/types/uswds__uswds/uswds__uswds-tests.ts
@@ -1,4 +1,8 @@
-import {
+import * as components from "@uswds/uswds/js";
+
+type ComponentKey = keyof typeof components;
+
+const {
     accordion,
     banner,
     button,
@@ -22,7 +26,7 @@ import {
     timePicker,
     tooltip,
     validator,
-} from "@uswds/uswds/js";
+} = components;
 
 const element = document.createElement("div");
 const buttonElement = document.createElement("button");
@@ -316,3 +320,30 @@ validator.on(); // $ExpectType void
 validator.on(element); // $ExpectType void
 validator.off(); // $ExpectType void
 validator.off(element); // $ExpectType void
+
+// Common Interface
+Object.keys(components).forEach((key) => {
+    const component = components[key as ComponentKey];
+    component.on(); // $ExpectType void
+    component.on(element); // $ExpectType void
+    component.off(); // $ExpectType void
+    component.off(element); // $ExpectType void
+});
+import("@uswds/uswds").then((imports) => {
+    Object.keys(components).forEach((key) => {
+        const component = imports[key as ComponentKey];
+        component.on(); // $ExpectType void
+        component.on(element); // $ExpectType void
+        component.off(); // $ExpectType void
+        component.off(element); // $ExpectType void
+    });
+});
+import("@uswds/uswds/src/js/components").then((imports) => {
+    Object.keys(components).forEach((key) => {
+        const component = imports[key as ComponentKey];
+        component.on(); // $ExpectType void
+        component.on(element); // $ExpectType void
+        component.off(); // $ExpectType void
+        component.off(element); // $ExpectType void
+    });
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   - Per https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68863#issuecomment-1974151251, these were missed in #68863 updates, exports meant to be kept in sync across 3 distinct entrypoints (`.`, `./js`, and `./src/js/components`)
   -  [`./src/js/components` references `uswds-core/src/js/index.js`](https://github.com/uswds/uswds/blob/98566ec5dc12807a2b0bc36699a033fe3a711d44/package.json#L37)
   - `.` entrypoint does not technically exist, mentioned in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68863#issuecomment-1974151251, but updated here for consistency / backwards-compatibility
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
   - Updated from `3.7.9999` to `3.8.9999` 
      - 3.8.0 release: https://github.com/uswds/uswds/releases/tag/v3.8.0
      - Manually inspected diff for no API changes: `git diff v3.7.0 v3.8.0 -- packages/**/*.js ':(exclude)*.stories.js' ':(exclude)*.spec.js'`
