### PR TITLE
[@types/which] Update the options of `which` for version 3.0.0.

### DIFF
--- a/types/which/index.d.ts
+++ b/types/which/index.d.ts
@@ -1,47 +1,57 @@
 /** Finds all instances of a specified executable in the PATH environment variable */
-declare function which(cmd: string, options: which.Options & which.AsyncOptions & which.OptionsAll): Promise<string[]>;
-declare function which(cmd: string, options?: which.Options & which.AsyncOptions & which.OptionsFirst): Promise<string>;
+
+type AppendNullIfNothrow<TOptions, TRet> = TOptions extends { nothrow: infer TVal }
+    // nothrow is specified
+    ? TVal extends false
+        // TVal is false
+        ? TRet
+        // TVal is boolean or true
+    : TRet | null
+    // nothrow not specified
+    : TRet;
+
+type TransformToArrayIfAll<TOptions, TRet> = TOptions extends { all: infer TVal }
+    // all is specified
+    ? TVal extends true
+        // TVal is true
+        ? readonly TRet[]
+    : TVal extends false
+        // TVal is false
+        ? TRet
+        // TVal is boolean
+    : readonly TRet[] | TRet
+    // all not specified
+    : TRet;
+
+type ReturnType<TOptions> = AppendNullIfNothrow<TOptions, TransformToArrayIfAll<TOptions, string>>;
+
+type Exact<T, U extends T> = {
+    [Key in keyof U]: Key extends keyof T ? U[Key]
+        : never;
+};
+
+declare function which<TOptions extends which.Options>(
+    cmd: string,
+    options?: Exact<which.Options, TOptions>,
+): Promise<ReturnType<Exact<which.Options, TOptions>>>;
 
 declare namespace which {
     /** Finds all instances of a specified executable in the PATH environment variable */
-    function sync(cmd: string, options: Options & OptionsAll & OptionsNoThrow): readonly string[] | null;
-    function sync(cmd: string, options: Options & OptionsFirst & OptionsNoThrow): string | null;
-    function sync(cmd: string, options: Options & OptionsAll & OptionsThrow): readonly string[];
-    function sync(cmd: string, options?: Options & OptionsFirst & OptionsThrow): string;
-    function sync(cmd: string, options: Options): string | readonly string[] | null;
+    function sync<TOptions extends Options>(
+        cmd: string,
+        options?: Exact<Options, TOptions>,
+    ): ReturnType<Exact<Options, TOptions>>;
 
-    /** Options that ask for all matches. */
-    interface OptionsAll extends AsyncOptions {
-        all: true;
-    }
-
-    /** Options that ask for the first match (the default behavior) */
-    interface OptionsFirst extends AsyncOptions {
-        all?: false | undefined;
-    }
-
-    /** Options that ask to receive null instead of a thrown error */
-    interface OptionsNoThrow extends Options {
-        nothrow: true;
-    }
-
-    /** Options that ask for a thrown error if executable is not found (the default behavior) */
-    interface OptionsThrow extends Options {
-        nothrow?: false | undefined;
-    }
-
-    /** Options for which() async API */
-    interface AsyncOptions {
+    /** Options for which() API */
+    interface Options {
         /** If true, return all matches, instead of just the first one. Note that this means the function returns an array of strings instead of a single string. */
         all?: boolean | undefined;
         /** Use instead of the PATH environment variable. */
         path?: string | undefined;
         /** Use instead of the PATHEXT environment variable. */
         pathExt?: string | undefined;
-    }
-
-    /** Options for which() sync and async APIs */
-    interface Options extends AsyncOptions {
+        /** Use instead of the platform's native path separator. */
+        delimiter?: string | undefined;
         /** If true, returns null when not found */
         nothrow?: boolean | undefined;
     }

--- a/types/which/tsconfig.json
+++ b/types/which/tsconfig.json
@@ -1,9 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "lib": [
-            "es6"
-        ],
+        "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
@@ -12,8 +10,5 @@
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
-    "files": [
-        "index.d.ts",
-        "which-tests.ts"
-    ]
+    "files": ["index.d.ts", "which-tests.ts"]
 }

--- a/types/which/which-tests.ts
+++ b/types/which/which-tests.ts
@@ -1,11 +1,25 @@
 import which = require("which");
 
-const path = which.sync("cat"); // $ExpectType string
+which.sync("cat"); // $ExpectType string
 
-const promise: Promise<string> = which("cat");
-const promise1: Promise<string> = which("cat", { all: false });
-const promise2: Promise<string[]> = which("cat", { all: true });
-const promise3: Promise<string> = which("cat", { nothrow: true });
+// Rewrite proomise to promise6 but using ExpectType
+which("cat"); // $ExpectType Promise<string>
+which("cat", { all: false }); // $ExpectType Promise<string>
+which("cat", { all: true }); // $ExpectType Promise<readonly string[]>
+which("cat", { nothrow: true }); // $ExpectType Promise<string | null>
+which("cat", { all: true, nothrow: true }); // $ExpectType Promise<readonly string[] | null>
+
+// @ts-expect-error -- `alll` is not a valid option
+which("cat", { alll: true, nothrow: true }); // $ExpectError
+
+// @ts-expect-error -- 42 is not a boolean | undefined
+which("cat", { all: 42, nothrow: true }); // $ExpectError
+
+// If we cannot infer the exact value passed to `all` or `nothrow`, we should give both options.
+var b: boolean = Math.random() < 0.5;
+which("cat", { all: b }); // $ExpectType Promise<string | readonly string[]>
+which("cat", { nothrow: b }); // $ExpectType Promise<string | null>
+which("cat", { all: b, nothrow: b }); // $ExpectType Promise<string | readonly string[] | null>
 
 which("node")
     .then(resolvedPath => {


### PR DESCRIPTION
Add `nothrow` option to both the sync and async APIs and add the missing `delimiter` option.

These have been available on the package since version 3.0.0: https://github.com/npm/node-which/commit/8b0187ceab57b0814ad6a77a5706319ffa5bf103

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test which`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/npm/node-which/blob/main/lib/index.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
