### PR TITLE
[esquery] fix type of `selector` parameter in `traverse`

### DIFF
--- a/types/esquery/esquery-tests.ts
+++ b/types/esquery/esquery-tests.ts
@@ -17,7 +17,7 @@ const selector = esquery.parse(s);
 const nodes = esquery.query(AST, s);
 
 // $ExpectType void
-esquery.traverse(AST, s, (node, parent, ancestry) => {});
+esquery.traverse(AST, selector, (node, parent, ancestry) => {});
 
 // $ExpectType Node[]
 esquery(AST, s);

--- a/types/esquery/index.d.ts
+++ b/types/esquery/index.d.ts
@@ -27,7 +27,7 @@ declare namespace query {
     /** From a JS AST and a selector AST, collect all JS AST nodes that match the selector. */
     function traverse(
         ast: Node,
-        selector: string,
+        selector: Selector,
         visitor: (node: Node, parent: Node, ancestry: Node[]) => void,
         options?: ESQueryOptions,
     ): void;


### PR DESCRIPTION
Fix type of `selector` parameter in `traverse` to be a `Selector` rather than a `string`.

https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69575

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/estools/esquery/blob/909bea6745d33d33870b5d2c3382b4561d00d923/esquery.js#L540-L553
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
