### PR TITLE
[@types/node]: Add missing options to `events.on`

### DIFF
--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -78,6 +78,22 @@ declare module "events" {
     interface StaticEventEmitterOptions {
         signal?: AbortSignal | undefined;
     }
+    interface StaticEventEmitterIteratorOptions extends StaticEventEmitterOptions {
+        /**
+         * Names of events that will end the iteration.
+         */
+        close?: string[];
+        /**
+         * The emitter is paused every time the size of events being buffered is higher than it. Supported only on emitters implementing pause() and resume() methods.
+         * @default Number.MAX_SAFE_INTEGER
+         */
+        highWaterMark?: number;
+        /**
+         * The emitter is resumed every time the size of events being buffered is lower than it. Supported only on emitters implementing pause() and resume() methods.
+         * @default 1
+         */
+        lowWaterMark?: number
+    }
     interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
     type EventMap<T> = Record<keyof T, any[]> | DefaultEventMap;
     type DefaultEventMap = [never];
@@ -254,6 +270,28 @@ declare module "events" {
          *
          * process.nextTick(() => ac.abort());
          * ```
+         *
+         * Use the `close` option to specify an array of event names that will end the iteration:
+         *
+         * ```js
+         * import { on, EventEmitter } from 'node:events';
+         * import process from 'node:process';
+         *
+         * const ee = new EventEmitter();
+         *
+         * // Emit later on
+         * process.nextTick(() => {
+         *   ee.emit('foo', 'bar');
+         *   ee.emit('foo', 42);
+         *   ee.emit('close');
+         * });
+         *
+         * for await (const event of on(ee, 'foo', { close: ['close'] })) {
+         *   console.log(event); // prints ['bar'] [42]
+         * }
+         * // the loop will exit after 'close' is emitted
+         * console.log('done'); // prints 'done'
+         * ```
          * @since v13.6.0, v12.16.0
          * @param eventName The name of the event being listened for
          * @return An `AsyncIterator` that iterates `eventName` events emitted by the `emitter`
@@ -261,7 +299,7 @@ declare module "events" {
         static on(
             emitter: NodeJS.EventEmitter,
             eventName: string,
-            options?: StaticEventEmitterOptions,
+            options?: StaticEventEmitterIteratorOptions,
         ): AsyncIterableIterator<any>;
         /**
          * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.

--- a/types/node/test/events.ts
+++ b/types/node/test/events.ts
@@ -100,6 +100,9 @@ async function test() {
         console.log(e);
     }
     events.on(new events.EventEmitter(), "test", { signal: new AbortController().signal });
+    events.on(new events.EventEmitter(), "test", { close: ["close"] });
+    events.on(new events.EventEmitter(), "test", { highWaterMark: 42 });
+    events.on(new events.EventEmitter(), "test", { lowWaterMark: 42 });
 }
 
 {


### PR DESCRIPTION
This pull request adds the missing options `close`, `highWaterMark`, and `lowWaterMark` to the options interface for `events.on`. They were probably missing because they forgot to add docs for it (https://github.com/nodejs/node/pull/52080).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v20.x/api/events.html#eventsonemitter-eventname-options

