### PR TITLE
[react] Remove `Readonly<P>` from class component constructor

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -995,7 +995,7 @@ declare namespace React {
          */
         context: unknown;
 
-        constructor(props: Readonly<P> | P);
+        constructor(props: P);
         /**
          * @deprecated
          * @see {@link https://legacy.reactjs.org/docs/legacy-context.html React Docs}

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -82,6 +82,14 @@ declare const container: Element;
         }
     }
     class BetterPropsAndStateChecksComponent extends React.Component<Props, State, Snapshot> {
+        constructor(props: Props) {
+            super(props);
+            // This should ideally error since `props` should not be mutated, but it doesn't.
+            props.foo = 2;
+            // @ts-expect-error
+            this.props = { type: "foo" };
+        }
+
         render() {
             return null;
         }
@@ -115,6 +123,13 @@ declare const container: Element;
                 hello: "world",
                 foo: 42,
             };
+        }
+    }
+
+    class InferredConstructorProps extends React.Component<{ value: string }> {
+        // @ts-expect-error ts(7006) Ideally, this would infer the props type from the type parameter but has implicit any.
+        constructor(props) {
+            super(props);
         }
     }
 }

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -996,7 +996,7 @@ declare namespace React {
          */
         context: unknown;
 
-        constructor(props: Readonly<P> | P);
+        constructor(props: P);
         /**
          * @deprecated
          * @see {@link https://legacy.reactjs.org/docs/legacy-context.html React Docs}

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -82,6 +82,14 @@ declare const container: Element;
         }
     }
     class BetterPropsAndStateChecksComponent extends React.Component<Props, State, Snapshot> {
+        constructor(props: Props) {
+            super(props);
+            // This should ideally error since `props` should not be mutated, but it doesn't.
+            props.foo = 2;
+            // @ts-expect-error
+            this.props = { type: "foo" };
+        }
+
         render() {
             return null;
         }
@@ -115,6 +123,13 @@ declare const container: Element;
                 hello: "world",
                 foo: 42,
             };
+        }
+    }
+
+    class InferredConstructorProps extends React.Component<{ value: string }> {
+        // @ts-expect-error ts(7006) Ideally, this would infer the props type from the type parameter but has implicit any.
+        constructor(props) {
+            super(props);
         }
     }
 }


### PR DESCRIPTION
`constructor(props: Readonly<Props>)` was added in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/26813 without adding tests validating the behavior.

It certainly doesn't work anymore since the added tests also passed with `Readonly<P>`.
Maybe it did work but then the change will almost certainly be marked as working as intended.

So I just remove it now since a lot of the ecosystem have inlined their own class component constructor without `Readonly<P>` that matches the legacy context constructur signature.
Legacy context will be removed in React 19 so we would break a lot of existing code for a feature that doesn't even work.

We still guard against mutating props when updating `this.props`. Just not the props that were passed to the constructor.