### PR TITLE
[video-react] Make all props of PlayerProps optional

### DIFF
--- a/types/video-react/index.d.ts
+++ b/types/video-react/index.d.ts
@@ -310,23 +310,23 @@ export interface PlayerProps extends RefAttributes<PlayerReference> {
     /**
      * Event on Play
      */
-    onPlay: () => void;
+    onPlay?: () => void;
     /**
      * Event on Ended
      */
-    onEnded: () => void;
+    onEnded?: () => void;
     /**
      * Event on Load start
      */
-    onLoadStart: () => void;
+    onLoadStart?: () => void;
     /**
      * Event on Pause start
      */
-    onPause: () => void;
+    onPause?: () => void;
     /**
      * Set the id of the video element.
      */
-    videoId: string;
+    videoId?: string;
 
     children?: React.ReactNode;
 }

--- a/types/video-react/video-react-tests.tsx
+++ b/types/video-react/video-react-tests.tsx
@@ -21,13 +21,23 @@ const testProps: PlayerProps = {
 
 function TestComponent(props: PlayerProps): React.JSX.Element {
     return (
-        <Player {...testProps}>
-            <ControlBar>
-                <CurrentTimeDisplay order={1} />
-                <DurationDisplay order={2} />
-                <ProgressControl order={3} />
-                <TimeDivider order={4} />
-            </ControlBar>
-        </Player>
+        <div>
+            <Player>
+                <ControlBar>
+                    <CurrentTimeDisplay order={1} />
+                    <DurationDisplay order={2} />
+                    <ProgressControl order={3} />
+                    <TimeDivider order={4} />
+                </ControlBar>
+            </Player>
+            <Player {...testProps}>
+                <ControlBar>
+                    <CurrentTimeDisplay order={1} />
+                    <DurationDisplay order={2} />
+                    <ProgressControl order={3} />
+                    <TimeDivider order={4} />
+                </ControlBar>
+            </Player>
+        </div>
     );
 }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/video-react/video-react/blob/master/README.md#installation example uses <Player> with no props, which current types don't support.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69556 added new props to PlayerProps but forgot to mark them as optional. That broke typechecking for users who don't supply those props.
