### PR TITLE
[yauzl-promise] adjust types following v4 rewrite

### DIFF
--- a/types/yauzl-promise/index.d.ts
+++ b/types/yauzl-promise/index.d.ts
@@ -44,19 +44,19 @@ export class ZipFile extends EventEmitter implements AsyncIterable<Entry> {
 }
 
 export interface ZipFileOptions {
-    decompress: boolean | null;
-    decrypt: boolean | null;
-    validateCrc32: boolean | null;
-    start: number | null;
-    end: number | null;
+    decompress?: boolean | null | undefined;
+    decrypt?: boolean | null | undefined;
+    validateCrc32?: boolean | null | undefined;
+    start?: number | null | undefined;
+    end?: number | null | undefined;
 }
 
 export interface Options {
-    decodeStrings?: boolean | undefined;
-    validateEntrySizes?: boolean | undefined;
-    validateFilenames?: boolean | undefined;
-    strictFilenames?: boolean | undefined;
-    supportMacArchive?: boolean | undefined;
+    decodeStrings?: boolean | null | undefined;
+    validateEntrySizes?: boolean | null | undefined;
+    validateFilenames?: boolean | null | undefined;
+    strictFilenames?: boolean | null | undefined;
+    supportMacArchive?: boolean | null | undefined;
 }
 
 export class Entry {

--- a/types/yauzl-promise/index.d.ts
+++ b/types/yauzl-promise/index.d.ts
@@ -88,4 +88,4 @@ export function fromReader(
 ): Promise<ZipFile>;
 
 export function dosDateTimeToDate(date: number, time: number): Date;
-export function validateFilename(filename: string): string | null;
+export function validateFilename(filename: string): void;

--- a/types/yauzl-promise/index.d.ts
+++ b/types/yauzl-promise/index.d.ts
@@ -71,7 +71,7 @@ export class Entry {
     openReadStream(options?: ZipFileOptions): Promise<Readable>;
 }
 
-export abstract class RandomAccessReader {
+export abstract class Reader {
     _createReadStream(start: number, length: number): Readable;
     _read(start: number, length: number): Promise<Buffer>;
     _open(): Promise<{}>;
@@ -79,17 +79,13 @@ export abstract class RandomAccessReader {
 }
 
 export function open(path: string, options?: Options): Promise<ZipFile>;
-// export function open(path: string): Promise<ZipFile>;
 export function fromFd(fd: number, options?: Options): Promise<ZipFile>;
-// export function fromFd(fd: number): Promise<ZipFile>;
 export function fromBuffer(buffer: Buffer, options?: Options): Promise<ZipFile>;
-// export function fromBuffer(buffer: Buffer): Promise<ZipFile>;
-export function fromRandomAccessReader(
-    reader: RandomAccessReader,
+export function fromReader(
+    reader: Reader,
     totalSize: number,
     options?: Options,
 ): Promise<ZipFile>;
-// export function fromRandomAccessReader(reader: RandomAccessReader, totalSize: number): Promise<ZipFile>;
 
 export function dosDateTimeToDate(date: number, time: number): Date;
 export function validateFilename(filename: string): string | null;

--- a/types/yauzl-promise/index.d.ts
+++ b/types/yauzl-promise/index.d.ts
@@ -21,18 +21,6 @@ export class ZipFile extends EventEmitter implements AsyncIterable<Entry> {
     readEntryCursor: boolean;
     validateEntrySizes: boolean;
 
-    constructor(
-        reader: RandomAccessReader,
-        centralDirectoryOffset: number,
-        fileSize: number,
-        entryCount: number,
-        comment: string,
-        autoClose: boolean,
-        lazyEntries: boolean,
-        decodeStrings: boolean,
-        validateEntrySizes: boolean,
-    );
-
     // These funcitons are custom to yauzl-promise
 
     close(): Promise<void>;

--- a/types/yauzl-promise/index.d.ts
+++ b/types/yauzl-promise/index.d.ts
@@ -44,26 +44,28 @@ export interface Options {
 }
 
 export class Entry {
+    /** This property can also be a Buffer if the option 'decodeStrings' is false */
     comment: string;
     compressedSize: number;
     compressionMethod: number;
     crc32: number;
     externalFileAttributes: number;
-    extraFieldLength: number;
     extraFields: Array<{ id: number; data: Buffer }>;
-    fileCommentLength: number;
+    fileDataOffset: null | number;
+    fileHeaderOffset: number;
+    /** This property can also be a Buffer if the option 'decodeStrings' is false */
     filename: string;
     filenameLength: number;
     generalPurposeBitFlag: number;
     internalFileAttributes: number;
-    lastModFileDate: number;
-    lastModFileTime: number;
-    relativeOffsetOfLocalHeader: number;
+    lastModDate: number;
+    lastModTime: number;
     uncompressedSize: number;
+    uncompressedSizeIsCertain: boolean;
     versionMadeBy: number;
     versionNeededToExtract: number;
 
-    getLastModDate(): Date;
+    getLastMod(): Date;
     isEncrypted(): boolean;
     isCompressed(): boolean;
     openReadStream(options?: ZipFileOptions): Promise<Readable>;

--- a/types/yauzl-promise/index.d.ts
+++ b/types/yauzl-promise/index.d.ts
@@ -24,7 +24,6 @@ export class ZipFile extends EventEmitter implements AsyncIterable<Entry> {
     close(): Promise<void>;
     readEntry(): Promise<Entry | null>;
     readEntries(numEntries?: number): Promise<Entry[]>;
-    walkEntries(callback: (entry: Entry) => Promise<void> | void, numEntries?: number): Promise<void>;
     openReadStream(entry: Entry, options?: ZipFileOptions): Promise<Readable>;
     [Symbol.asyncIterator](): AsyncIterator<Entry>;
 }

--- a/types/yauzl-promise/index.d.ts
+++ b/types/yauzl-promise/index.d.ts
@@ -21,10 +21,8 @@ export class ZipFile extends EventEmitter implements AsyncIterable<Entry> {
     readEntryCursor: boolean;
     validateEntrySizes: boolean;
 
-    // These funcitons are custom to yauzl-promise
-
     close(): Promise<void>;
-    readEntry(): Promise<Entry>;
+    readEntry(): Promise<Entry | null>;
     readEntries(numEntries?: number): Promise<Entry[]>;
     walkEntries(callback: (entry: Entry) => Promise<void> | void, numEntries?: number): Promise<void>;
     openReadStream(entry: Entry, options?: ZipFileOptions): Promise<Readable>;

--- a/types/yauzl-promise/index.d.ts
+++ b/types/yauzl-promise/index.d.ts
@@ -8,17 +8,16 @@ import { Readable } from "stream";
 // This class is not directly compatible with @types/yauzl 's ZipFile as this library changes the function signatures
 // Therefore, it is replaced, albeit with a significant portion
 export class ZipFile extends EventEmitter implements AsyncIterable<Entry> {
-    // This chunk taken directly from @types/yauzl
-    autoClose: boolean;
+    /** This property can also be a Buffer if the option 'decodeStrings' is false */
     comment: string;
-    decodeStrings: boolean;
-    emittedError: boolean;
-    entriesRead: number;
     entryCount: number;
-    fileSize: number;
+    entryCountIsCertain: boolean;
     isOpen: boolean;
-    lazyEntries: boolean;
-    readEntryCursor: boolean;
+    isZip64: boolean;
+
+    // These options do exist in the ZipFile class, but are not officially documented.
+    // Keeping them for backward compatibility with previous types version.
+    decodeStrings: boolean;
     validateEntrySizes: boolean;
 
     close(): Promise<void>;

--- a/types/yauzl-promise/yauzl-promise-tests.ts
+++ b/types/yauzl-promise/yauzl-promise-tests.ts
@@ -54,8 +54,28 @@ async function test() {
     await entry.openReadStream();
     await entry.openReadStream(zipOptions);
 
-    const filename = entry.filename;
-    const filenameLength = entry.filenameLength;
+    entry.comment; // $ExpectType string;
+    entry.compressedSize; // $ExpectType number;
+    entry.compressionMethod; // $ExpectType number;
+    entry.crc32; // $ExpectType number;
+    entry.externalFileAttributes; // $ExpectType number;
+    entry.extraFields; // $ExpectType { id: number; data: Buffer }[];
+    entry.fileDataOffset; // $ExpectType null | number;
+    entry.fileHeaderOffset; // $ExpectType number;
+    entry.filename; // $ExpectType string;
+    entry.filenameLength; // $ExpectType number;
+    entry.generalPurposeBitFlag; // $ExpectType number;
+    entry.internalFileAttributes; // $ExpectType number;
+    entry.lastModDate; // $ExpectType number;
+    entry.lastModTime; // $ExpectType number;
+    entry.uncompressedSize; // $ExpectType number;
+    entry.uncompressedSizeIsCertain; // $ExpectType boolean;
+    entry.versionMadeBy; // $ExpectType number;
+    entry.versionNeededToExtract; // $ExpectType number;
+
+    entry.getLastMod(); // $ExpectType Date
+    entry.isEncrypted(); // $ExpectType boolean
+    entry.isCompressed(); // $ExpectType boolean
 
     {
         let entry: yauzl.Entry;

--- a/types/yauzl-promise/yauzl-promise-tests.ts
+++ b/types/yauzl-promise/yauzl-promise-tests.ts
@@ -34,7 +34,9 @@ async function test() {
     const rar1 = await yauzl.fromRandomAccessReader(new FakeRaR(), 1);
     const rar2 = await yauzl.fromRandomAccessReader(new FakeRaR(), 1, options);
 
-    const entry = await zip.readEntry();
+    // $ExpectType Entry | null
+    const entryOrNull = await zip.readEntry();
+    const entry = entryOrNull!;
     await zip.readEntries();
     await zip.readEntries(1);
 

--- a/types/yauzl-promise/yauzl-promise-tests.ts
+++ b/types/yauzl-promise/yauzl-promise-tests.ts
@@ -34,6 +34,14 @@ async function test() {
     const rar1 = await yauzl.fromRandomAccessReader(new FakeRaR(), 1);
     const rar2 = await yauzl.fromRandomAccessReader(new FakeRaR(), 1, options);
 
+    zip.comment; // $ExpectType string
+    zip.entryCount; // $ExpectType number
+    zip.entryCountIsCertain; // $ExpectType boolean
+    zip.isOpen; // $ExpectType boolean
+    zip.isZip64; // $ExpectType boolean
+    zip.decodeStrings; // $ExpectType boolean
+    zip.validateEntrySizes; // $ExpectType boolean
+
     // $ExpectType Entry | null
     const entryOrNull = await zip.readEntry();
     const entry = entryOrNull!;

--- a/types/yauzl-promise/yauzl-promise-tests.ts
+++ b/types/yauzl-promise/yauzl-promise-tests.ts
@@ -53,4 +53,6 @@ async function test() {
         let entry: yauzl.Entry;
         for await (entry of zip) {}
     }
+
+    await zip.close();
 }

--- a/types/yauzl-promise/yauzl-promise-tests.ts
+++ b/types/yauzl-promise/yauzl-promise-tests.ts
@@ -49,14 +49,6 @@ async function test() {
     const filename = entry.filename;
     const filenameLength = entry.filenameLength;
 
-    await zip.walkEntries(async (entry: yauzl.Entry) => {
-        console.log("foo");
-    });
-
-    await zip.walkEntries(async (entry: yauzl.Entry) => {
-        console.log("foo");
-    }, 1);
-
     {
         let entry: yauzl.Entry;
         for await (entry of zip) {}

--- a/types/yauzl-promise/yauzl-promise-tests.ts
+++ b/types/yauzl-promise/yauzl-promise-tests.ts
@@ -1,6 +1,6 @@
 import * as yauzl from "yauzl-promise";
 
-class FakeRaR extends yauzl.RandomAccessReader {}
+class FakeReader extends yauzl.Reader {}
 
 const options: yauzl.Options = {
     decodeStrings: true,
@@ -31,8 +31,8 @@ async function test() {
     const buffer1 = await yauzl.fromBuffer(Buffer.from("test", "utf-8"));
     const buffer2 = await yauzl.fromBuffer(Buffer.from("test", "utf-8"), options);
 
-    const rar1 = await yauzl.fromRandomAccessReader(new FakeRaR(), 1);
-    const rar2 = await yauzl.fromRandomAccessReader(new FakeRaR(), 1, options);
+    const reader1 = await yauzl.fromReader(new FakeReader(), 1);
+    const reader2 = await yauzl.fromReader(new FakeReader(), 1, options);
 
     zip.comment; // $ExpectType string
     zip.entryCount; // $ExpectType number

--- a/types/yauzl-promise/yauzl-promise-tests.ts
+++ b/types/yauzl-promise/yauzl-promise-tests.ts
@@ -19,7 +19,7 @@ const zipOptions: yauzl.ZipFileOptions = {
 };
 
 const date = yauzl.dosDateTimeToDate(1, 1);
-const fn = yauzl.validateFilename("fake");
+yauzl.validateFilename("fake");
 
 async function test() {
     const zip = await yauzl.open("");


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/overlookmotel/yauzl-promise
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

# Description

Starting v4.0.0, `yauzl-promise` was rewritten from scratch. Cf. https://github.com/overlookmotel/yauzl-promise/compare/v3.0.0...v4.0.0

As such, several class properties were deleted/added/modified.

This PR is an attempt to fix the types to match the current implementation.

## Exported properties

I tried to reflect only the officially documented properties, even though several more exist in the implementation.
However, I left undocumented properties if they were already exported in DefinitelyTyped, to avoid unnecessary breaking changes.

## `comment` and `filename`: `string` or `Buffer`?

I've exported `ZipFile.comment`, `Entry.comment` and `Entry.filename` as `string`.
However, if the `decodeStrings` option is explicitly set to `false`, these 3 properties will effectively be `Buffer`s.

- I could have exported them as `string | Buffer`, but I suppose most of the library users use the default option, and expect `string`s.
- I probably could have make `ZipFile` and `Entry` generic classes, depending on the type of `decodeStrings`, but it felt overkill here, adding complexity.
- To alleviate this issue, I've added a `jsdoc` entry on the offending properties, to warn users of this fact.
