### PR TITLE
Update imagemin's Plugin to Uint8Array instead of Buffer.

### DIFF
--- a/types/imagemin/index.d.ts
+++ b/types/imagemin/index.d.ts
@@ -12,7 +12,7 @@ declare namespace imagemin {
     function buffer(input: Buffer, options?: BufferOptions): Promise<Buffer>;
 }
 
-export type Plugin = (input: Buffer) => Promise<Buffer>;
+export type Plugin = (input: Uint8Array) => Promise<Uint8Array>;
 
 export interface Options {
     destination?: string | undefined;

--- a/types/imagemin/package.json
+++ b/types/imagemin/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/imagemin",
-    "version": "9.0.0",
+    "version": "9.0.9999",
     "projects": [
         "https://github.com/imagemin/imagemin#readme"
     ],

--- a/types/imagemin/package.json
+++ b/types/imagemin/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/imagemin",
-    "version": "8.0.9999",
+    "version": "9.0.0",
     "projects": [
         "https://github.com/imagemin/imagemin#readme"
     ],


### PR DESCRIPTION
I noticed failures in web-scrobbler/web-scrobbler#4717. imagemin-pngquant@10 contains https://github.com/imagemin/imagemin-pngquant/commit/981b2167750f0d1caae09f852f6355cc3ffc0e51#diff-7aa4473ede4abd9ec099e87fec67fd57afafaf39e05d493ab4533acc38547eb8L58-R51, which replaces Buffer with Uint8Array, causing a type mismatch. imagemin@9 contains a similar change https://github.com/imagemin/imagemin/commit/0f2a0aa91084017501b638e55f1af827be9601c6#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R68, though that package's types are here and said change is less documented.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/imagemin/imagemin-pngquant/releases/tag/v10.0.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.