### PR TITLE
fix(babel/preset-env): fix type for core-js version

### DIFF
--- a/types/babel__preset-env/babel__preset-env-tests.ts
+++ b/types/babel__preset-env/babel__preset-env-tests.ts
@@ -203,6 +203,10 @@ options = {
 };
 
 options = {
+    corejs: "1.2.3",
+};
+
+options = {
     corejs: {
         version: 2,
         proposals: true,
@@ -212,6 +216,12 @@ options = {
 options = {
     corejs: {
         version: 3,
+        proposals: false,
+    },
+};
+options = {
+    corejs: {
+        version: "1.2.3",
         proposals: false,
     },
 };

--- a/types/babel__preset-env/index.d.ts
+++ b/types/babel__preset-env/index.d.ts
@@ -92,4 +92,7 @@ export type CorejsOption =
     | CorejsVersion
     | { version: CorejsVersion; proposals: boolean };
 
-export type CorejsVersion = 2 | 3;
+/**
+ * https://babeljs.io/docs/babel-preset-env#corejs
+ */
+export type CorejsVersion = 2 | 3 | string;


### PR DESCRIPTION
This change adds an option to specify version of core-js package with a string, what is required to use correct polyfills and transformations.
