### PR TITLE
[react-text-mask] Stop implicit return in ref callback

### DIFF
--- a/types/react-text-mask/react-text-mask-tests.tsx
+++ b/types/react-text-mask/react-text-mask-tests.tsx
@@ -41,7 +41,14 @@ function Test() {
                 value=""
                 placeholderChar="#"
                 render={(setRef, props) => {
-                    return <input {...props} ref={ref => ref && setRef(ref)} />;
+                    return (
+                        <input
+                            {...props}
+                            ref={ref => {
+                                ref && setRef(ref);
+                            }}
+                        />
+                    );
                 }}
             />
             <MaskedInput


### PR DESCRIPTION
In React 19, ref callbacks can return a cleanup function. Since ref callbacks were always supposed to be void, the ref cleanup types will start flagging implicit returns that don't return a function (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69065). We should've flagged the implicit return earlier and doing it before ref cleanup might needlessly break a lot of existing code. But we can stop using implicit return now to reduce the size of the React 19 PR. Overview of all implicit returns in DT can be seen in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69066.