### PR TITLE
[@types/dockerode] Improve AuthConfig and pull() types

### DIFF
--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -456,6 +456,17 @@ docker.listServices({ filters: { name: ["network-name"] } }).then(services => {
     return services.map(service => docker.getService(service.ID));
 });
 
+(async () => {
+    // $ExpectType ReadableStream
+    const pullStream = await docker.pull("hello-world", { authconfig: { username: "username", password: "password" } });
+
+    // $ExpectType Image
+    const pushImage = docker.getImage("hello-world");
+
+    // $ExpectType ReadableStream
+    const pushStream = await pushImage.push({ authconfig: { username: "username", password: "password" } });
+});
+
 const image = docker.getImage("imageName");
 image.remove({ force: true, noprune: false, abortSignal: new AbortController().signal }, (err, response) => {
     // NOOP;

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -2128,7 +2128,7 @@ declare class Dockerode {
     getEvents(callback: Callback<NodeJS.ReadableStream>): void;
     getEvents(options?: Dockerode.GetEventsOptions): Promise<NodeJS.ReadableStream>;
 
-    pull(repoTag: string, options: {}, callback: Callback<any>, auth?: {}): Dockerode.Image;
+    pull(repoTag: string, options: {}, callback: Callback<NodeJS.ReadableStream>, auth?: {}): Dockerode.Image;
     pull(repoTag: string, options?: {}): Promise<NodeJS.ReadableStream>;
 
     run(

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -999,9 +999,13 @@ declare namespace Dockerode {
     }
 
     interface AuthConfig {
-        username: string;
-        password: string;
-        serveraddress: string;
+        username?: string;
+        password?: string;
+        auth?: string;
+        serveraddress?: string;
+        identitytoken?: string;
+        registrytoken?: string;
+        /** @deprecated */
         email?: string | undefined;
     }
 
@@ -2125,7 +2129,7 @@ declare class Dockerode {
     getEvents(options?: Dockerode.GetEventsOptions): Promise<NodeJS.ReadableStream>;
 
     pull(repoTag: string, options: {}, callback: Callback<any>, auth?: {}): Dockerode.Image;
-    pull(repoTag: string, options?: {}): Promise<any>;
+    pull(repoTag: string, options?: {}): Promise<NodeJS.ReadableStream>;
 
     run(
         image: string,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Change to `AuthConfig` comes directly from the Docker source code: https://github.com/moby/moby/blob/b7c059886c0898436db90b4615a27cfb4d93ce34/api/types/registry/authconfig.go#L16-L34
  - Change to `pull()` reflects the fact that `pull()` is just a wrapper around `createImage()` and will thus have the same return value: https://github.com/apocas/dockerode/blob/0a1e34cd0d30d492fe2c6078ae73e2002a698b5a/lib/docker.js#L1446-L1466
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.