### PR TITLE
[create-react-class] Stop implicit return in ref callback

### DIFF
--- a/types/create-react-class/create-react-class-tests.ts
+++ b/types/create-react-class/create-react-class-tests.ts
@@ -68,7 +68,9 @@ const ClassicComponent: createReactClass.ClassicComponentClass<Props> = createRe
         return DOM.div(
             null,
             DOM.input({
-                ref: input => this._input = input,
+                ref: input => {
+                    this._input = input;
+                },
                 value: this.state.bar,
             }),
         );


### PR DESCRIPTION
In React 19, ref callbacks can return a cleanup function. Since ref callbacks were always supposed to be void, the ref cleanup types will start flagging implicit returns that don't return a function (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69065). We should've flagged the implicit return earlier and doing it before ref cleanup might needlessly break a lot of existing code. But we can stop using implicit return now to reduce the size of the React 19 PR. Overview of all implicit returns in DT can be seen in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69066.