### PR TITLE
fix(sparql-http-client): make `factory` option optional

### DIFF
--- a/types/sparql-http-client/ParsingClient.d.ts
+++ b/types/sparql-http-client/ParsingClient.d.ts
@@ -4,7 +4,7 @@ import { SimpleClient } from "./index.js";
 import ParsingQuery from "./ParsingQuery.js";
 
 interface BaseOptions<Q extends Quad, D extends DatasetCore<Q>> {
-    factory: Environment<DatasetCoreFactory<Q, Q, D>>;
+    factory?: Environment<DatasetCoreFactory<Q, Q, D>>;
     fetch?: typeof fetch;
     headers?: HeadersInit;
     password?: string;

--- a/types/sparql-http-client/StreamClient.d.ts
+++ b/types/sparql-http-client/StreamClient.d.ts
@@ -5,7 +5,7 @@ import StreamQuery from "./StreamQuery.js";
 import StreamStore from "./StreamStore.js";
 
 interface BaseOptions<Q extends BaseQuad> {
-    factory: Environment<DataFactory<Q> | DatasetCoreFactory>;
+    factory?: Environment<DataFactory<Q> | DatasetCoreFactory>;
     fetch?: typeof fetch;
     headers?: HeadersInit;
     password?: string;

--- a/types/sparql-http-client/sparql-http-client-tests.ts
+++ b/types/sparql-http-client/sparql-http-client-tests.ts
@@ -87,6 +87,9 @@ async function streamingClient() {
 
 async function parsingClient() {
     // construct
+    const usingDefaultFactory: ParsingClient = new ParsingClient({
+        endpointUrl,
+    });
     const minimalOptions: ParsingClient = new ParsingClient({
         endpointUrl,
         factory,

--- a/types/sparql-http-client/sparql-http-client-tests.ts
+++ b/types/sparql-http-client/sparql-http-client-tests.ts
@@ -24,6 +24,9 @@ const stream: Stream = <any> {};
 
 async function streamingClient() {
     // construct
+    const usingDefaultFactory: StreamClient = new StreamClient({
+        endpointUrl,
+    });
     const minimalOptions: StreamClient = new StreamClient({
         endpointUrl,
         factory,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [ParsingClient](https://github.com/rdf-ext/sparql-http-client/blob/2b169bb47211bee9e0d0df8f8d303df334ed93df/ParsingClient.js#L59), [StreamClient](https://github.com/rdf-ext/sparql-http-client/blob/2b169bb47211bee9e0d0df8f8d303df334ed93df/StreamClient.js#L79)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.