### PR TITLE
[react-native-datepicker] Stop implicit return in ref callback

### DIFF
--- a/types/react-native-datepicker/react-native-datepicker-tests.tsx
+++ b/types/react-native-datepicker/react-native-datepicker-tests.tsx
@@ -19,7 +19,9 @@ export default class MyDatePicker extends React.Component<{}, MyDatePickerState>
     render() {
         return (
             <DatePicker
-                ref={datepicker => this.datepicker = datepicker}
+                ref={datepicker => {
+                    this.datepicker = datepicker;
+                }}
                 style={{ width: 200 }}
                 date={this.state.date}
                 mode="date"


### PR DESCRIPTION
In React 19, ref callbacks can return a cleanup function. Since ref callbacks were always supposed to be void, the ref cleanup types will start flagging implicit returns that don't return a function (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69065). We should've flagged the implicit return earlier and doing it before ref cleanup might needlessly break a lot of existing code. But we can stop using implicit return now to reduce the size of the React 19 PR. Overview of all implicit returns in DT can be seen in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69066.