### PR TITLE
Allow mocha callbacks to use any subclass of Context

### DIFF
--- a/types/mocha/index.d.ts
+++ b/types/mocha/index.d.ts
@@ -1339,7 +1339,7 @@ declare namespace Mocha {
      *
      * @see https://mochajs.org/api/module-Context.html#~Context
      */
-    interface BaseContext {
+    class BaseContext {
         test?: Runnable | undefined;
         currentTest?: Test | undefined;
 
@@ -1389,7 +1389,7 @@ declare namespace Mocha {
         retries(n: number): this;
     }
 
-    interface Context extends BaseContext {
+    class Context extends BaseContext {
         /** Arbitrary, untyped fixtures. */
         [key: string]: any;
     }

--- a/types/mocha/index.d.ts
+++ b/types/mocha/index.d.ts
@@ -1335,11 +1335,20 @@ declare namespace Mocha {
     // #endregion Runnable untyped events
 
     /**
-     * Test context
+     * BaseContext does not actually exist at runtime, so the constructor is
+     * marked as protected.
+     *
+     * It is merely a definition that subclasses can extend to get the Context
+     * interface without a index-signature, since the index-signature breaks
+     * strong type checks on extensions of Context.
+     *
+     * This should contain all actual members of Context.
      *
      * @see https://mochajs.org/api/module-Context.html#~Context
      */
     class BaseContext {
+        protected constructor();
+
         test?: Runnable | undefined;
         currentTest?: Test | undefined;
 
@@ -1389,6 +1398,19 @@ declare namespace Mocha {
         retries(n: number): this;
     }
 
+    /**
+     * Test context.
+     *
+     * Inherits from BaseContext for the purpose of this definition, but
+     * BaseContext does not exist at runtime.
+     *
+     * Actual members of Context are defined on BaseContext above.  Context
+     * then adds the index-signature that allow arbitrary fields.  For strong
+     * typing of extensions to a Mocha context, create a type for your project
+     * that inherits from BaseContext.
+     *
+     * @see https://mochajs.org/api/module-Context.html#~Context
+     */
     class Context extends BaseContext {
         /** Arbitrary, untyped fixtures. */
         [key: string]: any;

--- a/types/mocha/index.d.ts
+++ b/types/mocha/index.d.ts
@@ -389,6 +389,8 @@ declare namespace Mocha {
          * - _Only available when invoked via the mocha CLI._
          */
         (fn: Func): void;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        <T extends BaseContext>(fn: Func<T>): void;
 
         /**
          * [bdd, qunit, tdd] Describe a "hook" to execute the given callback `fn`. The name of the
@@ -397,6 +399,8 @@ declare namespace Mocha {
          * - _Only available when invoked via the mocha CLI._
          */
         (fn: AsyncFunc): void;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        <T extends BaseContext>(fn: AsyncFunc<T>): void;
 
         /**
          * [bdd, qunit, tdd] Describe a "hook" to execute the given `title` and callback `fn`.
@@ -404,6 +408,8 @@ declare namespace Mocha {
          * - _Only available when invoked via the mocha CLI._
          */
         (name: string, fn?: Func): void;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        <T extends BaseContext>(name: string, fn?: Func<T>): void;
 
         /**
          * [bdd, qunit, tdd] Describe a "hook" to execute the given `title` and callback `fn`.
@@ -411,6 +417,8 @@ declare namespace Mocha {
          * - _Only available when invoked via the mocha CLI._
          */
         (name: string, fn?: AsyncFunc): void;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        <T extends BaseContext>(name: string, fn?: AsyncFunc<T>): void;
     }
 
     interface SuiteFunction {
@@ -484,6 +492,8 @@ declare namespace Mocha {
          * - _Only available when invoked via the mocha CLI._
          */
         (fn: Func): Test;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        <T extends BaseContext>(fn: Func<T>): Test;
 
         /**
          * Describe a specification or test-case with the given callback `fn` acting as a thunk.
@@ -492,6 +502,8 @@ declare namespace Mocha {
          * - _Only available when invoked via the mocha CLI._
          */
         (fn: AsyncFunc): Test;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        <T extends BaseContext>(fn: AsyncFunc<T>): Test;
 
         /**
          * Describe a specification or test-case with the given `title` and callback `fn` acting
@@ -500,6 +512,8 @@ declare namespace Mocha {
          * - _Only available when invoked via the mocha CLI._
          */
         (title: string, fn?: Func): Test;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        <T extends BaseContext>(title: string, fn?: Func<T>): Test;
 
         /**
          * Describe a specification or test-case with the given `title` and callback `fn` acting
@@ -508,6 +522,8 @@ declare namespace Mocha {
          * - _Only available when invoked via the mocha CLI._
          */
         (title: string, fn?: AsyncFunc): Test;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        <T extends BaseContext>(title: string, fn?: AsyncFunc<T>): Test;
 
         /**
          * Indicates this test should be executed exclusively.
@@ -540,6 +556,8 @@ declare namespace Mocha {
          * - _Only available when invoked via the mocha CLI._
          */
         (fn: Func): Test;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        <T extends BaseContext>(fn: Func<T>): void;
 
         /**
          * [bdd, tdd, qunit] Describe a specification or test-case with the given callback `fn`
@@ -549,6 +567,8 @@ declare namespace Mocha {
          * - _Only available when invoked via the mocha CLI._
          */
         (fn: AsyncFunc): Test;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        <T extends BaseContext>(fn: AsyncFunc<T>): void;
 
         /**
          * [bdd, tdd, qunit] Describe a specification or test-case with the given `title` and
@@ -557,6 +577,8 @@ declare namespace Mocha {
          * - _Only available when invoked via the mocha CLI._
          */
         (title: string, fn?: Func): Test;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        <T extends BaseContext>(title: string, fn?: Func<T>): void;
 
         /**
          * [bdd, tdd, qunit] Describe a specification or test-case with the given `title` and
@@ -565,6 +587,8 @@ declare namespace Mocha {
          * - _Only available when invoked via the mocha CLI._
          */
         (title: string, fn?: AsyncFunc): Test;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        <T extends BaseContext>(title: string, fn?: AsyncFunc<T>): void;
     }
 
     interface PendingTestFunction {
@@ -576,6 +600,8 @@ declare namespace Mocha {
          * - _Only available when invoked via the mocha CLI._
          */
         (fn: Func): Test;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        <T extends BaseContext>(fn: Func<T>): void;
 
         /**
          * [bdd, tdd, qunit] Describe a specification or test-case with the given callback `fn`
@@ -585,6 +611,8 @@ declare namespace Mocha {
          * - _Only available when invoked via the mocha CLI._
          */
         (fn: AsyncFunc): Test;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        <T extends BaseContext>(fn: AsyncFunc<T>): void;
 
         /**
          * [bdd, tdd, qunit] Describe a specification or test-case with the given `title` and
@@ -593,6 +621,8 @@ declare namespace Mocha {
          * - _Only available when invoked via the mocha CLI._
          */
         (title: string, fn?: Func): Test;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        <T extends BaseContext>(title: string, fn?: Func<T>): void;
 
         /**
          * [bdd, tdd, qunit] Describe a specification or test-case with the given `title` and
@@ -601,6 +631,8 @@ declare namespace Mocha {
          * - _Only available when invoked via the mocha CLI._
          */
         (title: string, fn?: AsyncFunc): Test;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        <T extends BaseContext>(title: string, fn?: AsyncFunc<T>): void;
     }
 
     /**
@@ -1307,9 +1339,7 @@ declare namespace Mocha {
      *
      * @see https://mochajs.org/api/module-Context.html#~Context
      */
-    class Context {
-        private _runnable;
-
+    interface BaseContext {
         test?: Runnable | undefined;
         currentTest?: Test | undefined;
 
@@ -1357,7 +1387,10 @@ declare namespace Mocha {
          * Set the number of allowed retries on failed tests.
          */
         retries(n: number): this;
+    }
 
+    interface Context extends BaseContext {
+        /** Arbitrary, untyped fixtures. */
         [key: string]: any;
     }
 
@@ -1873,6 +1906,8 @@ declare namespace Mocha {
          * @see https://mochajs.org/api/Mocha.Suite.html#beforeAll
          */
         beforeAll(fn?: Func): this;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        beforeAll<T extends BaseContext>(fn?: Func<T>): this;
 
         /**
          * Run `fn(test[, done])` before running tests.
@@ -1880,6 +1915,8 @@ declare namespace Mocha {
          * @see https://mochajs.org/api/Mocha.Suite.html#beforeAll
          */
         beforeAll(fn?: AsyncFunc): this;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        beforeAll<T extends BaseContext>(fn?: AsyncFunc<T>): this;
 
         /**
          * Run `fn(test[, done])` before running tests.
@@ -1887,6 +1924,8 @@ declare namespace Mocha {
          * @see https://mochajs.org/api/Mocha.Suite.html#beforeAll
          */
         beforeAll(title: string, fn?: Func): this;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        beforeAll<T extends BaseContext>(title: string, fn?: Func<T>): this;
 
         /**
          * Run `fn(test[, done])` before running tests.
@@ -1894,6 +1933,8 @@ declare namespace Mocha {
          * @see https://mochajs.org/api/Mocha.Suite.html#beforeAll
          */
         beforeAll(title: string, fn?: AsyncFunc): this;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        beforeAll<T extends BaseContext>(title: string, fn?: AsyncFunc<T>): this;
 
         /**
          * Run `fn(test[, done])` after running tests.
@@ -1901,6 +1942,8 @@ declare namespace Mocha {
          * @see https://mochajs.org/api/Mocha.Suite.html#afterAll
          */
         afterAll(fn?: Func): this;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        afterAll<T extends BaseContext>(fn?: Func<T>): this;
 
         /**
          * Run `fn(test[, done])` after running tests.
@@ -1908,6 +1951,8 @@ declare namespace Mocha {
          * @see https://mochajs.org/api/Mocha.Suite.html#afterAll
          */
         afterAll(fn?: AsyncFunc): this;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        afterAll<T extends BaseContext>(fn?: AsyncFunc<T>): this;
 
         /**
          * Run `fn(test[, done])` after running tests.
@@ -1915,6 +1960,8 @@ declare namespace Mocha {
          * @see https://mochajs.org/api/Mocha.Suite.html#afterAll
          */
         afterAll(title: string, fn?: Func): this;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        afterAll<T extends BaseContext>(title: string, fn?: Func<T>): this;
 
         /**
          * Run `fn(test[, done])` after running tests.
@@ -1922,6 +1969,8 @@ declare namespace Mocha {
          * @see https://mochajs.org/api/Mocha.Suite.html#afterAll
          */
         afterAll(title: string, fn?: AsyncFunc): this;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        afterAll<T extends BaseContext>(title: string, fn?: AsyncFunc<T>): this;
 
         /**
          * Run `fn(test[, done])` before each test case.
@@ -1929,6 +1978,8 @@ declare namespace Mocha {
          * @see https://mochajs.org/api/Mocha.Suite.html#beforeEach
          */
         beforeEach(fn?: Func): this;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        beforeEach<T extends BaseContext>(fn?: Func<T>): this;
 
         /**
          * Run `fn(test[, done])` before each test case.
@@ -1936,6 +1987,8 @@ declare namespace Mocha {
          * @see https://mochajs.org/api/Mocha.Suite.html#beforeEach
          */
         beforeEach(fn?: AsyncFunc): this;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        beforeEach<T extends BaseContext>(fn?: AsyncFunc<T>): this;
 
         /**
          * Run `fn(test[, done])` before each test case.
@@ -1943,6 +1996,8 @@ declare namespace Mocha {
          * @see https://mochajs.org/api/Mocha.Suite.html#beforeEach
          */
         beforeEach(title: string, fn?: Func): this;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        beforeEach<T extends BaseContext>(title: string, fn?: Func<T>): this;
 
         /**
          * Run `fn(test[, done])` before each test case.
@@ -1950,6 +2005,8 @@ declare namespace Mocha {
          * @see https://mochajs.org/api/Mocha.Suite.html#beforeEach
          */
         beforeEach(title: string, fn?: AsyncFunc): this;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        beforeEach<T extends BaseContext>(title: string, fn?: AsyncFunc<T>): this;
 
         /**
          * Run `fn(test[, done])` after each test case.
@@ -1957,6 +2014,8 @@ declare namespace Mocha {
          * @see https://mochajs.org/api/Mocha.Suite.html#afterEach
          */
         afterEach(fn?: Func): this;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        afterEach<T extends BaseContext>(fn?: Func<T>): this;
 
         /**
          * Run `fn(test[, done])` after each test case.
@@ -1964,6 +2023,8 @@ declare namespace Mocha {
          * @see https://mochajs.org/api/Mocha.Suite.html#afterEach
          */
         afterEach(fn?: AsyncFunc): this;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        afterEach<T extends BaseContext>(fn?: AsyncFunc<T>): this;
 
         /**
          * Run `fn(test[, done])` after each test case.
@@ -1971,6 +2032,8 @@ declare namespace Mocha {
          * @see https://mochajs.org/api/Mocha.Suite.html#afterEach
          */
         afterEach(title: string, fn?: Func): this;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        afterEach<T extends BaseContext>(title: string, fn?: Func<T>): this;
 
         /**
          * Run `fn(test[, done])` after each test case.
@@ -1978,6 +2041,8 @@ declare namespace Mocha {
          * @see https://mochajs.org/api/Mocha.Suite.html#afterEach
          */
         afterEach(title: string, fn?: AsyncFunc): this;
+        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+        afterEach<T extends BaseContext>(title: string, fn?: AsyncFunc<T>): this;
 
         /**
          * Add a test `suite`.
@@ -2278,12 +2343,12 @@ declare namespace Mocha {
     /**
      * Callback function used for tests and hooks.
      */
-    type Func = (this: Context, done: Done) => void;
+    type Func<T extends BaseContext = Context> = (this: T, done: Done) => void;
 
     /**
      * Async callback function used for tests and hooks.
      */
-    type AsyncFunc = (this: Context) => PromiseLike<any>;
+    type AsyncFunc<T extends BaseContext = Context> = (this: T) => PromiseLike<any>;
 
     /**
      * Options to pass to Mocha.
@@ -2822,41 +2887,57 @@ declare module "mocha/lib/interfaces/common" {
              * Execute before running tests.
              */
             before(fn?: Mocha.Func | Mocha.AsyncFunc): void;
+            // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+            before<T extends Mocha.BaseContext>(fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
 
             /**
              * Execute before running tests.
              */
             before(name: string, fn?: Mocha.Func | Mocha.AsyncFunc): void;
+            // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+            before<T extends Mocha.BaseContext>(name: string, fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
 
             /**
              * Execute after running tests.
              */
             after(fn?: Mocha.Func | Mocha.AsyncFunc): void;
+            // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+            after<T extends Mocha.BaseContext>(fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
 
             /**
              * Execute after running tests.
              */
             after(name: string, fn?: Mocha.Func | Mocha.AsyncFunc): void;
+            // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+            after<T extends Mocha.BaseContext>(name: string, fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
 
             /**
              * Execute before each test case.
              */
             beforeEach(fn?: Mocha.Func | Mocha.AsyncFunc): void;
+            // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+            beforeEach<T extends Mocha.BaseContext>(fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
 
             /**
              * Execute before each test case.
              */
             beforeEach(name: string, fn?: Mocha.Func | Mocha.AsyncFunc): void;
+            // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+            beforeEach<T extends Mocha.BaseContext>(name: string, fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
 
             /**
              * Execute after each test case.
              */
             afterEach(fn?: Mocha.Func | Mocha.AsyncFunc): void;
+            // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+            afterEach<T extends Mocha.BaseContext>(fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
 
             /**
              * Execute after each test case.
              */
             afterEach(name: string, fn?: Mocha.Func | Mocha.AsyncFunc): void;
+            // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+            afterEach<T extends Mocha.BaseContext>(name: string, fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
 
             suite: SuiteFunctions;
             test: TestFunctions;

--- a/types/mocha/index.d.ts
+++ b/types/mocha/index.d.ts
@@ -390,7 +390,7 @@ declare namespace Mocha {
          */
         (fn: Func): void;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T extends BaseContext>(fn: Func<T>): void;
+        <T extends Context>(fn: Func<T>): void;
 
         /**
          * [bdd, qunit, tdd] Describe a "hook" to execute the given callback `fn`. The name of the
@@ -400,7 +400,7 @@ declare namespace Mocha {
          */
         (fn: AsyncFunc): void;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T extends BaseContext>(fn: AsyncFunc<T>): void;
+        <T extends Context>(fn: AsyncFunc<T>): void;
 
         /**
          * [bdd, qunit, tdd] Describe a "hook" to execute the given `title` and callback `fn`.
@@ -409,7 +409,7 @@ declare namespace Mocha {
          */
         (name: string, fn?: Func): void;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T extends BaseContext>(name: string, fn?: Func<T>): void;
+        <T extends Context>(name: string, fn?: Func<T>): void;
 
         /**
          * [bdd, qunit, tdd] Describe a "hook" to execute the given `title` and callback `fn`.
@@ -418,7 +418,7 @@ declare namespace Mocha {
          */
         (name: string, fn?: AsyncFunc): void;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T extends BaseContext>(name: string, fn?: AsyncFunc<T>): void;
+        <T extends Context>(name: string, fn?: AsyncFunc<T>): void;
     }
 
     interface SuiteFunction {
@@ -493,7 +493,7 @@ declare namespace Mocha {
          */
         (fn: Func): Test;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T extends BaseContext>(fn: Func<T>): Test;
+        <T extends Context>(fn: Func<T>): Test;
 
         /**
          * Describe a specification or test-case with the given callback `fn` acting as a thunk.
@@ -503,7 +503,7 @@ declare namespace Mocha {
          */
         (fn: AsyncFunc): Test;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T extends BaseContext>(fn: AsyncFunc<T>): Test;
+        <T extends Context>(fn: AsyncFunc<T>): Test;
 
         /**
          * Describe a specification or test-case with the given `title` and callback `fn` acting
@@ -513,7 +513,7 @@ declare namespace Mocha {
          */
         (title: string, fn?: Func): Test;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T extends BaseContext>(title: string, fn?: Func<T>): Test;
+        <T extends Context>(title: string, fn?: Func<T>): Test;
 
         /**
          * Describe a specification or test-case with the given `title` and callback `fn` acting
@@ -523,7 +523,7 @@ declare namespace Mocha {
          */
         (title: string, fn?: AsyncFunc): Test;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T extends BaseContext>(title: string, fn?: AsyncFunc<T>): Test;
+        <T extends Context>(title: string, fn?: AsyncFunc<T>): Test;
 
         /**
          * Indicates this test should be executed exclusively.
@@ -557,7 +557,7 @@ declare namespace Mocha {
          */
         (fn: Func): Test;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T extends BaseContext>(fn: Func<T>): void;
+        <T extends Context>(fn: Func<T>): void;
 
         /**
          * [bdd, tdd, qunit] Describe a specification or test-case with the given callback `fn`
@@ -568,7 +568,7 @@ declare namespace Mocha {
          */
         (fn: AsyncFunc): Test;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T extends BaseContext>(fn: AsyncFunc<T>): void;
+        <T extends Context>(fn: AsyncFunc<T>): void;
 
         /**
          * [bdd, tdd, qunit] Describe a specification or test-case with the given `title` and
@@ -578,7 +578,7 @@ declare namespace Mocha {
          */
         (title: string, fn?: Func): Test;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T extends BaseContext>(title: string, fn?: Func<T>): void;
+        <T extends Context>(title: string, fn?: Func<T>): void;
 
         /**
          * [bdd, tdd, qunit] Describe a specification or test-case with the given `title` and
@@ -588,7 +588,7 @@ declare namespace Mocha {
          */
         (title: string, fn?: AsyncFunc): Test;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T extends BaseContext>(title: string, fn?: AsyncFunc<T>): void;
+        <T extends Context>(title: string, fn?: AsyncFunc<T>): void;
     }
 
     interface PendingTestFunction {
@@ -601,7 +601,7 @@ declare namespace Mocha {
          */
         (fn: Func): Test;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T extends BaseContext>(fn: Func<T>): void;
+        <T extends Context>(fn: Func<T>): void;
 
         /**
          * [bdd, tdd, qunit] Describe a specification or test-case with the given callback `fn`
@@ -612,7 +612,7 @@ declare namespace Mocha {
          */
         (fn: AsyncFunc): Test;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T extends BaseContext>(fn: AsyncFunc<T>): void;
+        <T extends Context>(fn: AsyncFunc<T>): void;
 
         /**
          * [bdd, tdd, qunit] Describe a specification or test-case with the given `title` and
@@ -622,7 +622,7 @@ declare namespace Mocha {
          */
         (title: string, fn?: Func): Test;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T extends BaseContext>(title: string, fn?: Func<T>): void;
+        <T extends Context>(title: string, fn?: Func<T>): void;
 
         /**
          * [bdd, tdd, qunit] Describe a specification or test-case with the given `title` and
@@ -632,7 +632,7 @@ declare namespace Mocha {
          */
         (title: string, fn?: AsyncFunc): Test;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T extends BaseContext>(title: string, fn?: AsyncFunc<T>): void;
+        <T extends Context>(title: string, fn?: AsyncFunc<T>): void;
     }
 
     /**
@@ -1335,20 +1335,11 @@ declare namespace Mocha {
     // #endregion Runnable untyped events
 
     /**
-     * BaseContext does not actually exist at runtime, so the constructor is
-     * marked as protected.
-     *
-     * It is merely a definition that subclasses can extend to get the Context
-     * interface without a index-signature, since the index-signature breaks
-     * strong type checks on extensions of Context.
-     *
-     * This should contain all actual members of Context.
+     * Test context
      *
      * @see https://mochajs.org/api/module-Context.html#~Context
      */
-    class BaseContext {
-        protected constructor();
-
+    class Context {
         test?: Runnable | undefined;
         currentTest?: Test | undefined;
 
@@ -1396,25 +1387,13 @@ declare namespace Mocha {
          * Set the number of allowed retries on failed tests.
          */
         retries(n: number): this;
-    }
 
-    /**
-     * Test context.
-     *
-     * Inherits from BaseContext for the purpose of this definition, but
-     * BaseContext does not exist at runtime.
-     *
-     * Actual members of Context are defined on BaseContext above.  Context
-     * then adds the index-signature that allow arbitrary fields.  For strong
-     * typing of extensions to a Mocha context, create a type for your project
-     * that inherits from BaseContext.
-     *
-     * @see https://mochajs.org/api/module-Context.html#~Context
-     */
-    class Context extends BaseContext {
-        constructor();
-
-        /** Arbitrary, untyped fixtures. */
+        /**
+         * Arbitrary, untyped fixtures.
+         *
+         * Don't want these?  Enable noPropertyAccessFromIndexSignature in tsconfig.
+         * @see https://www.typescriptlang.org/tsconfig/#noPropertyAccessFromIndexSignature
+         */
         [key: string]: any;
     }
 
@@ -1931,7 +1910,7 @@ declare namespace Mocha {
          */
         beforeAll(fn?: Func): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        beforeAll<T extends BaseContext>(fn?: Func<T>): this;
+        beforeAll<T extends Context>(fn?: Func<T>): this;
 
         /**
          * Run `fn(test[, done])` before running tests.
@@ -1940,7 +1919,7 @@ declare namespace Mocha {
          */
         beforeAll(fn?: AsyncFunc): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        beforeAll<T extends BaseContext>(fn?: AsyncFunc<T>): this;
+        beforeAll<T extends Context>(fn?: AsyncFunc<T>): this;
 
         /**
          * Run `fn(test[, done])` before running tests.
@@ -1949,7 +1928,7 @@ declare namespace Mocha {
          */
         beforeAll(title: string, fn?: Func): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        beforeAll<T extends BaseContext>(title: string, fn?: Func<T>): this;
+        beforeAll<T extends Context>(title: string, fn?: Func<T>): this;
 
         /**
          * Run `fn(test[, done])` before running tests.
@@ -1958,7 +1937,7 @@ declare namespace Mocha {
          */
         beforeAll(title: string, fn?: AsyncFunc): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        beforeAll<T extends BaseContext>(title: string, fn?: AsyncFunc<T>): this;
+        beforeAll<T extends Context>(title: string, fn?: AsyncFunc<T>): this;
 
         /**
          * Run `fn(test[, done])` after running tests.
@@ -1967,7 +1946,7 @@ declare namespace Mocha {
          */
         afterAll(fn?: Func): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        afterAll<T extends BaseContext>(fn?: Func<T>): this;
+        afterAll<T extends Context>(fn?: Func<T>): this;
 
         /**
          * Run `fn(test[, done])` after running tests.
@@ -1976,7 +1955,7 @@ declare namespace Mocha {
          */
         afterAll(fn?: AsyncFunc): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        afterAll<T extends BaseContext>(fn?: AsyncFunc<T>): this;
+        afterAll<T extends Context>(fn?: AsyncFunc<T>): this;
 
         /**
          * Run `fn(test[, done])` after running tests.
@@ -1985,7 +1964,7 @@ declare namespace Mocha {
          */
         afterAll(title: string, fn?: Func): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        afterAll<T extends BaseContext>(title: string, fn?: Func<T>): this;
+        afterAll<T extends Context>(title: string, fn?: Func<T>): this;
 
         /**
          * Run `fn(test[, done])` after running tests.
@@ -1994,7 +1973,7 @@ declare namespace Mocha {
          */
         afterAll(title: string, fn?: AsyncFunc): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        afterAll<T extends BaseContext>(title: string, fn?: AsyncFunc<T>): this;
+        afterAll<T extends Context>(title: string, fn?: AsyncFunc<T>): this;
 
         /**
          * Run `fn(test[, done])` before each test case.
@@ -2003,7 +1982,7 @@ declare namespace Mocha {
          */
         beforeEach(fn?: Func): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        beforeEach<T extends BaseContext>(fn?: Func<T>): this;
+        beforeEach<T extends Context>(fn?: Func<T>): this;
 
         /**
          * Run `fn(test[, done])` before each test case.
@@ -2012,7 +1991,7 @@ declare namespace Mocha {
          */
         beforeEach(fn?: AsyncFunc): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        beforeEach<T extends BaseContext>(fn?: AsyncFunc<T>): this;
+        beforeEach<T extends Context>(fn?: AsyncFunc<T>): this;
 
         /**
          * Run `fn(test[, done])` before each test case.
@@ -2021,7 +2000,7 @@ declare namespace Mocha {
          */
         beforeEach(title: string, fn?: Func): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        beforeEach<T extends BaseContext>(title: string, fn?: Func<T>): this;
+        beforeEach<T extends Context>(title: string, fn?: Func<T>): this;
 
         /**
          * Run `fn(test[, done])` before each test case.
@@ -2030,7 +2009,7 @@ declare namespace Mocha {
          */
         beforeEach(title: string, fn?: AsyncFunc): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        beforeEach<T extends BaseContext>(title: string, fn?: AsyncFunc<T>): this;
+        beforeEach<T extends Context>(title: string, fn?: AsyncFunc<T>): this;
 
         /**
          * Run `fn(test[, done])` after each test case.
@@ -2039,7 +2018,7 @@ declare namespace Mocha {
          */
         afterEach(fn?: Func): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        afterEach<T extends BaseContext>(fn?: Func<T>): this;
+        afterEach<T extends Context>(fn?: Func<T>): this;
 
         /**
          * Run `fn(test[, done])` after each test case.
@@ -2048,7 +2027,7 @@ declare namespace Mocha {
          */
         afterEach(fn?: AsyncFunc): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        afterEach<T extends BaseContext>(fn?: AsyncFunc<T>): this;
+        afterEach<T extends Context>(fn?: AsyncFunc<T>): this;
 
         /**
          * Run `fn(test[, done])` after each test case.
@@ -2057,7 +2036,7 @@ declare namespace Mocha {
          */
         afterEach(title: string, fn?: Func): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        afterEach<T extends BaseContext>(title: string, fn?: Func<T>): this;
+        afterEach<T extends Context>(title: string, fn?: Func<T>): this;
 
         /**
          * Run `fn(test[, done])` after each test case.
@@ -2066,7 +2045,7 @@ declare namespace Mocha {
          */
         afterEach(title: string, fn?: AsyncFunc): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        afterEach<T extends BaseContext>(title: string, fn?: AsyncFunc<T>): this;
+        afterEach<T extends Context>(title: string, fn?: AsyncFunc<T>): this;
 
         /**
          * Add a test `suite`.
@@ -2367,12 +2346,12 @@ declare namespace Mocha {
     /**
      * Callback function used for tests and hooks.
      */
-    type Func<T extends BaseContext = Context> = (this: T, done: Done) => void;
+    type Func<T extends Context = Context> = (this: T, done: Done) => void;
 
     /**
      * Async callback function used for tests and hooks.
      */
-    type AsyncFunc<T extends BaseContext = Context> = (this: T) => PromiseLike<any>;
+    type AsyncFunc<T extends Context = Context> = (this: T) => PromiseLike<any>;
 
     /**
      * Options to pass to Mocha.
@@ -2912,56 +2891,56 @@ declare module "mocha/lib/interfaces/common" {
              */
             before(fn?: Mocha.Func | Mocha.AsyncFunc): void;
             // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-            before<T extends Mocha.BaseContext>(fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
+            before<T extends Mocha.Context>(fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
 
             /**
              * Execute before running tests.
              */
             before(name: string, fn?: Mocha.Func | Mocha.AsyncFunc): void;
             // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-            before<T extends Mocha.BaseContext>(name: string, fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
+            before<T extends Mocha.Context>(name: string, fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
 
             /**
              * Execute after running tests.
              */
             after(fn?: Mocha.Func | Mocha.AsyncFunc): void;
             // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-            after<T extends Mocha.BaseContext>(fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
+            after<T extends Mocha.Context>(fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
 
             /**
              * Execute after running tests.
              */
             after(name: string, fn?: Mocha.Func | Mocha.AsyncFunc): void;
             // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-            after<T extends Mocha.BaseContext>(name: string, fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
+            after<T extends Mocha.Context>(name: string, fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
 
             /**
              * Execute before each test case.
              */
             beforeEach(fn?: Mocha.Func | Mocha.AsyncFunc): void;
             // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-            beforeEach<T extends Mocha.BaseContext>(fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
+            beforeEach<T extends Mocha.Context>(fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
 
             /**
              * Execute before each test case.
              */
             beforeEach(name: string, fn?: Mocha.Func | Mocha.AsyncFunc): void;
             // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-            beforeEach<T extends Mocha.BaseContext>(name: string, fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
+            beforeEach<T extends Mocha.Context>(name: string, fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
 
             /**
              * Execute after each test case.
              */
             afterEach(fn?: Mocha.Func | Mocha.AsyncFunc): void;
             // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-            afterEach<T extends Mocha.BaseContext>(fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
+            afterEach<T extends Mocha.Context>(fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
 
             /**
              * Execute after each test case.
              */
             afterEach(name: string, fn?: Mocha.Func | Mocha.AsyncFunc): void;
             // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-            afterEach<T extends Mocha.BaseContext>(name: string, fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
+            afterEach<T extends Mocha.Context>(name: string, fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
 
             suite: SuiteFunctions;
             test: TestFunctions;

--- a/types/mocha/index.d.ts
+++ b/types/mocha/index.d.ts
@@ -388,7 +388,6 @@ declare namespace Mocha {
          *
          * - _Only available when invoked via the mocha CLI._
          */
-        (fn: Func): void;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         <T extends Context>(fn: Func<T>): void;
 
@@ -398,7 +397,6 @@ declare namespace Mocha {
          *
          * - _Only available when invoked via the mocha CLI._
          */
-        (fn: AsyncFunc): void;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         <T extends Context>(fn: AsyncFunc<T>): void;
 
@@ -407,7 +405,6 @@ declare namespace Mocha {
          *
          * - _Only available when invoked via the mocha CLI._
          */
-        (name: string, fn?: Func): void;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         <T extends Context>(name: string, fn?: Func<T>): void;
 
@@ -416,7 +413,6 @@ declare namespace Mocha {
          *
          * - _Only available when invoked via the mocha CLI._
          */
-        (name: string, fn?: AsyncFunc): void;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         <T extends Context>(name: string, fn?: AsyncFunc<T>): void;
     }
@@ -491,7 +487,6 @@ declare namespace Mocha {
          *
          * - _Only available when invoked via the mocha CLI._
          */
-        (fn: Func): Test;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         <T extends Context>(fn: Func<T>): Test;
 
@@ -501,7 +496,6 @@ declare namespace Mocha {
          *
          * - _Only available when invoked via the mocha CLI._
          */
-        (fn: AsyncFunc): Test;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         <T extends Context>(fn: AsyncFunc<T>): Test;
 
@@ -511,7 +505,6 @@ declare namespace Mocha {
          *
          * - _Only available when invoked via the mocha CLI._
          */
-        (title: string, fn?: Func): Test;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         <T extends Context>(title: string, fn?: Func<T>): Test;
 
@@ -521,7 +514,6 @@ declare namespace Mocha {
          *
          * - _Only available when invoked via the mocha CLI._
          */
-        (title: string, fn?: AsyncFunc): Test;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         <T extends Context>(title: string, fn?: AsyncFunc<T>): Test;
 
@@ -555,7 +547,6 @@ declare namespace Mocha {
          *
          * - _Only available when invoked via the mocha CLI._
          */
-        (fn: Func): Test;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         <T extends Context>(fn: Func<T>): void;
 
@@ -566,7 +557,6 @@ declare namespace Mocha {
          *
          * - _Only available when invoked via the mocha CLI._
          */
-        (fn: AsyncFunc): Test;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         <T extends Context>(fn: AsyncFunc<T>): void;
 
@@ -576,7 +566,6 @@ declare namespace Mocha {
          *
          * - _Only available when invoked via the mocha CLI._
          */
-        (title: string, fn?: Func): Test;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         <T extends Context>(title: string, fn?: Func<T>): void;
 
@@ -586,7 +575,6 @@ declare namespace Mocha {
          *
          * - _Only available when invoked via the mocha CLI._
          */
-        (title: string, fn?: AsyncFunc): Test;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         <T extends Context>(title: string, fn?: AsyncFunc<T>): void;
     }
@@ -599,7 +587,6 @@ declare namespace Mocha {
          *
          * - _Only available when invoked via the mocha CLI._
          */
-        (fn: Func): Test;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         <T extends Context>(fn: Func<T>): void;
 
@@ -610,7 +597,6 @@ declare namespace Mocha {
          *
          * - _Only available when invoked via the mocha CLI._
          */
-        (fn: AsyncFunc): Test;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         <T extends Context>(fn: AsyncFunc<T>): void;
 
@@ -620,7 +606,6 @@ declare namespace Mocha {
          *
          * - _Only available when invoked via the mocha CLI._
          */
-        (title: string, fn?: Func): Test;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         <T extends Context>(title: string, fn?: Func<T>): void;
 
@@ -630,7 +615,6 @@ declare namespace Mocha {
          *
          * - _Only available when invoked via the mocha CLI._
          */
-        (title: string, fn?: AsyncFunc): Test;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         <T extends Context>(title: string, fn?: AsyncFunc<T>): void;
     }
@@ -1908,7 +1892,6 @@ declare namespace Mocha {
          *
          * @see https://mochajs.org/api/Mocha.Suite.html#beforeAll
          */
-        beforeAll(fn?: Func): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         beforeAll<T extends Context>(fn?: Func<T>): this;
 
@@ -1917,7 +1900,6 @@ declare namespace Mocha {
          *
          * @see https://mochajs.org/api/Mocha.Suite.html#beforeAll
          */
-        beforeAll(fn?: AsyncFunc): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         beforeAll<T extends Context>(fn?: AsyncFunc<T>): this;
 
@@ -1926,7 +1908,6 @@ declare namespace Mocha {
          *
          * @see https://mochajs.org/api/Mocha.Suite.html#beforeAll
          */
-        beforeAll(title: string, fn?: Func): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         beforeAll<T extends Context>(title: string, fn?: Func<T>): this;
 
@@ -1935,7 +1916,6 @@ declare namespace Mocha {
          *
          * @see https://mochajs.org/api/Mocha.Suite.html#beforeAll
          */
-        beforeAll(title: string, fn?: AsyncFunc): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         beforeAll<T extends Context>(title: string, fn?: AsyncFunc<T>): this;
 
@@ -1944,7 +1924,6 @@ declare namespace Mocha {
          *
          * @see https://mochajs.org/api/Mocha.Suite.html#afterAll
          */
-        afterAll(fn?: Func): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         afterAll<T extends Context>(fn?: Func<T>): this;
 
@@ -1953,7 +1932,6 @@ declare namespace Mocha {
          *
          * @see https://mochajs.org/api/Mocha.Suite.html#afterAll
          */
-        afterAll(fn?: AsyncFunc): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         afterAll<T extends Context>(fn?: AsyncFunc<T>): this;
 
@@ -1962,7 +1940,6 @@ declare namespace Mocha {
          *
          * @see https://mochajs.org/api/Mocha.Suite.html#afterAll
          */
-        afterAll(title: string, fn?: Func): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         afterAll<T extends Context>(title: string, fn?: Func<T>): this;
 
@@ -1971,7 +1948,6 @@ declare namespace Mocha {
          *
          * @see https://mochajs.org/api/Mocha.Suite.html#afterAll
          */
-        afterAll(title: string, fn?: AsyncFunc): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         afterAll<T extends Context>(title: string, fn?: AsyncFunc<T>): this;
 
@@ -1980,7 +1956,6 @@ declare namespace Mocha {
          *
          * @see https://mochajs.org/api/Mocha.Suite.html#beforeEach
          */
-        beforeEach(fn?: Func): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         beforeEach<T extends Context>(fn?: Func<T>): this;
 
@@ -1989,7 +1964,6 @@ declare namespace Mocha {
          *
          * @see https://mochajs.org/api/Mocha.Suite.html#beforeEach
          */
-        beforeEach(fn?: AsyncFunc): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         beforeEach<T extends Context>(fn?: AsyncFunc<T>): this;
 
@@ -1998,7 +1972,6 @@ declare namespace Mocha {
          *
          * @see https://mochajs.org/api/Mocha.Suite.html#beforeEach
          */
-        beforeEach(title: string, fn?: Func): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         beforeEach<T extends Context>(title: string, fn?: Func<T>): this;
 
@@ -2007,7 +1980,6 @@ declare namespace Mocha {
          *
          * @see https://mochajs.org/api/Mocha.Suite.html#beforeEach
          */
-        beforeEach(title: string, fn?: AsyncFunc): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         beforeEach<T extends Context>(title: string, fn?: AsyncFunc<T>): this;
 
@@ -2016,7 +1988,6 @@ declare namespace Mocha {
          *
          * @see https://mochajs.org/api/Mocha.Suite.html#afterEach
          */
-        afterEach(fn?: Func): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         afterEach<T extends Context>(fn?: Func<T>): this;
 
@@ -2025,7 +1996,6 @@ declare namespace Mocha {
          *
          * @see https://mochajs.org/api/Mocha.Suite.html#afterEach
          */
-        afterEach(fn?: AsyncFunc): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         afterEach<T extends Context>(fn?: AsyncFunc<T>): this;
 
@@ -2034,7 +2004,6 @@ declare namespace Mocha {
          *
          * @see https://mochajs.org/api/Mocha.Suite.html#afterEach
          */
-        afterEach(title: string, fn?: Func): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         afterEach<T extends Context>(title: string, fn?: Func<T>): this;
 
@@ -2043,7 +2012,6 @@ declare namespace Mocha {
          *
          * @see https://mochajs.org/api/Mocha.Suite.html#afterEach
          */
-        afterEach(title: string, fn?: AsyncFunc): this;
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         afterEach<T extends Context>(title: string, fn?: AsyncFunc<T>): this;
 
@@ -2889,56 +2857,48 @@ declare module "mocha/lib/interfaces/common" {
             /**
              * Execute before running tests.
              */
-            before(fn?: Mocha.Func | Mocha.AsyncFunc): void;
             // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
             before<T extends Mocha.Context>(fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
 
             /**
              * Execute before running tests.
              */
-            before(name: string, fn?: Mocha.Func | Mocha.AsyncFunc): void;
             // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
             before<T extends Mocha.Context>(name: string, fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
 
             /**
              * Execute after running tests.
              */
-            after(fn?: Mocha.Func | Mocha.AsyncFunc): void;
             // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
             after<T extends Mocha.Context>(fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
 
             /**
              * Execute after running tests.
              */
-            after(name: string, fn?: Mocha.Func | Mocha.AsyncFunc): void;
             // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
             after<T extends Mocha.Context>(name: string, fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
 
             /**
              * Execute before each test case.
              */
-            beforeEach(fn?: Mocha.Func | Mocha.AsyncFunc): void;
             // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
             beforeEach<T extends Mocha.Context>(fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
 
             /**
              * Execute before each test case.
              */
-            beforeEach(name: string, fn?: Mocha.Func | Mocha.AsyncFunc): void;
             // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
             beforeEach<T extends Mocha.Context>(name: string, fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
 
             /**
              * Execute after each test case.
              */
-            afterEach(fn?: Mocha.Func | Mocha.AsyncFunc): void;
             // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
             afterEach<T extends Mocha.Context>(fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
 
             /**
              * Execute after each test case.
              */
-            afterEach(name: string, fn?: Mocha.Func | Mocha.AsyncFunc): void;
             // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
             afterEach<T extends Mocha.Context>(name: string, fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
 

--- a/types/mocha/index.d.ts
+++ b/types/mocha/index.d.ts
@@ -1412,6 +1412,8 @@ declare namespace Mocha {
      * @see https://mochajs.org/api/module-Context.html#~Context
      */
     class Context extends BaseContext {
+        constructor();
+
         /** Arbitrary, untyped fixtures. */
         [key: string]: any;
     }

--- a/types/mocha/index.d.ts
+++ b/types/mocha/index.d.ts
@@ -548,7 +548,7 @@ declare namespace Mocha {
          * - _Only available when invoked via the mocha CLI._
          */
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T extends Context>(fn: Func<T>): void;
+        <T extends Context>(fn: Func<T>): Test;
 
         /**
          * [bdd, tdd, qunit] Describe a specification or test-case with the given callback `fn`
@@ -558,7 +558,7 @@ declare namespace Mocha {
          * - _Only available when invoked via the mocha CLI._
          */
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T extends Context>(fn: AsyncFunc<T>): void;
+        <T extends Context>(fn: AsyncFunc<T>): Test;
 
         /**
          * [bdd, tdd, qunit] Describe a specification or test-case with the given `title` and
@@ -567,7 +567,7 @@ declare namespace Mocha {
          * - _Only available when invoked via the mocha CLI._
          */
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T extends Context>(title: string, fn?: Func<T>): void;
+        <T extends Context>(title: string, fn?: Func<T>): Test;
 
         /**
          * [bdd, tdd, qunit] Describe a specification or test-case with the given `title` and
@@ -576,7 +576,7 @@ declare namespace Mocha {
          * - _Only available when invoked via the mocha CLI._
          */
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T extends Context>(title: string, fn?: AsyncFunc<T>): void;
+        <T extends Context>(title: string, fn?: AsyncFunc<T>): Test;
     }
 
     interface PendingTestFunction {
@@ -588,7 +588,7 @@ declare namespace Mocha {
          * - _Only available when invoked via the mocha CLI._
          */
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T extends Context>(fn: Func<T>): void;
+        <T extends Context>(fn: Func<T>): Test;
 
         /**
          * [bdd, tdd, qunit] Describe a specification or test-case with the given callback `fn`
@@ -598,7 +598,7 @@ declare namespace Mocha {
          * - _Only available when invoked via the mocha CLI._
          */
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T extends Context>(fn: AsyncFunc<T>): void;
+        <T extends Context>(fn: AsyncFunc<T>): Test;
 
         /**
          * [bdd, tdd, qunit] Describe a specification or test-case with the given `title` and
@@ -607,7 +607,7 @@ declare namespace Mocha {
          * - _Only available when invoked via the mocha CLI._
          */
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T extends Context>(title: string, fn?: Func<T>): void;
+        <T extends Context>(title: string, fn?: Func<T>): Test;
 
         /**
          * [bdd, tdd, qunit] Describe a specification or test-case with the given `title` and
@@ -616,7 +616,7 @@ declare namespace Mocha {
          * - _Only available when invoked via the mocha CLI._
          */
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        <T extends Context>(title: string, fn?: AsyncFunc<T>): void;
+        <T extends Context>(title: string, fn?: AsyncFunc<T>): Test;
     }
 
     /**

--- a/types/mocha/mocha-tests.ts
+++ b/types/mocha/mocha-tests.ts
@@ -1516,3 +1516,44 @@ function test_no_basecontext_constructor() {
     // @ts-expect-error
     return new LocalMocha.BaseContext();
 }
+
+// Importantly, this doesn't implement BaseContext, and it isn't empty.  For
+// some reason, TS treats empty classes as matching constraints.
+class ArbitraryClass {
+    someField: number;
+}
+
+// Context constraints should be enforced on callbacks.
+function test_constraints(suite: LocalMocha.Suite) {
+    // Should work.
+    const f1: LocalMocha.Func<LocalMocha.Context> = function(this: LocalMocha.Context) {};
+
+    // Should work.
+    const f2: LocalMocha.Func<ContextWithFixtures> = function(this: ContextWithFixtures) {};
+
+    // Doesn't implement BaseContext.
+    // @ts-expect-error
+    const f3: LocalMocha.Func<ArbitraryClass> = function(this: ArbitraryClass) {};
+
+    // Doesn't implement BaseContext.
+    // @ts-expect-error
+    const f4: LocalMocha.Func<string> = function(this: string) {};
+
+    // Doesn't match types.
+    // @ts-expect-error
+    const f5: LocalMocha.Func<LocalMocha.Context> = function(this: ArbitraryClass) {};
+
+    // Should work.
+    suite.beforeAll(function(this: LocalMocha.Context) {});
+
+    // Should work.
+    suite.beforeAll(function(this: ContextWithFixtures) {});
+
+    // Doesn't implement BaseContext.
+    // @ts-expect-error
+    suite.beforeAll(function(this: ArbitraryClass) {});
+
+    // Doesn't implement BaseContext.
+    // @ts-expect-error
+    suite.beforeAll(function(this: string) {});
+}

--- a/types/mocha/mocha-tests.ts
+++ b/types/mocha/mocha-tests.ts
@@ -1480,32 +1480,32 @@ function test_runnable_state(runnable: LocalMocha.Runnable) {
 
 // Extends BaseContext, which has no index signature for arbitrary fixtures
 interface ContextWithFixtures extends LocalMocha.BaseContext {
-  doSomethingSync(): void;
-  doSomethingAsync(): Promise<void>;
+    doSomethingSync(): void;
+    doSomethingAsync(): Promise<void>;
 }
 
 function test_context_subclass() {
-  describe('ContextWithFixtures', function() {
-    // Should be usable in hooks and in tests
-    beforeEach(function(this: ContextWithFixtures): void {
-      this.doSomethingSync();
-    });
+    describe("ContextWithFixtures", function() {
+        // Should be usable in hooks and in tests
+        beforeEach(function(this: ContextWithFixtures): void {
+            this.doSomethingSync();
+        });
 
-    it('calls synchronous function', function(this: ContextWithFixtures): void {
-      this.doSomethingSync();
-    });
+        it("calls synchronous function", function(this: ContextWithFixtures): void {
+            this.doSomethingSync();
+        });
 
-    it('calls async function', async function(this: ContextWithFixtures): Promise<void> {
-      await this.doSomethingAsync();
-    });
+        it("calls async function", async function(this: ContextWithFixtures): Promise<void> {
+            await this.doSomethingAsync();
+        });
 
-    it('fixtures are strongly typed', async function(this: ContextWithFixtures): Promise<void> {
-      // @ts-expect-error
-      this.doSomethingSync('extra argument');
-      // @ts-expect-error
-      await this.doSomethingAsync('extra argument');
-      // @ts-expect-error
-      this.doesNotExist = 5;
+        it("fixtures are strongly typed", async function(this: ContextWithFixtures): Promise<void> {
+            // @ts-expect-error
+            this.doSomethingSync("extra argument");
+            // @ts-expect-error
+            await this.doSomethingAsync("extra argument");
+            // @ts-expect-error
+            this.doesNotExist = 5;
+        });
     });
-  });
 }

--- a/types/mocha/mocha-tests.ts
+++ b/types/mocha/mocha-tests.ts
@@ -1509,3 +1509,10 @@ function test_context_subclass() {
         });
     });
 }
+
+// You should not be able to call new BaseContext(), because BaseContext exists
+// only as an abstractions in the definitions, not at runtime.
+function test_no_basecontext_constructor() {
+    // @ts-expect-error
+    return new LocalMocha.BaseContext();
+}

--- a/types/mocha/mocha-tests.ts
+++ b/types/mocha/mocha-tests.ts
@@ -1477,3 +1477,35 @@ function test_runnable_state(runnable: LocalMocha.Runnable) {
     runnable.state = "failed";
     runnable.state = "passed";
 }
+
+// Extends BaseContext, which has no index signature for arbitrary fixtures
+interface ContextWithFixtures extends LocalMocha.BaseContext {
+  doSomethingSync(): void;
+  doSomethingAsync(): Promise<void>;
+}
+
+function test_context_subclass() {
+  describe('ContextWithFixtures', function() {
+    // Should be usable in hooks and in tests
+    beforeEach(function(this: ContextWithFixtures): void {
+      this.doSomethingSync();
+    });
+
+    it('calls synchronous function', function(this: ContextWithFixtures): void {
+      this.doSomethingSync();
+    });
+
+    it('calls async function', async function(this: ContextWithFixtures): Promise<void> {
+      await this.doSomethingAsync();
+    });
+
+    it('fixtures are strongly typed', async function(this: ContextWithFixtures): Promise<void> {
+      // @ts-expect-error
+      this.doSomethingSync('extra argument');
+      // @ts-expect-error
+      await this.doSomethingAsync('extra argument');
+      // @ts-expect-error
+      this.doesNotExist = 5;
+    });
+  });
+}

--- a/types/mocha/mocha-tests.ts
+++ b/types/mocha/mocha-tests.ts
@@ -1478,9 +1478,9 @@ function test_runnable_state(runnable: LocalMocha.Runnable) {
     runnable.state = "passed";
 }
 
-// Extends BaseContext, which has no index signature for arbitrary fixtures
-interface ContextWithFixtures extends LocalMocha.BaseContext {
-    doSomethingSync(): void;
+// Extends Context with additional fixtures.
+interface ContextWithFixtures extends LocalMocha.Context {
+    doSomethingSync(arg: number): void;
     doSomethingAsync(): Promise<void>;
 }
 
@@ -1488,11 +1488,11 @@ function test_context_subclass() {
     describe("ContextWithFixtures", function() {
         // Should be usable in hooks and in tests
         beforeEach(function(this: ContextWithFixtures): void {
-            this.doSomethingSync();
+            this.doSomethingSync(5);
         });
 
         it("calls synchronous function", function(this: ContextWithFixtures): void {
-            this.doSomethingSync();
+            this.doSomethingSync(5);
         });
 
         it("calls async function", async function(this: ContextWithFixtures): Promise<void> {
@@ -1501,24 +1501,15 @@ function test_context_subclass() {
 
         it("fixtures are strongly typed", async function(this: ContextWithFixtures): Promise<void> {
             // @ts-expect-error
-            this.doSomethingSync("extra argument");
+            this.doSomethingSync("wrong argument type");
             // @ts-expect-error
             await this.doSomethingAsync("extra argument");
-            // @ts-expect-error
-            this.doesNotExist = 5;
         });
     });
 }
 
-// You should not be able to call new BaseContext(), because BaseContext exists
-// only as an abstractions in the definitions, not at runtime.
-function test_no_basecontext_constructor() {
-    // @ts-expect-error
-    return new LocalMocha.BaseContext();
-}
-
-// Importantly, this doesn't implement BaseContext, and it isn't empty.  For
-// some reason, TS treats empty classes as matching constraints.
+// Importantly, this doesn't extend Context, and it isn't empty.  For some
+// reason, TS treats empty classes as matching constraints.
 class ArbitraryClass {
     someField: number;
 }
@@ -1531,11 +1522,11 @@ function test_constraints(suite: LocalMocha.Suite) {
     // Should work.
     const f2: LocalMocha.Func<ContextWithFixtures> = function(this: ContextWithFixtures) {};
 
-    // Doesn't implement BaseContext.
+    // Doesn't extend Context.
     // @ts-expect-error
     const f3: LocalMocha.Func<ArbitraryClass> = function(this: ArbitraryClass) {};
 
-    // Doesn't implement BaseContext.
+    // Doesn't extend Context.
     // @ts-expect-error
     const f4: LocalMocha.Func<string> = function(this: string) {};
 
@@ -1549,11 +1540,11 @@ function test_constraints(suite: LocalMocha.Suite) {
     // Should work.
     suite.beforeAll(function(this: ContextWithFixtures) {});
 
-    // Doesn't implement BaseContext.
+    // Doesn't extend Context.
     // @ts-expect-error
     suite.beforeAll(function(this: ArbitraryClass) {});
 
-    // Doesn't implement BaseContext.
+    // Doesn't extend Context.
     // @ts-expect-error
     suite.beforeAll(function(this: string) {});
 }


### PR DESCRIPTION
When creating fixtures in Mocha, they get attached to Context, which includes an index signature for this purpose.  However, those fixtures will have no type information.

If a project wants to strongly type its fixtures, it needs to subclass Context.  But then, without this patch, the compiler will reject the use of those subclasses in Mocha callbacks.

---

**Update**: Updated again with latest design changes to the PR.

`Context`'s index signature prevents strong typing for Mocha fixtures.  To address this, a project should subclass `Context` and enable the compiler option `noPropertyAccessFromIndexSignature`, but the mocha types still need to use generics to allow the subclass for the type of `this` in callbacks.

Callback functions `Func` and `AsyncFunc` had `this: Context`, but now are generics with `this: T` and `T extends Context = Context`.

Leaving out the default `T = Context` breaks compilation, with errors like `Generic type 'AsyncFunc' requires 1 type argument(s)`.  But including it also leads to the assumption that we always pass `Context` instead of a subclass.

The solution is for each usage of `Func` and `AsyncFunc` in Mocha's API, to add a generic overload of the method.  If I pass a callback that uses strongly-typed fixtures in a `Context` subclass, the compiler can infer the generic type and properly check my usage of those fixtures.

For example, where we had this:

```ts
            before(fn?: Mocha.Func | Mocha.AsyncFunc): void;
```

we change to this:

```ts
            before<T extends Mocha.Context>(fn?: Mocha.Func<T> | Mocha.AsyncFunc<T>): void;
```

Each instance of this fails the linter check `@definitelytyped/no-unnecessary-generics` with `Type parameter T is used only once`.  The generic doesn't influence the return type, so this rule would steer us toward using `any` instead.  But this is clearly necessary to use the strongly-typed `this` we need to pass.  So each instance is preceded by `// eslint-disable-next-line @definitelytyped/no-unnecessary-generics`.

---

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://mochajs.org/#global-fixtures
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
