### PR TITLE
[snowflake-sdk]: Add keepAlive and column variant parsers to configureOptions and fix docs link

### DIFF
--- a/types/snowflake-sdk/index.d.ts
+++ b/types/snowflake-sdk/index.d.ts
@@ -608,9 +608,15 @@ export interface ConfigureOptions {
 
     /**
      * ### Related Docs
-     * - {@link https://docs.snowflake.com/en/user-guide/nodejs-driver-use.html#choosing-fail-open-or-fail-close-mode Choosing `Fail-Open` or `Fail-Close` Mode}
+     * - {@link https://docs.snowflake.com/user-guide/ocsp#fail-open-or-fail-close-behavior Choosing `Fail-Open` or `Fail-Close` Mode}
      */
     ocspFailOpen?: boolean | undefined;
+    jsonColumnVariantParser?: ((rawColumnValue: string) => any) | undefined;
+    xmlColumnVariantParser?: ((rawColumnValue: string) => any) | undefined;
+    /**
+     * Specifies whether to enable keep-alive functionality on the socket immediately after receiving a new connection request. Default value is true.
+     */
+    keepAlive?: boolean | undefined;
 }
 
 /**

--- a/types/snowflake-sdk/snowflake-sdk-tests.ts
+++ b/types/snowflake-sdk/snowflake-sdk-tests.ts
@@ -4,6 +4,9 @@ snowflake.configure({
     insecureConnect: true,
     logLevel: "ERROR",
     ocspFailOpen: true,
+    keepAlive: true,
+    jsonColumnVariantParser: undefined,
+    xmlColumnVariantParser: undefined
 });
 
 const connection = snowflake.createConnection({


### PR DESCRIPTION
## snowflake-sdk ConfigureOptions
Add keepAlive and column variant parsers to configureOptions and fix docs link.

- keepAlive 
- jsonColumnVariantParser
- xmlColumnVariantParser



- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [snowflake-sdk](https://github.com/snowflakedb/snowflake-connector-nodejs/blob/master/lib/core.js#L183)
-  If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. (seems like I don't need to update the version number?) 
