### PR TITLE
fix(react-refresh): fix incorrect type definitions of `react-refresh`

### DIFF
--- a/types/react-refresh/react-refresh-tests.ts
+++ b/types/react-refresh/react-refresh-tests.ts
@@ -7,7 +7,11 @@ const noop = () => {};
 
 ReactRefreshRuntime.collectCustomHooksForSignature(STRING);
 ReactRefreshRuntime.collectCustomHooksForSignature(noop);
-ReactRefreshRuntime.createSignatureFunctionForTransform();
+const _s = ReactRefreshRuntime.createSignatureFunctionForTransform();
+_s();
+_s(noop, STRING, true, () => [noop]);
+_s(noop, STRING, false);
+_s(noop, STRING);
 ReactRefreshRuntime.findAffectedHostInstances([]);
 ReactRefreshRuntime.findAffectedHostInstances([{ current: noop }]);
 // @ts-expect-error

--- a/types/react-refresh/react-refresh-tests.ts
+++ b/types/react-refresh/react-refresh-tests.ts
@@ -1,6 +1,6 @@
+import * as babel from "@babel/core";
 import * as ReactRefreshRuntime from "react-refresh/runtime";
 import ReactRefreshBabelPlugin = require("react-refresh/babel");
-import * as babel from "@babel/core";
 
 const STRING = "example string";
 const noop = () => {};
@@ -24,7 +24,7 @@ ReactRefreshRuntime.performReactRefresh();
 ReactRefreshRuntime.register("unknown type", STRING);
 ReactRefreshRuntime.register(noop, STRING);
 ReactRefreshRuntime.register({}, STRING);
-ReactRefreshRuntime.setSignature(noop, STRING, true, () => noop);
+ReactRefreshRuntime.setSignature(noop, STRING, true, () => [noop]);
 ReactRefreshRuntime.setSignature(noop, STRING, false);
 ReactRefreshRuntime.setSignature(noop, STRING);
 

--- a/types/react-refresh/runtime.d.ts
+++ b/types/react-refresh/runtime.d.ts
@@ -13,7 +13,7 @@ export function performReactRefresh(): RefreshUpdate | null;
 
 export function register(type: unknown, id: string): void;
 
-export function setSignature(type: unknown, key: string, forceReset?: boolean, getCustomHooks?: () => AnyFn): void;
+export function setSignature(type: unknown, key: string, forceReset?: boolean, getCustomHooks?: () => AnyFn[]): void;
 
 /**
  * This is lazily called during first render for a type.
@@ -55,6 +55,11 @@ export function hasUnrecoverableErrors(): boolean;
  *    () => [useCustomHook], // Lazy to avoid triggering inline requires
  * );
  */
-export function createSignatureFunctionForTransform(): void;
+export function createSignatureFunctionForTransform(): <T>(
+    type: T,
+    key: string,
+    forceReset?: boolean,
+    getCustomHooks?: () => AnyFn[],
+) => T | undefined;
 
 export function isLikelyComponentType(type: unknown): boolean;

--- a/types/react-refresh/runtime.d.ts
+++ b/types/react-refresh/runtime.d.ts
@@ -60,6 +60,9 @@ export function createSignatureFunctionForTransform(): <T>(
     key: string,
     forceReset?: boolean,
     getCustomHooks?: () => AnyFn[],
-) => T | undefined;
+) =>
+    | T
+    | // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+    void;
 
 export function isLikelyComponentType(type: unknown): boolean;

--- a/types/react-refresh/runtime.d.ts
+++ b/types/react-refresh/runtime.d.ts
@@ -65,10 +65,7 @@ export function createSignatureFunctionForTransform(): {
         key: string,
         forceReset?: boolean,
         getCustomHooks?: () => AnyFn[],
-    ):
-        | T
-        | // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-        void;
+    ): T;
 };
 
 export function isLikelyComponentType(type: unknown): boolean;

--- a/types/react-refresh/runtime.d.ts
+++ b/types/react-refresh/runtime.d.ts
@@ -55,14 +55,17 @@ export function hasUnrecoverableErrors(): boolean;
  *    () => [useCustomHook], // Lazy to avoid triggering inline requires
  * );
  */
-export function createSignatureFunctionForTransform(): <T>(
-    type: T,
-    key: string,
-    forceReset?: boolean,
-    getCustomHooks?: () => AnyFn[],
-) =>
-    | T
-    | // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-    void;
+export function createSignatureFunctionForTransform(): {
+    (): void;
+    <T>(
+        type: T,
+        key: string,
+        forceReset?: boolean,
+        getCustomHooks?: () => AnyFn[],
+    ):
+        | T
+        | // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+        void;
+};
 
 export function isLikelyComponentType(type: unknown): boolean;

--- a/types/react-refresh/runtime.d.ts
+++ b/types/react-refresh/runtime.d.ts
@@ -36,24 +36,27 @@ export function hasUnrecoverableErrors(): boolean;
  * Signatures let us decide whether the Hook order has changed on refresh.
  *
  * This function is intended to be used as a transform target, e.g.:
+ *
+ * ```
  * var _s = createSignatureFunctionForTransform()
- * @example
+ *
  * function Hello() {
- * const [foo, setFoo] = useState(0);
- *  const value = useCustomHook();
- * _s(); /* Call without arguments triggers collecting the custom Hook list.
- * This doesn't happen during the module evaluation because we
- * don't want to change the module order with inline requires.
- * Next calls are noops.
+ *   const [foo, setFoo] = useState(0);
+ *   const value = useCustomHook();
+ *   _s(); // Call without arguments triggers collecting the custom Hook list.
+ *         // This doesn't happen during the module evaluation because we
+ *         // don't want to change the module order with inline requires.
+ *         // Next calls are noops.
  *   return <h1>Hi</h1>;
  * }
- * @example
+ *
  * // Call with arguments attaches the signature to the type:
  * _s(
  *    Hello,
  *    'useState{[foo, setFoo]}(0)',
  *    () => [useCustomHook], // Lazy to avoid triggering inline requires
  * );
+ * ```
  */
 export function createSignatureFunctionForTransform(): {
     (): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
	- [`setSignature`](https://github.com/facebook/react/blob/4e8121a75ec7fa838fc781cbab418d40218678a9/packages/react-refresh/src/ReactFreshRuntime.js#L349)
	- [`createSignatureFunctionForTransform`](https://github.com/facebook/react/blob/4e8121a75ec7fa838fc781cbab418d40218678a9/packages/react-refresh/src/ReactFreshRuntime.js#L638)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.