### PR TITLE
[mdx] Fix CI

### DIFF
--- a/types/mdx/.eslintrc.json
+++ b/types/mdx/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-type-only-packages": "off"
+    }
+}


### PR DESCRIPTION
Fixes `mdx` failing on `master`:

```bash
$ pnpm run test mdx
  1:1  error  Packages should contain value components, not just types  @definitelytyped/no-type-only-packages
```