### PR TITLE
[reactabular-sticky] Stop implicit return in ref callback

### DIFF
--- a/types/reactabular-sticky/reactabular-sticky-tests.tsx
+++ b/types/reactabular-sticky/reactabular-sticky-tests.tsx
@@ -32,11 +32,15 @@ class ReactabularStickyTestComponent extends React.Component<Props> {
                     renderers={this.renderers}
                 >
                     <Sticky.Header
-                        ref={(obj) => this.tableHeader = obj && obj.container}
+                        ref={(obj) => {
+                            this.tableHeader = obj && obj.container;
+                        }}
                         tableBody={this.tableBody}
                     />
                     <Sticky.Body
-                        ref={(obj) => this.tableBody = obj && obj.ref}
+                        ref={(obj) => {
+                            this.tableBody = obj && obj.ref;
+                        }}
                         tableHeader={this.tableHeader}
                         rows={this.props.rows}
                         rowKey="id"


### PR DESCRIPTION
In React 19, ref callbacks can return a cleanup function. Since ref callbacks were always supposed to be void, the ref cleanup types will start flagging implicit returns that don't return a function (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69065). We should've flagged the implicit return earlier and doing it before ref cleanup might needlessly break a lot of existing code. But we can stop using implicit return now to reduce the size of the React 19 PR. Overview of all implicit returns in DT can be seen in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69066.