### PR TITLE
[jsprintmanager]: Updates license_url and WSStatus types for 3.0+

### DIFF
--- a/types/jsprintmanager/index.d.ts
+++ b/types/jsprintmanager/index.d.ts
@@ -162,6 +162,7 @@ export namespace JSPM {
 
     namespace JSPrintManager {
         let WS: JSPMWebSocket;
+        let license_url: string;
         let auto_reconnect: boolean;
         function start(secure?: boolean, host?: string, port?: number): Promise<void>;
         function getPrinters(): Promise<{}>;

--- a/types/jsprintmanager/index.d.ts
+++ b/types/jsprintmanager/index.d.ts
@@ -112,7 +112,7 @@ export namespace JSPM {
     enum WSStatus {
         Open = 0,
         Closed = 1,
-        BlackListed = 2,
+        Blocked = 2,
         WaitingForUserResponse = 3,
     }
     enum PrintRotation {

--- a/types/jsprintmanager/package.json
+++ b/types/jsprintmanager/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/jsprintmanager",
-    "version": "2.0.9999",
+    "version": "3.0.9999",
     "projects": [
         "https://github.com/neodynamic/JSPrintManager#readme"
     ],


### PR DESCRIPTION
Makes two changes:

Adds the `license_url` field to the `JSPrintManager` namespace, which has been present since at least version 2.0 of JSPrintManager. This is the current version of the package and does not require a version update. Documentation can be found here: https://www.neodynamic.com/Products/Help/JSPrintManager2.0/articles/license-registration.html.

Replaces the `BlackListed` value of the `WSStatus` enum with `Blocked`, which was changed in version 3.0 of JSPrintManager. Change can be seen by comparing the [documentation for version 2.0](https://www.neodynamic.com/Products/Help/JSPrintManager2.0/articles/jsprintmanager.html) with the [documentation for version 3.0](https://www.neodynamic.com/Products/Help/JSPrintManager3.0/articles/jsprintmanager.html).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test jsprintmanager`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see above
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
