### PR TITLE
[googlepay] add buttonRadius property to the ButtonOptions object

### DIFF
--- a/types/googlepay/googlepay-tests.ts
+++ b/types/googlepay/googlepay-tests.ts
@@ -126,6 +126,12 @@ function addGooglePayButton() {
     buttonOptions.buttonType = "long";
     buttonOptions.buttonType = "short";
 
+    buttonOptions.buttonRadius = -1;
+    buttonOptions.buttonRadius = 0;
+    buttonOptions.buttonRadius = 10;
+    buttonOptions.buttonRadius = 20;
+    buttonOptions.buttonRadius = 100;
+
     buttonOptions.buttonSizeMode = undefined;
     buttonOptions.buttonSizeMode = "fill";
     buttonOptions.buttonSizeMode = "static";

--- a/types/googlepay/index.d.ts
+++ b/types/googlepay/index.d.ts
@@ -1813,6 +1813,15 @@ declare namespace google.payments.api {
         buttonType?: ButtonType | undefined;
 
         /**
+         * Specifies the button corner radius in pixels. The minimum is 0 and the
+         * maximum depends on the height of the button. If the height is 40px (default height) then
+         * the maximum value for the buttonRadius is 20.
+         *
+         * @default 4
+         */
+        buttonRadius?: number | undefined;
+
+        /**
          * Determines how the button's size should change relative to the
          * button's parent element.
          *


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Google Pay ButtonOptions](https://developers.google.com/pay/api/web/reference/request-objects#ButtonOptions)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
