### PR TITLE
Node: `once` helper does not receive arbitrary objects that just have `once` method

### DIFF
--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -75,10 +75,6 @@ declare module "events" {
          */
         captureRejections?: boolean | undefined;
     }
-    // Any EventTarget with a Node-style `once` function
-    interface _NodeEventTarget {
-        once(eventName: string | symbol, listener: (...args: any[]) => void): this;
-    }
     // Any EventTarget with a DOM-style `addEventListener`
     interface _DOMEventTarget {
         addEventListener(
@@ -208,7 +204,7 @@ declare module "events" {
          * @since v11.13.0, v10.16.0
          */
         static once(
-            emitter: _NodeEventTarget,
+            emitter: NodeJS.EventEmitter,
             eventName: string | symbol,
             options?: StaticEventEmitterOptions,
         ): Promise<any[]>;
@@ -720,7 +716,7 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeAllListeners(event?: Key<unknown, T>): this;
+                removeAllListeners(eventName?: Key<unknown, T>): this;
                 /**
                  * By default `EventEmitter`s will print a warning if more than `10` listeners are
                  * added for a particular event. This is a useful default that helps finding


### PR DESCRIPTION
### Description

Current declarations for `once` helper in `node:events` module are incorrect. You cannot pass any object with `once` method to it.

### Example
```js
const {once} = await import("node:events")

const target = {
    once(...args) {
        console.log("once", args)
    }
}

once(target, "test")
```
Result:
```shell
TypeError [ERR_INVALID_ARG_TYPE]: The "emitter" argument must be an instance of EventEmitter. Received an instance of Object
```

Node version: v20.11.0

### Side change
I renamed parameter in `removeAllListeners` method, because around the file almost all such parameters are named as `eventName`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
