### PR TITLE
Add type variables to SenderPort and ReceiverPort in react-elm-components

### DIFF
--- a/types/react-elm-components/index.d.ts
+++ b/types/react-elm-components/index.d.ts
@@ -16,14 +16,14 @@ declare namespace Elm {
         init: ({ node, flags }: { node: HTMLElement; flags: any }) => any;
     }
 
-    interface SenderPort {
-        send: (data: any) => void;
+    interface SenderPort<Data> {
+        send: (data: Data) => void;
     }
-    interface ReceiverPort {
-        subscribe: (callback: (value: any) => void) => void;
+    interface ReceiverPort<Value> {
+        subscribe: (callback: (value: Value) => void) => void;
     }
     interface Ports {
-        [x: string]: SenderPort | ReceiverPort;
+        [x: string]: SenderPort<any> | ReceiverPort<any>;
     }
 }
 

--- a/types/react-elm-components/react-elm-components-tests.tsx
+++ b/types/react-elm-components/react-elm-components-tests.tsx
@@ -13,7 +13,7 @@ function App() {
 }
 
 function AppWithPorts() {
-    return <Elm src={Elm19Mock.main} ports={(ports: Record<string, any>) => {}} />;
+    return <Elm src={Elm19Mock.main} ports={(ports: Record<string, Elm.SenderPort<{ value: number }> | Elm.ReceiverPort<string>>) => {}} />;
 }
 
 function AppWithFlags() {

--- a/types/react-elm-components/react-elm-components-tests.tsx
+++ b/types/react-elm-components/react-elm-components-tests.tsx
@@ -13,7 +13,12 @@ function App() {
 }
 
 function AppWithPorts() {
-    return <Elm src={Elm19Mock.main} ports={(ports: Record<string, Elm.SenderPort<{ value: number }> | Elm.ReceiverPort<string>>) => {}} />;
+    return (
+        <Elm
+            src={Elm19Mock.main}
+            ports={(ports: Record<string, Elm.SenderPort<{ value: number }> | Elm.ReceiverPort<string>>) => {}}
+        />
+    );
 }
 
 function AppWithFlags() {


### PR DESCRIPTION
## Background

In order to add proper typings to ports, it would be nice to be able to specify the type of the data that a port sends to Elm, and the type of the data that is sent from Elm to JavaScript through a port.

## Template


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
