### PR TITLE
Add additional message types to castv2

### DIFF
--- a/types/castv2/castv2-tests.ts
+++ b/types/castv2/castv2-tests.ts
@@ -3,6 +3,7 @@ import {
     Client,
     ClientOptions,
     LaunchRequestMessage,
+    MediaStatusMessage,
     ReceiverLaunchErrorMessage,
     ReceiverLaunchStatusMessage,
     ReceiverMessage,
@@ -111,6 +112,11 @@ function handleStatusMessages(channel: Channel): void {
             }
             console.log(`isActiveInput: ${status.isActiveInput}`);
             console.log(`isStandBy: ${status.isStandBy}`);
+        } else if (message.type == "MEDIA_STATUS") {
+            const status = (message as MediaStatusMessage).status[0];
+            console.log(`mediaSessionId: ${status.mediaSessionId}`);
+            console.log(`playerState: ${status.playerState}`);
+            console.log(`currentTime: ${status.currentTime}`);
         }
     });
 }

--- a/types/castv2/index.d.ts
+++ b/types/castv2/index.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="node" />
 
+import { MediaInformation, MediaStatus } from "chromecast-caf-receiver/cast.framework.messages";
 import { EventEmitter } from "node:events";
 
 // To start a new client.
@@ -60,10 +61,10 @@ export interface ApplicationInfo {
 }
 
 export interface VolumeInfo {
-    controlType: string;
+    controlType?: string;
     level: number;
     muted: boolean;
-    stepInterval: number;
+    stepInterval?: number;
 }
 
 // A status message from the receiver.
@@ -89,6 +90,11 @@ export interface ReceiverLaunchStatusMessage extends ReceiverMessage {
     status: "USER_PENDING_AUTHORIZATION" | "USER_ALLOWED";
 }
 
+export interface MediaStatusMessage extends ReceiverMessage {
+    type: "MEDIA_STATUS";
+    status: MediaStatus[];
+}
+
 export type MessageHandler = (data: ReceiverMessage, broadcast: boolean) => void;
 
 export type ErrorHandler = (error: Error) => void;
@@ -105,6 +111,7 @@ export interface Channel extends EventEmitter {
     close(): void;
 
     on(eventName: "message", callback: MessageHandler): this;
+    on(eventName: "close", callback: () => void): this;
 }
 
 export class Client extends EventEmitter {
@@ -114,5 +121,11 @@ export class Client extends EventEmitter {
 
     createChannel(sourceId: string, destinationId: string, namespace: string, encoding: string): Channel;
 
+    on(
+        eventName: "message",
+        callback: (sourceId: string, destinationId: string, namespace: string, message: string) => void,
+    ): this;
+    on(eventName: "connect", callback: () => void): this;
     on(eventName: "error", callback: ErrorHandler): this;
+    on(eventName: "close", callback: () => void): this;
 }

--- a/types/castv2/package.json
+++ b/types/castv2/package.json
@@ -6,8 +6,8 @@
         "https://github.com/thibauts/node-castv2#readme"
     ],
     "dependencies": {
+        "@types/chromecast-caf-receiver": "*",
         "@types/events": "*",
-        "@types/mdns": "*",
         "@types/node": "*"
     },
     "devDependencies": {


### PR DESCRIPTION
This adds additional message types to castv2, leveraging some message definitions from chromecast-caf-receiver types.

This also fixes a couple of optional fields in VolumeInfo.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/cast/docs/media/messages#MediaStatusMess
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
