### PR TITLE
[react] Types for 18.3.1

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2126,6 +2126,21 @@ declare namespace React {
      */
     export function startTransition(scope: TransitionFunction): void;
 
+    /**
+     * Wrap any code rendering and triggering updates to your components into `act()` calls.
+     *
+     * Ensures that the behavior in your tests matches what happens in the browser
+     * more closely by executing pending `useEffect`s before returning. This also
+     * reduces the amount of re-renders done.
+     *
+     * @param callback A synchronous, void callback that will execute as a single, complete React commit.
+     *
+     * @see https://reactjs.org/blog/2019/02/06/react-v16.8.0.html#testing-hooks
+     */
+    // While act does always return Thenable, if a void function is passed, we pretend the return value is also void to not trigger dangling Promise lint rules.
+    export function act(callback: () => VoidOrUndefinedOnly): void;
+    export function act<T>(callback: () => T | Promise<T>): Promise<T>;
+
     export function useId(): string;
 
     /**

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -975,3 +975,9 @@ function propsInferenceHelpersTests() {
     // $ExpectType UnionProps & RefAttributes<HTMLDivElement>
     type UnionPropsForwardRefComponentPropsWithoutRef = React.ComponentProps<typeof UnionPropsForwardRefComponent>;
 }
+
+// act()
+{
+    // act() exposed from react
+    React.act(() => null);
+}

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -2127,6 +2127,21 @@ declare namespace React {
      */
     export function startTransition(scope: TransitionFunction): void;
 
+    /**
+     * Wrap any code rendering and triggering updates to your components into `act()` calls.
+     *
+     * Ensures that the behavior in your tests matches what happens in the browser
+     * more closely by executing pending `useEffect`s before returning. This also
+     * reduces the amount of re-renders done.
+     *
+     * @param callback A synchronous, void callback that will execute as a single, complete React commit.
+     *
+     * @see https://reactjs.org/blog/2019/02/06/react-v16.8.0.html#testing-hooks
+     */
+    // While act does always return Thenable, if a void function is passed, we pretend the return value is also void to not trigger dangling Promise lint rules.
+    export function act(callback: () => VoidOrUndefinedOnly): void;
+    export function act<T>(callback: () => T | Promise<T>): Promise<T>;
+
     export function useId(): string;
 
     /**

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -978,3 +978,9 @@ function propsInferenceHelpersTests() {
     // $ExpectType UnionProps & RefAttributes<HTMLDivElement>
     type UnionPropsForwardRefComponentPropsWithoutRef = React.ComponentProps<typeof UnionPropsForwardRefComponent>;
 }
+
+// act()
+{
+    // act() exposed from react
+    React.act(() => null);
+}


### PR DESCRIPTION
**Adds both the `act()` and `unstable_act()` methods, present in the React 18.3.1 release.**

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://github.com/facebook/react/commit/f1338f8080abd1386454a10bbf93d67bfe37ce85)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

