### PR TITLE
[simpl-schema] Support returning false in custom validator

### DIFF
--- a/types/simpl-schema/index.d.ts
+++ b/types/simpl-schema/index.d.ts
@@ -82,7 +82,7 @@ export interface AutoValueContext {
     value?: FieldInfo["value"] | undefined;
 }
 
-type Validator = (this: CustomValidationContext) => undefined | string | SimpleSchemaValidationError;
+type Validator = (this: CustomValidationContext) => undefined | string | false | SimpleSchemaValidationError;
 
 export interface SchemaDefinition {
     type: any;

--- a/types/simpl-schema/simpl-schema-tests.ts
+++ b/types/simpl-schema/simpl-schema-tests.ts
@@ -68,12 +68,12 @@ const schema: SimpleSchemaDefinition = {
         custom() {
             this.validationContext.addValidationErrors([{
                 name: "username",
-                type: "notUnique"
+                type: "notUnique",
             }]);
 
             return false;
-        }
-    }
+        },
+    },
 };
 
 const StringSchema = new SimpleSchema(schema);

--- a/types/simpl-schema/simpl-schema-tests.ts
+++ b/types/simpl-schema/simpl-schema-tests.ts
@@ -63,6 +63,17 @@ const schema: SimpleSchemaDefinition = {
             else if (text.length < 10) return SimpleSchema.ErrorTypes.MIN_STRING;
         },
     },
+    username: {
+        type: Date,
+        custom() {
+            this.validationContext.addValidationErrors([{
+                name: "username",
+                type: "notUnique"
+            }]);
+
+            return false;
+        }
+    }
 };
 
 const StringSchema = new SimpleSchema(schema);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  https://github.com/longshotlabs/simpl-schema/tree/1.13.1?tab=readme-ov-file#custom-field-validation

The docs for `addValidationErrors` says:

> Call this to add validation errors for any key. In general, you should use this to add errors for other keys. To add an error for the current key, return the error type string. If you do use this to add an error for the current key, return false from your custom validation function.

This PR fixes the types to allow returning false.