### PR TITLE
[react-dom-factories] Stop implicit return in ref callback

### DIFF
--- a/types/react-dom-factories/react-dom-factories-tests.ts
+++ b/types/react-dom-factories/react-dom-factories-tests.ts
@@ -36,10 +36,18 @@ function testsFromReact(htmlAttr: React.HTMLProps<HTMLElement>) {
     let domNodeRef: Element | null;
     DOM.div({ ref: "domRef" });
     // type of node should be inferred
-    DOM.div({ ref: node => domNodeRef = node });
+    DOM.div({
+        ref: node => {
+            domNodeRef = node;
+        },
+    });
 
     let inputNodeRef: HTMLInputElement | null;
-    DOM.input({ ref: node => inputNodeRef = node as HTMLInputElement });
+    DOM.input({
+        ref: node => {
+            inputNodeRef = node as HTMLInputElement;
+        },
+    });
 
     DOM.span(null);
 


### PR DESCRIPTION
In React 19, ref callbacks can return a cleanup function. Since ref callbacks were always supposed to be void, the ref cleanup types will start flagging implicit returns that don't return a function (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69065). We should've flagged the implicit return earlier and doing it before ref cleanup might needlessly break a lot of existing code. But we can stop using implicit return now to reduce the size of the React 19 PR. Overview of all implicit returns in DT can be seen in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69066.