### PR TITLE
Cytoscape layout options sort function

### DIFF
--- a/types/cytoscape/cytoscape-tests.ts
+++ b/types/cytoscape/cytoscape-tests.ts
@@ -943,7 +943,7 @@ const circleAllOptions: CircleLayoutOptions = {
     startAngle: 0,
     sweep: Math.PI,
     clockwise: false,
-    sort: (x, y) => 0,
+    sort: (x, y) => x.id().length - y.id().length,
     animate: true,
     animationDuration: 750,
     animationEasing: "ease",

--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -5259,12 +5259,9 @@ declare namespace cytoscape {
         padding?: number | undefined;
     }
 
-    interface SortableNode {
-        data: { weight: number };
-    }
-
-    // function(a, b){ return a.data('weight') - b.data('weight') }
-    type SortingFunction = (a: SortableNode, b: SortableNode) => number;
+    // A function that determines the order of the nodes. The return value has the same
+    // semantics as for compare function passed to Array.sort.
+    type SortingFunction = (a: NodeSingular, b: NodeSingular) => number;
 
     interface ShapedLayoutOptions extends BaseLayoutOptions, AnimatedLayoutOptions {
         // whether to fit to viewport


### PR DESCRIPTION
Requiring `SortableNode` is too strict and unnecessary in practice. The documentation shows using `data('weight')` as sorting criterion, but the `SortingFunction` should be allowed to use any means of sorting nodes it chooses. This is the only use of `interface SortableNode` so it is removed as well.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://js.cytoscape.org/#layouts/circle
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
