### PR TITLE
[react-props-decorators] Replace usage of deprecated types related to propTypes with their counterpart from the prop-types package

### DIFF
--- a/types/react-props-decorators/index.d.ts
+++ b/types/react-props-decorators/index.d.ts
@@ -1,13 +1,11 @@
-/// <reference types="react" />
-
-import * as React from "react";
+import type * as PropTypes from "prop-types";
 
 export interface ClassDecorator {
     // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
     <TFunction extends Function>(target: TFunction): TFunction | void;
 }
 
-declare var propTypes: (map: React.ValidationMap<any>) => ClassDecorator;
+declare var propTypes: (map: PropTypes.ValidationMap<any>) => ClassDecorator;
 declare var defaultProps: (defaultProps: any) => ClassDecorator;
 
 export { defaultProps, propTypes };

--- a/types/react-props-decorators/package.json
+++ b/types/react-props-decorators/package.json
@@ -6,10 +6,10 @@
         "https://github.com/popkirby/react-props-decorators"
     ],
     "dependencies": {
-        "@types/react": "*"
+        "@types/prop-types": "*"
     },
     "devDependencies": {
-        "@types/prop-types": "*",
+        "@types/react": "*",
         "@types/react-props-decorators": "workspace:."
     },
     "owners": [


### PR DESCRIPTION
The replaced types have been deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69002 in favor of their counterparts in prop-types. Check the PR description for an in-depth rationale. https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69011/ has an overview over all the affected packages.