### PR TITLE
[@types/hotwired__turbo] add types for StreamActions and events

### DIFF
--- a/types/hotwired__turbo/hotwired__turbo-tests.ts
+++ b/types/hotwired__turbo/hotwired__turbo-tests.ts
@@ -55,6 +55,8 @@ Turbo.visit("my-location");
 Turbo.visit("my-location", {});
 Turbo.visit("my-location", { action: "advance" });
 Turbo.visit("my-location", { action: "replace" });
+// @ts-expect-error
+Turbo.visit("my-location", { action: "magic" });
 
 Turbo.visit("my-location", {
     // @ts-expect-error
@@ -70,4 +72,22 @@ StreamActions.log = function() {
     // $ExpectType StreamElement
     this;
     console.log(this.getAttribute("message"));
-}
+};
+
+document.addEventListener("turbo:before-fetch-response", function(e) {
+    let { fetchResponse } = e.detail;
+    fetchResponse.header("foo");
+});
+
+document.addEventListener("turbo:before-render", function(e) {
+    e.detail.render = (currentElement, newElement) => {
+        // $ExpectType HTMLBodyElement
+        currentElement;
+        // $ExpectType HTMLBodyElement
+        newElement;
+    };
+});
+
+document.addEventListener("turbo:frame-missing", function(event) {
+    event.detail.visit(event.detail.response, {});
+});

--- a/types/hotwired__turbo/hotwired__turbo-tests.ts
+++ b/types/hotwired__turbo/hotwired__turbo-tests.ts
@@ -1,4 +1,4 @@
-import { FrameElement, StreamElement, visit } from "@hotwired/turbo";
+import { FrameElement, StreamActions, StreamElement, visit } from "@hotwired/turbo";
 
 const turboFrame = document.querySelector<FrameElement>("turbo-frame")!;
 
@@ -65,3 +65,9 @@ Turbo.visit("my-location", { frame: "mine" });
 
 // $ExpectType TurboSession
 Turbo.session;
+
+StreamActions.log = function() {
+    // $ExpectType StreamElement
+    this;
+    console.log(this.getAttribute("message"));
+}

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -71,6 +71,10 @@ export interface TurboSession {
     renderStreamMessage(message: unknown): void;
 }
 
+export const StreamActions: {
+    [action: string]: (this: StreamElement) => void;
+};
+
 export function visit(
     location: string,
     options?: { action?: "advance" | "replace"; frame?: string },

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -41,7 +41,13 @@ export class StreamElement extends HTMLElement {
 }
 
 export class FetchRequest {}
-export class FetchResponse {}
+export class FetchResponse {
+    header(key: string): string | undefined;
+    statusCode: number;
+    responseText: Promise<string>;
+    location: URL;
+    response: Response;
+}
 
 /**
  * Connects a stream source to the main session.
@@ -75,10 +81,12 @@ export const StreamActions: {
     [action: string]: (this: StreamElement) => void;
 };
 
-export function visit(
-    location: string,
-    options?: { action?: "advance" | "replace"; frame?: string },
-): void;
+export type Action = "advance" | "replace" | "restore";
+export interface VisitOptions {
+    action?: Action;
+    frame?: string;
+}
+export function visit(location: string, options?: VisitOptions): void;
 
 export interface TurboGlobal {
     /**
@@ -102,14 +110,117 @@ export interface TurboGlobal {
      */
     setConfirmMethod(confirmMethod: () => boolean): void;
 
-    visit(
-        location: string,
-        options?: { action?: "advance" | "replace"; frame?: string },
-    ): void;
+    visit(location: string, options?: { action?: Action; frame?: string }): void;
 
     session: TurboSession;
 }
 
 declare global {
     const Turbo: TurboGlobal;
+}
+
+export type Render = (currentElement: StreamElement) => Promise<void>;
+export type TimingData = unknown;
+export type VisitFallback = (location: string | Response, options: VisitOptions) => Promise<void>;
+
+export type TurboBeforeCacheEvent = CustomEvent;
+export type TurboBeforePrefetchEvent = CustomEvent;
+export type TurboBeforeRenderEvent = CustomEvent<{
+    newBody: HTMLBodyElement;
+    renderMethod: "replace" | "morph";
+    isPreview: boolean;
+    resume: (value?: any) => void;
+    render: (currentBody: HTMLBodyElement, newBody: HTMLBodyElement) => void;
+}>;
+export type TurboBeforeVisitEvent = CustomEvent<{ url: string }>;
+export type TurboClickEvent = CustomEvent<{
+    url: string;
+    originalEvent: MouseEvent;
+}>;
+export type TurboFrameLoadEvent = CustomEvent;
+export type TurboBeforeFrameRenderEvent = CustomEvent<{
+    newFrame: FrameElement;
+    resume: (value?: any) => void;
+    render: (currentFrame: FrameElement, newFrame: FrameElement) => void;
+}>;
+export type TurboFrameRenderEvent = CustomEvent<{
+    fetchResponse: FetchResponse;
+}>;
+export type TurboLoadEvent = CustomEvent<{ url: string; timing: TimingData }>;
+export type TurboRenderEvent = CustomEvent;
+export type TurboReloadEvent = CustomEvent;
+export type TurboVisitEvent = CustomEvent<{ url: string; action: Action }>;
+
+export type TurboBeforeStreamRenderEvent = CustomEvent<{
+    newStream: StreamElement;
+    render: Render;
+}>;
+
+export interface FormSubmission {
+    stop(): void;
+}
+export type FormSubmissionResult =
+    | { success: boolean; fetchResponse: FetchResponse }
+    | { success: false; error: Error };
+
+export type TurboSubmitStartEvent = CustomEvent<{
+    formSubmission: FormSubmission;
+}>;
+export type TurboSubmitEndEvent = CustomEvent<
+    & { formSubmission: FormSubmission }
+    & {
+        [K in keyof FormSubmissionResult]?: FormSubmissionResult[K];
+    }
+>;
+
+export type TurboFrameMissingEvent = CustomEvent<{
+    response: Response;
+    visit: VisitFallback;
+}>;
+
+export type TurboBeforeFetchRequestEvent = CustomEvent<{
+    fetchOptions: RequestInit;
+    url: URL;
+    resume: (value: any) => void;
+}>;
+
+export type TurboBeforeFetchResponseEvent = CustomEvent<{
+    fetchResponse: FetchResponse;
+}>;
+
+export type TurboFetchRequestErrorEvent = CustomEvent<{
+    request: FetchRequest;
+    error: Error;
+}>;
+
+export interface TurboElementEventMap {
+    "turbo:before-frame-render": TurboBeforeFrameRenderEvent;
+    "turbo:before-fetch-request": TurboBeforeFetchRequestEvent;
+    "turbo:before-fetch-response": TurboBeforeFetchResponseEvent;
+    "turbo:fetch-request-error": TurboFetchRequestErrorEvent;
+    "turbo:frame-load": TurboFrameLoadEvent;
+    "turbo:frame-render": TurboFrameRenderEvent;
+    "turbo:frame-missing": TurboFrameMissingEvent;
+    "turbo:submit-start": TurboSubmitStartEvent;
+    "turbo:submit-end": TurboSubmitEndEvent;
+}
+
+export interface TurboGlobalEventHandlersEventMap extends TurboElementEventMap {
+    "turbo:before-cache": TurboBeforeCacheEvent;
+    "turbo:before-prefetch": TurboBeforePrefetchEvent;
+    "turbo:before-stream-render": TurboBeforeStreamRenderEvent;
+    "turbo:before-render": TurboBeforeRenderEvent;
+    "turbo:before-visit": TurboBeforeVisitEvent;
+    "turbo:click": TurboClickEvent;
+    "turbo:load": TurboLoadEvent;
+    "turbo:render": TurboRenderEvent;
+    "turbo:reload": TurboReloadEvent;
+    "turbo:visit": TurboVisitEvent;
+}
+
+declare global {
+    /* eslint-disable @typescript-eslint/no-empty-interface */
+    interface ElementEventMap extends TurboElementEventMap {}
+    interface GlobalEventHandlersEventMap extends TurboGlobalEventHandlersEventMap {}
+    /* eslint-enable @typescript-eslint/no-empty-interface */
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

[Turbo manual](https://turbo.hotwired.dev/reference/events)

The new types are largely cribbed from @marcoroth's PR [adding better types for their events](https://github.com/hotwired/turbo/pull/800), and [older versions of Turbo](https://github.com/hotwired/turbo/tree/v7.3.0) from before they deleted all their Typescript
