### PR TITLE
Fix getFlattenedItemList type in index.d.ts

### DIFF
--- a/types/apple-mapkit-js-browser/index.d.ts
+++ b/types/apple-mapkit-js-browser/index.d.ts
@@ -2876,7 +2876,7 @@ declare namespace mapkit {
         /**
          * A flattened array of items that include annotations or overlays.
          */
-        getFlattenedItemList: Array<Annotation | Overlay>;
+        getFlattenedItemList: () => Array<Annotation | Overlay>;
         /**
          * A nested list of annotations, overlays, or other item collections.
          */


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.

Title: [apple-mapkit-js-browser] Fix type definition for getFlattenedItemList

- [x] Test the change in your own code. (Compile and run.)

- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.

- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).

- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).

- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.apple.com/documentation/mapkitjs/itemcollection/1452582-getflatteneditemlist

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

According to the Apple MapKit JS documentation, `getFlattenedItemList` is a function that returns an array of annotations and overlays, not a property directly holding the array. This PR fixes the type definition to match the actual API.


https://developer.apple.com/documentation/mapkitjs/itemcollection