### PR TITLE
[react-scroll-sync] Stop implicit return in ref callback

### DIFF
--- a/types/react-scroll-sync/react-scroll-sync-tests.tsx
+++ b/types/react-scroll-sync/react-scroll-sync-tests.tsx
@@ -9,7 +9,7 @@ import { ScrollSync, ScrollSyncPane } from "react-scroll-sync";
         <ScrollSyncPane enabled group="two" attachTo={document.body} innerRef={React.createRef()}>
             <div></div>
         </ScrollSyncPane>
-        <ScrollSyncPane enabled group={["one", "two"]} attachTo={document.body} innerRef={() => React.createRef()}>
+        <ScrollSyncPane enabled group={["one", "two"]} attachTo={document.body} innerRef={React.createRef()}>
             <div></div>
         </ScrollSyncPane>
     </ScrollSync>


### PR DESCRIPTION
In React 19, ref callbacks can return a cleanup function. Since ref callbacks were always supposed to be void, the ref cleanup types will start flagging implicit returns that don't return a function (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69065). We should've flagged the implicit return earlier and doing it before ref cleanup might needlessly break a lot of existing code. But we can stop using implicit return now to reduce the size of the React 19 PR. Overview of all implicit returns in DT can be seen in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69066.