### PR TITLE
[@types/chrome] Add cloudFileInfo to chrome.fileSystemProvider.notify

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -3894,6 +3894,8 @@ declare namespace chrome.fileSystemProvider {
         entryPath: string;
         /** The type of the change which happened to the entry. */
         changeType: string;
+        /** Information relating to the file if backed by a cloud file system. */
+        cloudFileInfo?: CloudFileInfo | undefined;
     }
 
     export interface NotificationOptions {


### PR DESCRIPTION
The [original PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69240) missed this inclusion in the `chrome.fileSystemProvider.notify` method (which is present on the original CL).  

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://crrev.com/c/5343674
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
