### PR TITLE
[react-size-reporter] Stop implicit return in ref callback

### DIFF
--- a/types/react-size-reporter/react-size-reporter-tests.tsx
+++ b/types/react-size-reporter/react-size-reporter-tests.tsx
@@ -19,7 +19,12 @@ class TestConsumer {
     sizeReporter?: ReactSizeReporterRef;
     render() {
         return (
-            <SizeReporter onSizeChange={() => {}} ref={ref => (ref ? (this.sizeReporter = ref) : undefined)}>
+            <SizeReporter
+                onSizeChange={() => {}}
+                ref={ref => {
+                    ref ? (this.sizeReporter = ref) : undefined;
+                }}
+            >
                 <div>CONTENT GOES HERE</div>
                 <div>AND HERE</div>
                 <button type="button" onClick={this.reattach}>


### PR DESCRIPTION
In React 19, ref callbacks can return a cleanup function. Since ref callbacks were always supposed to be void, the ref cleanup types will start flagging implicit returns that don't return a function (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69065). We should've flagged the implicit return earlier and doing it before ref cleanup might needlessly break a lot of existing code. But we can stop using implicit return now to reduce the size of the React 19 PR. Overview of all implicit returns in DT can be seen in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69066.