### PR TITLE
[create-react-class] Replace usage of deprecated types related to propTypes with their counterpart from the prop-types package

### DIFF
--- a/types/create-react-class/create-react-class-tests.ts
+++ b/types/create-react-class/create-react-class-tests.ts
@@ -1,5 +1,4 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import type * as PropTypes from "prop-types";
 import * as DOM from "react-dom-factories";
 import createReactClass = require("create-react-class");
 
@@ -97,7 +96,7 @@ const ClassicComponentNoState: createReactClass.ClassicComponentClass<{ text: st
 
 const displayName: string | undefined = ClassicComponent.displayName;
 const defaultProps: Props = ClassicComponent.getDefaultProps ? ClassicComponent.getDefaultProps() : {} as Props;
-const propTypes: React.ValidationMap<Props> | undefined = ClassicComponent.propTypes;
+const propTypes: PropTypes.ValidationMap<Props> | undefined = ClassicComponent.propTypes;
 
 //
 // Component API

--- a/types/create-react-class/index.d.ts
+++ b/types/create-react-class/index.d.ts
@@ -1,4 +1,5 @@
-import { Component, ComponentClass, ComponentLifecycle, ReactNode, ValidationMap } from "react";
+import type * as PropTypes from "prop-types";
+import { Component, ComponentClass, ComponentLifecycle, ReactNode } from "react";
 
 declare namespace createReactClass {
     interface Mixin<P, S> extends ComponentLifecycle<P, S> {
@@ -8,9 +9,9 @@ declare namespace createReactClass {
         } | undefined;
 
         displayName?: string | undefined;
-        propTypes?: ValidationMap<any> | undefined;
-        contextTypes?: ValidationMap<any> | undefined;
-        childContextTypes?: ValidationMap<any> | undefined;
+        propTypes?: PropTypes.ValidationMap<any> | undefined;
+        contextTypes?: PropTypes.ValidationMap<any> | undefined;
+        childContextTypes?: PropTypes.ValidationMap<any> | undefined;
 
         getDefaultProps?(): P;
         getInitialState?(): S;

--- a/types/create-react-class/package.json
+++ b/types/create-react-class/package.json
@@ -6,7 +6,8 @@
         "https://facebook.github.io/react/"
     ],
     "dependencies": {
-        "@types/react": "*"
+        "@types/react": "*",
+        "@types/prop-types": "*"
     },
     "devDependencies": {
         "@types/create-react-class": "workspace:.",


### PR DESCRIPTION
The replaced types have been deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69002 in favor of their counterparts in prop-types. Check the PR description for an in-depth rationale. https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69011/ has an overview over all the affected packages.