### PR TITLE
[react] Add tests showing inaccurate types for refs with cleanup functions

### DIFF
--- a/types/react/test/canary.tsx
+++ b/types/react/test/canary.tsx
@@ -182,8 +182,18 @@ function Optimistic() {
 }
 
 // ref cleanup
+const ref: React.RefCallback<HTMLDivElement> = current => {
+    // Should be non-nullable
+    // $ExpectType HTMLDivElement | null
+    current;
+    return function refCleanup() {
+    };
+};
 <div
     ref={current => {
+        // Should be non-nullable
+        // $ExpectType HTMLDivElement | null
+        current;
         return function refCleanup() {
         };
     }}

--- a/types/react/ts5.0/test/canary.tsx
+++ b/types/react/ts5.0/test/canary.tsx
@@ -182,8 +182,18 @@ function Optimistic() {
 }
 
 // ref cleanup
+const ref: React.RefCallback<HTMLDivElement> = current => {
+    // Should be non-nullable
+    // $ExpectType HTMLDivElement | null
+    current;
+    return function refCleanup() {
+    };
+};
 <div
     ref={current => {
+        // Should be non-nullable
+        // $ExpectType HTMLDivElement | null
+        current;
         return function refCleanup() {
         };
     }}


### PR DESCRIPTION

It doesn't look like we can [represent refs with cleanup functions in TypeScript](https://www.typescriptlang.org/play?jsx=1#code/PTAEGMHsCdoU3AF1IgngBzgZwFBs6AEpwBmAwgIYA2VARheANYA8AKgHygC8OooAPqAAUQ8AFdYcAHaIAXKFYBKbpyHKunAG6QAlgBNFvAcNET4M+a2NSxNdVt0GA3DhwhQAIQp63YMpBk4AA9EMWoUDB0pAHNQWngKRixQPUgAdylQCik9UHgsW0RkqNAdAFt0Kh1wHWRs1BwoKSxkeBJ5YnJqOgYWFugo6M4uYXFJGXtQAG8jMfNEFz53AD0AfiN4UOhMtRVpgF8XQ99QAFFNaVA0mCw4RoCW0EgqPU6O0koaeiZmfsHh0ZmaSISYzPhzYGLUArdbHE4AcUgkB87gA6jAkldagALUDBSrVWpZKRSSCICiIHQPe7NZD4qo1RBvIgfbrfPqIAYxAGmcZyUB-GKg2ZAmRQmEbOBbHag45w9yI5EnAACRQAtPiEIgNbAYDTHvQ9FRUKwMHBXqR3l0vr1fpz-txAXz5DYyrQ4NBheDRQsjBK+JsJDK9lM5S4EUifE1Hml9B7WNjssQAI5iHTwC3tFnWno-QVDR28+byfPWWxUL0QH3isBrSXS4Syo7hvQIKgUeCgKQUMrYdAMOCgABSAGUABrTIz4QenKhwXsyR1iKSMUkZKHT0AASRkXKw1Vn8+ByRGYL4KR0mnkZ-PeVIqytn1zLAAEqwALIAGQAIpfDwvEHYKE+GOECjlcdwvB8Zg9EvSUSC4KYi2BStvT5YDoVrdZb0DbZGxDUDQH2fY3CAiCwAAAyiFpsnAOAKKxGg4kHRAkSxVs4jEOpkDnCgY0HVIpAAcmQeI4ESFJ0kyVjQAo+oGJKJpEGCUJwnwQY8DNbMn3ZABBRBP3ElotyKEdIF7RBsUGNgeRFZ0FDLGgABocEmbR9GMEQ3McRRw3cfTQF4x5aiE5IsHMqUrJifVWlIAyjMQEysDMiyouiR82V6fTDL4xLTIiyzrPzHkIQmEM7PmGtQDrAMpSDfCNAOZsgA)