### PR TITLE
[webpack-env] Make `import.meta.webpackContext`  non-nullable

### DIFF
--- a/types/webpack-env/index.d.ts
+++ b/types/webpack-env/index.d.ts
@@ -351,7 +351,7 @@ interface ImportMeta {
      * `import.meta.webpackContext` as ESM alternative to `require.context`
      * Available: 5.70.0+
      */
-    webpackContext?: (
+    webpackContext: (
         request: string,
         options?: {
             recursive?: boolean;

--- a/types/webpack-env/webpack-env-tests.ts
+++ b/types/webpack-env/webpack-env-tests.ts
@@ -144,7 +144,7 @@ if (importMeta.webpack >= 5 && importMeta.webpackHot) {
     importMeta.webpackHot.removeStatusHandler(statusHandler);
 }
 
-if (importMeta.webpack >= 5 && importMeta.webpackContext) {
+if (importMeta.webpack >= 5) { // `import.meta.webpackContext` is only available there
     let context = importMeta.webpackContext("./somePath", {
         recursive: true,
         regExp: /some/,


### PR DESCRIPTION
It seems that the prop was made nullable because it's Webpack 5+, but I don’t think that should be a deterrent, or else all global types for all new APIs should be nullable.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://webpack.js.org/api/module-variables/#importmetawebpackcontext
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
