### PR TITLE
[lodash] fix _.has not to be inferred to never on or operator

### DIFF
--- a/types/lodash/common/common.d.ts
+++ b/types/lodash/common/common.d.ts
@@ -1,6 +1,7 @@
 import _ = require("../index");
 // eslint-disable-next-line @definitelytyped/strict-export-declare-modifiers
 type GlobalPartial<T> = Partial<T>;
+export const uniqueSymbol: unique symbol;
 declare module "../index" {
     type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
     type PartialObject<T> = GlobalPartial<T>;

--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -1328,7 +1328,7 @@ declare module "../index" {
          * _.has(other, 'a');
          * // => false
          */
-        has<T, K extends PropertyName>(object: T, path: K): object is T & {[uniqueSymbol]: unknown} & { [P in K]: P extends keyof T ? T[P] : Record<string, unknown> extends T ? T[keyof T] : unknown};
+        has<T, K extends PropertyName>(object: T, path: K): object is T & { [P in K]: P extends keyof T ? T[P] : Record<string, unknown> extends T ? T[keyof T] : unknown} & {[uniqueSymbol]: unknown};
         has<T>(object: T, path: PropertyPath): boolean;
     }
     interface LoDashImplicitWrapper<TValue> {

--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -1,4 +1,5 @@
 import _ = require("../index");
+import { uniqueSymbol } from "./common";
 declare module "../index" {
     interface LoDashStatic {
         /**
@@ -1327,7 +1328,7 @@ declare module "../index" {
          * _.has(other, 'a');
          * // => false
          */
-        has<T, K extends PropertyName>(object: T, path: K): object is T & { [P in K]: P extends keyof T ? T[P] : Record<string, unknown> extends T ? T[keyof T] : unknown};
+        has<T, K extends PropertyName>(object: T, path: K): object is T & {[uniqueSymbol]: unknown} & { [P in K]: P extends keyof T ? T[P] : Record<string, unknown> extends T ? T[keyof T] : unknown};
         has<T>(object: T, path: PropertyPath): boolean;
     }
     interface LoDashImplicitWrapper<TValue> {

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -5444,6 +5444,12 @@ fp.now(); // $ExpectType number
         const result: { a: number | string } = record;
         record; // $ExpectType Record<string, number | string>
     }
+    const data = {
+        level: 1,
+        length: 1,
+    };
+    _.has(data, 'level') || !!data.length;
+
     _(abcObject).has(""); // $ExpectType boolean
     _(abcObject).has(42); // $ExpectType boolean
     _(abcObject).has(["", 42]); // $ExpectType boolean


### PR DESCRIPTION
fixed #69528

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://lodash.com/docs/4.17.15#has>


