### PR TITLE
Fix types for fromRDF and toRDF to use RdfOrString instead of RdfDataSet

### DIFF
--- a/types/jsonld/index.d.ts
+++ b/types/jsonld/index.d.ts
@@ -12,6 +12,7 @@ export * from "./jsonld";
 // Some typealiases for better readability and some placeholders
 type MimeNQuad = "application/n-quads";
 type RdfDataSet = object; // Placeholder
+type RdfOrString = RdfDataSet|string;
 type Callback<T> = (err: Error, res: T) => void;
 
 /*
@@ -143,13 +144,13 @@ export function normalize(input: JsonLdDocument, options?: Options.Normalize): P
 
 export const canonize: typeof normalize;
 
-export function fromRDF(dataset: RdfDataSet, options: Options.FromRdf, callback: Callback<JsonLdArray>): void;
-export function fromRDF(dataset: RdfDataSet, callback: Callback<JsonLdArray>): void;
-export function fromRDF(dataset: RdfDataSet, options?: Options.FromRdf): Promise<JsonLdArray>;
+export function fromRDF(dataset: RdfOrString, options: Options.FromRdf, callback: Callback<JsonLdArray>): void;
+export function fromRDF(dataset: RdfOrString, callback: Callback<JsonLdArray>): void;
+export function fromRDF(dataset: RdfOrString, options?: Options.FromRdf): Promise<JsonLdArray>;
 
-export function toRDF(input: JsonLdDocument, callback: Callback<RdfDataSet>): void;
-export function toRDF(input: JsonLdDocument, options: Options.ToRdf, callback: Callback<RdfDataSet>): void;
-export function toRDF(input: JsonLdDocument, options?: Options.ToRdf): Promise<RdfDataSet>;
+export function toRDF(input: JsonLdDocument, callback: Callback<RdfOrString>): void;
+export function toRDF(input: JsonLdDocument, options: Options.ToRdf, callback: Callback<RdfOrString>): void;
+export function toRDF(input: JsonLdDocument, options?: Options.ToRdf): Promise<RdfOrString>;
 
 export let JsonLdProcessor: JsonLdProcessorInterface;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
I'm not sure what to add to the existing tests, this should return a string: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f6d4d15522356eba4a0267142834e3abc6b603fc/types/jsonld/jsonld-tests.ts#L203-L205
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<[Discussion](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/60661#discussioncomment-9537381)>>
- [NA] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

