### PR TITLE
[@types/simpl-schema] Update types to allow passing schema to constructor

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -1683,7 +1683,6 @@
         "sigmajs",
         "signalfx-collect",
         "signalr/v1",
-        "simpl-schema",
         "simple-cw-node",
         "simple-url-cache",
         "simple-xml",

--- a/attw.json
+++ b/attw.json
@@ -1683,6 +1683,7 @@
         "sigmajs",
         "signalfx-collect",
         "signalr/v1",
+        "simpl-schema",
         "simple-cw-node",
         "simple-url-cache",
         "simple-xml",

--- a/types/simpl-schema/index.d.ts
+++ b/types/simpl-schema/index.d.ts
@@ -167,7 +167,7 @@ interface SimpleSchemaMessageType {
 type SimpleSchemaMessagesDict = Record<string, SimpleSchemaMessageType>;
 
 export class SimpleSchema {
-    constructor(schema: SimpleSchemaDefinition, options?: SimpleSchemaOptions);
+    constructor(schema: SimpleSchemaDefinition | SimpleSchema, options?: SimpleSchemaOptions);
     namedContext(name?: string): SimpleSchemaValidationContextStatic;
     static isSimpleSchema(obj: any): boolean;
     static addValidator(validator: Validator): void;

--- a/types/simpl-schema/index.d.ts
+++ b/types/simpl-schema/index.d.ts
@@ -1,6 +1,6 @@
 import { check } from "meteor/check";
 
-interface ValidationContext extends SimpleSchemaValidationContextStatic {
+export interface ValidationContext extends SimpleSchemaValidationContextStatic {
     addValidationErrors(errors: any): void;
     clean(...args: any[]): any;
     getErrorForKey(key: any, ...args: any[]): any;
@@ -68,7 +68,7 @@ interface FieldInfo {
     operator: string | null;
 }
 
-interface AutoValueContext {
+export interface AutoValueContext {
     closestSubschemaFieldName: string | null;
     field: (fieldName: string) => FieldInfo;
     isModifier: boolean;
@@ -84,7 +84,7 @@ interface AutoValueContext {
 
 type Validator = (this: CustomValidationContext) => undefined | string | SimpleSchemaValidationError;
 
-interface SchemaDefinition {
+export interface SchemaDefinition {
     type: any;
     label?: string | (() => string) | undefined;
     optional?: boolean | (() => boolean) | undefined;
@@ -140,7 +140,7 @@ interface SimpleSchemaValidationError {
 
 type IntegerSchema = "SimpleSchema.Integer";
 
-type SimpleSchemaDefinition = {
+export type SimpleSchemaDefinition = {
     [key: string]:
         | SchemaDefinition
         | BooleanConstructor
@@ -166,8 +166,7 @@ interface SimpleSchemaMessageType {
 
 type SimpleSchemaMessagesDict = Record<string, SimpleSchemaMessageType>;
 
-declare class SimpleSchema {
-    static default: typeof SimpleSchema;
+export class SimpleSchema {
     constructor(schema: SimpleSchemaDefinition | SimpleSchema, options?: SimpleSchemaOptions);
     namedContext(name?: string): SimpleSchemaValidationContextStatic;
     static isSimpleSchema(obj: any): boolean;
@@ -288,8 +287,11 @@ interface MongoObjectStatic {
     affectsGenericKeyImplicit(key: string): any;
 }
 
-declare namespace SimpleSchema {
-    export { AutoValueContext, MongoObjectStatic, SchemaDefinition, SimpleSchemaDefinition, ValidationContext };
+export const SimpleSchemaValidationContext: SimpleSchemaValidationContextStatic;
+export const MongoObject: MongoObjectStatic;
+
+export interface MongoObject {
+    expandKey(val: any, key: string, obj: any): void;
 }
 
-export = SimpleSchema;
+export default SimpleSchema;

--- a/types/simpl-schema/index.d.ts
+++ b/types/simpl-schema/index.d.ts
@@ -1,6 +1,6 @@
 import { check } from "meteor/check";
 
-export interface ValidationContext extends SimpleSchemaValidationContextStatic {
+interface ValidationContext extends SimpleSchemaValidationContextStatic {
     addValidationErrors(errors: any): void;
     clean(...args: any[]): any;
     getErrorForKey(key: any, ...args: any[]): any;
@@ -68,7 +68,7 @@ interface FieldInfo {
     operator: string | null;
 }
 
-export interface AutoValueContext {
+interface AutoValueContext {
     closestSubschemaFieldName: string | null;
     field: (fieldName: string) => FieldInfo;
     isModifier: boolean;
@@ -84,7 +84,7 @@ export interface AutoValueContext {
 
 type Validator = (this: CustomValidationContext) => undefined | string | SimpleSchemaValidationError;
 
-export interface SchemaDefinition {
+interface SchemaDefinition {
     type: any;
     label?: string | (() => string) | undefined;
     optional?: boolean | (() => boolean) | undefined;
@@ -140,7 +140,7 @@ interface SimpleSchemaValidationError {
 
 type IntegerSchema = "SimpleSchema.Integer";
 
-export type SimpleSchemaDefinition = {
+type SimpleSchemaDefinition = {
     [key: string]:
         | SchemaDefinition
         | BooleanConstructor
@@ -166,7 +166,8 @@ interface SimpleSchemaMessageType {
 
 type SimpleSchemaMessagesDict = Record<string, SimpleSchemaMessageType>;
 
-export class SimpleSchema {
+declare class SimpleSchema {
+    static default: typeof SimpleSchema;
     constructor(schema: SimpleSchemaDefinition | SimpleSchema, options?: SimpleSchemaOptions);
     namedContext(name?: string): SimpleSchemaValidationContextStatic;
     static isSimpleSchema(obj: any): boolean;
@@ -287,11 +288,8 @@ interface MongoObjectStatic {
     affectsGenericKeyImplicit(key: string): any;
 }
 
-export const SimpleSchemaValidationContext: SimpleSchemaValidationContextStatic;
-export const MongoObject: MongoObjectStatic;
-
-export interface MongoObject {
-    expandKey(val: any, key: string, obj: any): void;
+declare namespace SimpleSchema {
+    export { AutoValueContext, MongoObjectStatic, SchemaDefinition, SimpleSchemaDefinition, ValidationContext };
 }
 
-export default SimpleSchema;
+export = SimpleSchema;

--- a/types/simpl-schema/simpl-schema-tests.ts
+++ b/types/simpl-schema/simpl-schema-tests.ts
@@ -182,6 +182,9 @@ SimpleSchema.setDefaultMessages({
 
 const objectKeysTestSchema = new SimpleSchema({});
 
+const firstSchema = new SimpleSchema({});
+new SimpleSchema(firstSchema);
+
 // No prefix passed
 // $ExpectType any[]
 objectKeysTestSchema.objectKeys();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://github.com/longshotlabs/simpl-schema/blob/489b75df55e5444171eda3acb2c53eb53865e589/package/lib/SimpleSchema.js#L55-L79

The schema is passed to `this.extend`, which [supports existing SimpleSchema instances](https://github.com/longshotlabs/simpl-schema/blob/489b75df55e5444171eda3acb2c53eb53865e589/package/lib/SimpleSchema.js#L514-L518). 
