### PR TITLE
[@types/passport-oauth2] Allow login rejects and unknown errors

### DIFF
--- a/types/passport-oauth2/index.d.ts
+++ b/types/passport-oauth2/index.d.ts
@@ -42,7 +42,7 @@ declare namespace OAuth2Strategy {
         verify(req: Request, state: string, meta: Metadata, callback: StateStoreVerifyCallback): void;
     }
 
-    type VerifyCallback = (err?: Error | null, user?: Express.User, info?: object) => void;
+    type VerifyCallback = (err?: Error | null | unknown, user?: Express.User | false, info?: object) => void;
 
     type VerifyFunction<TProfile = any, TResults = any> =
         | ((accessToken: string, refreshToken: string, profile: TProfile, verified: VerifyCallback) => void)

--- a/types/passport-oauth2/passport-oauth2-tests.ts
+++ b/types/passport-oauth2/passport-oauth2-tests.ts
@@ -138,11 +138,14 @@ const providerSpecificVerifyFunction: OAuth2Strategy.VerifyFunction<
 > = (accessToken, refreshToken, results, profile, verified) => {
     results.someProviderResultField;
     profile.someProviderProfileField;
+    verified(null, false);
 };
 const providerSpecificVerifyFunctionWithRequest: OAuth2Strategy.VerifyFunctionWithRequest<
     ProviderSpecificProfile,
     ProviderSpecificResults
 > = (req, accessToken, refreshToken, results, profile, verified) => {
+    let err: unknown;
     results.someProviderResultField;
     profile.someProviderProfileField;
+    verified(err);
 };


### PR DESCRIPTION
Added the possiblity to reject logins (user=false) and pass unknown errors

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Documentation within passport-oauth2](https://github.com/jaredhanson/passport-oauth2/blob/be9bf58cee75938c645a9609f0cc87c4c724e7c8/lib/strategy.js#L42)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
