### PR TITLE
[@types/d3-scale] Fix: function scaleQuantize

### DIFF
--- a/types/d3-scale/index.d.ts
+++ b/types/d3-scale/index.d.ts
@@ -1982,7 +1982,7 @@ export interface ScaleQuantize<Range, Unknown = never> {
  * @param range Array of range values.
  */
 // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-export function scaleQuantize<Range = number, Unknown = never>(range?: Iterable<Range>): ScaleQuantize<Range, Unknown>;
+export function scaleQuantize<Range = number | string, Unknown = never>(range?: Iterable<Range>): ScaleQuantize<Range, Unknown>;
 /**
  * Constructs a new quantize scale with the specified domain and range.
  * Thus, the default quantize scale is equivalent to the Math.round function.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://d3js.org/d3-scale/quantize#_quantize
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---
change
- `function scaleQuantize` Range type is number or string

In an official document, function scaleQuantize(domain, range) has parameter `range`
and `range`'s type can `string`

https://d3js.org/d3-scale/quantize#_quantize example
```
const color = d3.scaleQuantize([0, 1], ["brown", "steelblue"]);
color(0.49); // "brown"
color(0.51); // "steelblue"
```
