### PR TITLE
[react] Allow async actions for `React.startTransition()`

### DIFF
--- a/types/react/canary.d.ts
+++ b/types/react/canary.d.ts
@@ -102,6 +102,13 @@ declare module "." {
         (callback: () => Promise<VoidOrUndefinedOnly>): void;
     }
 
+    /**
+     * Similar to `useTransition` but allows uses where hooks are not available.
+     *
+     * @param callback An _asynchronous_ function which causes state updates that can be deferred.
+     */
+    export function startTransition(scope: () => Promise<VoidOrUndefinedOnly>): void;
+
     export function useOptimistic<State>(
         passthrough: State,
     ): [State, (action: State | ((pendingState: State) => State)) => void];

--- a/types/react/test/canary.tsx
+++ b/types/react/test/canary.tsx
@@ -98,6 +98,7 @@ function useAsyncAction() {
     function handleClick() {
         // $ExpectType void
         startTransition(async () => {});
+        React.startTransition(async () => {});
     }
 }
 

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -391,7 +391,7 @@ function startTransitionTest() {
         transitionToPage("/");
     });
 
-    // @ts-expect-error
+    // Will not type-check in a real project but accepted in DT tests since canary.d.ts is part of compilation.
     React.startTransition(async () => {});
 }
 


### PR DESCRIPTION
I accidentally assumed `TransitionStartFunction` also applies to `React.startTransition`.

I'm not actually sure if the type of  `React.startTransition` is equivalent to the transition function returned from `useTransition` by design so I don' reuse `TransitionStartFunction` for `startTransition` just yet.

In 19, we'll adjust `TransitionFunction` to include async transitions instead of overloading `TransitionStartFunction`. 

Would've been better to just use the same pattern we use to enhance ref cleanups or form actions. This change is just less invasive and 19 around the corner.