### PR TITLE
[geodesy] Fix mistake with geodesy transform definitions

### DIFF
--- a/types/geodesy/geodesy-tests.ts
+++ b/types/geodesy/geodesy-tests.ts
@@ -3,6 +3,7 @@
  */
 import Dms from "geodesy/dms";
 import LatLonEllipsoidalDatum from "geodesy/latlon-ellipsoidal-datum";
+import LatLonEllipsoidalReferenceFrame from "geodesy/latlon-ellipsoidal-referenceframe";
 import LatLonNvectorSpherical from "geodesy/latlon-nvector-spherical";
 import LatLonSpherical from "geodesy/latlon-spherical";
 import Mgrs, { LatLon as Latlon_Utm_Mgrs } from "geodesy/mgrs";
@@ -200,3 +201,13 @@ point3.toString("dms", 2); // 49°47′18.456″N, 097°26′35.016″W
 LatLonNvectorSpherical.intersection(point4, point5, point3, 1); // LatLon { lat: 49.7981787830497, lon: -97.44279718554108 }
 LatLonNvectorSpherical.areaOf(boundary, 6371e3); // 10768180.94129682 m^2
 LatLonNvectorSpherical.meanOf(boundary); // LatLon { lat: 49.783392242641824, lon: -97.43653998581752 }
+
+/**
+ * LatLonEllipsoidalReferenceFrame
+ */
+
+LatLonEllipsoidalReferenceFrame.transformParameters["SOMETHING→OTHER"] = {
+    epoch: "2010.0",
+    params: [1.6, 1.9, 2.4, -0.02, 0.0, 0.0, 0.0],
+    rates: [0.0, 0.0, -0.1, 0.03, 0.0, 0.0, 0.0],
+};

--- a/types/geodesy/latlon-ellipsoidal-referenceframe.d.ts
+++ b/types/geodesy/latlon-ellipsoidal-referenceframe.d.ts
@@ -8,8 +8,8 @@ import LatLonEllipsoidal, { Cartesian, Dms } from "./latlon-ellipsoidal";
 
 interface TxParam {
     epoch: string;
-    params: [number, number, number, number, number, number];
-    rates: [number, number, number, number, number, number];
+    params: [number, number, number, number, number, number, number];
+    rates: [number, number, number, number, number, number, number];
 }
 
 type TxParams = Plural<TxParam>;


### PR DESCRIPTION
The definition wrongly had the transform param length as 6, [when it is 7](https://github.com/chrisveness/geodesy/blob/761587cd748bd9f7c9825195eba4a9fc5891b859/latlon-ellipsoidal-referenceframe-txparams.js#L5).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chrisveness/geodesy/blob/761587cd748bd9f7c9825195eba4a9fc5891b859/latlon-ellipsoidal-referenceframe-txparams.js#L5


