### PR TITLE
Add allowEmptyArray option to qs.stringify

### DIFF
--- a/types/qs/index.d.ts
+++ b/types/qs/index.d.ts
@@ -25,6 +25,7 @@ declare namespace QueryString {
         addQueryPrefix?: boolean | undefined;
         charset?: "utf-8" | "iso-8859-1" | undefined;
         charsetSentinel?: boolean | undefined;
+        allowEmptyArrays?: boolean | undefined;
     }
 
     type IStringifyDynamicOptions<AllowDots extends BooleanOptional> = AllowDots extends true

--- a/types/qs/qs-tests.ts
+++ b/types/qs/qs-tests.ts
@@ -364,7 +364,7 @@ qs.parse("a=b&c=d", { delimiter: "&" });
 
 (() => {
     var withEmptyArrays = qs.stringify({ foo: [], bar: "baz" }, { allowEmptyArrays: true });
-    assert.deepEqual(withEmptyArrays,  "foo[]&bar=baz");
+    assert.deepEqual(withEmptyArrays, "foo[]&bar=baz");
 });
 
 (() => {

--- a/types/qs/qs-tests.ts
+++ b/types/qs/qs-tests.ts
@@ -363,6 +363,11 @@ qs.parse("a=b&c=d", { delimiter: "&" });
 });
 
 (() => {
+    var withEmptyArrays = qs.stringify({ foo: [], bar: "baz" }, { allowEmptyArrays: true });
+    assert.deepEqual(withEmptyArrays,  "foo[]&bar=baz");
+});
+
+(() => {
     var withDots = qs.parse("name%252Eobj.first=John&name%252Eobj.last=Doe", { decodeDotInKeys: true });
     assert.deepEqual(withDots, { "name.obj": { first: "John", last: "Doe" } });
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [stringify.js](https://github.com/ljharb/qs/blob/main/lib/stringify.js#L68) - [commit added](https://github.com/ljharb/qs/commit/f22b2bc0fa02eddc64779a328c4eaa73ede6fcf6)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

