### PR TITLE
[react/ts5.0] Allow async actions for `React.startTransition()`

### DIFF
--- a/types/react/ts5.0/canary.d.ts
+++ b/types/react/ts5.0/canary.d.ts
@@ -102,6 +102,13 @@ declare module "." {
         (callback: () => Promise<VoidOrUndefinedOnly>): void;
     }
 
+    /**
+     * Similar to `useTransition` but allows uses where hooks are not available.
+     *
+     * @param callback An _asynchronous_ function which causes state updates that can be deferred.
+     */
+    export function startTransition(scope: () => Promise<VoidOrUndefinedOnly>): void;
+
     export function useOptimistic<State>(
         passthrough: State,
     ): [State, (action: State | ((pendingState: State) => State)) => void];

--- a/types/react/ts5.0/test/canary.tsx
+++ b/types/react/ts5.0/test/canary.tsx
@@ -98,6 +98,7 @@ function useAsyncAction() {
     function handleClick() {
         // $ExpectType void
         startTransition(async () => {});
+        React.startTransition(async () => {});
     }
 }
 

--- a/types/react/ts5.0/test/hooks.tsx
+++ b/types/react/ts5.0/test/hooks.tsx
@@ -391,7 +391,7 @@ function startTransitionTest() {
         transitionToPage("/");
     });
 
-    // @ts-expect-error
+    // Will not type-check in a real project but accepted in DT tests since canary.d.ts is part of compilation.
     React.startTransition(async () => {});
 }
 


### PR DESCRIPTION
Backports https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69250/

CI failures are unrelated: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69307