### PR TITLE
[bandagedbd__bdapi] remove duplicate global variables

### DIFF
--- a/types/bandagedbd__bdapi/bandagedbd__bdapi-tests.ts
+++ b/types/bandagedbd__bdapi/bandagedbd__bdapi-tests.ts
@@ -3,7 +3,6 @@ window.BdApi; // $ExpectType BdApi
 global.BdApi; // $ExpectType BdApi
 
 // lodash is available globally in the discord app
-_;
 window._;
 
 BdApi; // $ExpectType BdApi

--- a/types/bandagedbd__bdapi/index.d.ts
+++ b/types/bandagedbd__bdapi/index.d.ts
@@ -6,7 +6,6 @@ export {};
 
 declare global {
     const BdApi: BdApiModule.BdApi;
-    const _: typeof _;
 
     interface Window {
         BdApi: BdApiModule.BdApi;


### PR DESCRIPTION
Found while fixing https://github.com/microsoft/TypeScript/pull/58326. This PR removes the duplicate declarations in this package.

`lodash` already has `export as namespace _`, making`declare global { const _: typeof _; }` redundant

Related: 
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69553
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69552