### PR TITLE
[react-native-ad-manager] Stop implicit return in ref callback

### DIFF
--- a/types/react-native-ad-manager/test/NativeAdView.tsx
+++ b/types/react-native-ad-manager/test/NativeAdView.tsx
@@ -64,7 +64,11 @@ export class NativeAdView extends React.Component<{
                 </View>
                 {data?.callToActionText && (
                     <View style={{ alignItems: "center" }}>
-                        <View ref={el => (this._triggerView = el)}>
+                        <View
+                            ref={el => {
+                                this._triggerView = el;
+                            }}
+                        >
                             <Text
                                 style={{
                                     fontSize: 15,


### PR DESCRIPTION
In React 19, ref callbacks can return a cleanup function. Since ref callbacks were always supposed to be void, the ref cleanup types will start flagging implicit returns that don't return a function (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69065). We should've flagged the implicit return earlier and doing it before ref cleanup might needlessly break a lot of existing code. But we can stop using implicit return now to reduce the size of the React 19 PR. Overview of all implicit returns in DT can be seen in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69066.