### PR TITLE
[material-ui] Replace usage of deprecated types related to propTypes with their counterpart from the prop-types package

### DIFF
--- a/types/material-ui/material-ui-tests.tsx
+++ b/types/material-ui/material-ui-tests.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import {
-  Component, ComponentClass, CSSProperties,
-  FunctionComponent, ReactElement, ReactInstance, ValidationMap
+  Component,
+  ComponentClass,
+  CSSProperties,
+  FunctionComponent,
+  ReactElement,
+  ReactInstance,
 } from 'react';
 import * as PropTypes from 'prop-types';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
@@ -2270,7 +2274,7 @@ const lightBaseTheme = {
 const lightMuiTheme = getMuiTheme(lightBaseTheme);
 
 class DeepDownTheTree extends Component<{} & {muiTheme: MuiTheme}> {
-  static propTypes: ValidationMap<any> = {
+  static propTypes: PropTypes.ValidationMap<any> = {
     muiTheme: PropTypes.object.isRequired,
   };
 


### PR DESCRIPTION
The replaced types have been deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69002 in favor of their counterparts in prop-types. Check the PR description for an in-depth rationale. https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69011/ has an overview over all the affected packages.