### PR TITLE
[@types/ysdk] Remove redundant wasShown property in showRewardedVideo callback

### DIFF
--- a/types/ysdk/index.d.ts
+++ b/types/ysdk/index.d.ts
@@ -68,7 +68,7 @@ export interface SDK {
         showRewardedVideo(opts?: {
             callbacks?: {
                 onOpen?: () => void;
-                onClose?: (wasShown: boolean) => void;
+                onClose?: () => void;
                 onError?: (error: string) => void;
                 onRewarded?: () => void;
             };

--- a/types/ysdk/package.json
+++ b/types/ysdk/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/ysdk",
-    "version": "1.0.9999",
+    "version": "1.0.19999",
     "nonNpm": true,
     "nonNpmDescription": "TypeScript type definitions for Yandex.Games SDK",
     "projects": [


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://yandex.com/dev/games/doc/en/sdk/sdk-adv#rewarded-video
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
