### PR TITLE
[@types/lodash] Infer lodash.throttle return type from 'leading' option

### DIFF
--- a/types/lodash/common/function.d.ts
+++ b/types/lodash/common/function.d.ts
@@ -1355,6 +1355,9 @@ declare module "../index" {
          */
         trailing?: boolean | undefined;
     }
+    interface ThrottleSettingsNoLeading extends ThrottleSettings {
+        leading: false;
+    }
     interface LoDashStatic {
         /**
          * Creates a throttled function that only invokes func at most once per every wait milliseconds. The throttled
@@ -1372,25 +1375,34 @@ declare module "../index" {
          * @param options.trailing Specify invoking on the trailing edge of the timeout.
          * @return Returns the new throttled function.
          */
-        throttle<T extends (...args: any) => any>(func: T, wait?: number, options?: ThrottleSettings): DebouncedFunc<T>;
+        throttle<T extends (...args: any) => any>(func: T, wait: number | undefined, options: ThrottleSettingsNoLeading): DebouncedFunc<T>;
+        throttle<T extends (...args: any) => any>(func: T, wait?: number, options?: ThrottleSettings): DebouncedFuncLeading<T>;
     }
     interface Function<T extends (...args: any) => any> {
         /**
          * @see _.throttle
          */
         throttle(
+            wait: number | undefined,
+            options: ThrottleSettingsNoLeading
+        ): T extends (...args: any[]) => any ? Function<DebouncedFunc<T>> : never;
+        throttle(
             wait?: number,
             options?: ThrottleSettings
-        ): T extends (...args: any[]) => any ? Function<DebouncedFunc<T>> : never;
+        ): T extends (...args: any[]) => any ? Function<DebouncedFuncLeading<T>> : never;
     }
     interface FunctionChain<T extends (...args: any) => any> {
         /**
          * @see _.throttle
          */
         throttle(
+            wait: number | undefined,
+            options: ThrottleSettingsNoLeading
+        ): T extends (...args: any[]) => any ? FunctionChain<DebouncedFunc<T>> : never;
+        throttle(
             wait?: number,
             options?: ThrottleSettings
-        ): T extends (...args: any[]) => any ? FunctionChain<DebouncedFunc<T>> : never;
+        ): T extends (...args: any[]) => any ? FunctionChain<DebouncedFuncLeading<T>> : never;
     }
     interface LoDashStatic {
         /**

--- a/types/lodash/common/function.d.ts
+++ b/types/lodash/common/function.d.ts
@@ -1355,9 +1355,7 @@ declare module "../index" {
          */
         trailing?: boolean | undefined;
     }
-    interface ThrottleSettingsNoLeading extends ThrottleSettings {
-        leading: false;
-    }
+    type ThrottleSettingsLeading = (ThrottleSettings & { leading: true }) | Omit<ThrottleSettings, 'leading'>
     interface LoDashStatic {
         /**
          * Creates a throttled function that only invokes func at most once per every wait milliseconds. The throttled
@@ -1375,34 +1373,34 @@ declare module "../index" {
          * @param options.trailing Specify invoking on the trailing edge of the timeout.
          * @return Returns the new throttled function.
          */
-        throttle<T extends (...args: any) => any>(func: T, wait: number | undefined, options: ThrottleSettingsNoLeading): DebouncedFunc<T>;
-        throttle<T extends (...args: any) => any>(func: T, wait?: number, options?: ThrottleSettings): DebouncedFuncLeading<T>;
+        throttle<T extends (...args: any) => any>(func: T, wait?: number, options?: ThrottleSettingsLeading): DebouncedFuncLeading<T>;
+        throttle<T extends (...args: any) => any>(func: T, wait?: number, options?: ThrottleSettings): DebouncedFunc<T>;
     }
     interface Function<T extends (...args: any) => any> {
         /**
          * @see _.throttle
          */
         throttle(
-            wait: number | undefined,
-            options: ThrottleSettingsNoLeading
-        ): T extends (...args: any[]) => any ? Function<DebouncedFunc<T>> : never;
+            wait?: number,
+            options?: ThrottleSettingsLeading
+        ): T extends (...args: any[]) => any ? Function<DebouncedFuncLeading<T>> : never;
         throttle(
             wait?: number,
             options?: ThrottleSettings
-        ): T extends (...args: any[]) => any ? Function<DebouncedFuncLeading<T>> : never;
+        ): T extends (...args: any[]) => any ? Function<DebouncedFunc<T>> : never;
     }
     interface FunctionChain<T extends (...args: any) => any> {
         /**
          * @see _.throttle
          */
         throttle(
-            wait: number | undefined,
-            options: ThrottleSettingsNoLeading
-        ): T extends (...args: any[]) => any ? FunctionChain<DebouncedFunc<T>> : never;
+            wait?: number,
+            options?: ThrottleSettingsLeading
+        ): T extends (...args: any[]) => any ? FunctionChain<DebouncedFuncLeading<T>> : never;
         throttle(
             wait?: number,
             options?: ThrottleSettings
-        ): T extends (...args: any[]) => any ? FunctionChain<DebouncedFuncLeading<T>> : never;
+        ): T extends (...args: any[]) => any ? FunctionChain<DebouncedFunc<T>> : never;
     }
     interface LoDashStatic {
         /**

--- a/types/lodash/fp.d.ts
+++ b/types/lodash/fp.d.ts
@@ -4173,10 +4173,10 @@ declare namespace _ {
     interface LodashThrottle {
         (wait: number): LodashThrottle1x1;
         <T extends (...args: any) => any>(wait: lodash.__, func: T): LodashThrottle1x2<T>;
-        <T extends (...args: any) => any>(wait: number, func: T): lodash.DebouncedFunc<T>;
+        <T extends (...args: any) => any>(wait: number, func: T): lodash.DebouncedFuncLeading<T>;
     }
-    type LodashThrottle1x1 = <T extends (...args: any) => any>(func: T) => lodash.DebouncedFunc<T>;
-    type LodashThrottle1x2<T extends (...args: any) => any> = (wait: number) => lodash.DebouncedFunc<T>;
+    type LodashThrottle1x1 = <T extends (...args: any) => any>(func: T) => lodash.DebouncedFuncLeading<T>;
+    type LodashThrottle1x2<T extends (...args: any) => any> = (wait: number) => lodash.DebouncedFuncLeading<T>;
     interface LodashThru {
         <T, TResult>(interceptor: (value: T) => TResult): LodashThru1x1<T, TResult>;
         <T>(interceptor: lodash.__, value: T): LodashThru1x2<T>;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -3656,28 +3656,53 @@ fp.now(); // $ExpectType number
 
 // _.throttle
 {
-    const options: _.ThrottleSettings = {
+    const optionsLeading: _.ThrottleSettingsLeading = {
         leading: true,
         trailing: false,
+    }
+    const badOptionsLeading: _.ThrottleSettingsLeading = {
+        // @ts-expect-error lodash will treat an explicit undefined the same as `leading: false`
+        leading: undefined,
     };
-    const optionsNoLeading: _.ThrottleSettingsNoLeading = {
+    const optionsNoLeading: _.ThrottleSettings = {
         leading: false,
     };
+
+    const optionsAmbiguous = {
+        leading: true,
+    };
+    const boolean: boolean = false;
+    const maybeUndefined = (function (): true | undefined { return true })();
 
     const func = (a: number, b: string): boolean => true;
 
     _.throttle(func); // $ExpectType DebouncedFuncLeading<(a: number, b: string) => boolean>
     _.throttle(func, 42); // $ExpectType DebouncedFuncLeading<(a: number, b: string) => boolean>
-    _.throttle(func, 42, options); // $ExpectType DebouncedFuncLeading<(a: number, b: string) => boolean>
-    _.throttle(func, 42, optionsNoLeading); // $ExpectType DebouncedFunc<(a: number, b: string) => boolean>
+    _.throttle(func, 42, {}); // $ExpectType DebouncedFuncLeading<(a: number, b: string) => boolean>
+    _.throttle(func, 42, { leading: true, trailing: false }); // $ExpectType DebouncedFuncLeading<(a: number, b: string) => boolean>
+    _.throttle(func, 42, { leading: false }); // $ExpectType DebouncedFunc<(a: number, b: string) => boolean>
+    _.throttle(func, 42, { leading: undefined }); // $ExpectType DebouncedFunc<(a: number, b: string) => boolean>
+    _.throttle(func, 42, { leading: boolean }); // $ExpectType DebouncedFunc<(a: number, b: string) => boolean>
+    _.throttle(func, 42, { leading: maybeUndefined }); // $ExpectType DebouncedFunc<(a: number, b: string) => boolean>
+    _.throttle(func, 42, optionsAmbiguous); // $ExpectType DebouncedFunc<(a: number, b: string) => boolean>
     _(func).throttle(); // $ExpectType Function<DebouncedFuncLeading<(a: number, b: string) => boolean>>
     _(func).throttle(42); // $ExpectType Function<DebouncedFuncLeading<(a: number, b: string) => boolean>>
-    _(func).throttle(42, options); // $ExpectType Function<DebouncedFuncLeading<(a: number, b: string) => boolean>>
-    _(func).throttle(42, optionsNoLeading); // $ExpectType Function<DebouncedFunc<(a: number, b: string) => boolean>>
+    _(func).throttle(42, {}); // $ExpectType Function<DebouncedFuncLeading<(a: number, b: string) => boolean>>
+    _(func).throttle(42, { leading: true, trailing: false }); // $ExpectType Function<DebouncedFuncLeading<(a: number, b: string) => boolean>>
+    _(func).throttle(42, { leading: false }); // $ExpectType Function<DebouncedFunc<(a: number, b: string) => boolean>>
+    _(func).throttle(42, { leading: undefined }); // $ExpectType Function<DebouncedFunc<(a: number, b: string) => boolean>>
+    _(func).throttle(42, { leading: boolean }); // $ExpectType Function<DebouncedFunc<(a: number, b: string) => boolean>>
+    _(func).throttle(42, { leading: maybeUndefined }); // $ExpectType Function<DebouncedFunc<(a: number, b: string) => boolean>>
+    _(func).throttle(42, optionsAmbiguous); // $ExpectType Function<DebouncedFunc<(a: number, b: string) => boolean>>
     _.chain(func).throttle(); // $ExpectType FunctionChain<DebouncedFuncLeading<(a: number, b: string) => boolean>>
     _.chain(func).throttle(42); // $ExpectType FunctionChain<DebouncedFuncLeading<(a: number, b: string) => boolean>>
-    _.chain(func).throttle(42, options); // $ExpectType FunctionChain<DebouncedFuncLeading<(a: number, b: string) => boolean>>
-    _.chain(func).throttle(42, optionsNoLeading); // $ExpectType FunctionChain<DebouncedFunc<(a: number, b: string) => boolean>>
+    _.chain(func).throttle(42, {}); // $ExpectType FunctionChain<DebouncedFuncLeading<(a: number, b: string) => boolean>>
+    _.chain(func).throttle(42, { leading: true, trailing: false }); // $ExpectType FunctionChain<DebouncedFuncLeading<(a: number, b: string) => boolean>>
+    _.chain(func).throttle(42, { leading: false }); // $ExpectType FunctionChain<DebouncedFunc<(a: number, b: string) => boolean>>
+    _.chain(func).throttle(42, { leading: undefined }); // $ExpectType FunctionChain<DebouncedFunc<(a: number, b: string) => boolean>>
+    _.chain(func).throttle(42, { leading: boolean }); // $ExpectType FunctionChain<DebouncedFunc<(a: number, b: string) => boolean>>
+    _.chain(func).throttle(42, { leading: maybeUndefined }); // $ExpectType FunctionChain<DebouncedFunc<(a: number, b: string) => boolean>>
+    _.chain(func).throttle(42, optionsAmbiguous); // $ExpectType FunctionChain<DebouncedFunc<(a: number, b: string) => boolean>>
 
     fp.throttle(42, func); // $ExpectType DebouncedFuncLeading<(a: number, b: string) => boolean>
     fp.throttle(42)(func); // $ExpectType DebouncedFuncLeading<(a: number, b: string) => boolean>

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -3660,21 +3660,27 @@ fp.now(); // $ExpectType number
         leading: true,
         trailing: false,
     };
+    const optionsNoLeading: _.ThrottleSettingsNoLeading = {
+        leading: false,
+    };
 
     const func = (a: number, b: string): boolean => true;
 
-    _.throttle(func); // $ExpectType DebouncedFunc<(a: number, b: string) => boolean>
-    _.throttle(func, 42); // $ExpectType DebouncedFunc<(a: number, b: string) => boolean>
-    _.throttle(func, 42, options); // $ExpectType DebouncedFunc<(a: number, b: string) => boolean>
-    _(func).throttle(); // $ExpectType Function<DebouncedFunc<(a: number, b: string) => boolean>>
-    _(func).throttle(42); // $ExpectType Function<DebouncedFunc<(a: number, b: string) => boolean>>
-    _(func).throttle(42, options); // $ExpectType Function<DebouncedFunc<(a: number, b: string) => boolean>>
-    _.chain(func).throttle(); // $ExpectType FunctionChain<DebouncedFunc<(a: number, b: string) => boolean>>
-    _.chain(func).throttle(42); // $ExpectType FunctionChain<DebouncedFunc<(a: number, b: string) => boolean>>
-    _.chain(func).throttle(42, options); // $ExpectType FunctionChain<DebouncedFunc<(a: number, b: string) => boolean>>
+    _.throttle(func); // $ExpectType DebouncedFuncLeading<(a: number, b: string) => boolean>
+    _.throttle(func, 42); // $ExpectType DebouncedFuncLeading<(a: number, b: string) => boolean>
+    _.throttle(func, 42, options); // $ExpectType DebouncedFuncLeading<(a: number, b: string) => boolean>
+    _.throttle(func, 42, optionsNoLeading); // $ExpectType DebouncedFunc<(a: number, b: string) => boolean>
+    _(func).throttle(); // $ExpectType Function<DebouncedFuncLeading<(a: number, b: string) => boolean>>
+    _(func).throttle(42); // $ExpectType Function<DebouncedFuncLeading<(a: number, b: string) => boolean>>
+    _(func).throttle(42, options); // $ExpectType Function<DebouncedFuncLeading<(a: number, b: string) => boolean>>
+    _(func).throttle(42, optionsNoLeading); // $ExpectType Function<DebouncedFunc<(a: number, b: string) => boolean>>
+    _.chain(func).throttle(); // $ExpectType FunctionChain<DebouncedFuncLeading<(a: number, b: string) => boolean>>
+    _.chain(func).throttle(42); // $ExpectType FunctionChain<DebouncedFuncLeading<(a: number, b: string) => boolean>>
+    _.chain(func).throttle(42, options); // $ExpectType FunctionChain<DebouncedFuncLeading<(a: number, b: string) => boolean>>
+    _.chain(func).throttle(42, optionsNoLeading); // $ExpectType FunctionChain<DebouncedFunc<(a: number, b: string) => boolean>>
 
-    fp.throttle(42, func); // $ExpectType DebouncedFunc<(a: number, b: string) => boolean>
-    fp.throttle(42)(func); // $ExpectType DebouncedFunc<(a: number, b: string) => boolean>
+    fp.throttle(42, func); // $ExpectType DebouncedFuncLeading<(a: number, b: string) => boolean>
+    fp.throttle(42)(func); // $ExpectType DebouncedFuncLeading<(a: number, b: string) => boolean>
 }
 
 // _.unary

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -3660,19 +3660,15 @@ fp.now(); // $ExpectType number
         leading: true,
         trailing: false,
     }
-    const badOptionsLeading: _.ThrottleSettingsLeading = {
-        // @ts-expect-error lodash will treat an explicit undefined the same as `leading: false`
-        leading: undefined,
-    };
     const optionsNoLeading: _.ThrottleSettings = {
         leading: false,
     };
 
     const optionsAmbiguous = {
-        leading: true,
+        leading: true as boolean,
     };
-    const boolean: boolean = false;
-    const maybeUndefined = (function (): true | undefined { return true })();
+    const boolean = false as boolean; // $ExpectType boolean
+    const maybeUndefined = true as true | undefined; // $ExpectType true | undefined
 
     const func = (a: number, b: string): boolean => true;
 
@@ -3681,31 +3677,41 @@ fp.now(); // $ExpectType number
     _.throttle(func, 42, {}); // $ExpectType DebouncedFuncLeading<(a: number, b: string) => boolean>
     _.throttle(func, 42, { leading: true, trailing: false }); // $ExpectType DebouncedFuncLeading<(a: number, b: string) => boolean>
     _.throttle(func, 42, { leading: false }); // $ExpectType DebouncedFunc<(a: number, b: string) => boolean>
-    _.throttle(func, 42, { leading: undefined }); // $ExpectType DebouncedFunc<(a: number, b: string) => boolean>
     _.throttle(func, 42, { leading: boolean }); // $ExpectType DebouncedFunc<(a: number, b: string) => boolean>
-    _.throttle(func, 42, { leading: maybeUndefined }); // $ExpectType DebouncedFunc<(a: number, b: string) => boolean>
     _.throttle(func, 42, optionsAmbiguous); // $ExpectType DebouncedFunc<(a: number, b: string) => boolean>
+
     _(func).throttle(); // $ExpectType Function<DebouncedFuncLeading<(a: number, b: string) => boolean>>
     _(func).throttle(42); // $ExpectType Function<DebouncedFuncLeading<(a: number, b: string) => boolean>>
     _(func).throttle(42, {}); // $ExpectType Function<DebouncedFuncLeading<(a: number, b: string) => boolean>>
     _(func).throttle(42, { leading: true, trailing: false }); // $ExpectType Function<DebouncedFuncLeading<(a: number, b: string) => boolean>>
     _(func).throttle(42, { leading: false }); // $ExpectType Function<DebouncedFunc<(a: number, b: string) => boolean>>
-    _(func).throttle(42, { leading: undefined }); // $ExpectType Function<DebouncedFunc<(a: number, b: string) => boolean>>
     _(func).throttle(42, { leading: boolean }); // $ExpectType Function<DebouncedFunc<(a: number, b: string) => boolean>>
-    _(func).throttle(42, { leading: maybeUndefined }); // $ExpectType Function<DebouncedFunc<(a: number, b: string) => boolean>>
     _(func).throttle(42, optionsAmbiguous); // $ExpectType Function<DebouncedFunc<(a: number, b: string) => boolean>>
+
     _.chain(func).throttle(); // $ExpectType FunctionChain<DebouncedFuncLeading<(a: number, b: string) => boolean>>
     _.chain(func).throttle(42); // $ExpectType FunctionChain<DebouncedFuncLeading<(a: number, b: string) => boolean>>
     _.chain(func).throttle(42, {}); // $ExpectType FunctionChain<DebouncedFuncLeading<(a: number, b: string) => boolean>>
     _.chain(func).throttle(42, { leading: true, trailing: false }); // $ExpectType FunctionChain<DebouncedFuncLeading<(a: number, b: string) => boolean>>
     _.chain(func).throttle(42, { leading: false }); // $ExpectType FunctionChain<DebouncedFunc<(a: number, b: string) => boolean>>
-    _.chain(func).throttle(42, { leading: undefined }); // $ExpectType FunctionChain<DebouncedFunc<(a: number, b: string) => boolean>>
     _.chain(func).throttle(42, { leading: boolean }); // $ExpectType FunctionChain<DebouncedFunc<(a: number, b: string) => boolean>>
-    _.chain(func).throttle(42, { leading: maybeUndefined }); // $ExpectType FunctionChain<DebouncedFunc<(a: number, b: string) => boolean>>
     _.chain(func).throttle(42, optionsAmbiguous); // $ExpectType FunctionChain<DebouncedFunc<(a: number, b: string) => boolean>>
 
     fp.throttle(42, func); // $ExpectType DebouncedFuncLeading<(a: number, b: string) => boolean>
     fp.throttle(42)(func); // $ExpectType DebouncedFuncLeading<(a: number, b: string) => boolean>
+
+    // _.throttle treats an explicit `leading: undefined` the same as `leading: false`
+    const badOptionsLeading: _.ThrottleSettingsLeading = {
+        // @ts-expect-error explicit undefined is not allowed here
+        leading: undefined,
+    };
+
+    // any invokation where leading might be set as undefined should return DebouncedFunc, not DebouncedFuncLeading
+    _.throttle(func, 42, { leading: undefined }); // $ExpectType DebouncedFunc<(a: number, b: string) => boolean>
+    _.throttle(func, 42, { leading: maybeUndefined }); // $ExpectType DebouncedFunc<(a: number, b: string) => boolean>
+    _.chain(func).throttle(42, { leading: undefined }); // $ExpectType FunctionChain<DebouncedFunc<(a: number, b: string) => boolean>>
+    _.chain(func).throttle(42, { leading: maybeUndefined }); // $ExpectType FunctionChain<DebouncedFunc<(a: number, b: string) => boolean>>
+    _(func).throttle(42, { leading: undefined }); // $ExpectType Function<DebouncedFunc<(a: number, b: string) => boolean>>
+    _(func).throttle(42, { leading: maybeUndefined }); // $ExpectType Function<DebouncedFunc<(a: number, b: string) => boolean>>
 }
 
 // _.unary


### PR DESCRIPTION
This sets the `throttle` types to follow the same pattern as `debounce` (which it calls directly), accounting for the different default values (throttle has `leading: true` by default, debounce has `leading: false`).

I'm less familiar with how the `fp` packages are supposed to work, didn't see a way to pass options. I changed the `lodash/fp/throttle` function to return the same value as `lodash/throttle` with default options (`DebounceFuncLeading`).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [lodash.throttle docs](https://lodash.com/docs/4.17.15#throttle)
  - [source](https://github.com/lodash/lodash/blob/main/src/throttle.ts)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
