### PR TITLE
[readable-stream] remove deprecated tag from Duplex.from

### DIFF
--- a/types/readable-stream/index.d.ts
+++ b/types/readable-stream/index.d.ts
@@ -277,11 +277,18 @@ declare namespace _Readable {
     type _IDuplex = _IReadable & _IWritable;
 
     class Duplex extends _Writable implements _IDuplex, /*extends*/ _Readable, Duplex {
-        /**
-         * This is a dummy function required to retain type compatibility to node.
-         * @deprecated DO NOT USE
-         */
-        static from(source: any): any;
+        static from(
+            src:
+                | Stream
+                | Blob
+                | ArrayBuffer
+                | string
+                | Iterable<any>
+                | AsyncIterable<any>
+                | AsyncGeneratorFunction
+                | Promise<any>
+                | { writable?: Writable; readable?: _Readable },
+        ): Duplex;
         allowHalfOpen: boolean;
         destroyed: boolean;
         // Readable
@@ -294,11 +301,11 @@ declare namespace _Readable {
         readonly readableObjectMode: boolean;
         readonly writableObjectMode: boolean;
 
-        readonly readableAborted: never;
-        readonly readableDidRead: never;
-        readonly writableEnded: never;
-        readonly writableFinished: never;
-        readonly writableCorked: never;
+        readonly readableAborted: boolean;
+        readonly readableDidRead: boolean;
+        readonly writableEnded: boolean;
+        readonly writableFinished: boolean;
+        readonly writableCorked: number;
 
         _readableState: ReadableState;
 
@@ -410,11 +417,11 @@ declare namespace _Readable {
     };
 
     class Readable extends _Readable {
-        readonly readableAborted: never;
-        readonly readableDidRead: never;
-        readonly readableEncoding: never;
-        readonly readableEnded: never;
-        readonly readableObjectMode: never;
+        readonly readableAborted: boolean;
+        readonly readableDidRead: boolean;
+        readonly readableEncoding: BufferEncoding | null;
+        readonly readableEnded: boolean;
+        readonly readableObjectMode: boolean;
 
         constructor(options?: ReadableOptions);
         pipe<T extends _IWritable>(destination: T, options?: { end?: boolean | undefined }): T;
@@ -645,10 +652,10 @@ declare namespace _Readable {
     }
 
     class Writable extends _Writable {
-        readonly writableEnded: never;
-        readonly writableFinished: never;
-        readonly writableObjectMode: never;
-        readonly writableCorked: never;
+        readonly writableEnded: boolean;
+        readonly writableFinished: boolean;
+        readonly writableObjectMode: boolean;
+        readonly writableCorked: number;
 
         constructor(opts?: WritableOptions);
     }

--- a/types/readable-stream/readable-stream-tests.ts
+++ b/types/readable-stream/readable-stream-tests.ts
@@ -101,7 +101,7 @@ function test() {
     streamT.unpipe(streamW);
     streamT._transformState.afterTransform = (err, data) => {};
 
-    const streamD = new RS_Duplex({
+    let streamD = new RS_Duplex({
         read(size: number) {
             assertType<number>(size);
         },
@@ -111,6 +111,12 @@ function test() {
             assertType<(err?: Error | null) => void>(cb);
         },
         writableObjectMode: false,
+    });
+    streamD = RS_Duplex.from(streamR);
+    streamD = RS_Duplex.from([streamR, streamW]);
+    streamD = RS_Duplex.from({
+        readable: streamR,
+        writable: streamW,
     });
     assertType<boolean>(streamD.allowHalfOpen);
     assertType<boolean>(streamD.readable);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

These were marked deprecated/never because readable-stream did not support them, but they've had parity with Node 18 since 4.0.0

Related nodejs/readable-stream#534

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://github.com/nodejs/readable-stream/releases/tag/v4.0.0)>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
