### PR TITLE
[react-native-modalbox] Stop implicit return in ref callback

### DIFF
--- a/types/react-native-modalbox/react-native-modalbox-tests.tsx
+++ b/types/react-native-modalbox/react-native-modalbox-tests.tsx
@@ -73,7 +73,9 @@ class Example extends React.Component<{}, State> {
 
                 <Modal
                     style={styles.modal}
-                    ref={(ref: Modal | null) => (this.modal1 = ref)}
+                    ref={(ref: Modal | null) => {
+                        this.modal1 = ref;
+                    }}
                     swipeToClose={this.state.swipeToClose}
                     onClosed={() => this.onClose()}
                     onOpened={() => this.onOpen()}
@@ -94,7 +96,9 @@ class Example extends React.Component<{}, State> {
                     style={[styles.modal, styles.modal2]}
                     backdrop={false}
                     position={"top"}
-                    ref={(ref: Modal | null) => (this.modal2 = ref)}
+                    ref={(ref: Modal | null) => {
+                        this.modal2 = ref;
+                    }}
                 >
                     <Text style={[styles.text, { color: "white" }]}>Modal on top</Text>
                 </Modal>
@@ -102,7 +106,9 @@ class Example extends React.Component<{}, State> {
                 <Modal
                     style={[styles.modal, styles.modal3]}
                     position={"center"}
-                    ref={(ref: Modal | null) => (this.modal3 = ref)}
+                    ref={(ref: Modal | null) => {
+                        this.modal3 = ref;
+                    }}
                     isDisabled={this.state.isDisabled}
                 >
                     <Text style={styles.text}>Modal centered</Text>
@@ -125,7 +131,9 @@ class Example extends React.Component<{}, State> {
                 <Modal
                     style={[styles.modal, styles.modal4]}
                     position={"bottom"}
-                    ref={(ref: Modal | null) => (this.modal6 = ref)}
+                    ref={(ref: Modal | null) => {
+                        this.modal6 = ref;
+                    }}
                     swipeArea={20}
                 >
                     <ScrollView>


### PR DESCRIPTION
In React 19, ref callbacks can return a cleanup function. Since ref callbacks were always supposed to be void, the ref cleanup types will start flagging implicit returns that don't return a function (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69065). We should've flagged the implicit return earlier and doing it before ref cleanup might needlessly break a lot of existing code. But we can stop using implicit return now to reduce the size of the React 19 PR. Overview of all implicit returns in DT can be seen in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69066.