### PR TITLE
[react] Add test cases to inference helpers when dealing with props containing unions and intersections

### DIFF
--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -909,4 +909,36 @@ function propsInferenceHelpersTests() {
         optional?: number;
         value: string;
     }
+
+    type UnionProps = { type: string } & ({ value: string } | { children: string });
+    class UnionPropsClassComponent extends React.Component<UnionProps> {
+        render() {
+            return null;
+        }
+    }
+    function UnionPropsFunctionComponent(props: UnionProps) {
+        return null;
+    }
+    const UnionPropsForwardRefComponent = React.forwardRef<HTMLDivElement, UnionProps>((props, ref) => {
+        return null;
+    });
+
+    // $ExpectType UnionProps
+    type UnionPropsClassComponentProps = React.ComponentProps<typeof UnionPropsClassComponent>;
+    // $ExpectType UnionProps & RefAttributes<UnionPropsClassComponent>
+    type UnionPropsClassComponentPropsWithRef = React.ComponentPropsWithRef<typeof UnionPropsClassComponent>;
+    // $ExpectType UnionProps
+    type UnionPropsClassComponentPropsWithoutRef = React.ComponentPropsWithoutRef<typeof UnionPropsClassComponent>;
+    // $ExpectType UnionProps
+    type UnionPropsFunctionComponentProps = React.ComponentProps<typeof UnionPropsFunctionComponent>;
+    // $ExpectType UnionProps
+    type UnionPropsFunctionComponentPropsWithRef = React.ComponentProps<typeof UnionPropsFunctionComponent>;
+    // $ExpectType UnionProps
+    type UnionPropsFunctionComponentPropsWithoutRef = React.ComponentProps<typeof UnionPropsFunctionComponent>;
+    // $ExpectType UnionProps & RefAttributes<HTMLDivElement>
+    type UnionPropsForwardRefComponentProps = React.ComponentProps<typeof UnionPropsForwardRefComponent>;
+    // $ExpectType UnionProps & RefAttributes<HTMLDivElement>
+    type UnionPropsForwardRefComponentPropsWithRef = React.ComponentProps<typeof UnionPropsForwardRefComponent>;
+    // $ExpectType UnionProps & RefAttributes<HTMLDivElement>
+    type UnionPropsForwardRefComponentPropsWithoutRef = React.ComponentProps<typeof UnionPropsForwardRefComponent>;
 }

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -912,4 +912,36 @@ function propsInferenceHelpersTests() {
         optional?: number;
         value: string;
     }
+
+    type UnionProps = { type: string } & ({ value: string } | { children: string });
+    class UnionPropsClassComponent extends React.Component<UnionProps> {
+        render() {
+            return null;
+        }
+    }
+    function UnionPropsFunctionComponent(props: UnionProps) {
+        return null;
+    }
+    const UnionPropsForwardRefComponent = React.forwardRef<HTMLDivElement, UnionProps>((props, ref) => {
+        return null;
+    });
+
+    // $ExpectType UnionProps
+    type UnionPropsClassComponentProps = React.ComponentProps<typeof UnionPropsClassComponent>;
+    // $ExpectType UnionProps & RefAttributes<UnionPropsClassComponent>
+    type UnionPropsClassComponentPropsWithRef = React.ComponentPropsWithRef<typeof UnionPropsClassComponent>;
+    // $ExpectType UnionProps
+    type UnionPropsClassComponentPropsWithoutRef = React.ComponentPropsWithoutRef<typeof UnionPropsClassComponent>;
+    // $ExpectType UnionProps
+    type UnionPropsFunctionComponentProps = React.ComponentProps<typeof UnionPropsFunctionComponent>;
+    // $ExpectType UnionProps
+    type UnionPropsFunctionComponentPropsWithRef = React.ComponentProps<typeof UnionPropsFunctionComponent>;
+    // $ExpectType UnionProps
+    type UnionPropsFunctionComponentPropsWithoutRef = React.ComponentProps<typeof UnionPropsFunctionComponent>;
+    // $ExpectType UnionProps & RefAttributes<HTMLDivElement>
+    type UnionPropsForwardRefComponentProps = React.ComponentProps<typeof UnionPropsForwardRefComponent>;
+    // $ExpectType UnionProps & RefAttributes<HTMLDivElement>
+    type UnionPropsForwardRefComponentPropsWithRef = React.ComponentProps<typeof UnionPropsForwardRefComponent>;
+    // $ExpectType UnionProps & RefAttributes<HTMLDivElement>
+    type UnionPropsForwardRefComponentPropsWithoutRef = React.ComponentProps<typeof UnionPropsForwardRefComponent>;
 }


### PR DESCRIPTION
Test cases are inspired by https://github.com/DefinitelyTyped/DefinitelyTyped/blob/8f55c538a5a29c8293ee3b5f1b51c020b3c6f58f/types/react-redux/react-redux-tests.tsx#L1769 which broke when working on React 19 types.
The added cases reflect the feature that broke in previous versions of the React 19 types.

