### PR TITLE
fix(@types/k6): exact optional property type mismatch

### DIFF
--- a/types/k6/http.d.ts
+++ b/types/k6/http.d.ts
@@ -300,7 +300,7 @@ export interface Params {
  * Used to infer response body type.
  */
 export interface RefinedParams<RT extends ResponseType | undefined> extends Params {
-    responseType?: RT;
+    responseType?: RT extends ResponseType ? RT : never;
 }
 
 /**


### PR DESCRIPTION
The provided type did not compile when `exactOptionalPropertyTypes` is configured. This commit resolves the compiler error encountered when compiling in this mode.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

I can't seem to get the packages tested individually (my Node+TS setup is segfaulting since a recent upgrade).
So I'll try to rely on CI to test my changes; my goal here is to make my local patch available to the repository, no strings attached.

Do note that Node's types also had this typing problem a while ago.
I opted for this solution to not break the signature of the typing library, but there are other solutions, too, such as allowing explicit `undefined`s in the extended types.
