### PR TITLE
[wordpress__edit-post] Use latest `@wordpress/components` types

### DIFF
--- a/types/wordpress__edit-post/components/block-settings-menu/plugin-block-settings-menu-item.d.ts
+++ b/types/wordpress__edit-post/components/block-settings-menu/plugin-block-settings-menu-item.d.ts
@@ -1,5 +1,5 @@
 import { Dashicon } from "@wordpress/components";
-import { ComponentType, JSX, MouseEventHandler } from "react";
+import { ComponentProps, ComponentType, JSX, MouseEventHandler } from "react";
 
 declare namespace PluginBlockSettingsMenuItem {
     interface Props {
@@ -13,7 +13,7 @@ declare namespace PluginBlockSettingsMenuItem {
          * A dashicon slug, or a custom JSX element.
          * @defaultValue `"admin-plugins"`
          */
-        icon?: JSX.Element | Dashicon.Icon | undefined;
+        icon?: JSX.Element | ComponentProps<typeof Dashicon>["icon"] | undefined;
         /**
          * The menu item text.
          */

--- a/types/wordpress__edit-post/components/header/plugin-more-menu-item.d.ts
+++ b/types/wordpress__edit-post/components/header/plugin-more-menu-item.d.ts
@@ -1,8 +1,8 @@
 import { Dashicon, MenuItem } from "@wordpress/components";
-import { ComponentType, JSX, ReactNode } from "react";
+import { ComponentProps, ComponentType, JSX, ReactNode } from "react";
 
 declare namespace PluginMoreMenuItem {
-    interface Props extends Omit<MenuItem.Props, "href"> {
+    interface Props extends Omit<ComponentProps<typeof MenuItem>, "href" | "icon"> {
         children: ReactNode;
         /**
          * When `href` is provided then the menu item is represented as an anchor rather than
@@ -13,7 +13,7 @@ declare namespace PluginMoreMenuItem {
          * A Dashicon slug or a custom JSX element to be rendered to the left of the menu item
          * label.
          */
-        icon?: Dashicon.Icon | JSX.Element | undefined;
+        icon?: ComponentProps<typeof Dashicon>["icon"] | JSX.Element | undefined;
         /**
          * The callback function to be executed when the user clicks the menu item.
          */

--- a/types/wordpress__edit-post/components/header/plugin-sidebar-more-menu-item.d.ts
+++ b/types/wordpress__edit-post/components/header/plugin-sidebar-more-menu-item.d.ts
@@ -1,5 +1,5 @@
 import { Dashicon } from "@wordpress/components";
-import { ComponentType, JSX, ReactNode } from "react";
+import { ComponentProps, ComponentType, JSX, ReactNode } from "react";
 
 declare namespace PluginSidebarMoreMenuItem {
     interface Props {
@@ -13,7 +13,7 @@ declare namespace PluginSidebarMoreMenuItem {
          * A Dashicon slug or a custom JSX element to be rendered to the left of the menu item
          * label.
          */
-        icon?: Dashicon.Icon | JSX.Element | undefined;
+        icon?: ComponentProps<typeof Dashicon>["icon"] | JSX.Element | undefined;
     }
 }
 

--- a/types/wordpress__edit-post/components/sidebar/plugin-document-setting-panel.d.ts
+++ b/types/wordpress__edit-post/components/sidebar/plugin-document-setting-panel.d.ts
@@ -1,5 +1,5 @@
 import { Dashicon, Slot } from "@wordpress/components";
-import { FC, JSX, ReactNode } from "react";
+import { ComponentProps, FC, JSX, ReactNode } from "react";
 
 declare namespace PluginDocumentSettingPanel {
     interface Props {
@@ -20,7 +20,7 @@ declare namespace PluginDocumentSettingPanel {
          * A Dashicon slug or a custom JSX element to be rendered when the sidebar is pinned to
          * toolbar.
          */
-        icon?: Dashicon.Icon | JSX.Element | undefined;
+        icon?: ComponentProps<typeof Dashicon>["icon"] | JSX.Element | undefined;
     }
 }
 
@@ -43,7 +43,7 @@ declare namespace PluginDocumentSettingPanel {
  */
 declare const PluginDocumentSettingPanel: {
     (props: PluginDocumentSettingPanel.Props): JSX.Element;
-    Slot: FC<Omit<Slot.Props, "name">>;
+    Slot: FC<Omit<ComponentProps<typeof Slot>, "name">>;
 };
 
 export default PluginDocumentSettingPanel;

--- a/types/wordpress__edit-post/components/sidebar/plugin-post-publish-panel.d.ts
+++ b/types/wordpress__edit-post/components/sidebar/plugin-post-publish-panel.d.ts
@@ -1,5 +1,5 @@
 import { Slot } from "@wordpress/components";
-import { FC, JSX, ReactNode } from "react";
+import { ComponentProps, FC, JSX, ReactNode } from "react";
 
 declare namespace PluginPostPublishPanel {
     interface Props {
@@ -42,7 +42,7 @@ declare namespace PluginPostPublishPanel {
  */
 declare const PluginPostPublishPanel: {
     (props: PluginPostPublishPanel.Props): JSX.Element;
-    Slot: FC<Omit<Slot.Props, "name">>;
+    Slot: FC<Omit<ComponentProps<typeof Slot>, "name">>;
 };
 
 export default PluginPostPublishPanel;

--- a/types/wordpress__edit-post/components/sidebar/plugin-post-status-info.d.ts
+++ b/types/wordpress__edit-post/components/sidebar/plugin-post-status-info.d.ts
@@ -1,5 +1,5 @@
 import { Slot } from "@wordpress/components";
-import { FC, JSX, ReactNode } from "react";
+import { ComponentProps, FC, JSX, ReactNode } from "react";
 
 declare namespace PluginPostStatusInfo {
     interface Props {
@@ -29,7 +29,7 @@ declare namespace PluginPostStatusInfo {
  */
 declare const PluginPostStatusInfo: {
     (props: PluginPostStatusInfo.Props): JSX.Element;
-    Slot: FC<Omit<Slot.Props, "name">>;
+    Slot: FC<Omit<ComponentProps<typeof Slot>, "name">>;
 };
 
 export default PluginPostStatusInfo;

--- a/types/wordpress__edit-post/components/sidebar/plugin-pre-publish-panel.d.ts
+++ b/types/wordpress__edit-post/components/sidebar/plugin-pre-publish-panel.d.ts
@@ -1,5 +1,5 @@
 import { Slot } from "@wordpress/components";
-import { FC, JSX, ReactNode } from "react";
+import { ComponentProps, FC, JSX, ReactNode } from "react";
 
 declare namespace PluginPrePublishPanel {
     interface Props {
@@ -42,7 +42,7 @@ declare namespace PluginPrePublishPanel {
  */
 declare const PluginPrePublishPanel: {
     (props: PluginPrePublishPanel.Props): JSX.Element;
-    Slot: FC<Omit<Slot.Props, "name">>;
+    Slot: FC<Omit<ComponentProps<typeof Slot>, "name">>;
 };
 
 export default PluginPrePublishPanel;

--- a/types/wordpress__edit-post/components/sidebar/plugin-sidebar.d.ts
+++ b/types/wordpress__edit-post/components/sidebar/plugin-sidebar.d.ts
@@ -1,5 +1,5 @@
 import { Dashicon } from "@wordpress/components";
-import { ComponentType, JSX, ReactNode } from "react";
+import { ComponentProps, ComponentType, JSX, ReactNode } from "react";
 
 declare namespace PluginSidebar {
     interface Props {
@@ -12,7 +12,7 @@ declare namespace PluginSidebar {
          * A Dashicon slug or a custom JSX element to be rendered when the sidebar is pinned to
          * toolbar.
          */
-        icon?: Dashicon.Icon | JSX.Element | undefined;
+        icon?: ComponentProps<typeof Dashicon>["icon"] | JSX.Element | undefined;
         /**
          * Whether to allow to pin sidebar to toolbar.
          * @defaultValue `true`

--- a/types/wordpress__edit-post/package.json
+++ b/types/wordpress__edit-post/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/react": "*",
-        "@types/wordpress__components": "*",
+        "@wordpress/components": "^27.3.0",
         "@wordpress/data": "^9.13.0",
         "@wordpress/element": "^5.0.0"
     },


### PR DESCRIPTION
Broke in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69133 probably due to a stale merge which we don't catch since CI does not test everything when running on master.