### PR TITLE
Bring back exported interfaces

### DIFF
--- a/types/sparql-http-client/ParsingClient.d.ts
+++ b/types/sparql-http-client/ParsingClient.d.ts
@@ -1,7 +1,8 @@
 import { Environment } from "@rdfjs/environment/Environment.js";
 import { DatasetCore, DatasetCoreFactory, Quad } from "@rdfjs/types";
-import { SimpleClient } from "./index.js";
+import { Client } from "./index.js";
 import ParsingQuery from "./ParsingQuery.js";
+import SimpleClient from "./SimpleClient.js";
 
 interface BaseOptions<Q extends Quad, D extends DatasetCore<Q>> {
     factory?: Environment<DatasetCoreFactory<Q, Q, D>>;
@@ -28,12 +29,15 @@ export type Options<Q extends Quad = Quad, D extends DatasetCore<Q> = DatasetCor
     | OptionWithStoreEndpoint<Q, D>
     | OptionWithUpdateEndpoint<Q, D>;
 
-declare class ParsingClient<Q extends Quad = Quad, D extends DatasetCore<Q> = DatasetCore<Q>>
+export type ParsingClient<D extends DatasetCore = DatasetCore> = Client<ParsingQuery<D>>;
+
+declare class ParsingClientImpl<Q extends Quad = Quad, D extends DatasetCore<Q> = DatasetCore<Q>>
     extends SimpleClient<ParsingQuery<D>>
+    implements ParsingClient<D>
 {
     constructor(
         options: Options<Q, D>,
     );
 }
 
-export default ParsingClient;
+export default ParsingClientImpl;

--- a/types/sparql-http-client/SimpleClient.d.ts
+++ b/types/sparql-http-client/SimpleClient.d.ts
@@ -43,7 +43,9 @@ interface QueryOptions {
     update?: boolean;
 }
 
-declare class SimpleClient<
+export type SimpleClient = Client<RawQuery>;
+
+declare class SimpleClientImpl<
     TQuery extends Query = RawQuery,
     TStore extends Store<BaseQuad> = never,
     TFactory = Environment<DataFactory | DatasetCoreFactory> | undefined,
@@ -80,4 +82,4 @@ declare class SimpleClient<
     postUrlencoded(query: string, options?: QueryOptions): Promise<Response>;
 }
 
-export default SimpleClient;
+export default SimpleClientImpl;

--- a/types/sparql-http-client/SimpleClient.d.ts
+++ b/types/sparql-http-client/SimpleClient.d.ts
@@ -4,11 +4,11 @@ import { Client, Query, Store } from "./index.js";
 import RawQuery from "./RawQuery.js";
 
 interface QueryConstructor {
-    new(options: { client: SimpleClient }): Query;
+    new(options: { client: SimpleClientImpl }): Query;
 }
 
 interface StoreConstructor {
-    new<Q extends BaseQuad = Quad>(options: { client: SimpleClient }): Store<Q>;
+    new<Q extends BaseQuad = Quad>(options: { client: SimpleClientImpl }): Store<Q>;
 }
 
 interface BaseOptions {

--- a/types/sparql-http-client/StreamClient.d.ts
+++ b/types/sparql-http-client/StreamClient.d.ts
@@ -24,7 +24,7 @@ interface OptionWithUpdateEndpoint<Q extends BaseQuad> extends BaseOptions<Q> {
     updateUrl: string;
 }
 
-export type Options<Q extends BaseQuad> =
+export type Options<Q extends BaseQuad = Quad> =
     | OptionWithQueryEndpoint<Q>
     | OptionWithStoreEndpoint<Q>
     | OptionWithUpdateEndpoint<Q>;

--- a/types/sparql-http-client/StreamClient.d.ts
+++ b/types/sparql-http-client/StreamClient.d.ts
@@ -1,6 +1,6 @@
 import { Environment } from "@rdfjs/environment/Environment.js";
 import { BaseQuad, DataFactory, DatasetCoreFactory, Quad } from "@rdfjs/types";
-import { SimpleClient } from "./index.js";
+import { Client, SimpleClient } from "./index.js";
 import StreamQuery from "./StreamQuery.js";
 import StreamStore from "./StreamStore.js";
 
@@ -29,10 +29,13 @@ export type Options<Q extends BaseQuad> =
     | OptionWithStoreEndpoint<Q>
     | OptionWithUpdateEndpoint<Q>;
 
-declare class StreamClient<Q extends BaseQuad = Quad>
+export type StreamClient<Q extends BaseQuad = Quad> = Client<StreamQuery<Q>, StreamStore<Q>>;
+
+declare class StreamClientImpl<Q extends BaseQuad = Quad>
     extends SimpleClient<StreamQuery, StreamStore<Q>, Environment<DataFactory<Q> | DatasetCoreFactory>>
+    implements StreamClient<Q>
 {
     constructor(options: Options<Q>);
 }
 
-export default StreamClient;
+export default StreamClientImpl;

--- a/types/sparql-http-client/sparql-http-client-tests.ts
+++ b/types/sparql-http-client/sparql-http-client-tests.ts
@@ -59,15 +59,15 @@ async function streamingClient() {
     });
 
     // query.select
-    const selectNoOptions: Readable = await fullOptions.query.select(query);
-    const selectFullOptions: Readable = await fullOptions.query.select(query, {
+    const selectNoOptions: Readable = fullOptions.query.select(query);
+    const selectFullOptions: Readable = fullOptions.query.select(query, {
         headers,
         operation: "postUrlencoded",
     });
 
     // query.construct
-    const constructNoOptions: Stream<TestQuad> & Readable = await fullOptions.query.construct(query);
-    const constructFullOptions: Stream<TestQuad> & Readable = await fullOptions.query.construct(query, {
+    const constructNoOptions: Stream<TestQuad> & Readable = fullOptions.query.construct(query);
+    const constructFullOptions: Stream<TestQuad> & Readable = fullOptions.query.construct(query, {
         headers,
         operation: "get",
     });

--- a/types/sparql-http-client/sparql-http-client-tests.ts
+++ b/types/sparql-http-client/sparql-http-client-tests.ts
@@ -1,9 +1,10 @@
 import { Environment } from "@rdfjs/environment/Environment.js";
 import { DataFactory, DatasetCore, DatasetCoreFactory, Quad, Quad_Graph, Stream, Term } from "@rdfjs/types";
 import StreamClient from "sparql-http-client";
-import ParsingClient from "sparql-http-client/ParsingClient.js";
+import ParsingClient, { ParsingClient as IParsingClient } from "sparql-http-client/ParsingClient.js";
 import RawQuery from "sparql-http-client/RawQuery.js";
-import SimpleClient from "sparql-http-client/SimpleClient.js";
+import SimpleClient, { SimpleClient as ISimpleClient } from "sparql-http-client/SimpleClient.js";
+import { StreamClient as IStreamClient } from "sparql-http-client/StreamClient.js";
 import StreamStore from "sparql-http-client/StreamStore.js";
 import { Readable } from "stream";
 
@@ -24,22 +25,22 @@ const stream: Stream = <any> {};
 
 async function streamingClient() {
     // construct
-    const usingDefaultFactory: StreamClient = new StreamClient({
+    const usingDefaultFactory: IStreamClient = new StreamClient({
         endpointUrl,
     });
-    const minimalOptions: StreamClient = new StreamClient({
+    const minimalOptions: IStreamClient = new StreamClient({
         endpointUrl,
         factory,
     });
-    const storeOnly: StreamClient = new StreamClient({
+    const storeOnly: IStreamClient = new StreamClient({
         storeUrl: endpointUrl,
         factory,
     });
-    const updateOnly: StreamClient = new StreamClient({
+    const updateOnly: IStreamClient = new StreamClient({
         updateUrl: endpointUrl,
         factory,
     });
-    const fullOptions: StreamClient<TestQuad> = new StreamClient({
+    const fullOptions: IStreamClient<TestQuad> = new StreamClient({
         endpointUrl,
         factory,
         fetch,
@@ -90,22 +91,22 @@ async function streamingClient() {
 
 async function parsingClient() {
     // construct
-    const usingDefaultFactory: ParsingClient = new ParsingClient({
+    const usingDefaultFactory: IParsingClient = new ParsingClient({
         endpointUrl,
     });
-    const minimalOptions: ParsingClient = new ParsingClient({
+    const minimalOptions: IParsingClient = new ParsingClient({
         endpointUrl,
         factory,
     });
-    const storeOnly: ParsingClient = new ParsingClient({
+    const storeOnly: IParsingClient = new ParsingClient({
         storeUrl: endpointUrl,
         factory,
     });
-    const updateOnly: ParsingClient = new ParsingClient({
+    const updateOnly: IParsingClient = new ParsingClient({
         updateUrl: endpointUrl,
         factory,
     });
-    const fullOptions: ParsingClient<TestQuad> = new ParsingClient({
+    const fullOptions: IParsingClient<DatasetCore<TestQuad>> = new ParsingClient({
         endpointUrl,
         factory,
         fetch,
@@ -175,6 +176,9 @@ async function simpleClient() {
         storeUrl,
         Store: StreamStore,
     });
+
+    // cast
+    const casted: ISimpleClient = client;
 
     // get
     const getNoOptions: Response = await client.get(query);


### PR DESCRIPTION
This restores the interfaces `SimpleClient`, `ParsingClient` and `StreamClient` which were previously exported in types for v2.

Also, adds a default for type argument of `Options` in `StreamClient.js`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: for example <https://github.com/DefinitelyTyped/DefinitelyTyped/blob/b84746ab5db34e652635f1346d701461a1a7de2d/types/sparql-http-client/StreamClient.d.ts#L62>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
