### PR TITLE
@TryGhost/content-api - Update 'version' in GhostContentAPIOptions

### DIFF
--- a/types/tryghost__content-api/index.d.ts
+++ b/types/tryghost__content-api/index.d.ts
@@ -222,10 +222,11 @@ export interface GhostContentAPIOptions {
     url: string;
     /**
      * Version of GhostContentAPI
-     *
-     * Supported Versions: 'v2', 'v3', 'v4', 'v5.0', 'canary'
+     * Should be in 'v{major}.{minor}' format.
+     * 
+     * Deprecated options: 'v2', 'v3', 'v4', 'v5', 'canary'
      */
-    version: "v2" | "v3" | "v4" | "v5.0" | "canary";
+    version: string;
     key: string;
     /** @deprecated since version v2 */
     host?: string | undefined;

--- a/types/tryghost__content-api/index.d.ts
+++ b/types/tryghost__content-api/index.d.ts
@@ -223,7 +223,7 @@ export interface GhostContentAPIOptions {
     /**
      * Version of GhostContentAPI
      * Should be in 'v{major}.{minor}' format.
-     * 
+     *
      * Deprecated options: 'v2', 'v3', 'v4', 'v5', 'canary'
      */
     version: string;

--- a/types/tryghost__content-api/tryghost__content-api-tests.ts
+++ b/types/tryghost__content-api/tryghost__content-api-tests.ts
@@ -10,7 +10,8 @@ const makeRequest = (options: MakeRequestOptions) => {
     return Promise.resolve(data);
 };
 
-const api = new GhostContentAPI({ url: "test", version: "v3", key: "", makeRequest }); // $ExpectType GhostAPI
+// Accept arbitrary version strings
+const api = new GhostContentAPI({ url: "test", version: "v5.9999", key: "", makeRequest }); // $ExpectType GhostAPI
 
 const pagesBrowsePromise = api.pages.browse(); // $ExpectType Promise<PostsOrPages>
 


### PR DESCRIPTION
The type of 'version' in GhostContentAPIOptions only accepts a short or'd list of literals ("v2", "v3", etc), but in reality the content-api package is expecting a string of the form `v\d+\.\d+` (in practice, this is just "v5.xx" right now) and complains about deprecation if you provide anything else. It is expected that the library user specify the minor version they are using, not just "v5.0".

Code ref: https://github.com/TryGhost/SDK/blob/%40tryghost/content-api%401.11.20/packages/content-api/lib/content-api.js#L82-L101

(You might see some code there that checks to see if `version` is a boolean, so that seems like it should be a valid type, but [other code](https://github.com/TryGhost/SDK/blob/%40tryghost/content-api%401.11.20/packages/content-api/lib/content-api.js#L82-L101) will fail if version is a boolean. Also the `@param` documentation is wrong for resolveAPIPrefix.)

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://github.com/TryGhost/SDK/blob/%40tryghost/content-api%401.11.20/packages/content-api/lib/content-api.js#L82-L101)
- [Fixing a previous/existing issue] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
