### PR TITLE
[Leaflet] setStyle now accepts optional radius

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -2092,7 +2092,7 @@ export class CircleMarker<P = any> extends Path {
     getLatLng(): LatLng;
     setRadius(radius: number): this;
     getRadius(): number;
-    setStyle(options: CircleMarkerOptions): this;
+    setStyle(options: Partial<CircleMarkerOptions>): this;
 
     options: CircleMarkerOptions;
     feature?: geojson.Feature<geojson.Point, P> | undefined;

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -988,3 +988,8 @@ circle = new L.Circle(latLng, { radius: "10" });
 circle = new L.Circle(latLng, {});
 // @ts-expect-error
 circle = new L.Circle(latLng);
+
+let circleMarker = new L.CircleMarker(latLng, { radius: 10 }).setStyle({});
+circleMarker = new L.CircleMarker(latLng, { radius: 10 }).setStyle({ radius: 10 });
+// @ts-expect-error
+circleMarker = new L.CircleMarker(latLng, { radius: 10 }).setStyle();


### PR DESCRIPTION
As mentioned in #69221, the setStyle requires a radius which should be optional. This PR should fix this issue. I've also provided tests for better safety.