### PR TITLE
[kap-plugin] Use correct version of electron-store

### DIFF
--- a/types/kap-plugin/index.d.ts
+++ b/types/kap-plugin/index.d.ts
@@ -1,4 +1,4 @@
-import * as ElectronStore from "electron-store";
+import ElectronStore = require("electron-store");
 import * as got from "got";
 import { JSONSchema7 } from "json-schema";
 

--- a/types/kap-plugin/package.json
+++ b/types/kap-plugin/package.json
@@ -11,7 +11,7 @@
         "@types/got": "^9",
         "@types/json-schema": "*",
         "@types/node": "*",
-        "electron-store": ">=8.0.2"
+        "electron-store": "^7.0.2"
     },
     "devDependencies": {
         "@types/kap-plugin": "workspace:."


### PR DESCRIPTION
CI says:

```
Error in kap-plugin
Error: 
/home/runner/work/DefinitelyTyped/DefinitelyTyped/types/kap-plugin/index.d.ts
  33:13  error  TypeScript@4.7, 4.8, 4.9, 5.0, 5.1, 5.2, 5.3, 5.4, 5.5 compile error: 
Cannot use namespace 'ElectronStore' as a type  @definitelytyped/expect

/home/runner/work/DefinitelyTyped/DefinitelyTyped/types/kap-plugin/kap-plugin-tests.ts
  24:9  error  TypeScript@4.7, 4.8, 4.9, 5.0, 5.1, 5.2, 5.3, 5.4, 5.5 expected type to be:
  string
got:
  any  @definitelytyped/expect

✖ 2 problems (2 errors, 0 warnings)
```

This is blocking #69212.

The actual version of `electron-store` should be v7, not `>=8`: https://github.com/wulkano/Kap/blob/c42692fa63ac71ed192e01684beb78a1b864aa88/package.json#L50

The `>=8` was added in #60932.