### PR TITLE
Use deploy key instead of PAT to run dprint

### DIFF
--- a/.github/workflows/format-and-commit.yml
+++ b/.github/workflows/format-and-commit.yml
@@ -16,8 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
-          # Use the bot token so that CI triggers on pushes; we want to know if formatting broke something.
-          token: ${{ secrets.GH_DT_MERGEBOT_TOKEN }}
+          # Use a deploy key so that CI triggers on pushes; we want to know if formatting broke something.
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: '20'


### PR DESCRIPTION
Using `secrets.GITHUB_TOKEN` does not trigger workflows to prevent cycles, but we want to run tests on push, hence using a PAT for pushing.

Instead of the PAT, use a deploy key that is tied to this repo only, which achieves the same thing without us issuing personal PATs.