### PR TITLE
[mdx] Stop relying on deprecated, global JSX namespace in React tests

### DIFF
--- a/types/mdx/package.json
+++ b/types/mdx/package.json
@@ -10,7 +10,7 @@
     "tsconfigs": ["tsconfig.preact.json", "tsconfig.react.json"],
     "devDependencies": {
         "@types/mdx": "workspace:.",
-        "@types/react": "*",
+        "@types/react": "^18",
         "preact": "*"
     },
     "owners": [

--- a/types/mdx/react-tests.tsx
+++ b/types/mdx/react-tests.tsx
@@ -1,6 +1,5 @@
 import { MDXComponents, MDXContent, MDXModule } from "mdx/types";
 import * as React from "react";
-import * as runtime from "react/jsx-runtime";
 import MyMarkdownComponent from "./MyComponent.markdown";
 import MyMDComponent from "./MyComponent.md";
 import MyMDownComponent from "./MyComponent.mdown";
@@ -11,14 +10,6 @@ import MyMKDownComponent from "./MyComponent.mkdown";
 import MyRonComponent from "./MyComponent.ron";
 
 // Test setup — User code
-
-declare module "mdx/types" {
-    namespace JSX {
-        type Element = runtime.JSX.Element;
-        type ElementClass = runtime.JSX.ElementClass;
-        type IntrinsicElements = runtime.JSX.IntrinsicElements;
-    }
-}
 
 interface CustomImageComponentProps extends React.ComponentPropsWithoutRef<"img"> {
     type?: "custom";

--- a/types/mdx/react-tests.tsx
+++ b/types/mdx/react-tests.tsx
@@ -1,5 +1,6 @@
 import { MDXComponents, MDXContent, MDXModule } from "mdx/types";
 import * as React from "react";
+import * as runtime from "react/jsx-runtime";
 import MyMarkdownComponent from "./MyComponent.markdown";
 import MyMDComponent from "./MyComponent.md";
 import MyMDownComponent from "./MyComponent.mdown";
@@ -10,6 +11,14 @@ import MyMKDownComponent from "./MyComponent.mkdown";
 import MyRonComponent from "./MyComponent.ron";
 
 // Test setup — User code
+
+declare module "mdx/types" {
+    namespace JSX {
+        type Element = runtime.JSX.Element;
+        type ElementClass = runtime.JSX.ElementClass;
+        type IntrinsicElements = runtime.JSX.IntrinsicElements;
+    }
+}
 
 interface CustomImageComponentProps extends React.ComponentPropsWithoutRef<"img"> {
     type?: "custom";


### PR DESCRIPTION
Uses same pattern as tests for Preact except using `ElementType` which we don't have in ts5.0 since it's not supported in those versions. 