### PR TITLE
Add fromfile_prefix_chars to ArgumentParserOptions in argparse

### DIFF
--- a/types/argparse/argparse-tests.ts
+++ b/types/argparse/argparse-tests.ts
@@ -350,3 +350,8 @@ let [ns, remaining] = intermixedArgsExample.parse_known_intermixed_args("doit 1 
 console.dir(ns);
 console.log(remaining);
 console.log("-----------");
+
+const fromfilePrefixCharsExample = new ArgumentParser({
+    fromfile_prefix_chars: "@",
+});
+fromfilePrefixCharsExample.add_argument("--foo");

--- a/types/argparse/index.d.ts
+++ b/types/argparse/index.d.ts
@@ -57,6 +57,7 @@ export interface ArgumentParserOptions {
     argument_default?: any;
     parents?: ArgumentParser[] | undefined;
     prefix_chars?: string | undefined;
+    fromfile_prefix_chars?: string | undefined;
     formatter_class?: {
         new(): HelpFormatter | ArgumentDefaultsHelpFormatter | RawDescriptionHelpFormatter | RawTextHelpFormatter;
     } | undefined;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.python.org/3/library/argparse.html#fromfile-prefix-chars This npm package is a direct port of the python library, and I have tested that these functions [exist](https://github.com/nodeca/argparse/blob/2.0.1/argparse.js#L2513-L2532) in the npm version too.