### PR TITLE
[lodash.memoize] Add optional `size` to the MapCache interface

### DIFF
--- a/types/lodash/common/common.d.ts
+++ b/types/lodash/common/common.d.ts
@@ -167,6 +167,10 @@ declare module "../index" {
          * Removes all key-value entries from the map.
          */
         clear?: (() => void) | undefined;
+        /**
+         * @returns the number of keys in the cache.
+         */
+        readonly size?: number;
     }
     interface MapCacheConstructor {
         new (): MapCache;

--- a/types/lodash/common/common.d.ts
+++ b/types/lodash/common/common.d.ts
@@ -170,7 +170,7 @@ declare module "../index" {
         /**
          * @returns the number of keys in the cache.
          */
-        readonly size?: number;
+        readonly size?: number | undefined;
     }
     interface MapCacheConstructor {
         new (): MapCache;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -3546,6 +3546,7 @@ fp.now(); // $ExpectType number
         has(key: string) { return true; },
         set(key: string, value: any): _.MapCache { return this; },
         clear() { },
+        size: 1,
     };
 
     const memoizeFn = (a1: string, a2: number): boolean => true;


### PR DESCRIPTION
Lodash has an internal function [memoizeCapped](https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L6426) which puts a limit on the cache of `memoize`. To implement a similar function with a custom cache size in my app, without casting to `any`, i need the `size` property.
I have used optional because of #54323

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L6426

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
