### PR TITLE
`once` helper does not receive arbitrary objects that just have `addEventListener` method

### DIFF
--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -75,16 +75,6 @@ declare module "events" {
          */
         captureRejections?: boolean | undefined;
     }
-    // Any EventTarget with a DOM-style `addEventListener`
-    interface _DOMEventTarget {
-        addEventListener(
-            eventName: string,
-            listener: (...args: any[]) => void,
-            opts?: {
-                once: boolean;
-            },
-        ): any;
-    }
     interface StaticEventEmitterOptions {
         signal?: AbortSignal | undefined;
     }
@@ -208,7 +198,7 @@ declare module "events" {
             eventName: string | symbol,
             options?: StaticEventEmitterOptions,
         ): Promise<any[]>;
-        static once(emitter: _DOMEventTarget, eventName: string, options?: StaticEventEmitterOptions): Promise<any[]>;
+        static once(emitter: EventTarget, eventName: string, options?: StaticEventEmitterOptions): Promise<any[]>;
         /**
          * ```js
          * import { on, EventEmitter } from 'node:events';
@@ -318,7 +308,7 @@ declare module "events" {
          * ```
          * @since v15.2.0, v14.17.0
          */
-        static getEventListeners(emitter: _DOMEventTarget | NodeJS.EventEmitter, name: string | symbol): Function[];
+        static getEventListeners(emitter: EventTarget | NodeJS.EventEmitter, name: string | symbol): Function[];
         /**
          * Returns the currently set max amount of listeners.
          *
@@ -347,7 +337,7 @@ declare module "events" {
          * ```
          * @since v19.9.0
          */
-        static getMaxListeners(emitter: _DOMEventTarget | NodeJS.EventEmitter): number;
+        static getMaxListeners(emitter: EventTarget | NodeJS.EventEmitter): number;
         /**
          * ```js
          * import { setMaxListeners, EventEmitter } from 'node:events';
@@ -362,7 +352,7 @@ declare module "events" {
          * @param eventsTargets Zero or more {EventTarget} or {EventEmitter} instances. If none are specified, `n` is set as the default max for all newly created {EventTarget} and {EventEmitter}
          * objects.
          */
-        static setMaxListeners(n?: number, ...eventTargets: Array<_DOMEventTarget | NodeJS.EventEmitter>): void;
+        static setMaxListeners(n?: number, ...eventTargets: Array<EventTarget | NodeJS.EventEmitter>): void;
         /**
          * Listens once to the `abort` event on the provided `signal`.
          *

--- a/types/node/test/events.ts
+++ b/types/node/test/events.ts
@@ -79,12 +79,14 @@ declare const any: any;
 }
 
 {
+    class CustomEventTarget extends EventTarget {
+        override addEventListener(name: string, listener: EventListener, opts: AddEventListenerOptions) {
+            setTimeout(() => listener(new Event(name)), 100);
+        }
+    }
+
     events.once(
-        {
-            addEventListener(name: string, listener: (res: number) => void, opts: { once: boolean }) {
-                setTimeout(() => listener(123), 100);
-            },
-        },
+        new CustomEventTarget(),
         "name",
     );
 }

--- a/types/node/test/events.ts
+++ b/types/node/test/events.ts
@@ -80,8 +80,12 @@ declare const any: any;
 
 {
     class CustomEventTarget extends EventTarget {
-        override addEventListener(name: string, listener: EventListener, opts: AddEventListenerOptions) {
-            setTimeout(() => listener(new Event(name)), 100);
+        override addEventListener(...args: Parameters<EventTarget["addEventListener"]>) {
+            const [name, listener] = args
+
+            if (typeof listener === "function") {
+                setTimeout(() => listener(new Event(name)), 100);
+            }
         }
     }
 

--- a/types/node/test/events.ts
+++ b/types/node/test/events.ts
@@ -81,7 +81,7 @@ declare const any: any;
 {
     class CustomEventTarget extends EventTarget {
         override addEventListener(...args: Parameters<EventTarget["addEventListener"]>) {
-            const [name, listener] = args
+            const [name, listener] = args;
 
             if (typeof listener === "function") {
                 setTimeout(() => listener(new Event(name)), 100);


### PR DESCRIPTION
### Description

Current declarations for `once` helper in `node:events` module are incorrect. You cannot pass any object with `addEventListener` method to it.

### Example
```js
const {once} = await import("node:events")

const target = {
    addEventListener(...args) {
        console.log("addEventListener", args)
    }
}

const controller = new AbortController()

const promise = once(target, "test", {signal: controller.signal})

controller.abort()
```
Result:
```shell
TypeError [ERR_INVALID_ARG_TYPE]: The "emitter" argument must be an instance of EventEmitter. Received an instance of Object
    at eventTargetAgnosticRemoveListener (node:events:1028:11) <- !!!PAY ATTENTION HERE!!!
    at EventTarget.abortListener (node:events:1004:7)
    at [nodejs.internal.kHybridDispatch] (node:internal/event_target:826:20)
    at EventTarget.dispatchEvent (node:internal/event_target:761:26)
    at abortSignal (node:internal/abort_controller:371:10)
    at AbortController.abort (node:internal/abort_controller:393:5)
```

Node version: v20.11.0

### Explanation
This error is happening in the example above, because I tried to cancel a subscription to event using the `AbortController`. Internal implementation of Node tries to call something like `removeEventListener`, but provided `target` doesn't have such a method and it causes the error.

I understand the initial reasoning for such declaration as `_DOMEventTarget`. As I see it, it was trying to provide minimal contract for DOM-like event target. But in reality minimal contract also contains at least `removeEventListener`. Also, I believe that the full contract of `EventTarget` is already quite minimal. It contains only 3 methods: `addEventListener`, `removeEventListener` and `dispatchEvent`. The contract of `EventEmitter` is much bigger, but other methods expect an object that fully covers this contract and it is OK (it is even written in the error message). So I propose to simplify declarations and make them more straight forward. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.