### PR TITLE
[relay-runtime] return undefined from readInlineFragment

### DIFF
--- a/types/relay-runtime/lib/store/readInlineData.d.ts
+++ b/types/relay-runtime/lib/store/readInlineData.d.ts
@@ -15,5 +15,5 @@ export function readInlineData<TKey extends KeyType>(
 
 export function readInlineData<TKey extends KeyType>(
     fragmentInput: GraphQLTaggedNode,
-    fragmentRef: TKey | null,
-): KeyTypeData<TKey> | null;
+    fragmentRef: TKey | null | undefined,
+): KeyTypeData<TKey> | null | undefined;


### PR DESCRIPTION
Same change was done to useFragment here: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67136/files

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/relay/blob/main/packages/relay-runtime/store/readInlineData.js#L37
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
