### PR TITLE
phoenix_live_view: Add longPollFallbackMs to SocketOptions

### DIFF
--- a/types/phoenix_live_view/index.d.ts
+++ b/types/phoenix_live_view/index.d.ts
@@ -27,7 +27,7 @@ export interface DomOptions {
 export type ViewLogger = (view: View, kind: string, msg: any, obj: any) => void;
 
 export interface SocketOptions {
-    longPollFallbackMs: number | undefined;
+    longPollFallbackMs?: number | undefined;
     bindingPrefix?: string | undefined;
     defaults?: Defaults | undefined;
     dom?: DomOptions | undefined;

--- a/types/phoenix_live_view/index.d.ts
+++ b/types/phoenix_live_view/index.d.ts
@@ -27,6 +27,7 @@ export interface DomOptions {
 export type ViewLogger = (view: View, kind: string, msg: any, obj: any) => void;
 
 export interface SocketOptions {
+    longPollFallbackMs: number | undefined;
     bindingPrefix?: string | undefined;
     defaults?: Defaults | undefined;
     dom?: DomOptions | undefined;


### PR DESCRIPTION
The [`phoenix_live_view.LiveSocket` passes its options to `phoenix.Socket`][liveview], and [longpoll fallback][phoenix] was added 4 months ago in [Phoenix 1.7.11][changelog].

[liveview]: https://github.com/phoenixframework/phoenix_live_view/blob/6648f774354e308efc26d7e44e6e68d5a1b12fe1/assets/js/phoenix_live_view/live_socket.js#L132
[phoenix]: https://github.com/phoenixframework/phoenix/blame/c54d90cd074e620bdc2f30146e072cbf25680705/assets/js/phoenix/socket.js#L119
[changelog]: https://hexdocs.pm/phoenix/changelog.html#1-7-11-2024-02-01

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: linked inline above.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. **please see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69617#issuecomment-2112106822**