### PR TITLE
[react-lazy-load-image-component] fix onLoad props

### DIFF
--- a/types/react-lazy-load-image-component/index.d.ts
+++ b/types/react-lazy-load-image-component/index.d.ts
@@ -1,4 +1,12 @@
-import { ComponentType, CSSProperties, FunctionComponent, ImgHTMLAttributes, ReactElement, ReactNode } from "react";
+import {
+    ComponentType,
+    CSSProperties,
+    FunctionComponent,
+    ImgHTMLAttributes,
+    ReactElement,
+    ReactEventHandler,
+    ReactNode,
+} from "react";
 
 export type DelayMethod = "debounce" | "throttle";
 export type Effect = "blur" | "black-and-white" | "opacity";
@@ -12,7 +20,7 @@ export interface CommonProps {
     /** @deprecated Use onLoad instead. This prop is only for backward compatibility. */
     afterLoad?: (() => any) | undefined;
     /** Function called when the image has been loaded. This is the same function as the onLoad of an <img> which contains an event object. */
-    onLoad?: (() => any) | undefined;
+    onLoad?: ReactEventHandler<HTMLImageElement>;
     /** Function called right before the placeholder is replaced with the image element. */
     beforeLoad?: (() => any) | undefined;
     /* Method from lodash to use to delay the scroll/resize events. */

--- a/types/react-lazy-load-image-component/react-lazy-load-image-component-tests.tsx
+++ b/types/react-lazy-load-image-component/react-lazy-load-image-component-tests.tsx
@@ -39,7 +39,7 @@ const ImageWithCallbacks = () => (
         threshold={200}
         beforeLoad={() => {}}
         afterLoad={() => {}} // deprecated
-        onLoad={() => {}}
+        onLoad={e => {}}
         placeholder={<span />}
         wrapperProps={{
             style: {


### PR DESCRIPTION
I modified the type incorrectly in the last pr(https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66479 ). The code written in the [official document](https://github.com/Aljullu/react-lazy-load-image-component?tab=readme-ov-file#props) is as follows. 

> Function called when the image has been loaded. This is the same function as the onLoad of an <img> which contains an event object.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Aljullu/react-lazy-load-image-component/releases/tag/1.6.0, https://github.com/Aljullu/react-lazy-load-image-component/pull/120, https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66479
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.