### PR TITLE
Remove Thenable related types from React canary

### DIFF
--- a/types/react/canary.d.ts
+++ b/types/react/canary.d.ts
@@ -31,30 +31,7 @@ declare const UNDEFINED_VOID_ONLY: unique symbol;
 type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 
 declare module "." {
-    interface ThenableImpl<T> {
-        then(onFulfill: (value: T) => unknown, onReject: (error: unknown) => unknown): void | PromiseLike<unknown>;
-    }
-    interface UntrackedThenable<T> extends ThenableImpl<T> {
-        status?: void;
-    }
-
-    export interface PendingThenable<T> extends ThenableImpl<T> {
-        status: "pending";
-    }
-
-    export interface FulfilledThenable<T> extends ThenableImpl<T> {
-        status: "fulfilled";
-        value: T;
-    }
-
-    export interface RejectedThenable<T> extends ThenableImpl<T> {
-        status: "rejected";
-        reason: unknown;
-    }
-
-    export type Thenable<T> = UntrackedThenable<T> | PendingThenable<T> | FulfilledThenable<T> | RejectedThenable<T>;
-
-    export type Usable<T> = Thenable<T> | Context<T>;
+    export type Usable<T> = PromiseLike<T> | Context<T>;
 
     export function use<T>(usable: Usable<T>): T;
 

--- a/types/react/ts5.0/canary.d.ts
+++ b/types/react/ts5.0/canary.d.ts
@@ -31,30 +31,7 @@ declare const UNDEFINED_VOID_ONLY: unique symbol;
 type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 
 declare module "." {
-    interface ThenableImpl<T> {
-        then(onFulfill: (value: T) => unknown, onReject: (error: unknown) => unknown): void | PromiseLike<unknown>;
-    }
-    interface UntrackedThenable<T> extends ThenableImpl<T> {
-        status?: void;
-    }
-
-    export interface PendingThenable<T> extends ThenableImpl<T> {
-        status: "pending";
-    }
-
-    export interface FulfilledThenable<T> extends ThenableImpl<T> {
-        status: "fulfilled";
-        value: T;
-    }
-
-    export interface RejectedThenable<T> extends ThenableImpl<T> {
-        status: "rejected";
-        reason: unknown;
-    }
-
-    export type Thenable<T> = UntrackedThenable<T> | PendingThenable<T> | FulfilledThenable<T> | RejectedThenable<T>;
-
-    export type Usable<T> = Thenable<T> | Context<T>;
+    export type Usable<T> = PromiseLike<T> | Context<T>;
 
     export function use<T>(usable: Usable<T>): T;
 


### PR DESCRIPTION
Thenable is a term that was once commonly used to describe what’s now known as PromiseLike in TypeScript.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69022#discussion_r1596718161
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

