### PR TITLE
[@types/lodash]: type-predicating for isEmpty on falsy primitive values

### DIFF
--- a/types/lodash/common/lang.d.ts
+++ b/types/lodash/common/lang.d.ts
@@ -572,10 +572,10 @@ declare module "../index" {
          * @return Returns true if value is empty, else false.
          */
         isEmpty<T extends { __trapAny: any }>(value?: T): boolean;
-        isEmpty(value: string): value is '';
-        isEmpty(value: Map<any, any> | Set<any> | List<any> | null | undefined): boolean;
+        isEmpty(value: any): value is '' | null | undefined | 0 | false;
+        isEmpty(value: Map<any, any> | Set<any> | List<any>): boolean;
         isEmpty(value: object): boolean;
-        isEmpty<T extends object>(value: T | null | undefined): value is EmptyObjectOf<T> | null | undefined;
+        isEmpty<T extends object>(value: T): value is EmptyObjectOf<T>;
         isEmpty(value?: any): boolean;
     }
     interface LoDashImplicitWrapper<TValue> {

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -4198,6 +4198,12 @@ fp.now(); // $ExpectType number
     if (_.isEmpty(foo)) {
         foo.bar = "baz";
     }
+
+    let unionFromEmptyAndNonEmpty: null | undefined | 0 | '' | object | boolean
+    unionFromEmptyAndNonEmpty = [null, undefined, 0 as const, '' as const, { test: 1 }, false, true][Math.round(Math.random() * 5)]
+    if (!_.isEmpty(unionFromEmptyAndNonEmpty)) {
+        const e = unionFromEmptyAndNonEmpty // $ExpectType true | object
+    }
 }
 
 // _.isEqual


### PR DESCRIPTION
Initial case I've run into:

```
const a: number[] | undefined
....
if (!isEmpty(a)) {
  a[0] // Error: a is possibly undefined
}
```

so I had to do fight Typescript here:

```
if (a && !isEmpty(a)) {
  a[0] // no error
}
```

`isEmpty` returns `true` for next primitive values:

* `false`
* `''`
* `0`
* `null`
* `undefined`

We definitely can trim them out of unions in compile time

Try [TS Playground](https://www.typescriptlang.org/play/?ssl=12&ssc=5&pln=3&pc=1#code/JYWwDg9gTgLgBAbzsAzgUXDAnnAvnAMyghDgHIAbCAEwEMUALMgbgChWB6DuagUwGMKtKLzggaAVwqjKNek0SducFcgB2MXlAK1+ogDIQAIvIDKMWjGD9FXVfZWoMYbAB4AKnF4APTWuooiHAA+sEwULRgAIJqWABccLSxeAB8ABQAbrQUErwA-AnuAJQJAEYQENJJbHYOqk6YWJnZuQlJWCVwWTmiqORkcAA+cGpSFENwEv68BMBqvNQTAAwTOhQovDXKdcjojc09CQCyka7tADSJsSkTprwwZ9cT+qgP7Smd5ZW81Uo7jnsXE1uq04BBSgArAQwT4VKpqLb-XbONyeHx+AJgyHQ9Ig3iFTp43ZwFFYADy2P4MDJBA8KUR-waQIOuQKVw6ZThPwRf3suD+-NY0ngwigCVGIFKWgA2gBdCZTPizeaLYajCjjYYocJzADmrGABDgaROMAYADoIv4SGkikVFPZRXAALxwaUARnOACZzgBmWWsQWG40AQiZ2DSortDtU-AgahQ33NVF1kagUGlS1lRV5SNUAD08oH2MK4KUEithu73S64NWDUaTZYLVbqDbowhWPZSrWloGvOtRJ3u7X6-zg2lw01Sh2u7H49q4DZXaVcw5C8WhfceOKxgrpsqFssJmQBsNwVCqRMvvDWItXdL1RRLoqZnMFpcVvQlwuYJdT4kgRxgmf5BJo2oJDWuCXGsGyytKpothAipNmalpJG2IC2nAABUcAAKxFAGE5hoCEbULO9jAYuoiutQa72BuuBAA). If type overriding is uncommented you will see how type is narrowed inside `if(!isEmpty(...))`



- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [isEmpty docs](https://lodash.com/docs/4.17.15#isEmpty)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.