### PR TITLE
[@types/chrome] Add cloudFileInfo to chrome.fileSystemProvider

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -3721,6 +3721,11 @@ declare namespace chrome.fileSystemProvider {
         id: string;
     }
 
+    export interface CloudFileInfo {
+        /** A tag that represents the version of the file. */
+        versionTag?: string | undefined;
+    }
+
     export interface EntryMetadata {
         /** True if it is a directory. Must be provided if requested in `options`. */
         isDirectory?: boolean;
@@ -3736,6 +3741,8 @@ declare namespace chrome.fileSystemProvider {
         thumbnail?: string | undefined;
         /** Optional. Cloud storage representation of this entry. Must be provided if requested in `options` and the file is backed by cloud storage. For local files not backed by cloud storage, it should be undefined when requested. */
         cloudIdentifier?: CloudIdentifier | undefined;
+        /** Optional. Information that identifies a specific file in the underlying cloud file system. Must be provided if requested in `options` and the file is backed by cloud storage. */
+        cloudFileInfo?: CloudFileInfo | undefined;
     }
 
     export interface FileSystemInfo {
@@ -3873,6 +3880,8 @@ declare namespace chrome.fileSystemProvider {
         thumbnail: boolean;
         /** Set to true if `cloudIdentifier` is requested. */
         cloudIdentifier: boolean;
+        /** Set to true if `cloudFileInfo` is requested. */
+        cloudFileInfo: boolean;
     }
 
     export interface DirectoryPathRequestedEventOptions extends RequestedEventOptions {
@@ -3981,7 +3990,7 @@ declare namespace chrome.fileSystemProvider {
         chrome.events.Event<
             (
                 options: OpenFileRequestedEventOptions,
-                successCallback: Function,
+                successCallback: (metadata?: EntryMetadata) => void,
                 errorCallback: (error: string) => void,
             ) => void
         >

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -2060,6 +2060,9 @@ function testFileSystemProvider() {
             if (options.cloudIdentifier) {
                 entryMetadata.cloudIdentifier = { providerName: "provider-name", id: "id" };
             }
+            if (options.cloudFileInfo) {
+                entryMetadata.cloudFileInfo = { versionTag: "versionA" };
+            }
         },
     );
 
@@ -2090,10 +2093,20 @@ function testFileSystemProvider() {
         ) => {},
     );
 
+    // Checking onCreateDirectoryRequested.
     chrome.fileSystemProvider.onCreateDirectoryRequested.addListener(
         (
             options: chrome.fileSystemProvider.CreateDirectoryRequestedEventOptions,
             successCallback: Function,
+            errorCallback: (error: string) => void,
+        ) => {},
+    );
+
+    // Checking onOpenFileRequested.
+    chrome.fileSystemProvider.onOpenFileRequested.addListener(
+        (
+            options: chrome.fileSystemProvider.OpenFileRequestedEventOptions,
+            successCallback: (metadata?: chrome.fileSystemProvider.EntryMetadata) => void,
             errorCallback: (error: string) => void,
         ) => {},
     );


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://crrev.com/c/5343674
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

As of ChromeOS 125 there is a new optional field added that enables some Cloud file system flows. The list PR above contains those changes.