### PR TITLE
[react] Revert "Allow React context in ReactNode"

### DIFF
--- a/types/react/canary.d.ts
+++ b/types/react/canary.d.ts
@@ -30,11 +30,6 @@ export {};
 declare const UNDEFINED_VOID_ONLY: unique symbol;
 type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 
-/**
- * @internal
- */
-interface ReactContextAsReactNode extends React.Context<React.ReactNode> {}
-
 declare module "." {
     interface ThenableImpl<T> {
         then(onFulfill: (value: T) => unknown, onReject: (error: unknown) => unknown): void | PromiseLike<unknown>;
@@ -162,7 +157,6 @@ declare module "." {
         | null
         | undefined;
     interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES {
-        contexts: ReactContextAsReactNode;
         promises: Promise<AwaitedReactNode>;
         bigints: bigint;
     }

--- a/types/react/test/canary.tsx
+++ b/types/react/test/canary.tsx
@@ -379,6 +379,7 @@ function formTest() {
 
     const RenderableContext = React.createContext<React.ReactNode>("HAL");
     const NestedContext = React.createContext(RenderableContext);
+    // @ts-expect-error TODO Is supported in Canary release channel
     let node: React.ReactNode = RenderableContext;
     // @ts-expect-error TODO context values are recursively unwrapped so this should be allowed by types.
     node = NestedContext;

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -740,6 +740,23 @@ class RenderChildren extends React.Component<{ children?: React.ReactNode }> {
         // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
         const node: Awaited<React.ReactNode> = await Promise.resolve("React");
     };
+
+    const RenderProps = (
+        { children }: { children: React.ReactNode | ((data: string) => React.ReactNode) },
+    ) => {
+        if (typeof children === "function") {
+            return children("data");
+        } else {
+            return children;
+        }
+    };
+    React.createElement(RenderProps, {
+        children: data => {
+            // $ExpectType string
+            data;
+            return null;
+        },
+    });
 }
 
 const Memoized1 = React.memo(function Foo(props: { foo: string }) {

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -741,15 +741,16 @@ class RenderChildren extends React.Component<{ children?: React.ReactNode }> {
         const node: Awaited<React.ReactNode> = await Promise.resolve("React");
     };
 
-    const RenderProps = (
-        { children }: { children: React.ReactNode | ((data: string) => React.ReactNode) },
-    ) => {
-        if (typeof children === "function") {
-            return children("data");
-        } else {
-            return children;
+    class RenderProps extends React.Component<{ children: React.ReactNode | ((data: string) => React.ReactNode) }> {
+        render() {
+            const { children } = this.props;
+            if (typeof children === "function") {
+                return children("data");
+            } else {
+                return children;
+            }
         }
-    };
+    }
     React.createElement(RenderProps, {
         children: data => {
             // $ExpectType string

--- a/types/react/ts5.0/canary.d.ts
+++ b/types/react/ts5.0/canary.d.ts
@@ -30,11 +30,6 @@ export {};
 declare const UNDEFINED_VOID_ONLY: unique symbol;
 type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 
-/**
- * @internal
- */
-interface ReactContextAsReactNode extends React.Context<React.ReactNode> {}
-
 declare module "." {
     interface ThenableImpl<T> {
         then(onFulfill: (value: T) => unknown, onReject: (error: unknown) => unknown): void | PromiseLike<unknown>;
@@ -162,7 +157,6 @@ declare module "." {
         | null
         | undefined;
     interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES {
-        contexts: ReactContextAsReactNode;
         promises: Promise<AwaitedReactNode>;
         bigints: bigint;
     }

--- a/types/react/ts5.0/test/canary.tsx
+++ b/types/react/ts5.0/test/canary.tsx
@@ -379,6 +379,7 @@ function formTest() {
 
     const RenderableContext = React.createContext<React.ReactNode>("HAL");
     const NestedContext = React.createContext(RenderableContext);
+    // @ts-expect-error TODO Is supported in Canary release channel
     let node: React.ReactNode = RenderableContext;
     // @ts-expect-error TODO context values are recursively unwrapped so this should be allowed by types.
     node = NestedContext;

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -744,15 +744,16 @@ class RenderChildren extends React.Component<{ children?: React.ReactNode }> {
         const node: Awaited<React.ReactNode> = await Promise.resolve("React");
     };
 
-    const RenderProps = (
-        { children }: { children: React.ReactNode | ((data: string) => React.ReactNode) },
-    ) => {
-        if (typeof children === "function") {
-            return children("data");
-        } else {
-            return children;
+    class RenderProps extends React.Component<{ children: React.ReactNode | ((data: string) => React.ReactNode) }> {
+        render() {
+            const { children } = this.props;
+            if (typeof children === "function") {
+                return children("data");
+            } else {
+                return children;
+            }
         }
-    };
+    }
     React.createElement(RenderProps, {
         children: data => {
             // $ExpectType string

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -743,6 +743,23 @@ class RenderChildren extends React.Component<{ children?: React.ReactNode }> {
         // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
         const node: Awaited<React.ReactNode> = await Promise.resolve("React");
     };
+
+    const RenderProps = (
+        { children }: { children: React.ReactNode | ((data: string) => React.ReactNode) },
+    ) => {
+        if (typeof children === "function") {
+            return children("data");
+        } else {
+            return children;
+        }
+    };
+    React.createElement(RenderProps, {
+        children: data => {
+            // $ExpectType string
+            data;
+            return null;
+        },
+    });
 }
 
 const Memoized1 = React.memo(function Foo(props: { foo: string }) {


### PR DESCRIPTION
Reverts https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69304

React context as ReactNode breaks render props when combined with "Switch <Context> to mean <Context.Provider>". We always hacked <Context.Provider> to work by treating it as a function. However, once we allow Context.Provider as a valid ReactNode, unions of ReactNode and functions (e.g. render props) can no longer refine the value via `typeof function` nor does contextual typing work (see added tests).

We probably need to add correct types for Context and then adjust `JSX.ElementType` accordingly. Though I fear TS will no longer be able to infer props.

React Context as a ReactNode is more for parity with usable values anyway. There's no observable difference between `<div>{React.createContext("value")}</div>` and `<div>{React.use(React.createContext("value"))}</div>` so I don't think it's worth shipping it in types in this state.
