### PR TITLE
[@types/wordpress__block-editor] Use first party WP components package types

### DIFF
--- a/types/wordpress__block-editor/components/alignment-toolbar.d.ts
+++ b/types/wordpress__block-editor/components/alignment-toolbar.d.ts
@@ -6,7 +6,7 @@ declare namespace AlignmentToolbar {
         alignmentControls?:
             | Array<{
                 align: string;
-                icon: Dashicon.Icon | JSX.Element;
+                icon: Parameters<typeof Dashicon>[0]["icon"] | JSX.Element;
                 title: string;
             }>
             | undefined;

--- a/types/wordpress__block-editor/components/block-controls.d.ts
+++ b/types/wordpress__block-editor/components/block-controls.d.ts
@@ -1,6 +1,10 @@
 import { Slot, ToolbarGroup } from "@wordpress/components";
 import { FC, JSX, ReactNode } from "react";
 
+type GetArrayTypeFromPossibleNestedArray<TestType extends Record<string,unknown> | Array<Record<string,unknown>>> = TestType extends Array<Record<string,unknown>> ? TestType[number] : TestType;
+
+type BlockControlControlsType = GetArrayTypeFromPossibleNestedArray<NonNullable<Parameters<typeof ToolbarGroup>[0]["controls"]>[number]>;
+
 declare namespace BlockControls {
     type BlockControlGroup =
         | "default"
@@ -9,14 +13,15 @@ declare namespace BlockControls {
         | "other"
         | "parent";
 
-    interface Props extends Pick<Parameters<typeof ToolbarGroup>[0], "controls"> {
+    interface Props {
+        controls?: Array<BlockControlControlsType | BlockControlControlsType[]>;
         children: ReactNode;
         group?: BlockControlGroup | undefined;
     }
 }
 declare const BlockControls: {
     (props: BlockControls.Props): JSX.Element;
-    Slot: FC<Omit<Slot.Props, "name">>;
+    Slot: FC<Omit<Parameters<typeof Slot>[0], "name">>;
 };
 
 export default BlockControls;

--- a/types/wordpress__block-editor/components/block-controls.d.ts
+++ b/types/wordpress__block-editor/components/block-controls.d.ts
@@ -1,4 +1,4 @@
-import { Slot, Toolbar } from "@wordpress/components";
+import { Slot, ToolbarGroup } from "@wordpress/components";
 import { FC, JSX, ReactNode } from "react";
 
 declare namespace BlockControls {
@@ -9,7 +9,7 @@ declare namespace BlockControls {
         | "other"
         | "parent";
 
-    interface Props extends Pick<Toolbar.Props, "controls"> {
+    interface Props extends Pick<Parameters<typeof ToolbarGroup>[0], "controls"> {
         children: ReactNode;
         group?: BlockControlGroup | undefined;
     }

--- a/types/wordpress__block-editor/components/block-controls.d.ts
+++ b/types/wordpress__block-editor/components/block-controls.d.ts
@@ -1,9 +1,12 @@
 import { Slot, ToolbarGroup } from "@wordpress/components";
 import { FC, JSX, ReactNode } from "react";
 
-type GetArrayTypeFromPossibleNestedArray<TestType extends Record<string,unknown> | Array<Record<string,unknown>>> = TestType extends Array<Record<string,unknown>> ? TestType[number] : TestType;
+type GetArrayTypeFromPossibleNestedArray<TestType extends Record<string, unknown> | Array<Record<string, unknown>>> =
+    TestType extends Array<Record<string, unknown>> ? TestType[number] : TestType;
 
-type BlockControlControlsType = GetArrayTypeFromPossibleNestedArray<NonNullable<Parameters<typeof ToolbarGroup>[0]["controls"]>[number]>;
+type BlockControlControlsType = GetArrayTypeFromPossibleNestedArray<
+    NonNullable<Parameters<typeof ToolbarGroup>[0]["controls"]>[number]
+>;
 
 declare namespace BlockControls {
     type BlockControlGroup =

--- a/types/wordpress__block-editor/components/block-format-controls.d.ts
+++ b/types/wordpress__block-editor/components/block-format-controls.d.ts
@@ -8,7 +8,7 @@ declare namespace BlockFormatControls {
 }
 declare const BlockFormatControls: {
     (props: BlockFormatControls.Props): JSX.Element;
-    Slot: FC<Omit<Slot.Props, "name">>;
+    Slot: FC<Omit<Parameters<typeof Slot>[0], "name">>;
 };
 
 export default BlockFormatControls;

--- a/types/wordpress__block-editor/components/block-icon.d.ts
+++ b/types/wordpress__block-editor/components/block-icon.d.ts
@@ -4,7 +4,7 @@ import { ComponentType } from "react";
 declare namespace BlockIcon {
     interface Props {
         className?: string | undefined;
-        icon: Icon.Props<any>["icon"];
+        icon: Parameters<typeof Icon>[0]["icon"];
         showColors?: boolean | undefined;
     }
 }

--- a/types/wordpress__block-editor/components/font-sizes.d.ts
+++ b/types/wordpress__block-editor/components/font-sizes.d.ts
@@ -4,7 +4,7 @@ import { ComponentType } from "react";
 import { EditorFontSize } from "../";
 
 export namespace FontSizePicker {
-    type Props = Omit<FSP.Props, "disableCustomFontSizes" | "fontSizes">;
+    type Props = Omit<Parameters<typeof FSP>[0], "disableCustomFontSizes" | "fontSizes">;
 }
 export const FontSizePicker: ComponentType<FontSizePicker.Props>;
 

--- a/types/wordpress__block-editor/components/inserter.d.ts
+++ b/types/wordpress__block-editor/components/inserter.d.ts
@@ -2,7 +2,7 @@ import { Dropdown } from "@wordpress/components";
 import { ComponentType } from "react";
 
 declare namespace Inserter {
-    interface Props extends Partial<Pick<Dropdown.Props, "position" | "renderToggle">> {
+    interface Props extends Partial<Pick<Parameters<typeof Dropdown>[0], "position" | "renderToggle">> {
         clientId?: string | undefined;
         disabled?: boolean | undefined;
         isAppender?: boolean | undefined;

--- a/types/wordpress__block-editor/components/inspector-advanced-controls.d.ts
+++ b/types/wordpress__block-editor/components/inspector-advanced-controls.d.ts
@@ -8,7 +8,7 @@ declare namespace InspectorAdvancedControls {
 }
 declare const InspectorAdvancedControls: {
     (props: InspectorAdvancedControls.Props): JSX.Element;
-    Slot: FC<Omit<Slot.Props, "name">>;
+    Slot: FC<Omit<Parameters<typeof Slot>[0], "name">>;
 };
 
 export default InspectorAdvancedControls;

--- a/types/wordpress__block-editor/components/inspector-controls.d.ts
+++ b/types/wordpress__block-editor/components/inspector-controls.d.ts
@@ -9,7 +9,7 @@ declare namespace InspectorControls {
 }
 declare const InspectorControls: {
     (props: InspectorControls.Props): JSX.Element;
-    Slot: FC<Omit<Slot.Props, "name">>;
+    Slot: FC<Omit<Parameters<typeof Slot>[0], "name">>;
 };
 
 export default InspectorControls;

--- a/types/wordpress__block-editor/components/media-placeholder.d.ts
+++ b/types/wordpress__block-editor/components/media-placeholder.d.ts
@@ -5,7 +5,7 @@ import { ComponentType, JSX, MouseEventHandler } from "react";
 declare namespace MediaPlaceholder {
     type MediaPlaceholderMultipleAction = "add";
 
-    interface Props<T extends boolean> extends Pick<DropZone.Props, "onHTMLDrop"> {
+    interface Props<T extends boolean> extends Pick<Parameters<typeof DropZone>[0], "onHTMLDrop"> {
         /**
          * A string passed to `FormFileUpload` that tells the browser which file types can be uploaded
          * to the upload window the browser use e.g: `image#<{(|,video#<{(|`.
@@ -47,7 +47,7 @@ declare namespace MediaPlaceholder {
         /**
          * Icon to display left of the title.
          */
-        icon?: Dashicon.Icon | JSX.Element | undefined;
+        icon?: Parameters<typeof Dashicon>[0]["icon"] | JSX.Element | undefined;
         /**
          * If `true`, the property changes the look of the placeholder to be adequate to scenarios
          * where new files are added to an already existing set of files, e.g., adding files to a

--- a/types/wordpress__block-editor/components/navigable-toolbar.d.ts
+++ b/types/wordpress__block-editor/components/navigable-toolbar.d.ts
@@ -1,8 +1,9 @@
 import { NavigableMenu } from "@wordpress/components";
 import { ComponentType } from "react";
 
+type NavigableMenuProps = Parameters<typeof NavigableMenu>[0];
 declare namespace NavigableToolbar {
-    interface Props extends NavigableMenu.Props {
+    interface Props extends NavigableMenuProps {
         focusOnMount?: boolean | undefined;
     }
 }

--- a/types/wordpress__block-editor/components/panel-color-settings.d.ts
+++ b/types/wordpress__block-editor/components/panel-color-settings.d.ts
@@ -3,10 +3,10 @@ import { ComponentType } from "react";
 
 declare namespace PanelColorSettings {
     type ColorSetting =
-        & Partial<ColorPalette.Props>
-        & Pick<ColorPalette.Props, "onChange" | "value">
+        & Partial<Parameters<typeof ColorPalette>[0]>
+        & Pick<Parameters<typeof ColorPalette>[0], "onChange" | "value">
         & { label: string };
-    interface Props extends Omit<PanelBody.Props, "children"> {
+    interface Props extends Omit<Parameters<typeof PanelBody>[0], "children"> {
         colorSettings: ColorSetting[];
         disableCustomColors?: boolean | undefined;
     }

--- a/types/wordpress__block-editor/components/rich-text.d.ts
+++ b/types/wordpress__block-editor/components/rich-text.d.ts
@@ -14,7 +14,7 @@ declare namespace RichText {
         /**
          * A list of autocompleters to use instead of the default.
          */
-        autocompleters?: Array<Autocomplete.Completer<any>> | undefined;
+        autocompleters?: Parameters<typeof Autocomplete>[0]["completers"] | undefined;
         children?: never | undefined;
         className?: string | undefined;
         identifier?: string | undefined;
@@ -93,8 +93,9 @@ export namespace RichTextShortcut {
 }
 export const RichTextShortcut: ComponentType<RichTextShortcut.Props>;
 
+type ToolbarButtonProps = Partial<Parameters<typeof ToolbarButton>[0]>;
 export namespace RichTextToolbarButton {
-    interface Props extends ToolbarButton.Props {
+    interface Props extends ToolbarButtonProps {
         name?: string | undefined;
         shortcutType?: keyof typeof displayShortcut | undefined;
         shortcutCharacter?: string | undefined;

--- a/types/wordpress__block-editor/components/url-popover.d.ts
+++ b/types/wordpress__block-editor/components/url-popover.d.ts
@@ -1,8 +1,7 @@
-import { Popover } from "@wordpress/components";
+import { PopoverProps } from "@wordpress/components/build-types/popover/types";
 import { ComponentType, JSX, ReactNode } from "react";
-
 declare namespace URLPopover {
-    interface Props extends Popover.Props {
+    interface Props extends PopoverProps {
         additionalControls?: ReactNode | undefined;
         /**
          * Callback used to return the React Elements that will be rendered inside the settings

--- a/types/wordpress__block-editor/package.json
+++ b/types/wordpress__block-editor/package.json
@@ -8,10 +8,10 @@
     "dependencies": {
         "@types/react": "*",
         "@types/wordpress__blocks": "*",
-        "@types/wordpress__components": "*",
         "@types/wordpress__keycodes": "*",
         "@wordpress/data": "^9.13.0",
         "@wordpress/element": "^5.0.0",
+        "@wordpress/components": "^27.2.0",
         "react-autosize-textarea": "^7.1.0"
     },
     "devDependencies": {

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -44,23 +44,44 @@ const STYLES = [{ css: ".foo { color: red; }" }, { css: ".bar { color: blue; }",
 <be.BlockControls
     controls={[
         {
-            icon: "yes",
+            icon: "admin-appearance",
             title: "Yes",
+            subscript: "Yes",
             onClick() {},
-            shortcut: {
-                display: "Yes",
-            },
+            isActive: false,
             isDisabled: false,
         },
         {
-            icon: "no",
+            icon: null,
             title: "No",
             onClick() {},
             subscript: "no",
             isActive: false,
-            shortcut: "No",
+            isDisabled: false,
         },
     ]}
+>
+    Hello World
+</be.BlockControls>;
+<be.BlockControls
+    controls={[[
+        {
+            icon: "admin-appearance",
+            title: "Yes",
+            subscript: "Yes",
+            onClick() {},
+            isActive: false,
+            isDisabled: false,
+        },
+        {
+            icon: null,
+            title: "No",
+            onClick() {},
+            subscript: "no",
+            isActive: false,
+            isDisabled: false,
+        },
+    ]]}
 >
     Hello World
 </be.BlockControls>;
@@ -336,6 +357,8 @@ be.withFontSizes("fontSize")(() => <h1>Hello World</h1>);
 <be.RichText.Content value="foo" />;
 <be.RichText.Content tagName="p" style={{ color: "blue" }} className="foo" value="Hello World" dir="rtl" />;
 <be.RichTextShortcut type="primary" character="b" onUse={() => console.log("Hello World")} />;
+<be.RichTextToolbarButton
+/>;
 <be.RichTextToolbarButton
     isActive
     name="bold"

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -357,8 +357,7 @@ be.withFontSizes("fontSize")(() => <h1>Hello World</h1>);
 <be.RichText.Content value="foo" />;
 <be.RichText.Content tagName="p" style={{ color: "blue" }} className="foo" value="Hello World" dir="rtl" />;
 <be.RichTextShortcut type="primary" character="b" onUse={() => console.log("Hello World")} />;
-<be.RichTextToolbarButton
-/>;
+<be.RichTextToolbarButton />;
 <be.RichTextToolbarButton
     isActive
     name="bold"


### PR DESCRIPTION
This started as simply a fix for the BlockControls component, but while I was working on that, I realised the tests for this package were incorrectly passing even though the types were wrong because this package had ` @types/wordpress__components` as a dependency.

To resolve this issue, I have swapped the dependency to the `@wordpress/components` package, and updated all references to be correct as per the newest version of `@wordpress/components`.

With that in mind, there are some changes I had to make outside of just changing locations of types, so I've marked these changes here:

1. Wordpress doesn't explicitly export its own prop types, so I have used Parameters combined with the component type to extract the types needed.
2. For BlockControls, the original types references the Toolbar component, however, in the components package, the Toolbar component doesn't have a "controls" prop, and the [source code for the BlockControls component](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/block-controls/fill.js ) shows this should actually be the ToolbarGroup component. For the tests, I updated the "controls" parameter to align it with the current attributes as found in the [toolbar group source code](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/toolbar/toolbar-group/index.tsx).
3. Also for BlockControls, the ToolbarGroup component has a type bug which prevents you from providing a single array instead of a nested array. To fix this bug in this package, I have extracted the array type and reformed the array.
4. For URLPopover, the Popover props type could not be retrieved the same way as other components, so I have reference the props type directly. This is potentially more brittle than the Parameters approach, but as far as I can see, it's the best way until Wordpress exports its own prop types.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

