### PR TITLE
[ini] add decoding options

### DIFF
--- a/types/ini/index.d.ts
+++ b/types/ini/index.d.ts
@@ -8,10 +8,14 @@ interface EncodeOptions {
     bracketedArray?: boolean;
 }
 
-export function decode(str: string): {
+interface DecodeOptions {
+    bracketedArray?: boolean;
+}
+
+export function decode(str: string, options?: DecodeOptions): {
     [key: string]: any;
 };
-export function parse(str: string): {
+export function parse(str: string, options?: DecodeOptions): {
     [key: string]: any;
 };
 export function encode(object: any, options?: EncodeOptions | string): string;

--- a/types/ini/ini-tests.ts
+++ b/types/ini/ini-tests.ts
@@ -7,15 +7,21 @@ const iniContent = "";
 // $ExpectType { [key: string]: any; }
 let decoded = ini.decode(iniContent);
 decoded = ini.parse(iniContent);
+decoded = ini.decode(iniContent, { bracketedArray: true });
+decoded = ini.parse(iniContent, { bracketedArray: true });
 
 // @ts-expect-error
 let badDecoded = ini.decode();
 // @ts-expect-error
 badDecoded = ini.decode(null);
 // @ts-expect-error
+badDecoded = ini.decode(iniContent, null);
+// @ts-expect-error
 badDecoded = ini.parse();
 // @ts-expect-error
 badDecoded = ini.parse(null);
+// @ts-expect-error
+badDecoded = ini.parse(iniContent, null);
 
 /* ini.encode() / ini.stringify() */
 


### PR DESCRIPTION
This PR simply adds the missing options to `decode` and `parse`, which currently today is only `bracketedArray`. This prevents issues when parsing options to the `decode` function and receiving a `Expected 1 arguments, but got 2.` type error.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/npm/ini/blob/main/lib/ini.js#L106-L107
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
