### PR TITLE
[forge-viewer] update for version 7.89

### DIFF
--- a/types/forge-viewer/forge-viewer-tests.ts
+++ b/types/forge-viewer/forge-viewer-tests.ts
@@ -1,7 +1,7 @@
 let viewer: Autodesk.Viewing.GuiViewer3D;
 const options = {
-    env: "AutodeskProduction",
-    api: "derivativeV2", // for models uploaded to EMEA change this option to 'derivativeV2_EU'
+    env: "AutodeskProduction2",
+    api: "streamingV2", // for models uploaded to EMEA change this option to 'streamingV2_EU'
     accessToken: "",
 };
 
@@ -61,6 +61,9 @@ Autodesk.Viewing.Initializer(options, async () => {
     await streamLineTests(viewer);
     await stringExtractorTests(viewer);
     await visualClustersTests(viewer);
+    await selectiveLoadingTest(viewer);
+    await cameraMappingTest(viewer);
+    await dbIdRemappingTest(viewer);
     // shutdown the viewer
     viewer.tearDown();
 });
@@ -661,4 +664,97 @@ function selectionTests(viewer: Autodesk.Viewing.GuiViewer3D) {
     }
 
     viewer.select([]);
+}
+
+async function selectiveLoadingTest(viewer: Autodesk.Viewing.GuiViewer3D): Promise<void> {
+    const documentId = "urn:dXJuOmFkc2sub2JqZWN0czpvcy5vYmplY3Q6bXktYnVja2V0L215LWF3ZXNvbWUtZm9yZ2UtZmlsZS5ydnQ";
+    const doc = await loadDocument(documentId);
+    const viewable = doc.getRoot().getDefaultGeometry();
+
+    let query = [{
+        $like: ['?Name', "'%2%'"]
+    }];
+    let fakeLoadedModel = await viewer.loadDocumentNode(doc, viewable, {
+        filter: {
+            property_query: query
+        }
+    });
+
+    await viewer.waitForLoadDone();
+
+    const propHashes = await fakeLoadedModel.getPropertyHashes();
+    viewer.unloadDocumentNode(fakeLoadedModel.getDocumentNode());
+
+    const matches = JSON.stringify(query).matchAll(/(["'])\?([\w\d\s]+)\1/g);
+    for (const match of matches) {
+        const attributeSearchString = match[2].trim();
+        query = propHashes.filter(propHash => propHash[1] === attributeSearchString)
+            .map(propHash => {
+                return {
+                    $like: [`s.props.${propHash[0]}`, query[0]['$like'][1]]
+                };
+            });
+    }
+
+
+    let model = await viewer.loadDocumentNode(doc, viewable, {
+        filter: {
+            property_query: query
+        }
+    });
+
+    await viewer.waitForLoadDone();
+}
+
+async function cameraMappingTest(viewer: Autodesk.Viewing.GuiViewer3D): Promise<void> {
+    const state = viewer.getState({ viewport: true });
+    const model = viewer.getAllModels()[0];
+    const invTransform = model.getInverseModelToViewerTransform();
+
+    const currentTarget = new THREE.Vector3().fromArray(state.viewport.target);
+    // {x: -14.770469665527344, y: 36.571967124938965, z: -1.212925910949707}
+
+    const currentPosition = new THREE.Vector3().fromArray(state.viewport.eye);
+    // {x: -14.870469093322754, y: 36.57156276702881, z: -1.212925910949707}
+
+    const originTarget = currentTarget.clone().applyMatrix4(invTransform);
+    // {x: -15.02436066552734, y: -8.984211875061035, z: 4.921260089050291}
+
+    const originPosition = currentPosition.clone().applyMatrix4(invTransform);
+    // {x: -15.12436009332275, y: -8.984616232971192, z: 4.921260089050291}
+
+    let data = '{"aspect":1.7963206307490145,"isPerspective":true,"fov":90.6808770984145,"position":[-15.165047992449978,-8.997701015094862,4.916143307734757],"target":[-15.02430824140946,-8.997131602441378,4.916143307734757],"up":[0,0,1],"orthoScale":1}';
+    const viewData = JSON.parse(data);
+    let view = new Autodesk.Viewing.UnifiedCamera();
+    view = Object.assign(view, {
+        aspect: viewData.aspect,
+        isPerspective: viewData.isPerspective,
+        fov: viewData.fov,
+        position: new THREE.Vector3().fromArray(viewData.position),
+        target: new THREE.Vector3().fromArray(viewData.target),
+        up: new THREE.Vector3().fromArray(viewData.up),
+        orthoScale: viewData.orthoScale
+    });
+
+    const offsetMatrix = model.getModelToViewerTransform();
+    view.position = view.position.applyMatrix4(offsetMatrix);
+    view.target = view.target.applyMatrix4(offsetMatrix);
+
+    viewer.impl.setViewFromCamera(view);
+}
+
+async function dbIdRemappingTest(viewer: Autodesk.Viewing.GuiViewer3D): Promise<void> {
+    // Override `PropDbLoader#load` so that the svf1/svf2 dbid mapping is always loaded.
+    const _load = Autodesk.Viewing.Private.PropDbLoader.prototype.load;
+    Autodesk.Viewing.Private.PropDbLoader.prototype.load = function () {
+        this.needsDbIdRemap = true;
+        _load.call(this);
+    }
+
+    // Override `PropDbLoader#processLoadResult` so that the dbid mapping is stored within all models (by default it is only stored in 2D models).
+    const _processLoadResult = Autodesk.Viewing.Private.PropDbLoader.prototype.processLoadResult;
+    Autodesk.Viewing.Private.PropDbLoader.prototype.processLoadResult = function (result) {
+        _processLoadResult.call(this, result);
+        this.model.idRemap = result.dbidOldToNew;
+    }
 }

--- a/types/forge-viewer/forge-viewer-tests.ts
+++ b/types/forge-viewer/forge-viewer-tests.ts
@@ -672,12 +672,12 @@ async function selectiveLoadingTest(viewer: Autodesk.Viewing.GuiViewer3D): Promi
     const viewable = doc.getRoot().getDefaultGeometry();
 
     let query = [{
-        $like: ['?Name', "'%2%'"]
+        $like: ["?Name", "'%2%'"],
     }];
     let fakeLoadedModel = await viewer.loadDocumentNode(doc, viewable, {
         filter: {
-            property_query: query
-        }
+            property_query: query,
+        },
     });
 
     await viewer.waitForLoadDone();
@@ -691,16 +691,15 @@ async function selectiveLoadingTest(viewer: Autodesk.Viewing.GuiViewer3D): Promi
         query = propHashes.filter(propHash => propHash[1] === attributeSearchString)
             .map(propHash => {
                 return {
-                    $like: [`s.props.${propHash[0]}`, query[0]['$like'][1]]
+                    $like: [`s.props.${propHash[0]}`, query[0]["$like"][1]],
                 };
             });
     }
 
-
     let model = await viewer.loadDocumentNode(doc, viewable, {
         filter: {
-            property_query: query
-        }
+            property_query: query,
+        },
     });
 
     await viewer.waitForLoadDone();
@@ -723,7 +722,8 @@ async function cameraMappingTest(viewer: Autodesk.Viewing.GuiViewer3D): Promise<
     const originPosition = currentPosition.clone().applyMatrix4(invTransform);
     // {x: -15.12436009332275, y: -8.984616232971192, z: 4.921260089050291}
 
-    let data = '{"aspect":1.7963206307490145,"isPerspective":true,"fov":90.6808770984145,"position":[-15.165047992449978,-8.997701015094862,4.916143307734757],"target":[-15.02430824140946,-8.997131602441378,4.916143307734757],"up":[0,0,1],"orthoScale":1}';
+    let data =
+        "{\"aspect\":1.7963206307490145,\"isPerspective\":true,\"fov\":90.6808770984145,\"position\":[-15.165047992449978,-8.997701015094862,4.916143307734757],\"target\":[-15.02430824140946,-8.997131602441378,4.916143307734757],\"up\":[0,0,1],\"orthoScale\":1}";
     const viewData = JSON.parse(data);
     let view = new Autodesk.Viewing.UnifiedCamera();
     view = Object.assign(view, {
@@ -733,7 +733,7 @@ async function cameraMappingTest(viewer: Autodesk.Viewing.GuiViewer3D): Promise<
         position: new THREE.Vector3().fromArray(viewData.position),
         target: new THREE.Vector3().fromArray(viewData.target),
         up: new THREE.Vector3().fromArray(viewData.up),
-        orthoScale: viewData.orthoScale
+        orthoScale: viewData.orthoScale,
     });
 
     const offsetMatrix = model.getModelToViewerTransform();
@@ -746,15 +746,15 @@ async function cameraMappingTest(viewer: Autodesk.Viewing.GuiViewer3D): Promise<
 async function dbIdRemappingTest(viewer: Autodesk.Viewing.GuiViewer3D): Promise<void> {
     // Override `PropDbLoader#load` so that the svf1/svf2 dbid mapping is always loaded.
     const _load = Autodesk.Viewing.Private.PropDbLoader.prototype.load;
-    Autodesk.Viewing.Private.PropDbLoader.prototype.load = function () {
+    Autodesk.Viewing.Private.PropDbLoader.prototype.load = function() {
         this.needsDbIdRemap = true;
         _load.call(this);
-    }
+    };
 
     // Override `PropDbLoader#processLoadResult` so that the dbid mapping is stored within all models (by default it is only stored in 2D models).
     const _processLoadResult = Autodesk.Viewing.Private.PropDbLoader.prototype.processLoadResult;
-    Autodesk.Viewing.Private.PropDbLoader.prototype.processLoadResult = function (result) {
+    Autodesk.Viewing.Private.PropDbLoader.prototype.processLoadResult = function(result) {
         _processLoadResult.call(this, result);
         this.model.idRemap = result.dbidOldToNew;
-    }
+    };
 }

--- a/types/forge-viewer/index.d.ts
+++ b/types/forge-viewer/index.d.ts
@@ -256,11 +256,16 @@ declare namespace Autodesk {
 
         interface LoadModelOptions {
             fileLoader?: FileLoader | undefined;
+            keepCurrentModels?: boolean,
             loadOptions?: object | undefined;
             sharedPropertyDbPath?: string | undefined;
-            ids?: string | undefined;
-            applyScaling?: string | { from: string; to: string };
+            ids?: number[] | undefined;
+            loadAsHidden?: boolean;
             modelNameOverride?: string;
+            placementTransform?: THREE.Matrix4 | undefined;
+            applyScaling?: string | { from: string; to: string };
+            applyPlacementInModelUnits?: boolean;
+            globalOffset?: THREE.Vector3 | undefined;
             [key: string]: any;
         }
 
@@ -503,6 +508,7 @@ declare namespace Autodesk {
             isRevitPdf(): boolean;
             isViewable(): boolean;
             isViewPreset(): boolean;
+            isMasterView(): boolean;
             lineageUrn(encode?: boolean): string;
             name(): string;
             search(propsToMatch: BubbleNodeSearchProps): BubbleNode[];
@@ -703,6 +709,7 @@ declare namespace Autodesk {
         class Model {
             id: number;
             visibilityManager: Private.VisibilityManager;
+            idRemap: Int32Array;
 
             clearThemingColors(): void;
             fetchTopology(maxSizeMB: number): Promise<object>;
@@ -757,7 +764,7 @@ declare namespace Autodesk {
                 errorCallback?: (err: any) => void,
                 options?: { needExternalId: boolean },
             ): void;
-            getPropertyDb(): PropDbLoader;
+            getPropertyDb(): Private.PropDbLoader;
             getPropertySet(
                 dbIds: number[],
                 options: {
@@ -774,6 +781,7 @@ declare namespace Autodesk {
                     needsExternalId?: boolean | undefined;
                 },
             ): Promise<PropertySet>;
+            getPropertyHashes(): Promise<string[]>;
             geomPolyCount(): number;
             getDefaultCamera(): THREE.Camera;
             getDisplayUnit(): string;
@@ -891,10 +899,6 @@ declare namespace Autodesk {
                 DIFF_TOOL_DEACTIVATED = "diff.tool.deactivated",
                 DIFF_TOOL_MODEL_VISIBILITY_CHANGED = "diff.tool.model.visibility.changed",
             }
-        }
-
-        interface PropDbLoader {
-            executeUserFunction(userFunc: (pdb: any, ...args: any[]) => any, args?: any): Promise<any>;
         }
 
         interface PropertyResult {
@@ -1198,7 +1202,7 @@ declare namespace Autodesk {
                 onErrorCallback?: (errorCode: number, errorMessage: string, errorArgs: any) => void,
             ): any;
             unloadModel(model: Model): void;
-            loadDocumentNode(avDocument: Document, manifestNode: any, /*BubbleNode*/ options?: object): Promise<Model>;
+            loadDocumentNode(avDocument: Document, manifestNode: any, /*BubbleNode*/ options?: LoadModelOptions): Promise<Model>;
             unloadDocumentNode(manifestNode: any /*BubbleNode*/): boolean;
             getDimensions(): Private.Dimensions;
             resize(): void;
@@ -1876,6 +1880,57 @@ declare namespace Autodesk {
                     vpId: number,
                 ): void;
                 onVertex?(cx: number, cy: number, vpId: number): void;
+            }
+
+            class PropDbLoader {
+                model: Autodesk.Viewing.Model;
+                needsDbIdRemap: boolean;
+                processLoadResult(result: any): void;
+                load(options: any): void;
+
+                getProperties(
+                    dbId: number,
+                    successCallback?: (r: PropertyResult) => void,
+                    errorCallback?: (err: any) => void,
+                ): void;
+                getProperties2(
+                    dbIds: number[],
+                    successCallback?: (r: PropertyResult) => void,
+                    errorCallback?: (err: any) => void,
+                    options?: { needExternalId: boolean },
+                ): void;
+                getBulkProperties(
+                    dbIds: number[],
+                    options?: {
+                        propFilter?: string[] | undefined;
+                        ignoreHidden?: boolean | undefined;
+                    },
+                    successCallback?: (r: PropertyResult[]) => void,
+                    errorCallback?: (err: any) => void,
+                    ignoreHidden?: boolean
+                ): void;
+                getBulkProperties2(
+                    dbIds: number[],
+                    options?: {
+                        propFilter?: string[] | undefined;
+                        categoryFilter?: string[] | undefined;
+                        ignoreHidden?: boolean | undefined;
+                        needExternalId?: boolean | undefined;
+                    },
+                    successCallback?: (r: PropertyResult[]) => void,
+                    errorCallback?: (s: any, m: any, d: any) => void,
+                ): void;
+                getPropertySet(
+                    dbIds: number[],
+                    options: {
+                        propFilter?: string[] | undefined;
+                        ignoreHidden?: boolean | undefined;
+                        needsExternalId?: boolean | undefined;
+                    },
+                ): void;
+                executeUserFunction(userFunc: (pdb: any, ...args: any[]) => any, args?: any): Promise<any>;
+                getLoadProgress(): number;
+                isLoadDone(): boolean;
             }
 
             interface GeometryList {

--- a/types/forge-viewer/index.d.ts
+++ b/types/forge-viewer/index.d.ts
@@ -256,7 +256,7 @@ declare namespace Autodesk {
 
         interface LoadModelOptions {
             fileLoader?: FileLoader | undefined;
-            keepCurrentModels?: boolean,
+            keepCurrentModels?: boolean;
             loadOptions?: object | undefined;
             sharedPropertyDbPath?: string | undefined;
             ids?: number[] | undefined;
@@ -1202,7 +1202,11 @@ declare namespace Autodesk {
                 onErrorCallback?: (errorCode: number, errorMessage: string, errorArgs: any) => void,
             ): any;
             unloadModel(model: Model): void;
-            loadDocumentNode(avDocument: Document, manifestNode: any, /*BubbleNode*/ options?: LoadModelOptions): Promise<Model>;
+            loadDocumentNode(
+                avDocument: Document,
+                manifestNode: any,
+                /*BubbleNode*/ options?: LoadModelOptions,
+            ): Promise<Model>;
             unloadDocumentNode(manifestNode: any /*BubbleNode*/): boolean;
             getDimensions(): Private.Dimensions;
             resize(): void;
@@ -1907,7 +1911,7 @@ declare namespace Autodesk {
                     },
                     successCallback?: (r: PropertyResult[]) => void,
                     errorCallback?: (err: any) => void,
-                    ignoreHidden?: boolean
+                    ignoreHidden?: boolean,
                 ): void;
                 getBulkProperties2(
                     dbIds: number[],

--- a/types/forge-viewer/package.json
+++ b/types/forge-viewer/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/forge-viewer",
-    "version": "7.89.0",
+    "version": "7.89.9999",
     "nonNpm": true,
     "nonNpmDescription": "Forge Viewer",
     "projects": [

--- a/types/forge-viewer/package.json
+++ b/types/forge-viewer/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/forge-viewer",
-    "version": "7.69.9999",
+    "version": "7.89.0",
     "nonNpm": true,
     "nonNpmDescription": "Forge Viewer",
     "projects": [
@@ -16,6 +16,10 @@
             "githubUsername": "Autodesk-Forge"
         },
         {
+            "name": "Autodesk Developer Advocacy and Support",
+            "githubUsername": "autodesk-platform-services"
+        },
+        {
             "name": "Alan Smith",
             "githubUsername": "alansmithnbs"
         },
@@ -26,6 +30,10 @@
         {
             "name": "Petr Broz",
             "githubUsername": "petrbroz"
+        },
+        {
+            "name": "Eason Kang",
+            "githubUsername": "yiskang"
         },
         {
             "name": "Cyrille Fauvel",

--- a/types/forge-viewer/tsconfig.json
+++ b/types/forge-viewer/tsconfig.json
@@ -3,7 +3,8 @@
         "module": "node16",
         "lib": [
             "es6",
-            "dom"
+            "dom",
+            "ES2020.String"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
- Move PropDbLoader to Private namespace and change its type from interface to class.
- Add some missing fields and functions to PropDbLoader and Model.
- Correct type declarations for LoadModelOptions and options in `viewer#loadDocumentNode`.
- Add isMasterView() to BubbleNode.
- Update test codes.
- Updated version number.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
         - https://aps.autodesk.com/en/docs/viewer/v7/reference/Private/PropDbLoader/
         - https://aps.autodesk.com/en/docs/viewer/v7/reference/Viewing/Model/
         - https://aps.autodesk.com/en/docs/viewer/v7/reference/Viewing/Viewer3D/#loadmodel-url-options-onsuccesscallback-onerrorcallback
         - https://aps.autodesk.com/en/docs/viewer/v7/reference/Viewing/BubbleNode/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
