### PR TITLE
fix(wktohtml): fix callback and return types

### DIFF
--- a/types/wkhtmltopdf/index.d.ts
+++ b/types/wkhtmltopdf/index.d.ts
@@ -3,6 +3,8 @@
 
 /// <reference types="node"/>
 
+import { Readable } from "stream";
+
 /**
  * Call wkhtmltopdf and write PDF
  * If options.output is defined the file will be returned in the stream
@@ -14,7 +16,7 @@ declare function wkhtmltopdf(
     html: string,
     options?: Options,
     callback?: (err: Error | null, stream?: NodeJS.ReadWriteStream) => void,
-): NodeJS.ReadWriteStream
+): Readable
 /**
  * Call wkhtmltopdf and write PDF
  * If options.output is defined the file will be returned in the stream
@@ -27,7 +29,7 @@ declare function wkhtmltopdf(
     url: string,
     options?: Options,
     callback?: (err: Error | null, stream?: NodeJS.ReadWriteStream) => void,
-): NodeJS.ReadWriteStream;
+): Readable;
 /**
  * Call wkhtmltopdf and write PDF
  * If options.output is defined the file will be returned in the stream
@@ -40,7 +42,7 @@ declare function wkhtmltopdf(
     inputStream: NodeJS.ReadStream,
     options?: Options,
     callback?: (err: Error | null, stream?: NodeJS.ReadWriteStream) => void,
-): NodeJS.ReadWriteStream;
+): Readable;
 
 declare namespace wkhtmltopdf {
     /**

--- a/types/wkhtmltopdf/index.d.ts
+++ b/types/wkhtmltopdf/index.d.ts
@@ -13,8 +13,8 @@
 declare function wkhtmltopdf(
     html: string,
     options?: Options,
-    callback?: (err: Error, stream: NodeJS.ReadWriteStream) => void,
-): NodeJS.ReadWriteStream;
+    callback?: (err: Error | null, stream?: NodeJS.ReadWriteStream) => void,
+): NodeJS.ReadWriteStream
 /**
  * Call wkhtmltopdf and write PDF
  * If options.output is defined the file will be returned in the stream
@@ -26,7 +26,7 @@ declare function wkhtmltopdf(
 declare function wkhtmltopdf(
     url: string,
     options?: Options,
-    callback?: (err: Error, stream: NodeJS.ReadWriteStream) => void,
+    callback?: (err: Error | null, stream?: NodeJS.ReadWriteStream) => void,
 ): NodeJS.ReadWriteStream;
 /**
  * Call wkhtmltopdf and write PDF

--- a/types/wkhtmltopdf/index.d.ts
+++ b/types/wkhtmltopdf/index.d.ts
@@ -16,7 +16,7 @@ declare function wkhtmltopdf(
     html: string,
     options?: Options,
     callback?: (err: Error | null, stream?: NodeJS.ReadWriteStream) => void,
-): Readable
+): Readable;
 /**
  * Call wkhtmltopdf and write PDF
  * If options.output is defined the file will be returned in the stream

--- a/types/wkhtmltopdf/index.d.ts
+++ b/types/wkhtmltopdf/index.d.ts
@@ -36,7 +36,11 @@ declare function wkhtmltopdf(
  * @param [options] Options
  * @param [callback] Callback
  */
-declare function wkhtmltopdf(inputStream: NodeJS.ReadStream, options?: Options): NodeJS.ReadWriteStream;
+declare function wkhtmltopdf(
+    inputStream: NodeJS.ReadStream,
+    options?: Options,
+    callback?: (err: Error | null, stream?: NodeJS.ReadWriteStream) => void,
+): NodeJS.ReadWriteStream;
 
 declare namespace wkhtmltopdf {
     /**

--- a/types/wkhtmltopdf/wkhtmltopdf-tests.ts
+++ b/types/wkhtmltopdf/wkhtmltopdf-tests.ts
@@ -1,19 +1,24 @@
 import wkhtmltopdf = require("wkhtmltopdf");
 
 // URL
-wkhtmltopdf("http://google.com/", { pageSize: "Letter" }); // $ExpectType Readable
+// $ExpectType Readable
+wkhtmltopdf("http://google.com/", { pageSize: "Letter" });
 
 // HTML
-wkhtmltopdf("<h1>Test</h1><p>Hello world</p>"); // $ExpectType Readable
+// $ExpectType Readable
+wkhtmltopdf("<h1>Test</h1><p>Hello world</p>");
 
 // output to a file directly
-wkhtmltopdf("http://apple.com/", { output: "out.pdf" }); // $ExpectType Readable
+// $ExpectType Readable
+wkhtmltopdf("http://apple.com/", { output: "out.pdf" });
 
 // Optional callback
-wkhtmltopdf("http://google.com/", { pageSize: "Letter" }, (err: Error | null, stream?: NodeJS.ReadWriteStream) => {}); // $ExpectType Readable
+// $ExpectType Readable
+wkhtmltopdf("http://google.com/", { pageSize: "Letter" }, (err: Error | null, stream?: NodeJS.ReadWriteStream) => {});
 
 // Repeatable options
-wkhtmltopdf("http://google.com/", { // $ExpectType Readable
+// $ExpectType Readable
+wkhtmltopdf("http://google.com/", {
     allow: ["path1", "path2"],
     customHeader: [
         ["name1", "value1"],
@@ -22,23 +27,27 @@ wkhtmltopdf("http://google.com/", { // $ExpectType Readable
 });
 
 // Ignore warning strings
-wkhtmltopdf("http://apple.com/", { // $ExpectType Readable
+// $ExpectType Readable
+wkhtmltopdf("http://apple.com/", {
     output: "out.pdf",
     ignore: ["QFont::setPixelSize: Pixel size <= 0 (0)"],
 });
 
 // RegExp also acceptable
-wkhtmltopdf("http://apple.com/", { // $ExpectType Readable
+// $ExpectType Readable
+wkhtmltopdf("http://apple.com/", {
     output: "out.pdf",
     ignore: [/QFont::setPixelSize/],
 });
 
 // Test debug types
-wkhtmltopdf("http://apple.com/", { // $ExpectType Readable
+// $ExpectType Readable
+wkhtmltopdf("http://apple.com/", {
     debug: true,
 });
 
-wkhtmltopdf("http://apple.com/", { // $ExpectType Readable
+// $ExpectType Readable
+wkhtmltopdf("http://apple.com/", {
     output: "test.pdf",
     debug: (data: Buffer) => {
         const dataString = data.toString();
@@ -56,7 +65,8 @@ wkhtmltopdf.shell; // $ExpectType string
 wkhtmltopdf.command; // $ExpectType string
 
 // Footer and header spacing type
-wkhtmltopdf("http://apple.com/", { // $ExpectType Readable
+// $ExpectType Readable
+wkhtmltopdf("http://apple.com/", {
     headerSpacing: 0,
     footerSpacing: 0,
 });

--- a/types/wkhtmltopdf/wkhtmltopdf-tests.ts
+++ b/types/wkhtmltopdf/wkhtmltopdf-tests.ts
@@ -10,7 +10,7 @@ wkhtmltopdf("<h1>Test</h1><p>Hello world</p>"); // $ExpectType ReadWriteStream
 wkhtmltopdf("http://apple.com/", { output: "out.pdf" }); // $ExpectType ReadWriteStream
 
 // Optional callback
-wkhtmltopdf("http://google.com/", { pageSize: "Letter" }, (err: Error, stream: NodeJS.ReadWriteStream) => {}); // $ExpectType void
+wkhtmltopdf("http://google.com/", { pageSize: "Letter" }, (err: Error | null, stream?: NodeJS.ReadWriteStream) => {}); // $ExpectType void
 
 // Repeatable options
 wkhtmltopdf("http://google.com/", { // $ExpectType NodeJS.ReadWriteStream

--- a/types/wkhtmltopdf/wkhtmltopdf-tests.ts
+++ b/types/wkhtmltopdf/wkhtmltopdf-tests.ts
@@ -1,19 +1,19 @@
 import wkhtmltopdf = require("wkhtmltopdf");
 
 // URL
-wkhtmltopdf("http://google.com/", { pageSize: "Letter" }); // $ExpectType NodeJS.ReadWriteStream
+wkhtmltopdf("http://google.com/", { pageSize: "Letter" }); // $ExpectType Readable
 
 // HTML
-wkhtmltopdf("<h1>Test</h1><p>Hello world</p>"); // $ExpectType ReadWriteStream
+wkhtmltopdf("<h1>Test</h1><p>Hello world</p>"); // $ExpectType Readable
 
 // output to a file directly
-wkhtmltopdf("http://apple.com/", { output: "out.pdf" }); // $ExpectType ReadWriteStream
+wkhtmltopdf("http://apple.com/", { output: "out.pdf" }); // $ExpectType Readable
 
 // Optional callback
-wkhtmltopdf("http://google.com/", { pageSize: "Letter" }, (err: Error | null, stream?: NodeJS.ReadWriteStream) => {}); // $ExpectType void
+wkhtmltopdf("http://google.com/", { pageSize: "Letter" }, (err: Error | null, stream?: NodeJS.ReadWriteStream) => {}); // $ExpectType Readable
 
 // Repeatable options
-wkhtmltopdf("http://google.com/", { // $ExpectType NodeJS.ReadWriteStream
+wkhtmltopdf("http://google.com/", { // $ExpectType Readable
     allow: ["path1", "path2"],
     customHeader: [
         ["name1", "value1"],
@@ -22,23 +22,23 @@ wkhtmltopdf("http://google.com/", { // $ExpectType NodeJS.ReadWriteStream
 });
 
 // Ignore warning strings
-wkhtmltopdf("http://apple.com/", { // $ExpectType ReadWriteStream
+wkhtmltopdf("http://apple.com/", { // $ExpectType Readable
     output: "out.pdf",
     ignore: ["QFont::setPixelSize: Pixel size <= 0 (0)"],
 });
 
 // RegExp also acceptable
-wkhtmltopdf("http://apple.com/", { // $ExpectType ReadWriteStream
+wkhtmltopdf("http://apple.com/", { // $ExpectType Readable
     output: "out.pdf",
     ignore: [/QFont::setPixelSize/],
 });
 
 // Test debug types
-wkhtmltopdf("http://apple.com/", { // $ExpectType ReadWriteStream
+wkhtmltopdf("http://apple.com/", { // $ExpectType Readable
     debug: true,
 });
 
-wkhtmltopdf("http://apple.com/", { // $ExpectType ReadWriteStream
+wkhtmltopdf("http://apple.com/", { // $ExpectType Readable
     output: "test.pdf",
     debug: (data: Buffer) => {
         const dataString = data.toString();
@@ -56,7 +56,7 @@ wkhtmltopdf.shell; // $ExpectType string
 wkhtmltopdf.command; // $ExpectType string
 
 // Footer and header spacing type
-wkhtmltopdf("http://apple.com/", { // $ExpectType ReadWriteStream
+wkhtmltopdf("http://apple.com/", { // $ExpectType Readable
     headerSpacing: 0,
     footerSpacing: 0,
 });


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test wktohtml`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Sources of `node-wkhtmltopdf`](https://github.com/devongovett/node-wkhtmltopdf/blob/master/index.js)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
    -  the fix is not linked to a change in the version of `node-wkhtmltopdf` (the current version is 3 years old)

---

In this PR, I:
- fix the callback type
  - error is nullable
  - stream is optional
- fix the return type
  - in the sources of node-wkhtmltopdf: wkhtmltopdf returns a `ChildProcess.stdout` which is a `stream.Readable`
  - `stream.Readable` is a subclass of `NodeJS.ReadWriteStream`

