### PR TITLE
[react] Add types for ref cleanup functions to Canary release channel

### DIFF
--- a/types/react/canary.d.ts
+++ b/types/react/canary.d.ts
@@ -109,4 +109,8 @@ declare module "." {
         passthrough: State,
         reducer: (state: State, action: Action) => State,
     ): [State, (action: Action) => void];
+
+    interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES {
+        cleanup: () => VoidOrUndefinedOnly;
+    }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -155,6 +155,8 @@ declare namespace React {
         readonly current: T | null;
     }
 
+    interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES {
+    }
     /**
      * A callback fired whenever the ref's value changes.
      *
@@ -168,7 +170,15 @@ declare namespace React {
      * <div ref={(node) => console.log(node)} />
      * ```
      */
-    type RefCallback<T> = { bivarianceHack(instance: T | null): void }["bivarianceHack"];
+    type RefCallback<T> = {
+        bivarianceHack(
+            instance: T | null,
+        ):
+            | void
+            | DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES[
+                keyof DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES
+            ];
+    }["bivarianceHack"];
 
     /**
      * A union type of all possible shapes for React refs.

--- a/types/react/test/canary.tsx
+++ b/types/react/test/canary.tsx
@@ -179,3 +179,26 @@ function Optimistic() {
         setStateDefaultAction("4");
     };
 }
+
+// ref cleanup
+<div
+    ref={current => {
+        return function refCleanup() {
+        };
+    }}
+/>;
+<div
+    // @ts-expect-error ref cleanup does not accept arguments
+    ref={current => {
+        // @ts-expect-error
+        return function refCleanup(implicitAny) {
+        };
+    }}
+/>;
+<div
+    // @ts-expect-error ref cleanup does not accept arguments
+    ref={current => {
+        return function refCleanup(neverPassed: string) {
+        };
+    }}
+/>;

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -297,7 +297,9 @@ React.cloneElement(element, {}, null);
 React.cloneElement(myElement);
 
 const clonedElement2: React.CElement<Props, ModernComponent> = React.cloneElement(element, {
-    ref: c => c && c.reset(),
+    ref: c => {
+        c && c.reset();
+    },
 });
 const clonedElement3: React.CElement<Props, ModernComponent> = React.cloneElement(element, {
     key: "8eac7",
@@ -377,7 +379,11 @@ class RefComponent extends React.Component<RCProps> {
 let componentRef: RefComponent | null = new RefComponent({});
 RefComponent.create({ ref: "componentRef" });
 // type of c should be inferred
-RefComponent.create({ ref: c => componentRef = c });
+RefComponent.create({
+    ref: c => {
+        componentRef = c;
+    },
+});
 componentRef.refMethod();
 
 let domNodeRef: Element | null;

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -546,7 +546,7 @@ imgProps.loading = "nonsense";
 // @ts-expect-error
 imgProps.decoding = "nonsense";
 type ImgPropsWithRef = React.ComponentPropsWithRef<"img">;
-// $ExpectType ((instance: HTMLImageElement | null) => void) | RefObject<HTMLImageElement> | null | undefined
+// $ExpectType ((instance: HTMLImageElement | null) => void | (() => VoidOrUndefinedOnly)) | RefObject<HTMLImageElement> | null | undefined
 type ImgPropsWithRefRef = ImgPropsWithRef["ref"];
 type ImgPropsWithoutRef = React.ComponentPropsWithoutRef<"img">;
 // $ExpectType false

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -909,4 +909,28 @@ function managingRefs() {
     // `inputRef.current` will contain `Element | null` at runtime
     // while it has `HTMLInputElement | null` at compiletime.
     <ElementComponent ref={inputRef} />;
+    // ref cleanup
+    <div
+        ref={current => {
+            return function refCleanup() {
+            };
+        }}
+    />;
+    <div
+        // Will not issue an error in a real project but does here since canary.d.ts is part of compilation.
+        // @ts-expect-error
+        ref={current => {
+            // @ts-expect-error
+            return function refCleanup(implicitAny) {
+            };
+        }}
+    />;
+    <div
+        // Will not issue an error in a real project but does here since canary.d.ts is part of compilation.
+        // @ts-expect-error
+        ref={current => {
+            return function refCleanup(neverPassed: string) {
+            };
+        }}
+    />;
 }

--- a/types/react/ts5.0/canary.d.ts
+++ b/types/react/ts5.0/canary.d.ts
@@ -109,4 +109,8 @@ declare module "." {
         passthrough: State,
         reducer: (state: State, action: Action) => State,
     ): [State, (action: Action) => void];
+
+    interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES {
+        cleanup: () => VoidOrUndefinedOnly;
+    }
 }

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -155,6 +155,8 @@ declare namespace React {
         readonly current: T | null;
     }
 
+    interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES {
+    }
     /**
      * A callback fired whenever the ref's value changes.
      *
@@ -168,7 +170,15 @@ declare namespace React {
      * <div ref={(node) => console.log(node)} />
      * ```
      */
-    type RefCallback<T> = { bivarianceHack(instance: T | null): void }["bivarianceHack"];
+    type RefCallback<T> = {
+        bivarianceHack(
+            instance: T | null,
+        ):
+            | void
+            | DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES[
+                keyof DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES
+            ];
+    }["bivarianceHack"];
 
     /**
      * A union type of all possible shapes for React refs.

--- a/types/react/ts5.0/test/canary.tsx
+++ b/types/react/ts5.0/test/canary.tsx
@@ -179,3 +179,26 @@ function Optimistic() {
         setStateDefaultAction("4");
     };
 }
+
+// ref cleanup
+<div
+    ref={current => {
+        return function refCleanup() {
+        };
+    }}
+/>;
+<div
+    // @ts-expect-error ref cleanup does not accept arguments
+    ref={current => {
+        // @ts-expect-error
+        return function refCleanup(implicitAny) {
+        };
+    }}
+/>;
+<div
+    // @ts-expect-error ref cleanup does not accept arguments
+    ref={current => {
+        return function refCleanup(neverPassed: string) {
+        };
+    }}
+/>;

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -300,7 +300,9 @@ React.cloneElement(element, {}, null);
 React.cloneElement(myElement);
 
 const clonedElement2: React.CElement<Props, ModernComponent> = React.cloneElement(element, {
-    ref: c => c && c.reset(),
+    ref: c => {
+        c && c.reset();
+    },
 });
 const clonedElement3: React.CElement<Props, ModernComponent> = React.cloneElement(element, {
     key: "8eac7",
@@ -380,7 +382,11 @@ class RefComponent extends React.Component<RCProps> {
 let componentRef: RefComponent | null = new RefComponent({});
 RefComponent.create({ ref: "componentRef" });
 // type of c should be inferred
-RefComponent.create({ ref: c => componentRef = c });
+RefComponent.create({
+    ref: c => {
+        componentRef = c;
+    },
+});
 componentRef.refMethod();
 
 let domNodeRef: Element | null;

--- a/types/react/ts5.0/test/tsx.tsx
+++ b/types/react/ts5.0/test/tsx.tsx
@@ -546,7 +546,7 @@ imgProps.loading = "nonsense";
 // @ts-expect-error
 imgProps.decoding = "nonsense";
 type ImgPropsWithRef = React.ComponentPropsWithRef<"img">;
-// $ExpectType ((instance: HTMLImageElement | null) => void) | RefObject<HTMLImageElement> | null | undefined
+// $ExpectType ((instance: HTMLImageElement | null) => void | (() => VoidOrUndefinedOnly)) | RefObject<HTMLImageElement> | null | undefined
 type ImgPropsWithRefRef = ImgPropsWithRef["ref"];
 type ImgPropsWithoutRef = React.ComponentPropsWithoutRef<"img">;
 // $ExpectType false

--- a/types/react/ts5.0/test/tsx.tsx
+++ b/types/react/ts5.0/test/tsx.tsx
@@ -909,4 +909,28 @@ function managingRefs() {
     // `inputRef.current` will contain `Element | null` at runtime
     // while it has `HTMLInputElement | null` at compiletime.
     <ElementComponent ref={inputRef} />;
+    // ref cleanup
+    <div
+        ref={current => {
+            return function refCleanup() {
+            };
+        }}
+    />;
+    <div
+        // Will not issue an error in a real project but does here since canary.d.ts is part of compilation.
+        // @ts-expect-error
+        ref={current => {
+            // @ts-expect-error
+            return function refCleanup(implicitAny) {
+            };
+        }}
+    />;
+    <div
+        // Will not issue an error in a real project but does here since canary.d.ts is part of compilation.
+        // @ts-expect-error
+        ref={current => {
+            return function refCleanup(neverPassed: string) {
+            };
+        }}
+    />;
 }


### PR DESCRIPTION
Adds types for https://github.com/facebook/react/pull/25686

These were already allowed since we accepted `void` as a return value which unfortunately means in TypeScript we can return anything in this position.
We could fix it by using the `VoidOrUndefinedOnly` hack but this might break a lot of code. Nobody has complained so far so it seems unnecessary to do this now instead of waiting for React 19.
