### PR TITLE
[jsrsasign] add missing null type in X509CRL.getRevCertArray()

### DIFF
--- a/types/jsrsasign/jsrsasign-tests.ts
+++ b/types/jsrsasign/jsrsasign-tests.ts
@@ -149,7 +149,7 @@ ODI4MDQ1MTI5WjANBgkqhkiG9w0BAQQFAANBAJorY7DUJ91uthNlAA+PT6zw6rVo
 uZLFeYZPNVXgF217YOCtJtKDT+16bR5kgk0p/1xIbgReshjMNTmXPqARNjE=
 -----END X509 CRL-----`);
 x509crl.getIssuer();
-x509crl.getRevCertArray();
+x509crl.getRevCertArray(); // $ExpectType RevokedCertificate[] | null
 x509crl.findRevCert(PEM_CERTIFICATE);
 x509crl.findRevCertBySN("0000");
 x509crl.getParam();

--- a/types/jsrsasign/modules/X509CRL.d.ts
+++ b/types/jsrsasign/modules/X509CRL.d.ts
@@ -180,7 +180,7 @@ declare namespace jsrsasign {
          * [{sn:"123a", date:"208025235959Z", ext: [{extname:"cRLReason",code:3}]},
          *  {sn:"123b", date:"208026235959Z", ext: [{extname:"cRLReason",code:0}]}]
          */
-        getRevCertArray(): RevokedCertificate[];
+        getRevCertArray(): RevokedCertificate[] | null;
 
         /**
          * get revokedCertificate JSON parameter<br/>


### PR DESCRIPTION
The null type is missing in [getRevCertArray()](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jsrsasign/modules/X509CRL.d.ts#L183) within the X509CRL.d.ts file.
```typescript
/**
 * get array for revokedCertificates field<br/>
 * name getRevCertArray
 * memberOf X509CRL#
 *
 * @return Array array of revokedCertificate parameter or null
 * @see X509CRL#getRevCert
 *
 * @description
 * This method returns parsed revokedCertificates field value as
 * array of revokedCertificate parameter.
 * If the field doesn't exists, it returns null.
 *
 * @example
 * crl = new X509CRL("-----BEGIN X509 CRL...");
 * crl.getRevCertArray() &rarr;
 * [{sn:"123a", date:"208025235959Z", ext: [{extname:"cRLReason",code:3}]},
 *  {sn:"123b", date:"208026235959Z", ext: [{extname:"cRLReason",code:0}]}]
 */
getRevCertArray(): RevokedCertificate[]; // this! + "| null"
```

The null type is also missing as described in the comments below.
- @ return Array array of revokedCertificate parameter or null
- If the field doesn't exists, it returns null.

The part implemented in JavaScript is as follows:
```javascript
this.getRevCertArray = function() {
  if (this.posRevCert == null) return null; // this line!
    var a = [];
    var idx = _getIdxbyList(this.hex, 0, [0, this.posRevCert]);
    var aIdx = _getChildIdx(this.hex, idx);
    for (var i = 0; i < aIdx.length; i++) {
    var hRevCert = _getTLV(this.hex, aIdx[i]);
    a.push(this.getRevCert(hRevCert));
  }
  return a;
};
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`]
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kjur/jsrsasign/blob/master/src/x509crl.js#L272
