### PR TITLE
[@types/wordpress__block-editor] Allow first param of innerBlocksProps to be output of useBlockProps

### DIFF
--- a/types/wordpress__block-editor/components/use-block-props.d.ts
+++ b/types/wordpress__block-editor/components/use-block-props.d.ts
@@ -24,7 +24,7 @@ export interface UseBlockProps {
                 [K in keyof Props]: K extends keyof Reserved ? never : Props[K];
             }
             & { ref?: Ref<unknown> },
-    ): Omit<Props, "ref"> & Merged & Reserved;
+    ): Omit<Props, "ref"> & Merged & Reserved & Record<string, unknown>;
 
     save: (props?: Record<string, unknown>) => Record<string, unknown>;
 }

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -612,6 +612,12 @@ be.useBlockProps.save({ foo: "bar" });
     children;
 }
 
+{
+    // Allow using blockProps as first parameter in useInnerBlocksProps.
+    const blockProps = be.useBlockProps({ foo: "bar" });
+    const innerBlocksProps = be.useInnerBlocksProps(blockProps);
+}
+
 // $ExpectType Record<string, unknown>
 be.useInnerBlocksProps.save();
 


### PR DESCRIPTION
This PR enables users to use the output of `useBlockProps` as the first parameter in `useInnerBlocksProps`. This seems to be the most common use case for using `useInnerBlocksProps` over `<InnerBlocks />` so should definitely be supported.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Wordpress Use Inner Blocks Props Documentation](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/nested-blocks-inner-blocks/#using-a-react-hook)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.