### PR TITLE
[react] Improve test coverage for type inference helpers

### DIFF
--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -812,3 +812,92 @@ const propsWithoutRef: React.PropsWithoutRef<UnionProps> = {
         notImplemented: 5,
     };
 }
+
+function propsInferenceHelpersTests() {
+    const divRef: React.Ref<HTMLDivElement> = React.createRef();
+
+    function FunctionComponent(props: { value: string; optional?: number; ref: React.Ref<HTMLDivElement> }) {
+        return null;
+    }
+    const functionComponentProps: React.ComponentProps<typeof FunctionComponent> = {
+        ref: divRef,
+        value: "string",
+    };
+    const functionComponentPropsWithRef: React.ComponentPropsWithRef<typeof FunctionComponent> = {
+        ref: divRef,
+        value: "string",
+    };
+    const functionComponentPropsWithoutRef: React.ComponentPropsWithoutRef<typeof FunctionComponent> = {
+        // @ts-expect-error ts(2353) Should be omitted.
+        ref: divRef,
+        value: "string",
+    };
+    interface ExtendedFunctionComponentProps extends React.ComponentPropsWithRef<typeof FunctionComponent> {
+        ref: React.Ref<HTMLDivElement>;
+        optional?: number;
+        value: string;
+    }
+
+    class ClassComponent extends React.Component<{ value: string; optional?: number }> {
+        render() {
+            return null;
+        }
+    }
+    const badClassComponentProps: React.ComponentProps<typeof ClassComponent> = {
+        // @ts-expect-error ts(2353) No ref typed currently.
+        ref: React.createRef<InstanceType<typeof ClassComponent>>(),
+        value: "string",
+    };
+    const classComponentProps: React.ComponentProps<typeof ClassComponent> = {
+        value: "string",
+    };
+    const classComponentPropsWithRef: React.ComponentPropsWithRef<typeof ClassComponent> = {
+        ref: React.createRef<InstanceType<typeof ClassComponent>>(),
+        value: "string",
+    };
+    const badClassComponentPropsWithRef: React.ComponentPropsWithRef<typeof ClassComponent> = {
+        // @ts-expect-error ts(2322) Wrong ref type
+        ref: (current: string) => {},
+        value: "string",
+    };
+    const classComponentPropsWithoutRef: React.ComponentPropsWithoutRef<typeof ClassComponent> = {
+        // @ts-expect-error ts(2353) Should be omitted.
+        ref: divRef,
+        value: "string",
+    };
+    interface ExtendedClassComponentProps extends React.ComponentPropsWithRef<typeof ClassComponent> {
+        ref: React.Ref<InstanceType<typeof ClassComponent>>;
+        optional?: number;
+        value: string;
+    }
+
+    const ForwardRefComponent = React.forwardRef<HTMLDivElement, { value: string; optional?: number }>((props, ref) => {
+        return null;
+    });
+    const badForwardRefComponentProps: React.ComponentProps<typeof ForwardRefComponent> = {
+        ref: divRef,
+        value: "string",
+    };
+    const forwardRefComponentProps: React.ComponentProps<typeof ForwardRefComponent> = {
+        value: "string",
+    };
+    const forwardRefComponentPropsWithRef: React.ComponentPropsWithRef<typeof ForwardRefComponent> = {
+        ref: divRef,
+        value: "string",
+    };
+    const badForwardRefComponentPropsWithRef: React.ComponentPropsWithRef<typeof ForwardRefComponent> = {
+        // FIXME: Should be an error.
+        ref: (current: string) => {},
+        value: "string",
+    };
+    const forwardRefComponentPropsWithoutRef: React.ComponentPropsWithoutRef<typeof ForwardRefComponent> = {
+        // @ts-expect-error ts(2353) Should be omitted.
+        ref: divRef,
+        value: "string",
+    };
+    interface ExtendedForwardRefComponentProps extends React.ComponentPropsWithRef<typeof ForwardRefComponent> {
+        ref: React.Ref<InstanceType<typeof ClassComponent>>;
+        optional?: number;
+        value: string;
+    }
+}

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -832,6 +832,7 @@ function propsInferenceHelpersTests() {
         ref: divRef,
         value: "string",
     };
+    // This tests that we can use an interface to extend inferred props types that would've also been extendable without the helper.
     interface ExtendedFunctionComponentProps extends React.ComponentPropsWithRef<typeof FunctionComponent> {
         ref: React.Ref<HTMLDivElement>;
         optional?: number;
@@ -865,6 +866,7 @@ function propsInferenceHelpersTests() {
         ref: divRef,
         value: "string",
     };
+    // This tests that we can use an interface to extend inferred props types that would've also been extendable without the helper.
     interface ExtendedClassComponentProps extends React.ComponentPropsWithRef<typeof ClassComponent> {
         ref: React.Ref<InstanceType<typeof ClassComponent>>;
         optional?: number;
@@ -895,6 +897,7 @@ function propsInferenceHelpersTests() {
         ref: divRef,
         value: "string",
     };
+    // This tests that we can use an interface to extend inferred props types that would've also been extendable without the helper.
     interface ExtendedForwardRefComponentProps extends React.ComponentPropsWithRef<typeof ForwardRefComponent> {
         ref: React.Ref<InstanceType<typeof ClassComponent>>;
         optional?: number;

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -815,3 +815,92 @@ const propsWithoutRef: React.PropsWithoutRef<UnionProps> = {
         notImplemented: 5,
     };
 }
+
+function propsInferenceHelpersTests() {
+    const divRef: React.Ref<HTMLDivElement> = React.createRef();
+
+    function FunctionComponent(props: { value: string; optional?: number; ref: React.Ref<HTMLDivElement> }) {
+        return null;
+    }
+    const functionComponentProps: React.ComponentProps<typeof FunctionComponent> = {
+        ref: divRef,
+        value: "string",
+    };
+    const functionComponentPropsWithRef: React.ComponentPropsWithRef<typeof FunctionComponent> = {
+        ref: divRef,
+        value: "string",
+    };
+    const functionComponentPropsWithoutRef: React.ComponentPropsWithoutRef<typeof FunctionComponent> = {
+        // @ts-expect-error ts(2353) Should be omitted.
+        ref: divRef,
+        value: "string",
+    };
+    interface ExtendedFunctionComponentProps extends React.ComponentPropsWithRef<typeof FunctionComponent> {
+        ref: React.Ref<HTMLDivElement>;
+        optional?: number;
+        value: string;
+    }
+
+    class ClassComponent extends React.Component<{ value: string; optional?: number }> {
+        render() {
+            return null;
+        }
+    }
+    const badClassComponentProps: React.ComponentProps<typeof ClassComponent> = {
+        // @ts-expect-error ts(2353) No ref typed currently.
+        ref: React.createRef<InstanceType<typeof ClassComponent>>(),
+        value: "string",
+    };
+    const classComponentProps: React.ComponentProps<typeof ClassComponent> = {
+        value: "string",
+    };
+    const classComponentPropsWithRef: React.ComponentPropsWithRef<typeof ClassComponent> = {
+        ref: React.createRef<InstanceType<typeof ClassComponent>>(),
+        value: "string",
+    };
+    const badClassComponentPropsWithRef: React.ComponentPropsWithRef<typeof ClassComponent> = {
+        // @ts-expect-error ts(2322) Wrong ref type
+        ref: (current: string) => {},
+        value: "string",
+    };
+    const classComponentPropsWithoutRef: React.ComponentPropsWithoutRef<typeof ClassComponent> = {
+        // @ts-expect-error ts(2353) Should be omitted.
+        ref: divRef,
+        value: "string",
+    };
+    interface ExtendedClassComponentProps extends React.ComponentPropsWithRef<typeof ClassComponent> {
+        ref: React.Ref<InstanceType<typeof ClassComponent>>;
+        optional?: number;
+        value: string;
+    }
+
+    const ForwardRefComponent = React.forwardRef<HTMLDivElement, { value: string; optional?: number }>((props, ref) => {
+        return null;
+    });
+    const badForwardRefComponentProps: React.ComponentProps<typeof ForwardRefComponent> = {
+        ref: divRef,
+        value: "string",
+    };
+    const forwardRefComponentProps: React.ComponentProps<typeof ForwardRefComponent> = {
+        value: "string",
+    };
+    const forwardRefComponentPropsWithRef: React.ComponentPropsWithRef<typeof ForwardRefComponent> = {
+        ref: divRef,
+        value: "string",
+    };
+    const badForwardRefComponentPropsWithRef: React.ComponentPropsWithRef<typeof ForwardRefComponent> = {
+        // FIXME: Should be an error.
+        ref: (current: string) => {},
+        value: "string",
+    };
+    const forwardRefComponentPropsWithoutRef: React.ComponentPropsWithoutRef<typeof ForwardRefComponent> = {
+        // @ts-expect-error ts(2353) Should be omitted.
+        ref: divRef,
+        value: "string",
+    };
+    interface ExtendedForwardRefComponentProps extends React.ComponentPropsWithRef<typeof ForwardRefComponent> {
+        ref: React.Ref<InstanceType<typeof ClassComponent>>;
+        optional?: number;
+        value: string;
+    }
+}

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -835,6 +835,7 @@ function propsInferenceHelpersTests() {
         ref: divRef,
         value: "string",
     };
+    // This tests that we can use an interface to extend inferred props types that would've also been extendable without the helper.
     interface ExtendedFunctionComponentProps extends React.ComponentPropsWithRef<typeof FunctionComponent> {
         ref: React.Ref<HTMLDivElement>;
         optional?: number;
@@ -868,6 +869,7 @@ function propsInferenceHelpersTests() {
         ref: divRef,
         value: "string",
     };
+    // This tests that we can use an interface to extend inferred props types that would've also been extendable without the helper.
     interface ExtendedClassComponentProps extends React.ComponentPropsWithRef<typeof ClassComponent> {
         ref: React.Ref<InstanceType<typeof ClassComponent>>;
         optional?: number;
@@ -898,6 +900,7 @@ function propsInferenceHelpersTests() {
         ref: divRef,
         value: "string",
     };
+    // This tests that we can use an interface to extend inferred props types that would've also been extendable without the helper.
     interface ExtendedForwardRefComponentProps extends React.ComponentPropsWithRef<typeof ForwardRefComponent> {
         ref: React.Ref<InstanceType<typeof ClassComponent>>;
         optional?: number;


### PR DESCRIPTION
I broke some of the use cases for the props inference helpers (`ComponentProps`, `ComponentPropsWithRef`, and `ComponentPropsWithoutRef`) when working on 19 types which I only discovered when testing the types on the Bluesky app. Now we at least this breakage immediately.

This probably doesn't cover all edge cases but at least now we have some coverage.