### PR TITLE
[react-image-gallery] Stop implicit return in ref callback

### DIFF
--- a/types/react-image-gallery/react-image-gallery-tests.tsx
+++ b/types/react-image-gallery/react-image-gallery-tests.tsx
@@ -44,6 +44,13 @@ class ImageGallery extends React.Component {
             onImageLoad: this.handleImageLoad,
         };
 
-        return <ReactImageGallery ref={r => (this.gallery = r)} {...props} />;
+        return (
+            <ReactImageGallery
+                ref={r => {
+                    this.gallery = r;
+                }}
+                {...props}
+            />
+        );
     }
 }


### PR DESCRIPTION
In React 19, ref callbacks can return a cleanup function. Since ref callbacks were always supposed to be void, the ref cleanup types will start flagging implicit returns that don't return a function (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69065). We should've flagged the implicit return earlier and doing it before ref cleanup might needlessly break a lot of existing code. But we can stop using implicit return now to reduce the size of the React 19 PR. Overview of all implicit returns in DT can be seen in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69066.