### PR TITLE
[node:net] Narrow LookupFunction callback definitions

### DIFF
--- a/types/node/v18/net.d.ts
+++ b/types/node/v18/net.d.ts
@@ -16,10 +16,14 @@ declare module "net" {
     import * as stream from "node:stream";
     import { Abortable, EventEmitter } from "node:events";
     import * as dns from "node:dns";
+
+    type LookupOneCallback = (err: null, address: string, family: number) => void;
+    type LookupAllCallback = (err: null, addresses: dns.LookupAddress[]) => void;
+    type LookupErrorCallback = (err: NodeJS.ErrnoException) => void;
     type LookupFunction = (
         hostname: string,
         options: dns.LookupOptions,
-        callback: (err: NodeJS.ErrnoException | null, address: string | dns.LookupAddress[], family?: number) => void,
+        callback: LookupOneCallback | LookupAllCallback | LookupErrorCallback,
     ) => void;
     interface AddressInfo {
         address: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test node`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v18.x/api/dns.html#dnslookuphostname-options-callback
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

When trying to implement a custom dns lookup function that needs to return an error to the callback, TS gives an error that not enough arguments have been provided to the callback:

```ts
import dns, { LookupOptions } from 'node:dns';

function lookup(hostname: string, options: LookupOptions, callback: (err: NodeJS.ErrnoException | null, address: string | dns.LookupAddress[], family?: number) => void) {
    if (hostname === 'bad-host.com') {
        // this requires two arguments
        // TS2554: Expected 2-3 arguments, but got 1
        callback(new Error('Bad host!'));
    } else {
        callback(null, '127.0.0.1', 4);
    }
}
```

This change means that this now works:

```ts
import dns, { LookupOptions } from 'node:dns';

function lookup(hostname: string, options: LookupOptions, callback: (err: NodeJS.ErrnoException | null, address?: string | dns.LookupAddress[], family?: number) => void) {
    if (hostname === 'bad-host.com') {
        callback(new Error('Bad host!'));
    } else {
        callback(null, '127.0.0.1', 4);
    }
}
```