### PR TITLE
feat: loadable__server, use PropsWithChildren type alias for ChunkExtractorManager props

### DIFF
--- a/types/loadable__server/index.d.ts
+++ b/types/loadable__server/index.d.ts
@@ -1,4 +1,4 @@
-import { Component, ComponentType, JSX, ReactElement } from "react";
+import { Component, ComponentType, JSX, PropsWithChildren, ReactElement } from "react";
 
 export type ChunkExtractorOptions =
     & {
@@ -134,4 +134,4 @@ export interface ChunkExtractorManagerProps {
     extractor: ChunkExtractor;
 }
 
-export class ChunkExtractorManager extends Component<ChunkExtractorManagerProps> {}
+export class ChunkExtractorManager extends Component<PropsWithChildren<ChunkExtractorManagerProps>> {}


### PR DESCRIPTION
The type definitions for React 18 removed children as a default prop, so components that accept children need to explicitly define children as a prop, or use the PropsWithChildren helper from @types/react to achieve the same result.  Since ChunkExtractorManager is designed to wrap a react tree, it needs to accept children and it's prop type should reflect that.  Note that this PR uses the PropsWithChildren helper which is backwards compatible with previous versions of React.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://solverfox.dev/writing/no-implicit-children/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
