### PR TITLE
async-retry: fix import from 'retry' dependency (exported type was renamed)

### DIFF
--- a/types/async-retry/index.d.ts
+++ b/types/async-retry/index.d.ts
@@ -1,4 +1,4 @@
-import { WrapOptions } from "retry";
+import { OperationOptions } from "retry";
 
 /**
  * Retrying made simple, easy, and async.
@@ -29,7 +29,7 @@ import { WrapOptions } from "retry";
 declare function AsyncRetry<TRet>(fn: AsyncRetry.RetryFunction<TRet>, opts?: AsyncRetry.Options): Promise<TRet>;
 
 declare namespace AsyncRetry {
-    interface Options extends WrapOptions {
+    interface Options extends OperationOptions {
         /**
          * An optional function that is invoked after a new retry is performed. It's passed the
          * `Error` that triggered it as a parameter.


### PR DESCRIPTION
`WrapOptions` was renamed to `OperationOptions` in more recent versions of `retry`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.