### PR TITLE
fix(docusign-esign): make state arg in getAuthorizationUri optional

### DIFF
--- a/types/docusign-esign/docusign-esign-tests.ts
+++ b/types/docusign-esign/docusign-esign-tests.ts
@@ -82,7 +82,7 @@ const getAuthorizationUri = (): string => {
     const client = apiClient();
 
     return client.getAuthorizationUri(apiClientId, scopes, redirectUri, responseType);
-}
+};
 
 const getAccessToken = async (): Promise<AccessToken> => {
     const privateKey: Buffer = Buffer.from("read private key file");

--- a/types/docusign-esign/docusign-esign-tests.ts
+++ b/types/docusign-esign/docusign-esign-tests.ts
@@ -74,6 +74,16 @@ const getDsRequestParams = async (): Promise<RequestParams> => {
     };
 };
 
+const getAuthorizationUri = (): string => {
+    const apiClientId = "api client id";
+    const redirectUri = "http://example.com";
+    const responseType = "token";
+
+    const client = apiClient();
+
+    return client.getAuthorizationUri(apiClientId, scopes, redirectUri, responseType);
+}
+
 const getAccessToken = async (): Promise<AccessToken> => {
     const privateKey: Buffer = Buffer.from("read private key file");
     const integratorKey = "integrator key";

--- a/types/docusign-esign/index.d.ts
+++ b/types/docusign-esign/index.d.ts
@@ -40,7 +40,7 @@ export class ApiClient {
         scopes: string[],
         redirectUri: string,
         responseType: string,
-        state: string,
+        state?: string,
     ): string;
 
     getBasePath(): string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [getAuthorizationUri on "How to Page"](https://developers.docusign.com/platform/auth/authcode/authcode-get-token/#:~:text=The%20getAuthorizationUri%20method%20is%20passed%20your%20app%27s%20integration%20key%2C%20requested%20scopes%2C%20the%20redirect%20URI%20to%20which%20the%20user%20and%20the%20authorization%20code%20will%20be%20directed%2C%20the%20response%20type%20(value%20of%20code)%2C%20and%20an%20optional%20state%20value.), [ApiClient.js](https://github.com/docusign/docusign-esign-node-client/blob/master/src/ApiClient.js#L836-L849)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
