### PR TITLE
[forge-viewer] added new error codes

### DIFF
--- a/types/forge-viewer/forge-viewer-tests.ts
+++ b/types/forge-viewer/forge-viewer-tests.ts
@@ -761,7 +761,6 @@ async function dbIdRemappingTest(viewer: Autodesk.Viewing.GuiViewer3D): Promise<
 }
 
 function errorCodeTests(): void {
-
     // $ExpectType ErrorCodes.UNKNOWN_FAILURE
     Autodesk.Viewing.ErrorCodes.UNKNOWN_FAILURE;
     // $ExpectType ErrorCodes.BAD_DATA
@@ -794,6 +793,4 @@ function errorCodeTests(): void {
     Autodesk.Viewing.ErrorCodes.WEBGL_LOST_CONTEXT;
     // $ExpectType ErrorCodes.LOAD_CANCELED
     Autodesk.Viewing.ErrorCodes.LOAD_CANCELED;
-
-
 }

--- a/types/forge-viewer/forge-viewer-tests.ts
+++ b/types/forge-viewer/forge-viewer-tests.ts
@@ -47,6 +47,7 @@ Autodesk.Viewing.Initializer(options, async () => {
     showHideTests(viewer);
     worldUpTests(viewer);
     selectionTests(viewer);
+    errorCodeTests();
     await bulkPropertiesTests(model);
     await compGeomTests(viewer);
     await dataVizTests(viewer);
@@ -757,4 +758,42 @@ async function dbIdRemappingTest(viewer: Autodesk.Viewing.GuiViewer3D): Promise<
         _processLoadResult.call(this, result);
         this.model.idRemap = result.dbidOldToNew;
     };
+}
+
+function errorCodeTests(): void {
+
+    // $ExpectType ErrorCodes.UNKNOWN_FAILURE
+    Autodesk.Viewing.ErrorCodes.UNKNOWN_FAILURE;
+    // $ExpectType ErrorCodes.BAD_DATA
+    Autodesk.Viewing.ErrorCodes.BAD_DATA;
+    // $ExpectType ErrorCodes.NETWORK_FAILURE
+    Autodesk.Viewing.ErrorCodes.NETWORK_FAILURE;
+    // $ExpectType ErrorCodes.NETWORK_ACCESS_DENIED
+    Autodesk.Viewing.ErrorCodes.NETWORK_ACCESS_DENIED;
+    // $ExpectType ErrorCodes.NETWORK_FILE_NOT_FOUND
+    Autodesk.Viewing.ErrorCodes.NETWORK_FILE_NOT_FOUND;
+    // $ExpectType ErrorCodes.NETWORK_SERVER_ERROR
+    Autodesk.Viewing.ErrorCodes.NETWORK_SERVER_ERROR;
+    // $ExpectType ErrorCodes.NETWORK_UNHANDLED_RESPONSE_CODE
+    Autodesk.Viewing.ErrorCodes.NETWORK_UNHANDLED_RESPONSE_CODE;
+    // $ExpectType ErrorCodes.BROWSER_WEBGL_NOT_SUPPORTED
+    Autodesk.Viewing.ErrorCodes.BROWSER_WEBGL_NOT_SUPPORTED;
+    // $ExpectType ErrorCodes.BAD_DATA_NO_VIEWABLE_CONTENT
+    Autodesk.Viewing.ErrorCodes.BAD_DATA_NO_VIEWABLE_CONTENT;
+    // $ExpectType ErrorCodes.BROWSER_WEBGL_DISABLED
+    Autodesk.Viewing.ErrorCodes.BROWSER_WEBGL_DISABLED;
+    // $ExpectType ErrorCodes.BAD_DATA_MODEL_IS_EMPTY
+    Autodesk.Viewing.ErrorCodes.BAD_DATA_MODEL_IS_EMPTY;
+    // $ExpectType ErrorCodes.RTC_ERROR
+    Autodesk.Viewing.ErrorCodes.RTC_ERROR;
+    // $ExpectType ErrorCodes.UNSUPORTED_FILE_EXTENSION
+    Autodesk.Viewing.ErrorCodes.UNSUPORTED_FILE_EXTENSION;
+    // $ExpectType ErrorCodes.VIEWER_INTERNAL_ERROR
+    Autodesk.Viewing.ErrorCodes.VIEWER_INTERNAL_ERROR;
+    // $ExpectType ErrorCodes.WEBGL_LOST_CONTEXT
+    Autodesk.Viewing.ErrorCodes.WEBGL_LOST_CONTEXT;
+    // $ExpectType ErrorCodes.LOAD_CANCELED
+    Autodesk.Viewing.ErrorCodes.LOAD_CANCELED;
+
+
 }

--- a/types/forge-viewer/index.d.ts
+++ b/types/forge-viewer/index.d.ts
@@ -32,6 +32,8 @@ declare namespace Autodesk {
             RTC_ERROR = 12,
             UNSUPORTED_FILE_EXTENSION = 13,
             VIEWER_INTERNAL_ERROR = 14,
+            WEBGL_LOST_CONTEXT = 15,
+            LOAD_CANCELED = 16,
         }
 
         enum SelectionMode {


### PR DESCRIPTION
Added 2 missing error codes in `Autodesk.Viewing.ErrorCodes`

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
<https://aps.autodesk.com/en/docs/viewer/v7/reference/ErrorCodes/>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.