### PR TITLE
Changed `stdout` and `stderr` from optional to required. Dockerode

### DIFF
--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -155,22 +155,22 @@ container.remove({ v: true, force: false, link: true }, (err, data) => {
     // NOOP
 });
 
-container.logs((err, logs) => {
+container.logs({stdout: true, stderr: false}, (err, logs) => {
     // $ExpectType Buffer
     logs;
 });
 
-container.logs({}, (err, logs) => {
+container.logs({stdout: false, stderr: true}, (err, logs) => {
     // $ExpectType Buffer
     logs;
 });
 
-container.logs({ follow: true }, (err, logs) => {
+container.logs({ stdout: false, stderr: true, follow: true }, (err, logs) => {
     // $ExpectType ReadableStream
     logs;
 });
 
-container.logs({ follow: false }, (err, logs) => {
+container.logs({ stdout: true, stderr: false, follow: false }, (err, logs) => {
     // $ExpectType Buffer
     logs;
 });
@@ -182,10 +182,16 @@ container.logs({ since: 0, until: 10, stdout: true, stderr: true });
 container.logs({ since: "12345.987654321", until: "54321.123456789", stdout: true, stderr: true });
 
 // $ExpectType Promise<ReadableStream>
-container.logs({ follow: true });
+container.logs({ stderr: true, stdout: false, follow: true });
 
 // $ExpectType Promise<Buffer>
-container.logs({ follow: false });
+container.logs({ stderr: true, stdout: false, follow: false });
+
+// $ExpectType Promise<ReadableStream>
+container.logs({ stderr: false, stdout: true, follow: true });
+
+// $ExpectType Promise<Buffer>
+container.logs({ stderr: false, stdout: true, follow: false });
 
 container.stats((err, logs) => {
     // $ExpectType ContainerStats

--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -175,6 +175,9 @@ container.logs({ stdout: true, stderr: false, follow: false }, (err, logs) => {
     logs;
 });
 
+// @ts-expect-error
+container.logs({});
+
 // $ExpectType Promise<Buffer>
 container.logs({ since: 0, until: 10, stdout: true, stderr: true });
 

--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -155,12 +155,12 @@ container.remove({ v: true, force: false, link: true }, (err, data) => {
     // NOOP
 });
 
-container.logs({stdout: true, stderr: false}, (err, logs) => {
+container.logs({ stdout: true, stderr: false }, (err, logs) => {
     // $ExpectType Buffer
     logs;
 });
 
-container.logs({stdout: false, stderr: true}, (err, logs) => {
+container.logs({ stdout: false, stderr: true }, (err, logs) => {
     // $ExpectType Buffer
     logs;
 });
@@ -175,22 +175,22 @@ container.logs({ stdout: true, stderr: false, follow: false }, (err, logs) => {
     logs;
 });
 
-container.logs({stdout: true}, (err, logs) => {
+container.logs({ stdout: true }, (err, logs) => {
     // $ExpectType Buffer
     logs;
 });
 
-container.logs({stdout: false}, (err, logs) => {
+container.logs({ stdout: false }, (err, logs) => {
     // $ExpectType Buffer
     logs;
 });
 
-container.logs({stderr: true}, (err, logs) => {
+container.logs({ stderr: true }, (err, logs) => {
     // $ExpectType Buffer
     logs;
 });
 
-container.logs({stderr: false}, (err, logs) => {
+container.logs({ stderr: false }, (err, logs) => {
     // $ExpectType Buffer
     logs;
 });

--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -175,6 +175,36 @@ container.logs({ stdout: true, stderr: false, follow: false }, (err, logs) => {
     logs;
 });
 
+container.logs({stdout: true}, (err, logs) => {
+    // $ExpectType Buffer
+    logs;
+});
+
+container.logs({stdout: false}, (err, logs) => {
+    // $ExpectType Buffer
+    logs;
+});
+
+container.logs({stderr: true}, (err, logs) => {
+    // $ExpectType Buffer
+    logs;
+});
+
+container.logs({stderr: false}, (err, logs) => {
+    // $ExpectType Buffer
+    logs;
+});
+
+container.logs({ stdout: false, stderr: true, follow: true }, (err, logs) => {
+    // $ExpectType ReadableStream
+    logs;
+});
+
+container.logs({ stdout: true, stderr: false, follow: false }, (err, logs) => {
+    // $ExpectType Buffer
+    logs;
+});
+
 // @ts-expect-error
 container.logs({});
 

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -1900,10 +1900,10 @@ declare namespace Dockerode {
         abortSignal?: AbortSignal;
     }
 
-    type ContainerLogsOptions = 
-    | (ContainerLogsOptionsBase & { stdout: boolean; stderr?: boolean | undefined })
-    | (ContainerLogsOptionsBase & { stderr: boolean; stdout?: boolean | undefined });
-    
+    type ContainerLogsOptions =
+        | (ContainerLogsOptionsBase & { stdout: boolean; stderr?: boolean | undefined })
+        | (ContainerLogsOptionsBase & { stderr: boolean; stdout?: boolean | undefined });
+
     interface ContainerAttachOptions {
         detachKeys?: string | undefined;
         hijack?: boolean | undefined;

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -1890,9 +1890,7 @@ declare namespace Dockerode {
         abortSignal?: AbortSignal;
     }
 
-    interface ContainerLogsOptions {
-        stdout: boolean;
-        stderr: boolean;
+    interface ContainerLogsOptionsBase {
         follow?: boolean | undefined;
         since?: number | string | undefined;
         until?: number | string | undefined;
@@ -1902,6 +1900,10 @@ declare namespace Dockerode {
         abortSignal?: AbortSignal;
     }
 
+    type ContainerLogsOptions = 
+    | (ContainerLogsOptionsBase & { stdout: boolean; stderr?: boolean | undefined })
+    | (ContainerLogsOptionsBase & { stderr: boolean; stdout?: boolean | undefined });
+    
     interface ContainerAttachOptions {
         detachKeys?: string | undefined;
         hijack?: boolean | undefined;

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -1891,8 +1891,8 @@ declare namespace Dockerode {
     }
 
     interface ContainerLogsOptions {
-        stdout?: boolean | undefined;
-        stderr?: boolean | undefined;
+        stdout: boolean;
+        stderr: boolean;
         follow?: boolean | undefined;
         since?: number | string | undefined;
         until?: number | string | undefined;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
Docs:
1. https://github.com/apocas/dockerode
2. https://docs.docker.com/engine/api/v1.37/#tag/Container/operation/ContainerLogs

Example:
 - Before:
<img width="418" alt="Code_-_Insiders_5F0342ttCx" src="https://github.com/DefinitelyTyped/DefinitelyTyped/assets/39876128/0d819ed2-a3f4-4d3a-a2a0-6a8999c4b277">

 - After:
<img width="417" alt="Code_-_Insiders_QOdCZwiaMm" src="https://github.com/DefinitelyTyped/DefinitelyTyped/assets/39876128/32ff0b4f-dc36-4459-9dd9-ab3f2110c3ce">
<img width="581" alt="Code_-_Insiders_CuVr29bYUo" src="https://github.com/DefinitelyTyped/DefinitelyTyped/assets/39876128/ffcad7b2-270d-42f4-a971-8e9184856da7">

**Basically, if `stdout` or `stderr` are not provided in the options, dockerode will throw an error because one of them must be provided.**

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
