### PR TITLE
[react] Types for 18.3

### DIFF
--- a/types/react-dom/index.d.ts
+++ b/types/react-dom/index.d.ts
@@ -44,13 +44,7 @@ export const hydrate: Renderer;
 
 export function flushSync<R>(fn: () => R): R;
 
-/**
- * @deprecated
- */
 export function unstable_batchedUpdates<A, R>(callback: (a: A) => R, a: A): R;
-/**
- * @deprecated
- */
 export function unstable_batchedUpdates<R>(callback: () => R): R;
 
 /**

--- a/types/react-dom/index.d.ts
+++ b/types/react-dom/index.d.ts
@@ -17,7 +17,13 @@ import {
     ReactPortal,
 } from "react";
 
+/**
+ * @deprecated See https://react.dev/reference/react-dom/findDOMNode#alternatives
+ */
 export function findDOMNode(instance: ReactInstance | null | undefined): Element | null | Text;
+/**
+ * @deprecated See https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis
+ */
 export function unmountComponentAtNode(container: Element | DocumentFragment): boolean;
 
 export function createPortal(
@@ -27,26 +33,47 @@ export function createPortal(
 ): ReactPortal;
 
 export const version: string;
+/**
+ * @deprecated See https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis
+ */
 export const render: Renderer;
+/**
+ * @deprecated See https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis
+ */
 export const hydrate: Renderer;
 
 export function flushSync<R>(fn: () => R): R;
 
+/**
+ * @deprecated
+ */
 export function unstable_batchedUpdates<A, R>(callback: (a: A) => R, a: A): R;
+/**
+ * @deprecated
+ */
 export function unstable_batchedUpdates<R>(callback: () => R): R;
 
+/**
+ * @deprecated
+ */
 export function unstable_renderSubtreeIntoContainer<T extends Element>(
     parentComponent: Component<any>,
     element: DOMElement<DOMAttributes<T>, T>,
     container: Element,
     callback?: (element: T) => any,
 ): T;
+/**
+ * @deprecated
+ */
 export function unstable_renderSubtreeIntoContainer<P, T extends Component<P, ComponentState>>(
     parentComponent: Component<any>,
     element: CElement<P, T>,
     container: Element,
     callback?: (component: T) => any,
 ): T;
+/**
+ * @deprecated
+ */
 export function unstable_renderSubtreeIntoContainer<P>(
     parentComponent: Component<any>,
     element: ReactElement<P>,
@@ -61,36 +88,54 @@ export interface Renderer {
     // Deprecated(render): The return value is deprecated.
     // In future releases the render function's return type will be void.
 
+    /**
+     * @deprecated See https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis
+     */
     <T extends Element>(
         element: DOMElement<DOMAttributes<T>, T>,
         container: Container | null,
         callback?: () => void,
     ): T;
 
+    /**
+     * @deprecated See https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis
+     */
     (
         element: Array<DOMElement<DOMAttributes<any>, any>>,
         container: Container | null,
         callback?: () => void,
     ): Element;
 
+    /**
+     * @deprecated See https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis
+     */
     (
         element: FunctionComponentElement<any> | Array<FunctionComponentElement<any>>,
         container: Container | null,
         callback?: () => void,
     ): void;
 
+    /**
+     * @deprecated See https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis
+     */
     <P, T extends Component<P, ComponentState>>(
         element: CElement<P, T>,
         container: Container | null,
         callback?: () => void,
     ): T;
 
+    /**
+     * @deprecated See https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis
+     */
     (
         element: Array<CElement<any, Component<any, ComponentState>>>,
         container: Container | null,
         callback?: () => void,
     ): Component<any, ComponentState>;
 
+    /**
+     * @deprecated See https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis
+     */
     <P>(
         element: ReactElement<P>,
         container: Container | null,
@@ -98,6 +143,9 @@ export interface Renderer {
         // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
     ): Component<P, ComponentState> | Element | void;
 
+    /**
+     * @deprecated See https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis
+     */
     (
         element: ReactElement[],
         container: Container | null,

--- a/types/react-dom/package.json
+++ b/types/react-dom/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/react-dom",
-    "version": "18.2.9999",
+    "version": "18.3.9999",
     "projects": [
         "https://reactjs.org"
     ],

--- a/types/react-dom/server.d.ts
+++ b/types/react-dom/server.d.ts
@@ -90,6 +90,8 @@ export function renderToStaticMarkup(element: ReactNode, options?: ServerOptions
  * Similar to `renderToNodeStream`, except this doesn't create extra DOM attributes
  * such as `data-reactid`, that React uses internally. The HTML output by this stream
  * is exactly equal to what `ReactDOMServer.renderToStaticMarkup()` would return.
+ *
+ * @deprecated
  */
 export function renderToStaticNodeStream(element: ReactNode, options?: ServerOptions): NodeJS.ReadableStream;
 

--- a/types/react-dom/test-utils/index.d.ts
+++ b/types/react-dom/test-utils/index.d.ts
@@ -194,10 +194,12 @@ export namespace Simulate {
 
 /**
  * Render a React element into a detached DOM node in the document. __This function requires a DOM__.
+ * @deprecated https://react.dev/warnings/react-dom-test-utils
  */
 export function renderIntoDocument<T extends Element>(
     element: DOMElement<any, T>,
 ): T;
+/** @deprecated https://react.dev/warnings/react-dom-test-utils */
 export function renderIntoDocument(
     element: FunctionComponentElement<any>,
 ): void;
@@ -205,9 +207,15 @@ export function renderIntoDocument(
 // calls to `renderIntoDocument` choose the last overload on the
 // subtype-relation pass and get an undesirably broad return type.  Using `P`
 // allows this overload to match on the subtype-relation pass.
+/**
+ * @deprecated https://react.dev/warnings/react-dom-test-utils
+ */
 export function renderIntoDocument<P, T extends Component<P>>(
     element: CElement<P, T>,
 ): T;
+/**
+ * @deprecated https://react.dev/warnings/react-dom-test-utils
+ */
 export function renderIntoDocument<P>(
     element: ReactElement<P>,
 ): Component<P> | Element | void;
@@ -216,6 +224,7 @@ export function renderIntoDocument<P>(
  * Pass a mocked component module to this method to augment it with useful methods that allow it to
  * be used as a dummy React component. Instead of rendering as usual, the component will become
  * a simple `<div>` (or other tag if `mockTagName` is provided) containing any provided children.
+ * @deprecated https://react.dev/warnings/react-dom-test-utils
  */
 export function mockComponent(
     mocked: MockedComponentClass,
@@ -224,11 +233,13 @@ export function mockComponent(
 
 /**
  * Returns `true` if `element` is any React element.
+ * @deprecated https://react.dev/warnings/react-dom-test-utils
  */
 export function isElement(element: any): boolean;
 
 /**
  * Returns `true` if `element` is a React element whose type is of a React `componentClass`.
+ * @deprecated https://react.dev/warnings/react-dom-test-utils
  */
 export function isElementOfType<T extends HTMLElement>(
     element: ReactElement,
@@ -236,6 +247,7 @@ export function isElementOfType<T extends HTMLElement>(
 ): element is ReactHTMLElement<T>;
 /**
  * Returns `true` if `element` is a React element whose type is of a React `componentClass`.
+ * @deprecated https://react.dev/warnings/react-dom-test-utils
  */
 export function isElementOfType<P extends DOMAttributes<{}>, T extends Element>(
     element: ReactElement,
@@ -243,6 +255,7 @@ export function isElementOfType<P extends DOMAttributes<{}>, T extends Element>(
 ): element is DOMElement<P, T>;
 /**
  * Returns `true` if `element` is a React element whose type is of a React `componentClass`.
+ * @deprecated https://react.dev/warnings/react-dom-test-utils
  */
 export function isElementOfType<P>(
     element: ReactElement,
@@ -250,6 +263,7 @@ export function isElementOfType<P>(
 ): element is FunctionComponentElement<P>;
 /**
  * Returns `true` if `element` is a React element whose type is of a React `componentClass`.
+ * @deprecated https://react.dev/warnings/react-dom-test-utils
  */
 export function isElementOfType<P, T extends Component<P>, C extends ComponentClass<P>>(
     element: ReactElement,
@@ -258,14 +272,17 @@ export function isElementOfType<P, T extends Component<P>, C extends ComponentCl
 
 /**
  * Returns `true` if `instance` is a DOM component (such as a `<div>` or `<span>`).
+ * @deprecated https://react.dev/warnings/react-dom-test-utils
  */
 export function isDOMComponent(instance: ReactInstance): instance is Element;
 /**
  * Returns `true` if `instance` is a user-defined component, such as a class or a function.
+ * @deprecated https://react.dev/warnings/react-dom-test-utils
  */
 export function isCompositeComponent(instance: ReactInstance): instance is Component<any>;
 /**
  * Returns `true` if `instance` is a component whose type is of a React `componentClass`.
+ * @deprecated https://react.dev/warnings/react-dom-test-utils
  */
 export function isCompositeComponentWithType<T extends Component<any>, C extends ComponentClass<any>>(
     instance: ReactInstance,
@@ -276,6 +293,7 @@ export function isCompositeComponentWithType<T extends Component<any>, C extends
  * Traverse all components in `tree` and accumulate all components where
  * `test(component)` is `true`. This is not that useful on its own, but it's used
  * as a primitive for other test utils.
+ * @deprecated https://react.dev/warnings/react-dom-test-utils
  */
 export function findAllInRenderedTree(
     root: Component<any>,
@@ -285,6 +303,7 @@ export function findAllInRenderedTree(
 /**
  * Finds all DOM elements of components in the rendered tree that are
  * DOM components with the class name matching `className`.
+ * @deprecated https://react.dev/warnings/react-dom-test-utils
  */
 export function scryRenderedDOMComponentsWithClass(
     root: Component<any>,
@@ -294,6 +313,7 @@ export function scryRenderedDOMComponentsWithClass(
  * Like `scryRenderedDOMComponentsWithClass()` but expects there to be one result,
  * and returns that one result, or throws exception if there is any other
  * number of matches besides one.
+ * @deprecated https://react.dev/warnings/react-dom-test-utils
  */
 export function findRenderedDOMComponentWithClass(
     root: Component<any>,
@@ -303,6 +323,7 @@ export function findRenderedDOMComponentWithClass(
 /**
  * Finds all DOM elements of components in the rendered tree that are
  * DOM components with the tag name matching `tagName`.
+ * @deprecated https://react.dev/warnings/react-dom-test-utils
  */
 export function scryRenderedDOMComponentsWithTag(
     root: Component<any>,
@@ -312,6 +333,7 @@ export function scryRenderedDOMComponentsWithTag(
  * Like `scryRenderedDOMComponentsWithTag()` but expects there to be one result,
  * and returns that one result, or throws exception if there is any other
  * number of matches besides one.
+ * @deprecated https://react.dev/warnings/react-dom-test-utils
  */
 export function findRenderedDOMComponentWithTag(
     root: Component<any>,
@@ -320,6 +342,7 @@ export function findRenderedDOMComponentWithTag(
 
 /**
  * Finds all instances of components with type equal to `componentClass`.
+ * @deprecated https://react.dev/warnings/react-dom-test-utils
  */
 export function scryRenderedComponentsWithType<T extends Component<any>, C extends ComponentClass<any>>(
     root: Component<any>,
@@ -330,6 +353,7 @@ export function scryRenderedComponentsWithType<T extends Component<any>, C exten
  * Same as `scryRenderedComponentsWithType()` but expects there to be one result
  * and returns that one result, or throws exception if there is any other
  * number of matches besides one.
+ * @deprecated https://react.dev/warnings/react-dom-test-utils
  */
 export function findRenderedComponentWithType<T extends Component<any>, C extends ComponentClass<any>>(
     root: Component<any>,
@@ -338,9 +362,18 @@ export function findRenderedComponentWithType<T extends Component<any>, C extend
 
 /**
  * Call this in your tests to create a shallow renderer.
+ * @deprecated https://react.dev/warnings/react-dom-test-utils
  */
 export function createRenderer(): ShallowRenderer;
 
+// NOTES
+// - the order of these signatures matters - typescript will check the signatures in source order.
+//   If the `() => VoidOrUndefinedOnly` signature is first, it'll erroneously match a Promise returning function for users with
+//   `strictNullChecks: false`.
+// - VoidOrUndefinedOnly is there to forbid any non-void return values for users with `strictNullChecks: true`
+declare const UNDEFINED_VOID_ONLY: unique symbol;
+// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 /**
  * Wrap any code rendering and triggering updates to your components into `act()` calls.
  *
@@ -351,17 +384,14 @@ export function createRenderer(): ShallowRenderer;
  * @param callback A synchronous, void callback that will execute as a single, complete React commit.
  *
  * @see https://reactjs.org/blog/2019/02/06/react-v16.8.0.html#testing-hooks
+ *
+ * @deprecated https://react.dev/warnings/react-dom-test-utils
  */
-// NOTES
-// - the order of these signatures matters - typescript will check the signatures in source order.
-//   If the `() => VoidOrUndefinedOnly` signature is first, it'll erroneously match a Promise returning function for users with
-//   `strictNullChecks: false`.
-// - VoidOrUndefinedOnly is there to forbid any non-void return values for users with `strictNullChecks: true`
-declare const UNDEFINED_VOID_ONLY: unique symbol;
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 // While act does always return Thenable, if a void function is passed, we pretend the return value is also void to not trigger dangling Promise lint rules.
 export function act(callback: () => VoidOrUndefinedOnly): void;
+/**
+ * @deprecated https://react.dev/warnings/react-dom-test-utils
+ */
 export function act<T>(callback: () => T | Promise<T>): Promise<T>;
 
 // Intentionally doesn't extend PromiseLike<never>.

--- a/types/react-is/index.d.ts
+++ b/types/react-is/index.d.ts
@@ -8,6 +8,9 @@ import { ElementType, LazyExoticComponent, MemoExoticComponent, ReactElement } f
 
 export function typeOf(value: any): symbol | undefined;
 export function isValidElementType(value: any): value is ElementType;
+/**
+ * @deprecated
+ */
 export function isAsyncMode(value: any): value is ReactElement;
 export function isContextConsumer(value: any): value is ReactElement;
 export function isContextProvider(value: any): value is ReactElement;
@@ -21,6 +24,9 @@ export function isPortal(value: any): value is ReactElement;
 export function isStrictMode(value: any): value is ReactElement;
 export function isSuspense(value: any): value is ReactElement;
 
+/**
+ * @deprecated
+ */
 export const AsyncMode: symbol;
 export const ContextConsumer: symbol;
 export const ContextProvider: symbol;

--- a/types/react-is/package.json
+++ b/types/react-is/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/react-is",
-    "version": "18.2.9999",
+    "version": "18.3.9999",
     "projects": [
         "https://reactjs.org/"
     ],

--- a/types/react-test-renderer/index.d.ts
+++ b/types/react-test-renderer/index.d.ts
@@ -42,6 +42,10 @@ export interface ReactTestRenderer {
 export interface TestRendererOptions {
     createNodeMock(element: ReactElement): any;
 }
+
+/**
+ * @deprecated See https://react.dev/warnings/react-test-renderer
+ */
 export function create(nextElement: ReactElement, options?: TestRendererOptions): ReactTestRenderer;
 
 // VoidOrUndefinedOnly is here to forbid any sneaky "Promise" returns.
@@ -59,6 +63,7 @@ type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
  * @param callback An asynchronous, void callback that will execute as a single, complete React commit.
  *
  * @see https://reactjs.org/blog/2019/02/06/react-v16.8.0.html#testing-hooks
+ * @deprecated See https://react.dev/warnings/react-test-renderer
  */
 // VoidOrUndefinedOnly is here to forbid any sneaky return values
 export function act(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undefined>;
@@ -72,6 +77,7 @@ export function act(callback: () => Promise<VoidOrUndefinedOnly>): Promise<undef
  * @param callback A synchronous, void callback that will execute as a single, complete React commit.
  *
  * @see https://reactjs.org/blog/2019/02/06/react-v16.8.0.html#testing-hooks
+ * @deprecated See https://react.dev/warnings/react-test-renderer
  */
 export function act(callback: () => VoidOrUndefinedOnly): DebugPromiseLike;
 

--- a/types/react-test-renderer/package.json
+++ b/types/react-test-renderer/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/react-test-renderer",
-    "version": "18.0.9999",
+    "version": "18.3.9999",
     "projects": [
         "https://facebook.github.io/react/"
     ],

--- a/types/react-test-renderer/shallow/index.d.ts
+++ b/types/react-test-renderer/shallow/index.d.ts
@@ -18,5 +18,6 @@ export interface ShallowRenderer {
 
 /**
  * Call this in your tests to create a shallow renderer.
+ * @deprecated See https://react.dev/warnings/react-test-renderer
  */
 export function createRenderer(): ShallowRenderer;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -222,7 +222,7 @@ declare namespace React {
         C extends
             | ForwardRefExoticComponent<any>
             | { new(props: any): Component<any> }
-            | ((props: any, context?: any) => ReactNode)
+            | ((props: any, deprecatedLegacyContext?: any) => ReactNode)
             | keyof JSX.IntrinsicElements,
     > =
         // need to check first if `ref` is a valid prop for ts@3.0
@@ -1105,7 +1105,15 @@ declare namespace React {
      * ```
      */
     interface FunctionComponent<P = {}> {
-        (props: P, context?: any): ReactNode;
+        (
+            props: P,
+            /**
+             * @deprecated
+             *
+             * @see {@link https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods React Docs}
+             */
+            deprecatedLegacyContext?: any,
+        ): ReactNode;
         /**
          * Used to declare the types of the props accepted by the
          * component. These types will be checked during rendering
@@ -1145,6 +1153,8 @@ declare namespace React {
          *   name: 'John Doe'
          * }
          * ```
+         *
+         * @deprecated Use {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#default_value|default values for destructuring assignments instead}.
          */
         defaultProps?: Partial<P> | undefined;
         /**
@@ -1182,9 +1192,20 @@ declare namespace React {
      * @see {@link React.FunctionComponent}
      */
     interface VoidFunctionComponent<P = {}> {
-        (props: P, context?: any): ReactNode;
+        (
+            props: P,
+            /**
+             * @deprecated
+             *
+             * @see {@link https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods React Docs}
+             */
+            deprecatedLegacyContext?: any,
+        ): ReactNode;
         propTypes?: WeakValidationMap<P> | undefined;
         contextTypes?: ValidationMap<any> | undefined;
+        /**
+         * @deprecated Use {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#default_value|default values for destructuring assignments instead}.
+         */
         defaultProps?: Partial<P> | undefined;
         displayName?: string | undefined;
     }
@@ -1245,7 +1266,15 @@ declare namespace React {
      * @template S The internal state of the component.
      */
     interface ComponentClass<P = {}, S = ComponentState> extends StaticLifecycle<P, S> {
-        new(props: P, context?: any): Component<P, S>;
+        new(
+            props: P,
+            /**
+             * @deprecated
+             *
+             * @see {@link https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods React Docs}
+             */
+            deprecatedLegacyContext?: any,
+        ): Component<P, S>;
         /**
          * Used to declare the types of the props accepted by the
          * component. These types will be checked during rendering
@@ -1297,7 +1326,7 @@ declare namespace React {
      * @see {@link https://www.npmjs.com/package/create-react-class `create-react-class` on npm}
      */
     interface ClassicComponentClass<P = {}> extends ComponentClass<P> {
-        new(props: P, context?: any): ClassicComponent<P, ComponentState>;
+        new(props: P, deprecatedLegacyContext?: any): ClassicComponent<P, ComponentState>;
         getDefaultProps?(): P;
     }
 
@@ -1312,7 +1341,7 @@ declare namespace React {
      */
     type ClassType<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>> =
         & C
-        & (new(props: P, context?: any) => T);
+        & (new(props: P, deprecatedLegacyContext?: any) => T);
 
     //
     // Component Specs and Lifecycle
@@ -1527,6 +1556,9 @@ declare namespace React {
      * @see {@link ExoticComponent}
      */
     interface ForwardRefExoticComponent<P> extends NamedExoticComponent<P> {
+        /**
+         * @deprecated Use {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#default_value|default values for destructuring assignments instead}.
+         */
         defaultProps?: Partial<P> | undefined;
         propTypes?: WeakValidationMap<P> | undefined;
     }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -493,21 +493,27 @@ declare namespace React {
     // ----------------------------------------------------------------------
 
     // DOM Elements
+    /** @deprecated */
     function createFactory<T extends HTMLElement>(
         type: keyof ReactHTML,
     ): HTMLFactory<T>;
+    /** @deprecated */
     function createFactory(
         type: keyof ReactSVG,
     ): SVGFactory;
+    /** @deprecated */
     function createFactory<P extends DOMAttributes<T>, T extends Element>(
         type: string,
     ): DOMFactory<P, T>;
 
     // Custom components
+    /** @deprecated */
     function createFactory<P>(type: FunctionComponent<P>): FunctionComponentFactory<P>;
+    /** @deprecated */
     function createFactory<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>>(
         type: ClassType<P, T, C>,
     ): CFactory<P, T>;
+    /** @deprecated */
     function createFactory<P>(type: ComponentClass<P>): Factory<P>;
 
     // DOM Elements

--- a/types/react/package.json
+++ b/types/react/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/react",
-    "version": "18.2.9999",
+    "version": "18.3.9999",
     "projects": [
         "https://react.dev/"
     ],

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -222,7 +222,7 @@ declare namespace React {
         C extends
             | ForwardRefExoticComponent<any>
             | { new(props: any): Component<any> }
-            | ((props: any, context?: any) => ReactElement | null)
+            | ((props: any, deprecatedLegacyContext?: any) => ReactElement | null)
             | keyof JSX.IntrinsicElements,
     > =
         // need to check first if `ref` is a valid prop for ts@3.0
@@ -1106,7 +1106,15 @@ declare namespace React {
      * ```
      */
     interface FunctionComponent<P = {}> {
-        (props: P, context?: any): ReactElement<any, any> | null;
+        (
+            props: P,
+            /**
+             * @deprecated
+             *
+             * @see {@link https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods React Docs}
+             */
+            deprecatedLegacyContext?: any,
+        ): ReactElement<any, any> | null;
         /**
          * Used to declare the types of the props accepted by the
          * component. These types will be checked during rendering
@@ -1146,6 +1154,8 @@ declare namespace React {
          *   name: 'John Doe'
          * }
          * ```
+         *
+         * @deprecated Use {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#default_value|default values for destructuring assignments instead}.
          */
         defaultProps?: Partial<P> | undefined;
         /**
@@ -1183,9 +1193,20 @@ declare namespace React {
      * @see {@link React.FunctionComponent}
      */
     interface VoidFunctionComponent<P = {}> {
-        (props: P, context?: any): ReactElement<any, any> | null;
+        (
+            props: P,
+            /**
+             * @deprecated
+             *
+             * @see {@link https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods React Docs}
+             */
+            deprecatedLegacyContext?: any,
+        ): ReactElement<any, any> | null;
         propTypes?: WeakValidationMap<P> | undefined;
         contextTypes?: ValidationMap<any> | undefined;
+        /**
+         * @deprecated Use {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#default_value|default values for destructuring assignments instead}.
+         */
         defaultProps?: Partial<P> | undefined;
         displayName?: string | undefined;
     }
@@ -1246,7 +1267,15 @@ declare namespace React {
      * @template S The internal state of the component.
      */
     interface ComponentClass<P = {}, S = ComponentState> extends StaticLifecycle<P, S> {
-        new(props: P, context?: any): Component<P, S>;
+        new(
+            props: P,
+            /**
+             * @deprecated
+             *
+             * @see {@link https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods React Docs}
+             */
+            deprecatedLegacyContext?: any,
+        ): Component<P, S>;
         /**
          * Used to declare the types of the props accepted by the
          * component. These types will be checked during rendering
@@ -1298,7 +1327,7 @@ declare namespace React {
      * @see {@link https://www.npmjs.com/package/create-react-class `create-react-class` on npm}
      */
     interface ClassicComponentClass<P = {}> extends ComponentClass<P> {
-        new(props: P, context?: any): ClassicComponent<P, ComponentState>;
+        new(props: P, deprecatedLegacyContext?: any): ClassicComponent<P, ComponentState>;
         getDefaultProps?(): P;
     }
 
@@ -1313,7 +1342,7 @@ declare namespace React {
      */
     type ClassType<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>> =
         & C
-        & (new(props: P, context?: any) => T);
+        & (new(props: P, deprecatedLegacyContext?: any) => T);
 
     //
     // Component Specs and Lifecycle
@@ -1528,6 +1557,9 @@ declare namespace React {
      * @see {@link ExoticComponent}
      */
     interface ForwardRefExoticComponent<P> extends NamedExoticComponent<P> {
+        /**
+         * @deprecated Use {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#default_value|default values for destructuring assignments instead}.
+         */
         defaultProps?: Partial<P> | undefined;
         propTypes?: WeakValidationMap<P> | undefined;
     }

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -494,21 +494,27 @@ declare namespace React {
     // ----------------------------------------------------------------------
 
     // DOM Elements
+    /** @deprecated */
     function createFactory<T extends HTMLElement>(
         type: keyof ReactHTML,
     ): HTMLFactory<T>;
+    /** @deprecated */
     function createFactory(
         type: keyof ReactSVG,
     ): SVGFactory;
+    /** @deprecated */
     function createFactory<P extends DOMAttributes<T>, T extends Element>(
         type: string,
     ): DOMFactory<P, T>;
 
     // Custom components
+    /** @deprecated */
     function createFactory<P>(type: FunctionComponent<P>): FunctionComponentFactory<P>;
+    /** @deprecated */
     function createFactory<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>>(
         type: ClassType<P, T, C>,
     ): CFactory<P, T>;
+    /** @deprecated */
     function createFactory<P>(type: ComponentClass<P>): Factory<P>;
 
     // DOM Elements

--- a/types/react/ts5.0/test/tsx.tsx
+++ b/types/react/ts5.0/test/tsx.tsx
@@ -170,6 +170,7 @@ React.createContext();
 const UndefinedContext = React.createContext(undefined);
 // @ts-expect-error Forgot value even if it can be undefined
 <UndefinedContext.Provider />;
+<UndefinedContext.Provider value={undefined} />;
 
 // unstable APIs should not be part of the typings
 // @ts-expect-error


### PR DESCRIPTION
Only adds `@deprecation` annotations.

Types for https://github.com/facebook/react/pull/28843

Errors are expected due to 18.3 not existing on NPM yet.