### PR TITLE
fix(pngjs): add re-export for browser usage

### DIFF
--- a/types/pngjs/browser.d.ts
+++ b/types/pngjs/browser.d.ts
@@ -1,0 +1,1 @@
+export * from "./";

--- a/types/pngjs/pngjs-tests.ts
+++ b/types/pngjs/pngjs-tests.ts
@@ -1,4 +1,5 @@
 import { PNG } from "pngjs";
+import { PNG as BrowserPNG } from 'pngjs/browser';
 import { createDeflate } from "zlib";
 import fs = require("fs");
 
@@ -23,7 +24,28 @@ const pngs = [
         skipRescale: false,
         width: 1,
     }),
-    new PNG({ filterType: [1, 2, 3] }),
+    new BrowserPNG(),
+    new BrowserPNG({ filterType: [1, 2, 3] }),
+    new BrowserPNG({}),
+        new BrowserPNG({ width: 1 }),
+        new BrowserPNG({ checkCRC: false }),
+        new BrowserPNG({ deflateChunkSize: 3 }),
+        new BrowserPNG({
+            bitDepth: 8,
+            checkCRC: true,
+            colorType: 4,
+            deflateChunkSize: 1,
+            deflateFactory: createDeflate,
+            deflateLevel: 1,
+            deflateStrategy: 1,
+            fill: false,
+            filterType: 4,
+            height: 1,
+            inputHasAlpha: false,
+            skipRescale: false,
+            width: 1,
+        }),
+        new BrowserPNG({ filterType: [1, 2, 3] }),
 ];
 
 const png = pngs[0];


### PR DESCRIPTION
As per #69449, this adds re-export to use documented 'pngjs/browser'.

Thanks!

/cc @moritz-t-w

Fixes #69449

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.