### PR TITLE
[lodash] add type guard signature for has

### DIFF
--- a/types/lodash/common/common.d.ts
+++ b/types/lodash/common/common.d.ts
@@ -2,6 +2,7 @@ import _ = require("../index");
 // eslint-disable-next-line @definitelytyped/strict-export-declare-modifiers
 type GlobalPartial<T> = Partial<T>;
 declare module "../index" {
+    type RequiredBy<T, K extends keyof T> = T & Required<Pick<T, K>>;
     type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
     type PartialObject<T> = GlobalPartial<T>;
     type Many<T> = T | readonly T[];

--- a/types/lodash/common/common.d.ts
+++ b/types/lodash/common/common.d.ts
@@ -2,7 +2,6 @@ import _ = require("../index");
 // eslint-disable-next-line @definitelytyped/strict-export-declare-modifiers
 type GlobalPartial<T> = Partial<T>;
 declare module "../index" {
-    type RequiredBy<T, K extends keyof T> = T & Required<Pick<T, K>>;
     type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
     type PartialObject<T> = GlobalPartial<T>;
     type Many<T> = T | readonly T[];

--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -1327,7 +1327,7 @@ declare module "../index" {
          * _.has(other, 'a');
          * // => false
          */
-        has<T, K extends keyof T>(object: T, path: K): object is RequiredBy<T, K>;
+        has<T, K extends PropertyName>(object: T, path: K): object is T & Record<string, unknown> & { [P in K]: P extends keyof T ? T[P] : Record<string, unknown> extends T ? T[keyof T] : unknown};
         has<T>(object: T, path: PropertyPath): boolean;
     }
     interface LoDashImplicitWrapper<TValue> {

--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -1327,6 +1327,7 @@ declare module "../index" {
          * _.has(other, 'a');
          * // => false
          */
+        has<T, K extends keyof T>(object: T, path: K): object is RequiredBy<T, K>;
         has<T>(object: T, path: PropertyPath): boolean;
     }
     interface LoDashImplicitWrapper<TValue> {

--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -1327,7 +1327,7 @@ declare module "../index" {
          * _.has(other, 'a');
          * // => false
          */
-        has<T, K extends PropertyName>(object: T, path: K): object is T & Record<string, unknown> & { [P in K]: P extends keyof T ? T[P] : Record<string, unknown> extends T ? T[keyof T] : unknown};
+        has<T, K extends PropertyName>(object: T, path: K): object is T & { [P in K]: P extends keyof T ? T[P] : Record<string, unknown> extends T ? T[keyof T] : unknown};
         has<T>(object: T, path: PropertyPath): boolean;
     }
     interface LoDashImplicitWrapper<TValue> {

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -5424,6 +5424,12 @@ fp.now(); // $ExpectType number
     _.has(abcObject, ""); // $ExpectType boolean
     _.has(abcObject, 42); // $ExpectType boolean
     _.has(abcObject, ["", 42]); // $ExpectType boolean
+    const partialObject: { a?: number; b?: string } = {};
+    if (_.has(partialObject, 'a')) {
+        partialObject.a; // $ExpectType number
+    } else {
+        partialObject.a; // $ExpectType number | undefined
+    }
     _(abcObject).has(""); // $ExpectType boolean
     _(abcObject).has(42); // $ExpectType boolean
     _(abcObject).has(["", 42]); // $ExpectType boolean

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -5424,11 +5424,25 @@ fp.now(); // $ExpectType number
     _.has(abcObject, ""); // $ExpectType boolean
     _.has(abcObject, 42); // $ExpectType boolean
     _.has(abcObject, ["", 42]); // $ExpectType boolean
-    const partialObject: { a?: number; b?: string } = {};
-    if (_.has(partialObject, 'a')) {
-        partialObject.a; // $ExpectType number
+    if (_.has(abcObject, 'd')) {
+        abcObject.d // $ExpectType unknown
     } else {
+        abcObject; // $ExpectType AbcObject
+    }
+    const partialObject: Partial<AbcObject> = {};
+    if (_.has(partialObject, 'a')) {
         partialObject.a; // $ExpectType number | undefined
+    } else {
+        partialObject; // $ExpectType Partial<AbcObject>
+    }
+    const record: Record<string, number | string> = {};
+    if (_.has(record, 'a')) {
+        record.a; // $ExpectType number | string
+        const result: { a: number | string } = record;
+    } else {
+        // @ts-expect-error
+        const result: { a: number | string } = record;
+        record; // $ExpectType Record<string, number | string>
     }
     _(abcObject).has(""); // $ExpectType boolean
     _(abcObject).has(42); // $ExpectType boolean


### PR DESCRIPTION
If `_.has(object, 'a')` is true, then property 'a' is not optional.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://lodash.com/docs/4.17.15#has