### PR TITLE
[react-svg-pan-zoom] Stop implicit return in ref callback

### DIFF
--- a/types/react-svg-pan-zoom/react-svg-pan-zoom-tests.tsx
+++ b/types/react-svg-pan-zoom/react-svg-pan-zoom-tests.tsx
@@ -101,7 +101,9 @@ class Example1 extends React.Component<{}, State> {
                     onChangeValue={(value: Value) => this.setState({ value })}
                     width={500}
                     height={500}
-                    ref={Viewer => this.Viewer = Viewer}
+                    ref={Viewer => {
+                        this.Viewer = Viewer;
+                    }}
                     onClick={(event: ViewerMouseEvent<any>) =>
                         console.log("click", event.x, event.y, event.originalEvent)}
                     onMouseUp={(event: ViewerMouseEvent<any>) => console.log("up", event.x, event.y)}


### PR DESCRIPTION
In React 19, ref callbacks can return a cleanup function. Since ref callbacks were always supposed to be void, the ref cleanup types will start flagging implicit returns that don't return a function (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69065). We should've flagged the implicit return earlier and doing it before ref cleanup might needlessly break a lot of existing code. But we can stop using implicit return now to reduce the size of the React 19 PR. Overview of all implicit returns in DT can be seen in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69066.