### PR TITLE
[recompose] Replace usage of deprecated types related to propTypes with their counterpart from the prop-types package

### DIFF
--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -1,8 +1,9 @@
 /// <reference types="react" />
 
 declare module "recompose" {
+    import type * as PropTypes from "prop-types";
     import * as React from "react";
-    import { ComponentClass, ComponentType as Component, FunctionComponent, ValidationMap } from "react";
+    import { ComponentClass, ComponentType as Component, FunctionComponent } from "react";
 
     type mapper<TInner, TOutter> = (input: TInner) => TOutter;
     type predicate<T> = mapper<T, boolean>;
@@ -209,13 +210,13 @@ declare module "recompose" {
 
     // withContext: https://github.com/acdlite/recompose/blob/master/docs/API.md#withContext
     export function withContext<TContext, TProps>(
-        childContextTypes: ValidationMap<TContext>,
+        childContextTypes: PropTypes.ValidationMap<TContext>,
         getChildContext: mapper<TProps, any>,
     ): InferableComponentEnhancer<{}>;
 
     // getContext: https://github.com/acdlite/recompose/blob/master/docs/API.md#getContext
     export function getContext<TContext>(
-        contextTypes: ValidationMap<TContext>,
+        contextTypes: PropTypes.ValidationMap<TContext>,
     ): InferableComponentEnhancer<TContext>;
 
     interface _ReactLifeCycleFunctionsThisArguments<TProps, TState> {
@@ -320,7 +321,7 @@ declare module "recompose" {
 
     // setPropTypes: https://github.com/acdlite/recompose/blob/master/docs/API.md#setPropTypes
     export function setPropTypes<P>(
-        propTypes: ValidationMap<P>,
+        propTypes: PropTypes.ValidationMap<P>,
     ): <T extends Component<P>>(component: T) => T;
 
     // setDisplayName: https://github.com/acdlite/recompose/blob/master/docs/API.md#setDisplayName

--- a/types/recompose/package.json
+++ b/types/recompose/package.json
@@ -6,10 +6,10 @@
         "https://github.com/acdlite/recompose"
     ],
     "dependencies": {
+        "@types/prop-types": "*",
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/prop-types": "*",
         "@types/recompose": "workspace:."
     },
     "owners": [


### PR DESCRIPTION
The replaced types have been deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69002 in favor of their counterparts in prop-types. Check the PR description for an in-depth rationale. https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69011/ has an overview over all the affected packages.