### PR TITLE
[color-hash] Types for version 2.0

### DIFF
--- a/types/color-hash/color-hash-tests.ts
+++ b/types/color-hash/color-hash-tests.ts
@@ -1,10 +1,13 @@
-import ColorHash = require("color-hash");
+import ColorHash from "color-hash";
 
 const colorHash = new ColorHash();
 
-const result1: [number, number, number] = colorHash.hsl("Hello World");
-const result2: [number, number, number] = colorHash.rgb("Hello World");
-const result3: string = colorHash.hex("Hello World");
+// $ExpectType ColorValueArray
+const result1 = colorHash.hsl("Hello World");
+// $ExpectType ColorValueArray
+const result2 = colorHash.rgb("Hello World");
+// $ExpectType string
+const result3 = colorHash.hex("Hello World");
 
 // Custom Hash
 const customHash = (str: string) => 5;
@@ -29,3 +32,6 @@ new ColorHash({ lightness: [0.2, 0.35, 0.5, 0.65, 0.8] });
 // Custom Saturation
 new ColorHash({ saturation: 0.5 });
 new ColorHash({ saturation: [0.2, 0.35, 0.5, 0.65, 0.8] });
+
+// bkdr Hash
+new ColorHash({ hash: "bkdr" });

--- a/types/color-hash/index.d.ts
+++ b/types/color-hash/index.d.ts
@@ -1,21 +1,21 @@
-type ColorValueArray = [number, number, number];
+export type ColorValueArray = [number, number, number];
 
-interface HueObject {
+export interface HueObject {
     min: number;
     max: number;
 }
 
-type Hue = number | HueObject | readonly HueObject[];
-type Lightness = number | number[];
-type Saturation = number | number[];
+export type Hue = number | HueObject | readonly HueObject[];
+export type Lightness = number | number[];
+export type Saturation = number | number[];
 
-type HashFunction = (input: string) => number;
+export type HashFunction = (input: string) => number;
 
-interface ColorHashOptions {
-    lightness?: Lightness | undefined;
-    saturation?: Saturation | undefined;
-    hue?: Hue | undefined;
-    hash?: HashFunction | undefined;
+export interface ColorHashOptions {
+    lightness?: Lightness;
+    saturation?: Saturation;
+    hue?: Hue;
+    hash?: HashFunction | "bkdr";
 }
 
 declare class ColorHash {
@@ -48,5 +48,4 @@ declare class ColorHash {
     hex(input: string): string;
 }
 
-export as namespace ColorHash;
-export = ColorHash;
+export default ColorHash;

--- a/types/color-hash/index.d.ts
+++ b/types/color-hash/index.d.ts
@@ -1,25 +1,27 @@
-export type ColorValueArray = [number, number, number];
+declare namespace ColorHash {
+    type ColorValueArray = [number, number, number];
 
-export interface HueObject {
-    min: number;
-    max: number;
-}
+    interface HueObject {
+        min: number;
+        max: number;
+    }
 
-export type Hue = number | HueObject | readonly HueObject[];
-export type Lightness = number | number[];
-export type Saturation = number | number[];
+    type Hue = number | HueObject | readonly HueObject[];
+    type Lightness = number | number[];
+    type Saturation = number | number[];
 
-export type HashFunction = (input: string) => number;
+    type HashFunction = (input: string) => number;
 
-export interface ColorHashOptions {
-    lightness?: Lightness;
-    saturation?: Saturation;
-    hue?: Hue;
-    hash?: HashFunction | "bkdr";
+    interface ColorHashOptions {
+        lightness?: Lightness;
+        saturation?: Saturation;
+        hue?: Hue;
+        hash?: HashFunction | "bkdr";
+    }
 }
 
 declare class ColorHash {
-    constructor(options?: ColorHashOptions);
+    constructor(options?: ColorHash.ColorHashOptions);
 
     /**
      * Returns the hash in [h, s, l].
@@ -28,7 +30,7 @@ declare class ColorHash {
      * @param input string to hash
      * @returns [h, s, l]
      */
-    hsl(input: string): ColorValueArray;
+    hsl(input: string): ColorHash.ColorValueArray;
 
     /**
      * Returns the hash in [r, g, b].
@@ -37,7 +39,7 @@ declare class ColorHash {
      * @param input string to hash
      * @returns [r, g, b]
      */
-    rgb(input: string): ColorValueArray;
+    rgb(input: string): ColorHash.ColorValueArray;
 
     /**
      * Returns the hash in hex.
@@ -48,4 +50,4 @@ declare class ColorHash {
     hex(input: string): string;
 }
 
-export default ColorHash;
+export = ColorHash;

--- a/types/color-hash/package.json
+++ b/types/color-hash/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/color-hash",
-    "version": "1.0.9999",
+    "version": "2.0.9999",
     "projects": [
         "https://github.com/zenozeng/color-hash"
     ],


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/zenozeng/color-hash/blob/main/CHANGELOG.md#v200
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.



Version 2.0 released 2 years ago, the library was rewritten to typescript, however it does not come bundled with a .d.ts file. There is an issue open for this: https://github.com/zenozeng/color-hash/issues/38, however the author has not responded to it. The changes I'm making are:
*  include string `'bkdr'` as a valid hash function (https://github.com/zenozeng/color-hash/blob/5f717328a019f94bded34b88028105a7f467653d/mod.ts#L46),
* export utility types

I am not sure about the `export =` vs `export default` situation here - the source code uses `export default ColorHash`, but the distributed package uses `exports["default"] = ColorHash`. I hope this is correct.