### PR TITLE
API Gateway Policy Effect can only be `Allow` or `Deny` in @types/aws-lambda

### DIFF
--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -48,6 +48,7 @@ import {
     ProxyCallback,
     ProxyHandler,
     Statement,
+    StatementEffect,
 } from "aws-lambda";
 
 interface CustomAuthorizerContext extends APIGatewayAuthorizerResultContext {
@@ -757,7 +758,7 @@ const legacyAuthorizerHandler: CustomAuthorizerHandler = async (event, context, 
     return result;
 };
 
-function createPolicyDocument(effect: "Allow" | "Deny" = "Deny"): PolicyDocument {
+function createPolicyDocument(effect: StatementEffect = "Deny"): PolicyDocument {
     let statement: Statement = {
         Action: str,
         Effect: effect,

--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -757,10 +757,10 @@ const legacyAuthorizerHandler: CustomAuthorizerHandler = async (event, context, 
     return result;
 };
 
-function createPolicyDocument(): PolicyDocument {
+function createPolicyDocument(effect: 'Allow' | 'Deny' = 'Deny'): PolicyDocument {
     let statement: Statement = {
         Action: str,
-        Effect: str,
+        Effect: effect,
         Resource: str,
     };
 
@@ -786,7 +786,7 @@ function createPolicyDocument(): PolicyDocument {
     statement = {
         Sid: str,
         Action: [str, str],
-        Effect: str,
+        Effect: effect,
         Resource: [str, str],
         Condition: {
             condition1: { key: "value" },
@@ -804,11 +804,11 @@ function createPolicyDocument(): PolicyDocument {
         NotPrincipal: [str, str],
     };
 
-    statement = { Action: str, Principal: str, Effect: str };
+    statement = { Action: str, Principal: str, Effect: effect };
 
-    statement = { Action: str, NotPrincipal: { Service: str }, Effect: str };
+    statement = { Action: str, NotPrincipal: { Service: str }, Effect: effect };
 
-    statement = { Effect: str, NotAction: str, NotResource: str };
+    statement = { Effect: effect, NotAction: str, NotResource: str };
 
     let policyDocument: PolicyDocument = { Version: str, Statement: [statement] };
 

--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -781,15 +781,15 @@ function createPolicyDocument(effect: "Allow" | "Deny" = "Deny"): PolicyDocument
 
     // Lowercase allow for effect
     // @ts-expect-error
-    statement = { Effect: 'allow', Action: str, Resource: 123 };
+    statement = { Effect: "allow", Action: str, Resource: 123 };
 
     // Lowercase deny for effect
     // @ts-expect-error
-    statement = { Effect: 'deny', Action: str, Resource: 123 };
+    statement = { Effect: "deny", Action: str, Resource: 123 };
 
     // Invalid effect
     // @ts-expect-error
-    statement = { Effect: 'foo', Action: str, Resource: 123 };
+    statement = { Effect: "foo", Action: str, Resource: 123 };
 
     // No Effect
     // @ts-expect-error

--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -779,6 +779,18 @@ function createPolicyDocument(effect: "Allow" | "Deny" = "Deny"): PolicyDocument
     // @ts-expect-error
     statement = { Effect: str, Action: str, Principal: 123, Resource: str };
 
+    // Lowercase allow for effect
+    // @ts-expect-error
+    statement = { Effect: 'allow', Action: str, Resource: 123 };
+
+    // Lowercase deny for effect
+    // @ts-expect-error
+    statement = { Effect: 'deny', Action: str, Resource: 123 };
+
+    // Invalid effect
+    // @ts-expect-error
+    statement = { Effect: 'foo', Action: str, Resource: 123 };
+
     // No Effect
     // @ts-expect-error
     statement = { Action: str, Principal: str };

--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -757,7 +757,7 @@ const legacyAuthorizerHandler: CustomAuthorizerHandler = async (event, context, 
     return result;
 };
 
-function createPolicyDocument(effect: 'Allow' | 'Deny' = 'Deny'): PolicyDocument {
+function createPolicyDocument(effect: "Allow" | "Deny" = "Deny"): PolicyDocument {
     let statement: Statement = {
         Action: str,
         Effect: effect,

--- a/types/aws-lambda/test/iot-authorizer-tests.ts
+++ b/types/aws-lambda/test/iot-authorizer-tests.ts
@@ -117,15 +117,15 @@ function createPolicyDocument(effect: "Allow" | "Deny" = "Deny"): PolicyDocument
 
     // Lowercase allow for effect
     // @ts-expect-error
-    statement = { Effect: 'allow', Action: str, Resource: 123 };
+    statement = { Effect: "allow", Action: str, Resource: 123 };
 
     // Lowercase deny for effect
     // @ts-expect-error
-    statement = { Effect: 'deny', Action: str, Resource: 123 };
+    statement = { Effect: "deny", Action: str, Resource: 123 };
 
     // Invalid effect
     // @ts-expect-error
-    statement = { Effect: 'foo', Action: str, Resource: 123 };
+    statement = { Effect: "foo", Action: str, Resource: 123 };
 
     // No Effect
     // @ts-expect-error

--- a/types/aws-lambda/test/iot-authorizer-tests.ts
+++ b/types/aws-lambda/test/iot-authorizer-tests.ts
@@ -115,6 +115,18 @@ function createPolicyDocument(effect: "Allow" | "Deny" = "Deny"): PolicyDocument
     // @ts-expect-error
     statement = { Effect: effect, Action: str, Principal: 123, Resource: str };
 
+    // Lowercase allow for effect
+    // @ts-expect-error
+    statement = { Effect: 'allow', Action: str, Resource: 123 };
+
+    // Lowercase deny for effect
+    // @ts-expect-error
+    statement = { Effect: 'deny', Action: str, Resource: 123 };
+
+    // Invalid effect
+    // @ts-expect-error
+    statement = { Effect: 'foo', Action: str, Resource: 123 };
+
     // No Effect
     // @ts-expect-error
     statement = { Action: str, Principal: str };

--- a/types/aws-lambda/test/iot-authorizer-tests.ts
+++ b/types/aws-lambda/test/iot-authorizer-tests.ts
@@ -93,7 +93,7 @@ const iotCustomAuthorizerHandler: IoTCustomAuthorizerHandler = async (event, con
     return result;
 };
 
-function createPolicyDocument(effect: 'Allow' | 'Deny' = 'Deny'): PolicyDocument {
+function createPolicyDocument(effect: "Allow" | "Deny" = "Deny"): PolicyDocument {
     let statement: Statement = {
         Action: str,
         Effect: effect,

--- a/types/aws-lambda/test/iot-authorizer-tests.ts
+++ b/types/aws-lambda/test/iot-authorizer-tests.ts
@@ -8,6 +8,7 @@ import {
     IoTProtocolType,
     PolicyDocument,
     Statement,
+    StatementEffect,
 } from "aws-lambda";
 
 // IoT Custom Authorizer
@@ -93,7 +94,7 @@ const iotCustomAuthorizerHandler: IoTCustomAuthorizerHandler = async (event, con
     return result;
 };
 
-function createPolicyDocument(effect: "Allow" | "Deny" = "Deny"): PolicyDocument {
+function createPolicyDocument(effect: StatementEffect = "Deny"): PolicyDocument {
     let statement: Statement = {
         Action: str,
         Effect: effect,

--- a/types/aws-lambda/test/iot-authorizer-tests.ts
+++ b/types/aws-lambda/test/iot-authorizer-tests.ts
@@ -93,27 +93,27 @@ const iotCustomAuthorizerHandler: IoTCustomAuthorizerHandler = async (event, con
     return result;
 };
 
-function createPolicyDocument(): PolicyDocument {
+function createPolicyDocument(effect: 'Allow' | 'Deny' = 'Deny'): PolicyDocument {
     let statement: Statement = {
         Action: str,
-        Effect: str,
+        Effect: effect,
         Resource: str,
     };
 
     // @ts-expect-error
-    statement = { Effect: str, Action: str, Principal: 123 };
+    statement = { Effect: effect, Action: str, Principal: 123 };
 
     // Bad Resource
     // @ts-expect-error
-    statement = { Effect: str, Action: str, Resource: 123 };
+    statement = { Effect: effect, Action: str, Resource: 123 };
 
     // Bad Resource with valid Principal
     // @ts-expect-error
-    statement = { Effect: str, Action: str, Principal: { Service: str }, Resource: 123 };
+    statement = { Effect: effect, Action: str, Principal: { Service: str }, Resource: 123 };
 
     // Bad principal with valid Resource
     // @ts-expect-error
-    statement = { Effect: str, Action: str, Principal: 123, Resource: str };
+    statement = { Effect: effect, Action: str, Principal: 123, Resource: str };
 
     // No Effect
     // @ts-expect-error
@@ -122,7 +122,7 @@ function createPolicyDocument(): PolicyDocument {
     statement = {
         Sid: str,
         Action: [str, str],
-        Effect: str,
+        Effect: effect,
         Resource: [str, str],
         Condition: {
             condition1: { key: "value" },
@@ -140,11 +140,11 @@ function createPolicyDocument(): PolicyDocument {
         NotPrincipal: [str, str],
     };
 
-    statement = { Action: str, Principal: str, Effect: str };
+    statement = { Action: str, Principal: str, Effect: effect };
 
-    statement = { Action: str, NotPrincipal: { Service: str }, Effect: str };
+    statement = { Action: str, NotPrincipal: { Service: str }, Effect: effect };
 
-    statement = { Effect: str, NotAction: str, NotResource: str };
+    statement = { Effect: effect, NotAction: str, NotResource: str };
 
     let policyDocument: PolicyDocument = { Version: str, Statement: [statement] };
 

--- a/types/aws-lambda/trigger/api-gateway-authorizer.d.ts
+++ b/types/aws-lambda/trigger/api-gateway-authorizer.d.ts
@@ -221,7 +221,7 @@ export interface Condition {
 export type Statement = BaseStatement & StatementAction & (StatementResource | StatementPrincipal);
 
 export interface BaseStatement {
-    Effect: 'Allow' | 'Deny';
+    Effect: "Allow" | "Deny";
     Sid?: string | undefined;
     Condition?: ConditionBlock | undefined;
 }

--- a/types/aws-lambda/trigger/api-gateway-authorizer.d.ts
+++ b/types/aws-lambda/trigger/api-gateway-authorizer.d.ts
@@ -221,7 +221,7 @@ export interface Condition {
 export type Statement = BaseStatement & StatementAction & (StatementResource | StatementPrincipal);
 
 export interface BaseStatement {
-    Effect: string;
+    Effect: 'Allow' | 'Deny';
     Sid?: string | undefined;
     Condition?: ConditionBlock | undefined;
 }

--- a/types/aws-lambda/trigger/api-gateway-authorizer.d.ts
+++ b/types/aws-lambda/trigger/api-gateway-authorizer.d.ts
@@ -220,8 +220,10 @@ export interface Condition {
  */
 export type Statement = BaseStatement & StatementAction & (StatementResource | StatementPrincipal);
 
+export type StatementEffect = "Allow" | "Deny";
+
 export interface BaseStatement {
-    Effect: "Allow" | "Deny";
+    Effect: StatementEffect;
     Sid?: string | undefined;
     Condition?: ConditionBlock | undefined;
 }


### PR DESCRIPTION
API Gateway Policy Effect can only be `Allow` or `Deny` as mentioned in [the API Gateway Control Access Policy Language documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-control-access-policy-language-overview.html)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
