### PR TITLE
[react] Allow React context in ReactNode

### DIFF
--- a/types/react/canary.d.ts
+++ b/types/react/canary.d.ts
@@ -30,6 +30,12 @@ export {};
 declare const UNDEFINED_VOID_ONLY: unique symbol;
 type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 
+/**
+ * @internal
+ */
+// TODO: Do we need a non-recursive copy like we do in AwaitedReactNode to unwrap the context value?
+interface ReactContextAsReactNode extends React.Context<React.ReactNode> {}
+
 declare module "." {
     interface ThenableImpl<T> {
         then(onFulfill: (value: T) => unknown, onReject: (error: unknown) => unknown): void | PromiseLike<unknown>;
@@ -140,5 +146,24 @@ declare module "." {
         onTransitionRunCapture?: TransitionEventHandler<T> | undefined;
         onTransitionStart?: TransitionEventHandler<T> | undefined;
         onTransitionStartCapture?: TransitionEventHandler<T> | undefined;
+    }
+
+    /**
+     * @internal Use `Awaited<ReactNode>` instead
+     */
+    // Helper type to enable `Awaited<ReactNode>`.
+    // Must be a copy of the non-thenables of `ReactNode`.
+    type AwaitedReactNode =
+        | ReactElement
+        | string
+        | number
+        | Iterable<AwaitedReactNode>
+        | ReactPortal
+        | boolean
+        | null
+        | undefined;
+    interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES {
+        contexts: ReactContextAsReactNode;
+        promises: Promise<AwaitedReactNode>;
     }
 }

--- a/types/react/canary.d.ts
+++ b/types/react/canary.d.ts
@@ -33,7 +33,6 @@ type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 /**
  * @internal
  */
-// TODO: Do we need a non-recursive copy like we do in AwaitedReactNode to unwrap the context value?
 interface ReactContextAsReactNode extends React.Context<React.ReactNode> {}
 
 declare module "." {

--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -42,24 +42,6 @@ declare const UNDEFINED_VOID_ONLY: unique symbol;
 type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 
 declare module "." {
-    /**
-     * @internal Use `Awaited<ReactNode>` instead
-     */
-    // Helper type to enable `Awaited<ReactNode>`.
-    // Must be a copy of the non-thenables of `ReactNode`.
-    type AwaitedReactNode =
-        | ReactElement
-        | string
-        | number
-        | Iterable<AwaitedReactNode>
-        | ReactPortal
-        | boolean
-        | null
-        | undefined;
-    interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES {
-        promises: Promise<AwaitedReactNode>;
-    }
-
     export interface SuspenseProps {
         /**
          * The presence of this prop indicates that the content is computationally expensive to render.

--- a/types/react/test/canary.tsx
+++ b/types/react/test/canary.tsx
@@ -359,3 +359,31 @@ function formTest() {
         event;
     }}
 />;
+
+// ReactNode tests
+{
+    // @ts-expect-error
+    const render: React.ReactNode = () => React.createElement("div");
+    // @ts-expect-error
+    const emptyObject: React.ReactNode = {};
+    // @ts-expect-error
+    const plainObject: React.ReactNode = { dave: true };
+    const promise: React.ReactNode = Promise.resolve("React");
+    // @ts-expect-error plain objects are not allowed
+    <div>{{ dave: true }}</div>;
+    <div>{Promise.resolve("React")}</div>;
+
+    const asyncTests = async function asyncTests() {
+        const node: Awaited<React.ReactNode> = await Promise.resolve("React");
+    };
+
+    const RenderableContext = React.createContext<React.ReactNode>("HAL");
+    const NestedContext = React.createContext(RenderableContext);
+    let node: React.ReactNode = RenderableContext;
+    // @ts-expect-error TODO context values are recursively unwrapped so this should be allowed by types.
+    node = NestedContext;
+
+    const NotRenderableContext = React.createContext(() => {});
+    // @ts-expect-error
+    node: React.ReactNode = NotRenderableContext;
+}

--- a/types/react/test/experimental.tsx
+++ b/types/react/test/experimental.tsx
@@ -72,24 +72,6 @@ function useEvent() {
     );
 }
 
-// ReactNode tests
-{
-    // @ts-expect-error
-    const render: React.ReactNode = () => React.createElement("div");
-    // @ts-expect-error
-    const emptyObject: React.ReactNode = {};
-    // @ts-expect-error
-    const plainObject: React.ReactNode = { dave: true };
-    const promise: React.ReactNode = Promise.resolve("React");
-    // @ts-expect-error plain objects are not allowed
-    <div>{{ dave: true }}</div>;
-    <div>{Promise.resolve("React")}</div>;
-
-    const asyncTests = async function asyncTests() {
-        const node: Awaited<React.ReactNode> = await Promise.resolve("React");
-    };
-}
-
 function elementTypeTests() {
     const ReturnPromise = () => Promise.resolve("React");
     const FCPromise: React.FC = ReturnPromise;

--- a/types/react/ts5.0/canary.d.ts
+++ b/types/react/ts5.0/canary.d.ts
@@ -30,6 +30,12 @@ export {};
 declare const UNDEFINED_VOID_ONLY: unique symbol;
 type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 
+/**
+ * @internal
+ */
+// TODO: Do we need a non-recursive copy like we do in AwaitedReactNode to unwrap the context value?
+interface ReactContextAsReactNode extends React.Context<React.ReactNode> {}
+
 declare module "." {
     interface ThenableImpl<T> {
         then(onFulfill: (value: T) => unknown, onReject: (error: unknown) => unknown): void | PromiseLike<unknown>;
@@ -140,5 +146,24 @@ declare module "." {
         onTransitionRunCapture?: TransitionEventHandler<T> | undefined;
         onTransitionStart?: TransitionEventHandler<T> | undefined;
         onTransitionStartCapture?: TransitionEventHandler<T> | undefined;
+    }
+
+    /**
+     * @internal Use `Awaited<ReactNode>` instead
+     */
+    // Helper type to enable `Awaited<ReactNode>`.
+    // Must be a copy of the non-thenables of `ReactNode`.
+    type AwaitedReactNode =
+        | ReactElement
+        | string
+        | number
+        | Iterable<AwaitedReactNode>
+        | ReactPortal
+        | boolean
+        | null
+        | undefined;
+    interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES {
+        contexts: ReactContextAsReactNode;
+        promises: Promise<AwaitedReactNode>;
     }
 }

--- a/types/react/ts5.0/canary.d.ts
+++ b/types/react/ts5.0/canary.d.ts
@@ -33,7 +33,6 @@ type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 /**
  * @internal
  */
-// TODO: Do we need a non-recursive copy like we do in AwaitedReactNode to unwrap the context value?
 interface ReactContextAsReactNode extends React.Context<React.ReactNode> {}
 
 declare module "." {

--- a/types/react/ts5.0/experimental.d.ts
+++ b/types/react/ts5.0/experimental.d.ts
@@ -42,24 +42,6 @@ declare const UNDEFINED_VOID_ONLY: unique symbol;
 type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 
 declare module "." {
-    /**
-     * @internal Use `Awaited<ReactNode>` instead
-     */
-    // Helper type to enable `Awaited<ReactNode>`.
-    // Must be a copy of the non-thenables of `ReactNode`.
-    type AwaitedReactNode =
-        | ReactElement
-        | string
-        | number
-        | Iterable<AwaitedReactNode>
-        | ReactPortal
-        | boolean
-        | null
-        | undefined;
-    interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES {
-        promises: Promise<AwaitedReactNode>;
-    }
-
     export interface SuspenseProps {
         /**
          * The presence of this prop indicates that the content is computationally expensive to render.

--- a/types/react/ts5.0/test/canary.tsx
+++ b/types/react/ts5.0/test/canary.tsx
@@ -359,3 +359,31 @@ function formTest() {
         event;
     }}
 />;
+
+// ReactNode tests
+{
+    // @ts-expect-error
+    const render: React.ReactNode = () => React.createElement("div");
+    // @ts-expect-error
+    const emptyObject: React.ReactNode = {};
+    // @ts-expect-error
+    const plainObject: React.ReactNode = { dave: true };
+    const promise: React.ReactNode = Promise.resolve("React");
+    // @ts-expect-error plain objects are not allowed
+    <div>{{ dave: true }}</div>;
+    <div>{Promise.resolve("React")}</div>;
+
+    const asyncTests = async function asyncTests() {
+        const node: Awaited<React.ReactNode> = await Promise.resolve("React");
+    };
+
+    const RenderableContext = React.createContext<React.ReactNode>("HAL");
+    const NestedContext = React.createContext(RenderableContext);
+    let node: React.ReactNode = RenderableContext;
+    // @ts-expect-error TODO context values are recursively unwrapped so this should be allowed by types.
+    node = NestedContext;
+
+    const NotRenderableContext = React.createContext(() => {});
+    // @ts-expect-error
+    node: React.ReactNode = NotRenderableContext;
+}

--- a/types/react/ts5.0/test/experimental.tsx
+++ b/types/react/ts5.0/test/experimental.tsx
@@ -72,24 +72,6 @@ function useEvent() {
     );
 }
 
-// ReactNode tests
-{
-    // @ts-expect-error
-    const render: React.ReactNode = () => React.createElement("div");
-    // @ts-expect-error
-    const emptyObject: React.ReactNode = {};
-    // @ts-expect-error
-    const plainObject: React.ReactNode = { dave: true };
-    const promise: React.ReactNode = Promise.resolve("React");
-    // @ts-expect-error plain objects are not allowed
-    <div>{{ dave: true }}</div>;
-    <div>{Promise.resolve("React")}</div>;
-
-    const asyncTests = async function asyncTests() {
-        const node: Awaited<React.ReactNode> = await Promise.resolve("React");
-    };
-}
-
 function elementTypeTests() {
     const ReturnPromise = () => Promise.resolve("React");
     // @ts-expect-error Needs https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65135


### PR DESCRIPTION
CI failures are unrelated: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69307

Does not support nested context even though context values are recursively unwrapped at runtime where `{React.createContext(React.createContext('render me'))}` should work.

Modelling this with types is a bit more involved and practically probably not that relevant. We can work on it once we see legit use cases.

Also moved promise as a node to types for Canary release channel.