### PR TITLE
[npm-registry-fetch] Add `authType` field to `AuthOptions`

### DIFF
--- a/types/npm-registry-fetch/index.d.ts
+++ b/types/npm-registry-fetch/index.d.ts
@@ -42,6 +42,11 @@ declare namespace fetch {
     interface AuthOptions {
         "always-auth"?: boolean | undefined;
         alwaysAuth?: boolean | undefined;
+        /**
+         * This value wii be set to the `npm-auth-type` http header field.
+         * See: https://docs.npmjs.com/cli/commands/npm-login
+         */
+        authType?: "web" | "legacy" | undefined;
         email?: string | undefined;
         /**
          * Password used for basic authentication. For the more modern

--- a/types/npm-registry-fetch/npm-registry-fetch-tests.ts
+++ b/types/npm-registry-fetch/npm-registry-fetch-tests.ts
@@ -21,6 +21,7 @@ const retry: fetch.FetchRetryOptions = {
 
 const opts: fetch.Options = {
     alwaysAuth: false,
+    authType: "web",
     fetchRetries: 42,
     fetchRetryFactor: 10,
     fetchRetryMaxtimeout: 10000,
@@ -29,7 +30,7 @@ const opts: fetch.Options = {
     ignoreBody: true,
     isFromCI: false,
     localAddress: "address.local",
-    mapJSON: obj => obj.toString(),
+    mapJSON: (obj) => obj.toString(),
     maxSockets: 42,
     npmSession: "session",
     preferOffline: false,


### PR DESCRIPTION
The `authType` option is used as `npm-auth-type` request header field. ref:
- https://github.com/npm/npm-registry-fetch/blob/ceaf77ece4eb71a4ab1f9542bf4e75aec0dd4b05/lib/index.js#L218-L220
- https://docs.npmjs.com/cli/v10/commands/npm-login

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/npm/npm-registry-fetch/blob/ceaf77ece4eb71a4ab1f9542bf4e75aec0dd4b05/lib/index.js#L218-L220>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
