### PR TITLE
[meteor] Test integration with modern React APIs

### DIFF
--- a/types/meteor/test/server-render.tsx
+++ b/types/meteor/test/server-render.tsx
@@ -1,9 +1,10 @@
 import { onPageLoad, ServerSink } from "meteor/server-render";
 import * as React from 'react';
-import { renderToString, renderToNodeStream } from 'react-dom/server';
+import { renderToString, renderToPipeableStream } from 'react-dom/server';
 import { flushSync } from 'react-dom';
 import { hydrateRoot } from 'react-dom/client';
 import { ServerStyleSheet } from "styled-components";
+import { PassThrough } from 'stream'
 
 // Based on https://docs.meteor.com/packages/server-render.html
 
@@ -12,7 +13,13 @@ onPageLoad(sink => {
 });
 
 onPageLoad(sink => {
-  sink.renderIntoElementById("app", renderToNodeStream(<div>Hello World</div>));
+    const passthrough = new PassThrough();
+    const {pipe} = renderToPipeableStream(<div>Hello World</div>, {
+        onShellReady() {
+            pipe(passthrough);
+        }
+    });
+    sink.renderIntoElementById("app", passthrough);
 });
 
 onPageLoad(async () => {


### PR DESCRIPTION
`renderToNodeStream` is deprecated and will be removed in React 19. Now we're testing integration with `renderToPipeableStream` instead of `renderToNodeStream`
