### PR TITLE
[@types/jquery] Fix link to shorthands and adjust description

### DIFF
--- a/types/jquery/JQuery.d.ts
+++ b/types/jquery/JQuery.d.ts
@@ -1574,25 +1574,25 @@ $( "div.test" ).bind({
      * Bind an event handler to the "blur" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/blur/ }\`
+     * @see \`{@link https://api.jquery.com/blur-shorthand/ }\`
      * @since 1.4.3
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.blur(fn)` use `.on("blur", fn)`. Instead of `.blur()` use `.trigger("blur")`.
      */
     blur<TData>(eventData: TData, handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, "blur">): this;
     /**
      * Bind an event handler to the "blur" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/blur/ }\`
+     * @see \`{@link https://api.jquery.com/blur-shorthand/ }\`
      * @since 1.0
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.blur(fn)` use `.on("blur", fn)`. Instead of `.blur()` use `.trigger("blur")`.
      * @example ​ ````To trigger the blur event on all paragraphs:
 ```javascript
 $( "p" ).blur();
@@ -1607,13 +1607,13 @@ $( "p" ).blur();
      * Bind an event handler to the "change" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/change/ }\`
+     * @see \`{@link https://api.jquery.com/change-shorthand/ }\`
      * @since 1.4.3
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.change(fn)` use `.on("change", fn)`. Instead of `.change()` use `.trigger("change")`.
      */
     change<TData>(
         eventData: TData,
@@ -1622,13 +1622,13 @@ $( "p" ).blur();
     /**
      * Bind an event handler to the "change" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/change/ }\`
+     * @see \`{@link https://api.jquery.com/change-shorthand/ }\`
      * @since 1.0
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.change(fn)` use `.on("change", fn)`. Instead of `.change()` use `.trigger("change")`.
      * @example ​ ````Attaches a change event to the select that gets the text for each selected option and writes them in the div.  It then triggers the event for the initial text draw.
 ```html
 <!doctype html>
@@ -2171,13 +2171,13 @@ $( "#frameDemo" ).contents().find( "a" ).css( "background-color", "#BADA55" );
      * Bind an event handler to the "contextmenu" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/contextmenu/ }\`
+     * @see \`{@link https://api.jquery.com/contextmenu-shorthand/ }\`
      * @since 1.4.3
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.contextmenu(fn)` use `.on("contextmenu", fn)`. Instead of `.contextmenu()` use `.trigger("contextmenu")`.
      */
     contextmenu<TData>(
         eventData: TData,
@@ -2186,13 +2186,13 @@ $( "#frameDemo" ).contents().find( "a" ).css( "background-color", "#BADA55" );
     /**
      * Bind an event handler to the "contextmenu" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/contextmenu/ }\`
+     * @see \`{@link https://api.jquery.com/contextmenu-shorthand/ }\`
      * @since 1.0
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.contextmenu(fn)` use `.on("contextmenu", fn)`. Instead of `.contextmenu()` use `.trigger("contextmenu")`.
      * @example ​ ````To show a &quot;Hello World!&quot; alert box when the contextmenu event is triggered on a paragraph on the page:
 ```javascript
 $( "p" ).contextmenu(function() {
@@ -2703,13 +2703,13 @@ $( "button" ).click(function() {
      * Bind an event handler to the "dblclick" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/dblclick/ }\`
+     * @see \`{@link https://api.jquery.com/dblclick-shorthand/ }\`
      * @since 1.4.3
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.dblclick(fn)` use `.on("dblclick", fn)`. Instead of `.dblclick()` use `.trigger("dblclick")`.
      */
     dblclick<TData>(
         eventData: TData,
@@ -2718,13 +2718,13 @@ $( "button" ).click(function() {
     /**
      * Bind an event handler to the "dblclick" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/dblclick/ }\`
+     * @see \`{@link https://api.jquery.com/dblclick-shorthand/ }\`
      * @since 1.0
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.dblclick(fn)` use `.on("dblclick", fn)`. Instead of `.dblclick()` use `.trigger("dblclick")`.
      * @example ​ ````To bind a &quot;Hello World!&quot; alert box to the dblclick event on every paragraph on the page:
 ```javascript
 $( "p" ).dblclick(function() {
@@ -4406,13 +4406,13 @@ $( "p span" ).first().addClass( "highlight" );
      * Bind an event handler to the "focus" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/focus/ }\`
+     * @see \`{@link https://api.jquery.com/focus-shorthand/ }\`
      * @since 1.4.3
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.focus(fn)` use `.on("focus", fn)`. Instead of `.focus()` use `.trigger("focus")`.
      */
     focus<TData>(
         eventData: TData,
@@ -4421,13 +4421,13 @@ $( "p span" ).first().addClass( "highlight" );
     /**
      * Bind an event handler to the "focus" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/focus/ }\`
+     * @see \`{@link https://api.jquery.com/focus-shorthand/ }\`
      * @since 1.0
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.focus(fn)` use `.on("focus", fn)`. Instead of `.focus()` use `.trigger("focus")`.
      * @example ​ ````Fire focus.
 ```html
 <!doctype html>
@@ -4478,13 +4478,13 @@ $( document ).ready(function() {
      * Bind an event handler to the "focusin" event.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/focusin/ }\`
+     * @see \`{@link https://api.jquery.com/focusin-shorthand/ }\`
      * @since 1.4.3
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.focusin(fn)` use `.on("focusin", fn)`. Instead of `.focusin()` use `.trigger("focusin")`.
      */
     focusin<TData>(
         eventData: TData,
@@ -4493,13 +4493,13 @@ $( document ).ready(function() {
     /**
      * Bind an event handler to the "focusin" event.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/focusin/ }\`
+     * @see \`{@link https://api.jquery.com/focusin-shorthand/ }\`
      * @since 1.4
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.focusin(fn)` use `.on("focusin", fn)`. Instead of `.focusin()` use `.focusin("click")`.
      * @example ​ ````Watch for a focus to occur within the paragraphs on the page.
 ```html
 <!doctype html>
@@ -4544,7 +4544,7 @@ $( "p" ).focusin(function() {
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.focusout(fn)` use `.on("focusout", fn)`. Instead of `.focusout()` use `.trigger("focusout")`.
      */
     focusout<TData>(
         eventData: TData,
@@ -4559,7 +4559,7 @@ $( "p" ).focusin(function() {
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.focusout(fn)` use `.on("focusout", fn)`. Instead of `.focusout()` use `.trigger("focusout")`.
      * @example ​ ````Watch for a loss of focus to occur inside paragraphs and note the difference between the focusout count and the blur count. (The blur count does not change because those events do not bubble.)
 ```html
 <!doctype html>
@@ -6031,13 +6031,13 @@ $( "li" ).click(function() {
      * Bind an event handler to the "keydown" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/keydown/ }\`
+     * @see \`{@link https://api.jquery.com/keydown-shorthand/ }\`
      * @since 1.4.3
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.keydown(fn)` use `.on("keydown", fn)`. Instead of `.keydown()` use `.trigger("keydown")`.
      */
     keydown<TData>(
         eventData: TData,
@@ -6046,13 +6046,13 @@ $( "li" ).click(function() {
     /**
      * Bind an event handler to the "keydown" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/keydown/ }\`
+     * @see \`{@link https://api.jquery.com/keydown-shorthand/ }\`
      * @since 1.0
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.keydown(fn)` use `.on("keydown", fn)`. Instead of `.keydown()` use `.trigger("keydown")`.
      * @example ​ ````Show the event object for the keydown handler when a key is pressed in the input.
 ```html
 <!doctype html>
@@ -6123,13 +6123,13 @@ $( "#other" ).click(function() {
      * Bind an event handler to the "keypress" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/keypress/ }\`
+     * @see \`{@link https://api.jquery.com/keypress-shorthand/ }\`
      * @since 1.4.3
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.keypress(fn)` use `.on("keypress", fn)`. Instead of `.keypress()` use `.trigger("keypress")`.
      */
     keypress<TData>(
         eventData: TData,
@@ -6138,13 +6138,13 @@ $( "#other" ).click(function() {
     /**
      * Bind an event handler to the "keypress" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/keypress/ }\`
+     * @see \`{@link https://api.jquery.com/keypress-shorthand/ }\`
      * @since 1.0
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.keypress(fn)` use `.on("keypress", fn)`. Instead of `.keypress()` use `.trigger("keypress")`.
      * @example ​ ````Show the event object when a key is pressed in the input. Note: This demo relies on a simple $.print() plugin (https://api.jquery.com/resources/events.js) for the event object&#39;s output.
 ```html
 <!doctype html>
@@ -6221,7 +6221,7 @@ $( "#other" ).click(function() {
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.keyup(fn)` use `.on("keyup", fn)`. Instead of `.keyup()` use `.trigger("keyup")`.
      */
     keyup<TData>(
         eventData: TData,
@@ -6236,7 +6236,7 @@ $( "#other" ).click(function() {
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.keyup(fn)` use `.on("keyup", fn)`. Instead of `.keyup()` use `.trigger("keyup")`.
      * @example ​ ````Show the event object for the keyup handler (using a simple $.print plugin) when a key is released in the input.
 ```html
 <!doctype html>
@@ -6676,13 +6676,13 @@ $( "input" ).click(function() {
      * Bind an event handler to the "mousedown" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/mousedown/ }\`
+     * @see \`{@link https://api.jquery.com/mousedown-shorthand/ }\`
      * @since 1.4.3
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.mousedown(fn)` use `.on("mousedown", fn)`. Instead of `.mousedown()` use `.trigger("mousedown")`.
      */
     mousedown<TData>(
         eventData: TData,
@@ -6691,13 +6691,13 @@ $( "input" ).click(function() {
     /**
      * Bind an event handler to the "mousedown" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/mousedown/ }\`
+     * @see \`{@link https://api.jquery.com/mousedown-shorthand/ }\`
      * @since 1.0
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.mousedown(fn)` use `.on("mousedown", fn)`. Instead of `.mousedown()` use `.trigger("mousedown")`.
      * @example ​ ````Show texts when mouseup and mousedown event triggering.
 ```html
 <!doctype html>
@@ -6734,13 +6734,13 @@ $( "p" )
      * Bind an event handler to be fired when the mouse enters an element, or trigger that handler on an element.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/mouseenter/ }\`
+     * @see \`{@link https://api.jquery.com/mouseenter-shorthand/ }\`
      * @since 1.4.3
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.mouseenter(fn)` use `.on("mouseenter", fn)`. Instead of `.mouseenter()` use `.trigger("mouseenter")`.
      */
     mouseenter<TData>(
         eventData: TData,
@@ -6749,13 +6749,13 @@ $( "p" )
     /**
      * Bind an event handler to be fired when the mouse enters an element, or trigger that handler on an element.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/mouseenter/ }\`
+     * @see \`{@link https://api.jquery.com/mouseenter-shorthand/ }\`
      * @since 1.0
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.mouseenter(fn)` use `.on("mouseenter", fn)`. Instead of `.mouseenter()` use `.trigger("mouseenter")`.
      * @example ​ ````Show texts when mouseenter and mouseout event triggering.
     mouseover fires when the pointer moves into the child element as well, while mouseenter fires only when the pointer moves into the bound element.
 ```html
@@ -6835,13 +6835,13 @@ $( "div.enterleave" )
      * Bind an event handler to be fired when the mouse leaves an element, or trigger that handler on an element.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/mouseleave/ }\`
+     * @see \`{@link https://api.jquery.com/mouseleave-shorthand/ }\`
      * @since 1.4.3
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.mouseleave(fn)` use `.on("mouseleave", fn)`. Instead of `.mouseleave()` use `.trigger("mouseleave")`.
      */
     mouseleave<TData>(
         eventData: TData,
@@ -6850,13 +6850,13 @@ $( "div.enterleave" )
     /**
      * Bind an event handler to be fired when the mouse leaves an element, or trigger that handler on an element.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/mouseleave/ }\`
+     * @see \`{@link https://api.jquery.com/mouseleave-shorthand/ }\`
      * @since 1.0
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.mouseleave(fn)` use `.on("mouseleave", fn)`. Instead of `.mouseleave()` use `.trigger("mouseleave")`.
      * @example ​ ````Show number of times mouseout and mouseleave events are triggered. mouseout fires when the pointer moves out of child element as well, while mouseleave fires only when the pointer moves out of the bound element.
 ```html
 <!doctype html>
@@ -6934,13 +6934,13 @@ $( "div.enterleave" )
      * Bind an event handler to the "mousemove" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/mousemove/ }\`
+     * @see \`{@link https://api.jquery.com/mousemove-shorthand/ }\`
      * @since 1.4.3
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.mousemove(fn)` use `.on("mousemove", fn)`. Instead of `.mousemove()` use `.trigger("mousemove")`.
      */
     mousemove<TData>(
         eventData: TData,
@@ -6949,13 +6949,13 @@ $( "div.enterleave" )
     /**
      * Bind an event handler to the "mousemove" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/mousemove/ }\`
+     * @see \`{@link https://api.jquery.com/mousemove-shorthand/ }\`
      * @since 1.0
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.mousemove(fn)` use `.on("mousemove", fn)`. Instead of `.mousemove()` use `.trigger("mousemove")`.
      * @example ​ ````Show the mouse coordinates when the mouse is moved over the yellow div.  Coordinates are relative to the window, which in this case is the iframe.
 ```html
 <!doctype html>
@@ -7018,13 +7018,13 @@ $( "div" ).mousemove(function( event ) {
      * Bind an event handler to the "mouseout" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/mouseout/ }\`
+     * @see \`{@link https://api.jquery.com/mouseout-shorthand/ }\`
      * @since 1.4.3
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.mouseout(fn)` use `.on("mouseout", fn)`. Instead of `.mouseout()` use `.trigger("mouseout")`.
      */
     mouseout<TData>(
         eventData: TData,
@@ -7033,13 +7033,13 @@ $( "div" ).mousemove(function( event ) {
     /**
      * Bind an event handler to the "mouseout" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/mouseout/ }\`
+     * @see \`{@link https://api.jquery.com/mouseout-shorthand/ }\`
      * @since 1.0
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.mouseout(fn)` use `.on("mouseout", fn)`. Instead of `.mouseout()` use `.trigger("mouseout")`.
      * @example ​ ````Show the number of times mouseout and mouseleave events are triggered.
   mouseout fires when the pointer moves out of the child element as well, while mouseleave fires only when the pointer moves out of the bound element.
 ```html
@@ -7119,13 +7119,13 @@ $( "div.enterleave" )
      * Bind an event handler to the "mouseover" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/mouseover/ }\`
+     * @see \`{@link https://api.jquery.com/mouseover-shorthand/ }\`
      * @since 1.4.3
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.mouseover(fn)` use `.on("mouseover", fn)`. Instead of `.mouseover()` use `.trigger("mouseover")`.
      */
     mouseover<TData>(
         eventData: TData,
@@ -7134,13 +7134,13 @@ $( "div.enterleave" )
     /**
      * Bind an event handler to the "mouseover" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/mouseover/ }\`
+     * @see \`{@link https://api.jquery.com/mouseover-shorthand/ }\`
      * @since 1.0
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.mouseover(fn)` use `.on("mouseover", fn)`. Instead of `.mouseover()` use `.trigger("mouseover")`.
      * @example ​ ````Show the number of times mouseover and mouseenter events are triggered.
 mouseover fires when the pointer moves into the child element as well, while mouseenter fires only when the pointer moves into the bound element.
 ```html
@@ -7220,13 +7220,13 @@ $( "div.enterleave" )
      * Bind an event handler to the "mouseup" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/mouseup/ }\`
+     * @see \`{@link https://api.jquery.com/mouseup-shorthand/ }\`
      * @since 1.4.3
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.mouseup(fn)` use `.on("mouseup", fn)`. Instead of `.mouseup()` use `.trigger("mouseup")`.
      */
     mouseup<TData>(
         eventData: TData,
@@ -7235,13 +7235,13 @@ $( "div.enterleave" )
     /**
      * Bind an event handler to the "mouseup" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/mouseup/ }\`
+     * @see \`{@link https://api.jquery.com/mouseup-shorthand/ }\`
      * @since 1.0
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.mouseup(fn)` use `.on("mouseup", fn)`. Instead of `.mouseup()` use `.trigger("mouseup")`.
      * @example ​ ````Show texts when mouseup and mousedown event triggering.
 ```html
 <!doctype html>
@@ -10341,13 +10341,13 @@ $( "button" ).on( "click", function() {
      * Bind an event handler to the "resize" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/resize/ }\`
+     * @see \`{@link https://api.jquery.com/resize-shorthand/ }\`
      * @since 1.4.3
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.resize(fn)` use `.on("resize", fn)`. Instead of `.resize()` use `.trigger("resize")`.
      */
     resize<TData>(
         eventData: TData,
@@ -10356,13 +10356,13 @@ $( "button" ).on( "click", function() {
     /**
      * Bind an event handler to the "resize" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/resize/ }\`
+     * @see \`{@link https://api.jquery.com/resize-shorthand/ }\`
      * @since 1.0
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.resize(fn)` use `.on("resize", fn)`. Instead of `.resize()` use `.trigger("resize")`.
      * @example ​ ````To see the window width while (or after) it is resized, try:
 ```javascript
 $( window ).resize(function() {
@@ -10379,13 +10379,13 @@ $( window ).resize(function() {
      * Bind an event handler to the "scroll" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/scroll/ }\`
+     * @see \`{@link https://api.jquery.com/scroll-shorthand/ }\`
      * @since 1.4.3
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.scroll(fn)` use `.on("scroll", fn)`. Instead of `.scroll()` use `.trigger("scroll")`.
      */
     scroll<TData>(
         eventData: TData,
@@ -10394,13 +10394,13 @@ $( window ).resize(function() {
     /**
      * Bind an event handler to the "scroll" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/scroll/ }\`
+     * @see \`{@link https://api.jquery.com/scroll-shorthand/ }\`
      * @since 1.0
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.scroll(fn)` use `.on("scroll", fn)`. Instead of `.scroll()` use `.trigger("scroll")`.
      * @example ​ ````To do something when your page is scrolled:
 ```html
 <!doctype html>
@@ -10609,13 +10609,13 @@ $( "p:last" ).text( "scrollTop:" + p.scrollTop() );
      * Bind an event handler to the "select" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/select/ }\`
+     * @see \`{@link https://api.jquery.com/select-shorthand/ }\`
      * @since 1.4.3
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.select(fn)` use `.on("select", fn)`. Instead of `.select()` use `.trigger("select")`.
      */
     select<TData>(
         eventData: TData,
@@ -10624,13 +10624,13 @@ $( "p:last" ).text( "scrollTop:" + p.scrollTop() );
     /**
      * Bind an event handler to the "select" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/select/ }\`
+     * @see \`{@link https://api.jquery.com/select-shorthand/ }\`
      * @since 1.0
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.select(fn)` use `.on("select", fn)`. Instead of `.select()` use `.trigger("select")`.
      * @example ​ ````To do something when text in input boxes is selected:
 ```html
 <!doctype html>
@@ -11655,13 +11655,13 @@ $( "#toggle" ).on( "click", function() {
      * Bind an event handler to the "submit" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/submit/ }\`
+     * @see \`{@link https://api.jquery.com/submit-shorthand/ }\`
      * @since 1.4.3
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.submit(fn)` use `.on("submit", fn)`. Instead of `.submit()` use `.trigger("submit")`.
      */
     submit<TData>(
         eventData: TData,
@@ -11670,13 +11670,13 @@ $( "#toggle" ).on( "click", function() {
     /**
      * Bind an event handler to the "submit" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
-     * @see \`{@link https://api.jquery.com/submit/ }\`
+     * @see \`{@link https://api.jquery.com/submit-shorthand/ }\`
      * @since 1.0
      * @deprecated ​ Deprecated since 3.3. Use \`{@link on }\` or \`{@link trigger }\`.
      *
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
-     * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
+     * **Solution**: Instead of `.submit(fn)` use `.on("submit", fn)`. Instead of `.submit()` use `.trigger("submit")`.
      * @example ​ ````If you&#39;d like to prevent forms from being submitted unless a flag variable is set, try:
 ```html
 <!doctype html>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

The urls pointed to the wrong page which had a link to the correct one.
The description had an `click` example and not matching the `blur` context.