### PR TITLE
[quill] Remove from attw.json failingPackages

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -1468,7 +1468,6 @@
         "qlik-visualizationextensions",
         "query-string-params",
         "quicksettings",
-        "quill",
         "qunit/v1",
         "rabbit.js",
         "radium",


### PR DESCRIPTION
A new version of the implementation package fixed whatever error was expected in the types.
