### PR TITLE
[snowflake-sdk] Add requestId to connection.execute options

### DIFF
--- a/types/snowflake-sdk/index.d.ts
+++ b/types/snowflake-sdk/index.d.ts
@@ -571,6 +571,12 @@ export type Connection = NodeJS.EventEmitter & {
         fetchAsString?: Array<"String" | "Boolean" | "Number" | "Date" | "JSON" | "Buffer"> | undefined;
         complete?: (err: SnowflakeError | undefined, stmt: Statement, rows: any[] | undefined) => void;
         parameters?: Record<string, unknown>;
+
+        /**
+         * ### Related Docs
+         * - {@link https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver-execute#resubmitting-requests Resubmitting Requests}
+         */
+        requestId?: string;
     }): Statement;
 
     /**

--- a/types/snowflake-sdk/snowflake-sdk-tests.ts
+++ b/types/snowflake-sdk/snowflake-sdk-tests.ts
@@ -107,6 +107,11 @@ const connectCallback = (err: snowflake.SnowflakeError | undefined, conn: snowfl
         // @ts-expect-error
         parameters: "not-a-record",
     });
+
+    conn.execute({
+        sqlText: "",
+        requestId: "",
+    });
 };
 connection.connect(connectCallback);
 connection.connectAsync(connectCallback).then(() => {});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver-execute#resubmitting-requests
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. --> already existed: https://github.com/snowflakedb/snowflake-connector-nodejs/blob/master/lib/connection/statement.js#L383-L389