### PR TITLE
[vinyl][vinyl-file] Fix 5.5 nightly errors

### DIFF
--- a/types/vinyl-file/index.d.ts
+++ b/types/vinyl-file/index.d.ts
@@ -15,21 +15,6 @@ export interface VinylFileOptions {
     read?: boolean | undefined;
 }
 export interface VinylFile extends File {
-    /** Returns true if the file contents are a Buffer, otherwise false */
-    isStream: () => boolean;
-
-    /** Returns true if the file contents are a Stream, otherwise false */
-    isBuffer: () => boolean;
-
-    /** Returns true if the file contents are null, otherwise false */
-    isNull: () => boolean;
-
-    /** Returns true if the file represents a directory, otherwise false */
-    isDirectory: () => boolean;
-
-    /** Returns true if the file represents a symbolic link, otherwise false */
-    isSymbolic: () => boolean;
-
     /** Returns a new Vinyl object with all attributes cloned. */
     clone(opts?: { contents?: boolean | undefined; deep?: boolean | undefined } | boolean): this;
 

--- a/types/vinyl/index.d.ts
+++ b/types/vinyl/index.d.ts
@@ -335,7 +335,6 @@ declare namespace File {
     interface BufferFile extends File {
         contents: Buffer;
         isStream(): this is never;
-        isBuffer(): true;
         isNull(): this is never;
         isDirectory(): this is never;
         isSymbolic(): this is never;
@@ -343,7 +342,6 @@ declare namespace File {
 
     interface StreamFile extends File {
         contents: NodeJS.ReadableStream;
-        isStream(): true;
         isBuffer(): this is never;
         isNull(): this is never;
         isDirectory(): this is never;
@@ -354,18 +352,15 @@ declare namespace File {
         contents: null;
         isStream(): this is never;
         isBuffer(): this is never;
-        isNull(): true;
         isDirectory(): this is DirectoryFile;
         isSymbolic(): this is SymbolicFile;
     }
 
     interface DirectoryFile extends NullFile {
-        isDirectory(): true;
         isSymbolic(): this is never;
     }
 
     interface SymbolicFile extends NullFile {
         isDirectory(): this is never;
-        isSymbolic(): true;
     }
 }


### PR DESCRIPTION
https://github.com/microsoft/TypeScript/pull/57341 got merged, which causes this library to have errors on the methods that override methods that have a `this is X` type predicate as return type.

Similar to what TypeScript already did for non-`this` type predicates, a function or method is only assignable to another one that has a `this` type predicate return type if it also has a type predicate return type. Example:

```ts
interface Animal {
    isDog(): this is Dog;
    isAnimal(x: unknown): x is Animal;
    isCat(): this is Cat;
}

interface Dog extends Animal {
    isDog(): boolean; // error starting with ts 5.5
    isAnimal(x: unknown): boolean; // already an error
    isCat(): this is Cat; // ok
}

interface Cat extends Animal {}
```

