### PR TITLE
[react-codemirror] Stop implicit return in ref callback

### DIFF
--- a/types/react-codemirror/react-codemirror-tests.tsx
+++ b/types/react-codemirror/react-codemirror-tests.tsx
@@ -37,7 +37,9 @@ class CodemirrorTest extends React.Component {
                     onScroll={onScroll}
                     options={options}
                     preserveScrollPosition={true}
-                    ref={(r: Codemirror | null) => this.editorRef = r}
+                    ref={(r: Codemirror | null) => {
+                        this.editorRef = r;
+                    }}
                     value="foo bar"
                 />
             </div>


### PR DESCRIPTION
In React 19, ref callbacks can return a cleanup function. Since ref callbacks were always supposed to be void, the ref cleanup types will start flagging implicit returns that don't return a function (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69065). We should've flagged the implicit return earlier and doing it before ref cleanup might needlessly break a lot of existing code. But we can stop using implicit return now to reduce the size of the React 19 PR. Overview of all implicit returns in DT can be seen in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69066.