### PR TITLE
[plotly.js] Fix TS2430 error with `exactOptionalPropertyTypes`

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -118,12 +118,12 @@ export interface PlotScene {
 }
 
 export interface PlotRelayoutEvent extends Partial<Layout> {
-    "xaxis.range[0]"?: number | undefined;
-    "xaxis.range[1]"?: number | undefined;
-    "yaxis.range[0]"?: number | undefined;
-    "yaxis.range[1]"?: number | undefined;
-    "xaxis.autorange"?: boolean | undefined;
-    "yaxis.autorange"?: boolean | undefined;
+    "xaxis.range[0]"?: number;
+    "xaxis.range[1]"?: number;
+    "yaxis.range[0]"?: number;
+    "yaxis.range[1]"?: number;
+    "xaxis.autorange"?: boolean;
+    "yaxis.autorange"?: boolean;
 }
 
 export interface ClickAnnotationEvent {


### PR DESCRIPTION
An automated change #54346 that was intended to fix errors with `exactOptionalPropertyTypes` actually introduced an error with `exactOptionalPropertyTypes` here. Fix it.

```console
$ echo 'import "plotly.js"' > test.ts
$ tsc --strict --exactOptionalPropertyTypes test.ts
node_modules/@types/plotly.js/index.d.ts:120:18 - error TS2430: Interface 'PlotRelayoutEvent' incorrectly extends interface 'Partial<Layout>'.
  Types of property '"xaxis.range[0]"' are incompatible.
    Type 'number | undefined' is not assignable to type 'Datum'.
      Type 'undefined' is not assignable to type 'Datum'.

120 export interface PlotRelayoutEvent extends Partial<Layout> {
                     ~~~~~~~~~~~~~~~~~

Found 1 error in node_modules/@types/plotly.js/index.d.ts:120
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
