### PR TITLE
[@types/lodash] Perfor: Includes method definitely not friendly

### DIFF
--- a/types/lodash/common/collection.d.ts
+++ b/types/lodash/common/collection.d.ts
@@ -1004,7 +1004,7 @@ declare module "../index" {
          * @param fromIndex The index to search from.
          * @return True if the target element is found, else false.
          */
-        includes<T>(collection: Dictionary<T> | NumericDictionary<T> | null | undefined, target: unknow, fromIndex?: number): target is T;
+        includes<T>(collection: Dictionary<T> | NumericDictionary<T> | null | undefined, target: unknown, fromIndex?: number): target is T;
     }
     interface Object<T> {
         /**

--- a/types/lodash/common/collection.d.ts
+++ b/types/lodash/common/collection.d.ts
@@ -1004,7 +1004,7 @@ declare module "../index" {
          * @param fromIndex The index to search from.
          * @return True if the target element is found, else false.
          */
-        includes<T>(collection: Dictionary<T> | NumericDictionary<T> | null | undefined, target: T, fromIndex?: number): boolean;
+        includes<T>(collection: Dictionary<T> | NumericDictionary<T> | null | undefined, target: unknow, fromIndex?: number): target is T;
     }
     interface Object<T> {
         /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

The `includes` target value must be `Array like item` some times not be friendly:
```typescript
import { includes } from 'lodash-es'
const someVars: string | number = 'foo';
// It will throw error for `someVars` not be `number` type
const isInclude = includes([1, 2, 3], someVars);
```