### PR TITLE
Update index.d.ts

### DIFF
--- a/types/cookie/cookie-tests.ts
+++ b/types/cookie/cookie-tests.ts
@@ -12,7 +12,7 @@ function test_serialize(): void {
 }
 
 function test_parse(): void {
-    let retVal: Record<string, string>;
+    let retVal: Record<string, string | undefined>;
 
     retVal = parse("foo=bar; bar=baz;");
     retVal = cookie.parse("foo=bar; bar=baz", { decode: x => x });

--- a/types/cookie/index.d.ts
+++ b/types/cookie/index.d.ts
@@ -141,7 +141,7 @@ export interface CookieParseOptions {
  * @param str the string representing a `Cookie` header value
  * @param [options] object containing parsing options
  */
-export function parse(str: string, options?: CookieParseOptions): Record<string, string>;
+export function parse(str: string, options?: CookieParseOptions): Record<string, string | undefined>;
 
 /**
  * Serialize a cookie name-value pair into a `Set-Cookie` header string.


### PR DESCRIPTION
this fixes:
```ts
import cookie from "cookie";

console.log(cookie.parse("hello=world").world);
```
now `world` is `string | undefined` instead of always `string`