### PR TITLE
[react-motion-slider] Stop implicit return in ref callback

### DIFF
--- a/types/react-motion-slider/react-motion-slider-tests.tsx
+++ b/types/react-motion-slider/react-motion-slider-tests.tsx
@@ -7,7 +7,14 @@ class Test extends React.Component {
     public render() {
         return (
             <div onMouseEnter={this.onMouseEnter.bind(this)}>
-                <Slider currentIndex={1} autoHeight align="center" ref={ref => this.slider = ref}>
+                <Slider
+                    currentIndex={1}
+                    autoHeight
+                    align="center"
+                    ref={ref => {
+                        this.slider = ref;
+                    }}
+                >
                     <div key="slide1" />
                     <div key="slide2" />
                 </Slider>


### PR DESCRIPTION
In React 19, ref callbacks can return a cleanup function. Since ref callbacks were always supposed to be void, the ref cleanup types will start flagging implicit returns that don't return a function (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69065). We should've flagged the implicit return earlier and doing it before ref cleanup might needlessly break a lot of existing code. But we can stop using implicit return now to reduce the size of the React 19 PR. Overview of all implicit returns in DT can be seen in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69066.