### PR TITLE
[react-input-mask] Stop implicit return in ref callback

### DIFF
--- a/types/react-input-mask/react-input-mask-tests.tsx
+++ b/types/react-input-mask/react-input-mask-tests.tsx
@@ -15,5 +15,10 @@ const mask = [firstLetter, digit, letter, " ", digit, letter, digit];
     <ReactInputMask mask="99/99/9999" placeholder="Enter birthdate" />
     <ReactInputMask mask="+7 (999) 999-99-99" />
     <ReactInputMask mask={mask} />
-    <ReactInputMask mask="+7 (999) 999-99-99" inputRef={(node) => ref = node} />
+    <ReactInputMask
+        mask="+7 (999) 999-99-99"
+        inputRef={(node) => {
+            ref = node;
+        }}
+    />
 </div>;

--- a/types/react-input-mask/v1/react-input-mask-tests.tsx
+++ b/types/react-input-mask/v1/react-input-mask-tests.tsx
@@ -9,5 +9,10 @@ let ref: HTMLInputElement | null = null;
     <ReactInputMask mask="99-99-9999" defaultValue="13-00-2017" />
     <ReactInputMask mask="99/99/9999" placeholder="Enter birthdate" />
     <ReactInputMask mask="+7 (999) 999-99-99" />
-    <ReactInputMask mask="+7 (999) 999-99-99" inputRef={(node) => ref = node} />
+    <ReactInputMask
+        mask="+7 (999) 999-99-99"
+        inputRef={(node) => {
+            ref = node;
+        }}
+    />
 </div>;


### PR DESCRIPTION
In React 19, ref callbacks can return a cleanup function. Since ref callbacks were always supposed to be void, the ref cleanup types will start flagging implicit returns that don't return a function (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69065). We should've flagged the implicit return earlier and doing it before ref cleanup might needlessly break a lot of existing code. But we can stop using implicit return now to reduce the size of the React 19 PR. Overview of all implicit returns in DT can be seen in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69066.