### PR TITLE
Add Dirent.parentPath to fs.d.ts

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -241,8 +241,14 @@ declare module "fs" {
          */
         name: string;
         /**
+         * The path to the parent directory that this `fs.Dirent` object refers to.
+         * @since v21.4.0, v20.12.0, v18.20.0
+         */
+        parentPath: string;
+        /**
          * The base path that this `fs.Dirent` object refers to.
          * @since v20.1.0
+         * @deprecated since v21.5.0, v20.12.0, v18.20.0
          */
         path: string;
     }


### PR DESCRIPTION
Add Dirent.parentPath (since v21.4.0, v20.12.0, v18.20.0) 
Mark Dirent.path as deprecated

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/fs.html#direntparentpath
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
