### PR TITLE
[cytoscape] Fixes typing of arguments to concentric, levelWidth callbacks

### DIFF
--- a/types/cytoscape/cytoscape-tests.ts
+++ b/types/cytoscape/cytoscape-tests.ts
@@ -997,7 +997,7 @@ const concentricAllOptions: ConcentricLayoutOptions = {
     height: 5,
     width: 3,
     spacingFactor: 7,
-    concentric: _node => 6,
+    concentric: _node => _node.neighborhood().size(),
     levelWidth: _nodes => 5,
     animate: true,
     animationDuration: 50,

--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -5343,9 +5343,9 @@ declare namespace cytoscape {
         // Applies a multiplicative factor (>0) to expand or compress the overall area that the nodes take up
         spacingFactor?: number;
         // returns numeric value for each node, placing higher nodes in levels towards the centre
-        concentric?(node: { degree(): number }): number;
+        concentric?(node: NodeSingular): number;
         // the variation of concentric values in each level
-        levelWidth?(node: { maxDegree(): number }): number;
+        levelWidth?(node: NodeCollection): number;
     }
 
     /**


### PR DESCRIPTION
ConcentricLayoutOptions can include two callbacks that are invoked with a single node and all nodes in the layout respectively. The previous typing was based on the example use in the documentation and prevented use of other node properties to be accessed.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [call to `concentric` callback](https://github.com/cytoscape/cytoscape.js/blob/5d09bdff993af962c206d216147a37044b4a36a1/src/extensions/layout/concentric.js#L65) with node argument, [call to `levelWidth` callback](https://github.com/cytoscape/cytoscape.js/blob/5d09bdff993af962c206d216147a37044b4a36a1/src/extensions/layout/concentric.js#L91) with all nodes as argument.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
