### PR TITLE
[@types/three] Add missing mode argument for TransformControls.d.ts events

### DIFF
--- a/types/three/examples/jsm/controls/TransformControls.d.ts
+++ b/types/three/examples/jsm/controls/TransformControls.d.ts
@@ -2,8 +2,8 @@ import { Camera, Mesh, MOUSE, Object3D, Object3DEventMap, Quaternion, Raycaster,
 
 export interface TransformControlsEventMap extends Object3DEventMap {
     change: {};
-    mouseDown: {};
-    mouseUp: {};
+    mouseDown: { mode: string };
+    mouseUp: { mode: string };
     objectChange: {};
     "camera-changed": { value: unknown };
     "object-changed": { value: unknown };


### PR DESCRIPTION
The `TransformControls` actually returns the mode each time `mouseDown` and `mouseUp` events are triggered (same behaviour for older library versions).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mrdoob/three.js/blob/master/examples/jsm/controls/TransformControls.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
