### PR TITLE
Put `asserts` on various `assert` functions.

### DIFF
--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -1465,6 +1465,8 @@ class CrashyObject {
     }
 }
 
+declare function foobar<T>(): T;
+
 suite("assert", () => {
     test("assert", () => {
         const foo = "bar" as string;
@@ -2488,5 +2490,97 @@ suite("assert", () => {
             { matcha: "yum" },
             "Should have correct value of the property",
         );
+    });
+});
+
+suite("narrowing", () => {
+    test("assert", () => {
+        const x = foobar<null | number>();
+        assert(typeof x === "number");
+        const y: number = x;
+    });
+
+    test("isOk", () => {
+        const x = foobar<null | number>();
+        assert.isOk(typeof x === "number");
+        const y: number = x;
+    });
+
+    test("ok", () => {
+        const x = foobar<null | number>();
+        assert.ok(typeof x === "number");
+        const y: number = x;
+    });
+
+    test("isTrue", () => {
+        const x = foobar<true | number>();
+        assert.isTrue(x);
+        const y: true = x;
+    });
+
+    test("isFalse", () => {
+        const x = foobar<false | number>();
+        assert.isFalse(x);
+        const y: false = x;
+    });
+
+    test("isNotTrue", () => {
+        const x = foobar<true | number>();
+        assert.isNotTrue(x);
+        const y: number = x;
+    });
+
+    test("isNotFalse", () => {
+        const x = foobar<false | number>();
+        assert.isNotFalse(x);
+        const y: number = x;
+    });
+
+    test("isNull", () => {
+        const x = foobar<null | number>();
+        assert.isNull(x);
+        const y: null = x;
+    });
+
+    test("isNotNull", () => {
+        const x = foobar<null | number>();
+        assert.isNotNull(x);
+        const y: number = x;
+    });
+
+    test("exists", () => {
+        const x = foobar<null | undefined | number>();
+        assert.exists(x);
+        const y: number = x;
+    });
+
+    test("notExists", () => {
+        const x = foobar<null | undefined | number>();
+        assert.notExists(x);
+        const y: null | undefined = x;
+    });
+
+    test("isUndefined", () => {
+        const x = foobar<undefined | number>();
+        assert.isUndefined(x);
+        const y: undefined = x;
+    });
+
+    test("isDefined", () => {
+        const x = foobar<undefined | number>();
+        assert.isDefined(x);
+        const y: number = x;
+    });
+
+    test("instanceOf", () => {
+        const x = foobar<Foo | null>();
+        assert.instanceOf(x, Foo);
+        const y: Foo = x;
+    });
+
+    test("notInstanceOf", () => {
+        const x = foobar<Foo | null>();
+        assert.notInstanceOf(x, Foo);
+        const y: null = x;
     });
 });

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -9,6 +9,10 @@ declare namespace Chai {
         exists: boolean;
     }
 
+    interface Constructor<T> {
+        new(...args: any[]): T;
+    }
+
     interface ErrorConstructor {
         new(...args: any[]): Error;
     }
@@ -417,20 +421,18 @@ declare namespace Chai {
         /**
          * Asserts that object is truthy.
          *
-         * T   Type of object.
          * @param object   Object to test.
          * @param message    Message to display on error.
          */
-        isOk<T>(value: T, message?: string): void;
+        isOk(value: unknown, message?: string): asserts value;
 
         /**
          * Asserts that object is truthy.
          *
-         * T   Type of object.
          * @param object   Object to test.
          * @param message    Message to display on error.
          */
-        ok<T>(value: T, message?: string): void;
+        ok(value: unknown, message?: string): asserts value;
 
         /**
          * Asserts that object is falsy.
@@ -559,20 +561,18 @@ declare namespace Chai {
         /**
          * Asserts that value is true.
          *
-         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isTrue<T>(value: T, message?: string): void;
+        isTrue(value: unknown, message?: string): asserts value is true;
 
         /**
          * Asserts that value is false.
          *
-         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isFalse<T>(value: T, message?: string): void;
+        isFalse(value: unknown, message?: string): asserts value is false;
 
         /**
          * Asserts that value is not true.
@@ -581,25 +581,23 @@ declare namespace Chai {
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isNotTrue<T>(value: T, message?: string): void;
+        isNotTrue<T>(value: T, message?: string): asserts value is Exclude<T, true>;
 
         /**
          * Asserts that value is not false.
          *
-         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isNotFalse<T>(value: T, message?: string): void;
+        isNotFalse<T>(value: T, message?: string): asserts value is Exclude<T, false>;
 
         /**
          * Asserts that value is null.
          *
-         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isNull<T>(value: T, message?: string): void;
+        isNull(value: unknown, message?: string): asserts value is null;
 
         /**
          * Asserts that value is not null.
@@ -608,7 +606,7 @@ declare namespace Chai {
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isNotNull<T>(value: T, message?: string): void;
+        isNotNull<T>(value: T, message?: string): asserts value is Exclude<T, null>;
 
         /**
          * Asserts that value is NaN.
@@ -635,25 +633,25 @@ declare namespace Chai {
          * @param value   Actual value.
          * @param message    Message to display on error.
          */
-        exists<T>(value: T, message?: string): void;
+        exists<T>(value: T, message?: string): asserts value is NonNullable<T>;
 
         /**
          * Asserts that the target is either null or undefined.
          *
-         * T   Type of value.
          * @param value   Actual value.
          * @param message    Message to display on error.
          */
-        notExists<T>(value: T, message?: string): void;
+        notExists(value: unknown, message?: string): asserts value is
+            | null
+            | undefined;
 
         /**
          * Asserts that value is undefined.
          *
-         * T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isUndefined<T>(value: T, message?: string): void;
+        isUndefined(value: unknown, message?: string): asserts value is undefined;
 
         /**
          * Asserts that value is not undefined.
@@ -662,7 +660,7 @@ declare namespace Chai {
          * @param value   Actual value.
          * @param message   Message to display on error.
          */
-        isDefined<T>(value: T, message?: string): void;
+        isDefined<T>(value: T, message?: string): asserts value is Exclude<T, undefined>;
 
         /**
          * Asserts that value is a function.
@@ -808,22 +806,27 @@ declare namespace Chai {
         /**
          * Asserts that value is an instance of constructor.
          *
-         * T   Type of value.
+         * T   Expected type of value.
          * @param value   Actual value.
          * @param constructor   Potential expected contructor of value.
          * @param message   Message to display on error.
          */
-        instanceOf<T>(value: T, constructor: Function, message?: string): void;
+        instanceOf<T>(
+            value: unknown,
+            constructor: Constructor<T>,
+            message?: string,
+        ): asserts value is T;
 
         /**
          * Asserts that value is not an instance of constructor.
          *
          * T   Type of value.
+         * U   Type that value shouldn't be an instance of.
          * @param value   Actual value.
          * @param constructor   Potential expected contructor of value.
          * @param message   Message to display on error.
          */
-        notInstanceOf<T>(value: T, type: Function, message?: string): void;
+        notInstanceOf<T, U>(value: T, type: Constructor<U>, message?: string): asserts value is Exclude<T, U>;
 
         /**
          * Asserts that haystack includes needle.


### PR DESCRIPTION
This was battle-tested in Chrome DevTools now, and adds a bunch of `asserts` onto various functions on the `assert` function (as well as the `assert` function itself) to help with type narrowing in unit tests when using Chai.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (we have patched the `asserts` into `@types/chai` (a slightly older version) for [Chrome DevTools](https://source.chromium.org/chromium/chromium/src/+/main:third_party/devtools-frontend/src/node_modules/@types/chai/index.d.ts;drc=11565081e8b2e0a93ac446f0a3b89f8e8ab71b75)).
- [x] Add or edit tests to reflect the change (the `chai-test.ts` contains a new test suite for type narrowing).
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.chaijs.com/api/assert/

Why?

This is a reland with a bugfix and some additions of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68780, where this time we have battle-tested it in Chrome DevTools first, and we're now ready and confident in upstreaming these changes.

@sheetalkamat @weswigham can you take a look again please?