### PR TITLE
[regenerator-runtime] remove duplicate global variables

### DIFF
--- a/types/regenerator-runtime/index.d.ts
+++ b/types/regenerator-runtime/index.d.ts
@@ -1,7 +1,4 @@
 export as namespace regeneratorRuntime;
-declare global {
-    var regeneratorRuntime: typeof import(".");
-}
 
 /**
  * The implementation of the generator.

--- a/types/regenerator-runtime/regenerator-runtime-tests.ts
+++ b/types/regenerator-runtime/regenerator-runtime-tests.ts
@@ -6,9 +6,6 @@ import regenerator = require("regenerator-runtime");
  */
 declare function expectType<T>(value: T): T;
 
-expectType<typeof regenerator>(regeneratorRuntime);
-expectType<typeof regeneratorRuntime>(regenerator);
-
 declare const number: number;
 declare const anyArray: object[];
 declare const anyArrayLike: ArrayLike<object>;


### PR DESCRIPTION
Found while fixing https://github.com/microsoft/TypeScript/pull/58326. This PR removes the duplicate declarations in this package.

`export as namespace regeneratorRuntime` makes `declare global { var regeneratorRuntime: typeof import("."); }` redundant.

Related: 
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69553
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69551