### PR TITLE
[react-syntax-highlighter] add missing definition in for prism style

### DIFF
--- a/types/react-syntax-highlighter/index.d.ts
+++ b/types/react-syntax-highlighter/index.d.ts
@@ -708,6 +708,7 @@ declare module "react-syntax-highlighter/dist/esm/styles/prism" {
     export { default as cb } from "react-syntax-highlighter/dist/esm/styles/prism/cb";
     export { default as coldarkCold } from "react-syntax-highlighter/dist/esm/styles/prism/coldark-cold";
     export { default as coldarkDark } from "react-syntax-highlighter/dist/esm/styles/prism/coldark-dark";
+    export { default as coyWithoutShadows } from "react-syntax-highlighter/dist/esm/styles/prism/coy-without-shadows";
     export { default as coy } from "react-syntax-highlighter/dist/esm/styles/prism/coy";
     export { default as darcula } from "react-syntax-highlighter/dist/esm/styles/prism/darcula";
     export { default as dark } from "react-syntax-highlighter/dist/esm/styles/prism/dark";
@@ -722,10 +723,13 @@ declare module "react-syntax-highlighter/dist/esm/styles/prism" {
     export { default as ghcolors } from "react-syntax-highlighter/dist/esm/styles/prism/ghcolors";
     export { default as gruvboxDark } from "react-syntax-highlighter/dist/esm/styles/prism/gruvbox-dark";
     export { default as gruvboxLight } from "react-syntax-highlighter/dist/esm/styles/prism/gruvbox-light";
+    export { default as holiTheme } from "react-syntax-highlighter/dist/esm/styles/prism/holi-theme";
     export { default as hopscotch } from "react-syntax-highlighter/dist/esm/styles/prism/hopscotch";
+    export { default as lucario } from "react-syntax-highlighter/dist/esm/styles/prism/lucario";
     export { default as materialDark } from "react-syntax-highlighter/dist/esm/styles/prism/material-dark";
     export { default as materialLight } from "react-syntax-highlighter/dist/esm/styles/prism/material-light";
     export { default as materialOceanic } from "react-syntax-highlighter/dist/esm/styles/prism/material-oceanic";
+    export { default as nightOwl } from "react-syntax-highlighter/dist/esm/styles/prism/night-owl";
     export { default as nord } from "react-syntax-highlighter/dist/esm/styles/prism/nord";
     export { default as okaidia } from "react-syntax-highlighter/dist/esm/styles/prism/okaidia";
     export { default as oneDark } from "react-syntax-highlighter/dist/esm/styles/prism/one-dark";
@@ -733,6 +737,7 @@ declare module "react-syntax-highlighter/dist/esm/styles/prism" {
     export { default as pojoaque } from "react-syntax-highlighter/dist/esm/styles/prism/pojoaque";
     export { default as prism } from "react-syntax-highlighter/dist/esm/styles/prism/prism";
     export { default as shadesOfPurple } from "react-syntax-highlighter/dist/esm/styles/prism/shades-of-purple";
+    export { default as solarizedDarkAtom } from "react-syntax-highlighter/dist/esm/styles/prism/solarized-dark-atom";
     export { default as solarizedlight } from "react-syntax-highlighter/dist/esm/styles/prism/solarizedlight";
     export { default as synthwave84 } from "react-syntax-highlighter/dist/esm/styles/prism/synthwave84";
     export { default as tomorrow } from "react-syntax-highlighter/dist/esm/styles/prism/tomorrow";
@@ -740,6 +745,7 @@ declare module "react-syntax-highlighter/dist/esm/styles/prism" {
     export { default as vs } from "react-syntax-highlighter/dist/esm/styles/prism/vs";
     export { default as vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism/vsc-dark-plus";
     export { default as xonokai } from "react-syntax-highlighter/dist/esm/styles/prism/xonokai";
+    export { default as zTouch } from "react-syntax-highlighter/dist/esm/styles/prism/z-touch";
 }
 
 declare module "react-syntax-highlighter/dist/esm/styles/prism/a11y-dark" {
@@ -768,6 +774,11 @@ declare module "react-syntax-highlighter/dist/esm/styles/prism/coldark-cold" {
 }
 
 declare module "react-syntax-highlighter/dist/esm/styles/prism/coldark-dark" {
+    const style: { [key: string]: React.CSSProperties };
+    export default style;
+}
+
+declare module "react-syntax-highlighter/dist/esm/styles/prism/coy-without-shadows" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
@@ -842,7 +853,17 @@ declare module "react-syntax-highlighter/dist/esm/styles/prism/gruvbox-light" {
     export default style;
 }
 
+declare module "react-syntax-highlighter/dist/esm/styles/prism/holi-theme" {
+    const style: { [key: string]: React.CSSProperties };
+    export default style;
+}
+
 declare module "react-syntax-highlighter/dist/esm/styles/prism/hopscotch" {
+    const style: { [key: string]: React.CSSProperties };
+    export default style;
+}
+
+declare module "react-syntax-highlighter/dist/esm/styles/prism/lucario" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
@@ -858,6 +879,11 @@ declare module "react-syntax-highlighter/dist/esm/styles/prism/material-light" {
 }
 
 declare module "react-syntax-highlighter/dist/esm/styles/prism/material-oceanic" {
+    const style: { [key: string]: React.CSSProperties };
+    export default style;
+}
+
+declare module "react-syntax-highlighter/dist/esm/styles/prism/night-owl" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }
@@ -897,6 +923,11 @@ declare module "react-syntax-highlighter/dist/esm/styles/prism/shades-of-purple"
     export default style;
 }
 
+declare module "react-syntax-highlighter/dist/esm/styles/prism/solarized-dark-atom" {
+    const style: { [key: string]: React.CSSProperties };
+    export default style;
+}
+
 declare module "react-syntax-highlighter/dist/esm/styles/prism/solarizedlight" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
@@ -928,6 +959,11 @@ declare module "react-syntax-highlighter/dist/esm/styles/prism/vsc-dark-plus" {
 }
 
 declare module "react-syntax-highlighter/dist/esm/styles/prism/xonokai" {
+    const style: { [key: string]: React.CSSProperties };
+    export default style;
+}
+
+declare module "react-syntax-highlighter/dist/esm/styles/prism/z-touch" {
     const style: { [key: string]: React.CSSProperties };
     export default style;
 }

--- a/types/react-syntax-highlighter/react-syntax-highlighter-tests.tsx
+++ b/types/react-syntax-highlighter/react-syntax-highlighter-tests.tsx
@@ -11,7 +11,54 @@ import createElement from "react-syntax-highlighter/dist/esm/create-element";
 import javascript from "react-syntax-highlighter/dist/esm/languages/hljs/javascript";
 import PrismSyntaxHighlighter from "react-syntax-highlighter/dist/esm/prism";
 import { docco } from "react-syntax-highlighter/dist/esm/styles/hljs";
-import { coldarkCold, coldarkDark, oneDark, oneLight } from "react-syntax-highlighter/dist/esm/styles/prism";
+import {
+    a11yDark,
+    atomDark,
+    base16AteliersulphurpoolLight,
+    cb,
+    coldarkCold,
+    coldarkDark,
+    coy,
+    coyWithoutShadows,
+    darcula,
+    dark,
+    dracula,
+    duotoneDark,
+    duotoneEarth,
+    duotoneForest,
+    duotoneLight,
+    duotoneSea,
+    duotoneSpace,
+    // @ts-expect-error
+    foo,
+    funky,
+    ghcolors,
+    gruvboxDark,
+    gruvboxLight,
+    holiTheme,
+    hopscotch,
+    lucario,
+    materialDark,
+    materialLight,
+    materialOceanic,
+    nightOwl,
+    nord,
+    okaidia,
+    oneDark,
+    oneLight,
+    pojoaque,
+    prism,
+    shadesOfPurple,
+    solarizedDarkAtom,
+    solarizedlight,
+    synthwave84,
+    tomorrow,
+    twilight,
+    vs,
+    vscDarkPlus,
+    xonokai,
+    zTouch,
+} from "react-syntax-highlighter/dist/esm/styles/prism";
 
 const codeString = `class CPP {
     private year: number;


### PR DESCRIPTION
1. prism styles are updated, avilable stylesheet props reference: [AVAILABLE_STYLES_PRISM](https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/AVAILABLE_STYLES_PRISM.MD)
2. add relevant test.



Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/AVAILABLE_STYLES_PRISM.MD>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
