### PR TITLE
[@types/fs-readdir-recursive] Complete typings

### DIFF
--- a/types/fs-readdir-recursive/fs-readdir-recursive-tests.ts
+++ b/types/fs-readdir-recursive/fs-readdir-recursive-tests.ts
@@ -2,3 +2,14 @@ import readdirRecursive = require("fs-readdir-recursive");
 
 const unfilteredPaths: string[] = readdirRecursive("path");
 const filteredPaths: string[] = readdirRecursive("path", (name: string, index: number, dir: string) => name[0] !== ".");
+const mergedFilteredPaths: string[] = readdirRecursive(
+    "another-path",
+    (name: string, index: number, dir: string) => name[0] !== ".",
+    filteredPaths,
+);
+const filteredJoinedPaths: string[] = readdirRecursive(
+    "",
+    (name: string, index: number, dir: string) => name[0] !== ".",
+    [],
+    "path",
+);

--- a/types/fs-readdir-recursive/index.d.ts
+++ b/types/fs-readdir-recursive/index.d.ts
@@ -1,6 +1,8 @@
 declare function readdirRecursive(
     path: string,
     filter?: (name: string, index: number, dir: string) => boolean,
+    files?: string[],
+    prefix?: string,
 ): string[];
 
 export = readdirRecursive;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/fs-utils/fs-readdir-recursive/blob/f810b44477696081ebef9c0d5eafb24005c8e82b/index.js#L6

The previous definition was missing the third and the fourth parameter. Spot this issue when I am working on a Babel PR https://github.com/babel/babel/pull/16459/files#r1586574307