### PR TITLE
conventional-changelog-core: Inline deleted options types

### DIFF
--- a/types/conventional-changelog-core/index.d.ts
+++ b/types/conventional-changelog-core/index.d.ts
@@ -289,81 +289,81 @@ declare namespace conventionalChangelogCore {
              */
             interface RecommendedBumpOptions {
                 /**
-                * If `true`, reverted commits will be ignored.
-                *
-                * @default
-                * true
-                */
+                 * If `true`, reverted commits will be ignored.
+                 *
+                 * @default
+                 * true
+                 */
                 ignoreReverted?: boolean | undefined;
 
                 /**
-                * It's recommended to use a preset so you don't have to define everything
-                * yourself.
-                *
-                * The value is passed to [`conventional-changelog-preset-loader`](https://www.npmjs.com/package/conventional-changelog-preset-loader).
-                */
+                 * It's recommended to use a preset so you don't have to define everything
+                 * yourself.
+                 *
+                 * The value is passed to [`conventional-changelog-preset-loader`](https://www.npmjs.com/package/conventional-changelog-preset-loader).
+                 */
                 preset?: string | undefined;
 
                 /**
-                * This should serve as default values for other arguments of
-                * `conventional-recommended-bump` so you don't need to rewrite the same or
-                * similar config across your projects.
-                *
-                * @remarks
-                * `config` option will be overwritten by the value loaded by
-                * `conventional-changelog-preset-loader` if the `preset` options is set.
-                */
+                 * This should serve as default values for other arguments of
+                 * `conventional-recommended-bump` so you don't need to rewrite the same or
+                 * similar config across your projects.
+                 *
+                 * @remarks
+                 * `config` option will be overwritten by the value loaded by
+                 * `conventional-changelog-preset-loader` if the `preset` options is set.
+                 */
                 config?: Config<Commit, BaseContext> | undefined;
 
                 /**
-                * A function that takes parsed commits as an argument.
-                *
-                * ```
-                * whatBump(commits) {};
-                * ```
-                *
-                * `commits` is an array of all commits from last semver tag to `HEAD` as parsed
-                * by `conventional-commits-parser`.
-                *
-                * This should return an object including but not limited to `level` and `reason`.
-                * `level` is a `number` indicating what bump it should be and `reason` is the
-                * reason of such release.
-                */
+                 * A function that takes parsed commits as an argument.
+                 *
+                 * ```
+                 * whatBump(commits) {};
+                 * ```
+                 *
+                 * `commits` is an array of all commits from last semver tag to `HEAD` as parsed
+                 * by `conventional-commits-parser`.
+                 *
+                 * This should return an object including but not limited to `level` and `reason`.
+                 * `level` is a `number` indicating what bump it should be and `reason` is the
+                 * reason of such release.
+                 */
                 whatBump?: RecommendedBumpOptions.WhatBump | undefined;
 
                 /**
-                * Specify a prefix for the git tag that will be taken into account during the
-                * comparison.
-                *
-                * For instance if your version tag is prefixed by `version/` instead of `v` you
-                * would specifying `--tagPrefix=version/` using the CLI, or `version/` as the
-                * value of the `tagPrefix` option.
-                */
+                 * Specify a prefix for the git tag that will be taken into account during the
+                 * comparison.
+                 *
+                 * For instance if your version tag is prefixed by `version/` instead of `v` you
+                 * would specifying `--tagPrefix=version/` using the CLI, or `version/` as the
+                 * value of the `tagPrefix` option.
+                 */
                 tagPrefix?: string | undefined;
 
                 /**
-                * If given, unstable tags (e.g. `x.x.x-alpha.1`, `x.x.x-rc.2`) will be skipped.
-                */
+                 * If given, unstable tags (e.g. `x.x.x-alpha.1`, `x.x.x-rc.2`) will be skipped.
+                 */
                 skipUnstable?: boolean | undefined;
 
                 /**
-                * Specify the name of a package in a [Lerna](https://lernajs.io/)-managed
-                * repository. The package name will be used when fetching all changes to a
-                * package since the last time that package was released.
-                *
-                * For instance if your project contained a package named
-                * `conventional-changelog`, you could have only commits that have happened
-                * since the last release of `conventional-changelog` was tagged by
-                * specifying `--lernaPackage=conventional-changelog` using the CLI, or
-                * `conventional-changelog` as the value of the `lernaPackage` option.
-                */
+                 * Specify the name of a package in a [Lerna](https://lernajs.io/)-managed
+                 * repository. The package name will be used when fetching all changes to a
+                 * package since the last time that package was released.
+                 *
+                 * For instance if your project contained a package named
+                 * `conventional-changelog`, you could have only commits that have happened
+                 * since the last release of `conventional-changelog` was tagged by
+                 * specifying `--lernaPackage=conventional-changelog` using the CLI, or
+                 * `conventional-changelog` as the value of the `lernaPackage` option.
+                 */
                 lernaPackage?: string | undefined;
 
                 /**
-                * Specify the path to only calculate with git commits related to the path.
-                * If you want to calculate recommended bumps of packages in a Lerna-managed
-                * repository, path should be use along with lernaPackage for each of the package.
-                */
+                 * Specify the path to only calculate with git commits related to the path.
+                 * If you want to calculate recommended bumps of packages in a Lerna-managed
+                 * repository, path should be use along with lernaPackage for each of the package.
+                 */
                 path?: string | undefined;
             }
 

--- a/types/conventional-changelog-core/index.d.ts
+++ b/types/conventional-changelog-core/index.d.ts
@@ -4,7 +4,6 @@ import * as Stream from "stream";
 
 import { Context as BaseContext, Options as BaseWriterOptions } from "conventional-changelog-writer";
 import { Commit, Options as BaseParserOptions } from "conventional-commits-parser";
-import { Options as RecommendedBumpOptions } from "conventional-recommended-bump";
 import { ExecOptions as GitRawExecOptions, GitOptions as BaseGitRawCommitsOptions } from "git-raw-commits";
 
 import { Package } from "normalize-package-data";
@@ -277,6 +276,107 @@ declare namespace conventionalChangelogCore {
                 writerOpts?: WriterOptions<TCommit, TContext> | undefined;
             }
 
+            /**
+             * `recommendedBumpOpts` is an object with the following properties:
+             * * `ignoreReverted`
+             * * `preset`
+             * * `config`
+             * * `whatBump`
+             * * `tagPrefix`
+             * * `skipUnstable`
+             * * `lernaPackage`
+             * * `path`
+             */
+            interface RecommendedBumpOptions {
+                /**
+                * If `true`, reverted commits will be ignored.
+                *
+                * @default
+                * true
+                */
+                ignoreReverted?: boolean | undefined;
+
+                /**
+                * It's recommended to use a preset so you don't have to define everything
+                * yourself.
+                *
+                * The value is passed to [`conventional-changelog-preset-loader`](https://www.npmjs.com/package/conventional-changelog-preset-loader).
+                */
+                preset?: string | undefined;
+
+                /**
+                * This should serve as default values for other arguments of
+                * `conventional-recommended-bump` so you don't need to rewrite the same or
+                * similar config across your projects.
+                *
+                * @remarks
+                * `config` option will be overwritten by the value loaded by
+                * `conventional-changelog-preset-loader` if the `preset` options is set.
+                */
+                config?: Config<Commit, BaseContext> | undefined;
+
+                /**
+                * A function that takes parsed commits as an argument.
+                *
+                * ```
+                * whatBump(commits) {};
+                * ```
+                *
+                * `commits` is an array of all commits from last semver tag to `HEAD` as parsed
+                * by `conventional-commits-parser`.
+                *
+                * This should return an object including but not limited to `level` and `reason`.
+                * `level` is a `number` indicating what bump it should be and `reason` is the
+                * reason of such release.
+                */
+                whatBump?: RecommendedBumpOptions.WhatBump | undefined;
+
+                /**
+                * Specify a prefix for the git tag that will be taken into account during the
+                * comparison.
+                *
+                * For instance if your version tag is prefixed by `version/` instead of `v` you
+                * would specifying `--tagPrefix=version/` using the CLI, or `version/` as the
+                * value of the `tagPrefix` option.
+                */
+                tagPrefix?: string | undefined;
+
+                /**
+                * If given, unstable tags (e.g. `x.x.x-alpha.1`, `x.x.x-rc.2`) will be skipped.
+                */
+                skipUnstable?: boolean | undefined;
+
+                /**
+                * Specify the name of a package in a [Lerna](https://lernajs.io/)-managed
+                * repository. The package name will be used when fetching all changes to a
+                * package since the last time that package was released.
+                *
+                * For instance if your project contained a package named
+                * `conventional-changelog`, you could have only commits that have happened
+                * since the last release of `conventional-changelog` was tagged by
+                * specifying `--lernaPackage=conventional-changelog` using the CLI, or
+                * `conventional-changelog` as the value of the `lernaPackage` option.
+                */
+                lernaPackage?: string | undefined;
+
+                /**
+                * Specify the path to only calculate with git commits related to the path.
+                * If you want to calculate recommended bumps of packages in a Lerna-managed
+                * repository, path should be use along with lernaPackage for each of the package.
+                */
+                path?: string | undefined;
+            }
+
+            namespace RecommendedBumpOptions {
+                type WhatBump = (commits: Commit[]) => WhatBump.Result;
+
+                namespace WhatBump {
+                    interface Result {
+                        level?: number | undefined;
+                        reason?: string | undefined;
+                    }
+                }
+            }
             export { FunctionType as Function, ObjectType as Object };
         }
 


### PR DESCRIPTION
conventional-recommended-bump was recently deleted in favour of the official types, which don't include the Options type used by conventional-changelog-core. This PR inlines the RecommendedBumpOptions into conventional-changelog-core. In my opinion, this is an improvement anyway since there was a circular dependency between the two packages.
