### PR TITLE
build(rdf-utils-dataset): is actually ESM

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -1481,7 +1481,6 @@
         "rbush",
         "rc-switch",
         "rc-tooltip",
-        "rdf-utils-dataset",
         "rdfjs__serializer-rdfjs",
         "react-add-to-calendar",
         "react-animals",

--- a/types/rdf-utils-dataset/index.d.ts
+++ b/types/rdf-utils-dataset/index.d.ts
@@ -1,4 +1,4 @@
-import resource from "./resource";
-import resourcesToGraph from "./resourcesToGraph";
+import resource from "./resource.js";
+import resourcesToGraph from "./resourcesToGraph.js";
 
 export { resource, resourcesToGraph };

--- a/types/rdf-utils-dataset/package.json
+++ b/types/rdf-utils-dataset/package.json
@@ -2,6 +2,7 @@
     "private": true,
     "name": "@types/rdf-utils-dataset",
     "version": "2.0.9999",
+    "type": "module",
     "projects": [
         "https://github.com/rdf-ext/rdf-utils-dataset"
     ],


### PR DESCRIPTION
Resolves this warning I got in another CI log

```
Warnings in rdf-utils-dataset
Ignoring attw failure because "rdf-utils-dataset" is listed in 'failingPackages'.

@arethetypeswrong/cli
rdf-utils-dataset v2.0.0
@types/rdf-utils-dataset v2.0.9999

 (ignoring rules: 'no-resolution', 'cjs-only-exports-default', 'unexpected-module-syntax', 'cjs-resolves-to-esm')

🎭 Import resolved to a CommonJS type declaration file, but an ESM JavaScript file. https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseCJS.md


┌───────────────────┬────────────────────────┐
│                   │ "rdf-utils-dataset"    │
├───────────────────┼────────────────────────┤
│ node10            │ 🟢                     │
├───────────────────┼────────────────────────┤
│ node16 (from CJS) │ 🎭 Masquerading as CJS │
├───────────────────┼────────────────────────┤
│ node16 (from ESM) │ 🎭 Masquerading as CJS │
├───────────────────┼────────────────────────┤
│ bundler           │ 🟢                     │
└───────────────────┴────────────────────────┘
```