### PR TITLE
Emscripten: Added more types

### DIFF
--- a/types/emscripten/emscripten-tests.ts
+++ b/types/emscripten/emscripten-tests.ts
@@ -116,7 +116,7 @@ function FSTest(): void {
 
     FS.createDataFile("/", "dummy2", data, true, true, true);
 
-    const lookup = FS.lookupPath("path", { parent: true });
+    const lookup = FS.lookupPath("path", { parent: true, follow: false });
     // $ExpectType number
     lookup.node.mode;
 

--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -134,6 +134,16 @@ declare namespace FS {
         readonly isAppend: boolean;
         flags: number;
         position: number;
+        fd?: number;
+        nfd?: number;
+    }
+
+    interface StreamOps {
+        open(stream: FSStream): void;
+        close(stream: FSStream): void;
+        read(stream: FSStream, buffer: Uint8Array, offset: number, length: number, position: number): number;
+        write(stream: FSStream, buffer: Uint8Array, offset: number, length: number, position: number): number;
+        llseek(stream: FSStream, offset: number, whence: number): number;
     }
 
     class FSNode {
@@ -153,21 +163,75 @@ declare namespace FS {
         readonly isDevice: boolean;
     }
 
+    interface NodeOps {
+        getattr(node: FS.FSNode): Stats;
+        setattr(node: FS.FSNode, attr: Stats): void;
+        lookup(parent: FS.FSNode, name: string): FS.FSNode;
+        mknod(parent: FS.FSNode, name: string, mode: number, dev: unknown): FS.FSNode;
+        rename(oldNode: FS.FSNode, newDir: FS.FSNode, newName: string): void;
+        unlink(parent: FS.FSNode, name: string): void;
+        rmdir(parent: FS.FSNode, name: string): void;
+        readdir(node: FS.FSNode): string[];
+        symlink(parent: FS.FSNode, newName: string, oldPath: string): void;
+        readlink(node: FS.FSNode): string;
+    }
+
+    interface Stats {
+        dev: number;
+        ino: number;
+        mode: number;
+        nlink: number;
+        uid: number;
+        gid: number;
+        rdev: number;
+        size: number;
+        blksize: number;
+        blocks: number;
+        atime: Date;
+        mtime: Date;
+        ctime: Date;
+        timestamp?: number;
+    }
+
     class ErrnoError extends Error {
         name: "ErronoError";
         errno: number;
         code: string;
+        constructor(errno: number);
     }
 
     let ignorePermissions: boolean;
-    let trackingDelegate: any;
+    let trackingDelegate: {
+        onOpenFile(path: string, trackingFlags: number);
+        onCloseFile(path: string);
+        onSeekFile(path: string, position: number, whence: number);
+        onReadFile(path: string, bytesRead: number);
+        onWriteToFile(path: string, bytesWritten: number);
+        onMakeDirectory(path: string, mode: number);
+        onMakeSymlink(oldpath: string, newpath: string);
+        willMovePath(old_path: string, new_path: string);
+        onMovePath(old_path: string, new_path: string);
+        willDeletePath(path: string);
+        onDeletePath(path: string);
+    };
     let tracking: any;
-    let genericErrors: any;
+    let genericErrors: Record<number, ErrnoError>;
 
     //
     // paths
     //
-    function lookupPath(path: string, opts: any): Lookup;
+    function lookupPath(
+        path: string,
+        opts: Partial<{
+            follow_mount: boolean;
+            /**
+             * by default, lookupPath will not follow a symlink if it is the final path component.
+             * setting opts.follow = true will override this behavior.
+             */
+            follow: boolean;
+            recurse_count: number;
+        }>,
+    ): Lookup;
     function getPath(node: FSNode): string;
     function analyzePath(path: string, dontResolveLastLink?: boolean): Analyze;
 
@@ -188,26 +252,28 @@ declare namespace FS {
     function major(dev: number): number;
     function minor(dev: number): number;
     function makedev(ma: number, mi: number): number;
-    function registerDevice(dev: number, ops: any): void;
+    function registerDevice(dev: number, ops: StreamOps): void;
+    function getDevice(dev: number): { stream_ops: StreamOps };
 
     //
     // core
     //
+    function getMounts(mount: Mount): Mount[];
     function syncfs(populate: boolean, callback: (e: any) => any): void;
     function syncfs(callback: (e: any) => any, populate?: boolean): void;
     function mount(type: Emscripten.FileSystemType, opts: any, mountpoint: string): any;
     function unmount(mountpoint: string): void;
 
-    function mkdir(path: string, mode?: number): any;
-    function mkdev(path: string, mode?: number, dev?: number): any;
-    function symlink(oldpath: string, newpath: string): any;
+    function mkdir(path: string, mode?: number): FSNode;
+    function mkdev(path: string, mode?: number, dev?: number): FSNode;
+    function symlink(oldpath: string, newpath: string): FSNode;
     function rename(old_path: string, new_path: string): void;
     function rmdir(path: string): void;
-    function readdir(path: string): any;
+    function readdir(path: string): string[];
     function unlink(path: string): void;
     function readlink(path: string): string;
-    function stat(path: string, dontFollow?: boolean): any;
-    function lstat(path: string): any;
+    function stat(path: string, dontFollow?: boolean): Stats;
+    function lstat(path: string): Stats;
     function chmod(path: string, mode: number, dontFollow?: boolean): void;
     function lchmod(path: string, mode: number): void;
     function fchmod(fd: number, mode: number): void;
@@ -219,7 +285,7 @@ declare namespace FS {
     function utime(path: string, atime: number, mtime: number): void;
     function open(path: string, flags: string, mode?: number, fd_start?: number, fd_end?: number): FSStream;
     function close(stream: FSStream): void;
-    function llseek(stream: FSStream, offset: number, whence: number): any;
+    function llseek(stream: FSStream, offset: number, whence: number): number;
     function read(stream: FSStream, buffer: ArrayBufferView, offset: number, length: number, position?: number): number;
     function write(
         stream: FSStream,
@@ -238,7 +304,10 @@ declare namespace FS {
         position: number,
         prot: number,
         flags: number,
-    ): any;
+    ): {
+        allocated: boolean;
+        ptr: number;
+    };
     function ioctl(stream: FSStream, cmd: any, arg: any): any;
     function readFile(path: string, opts: { encoding: "binary"; flags?: string | undefined }): Uint8Array;
     function readFile(path: string, opts: { encoding: "utf8"; flags?: string | undefined }): string;

--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -164,16 +164,16 @@ declare namespace FS {
     }
 
     interface NodeOps {
-        getattr(node: FS.FSNode): Stats;
-        setattr(node: FS.FSNode, attr: Stats): void;
-        lookup(parent: FS.FSNode, name: string): FS.FSNode;
-        mknod(parent: FS.FSNode, name: string, mode: number, dev: unknown): FS.FSNode;
-        rename(oldNode: FS.FSNode, newDir: FS.FSNode, newName: string): void;
-        unlink(parent: FS.FSNode, name: string): void;
-        rmdir(parent: FS.FSNode, name: string): void;
-        readdir(node: FS.FSNode): string[];
-        symlink(parent: FS.FSNode, newName: string, oldPath: string): void;
-        readlink(node: FS.FSNode): string;
+        getattr(node: FSNode): Stats;
+        setattr(node: FSNode, attr: Stats): void;
+        lookup(parent: FSNode, name: string): FSNode;
+        mknod(parent: FSNode, name: string, mode: number, dev: unknown): FSNode;
+        rename(oldNode: FSNode, newDir: FSNode, newName: string): void;
+        unlink(parent: FSNode, name: string): void;
+        rmdir(parent: FSNode, name: string): void;
+        readdir(node: FSNode): string[];
+        symlink(parent: FSNode, newName: string, oldPath: string): void;
+        readlink(node: FSNode): string;
     }
 
     interface Stats {

--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -202,17 +202,17 @@ declare namespace FS {
 
     let ignorePermissions: boolean;
     let trackingDelegate: {
-        onOpenFile(path: string, trackingFlags: number);
-        onCloseFile(path: string);
-        onSeekFile(path: string, position: number, whence: number);
-        onReadFile(path: string, bytesRead: number);
-        onWriteToFile(path: string, bytesWritten: number);
-        onMakeDirectory(path: string, mode: number);
-        onMakeSymlink(oldpath: string, newpath: string);
-        willMovePath(old_path: string, new_path: string);
-        onMovePath(old_path: string, new_path: string);
-        willDeletePath(path: string);
-        onDeletePath(path: string);
+        onOpenFile(path: string, trackingFlags: number): unknown;
+        onCloseFile(path: string): unknown;
+        onSeekFile(path: string, position: number, whence: number): unknown;
+        onReadFile(path: string, bytesRead: number): unknown;
+        onWriteToFile(path: string, bytesWritten: number): unknown;
+        onMakeDirectory(path: string, mode: number): unknown;
+        onMakeSymlink(oldpath: string, newpath: string): unknown;
+        willMovePath(old_path: string, new_path: string): unknown;
+        onMovePath(old_path: string, new_path: string): unknown;
+        willDeletePath(path: string): unknown;
+        onDeletePath(path: string): unknown;
     };
     let tracking: any;
     let genericErrors: Record<number, ErrnoError>;
@@ -230,6 +230,7 @@ declare namespace FS {
              */
             follow: boolean;
             recurse_count: number;
+            parent: boolean;
         }>,
     ): Lookup;
     function getPath(node: FSNode): string;
@@ -252,7 +253,7 @@ declare namespace FS {
     function major(dev: number): number;
     function minor(dev: number): number;
     function makedev(ma: number, mi: number): number;
-    function registerDevice(dev: number, ops: StreamOps): void;
+    function registerDevice(dev: number, ops: Partial<StreamOps>): void;
     function getDevice(dev: number): { stream_ops: StreamOps };
 
     //


### PR DESCRIPTION
The PR adds additional types to the `@types/emscripten` package. The types were created by observing implementations in [emscripten:src/library_fs.js](https://github.com/emscripten-core/emscripten/blob/main/src/library_fs.js), [emscripten:src/library_memfs.js](https://github.com/emscripten-core/emscripten/blob/main/src/library_memfs.js), and other Emscripten source files.

I've tested the changes using `pnpm test emscripten` and by replacing the files in `node_modules` and they work as intended.

Proactively pinging:
@lourd (@types/emscripten)
@brendandahl (Emscripten)
@kripken (Emscripten)