### PR TITLE
[@types/chromecast-caf-sender] update RemotePlayerEventType

### DIFF
--- a/types/chromecast-caf-sender/index.d.ts
+++ b/types/chromecast-caf-sender/index.d.ts
@@ -55,6 +55,8 @@ declare namespace cast.framework {
         ANY_CHANGE = "anyChanged",
         IS_CONNECTED_CHANGED = "isConnectedChanged",
         IS_MEDIA_LOADED_CHANGED = "isMediaLoadedChanged",
+        QUEUE_DATA_CHANGED = "queueDataChanged",
+        VIDEO_INFO_CHANGED = "videoInfoChanged",
         DURATION_CHANGED = "durationChanged",
         CURRENT_TIME_CHANGED = "currentTimeChanged",
         IS_PAUSED_CHANGED = "isPausedChanged",
@@ -70,7 +72,15 @@ declare namespace cast.framework {
         MEDIA_INFO_CHANGED = "mediaInfoChanged",
         IMAGE_URL_CHANGED = "imageUrlChanged",
         PLAYER_STATE_CHANGED = "playerStateChanged",
-        LIVE_SEEKABLE_RANGE_CHANGED = "liveSeekableRange",
+        IS_PLAYING_BREAK_CHANGED = "isPlayingBreakChanged",
+        NUMBER_BREAK_CLIPS_CHANGED = "numberBreakClipsChanged",
+        CURRENT_BREAK_CLIP_NUMBER_CHANGED = "currentBreakClipNumberChanged",
+        CURRENT_BREAK_TIME_CHANGED = "currentBreakTimeChanged",
+        CURRENT_BREAK_CLIP_TIME_CHANGED = "currentBreakClipTimeChanged",
+        BREAK_ID_CHANGED = "breakIdChanged",
+        BREAK_CLIP_ID_CHANGED = "breakClipIdChanged",
+        WHEN_SKIPPABLE_CHANGED = "whenSkippableChanged",
+        LIVE_SEEKABLE_RANGE_CHANGED = "liveSeekableRangeChanged",
     }
 
     enum ActiveInputState {

--- a/types/chromecast-caf-sender/package.json
+++ b/types/chromecast-caf-sender/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/chromecast-caf-sender",
-    "version": "1.0.10",
+    "version": "1.0.9999",
     "nonNpm": true,
     "nonNpmDescription": "Cast Application Framework Sender API",
     "projects": [

--- a/types/chromecast-caf-sender/package.json
+++ b/types/chromecast-caf-sender/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/chromecast-caf-sender",
-    "version": "1.0.9999",
+    "version": "1.0.10",
     "nonNpm": true,
     "nonNpmDescription": "Cast Application Framework Sender API",
     "projects": [


### PR DESCRIPTION
#### update @types/chromecast-caf-sender RemotePlayerEventType

- [Google casts docs: RemotePlayerEventType](https://developers.google.com/cast/docs/reference/web_sender/cast.framework#.RemotePlayerEventType)
- Below snippet taken from the text/js response of https://www.gstatic.com/cast/sdk/libs/sender/1.0/cast_framework.js
```
l("cast.framework.RemotePlayerEventType", {
        ANY_CHANGE: "anyChanged",
        IS_CONNECTED_CHANGED: "isConnectedChanged",
        IS_MEDIA_LOADED_CHANGED: "isMediaLoadedChanged",
        QUEUE_DATA_CHANGED: "queueDataChanged",
        VIDEO_INFO_CHANGED: "videoInfoChanged",
        DURATION_CHANGED: "durationChanged",
        CURRENT_TIME_CHANGED: "currentTimeChanged",
        IS_PAUSED_CHANGED: "isPausedChanged",
        VOLUME_LEVEL_CHANGED: "volumeLevelChanged",
        CAN_CONTROL_VOLUME_CHANGED: "canControlVolumeChanged",
        IS_MUTED_CHANGED: "isMutedChanged",
        CAN_PAUSE_CHANGED: "canPauseChanged",
        CAN_SEEK_CHANGED: "canSeekChanged",
        DISPLAY_NAME_CHANGED: "displayNameChanged",
        STATUS_TEXT_CHANGED: "statusTextChanged",
        TITLE_CHANGED: "titleChanged",
        DISPLAY_STATUS_CHANGED: "displayStatusChanged",
        MEDIA_INFO_CHANGED: "mediaInfoChanged",
        IMAGE_URL_CHANGED: "imageUrlChanged",
        PLAYER_STATE_CHANGED: "playerStateChanged",
        IS_PLAYING_BREAK_CHANGED: "isPlayingBreakChanged",
        NUMBER_BREAK_CLIPS_CHANGED: "numberBreakClipsChanged",
        CURRENT_BREAK_CLIP_NUMBER_CHANGED: "currentBreakClipNumberChanged",
        CURRENT_BREAK_TIME_CHANGED: "currentBreakTimeChanged",
        CURRENT_BREAK_CLIP_TIME_CHANGED: "currentBreakClipTimeChanged",
        BREAK_ID_CHANGED: "breakIdChanged",
        BREAK_CLIP_ID_CHANGED: "breakClipIdChanged",
        WHEN_SKIPPABLE_CHANGED: "whenSkippableChanged",
        LIVE_SEEKABLE_RANGE_CHANGED: "liveSeekableRangeChanged"
    });
```