### PR TITLE
[react-native-material-menu] Stop implicit return in ref callback

### DIFF
--- a/types/react-native-material-menu/react-native-material-menu-tests.tsx
+++ b/types/react-native-material-menu/react-native-material-menu-tests.tsx
@@ -6,7 +6,9 @@ import Menu, { MenuDivider, MenuItem } from "react-native-material-menu";
 class App extends React.PureComponent {
     _menu: Menu | null = null;
 
-    setMenuRef = (ref: Menu | null) => (this._menu = ref);
+    setMenuRef = (ref: Menu | null) => {
+        this._menu = ref;
+    };
 
     hideMenu = (onHidden?: () => void) => this._menu && this._menu.hide(onHidden);
 


### PR DESCRIPTION
In React 19, ref callbacks can return a cleanup function. Since ref callbacks were always supposed to be void, the ref cleanup types will start flagging implicit returns that don't return a function (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69065). We should've flagged the implicit return earlier and doing it before ref cleanup might needlessly break a lot of existing code. But we can stop using implicit return now to reduce the size of the React 19 PR. Overview of all implicit returns in DT can be seen in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69066.