### PR TITLE
[aws-lambda] Add `requestHeaders` to `AppSyncAuthorizerEvent`

### DIFF
--- a/types/aws-lambda/test/appsync-resolver-tests.ts
+++ b/types/aws-lambda/test/appsync-resolver-tests.ts
@@ -179,6 +179,8 @@ const authorizerHandler: AppSyncAuthorizerHandler<AuthorizorTestArguments> = asy
     str = event.requestContext.requestId;
     anyObj = event.requestContext.variables;
     strOrUndefined = event.requestContext.operationName ? event.requestContext.operationName : undefined;
+    const headers = event.requestHeaders; // $ExpectType AppSyncAuthorizerEventHeaders
+    strOrUndefined = event.requestHeaders["example"];
 
     return {
         isAuthorized: true,

--- a/types/aws-lambda/trigger/appsync-resolver.d.ts
+++ b/types/aws-lambda/trigger/appsync-resolver.d.ts
@@ -30,6 +30,10 @@ export interface AppSyncResolverEventHeaders {
     [name: string]: string | undefined;
 }
 
+export interface AppSyncAuthorizerEventHeaders {
+    [name: string]: string | undefined;
+}
+
 export type AppSyncIdentity =
     | AppSyncIdentityIAM
     | AppSyncIdentityCognito
@@ -76,6 +80,7 @@ export interface AppSyncAuthorizerEvent {
         operationName?: string;
         variables: { [key: string]: any };
     };
+    requestHeaders: AppSyncAuthorizerEventHeaders;
 }
 
 export interface AppSyncAuthorizerResult<TResolverContext = undefined> {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://docs.aws.amazon.com/appsync/latest/devguide/security-authz.html#aws-lambda-authorization
  - https://aws.amazon.com/about-aws/whats-new/2024/04/aws-appsync-application-headers-lambda-authorizer-functions/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.