### PR TITLE
[react-native-popup-dialog] Stop implicit return in ref callback

### DIFF
--- a/types/react-native-popup-dialog/react-native-popup-dialog-tests.tsx
+++ b/types/react-native-popup-dialog/react-native-popup-dialog-tests.tsx
@@ -46,14 +46,17 @@ class Test extends React.Component<any> {
                     onPress={() => this.showPopupDialog(this.slidingPopupDialog)}
                     title="Show Sliding Dialog"
                 />
-
                 <Dialog
-                    ref={(popupDialog) => this.fadingPopupDialog = popupDialog}
+                    ref={popupDialog => {
+                        this.fadingPopupDialog = popupDialog;
+                    }}
                     dialogTitle={<DialogTitle title="Popup Dialog - Fade Animation" />}
                     dialogAnimation={fadeAnimation}
                 />
                 <Dialog
-                    ref={(popupDialog) => this.scalingPopupDialog = popupDialog}
+                    ref={popupDialog => {
+                        this.scalingPopupDialog = popupDialog;
+                    }}
                     dialogTitle={<DialogTitle title="Popup Dialog - Scale Animation" />}
                     dialogAnimation={scaleAnimation}
                     footer={
@@ -74,7 +77,9 @@ class Test extends React.Component<any> {
                     }
                 />
                 <Dialog
-                    ref={(popupDialog) => this.slidingPopupDialog = popupDialog}
+                    ref={popupDialog => {
+                        this.slidingPopupDialog = popupDialog;
+                    }}
                     dialogTitle={<DialogTitle title="Popup Dialog - Slide Animation" />}
                     width={300}
                     height={300}


### PR DESCRIPTION
In React 19, ref callbacks can return a cleanup function. Since ref callbacks were always supposed to be void, the ref cleanup types will start flagging implicit returns that don't return a function (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69065). We should've flagged the implicit return earlier and doing it before ref cleanup might needlessly break a lot of existing code. But we can stop using implicit return now to reduce the size of the React 19 PR. Overview of all implicit returns in DT can be seen in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69066.