### PR TITLE
[@babel/traverse] Improve performance of mapped Visitor type

### DIFF
--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -299,7 +299,7 @@ export class Binding {
 export type Visitor<S = unknown> =
     & VisitNodeObject<S, Node>
     & {
-        [Type in Node["type"]]?: VisitNode<S, Extract<Node, { type: Type }>>;
+        [N in Node as N["type"]]?: VisitNode<S, N extends { type: N["type"] } ? N : never>;
     }
     & {
         [K in keyof t.Aliases]?: VisitNode<S, t.Aliases[K]>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: **N/A**
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json` - **N/A**.


Minimal repro of noticeable performance drain in [this StackBlitz](https://stackblitz.com/edit/stackblitz-starters-tuwp78) with this MR change applied as patch.

Before (prod):

![Screenshot 2024-05-05 171002](https://github.com/DefinitelyTyped/DefinitelyTyped/assets/26072111/7da96790-7535-4831-be94-869885b90d81)

After (this branch):

![Screenshot 2024-05-05 171148](https://github.com/DefinitelyTyped/DefinitelyTyped/assets/26072111/5dad2a07-081c-465a-990a-12055f8caad1)

Note the ~100x drop in instantiations. I'm unsure what the root cause of this is so if anyone could share any wisdom on how/why tsc treats this different to `Extract` it'd be really appreciated!