### PR TITLE
[@types/node] Make it possible to use `static EventEmitter.on` with `EventTarget`

### DIFF
--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -260,6 +260,11 @@ declare module "events" {
          */
         static on(
             emitter: NodeJS.EventEmitter,
+            eventName: string | symbol,
+            options?: StaticEventEmitterOptions,
+        ): AsyncIterableIterator<any>;
+        static on(
+            emitter: EventTarget,
             eventName: string,
             options?: StaticEventEmitterOptions,
         ): AsyncIterableIterator<any>;

--- a/types/node/test/events.ts
+++ b/types/node/test/events.ts
@@ -102,6 +102,20 @@ async function test() {
     events.on(new events.EventEmitter(), "test", { signal: new AbortController().signal });
 }
 
+async function testWithSymbol() {
+    for await (const e of events.on(new events.EventEmitter(), Symbol("test"))) {
+        console.log(e);
+    }
+    events.on(new events.EventEmitter(), Symbol("test"), { signal: new AbortController().signal });
+}
+
+async function testEventTarget() {
+    for await (const e of events.on(new EventTarget(), "test")) {
+        console.log(e);
+    }
+    events.on(new EventTarget(), "test", { signal: new AbortController().signal });
+}
+
 {
     emitter.on(events.errorMonitor, listener);
     emitter.on(events.EventEmitter.errorMonitor, listener);


### PR DESCRIPTION
Actually `static EventEmitter.on` supports `EventTarget` as parameter. Tested with Node v20.11.0.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
