### PR TITLE
[winjs] Fix 5.5 nightly errors

### DIFF
--- a/types/winjs/index.d.ts
+++ b/types/winjs/index.d.ts
@@ -10023,7 +10023,10 @@ declare namespace WinJS.Utilities {
          * @param callbackfn A function that accepts up to three arguments. The every method calls the callbackfn function for each element in array1 until the callbackfn returns false, or until the end of the array.
          * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
          */
-        every<S extends T>(callbackFn: (value: T, index: number, array: T[]) => value is S, thisArg?: any): this is QueryCollection<S>;
+        every<S extends T>(
+            callbackFn: (value: T, index: number, array: T[]) => value is S,
+            thisArg?: any,
+        ): this is QueryCollection<S>;
         /**
          * Determines whether all the members of an array satisfy the specified test.
          * @param callbackfn A function that accepts up to three arguments. The every method calls the callbackfn function for each element in array1 until the callbackfn returns false, or until the end of the array.

--- a/types/winjs/index.d.ts
+++ b/types/winjs/index.d.ts
@@ -10023,6 +10023,12 @@ declare namespace WinJS.Utilities {
          * @param callbackfn A function that accepts up to three arguments. The every method calls the callbackfn function for each element in array1 until the callbackfn returns false, or until the end of the array.
          * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
          */
+        every<S extends T>(callbackFn: (value: T, index: number, array: T[]) => value is S, thisArg?: any): this is QueryCollection<S>;
+        /**
+         * Determines whether all the members of an array satisfy the specified test.
+         * @param callbackfn A function that accepts up to three arguments. The every method calls the callbackfn function for each element in array1 until the callbackfn returns false, or until the end of the array.
+         * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+         */
         every(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
 
         /**


### PR DESCRIPTION
https://github.com/microsoft/TypeScript/pull/57341 got merged, which causes this library to have errors on the methods that override methods that have a `this is X` type predicate as return type.

Similar to what TypeScript already did for non-`this` type predicates, a function or method is only assignable to another one that has a `this` type predicate return type if it also has a type predicate return type. Example:

```ts
interface Animal {
    isDog(): this is Dog;
    isAnimal(x: unknown): x is Animal;
    isCat(): this is Cat;
}

interface Dog extends Animal {
    isDog(): boolean; // error starting with ts 5.5
    isAnimal(x: unknown): boolean; // already an error
    isCat(): this is Cat; // ok
}

interface Cat extends Animal {}
```

