### PR TITLE
[karma-chai-sinon] remove duplicate global variables

### DIFF
--- a/types/karma-chai-sinon/index.d.ts
+++ b/types/karma-chai-sinon/index.d.ts
@@ -1,9 +1,6 @@
 /// <reference types="chai" />
-import Sinon = require("sinon");
+/// <reference types="sinon" />
 
-declare global {
-    var should: Chai.Should;
-    var expect: Chai.ExpectStatic;
-    var assert: Chai.AssertStatic;
-    var sinon: Sinon.SinonStatic;
-}
+declare var should: Chai.Should;
+declare var expect: Chai.ExpectStatic;
+declare var assert: Chai.AssertStatic;

--- a/types/karma-chai-sinon/karma-chai-sinon-tests.ts
+++ b/types/karma-chai-sinon/karma-chai-sinon-tests.ts
@@ -1,4 +1,3 @@
 should.not.equal(1, 2);
 expect(1 === 1);
 assert.isTrue(true);
-sinon.spy();


### PR DESCRIPTION
Found while fixing https://github.com/microsoft/TypeScript/pull/58326. This PR removes the duplicate declarations in this package.

Sinon already contains `export as namespace sinon`, so `declare global { var Sinon }` was a duplicate declaration.

Related: 
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69552
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69551