### PR TITLE
[react-alert] Stop implicit return in ref callback

### DIFF
--- a/types/react-alert/v2/react-alert-tests.tsx
+++ b/types/react-alert/v2/react-alert-tests.tsx
@@ -24,7 +24,12 @@ export default class App extends React.Component {
     render() {
         return (
             <div>
-                <AlertContainer ref={a => (this.msg = a!)} {...this.alertOptions} />
+                <AlertContainer
+                    ref={a => {
+                        this.msg = a!;
+                    }}
+                    {...this.alertOptions}
+                />
                 <button onClick={this.showAlert}>Show Alert</button>
             </div>
         );


### PR DESCRIPTION
In React 19, ref callbacks can return a cleanup function. Since ref callbacks were always supposed to be void, the ref cleanup types will start flagging implicit returns that don't return a function (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69065). We should've flagged the implicit return earlier and doing it before ref cleanup might needlessly break a lot of existing code. But we can stop using implicit return now to reduce the size of the React 19 PR. Overview of all implicit returns in DT can be seen in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69066.