### PR TITLE
Export types from assert.strict namespace

### DIFF
--- a/types/node/assert.d.ts
+++ b/types/node/assert.d.ts
@@ -959,6 +959,53 @@ declare module "assert" {
          * @since v13.6.0, v12.16.0
          */
         function doesNotMatch(value: string, regExp: RegExp, message?: string | Error): void;
+        /**
+         * In strict assertion mode, non-strict methods behave like their corresponding strict methods. For example,
+         * {@link deepEqual} will behave like {@link deepStrictEqual}.
+         *
+         * In strict assertion mode, error messages for objects display a diff. In legacy assertion mode, error
+         * messages for objects display the objects, often truncated.
+         *
+         * To use strict assertion mode:
+         *
+         * ```js
+         * import { strict as assert } from 'node:assert';COPY
+         * import assert from 'node:assert/strict';
+         * ```
+         *
+         * Example error diff:
+         *
+         * ```js
+         * import { strict as assert } from 'node:assert';
+         *
+         * assert.deepEqual([[[1, 2, 3]], 4, 5], [[[1, 2, '3']], 4, 5]);
+         * // AssertionError: Expected inputs to be strictly deep-equal:
+         * // + actual - expected ... Lines skipped
+         * //
+         * //   [
+         * //     [
+         * // ...
+         * //       2,
+         * // +     3
+         * // -     '3'
+         * //     ],
+         * // ...
+         * //     5
+         * //   ]
+         * ```
+         *
+         * To deactivate the colors, use the `NO_COLOR` or `NODE_DISABLE_COLORS` environment variables. This will also
+         * deactivate the colors in the REPL. For more on color support in terminal environments, read the tty
+         * `getColorDepth()` documentation.
+         *
+         * @since v15.0.0, v13.9.0, v12.16.2, v9.9.0
+         */
+        namespace strict {
+            type AssertionError = assert.AssertionError;
+            type AssertPredicate = assert.AssertPredicate;
+            type CallTrackerCall = assert.CallTrackerCall;
+            type CallTrackerReportInformation = assert.CallTrackerReportInformation;
+        }
         const strict:
             & Omit<
                 typeof assert,

--- a/types/node/test/assert.ts
+++ b/types/node/test/assert.ts
@@ -108,6 +108,8 @@ assert.ok(1);
 assert.strict.strict.strict(1);
 assert.strict.strict(1);
 assert.strict(1);
+
+const strictAssertionError: assert.strict.AssertionError = new assert.strict.AssertionError();
 assert(1);
 
 assert.match("test", /test/, new Error("yeet"));


### PR DESCRIPTION
The namespace is needed to re-export types from assert.

I also added docs for `assert.strict`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/assert.html#strict-assertion-mode
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
