### PR TITLE
[react] Remove unused `@types/scheduler` dependency

### DIFF
--- a/types/react/package.json
+++ b/types/react/package.json
@@ -57,7 +57,6 @@
     },
     "dependencies": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
         "csstype": "^3.0.2"
     },
     "devDependencies": {


### PR DESCRIPTION
Usage was removed in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65812