### PR TITLE
[react] Mark error from componentDidCatch to be `unknown`

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -614,7 +614,7 @@ declare namespace React {
          * Catches exceptions generated in descendant components. Unhandled exceptions will cause
          * the entire component tree to unmount.
          */
-        componentDidCatch?(error: Error, errorInfo: ErrorInfo): void;
+        componentDidCatch?(error: unknown, errorInfo: ErrorInfo): void;
     }
 
     // Unfortunately, we have no way of declaring that the component constructor must implement this

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -636,7 +636,7 @@ declare namespace React {
          * Catches exceptions generated in descendant components. Unhandled exceptions will cause
          * the entire component tree to unmount.
          */
-        componentDidCatch?(error: Error, errorInfo: ErrorInfo): void;
+        componentDidCatch?(error: unknown, errorInfo: ErrorInfo): void;
     }
 
     // Unfortunately, we have no way of declaring that the component constructor must implement this

--- a/types/react/v17/index.d.ts
+++ b/types/react/v17/index.d.ts
@@ -636,7 +636,7 @@ declare namespace React {
          * Catches exceptions generated in descendant components. Unhandled exceptions will cause
          * the entire component tree to unmount.
          */
-        componentDidCatch?(error: Error, errorInfo: ErrorInfo): void;
+        componentDidCatch?(error: unknown, errorInfo: ErrorInfo): void;
     }
 
     // Unfortunately, we have no way of declaring that the component constructor must implement this


### PR DESCRIPTION
Given anything can be thrown in JavaScript, it is more accurate to treat the `error` argument that is passed into `componentDidCatch` as `unknown`. That allows users to explicitly handle it via `instanceof Error`, or understand if something in their components is throwing a non-error (object, string or primitive).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

`componentDidCatch` takes an `error` that comes from `errorInfo.value`.

https://github.com/facebook/react/blob/cb151849e13f46ec64570519cb93d5939fb60cab/packages/react-reconciler/src/ReactFiberThrow.js#L150-L154

which is typed as `CapturedValue<mixed>`

https://github.com/facebook/react/blob/cb151849e13f46ec64570519cb93d5939fb60cab/packages/react-reconciler/src/ReactFiberThrow.js#L118

which is a generic 

https://github.com/facebook/react/blob/cb151849e13f46ec64570519cb93d5939fb60cab/packages/react-reconciler/src/ReactCapturedValue.js#L16-L20

which means that `errorInfo.value` is typed as `mixed` with flow, meaning it should be `unknown` here.

ref: https://github.com/getsentry/sentry-javascript/issues/11728