### PR TITLE
[node] Revert 20.13 changes that were missing version bump

### DIFF
--- a/types/node/assert.d.ts
+++ b/types/node/assert.d.ts
@@ -1,7 +1,7 @@
 /**
  * The `node:assert` module provides a set of assertion functions for verifying
  * invariants.
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/assert.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/assert.js)
  */
 declare module "assert" {
     /**

--- a/types/node/async_hooks.d.ts
+++ b/types/node/async_hooks.d.ts
@@ -12,7 +12,7 @@
  * import async_hooks from 'node:async_hooks';
  * ```
  * @experimental
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/async_hooks.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/async_hooks.js)
  */
 declare module "async_hooks" {
     /**

--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -41,7 +41,7 @@
  * // Creates a Buffer containing the Latin-1 bytes [0x74, 0xe9, 0x73, 0x74].
  * const buf7 = Buffer.from('tést', 'latin1');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/buffer.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/buffer.js)
  */
 declare module "buffer" {
     import { BinaryLike } from "node:crypto";

--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -25,7 +25,7 @@
  * limited (and platform-specific) capacity. If the subprocess writes to
  * stdout in excess of that limit without the output being captured, the
  * subprocess blocks waiting for the pipe buffer to accept more data. This is
- * identical to the behavior of pipes in the shell. Use the `{ stdio: 'ignore' }` option if the output will not be consumed.
+ * identical to the behavior of pipes in the shell. Use the `{ stdio: 'ignore' }`option if the output will not be consumed.
  *
  * The command lookup is performed using the `options.env.PATH` environment
  * variable if `env` is in the `options` object. Otherwise, `process.env.PATH` is
@@ -38,7 +38,7 @@
  * lexicographically sorts the `env` keys and uses the first one that
  * case-insensitively matches. Only first (in lexicographic order) entry will be
  * passed to the subprocess. This might lead to issues on Windows when passing
- * objects to the `env` option that have multiple variants of the same key, such as `PATH` and `Path`.
+ * objects to the `env` option that have multiple variants of the same key, such as`PATH` and `Path`.
  *
  * The {@link spawn} method spawns the child process asynchronously,
  * without blocking the Node.js event loop. The {@link spawnSync} function provides equivalent functionality in a synchronous manner that blocks
@@ -63,17 +63,16 @@
  * For certain use cases, such as automating shell scripts, the `synchronous counterparts` may be more convenient. In many cases, however,
  * the synchronous methods can have significant impact on performance due to
  * stalling the event loop while spawned processes complete.
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/child_process.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/child_process.js)
  */
 declare module "child_process" {
     import { ObjectEncodingOptions } from "node:fs";
     import { Abortable, EventEmitter } from "node:events";
-    import * as dgram from "node:dgram";
     import * as net from "node:net";
     import { Pipe, Readable, Stream, Writable } from "node:stream";
     import { URL } from "node:url";
     type Serializable = string | object | number | boolean | bigint;
-    type SendHandle = net.Socket | net.Server | dgram.Socket | undefined;
+    type SendHandle = net.Socket | net.Server;
     /**
      * Instances of the `ChildProcess` represent spawned child processes.
      *
@@ -144,7 +143,7 @@ declare module "child_process" {
         /**
          * A sparse array of pipes to the child process, corresponding with positions in
          * the `stdio` option passed to {@link spawn} that have been set
-         * to the value `'pipe'`. `subprocess.stdio[0]`, `subprocess.stdio[1]`, and `subprocess.stdio[2]` are also available as `subprocess.stdin`, `subprocess.stdout`, and `subprocess.stderr`,
+         * to the value `'pipe'`. `subprocess.stdio[0]`, `subprocess.stdio[1]`, and`subprocess.stdio[2]` are also available as `subprocess.stdin`,`subprocess.stdout`, and `subprocess.stderr`,
          * respectively.
          *
          * In the following example, only the child's fd `1` (stdout) is configured as a
@@ -213,7 +212,7 @@ declare module "child_process" {
         readonly pid?: number | undefined;
         /**
          * The `subprocess.connected` property indicates whether it is still possible to
-         * send and receive messages from a child process. When `subprocess.connected` is `false`, it is no longer possible to send or receive messages.
+         * send and receive messages from a child process. When `subprocess.connected` is`false`, it is no longer possible to send or receive messages.
          * @since v0.7.2
          */
         readonly connected: boolean;
@@ -273,7 +272,7 @@ declare module "child_process" {
          * See [`kill(2)`](http://man7.org/linux/man-pages/man2/kill.2.html) for reference.
          *
          * On Windows, where POSIX signals do not exist, the `signal` argument will be
-         * ignored, and the process will be killed forcefully and abruptly (similar to `'SIGKILL'`).
+         * ignored, and the process will be killed forcefully and abruptly (similar to`'SIGKILL'`).
          * See `Signal Events` for more details.
          *
          * On Linux, child processes of child processes will not be terminated
@@ -347,20 +346,20 @@ declare module "child_process" {
          *
          * There is a special case when sending a `{cmd: 'NODE_foo'}` message. Messages
          * containing a `NODE_` prefix in the `cmd` property are reserved for use within
-         * Node.js core and will not be emitted in the child's `'message'` event. Rather, such messages are emitted using the `'internalMessage'` event and are consumed internally by Node.js.
-         * Applications should avoid using such messages or listening for `'internalMessage'` events as it is subject to change without notice.
+         * Node.js core and will not be emitted in the child's `'message'` event. Rather, such messages are emitted using the`'internalMessage'` event and are consumed internally by Node.js.
+         * Applications should avoid using such messages or listening for`'internalMessage'` events as it is subject to change without notice.
          *
          * The optional `sendHandle` argument that may be passed to `subprocess.send()` is
          * for passing a TCP server or socket object to the child process. The child will
          * receive the object as the second argument passed to the callback function
-         * registered on the `'message'` event. Any data that is received and buffered in
-         * the socket will not be sent to the child. Sending IPC sockets is not supported on Windows.
+         * registered on the `'message'` event. Any data that is received
+         * and buffered in the socket will not be sent to the child.
          *
          * The optional `callback` is a function that is invoked after the message is
          * sent but before the child may have received it. The function is called with a
          * single argument: `null` on success, or an `Error` object on failure.
          *
-         * If no `callback` function is provided and the message cannot be sent, an `'error'` event will be emitted by the `ChildProcess` object. This can
+         * If no `callback` function is provided and the message cannot be sent, an`'error'` event will be emitted by the `ChildProcess` object. This can
          * happen, for instance, when the child process has already exited.
          *
          * `subprocess.send()` will return `false` if the channel has closed or when the
@@ -401,8 +400,8 @@ declare module "child_process" {
          * Once the server is now shared between the parent and child, some connections
          * can be handled by the parent and some by the child.
          *
-         * While the example above uses a server created using the `node:net` module, `node:dgram` module servers use exactly the same workflow with the exceptions of
-         * listening on a `'message'` event instead of `'connection'` and using `server.bind()` instead of `server.listen()`. This is, however, only
+         * While the example above uses a server created using the `node:net` module,`node:dgram` module servers use exactly the same workflow with the exceptions of
+         * listening on a `'message'` event instead of `'connection'` and using`server.bind()` instead of `server.listen()`. This is, however, only
          * supported on Unix platforms.
          *
          * #### Example: sending a socket object
@@ -455,7 +454,6 @@ declare module "child_process" {
          * as the connection may have been closed during the time it takes to send the
          * connection to the child.
          * @since v0.5.9
-         * @param sendHandle `undefined`, or a [`net.Socket`](https://nodejs.org/docs/latest-v20.x/api/net.html#class-netsocket), [`net.Server`](https://nodejs.org/docs/latest-v20.x/api/net.html#class-netserver), or [`dgram.Socket`](https://nodejs.org/docs/latest-v20.x/api/dgram.html#class-dgramsocket) object.
          * @param options The `options` argument, if present, is an object used to parameterize the sending of certain types of handles. `options` supports the following properties:
          */
         send(message: Serializable, callback?: (error: Error | null) => void): boolean;
@@ -484,7 +482,7 @@ declare module "child_process" {
         disconnect(): void;
         /**
          * By default, the parent will wait for the detached child to exit. To prevent the
-         * parent from waiting for a given `subprocess` to exit, use the `subprocess.unref()` method. Doing so will cause the parent's event loop to not
+         * parent from waiting for a given `subprocess` to exit, use the`subprocess.unref()` method. Doing so will cause the parent's event loop to not
          * include the child in its reference count, allowing the parent to exit
          * independently of the child, unless there is an established IPC channel between
          * the child and the parent.
@@ -680,7 +678,7 @@ declare module "child_process" {
         stdio: [Stdin, Stdout, Stderr];
     }
     /**
-     * The `child_process.spawn()` method spawns a new process using the given `command`, with command-line arguments in `args`. If omitted, `args` defaults
+     * The `child_process.spawn()` method spawns a new process using the given`command`, with command-line arguments in `args`. If omitted, `args` defaults
      * to an empty array.
      *
      * **If the `shell` option is enabled, do not pass unsanitized user input to this**
@@ -778,10 +776,10 @@ declare module "child_process" {
      * Certain platforms (macOS, Linux) will use the value of `argv[0]` for the process
      * title while others (Windows, SunOS) will use `command`.
      *
-     * Node.js overwrites `argv[0]` with `process.execPath` on startup, so `process.argv[0]` in a Node.js child process will not match the `argv0` parameter passed to `spawn` from the parent. Retrieve
-     * it with the `process.argv0` property instead.
+     * Node.js overwrites `argv[0]` with `process.execPath` on startup, so`process.argv[0]` in a Node.js child process will not match the `argv0`parameter passed to `spawn` from the parent. Retrieve
+     * it with the`process.argv0` property instead.
      *
-     * If the `signal` option is enabled, calling `.abort()` on the corresponding `AbortController` is similar to calling `.kill()` on the child process except
+     * If the `signal` option is enabled, calling `.abort()` on the corresponding`AbortController` is similar to calling `.kill()` on the child process except
      * the error passed to the callback will be an `AbortError`:
      *
      * ```js
@@ -919,9 +917,9 @@ declare module "child_process" {
      * **Never pass unsanitized user input to this function. Any input containing shell**
      * **metacharacters may be used to trigger arbitrary command execution.**
      *
-     * If a `callback` function is provided, it is called with the arguments `(error, stdout, stderr)`. On success, `error` will be `null`. On error, `error` will be an instance of `Error`. The
+     * If a `callback` function is provided, it is called with the arguments`(error, stdout, stderr)`. On success, `error` will be `null`. On error,`error` will be an instance of `Error`. The
      * `error.code` property will be
-     * the exit code of the process. By convention, any exit code other than `0` indicates an error. `error.signal` will be the signal that terminated the
+     * the exit code of the process. By convention, any exit code other than `0`indicates an error. `error.signal` will be the signal that terminated the
      * process.
      *
      * The `stdout` and `stderr` arguments passed to the callback will contain the
@@ -951,7 +949,7 @@ declare module "child_process" {
      * the existing process and uses a shell to execute the command.
      *
      * If this method is invoked as its `util.promisify()` ed version, it returns
-     * a `Promise` for an `Object` with `stdout` and `stderr` properties. The returned `ChildProcess` instance is attached to the `Promise` as a `child` property. In
+     * a `Promise` for an `Object` with `stdout` and `stderr` properties. The returned`ChildProcess` instance is attached to the `Promise` as a `child` property. In
      * case of an error (including any error resulting in an exit code other than 0), a
      * rejected promise is returned, with the same `error` object given in the
      * callback, but with two additional properties `stdout` and `stderr`.
@@ -968,7 +966,7 @@ declare module "child_process" {
      * lsExample();
      * ```
      *
-     * If the `signal` option is enabled, calling `.abort()` on the corresponding `AbortController` is similar to calling `.kill()` on the child process except
+     * If the `signal` option is enabled, calling `.abort()` on the corresponding`AbortController` is similar to calling `.kill()` on the child process except
      * the error passed to the callback will be an `AbortError`:
      *
      * ```js
@@ -1113,7 +1111,7 @@ declare module "child_process" {
      * encoding, `Buffer` objects will be passed to the callback instead.
      *
      * If this method is invoked as its `util.promisify()` ed version, it returns
-     * a `Promise` for an `Object` with `stdout` and `stderr` properties. The returned `ChildProcess` instance is attached to the `Promise` as a `child` property. In
+     * a `Promise` for an `Object` with `stdout` and `stderr` properties. The returned`ChildProcess` instance is attached to the `Promise` as a `child` property. In
      * case of an error (including any error resulting in an exit code other than 0), a
      * rejected promise is returned, with the same `error` object given in the
      * callback, but with two additional properties `stdout` and `stderr`.
@@ -1132,7 +1130,7 @@ declare module "child_process" {
      * **function. Any input containing shell metacharacters may be used to trigger**
      * **arbitrary command execution.**
      *
-     * If the `signal` option is enabled, calling `.abort()` on the corresponding `AbortController` is similar to calling `.kill()` on the child process except
+     * If the `signal` option is enabled, calling `.abort()` on the corresponding`AbortController` is similar to calling `.kill()` on the child process except
      * the error passed to the callback will be an `AbortError`:
      *
      * ```js
@@ -1356,7 +1354,7 @@ declare module "child_process" {
      * required, spawning a large number of child Node.js processes is not
      * recommended.
      *
-     * By default, `child_process.fork()` will spawn new Node.js instances using the `process.execPath` of the parent process. The `execPath` property in the `options` object allows for an alternative
+     * By default, `child_process.fork()` will spawn new Node.js instances using the `process.execPath` of the parent process. The `execPath` property in the`options` object allows for an alternative
      * execution path to be used.
      *
      * Node.js processes launched with a custom `execPath` will communicate with the
@@ -1366,9 +1364,9 @@ declare module "child_process" {
      * Unlike the [`fork(2)`](http://man7.org/linux/man-pages/man2/fork.2.html) POSIX system call, `child_process.fork()` does not clone the
      * current process.
      *
-     * The `shell` option available in {@link spawn} is not supported by `child_process.fork()` and will be ignored if set.
+     * The `shell` option available in {@link spawn} is not supported by`child_process.fork()` and will be ignored if set.
      *
-     * If the `signal` option is enabled, calling `.abort()` on the corresponding `AbortController` is similar to calling `.kill()` on the child process except
+     * If the `signal` option is enabled, calling `.abort()` on the corresponding`AbortController` is similar to calling `.kill()` on the child process except
      * the error passed to the callback will be an `AbortError`:
      *
      * ```js
@@ -1477,7 +1475,7 @@ declare module "child_process" {
      * The `child_process.execSync()` method is generally identical to {@link exec} with the exception that the method will not return
      * until the child process has fully closed. When a timeout has been encountered
      * and `killSignal` is sent, the method won't return until the process has
-     * completely exited. If the child process intercepts and handles the `SIGTERM` signal and doesn't exit, the parent process will wait until the child process
+     * completely exited. If the child process intercepts and handles the `SIGTERM`signal and doesn't exit, the parent process will wait until the child process
      * has exited.
      *
      * If the process times out or has a non-zero exit code, this method will throw.

--- a/types/node/cluster.d.ts
+++ b/types/node/cluster.d.ts
@@ -50,7 +50,7 @@
  * ```
  *
  * On Windows, it is not yet possible to set up a named pipe server in a worker.
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/cluster.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/cluster.js)
  */
 declare module "cluster" {
     import * as child from "node:child_process";

--- a/types/node/console.d.ts
+++ b/types/node/console.d.ts
@@ -54,7 +54,7 @@
  * myConsole.warn(`Danger ${name}! Danger!`);
  * // Prints: Danger Will Robinson! Danger!, to err
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/console.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/console.js)
  */
 declare module "console" {
     import console = require("node:console");

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -14,7 +14,7 @@
  * // Prints:
  * //   c0fa1bc00531bd78ef38c628449c5102aeabd49b5dc3a2a516ea6ea959d6658e
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/crypto.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/crypto.js)
  */
 declare module "crypto" {
     import * as stream from "node:stream";
@@ -470,7 +470,6 @@ declare module "crypto" {
      * //   7fd04df92f636fd450bc841c9418e5825c17f33ad9c87c518115a45971f7f77e
      * ```
      * @since v0.1.94
-     * @deprecated Since v20.13.0 Calling `Hmac` class directly with `Hmac()` or `new Hmac()` is deprecated due to being internals, not intended for public use. Please use the {@link createHmac} method to create Hmac instances.
      */
     class Hmac extends stream.Transform {
         private constructor();

--- a/types/node/dgram.d.ts
+++ b/types/node/dgram.d.ts
@@ -23,7 +23,7 @@
  * server.bind(41234);
  * // Prints: server listening 0.0.0.0:41234
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/dgram.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/dgram.js)
  */
 declare module "dgram" {
     import { AddressInfo } from "node:net";

--- a/types/node/diagnostics_channel.d.ts
+++ b/types/node/diagnostics_channel.d.ts
@@ -20,7 +20,7 @@
  * should generally include the module name to avoid collisions with data from
  * other modules.
  * @since v15.1.0, v14.17.0
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/diagnostics_channel.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/diagnostics_channel.js)
  */
 declare module "diagnostics_channel" {
     import { AsyncLocalStorage } from "node:async_hooks";
@@ -419,9 +419,6 @@ declare module "diagnostics_channel" {
          * This will run the given function using `channel.runStores(context, ...)` on the `start` channel which ensures all
          * events should have any bound stores set to match this trace context.
          *
-         * To ensure only correct trace graphs are formed, events will only be published if subscribers are present prior to starting the trace. Subscriptions
-         * which are added after the trace begins will not receive future events from that trace, only future traces will be seen.
-         *
          * ```js
          * import diagnostics_channel from 'node:diagnostics_channel';
          *
@@ -453,9 +450,6 @@ declare module "diagnostics_channel" {
          * produce an `error event` if the given function throws an error or the
          * returned promise rejects. This will run the given function using `channel.runStores(context, ...)` on the `start` channel which ensures all
          * events should have any bound stores set to match this trace context.
-         *
-         * To ensure only correct trace graphs are formed, events will only be published if subscribers are present prior to starting the trace. Subscriptions
-         * which are added after the trace begins will not receive future events from that trace, only future traces will be seen.
          *
          * ```js
          * import diagnostics_channel from 'node:diagnostics_channel';
@@ -507,9 +501,6 @@ declare module "diagnostics_channel" {
          *
          * The callback will also be run with `channel.runStores(context, ...)` which
          * enables context loss recovery in some cases.
-         *
-         * To ensure only correct trace graphs are formed, events will only be published if subscribers are present prior to starting the trace. Subscriptions
-         * which are added after the trace begins will not receive future events from that trace, only future traces will be seen.
          *
          * ```js
          * import diagnostics_channel from 'node:diagnostics_channel';

--- a/types/node/dns.d.ts
+++ b/types/node/dns.d.ts
@@ -42,7 +42,7 @@
  * ```
  *
  * See the [Implementation considerations section](https://nodejs.org/docs/latest-v20.x/api/dns.html#implementation-considerations) for more information.
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/dns.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/dns.js)
  */
 declare module "dns" {
     import * as dnsPromises from "node:dns/promises";
@@ -64,7 +64,7 @@ declare module "dns" {
     export const ALL: number;
     export interface LookupOptions {
         /**
-         * The record family. Must be `4`, `6`, or `0`. For backward compatibility reasons, `'IPv4'` and `'IPv6'` are interpreted
+         * The record family. Must be `4`, `6`, or `0`. For backward compatibility reasons,`'IPv4'` and `'IPv6'` are interpreted
          * as `4` and `6` respectively. The value 0 indicates that either an IPv4 or IPv6 address is returned. If the value `0` is used
          * with `{ all: true } (see below)`, both IPv4 and IPv6 addresses are returned.
          * @default 0
@@ -81,17 +81,8 @@ declare module "dns" {
          */
         all?: boolean | undefined;
         /**
-         * When `verbatim`, the resolved addresses are return unsorted. When `ipv4first`, the resolved addresses are sorted
-         * by placing IPv4 addresses before IPv6 addresses. When `ipv6first`, the resolved addresses are sorted by placing IPv6
-         * addresses before IPv4 addresses. Default value is configurable using
-         * {@link setDefaultResultOrder} or [`--dns-result-order`](https://nodejs.org/docs/latest-v20.x/api/cli.html#--dns-result-orderorder).
-         * @default `verbatim` (addresses are not reordered)
-         */
-        order?: "ipv4first" | "ipv6first" | "verbatim" | undefined;
-        /**
          * When `true`, the callback receives IPv4 and IPv6 addresses in the order the DNS resolver returned them. When `false`, IPv4
-         * addresses are placed before IPv6 addresses. This option will be deprecated in favor of `order`. When both are specified,
-         * `order` has higher precedence. New code should only use `order`. Default value is configurable using {@link setDefaultResultOrder}
+         * addresses are placed before IPv6 addresses. Default value is configurable using {@link setDefaultResultOrder()}
          * or [`--dns-result-order`](https://nodejs.org/docs/latest-v20.x/api/cli.html#--dns-result-orderorder).
          * @default true (addresses are not reordered)
          */
@@ -672,15 +663,14 @@ declare module "dns" {
         callback: (err: NodeJS.ErrnoException | null, hostnames: string[]) => void,
     ): void;
     /**
-     * Get the default value for `order` in {@link lookup} and [`dnsPromises.lookup()`](https://nodejs.org/docs/latest-v20.x/api/dns.html#dnspromiseslookuphostname-options).
+     * Get the default value for `verbatim` in {@link lookup} and [`dnsPromises.lookup()`](https://nodejs.org/docs/latest-v20.x/api/dns.html#dnspromiseslookuphostname-options).
      * The value could be:
      *
-     * * `ipv4first`: for `order` defaulting to `ipv4first`.
-     * * `ipv6first`: for `order` defaulting to `ipv6first`.
-     * * `verbatim`: for `order` defaulting to `verbatim`.
+     * * `ipv4first`: for `verbatim` defaulting to `false`.
+     * * `verbatim`: for `verbatim` defaulting to `true`.
      * @since v18.17.0
      */
-    export function getDefaultResultOrder(): "ipv4first" | "ipv6first" | "verbatim";
+    export function getDefaultResultOrder(): "ipv4first" | "verbatim";
     /**
      * Sets the IP address and port of servers to be used when performing DNS
      * resolution. The `servers` argument is an array of [RFC 5952](https://tools.ietf.org/html/rfc5952#section-6) formatted
@@ -727,21 +717,20 @@ declare module "dns" {
      */
     export function getServers(): string[];
     /**
-     * Set the default value of `order` in {@link lookup} and [`dnsPromises.lookup()`](https://nodejs.org/docs/latest-v20.x/api/dns.html#dnspromiseslookuphostname-options).
+     * Set the default value of `verbatim` in {@link lookup} and [`dnsPromises.lookup()`](https://nodejs.org/docs/latest-v20.x/api/dns.html#dnspromiseslookuphostname-options).
      * The value could be:
      *
-     * * `ipv4first`: sets default `order` to `ipv4first`.
-     * * `ipv6first`: sets default `order` to `ipv6first`.
-     * * `verbatim`: sets default `order` to `verbatim`.
+     * * `ipv4first`: sets default `verbatim` `false`.
+     * * `verbatim`: sets default `verbatim` `true`.
      *
      * The default is `verbatim` and {@link setDefaultResultOrder} have higher
      * priority than [`--dns-result-order`](https://nodejs.org/docs/latest-v20.x/api/cli.html#--dns-result-orderorder). When using
      * [worker threads](https://nodejs.org/docs/latest-v20.x/api/worker_threads.html), {@link setDefaultResultOrder} from the main
      * thread won't affect the default dns orders in workers.
      * @since v16.4.0, v14.18.0
-     * @param order must be `'ipv4first'`, `'ipv6first'` or `'verbatim'`.
+     * @param order must be `'ipv4first'` or `'verbatim'`.
      */
-    export function setDefaultResultOrder(order: "ipv4first" | "ipv6first" | "verbatim"): void;
+    export function setDefaultResultOrder(order: "ipv4first" | "verbatim"): void;
     // Error codes
     export const NODATA: "NODATA";
     export const FORMERR: "FORMERR";

--- a/types/node/dns/promises.d.ts
+++ b/types/node/dns/promises.d.ts
@@ -338,7 +338,7 @@ declare module "dns/promises" {
      * progress.
      *
      * This method works much like [resolve.conf](https://man7.org/linux/man-pages/man5/resolv.conf.5.html).
-     * That is, if attempting to resolve with the first server provided results in a `NOTFOUND` error, the `resolve()` method will _not_ attempt to resolve with
+     * That is, if attempting to resolve with the first server provided results in a`NOTFOUND` error, the `resolve()` method will _not_ attempt to resolve with
      * subsequent servers provided. Fallback DNS servers will only be used if the
      * earlier ones time out or result in some other error.
      * @since v10.6.0
@@ -346,20 +346,19 @@ declare module "dns/promises" {
      */
     function setServers(servers: readonly string[]): void;
     /**
-     * Set the default value of `order` in `dns.lookup()` and `{@link lookup}`. The value could be:
+     * Set the default value of `verbatim` in `dns.lookup()` and `dnsPromises.lookup()`. The value could be:
      *
-     * * `ipv4first`: sets default `order` to `ipv4first`.
-     * * `ipv6first`: sets default `order` to `ipv6first`.
-     * * `verbatim`: sets default `order` to `verbatim`.
+     * * `ipv4first`: sets default `verbatim` `false`.
+     * * `verbatim`: sets default `verbatim` `true`.
      *
      * The default is `verbatim` and [dnsPromises.setDefaultResultOrder()](https://nodejs.org/docs/latest-v20.x/api/dns.html#dnspromisessetdefaultresultorderorder)
      * have higher priority than [`--dns-result-order`](https://nodejs.org/docs/latest-v20.x/api/cli.html#--dns-result-orderorder).
      * When using [worker threads](https://nodejs.org/docs/latest-v20.x/api/worker_threads.html), [`dnsPromises.setDefaultResultOrder()`](https://nodejs.org/docs/latest-v20.x/api/dns.html#dnspromisessetdefaultresultorderorder)
      * from the main thread won't affect the default dns orders in workers.
      * @since v16.4.0, v14.18.0
-     * @param order must be `'ipv4first'`, `'ipv6first'` or `'verbatim'`.
+     * @param order must be `'ipv4first'` or `'verbatim'`.
      */
-    function setDefaultResultOrder(order: "ipv4first" | "ipv6first" | "verbatim"): void;
+    function setDefaultResultOrder(order: "ipv4first" | "verbatim"): void;
     const NODATA: "NODATA";
     const FORMERR: "FORMERR";
     const SERVFAIL: "SERVFAIL";

--- a/types/node/domain.d.ts
+++ b/types/node/domain.d.ts
@@ -12,7 +12,7 @@
  * will be notified, rather than losing the context of the error in the `process.on('uncaughtException')` handler, or causing the program to
  * exit immediately with an error code.
  * @deprecated Since v1.4.2 - Deprecated
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/domain.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/domain.js)
  */
 declare module "domain" {
     import EventEmitter = require("node:events");

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -32,7 +32,7 @@
  * });
  * myEmitter.emit('event');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/events.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/events.js)
  */
 declare module "events" {
     import { AsyncResource, AsyncResourceOptions } from "node:async_hooks";
@@ -76,27 +76,7 @@ declare module "events" {
         captureRejections?: boolean | undefined;
     }
     interface StaticEventEmitterOptions {
-        /**
-         * Can be used to cancel awaiting events.
-         */
         signal?: AbortSignal | undefined;
-        /**
-         * Names of events that will end the iteration.
-         */
-        close?: string[] | undefined;
-        /**
-         * The high watermark. The emitter is paused every time the size
-         * of events being buffered is higher than it. Supported only
-         * on emitters implementing `pause()` and `resume()` methods.
-         * @default `Number.MAX_SAFE_INTEGER`
-         */
-        highWaterMark?: number | undefined;
-        /**
-         * The low watermark. The emitter is resumed every time the size of events being buffered
-         * is lower than it. Supported only on emitters implementing `pause()` and `resume()` methods.
-         * @default 1
-         */
-        lowWaterMark?: number | undefined;
     }
     interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
     type EventMap<T> = Record<keyof T, any[]> | DefaultEventMap;
@@ -216,7 +196,7 @@ declare module "events" {
         static once(
             emitter: NodeJS.EventEmitter,
             eventName: string | symbol,
-            options?: Pick<StaticEventEmitterOptions, "signal">,
+            options?: StaticEventEmitterOptions,
         ): Promise<any[]>;
         static once(emitter: EventTarget, eventName: string, options?: StaticEventEmitterOptions): Promise<any[]>;
         /**

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -16,7 +16,7 @@
  *
  * All file system operations have synchronous, callback, and promise-based
  * forms, and are accessible using both CommonJS syntax and ES6 Modules (ESM).
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/fs.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/fs.js)
  */
 declare module "fs" {
     import * as stream from "node:stream";
@@ -77,7 +77,7 @@ declare module "fs" {
      * their synchronous counterparts are of this type.
      * If `bigint` in the `options` passed to those methods is true, the numeric values
      * will be `bigint` instead of `number`, and the object will contain additional
-     * nanosecond-precision properties suffixed with `Ns`. `Stat` objects are not to be created directly using the `new` keyword.
+     * nanosecond-precision properties suffixed with `Ns`.
      *
      * ```console
      * Stats {
@@ -128,7 +128,6 @@ declare module "fs" {
      *   ctime: Mon, 10 Oct 2011 23:24:11 GMT,
      *   birthtime: Mon, 10 Oct 2011 23:24:11 GMT }
      * ```
-     * @deprecated Since v20.13.0. Public constructor is deprecated.
      * @since v0.1.21
      */
     export class Stats {}

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -26,8 +26,8 @@
  *
  * See `message.headers` for details on how duplicate headers are handled.
  *
- * The raw headers as they were received are retained in the `rawHeaders` property, which is an array of `[key, value, key2, value2, ...]`. For
- * example, the previous message header object might have a `rawHeaders` list like the following:
+ * The raw headers as they were received are retained in the `rawHeaders`property, which is an array of `[key, value, key2, value2, ...]`. For
+ * example, the previous message header object might have a `rawHeaders`list like the following:
  *
  * ```js
  * [ 'ConTent-Length', '123456',
@@ -37,7 +37,7 @@
  *   'Host', 'example.com',
  *   'accepT', '*' ]
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/http.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/http.js)
  */
 declare module "http" {
     import * as stream from "node:stream";
@@ -282,8 +282,9 @@ declare module "http" {
          */
         insecureHTTPParser?: boolean | undefined;
         /**
-         * Optionally overrides the value of `--max-http-header-size` for requests received by
-         * this server, i.e. the maximum length of request headers in bytes.
+         * Optionally overrides the value of
+         * `--max-http-header-size` for requests received by this server, i.e.
+         * the maximum length of request headers in bytes.
          * @default 16384
          * @since v13.3.0
          */
@@ -387,7 +388,7 @@ declare module "http" {
          * The number of milliseconds of inactivity a server needs to wait for additional
          * incoming data, after it has finished writing the last response, before a socket
          * will be destroyed. If the server receives new data before the keep-alive
-         * timeout has fired, it will reset the regular inactivity timeout, i.e., `server.timeout`.
+         * timeout has fired, it will reset the regular inactivity timeout, i.e.,`server.timeout`.
          *
          * A value of `0` will disable the keep-alive timeout behavior on incoming
          * connections.
@@ -574,7 +575,7 @@ declare module "http" {
         readonly socket: Socket | null;
         constructor();
         /**
-         * Once a socket is associated with the message and is connected, `socket.setTimeout()` will be called with `msecs` as the first parameter.
+         * Once a socket is associated with the message and is connected,`socket.setTimeout()` will be called with `msecs` as the first parameter.
          * @since v0.9.12
          * @param callback Optional function to be called when a timeout occurs. Same as binding to the `timeout` event.
          */
@@ -690,7 +691,7 @@ declare module "http" {
          * packet.
          *
          * It is usually desired (it saves a TCP round-trip), but not when the first
-         * data is not sent until possibly much later. `outgoingMessage.flushHeaders()` bypasses the optimization and kickstarts the message.
+         * data is not sent until possibly much later. `outgoingMessage.flushHeaders()`bypasses the optimization and kickstarts the message.
          * @since v1.6.0
          */
         flushHeaders(): void;
@@ -731,7 +732,7 @@ declare module "http" {
          */
         statusMessage: string;
         /**
-         * If set to `true`, Node.js will check whether the `Content-Length` header value and the size of the body, in bytes, are equal.
+         * If set to `true`, Node.js will check whether the `Content-Length`header value and the size of the body, in bytes, are equal.
          * Mismatching the `Content-Length` header value will result
          * in an `Error` being thrown, identified by `code:``'ERR_HTTP_CONTENT_LENGTH_MISMATCH'`.
          * @since v18.10.0, v16.18.0
@@ -742,7 +743,7 @@ declare module "http" {
         detachSocket(socket: Socket): void;
         /**
          * Sends an HTTP/1.1 100 Continue message to the client, indicating that
-         * the request body should be sent. See the `'checkContinue'` event on `Server`.
+         * the request body should be sent. See the `'checkContinue'` event on`Server`.
          * @since v0.3.0
          */
         writeContinue(callback?: () => void): void;
@@ -862,10 +863,10 @@ declare module "http" {
     /**
      * This object is created internally and returned from {@link request}. It
      * represents an _in-progress_ request whose header has already been queued. The
-     * header is still mutable using the `setHeader(name, value)`, `getHeader(name)`, `removeHeader(name)` API. The actual header will
+     * header is still mutable using the `setHeader(name, value)`,`getHeader(name)`, `removeHeader(name)` API. The actual header will
      * be sent along with the first data chunk or when calling `request.end()`.
      *
-     * To get the response, add a listener for `'response'` to the request object. `'response'` will be emitted from the request object when the response
+     * To get the response, add a listener for `'response'` to the request object.`'response'` will be emitted from the request object when the response
      * headers have been received. The `'response'` event is executed with one
      * argument which is an instance of {@link IncomingMessage}.
      *
@@ -881,10 +882,10 @@ declare module "http" {
      * the data is read it will consume memory that can eventually lead to a
      * 'process out of memory' error.
      *
-     * For backward compatibility, `res` will only emit `'error'` if there is an `'error'` listener registered.
+     * For backward compatibility, `res` will only emit `'error'` if there is an`'error'` listener registered.
      *
      * Set `Content-Length` header to limit the response body size.
-     * If `response.strictContentLength` is set to `true`, mismatching the `Content-Length` header value will result in an `Error` being thrown,
+     * If `response.strictContentLength` is set to `true`, mismatching the`Content-Length` header value will result in an `Error` being thrown,
      * identified by `code:``'ERR_HTTP_CONTENT_LENGTH_MISMATCH'`.
      *
      * `Content-Length` value should be in bytes, not characters. Use `Buffer.byteLength()` to determine the length of the body in bytes.
@@ -895,7 +896,7 @@ declare module "http" {
          * The `request.aborted` property will be `true` if the request has
          * been aborted.
          * @since v0.11.14
-         * @deprecated Since v17.0.0, v16.12.0 - Check `destroyed` instead.
+         * @deprecated Since v17.0.0,v16.12.0 - Check `destroyed` instead.
          */
         aborted: boolean;
         /**
@@ -1127,7 +1128,7 @@ declare module "http" {
      * access response
      * status, headers, and data.
      *
-     * Different from its `socket` value which is a subclass of `stream.Duplex`, the `IncomingMessage` itself extends `stream.Readable` and is created separately to
+     * Different from its `socket` value which is a subclass of `stream.Duplex`, the`IncomingMessage` itself extends `stream.Readable` and is created separately to
      * parse and emit the incoming HTTP headers and payload, as the underlying socket
      * may be reused multiple times in case of keep-alive.
      * @since v0.1.17
@@ -1146,7 +1147,7 @@ declare module "http" {
          * client response, the HTTP version of the connected-to server.
          * Probably either `'1.1'` or `'1.0'`.
          *
-         * Also `message.httpVersionMajor` is the first integer and `message.httpVersionMinor` is the second.
+         * Also `message.httpVersionMajor` is the first integer and`message.httpVersionMinor` is the second.
          * @since v0.1.1
          */
         httpVersion: string;
@@ -1211,8 +1212,8 @@ declare module "http" {
          * Duplicates in raw headers are handled in the following ways, depending on the
          * header name:
          *
-         * * Duplicates of `age`, `authorization`, `content-length`, `content-type`, `etag`, `expires`, `from`, `host`, `if-modified-since`, `if-unmodified-since`, `last-modified`, `location`,
-         * `max-forwards`, `proxy-authorization`, `referer`, `retry-after`, `server`, or `user-agent` are discarded.
+         * * Duplicates of `age`, `authorization`, `content-length`, `content-type`,`etag`, `expires`, `from`, `host`, `if-modified-since`, `if-unmodified-since`,`last-modified`, `location`,
+         * `max-forwards`, `proxy-authorization`, `referer`,`retry-after`, `server`, or `user-agent` are discarded.
          * To allow duplicate values of the headers listed above to be joined,
          * use the option `joinDuplicateHeaders` in {@link request} and {@link createServer}. See RFC 9110 Section 5.3 for more
          * information.
@@ -1306,32 +1307,29 @@ declare module "http" {
          * To parse the URL into its parts:
          *
          * ```js
-         * new URL(`http://${process.env.HOST ?? 'localhost'}${request.url}`);
+         * new URL(request.url, `http://${request.headers.host}`);
          * ```
          *
-         * When `request.url` is `'/status?name=ryan'` and `process.env.HOST` is undefined:
+         * When `request.url` is `'/status?name=ryan'` and `request.headers.host` is`'localhost:3000'`:
          *
          * ```console
          * $ node
-         * > new URL(`http://${process.env.HOST ?? 'localhost'}${request.url}`);
+         * > new URL(request.url, `http://${request.headers.host}`)
          * URL {
-         *   href: 'http://localhost/status?name=ryan',
-         *   origin: 'http://localhost',
+         *   href: 'http://localhost:3000/status?name=ryan',
+         *   origin: 'http://localhost:3000',
          *   protocol: 'http:',
          *   username: '',
          *   password: '',
-         *   host: 'localhost',
+         *   host: 'localhost:3000',
          *   hostname: 'localhost',
-         *   port: '',
+         *   port: '3000',
          *   pathname: '/status',
          *   search: '?name=ryan',
          *   searchParams: URLSearchParams { 'name' => 'ryan' },
          *   hash: ''
          * }
          * ```
-         *
-         * Ensure that you set `process.env.HOST` to the server's host name, or consider replacing this part entirely. If using `req.headers.host`, ensure proper
-         * validation is used, as clients may specify a custom `Host` header.
          * @since v0.1.90
          */
         url?: string | undefined;
@@ -1350,7 +1348,7 @@ declare module "http" {
          */
         statusMessage?: string | undefined;
         /**
-         * Calls `destroy()` on the socket that received the `IncomingMessage`. If `error` is provided, an `'error'` event is emitted on the socket and `error` is passed
+         * Calls `destroy()` on the socket that received the `IncomingMessage`. If `error`is provided, an `'error'` event is emitted on the socket and `error` is passed
          * as an argument to any listeners on the event.
          * @since v0.3.0
          */
@@ -1394,7 +1392,7 @@ declare module "http" {
      * for a given host and port, reusing a single socket connection for each
      * until the queue is empty, at which time the socket is either destroyed
      * or put into a pool where it is kept to be used again for requests to the
-     * same host and port. Whether it is destroyed or pooled depends on the `keepAlive` `option`.
+     * same host and port. Whether it is destroyed or pooled depends on the`keepAlive` `option`.
      *
      * Pooled connections have TCP Keep-Alive enabled for them, but servers may
      * still close idle connections, in which case they will be removed from the
@@ -1425,7 +1423,7 @@ declare module "http" {
      * });
      * ```
      *
-     * An agent may also be used for an individual request. By providing `{agent: false}` as an option to the `http.get()` or `http.request()`functions, a one-time use `Agent` with default options
+     * An agent may also be used for an individual request. By providing`{agent: false}` as an option to the `http.get()` or `http.request()`functions, a one-time use `Agent` with default options
      * will be used
      * for the client connection.
      *
@@ -1440,17 +1438,6 @@ declare module "http" {
      * }, (res) => {
      *   // Do stuff with response
      * });
-     * ```
-     *
-     * `options` in [`socket.connect()`](https://nodejs.org/docs/latest-v20.x/api/net.html#socketconnectoptions-connectlistener) are also supported.
-     *
-     * To configure any of them, a custom {@link Agent} instance must be created.
-     *
-     * ```js
-     * const http = require('node:http');
-     * const keepAliveAgent = new http.Agent({ keepAlive: true });
-     * options.agent = keepAliveAgent;
-     * http.request(options, onResponseCallback)
      * ```
      * @since v0.3.4
      */
@@ -1574,7 +1561,7 @@ declare module "http" {
      * `url` can be a string or a `URL` object. If `url` is a
      * string, it is automatically parsed with `new URL()`. If it is a `URL` object, it will be automatically converted to an ordinary `options` object.
      *
-     * If both `url` and `options` are specified, the objects are merged, with the `options` properties taking precedence.
+     * If both `url` and `options` are specified, the objects are merged, with the`options` properties taking precedence.
      *
      * The optional `callback` parameter will be added as a one-time listener for
      * the `'response'` event.
@@ -1674,7 +1661,7 @@ declare module "http" {
      * the following events will be emitted in the following order:
      *
      * * `'socket'`
-     * * `'error'` with an error with message `'Error: socket hang up'` and code `'ECONNRESET'`
+     * * `'error'` with an error with message `'Error: socket hang up'` and code`'ECONNRESET'`
      * * `'close'`
      *
      * In the case of a premature connection close after the response is received,
@@ -1685,15 +1672,15 @@ declare module "http" {
      *    * `'data'` any number of times, on the `res` object
      * * (connection closed here)
      * * `'aborted'` on the `res` object
+     * * `'error'` on the `res` object with an error with message`'Error: aborted'` and code `'ECONNRESET'`
      * * `'close'`
-     * * `'error'` on the `res` object with an error with message `'Error: aborted'` and code `'ECONNRESET'`
      * * `'close'` on the `res` object
      *
      * If `req.destroy()` is called before a socket is assigned, the following
      * events will be emitted in the following order:
      *
      * * (`req.destroy()` called here)
-     * * `'error'` with an error with message `'Error: socket hang up'` and code `'ECONNRESET'`, or the error with which `req.destroy()` was called
+     * * `'error'` with an error with message `'Error: socket hang up'` and code`'ECONNRESET'`, or the error with which `req.destroy()` was called
      * * `'close'`
      *
      * If `req.destroy()` is called before the connection succeeds, the following
@@ -1701,7 +1688,7 @@ declare module "http" {
      *
      * * `'socket'`
      * * (`req.destroy()` called here)
-     * * `'error'` with an error with message `'Error: socket hang up'` and code `'ECONNRESET'`, or the error with which `req.destroy()` was called
+     * * `'error'` with an error with message `'Error: socket hang up'` and code`'ECONNRESET'`, or the error with which `req.destroy()` was called
      * * `'close'`
      *
      * If `req.destroy()` is called after the response is received, the following
@@ -1712,8 +1699,8 @@ declare module "http" {
      *    * `'data'` any number of times, on the `res` object
      * * (`req.destroy()` called here)
      * * `'aborted'` on the `res` object
+     * * `'error'` on the `res` object with an error with message `'Error: aborted'`and code `'ECONNRESET'`, or the error with which `req.destroy()` was called
      * * `'close'`
-     * * `'error'` on the `res` object with an error with message `'Error: aborted'` and code `'ECONNRESET'`, or the error with which `req.destroy()` was called
      * * `'close'` on the `res` object
      *
      * If `req.abort()` is called before a socket is assigned, the following
@@ -1729,7 +1716,7 @@ declare module "http" {
      * * `'socket'`
      * * (`req.abort()` called here)
      * * `'abort'`
-     * * `'error'` with an error with message `'Error: socket hang up'` and code `'ECONNRESET'`
+     * * `'error'` with an error with message `'Error: socket hang up'` and code`'ECONNRESET'`
      * * `'close'`
      *
      * If `req.abort()` is called after the response is received, the following
@@ -1741,16 +1728,16 @@ declare module "http" {
      * * (`req.abort()` called here)
      * * `'abort'`
      * * `'aborted'` on the `res` object
-     * * `'error'` on the `res` object with an error with message `'Error: aborted'` and code `'ECONNRESET'`.
+     * * `'error'` on the `res` object with an error with message`'Error: aborted'` and code `'ECONNRESET'`.
      * * `'close'`
      * * `'close'` on the `res` object
      *
      * Setting the `timeout` option or using the `setTimeout()` function will
      * not abort the request or do anything besides add a `'timeout'` event.
      *
-     * Passing an `AbortSignal` and then calling `abort()` on the corresponding `AbortController` will behave the same way as calling `.destroy()` on the
+     * Passing an `AbortSignal` and then calling `abort()` on the corresponding`AbortController` will behave the same way as calling `.destroy()` on the
      * request. Specifically, the `'error'` event will be emitted with an error with
-     * the message `'AbortError: The operation was aborted'`, the code `'ABORT_ERR'` and the `cause`, if one was provided.
+     * the message `'AbortError: The operation was aborted'`, the code `'ABORT_ERR'`and the `cause`, if one was provided.
      * @since v0.3.6
      */
     function request(options: RequestOptions | string | URL, callback?: (res: IncomingMessage) => void): ClientRequest;
@@ -1761,7 +1748,7 @@ declare module "http" {
     ): ClientRequest;
     /**
      * Since most requests are GET requests without bodies, Node.js provides this
-     * convenience method. The only difference between this method and {@link request} is that it sets the method to GET by default and calls `req.end()` automatically. The callback must take care to
+     * convenience method. The only difference between this method and {@link request} is that it sets the method to GET by default and calls `req.end()`automatically. The callback must take care to
      * consume the response
      * data for reasons stated in {@link ClientRequest} section.
      *
@@ -1822,7 +1809,7 @@ declare module "http" {
     function get(options: RequestOptions | string | URL, callback?: (res: IncomingMessage) => void): ClientRequest;
     function get(url: string | URL, options: RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
     /**
-     * Performs the low-level validations on the provided `name` that are done when `res.setHeader(name, value)` is called.
+     * Performs the low-level validations on the provided `name` that are done when`res.setHeader(name, value)` is called.
      *
      * Passing illegal value as `name` will result in a `TypeError` being thrown,
      * identified by `code: 'ERR_INVALID_HTTP_TOKEN'`.
@@ -1848,7 +1835,7 @@ declare module "http" {
      */
     function validateHeaderName(name: string): void;
     /**
-     * Performs the low-level validations on the provided `value` that are done when `res.setHeader(name, value)` is called.
+     * Performs the low-level validations on the provided `value` that are done when`res.setHeader(name, value)` is called.
      *
      * Passing illegal value as `value` will result in a `TypeError` being thrown.
      *
@@ -1890,12 +1877,6 @@ declare module "http" {
      * @param [max=1000]
      */
     function setMaxIdleHTTPParsers(max: number): void;
-    /**
-     * Global instance of `Agent` which is used as the default for all HTTP client
-     * requests. Diverges from a default `Agent` configuration by having `keepAlive`
-     * enabled and a `timeout` of 5 seconds.
-     * @since v0.5.9
-     */
     let globalAgent: Agent;
     /**
      * Read-only property specifying the maximum allowed size of HTTP headers in bytes.

--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -6,7 +6,7 @@
  * const http2 = require('node:http2');
  * ```
  * @since v8.4.0
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/http2.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/http2.js)
  */
 declare module "http2" {
     import EventEmitter = require("node:events");

--- a/types/node/https.d.ts
+++ b/types/node/https.d.ts
@@ -1,7 +1,7 @@
 /**
  * HTTPS is the HTTP protocol over TLS/SSL. In Node.js this is implemented as a
  * separate module.
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/https.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/https.js)
  */
 declare module "https" {
     import { Duplex } from "node:stream";

--- a/types/node/inspector.d.ts
+++ b/types/node/inspector.d.ts
@@ -20,7 +20,7 @@
  * ```js
  * import * as inspector from 'node:inspector';
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/inspector.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/inspector.js)
  */
 declare module 'inspector' {
     import EventEmitter = require('node:events');

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -10,7 +10,7 @@
  * ```js
  * const net = require('node:net');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/net.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/net.js)
  */
 declare module "net" {
     import * as stream from "node:stream";
@@ -899,16 +899,13 @@ declare module "net" {
     function setDefaultAutoSelectFamily(value: boolean): void;
     /**
      * Gets the current default value of the `autoSelectFamilyAttemptTimeout` option of `socket.connect(options)`.
-     * The initial default value is `250` or the value specified via the command line option `--network-family-autoselection-attempt-timeout`.
-     * @returns The current default value of the `autoSelectFamilyAttemptTimeout` option.
-     * @since v19.8.0, v18.8.0
+     * The initial default value is `250`.
+     * @since v19.8.0
      */
     function getDefaultAutoSelectFamilyAttemptTimeout(): number;
     /**
      * Sets the default value of the `autoSelectFamilyAttemptTimeout` option of `socket.connect(options)`.
-     * @param value The new default value, which must be a positive number. If the number is less than `10`, the value `10` is used instead. The initial default value is `250` or the value specified via the command line
-     * option `--network-family-autoselection-attempt-timeout`.
-     * @since v19.8.0, v18.8.0
+     * @since v19.8.0
      */
     function setDefaultAutoSelectFamilyAttemptTimeout(value: number): void;
     /**

--- a/types/node/os.d.ts
+++ b/types/node/os.d.ts
@@ -5,7 +5,7 @@
  * ```js
  * const os = require('node:os');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/os.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/os.js)
  */
 declare module "os" {
     interface CpuInfo {

--- a/types/node/path.d.ts
+++ b/types/node/path.d.ts
@@ -13,7 +13,7 @@ declare module "path/win32" {
  * ```js
  * const path = require('node:path');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/path.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/path.js)
  */
 declare module "path" {
     namespace path {

--- a/types/node/perf_hooks.d.ts
+++ b/types/node/perf_hooks.d.ts
@@ -27,7 +27,7 @@
  *   performance.measure('A to B', 'A', 'B');
  * });
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/perf_hooks.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/perf_hooks.js)
  */
 declare module "perf_hooks" {
     import { AsyncResource } from "node:async_hooks";
@@ -151,11 +151,6 @@ declare module "perf_hooks" {
          */
         readonly loopStart: number;
         /**
-         * The high resolution millisecond timestamp at which the Node.js process was initialized.
-         * @since v8.5.0
-         */
-        readonly nodeStart: number;
-        /**
          * The high resolution millisecond timestamp at which the V8 platform was
          * initialized.
          * @since v8.5.0
@@ -168,12 +163,12 @@ declare module "perf_hooks" {
         utilization: number;
     }
     /**
-     * @param utilization1 The result of a previous call to `eventLoopUtilization()`.
-     * @param utilization2 The result of a previous call to `eventLoopUtilization()` prior to `utilization1`.
+     * @param util1 The result of a previous call to eventLoopUtilization()
+     * @param util2 The result of a previous call to eventLoopUtilization() prior to util1
      */
     type EventLoopUtilityFunction = (
-        utilization1?: EventLoopUtilization,
-        utilization2?: EventLoopUtilization,
+        util1?: EventLoopUtilization,
+        util2?: EventLoopUtilization,
     ) => EventLoopUtilization;
     interface MarkOptions {
         /**
@@ -182,7 +177,7 @@ declare module "perf_hooks" {
         detail?: unknown | undefined;
         /**
          * An optional timestamp to be used as the mark time.
-         * @default `performance.now()`
+         * @default `performance.now()`.
          */
         startTime?: number | undefined;
     }
@@ -206,36 +201,26 @@ declare module "perf_hooks" {
     }
     interface TimerifyOptions {
         /**
-         * A histogram object created using `perf_hooks.createHistogram()` that will record runtime
-         * durations in nanoseconds.
+         * A histogram object created using
+         * `perf_hooks.createHistogram()` that will record runtime durations in
+         * nanoseconds.
          */
         histogram?: RecordableHistogram | undefined;
     }
     interface Performance {
         /**
-         * If `name` is not provided, removes all `PerformanceMark` objects from the Performance Timeline.
-         * If `name` is provided, removes only the named mark.
-         * @since v8.5.0
+         * If name is not provided, removes all PerformanceMark objects from the Performance Timeline.
+         * If name is provided, removes only the named mark.
+         * @param name
          */
         clearMarks(name?: string): void;
         /**
-         * If `name` is not provided, removes all `PerformanceMeasure` objects from the Performance Timeline.
-         * If `name` is provided, removes only the named measure.
+         * If name is not provided, removes all PerformanceMeasure objects from the Performance Timeline.
+         * If name is provided, removes only the named measure.
+         * @param name
          * @since v16.7.0
          */
         clearMeasures(name?: string): void;
-        /**
-         * If `name` is not provided, removes all `PerformanceResourceTiming` objects from the Resource Timeline.
-         * If `name` is provided, removes only the named resource.
-         * @since v18.2.0, v16.17.0
-         */
-        clearResourceTimings(name?: string): void;
-        /**
-         * eventLoopUtilization is similar to CPU utilization except that it is calculated using high precision wall-clock time.
-         * It represents the percentage of time the event loop has spent outside the event loop's event provider (e.g. epoll_wait).
-         * No other CPU idle time is taken into consideration.
-         */
-        eventLoopUtilization: EventLoopUtilityFunction;
         /**
          * Returns a list of `PerformanceEntry` objects in chronological order with respect to `performanceEntry.startTime`.
          * If you are only interested in performance entries of certain types or that have certain names, see
@@ -259,17 +244,14 @@ declare module "perf_hooks" {
          */
         getEntriesByType(type: EntryType): PerformanceEntry[];
         /**
-         * Creates a new `PerformanceMark` entry in the Performance Timeline.
-         * A `PerformanceMark` is a subclass of `PerformanceEntry` whose `performanceEntry.entryType` is always `'mark'`,
-         * and whose `performanceEntry.duration` is always `0`.
+         * Creates a new PerformanceMark entry in the Performance Timeline.
+         * A PerformanceMark is a subclass of PerformanceEntry whose performanceEntry.entryType is always 'mark',
+         * and whose performanceEntry.duration is always 0.
          * Performance marks are used to mark specific significant moments in the Performance Timeline.
-         *
-         * The created `PerformanceMark` entry is put in the global Performance Timeline and can be queried with
-         * `performance.getEntries`, `performance.getEntriesByName`, and `performance.getEntriesByType`. When the observation is
-         * performed, the entries should be cleared from the global Performance Timeline manually with `performance.clearMarks`.
          * @param name
+         * @return The PerformanceMark entry that was created
          */
-        mark(name: string, options?: MarkOptions): PerformanceMark;
+        mark(name?: string, options?: MarkOptions): PerformanceMark;
         /**
          * Creates a new PerformanceMeasure entry in the Performance Timeline.
          * A PerformanceMeasure is a subclass of PerformanceEntry whose performanceEntry.entryType is always 'measure',
@@ -289,74 +271,31 @@ declare module "perf_hooks" {
         measure(name: string, startMark?: string, endMark?: string): PerformanceMeasure;
         measure(name: string, options: MeasureOptions): PerformanceMeasure;
         /**
-         * _This property is an extension by Node.js. It is not available in Web browsers._
-         *
-         * An instance of the `PerformanceNodeTiming` class that provides performance metrics for specific Node.js operational milestones.
-         * @since v8.5.0
+         * An instance of the PerformanceNodeTiming class that provides performance metrics for specific Node.js operational milestones.
          */
         readonly nodeTiming: PerformanceNodeTiming;
         /**
-         * Returns the current high resolution millisecond timestamp, where 0 represents the start of the current `node` process.
-         * @since v8.5.0
+         * @return the current high resolution millisecond timestamp
          */
         now(): number;
         /**
-         * Sets the global performance resource timing buffer size to the specified number of "resource" type performance entry objects.
-         *
-         * By default the max buffer size is set to 250.
-         * @since v18.8.0
-         */
-        setResourceTimingBufferSize(maxSize: number): void;
-        /**
-         * The [`timeOrigin`](https://w3c.github.io/hr-time/#dom-performance-timeorigin) specifies the high resolution millisecond timestamp
-         * at which the current `node` process began, measured in Unix time.
-         * @since v8.5.0
+         * The timeOrigin specifies the high resolution millisecond timestamp from which all performance metric durations are measured.
          */
         readonly timeOrigin: number;
         /**
-         * _This property is an extension by Node.js. It is not available in Web browsers._
-         *
          * Wraps a function within a new function that measures the running time of the wrapped function.
-         * A `PerformanceObserver` must be subscribed to the `'function'` event type in order for the timing details to be accessed.
-         *
-         * ```js
-         * const {
-         *   performance,
-         *   PerformanceObserver,
-         * } = require('node:perf_hooks');
-         *
-         * function someFunction() {
-         *   console.log('hello world');
-         * }
-         *
-         * const wrapped = performance.timerify(someFunction);
-         *
-         * const obs = new PerformanceObserver((list) => {
-         *   console.log(list.getEntries()[0].duration);
-         *
-         *   performance.clearMarks();
-         *   performance.clearMeasures();
-         *   obs.disconnect();
-         * });
-         * obs.observe({ entryTypes: ['function'] });
-         *
-         * // A performance timeline entry will be created
-         * wrapped();
-         * ```
-         *
-         * If the wrapped function returns a promise, a finally handler will be attached to the promise and the duration will be reported
-         * once the finally handler is invoked.
+         * A PerformanceObserver must be subscribed to the 'function' event type in order for the timing details to be accessed.
          * @param fn
          */
         timerify<T extends (...params: any[]) => any>(fn: T, options?: TimerifyOptions): T;
         /**
-         * An object which is JSON representation of the performance object. It is similar to
-         * [`window.performance.toJSON`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/toJSON) in browsers.
-         * @since v16.1.0
+         * eventLoopUtilization is similar to CPU utilization except that it is calculated using high precision wall-clock time.
+         * It represents the percentage of time the event loop has spent outside the event loop's event provider (e.g. epoll_wait).
+         * No other CPU idle time is taken into consideration.
          */
-        toJSON(): any;
+        eventLoopUtilization: EventLoopUtilityFunction;
     }
-    class PerformanceObserverEntryList {
+    interface PerformanceObserverEntryList {
         /**
          * Returns a list of `PerformanceEntry` objects in chronological order
          * with respect to `performanceEntry.startTime`.
@@ -536,103 +475,6 @@ declare module "perf_hooks" {
                 },
         ): void;
     }
-    /**
-     * Provides detailed network timing data regarding the loading of an application's resources.
-     *
-     * The constructor of this class is not exposed to users directly.
-     * @since v18.2.0, v16.17.0
-     */
-    class PerformanceResourceTiming extends PerformanceEntry {
-        protected constructor();
-        /**
-         * The high resolution millisecond timestamp at immediately before dispatching the `fetch`
-         * request. If the resource is not intercepted by a worker the property will always return 0.
-         * @since v18.2.0, v16.17.0
-         */
-        readonly workerStart: number;
-        /**
-         * The high resolution millisecond timestamp that represents the start time of the fetch which
-         * initiates the redirect.
-         * @since v18.2.0, v16.17.0
-         */
-        readonly redirectStart: number;
-        /**
-         * The high resolution millisecond timestamp that will be created immediately after receiving
-         * the last byte of the response of the last redirect.
-         * @since v18.2.0, v16.17.0
-         */
-        readonly redirectEnd: number;
-        /**
-         * The high resolution millisecond timestamp immediately before the Node.js starts to fetch the resource.
-         * @since v18.2.0, v16.17.0
-         */
-        readonly fetchStart: number;
-        /**
-         * The high resolution millisecond timestamp immediately before the Node.js starts the domain name lookup
-         * for the resource.
-         * @since v18.2.0, v16.17.0
-         */
-        readonly domainLookupStart: number;
-        /**
-         * The high resolution millisecond timestamp representing the time immediately after the Node.js finished
-         * the domain name lookup for the resource.
-         * @since v18.2.0, v16.17.0
-         */
-        readonly domainLookupEnd: number;
-        /**
-         * The high resolution millisecond timestamp representing the time immediately before Node.js starts to
-         * establish the connection to the server to retrieve the resource.
-         * @since v18.2.0, v16.17.0
-         */
-        readonly connectStart: number;
-        /**
-         * The high resolution millisecond timestamp representing the time immediately after Node.js finishes
-         * establishing the connection to the server to retrieve the resource.
-         * @since v18.2.0, v16.17.0
-         */
-        readonly connectEnd: number;
-        /**
-         * The high resolution millisecond timestamp representing the time immediately before Node.js starts the
-         * handshake process to secure the current connection.
-         * @since v18.2.0, v16.17.0
-         */
-        readonly secureConnectionStart: number;
-        /**
-         * The high resolution millisecond timestamp representing the time immediately before Node.js receives the
-         * first byte of the response from the server.
-         * @since v18.2.0, v16.17.0
-         */
-        readonly requestStart: number;
-        /**
-         * The high resolution millisecond timestamp representing the time immediately after Node.js receives the
-         * last byte of the resource or immediately before the transport connection is closed, whichever comes first.
-         * @since v18.2.0, v16.17.0
-         */
-        readonly responseEnd: number;
-        /**
-         * A number representing the size (in octets) of the fetched resource. The size includes the response header
-         * fields plus the response payload body.
-         * @since v18.2.0, v16.17.0
-         */
-        readonly transferSize: number;
-        /**
-         * A number representing the size (in octets) received from the fetch (HTTP or cache), of the payload body, before
-         * removing any applied content-codings.
-         * @since v18.2.0, v16.17.0
-         */
-        readonly encodedBodySize: number;
-        /**
-         * A number representing the size (in octets) received from the fetch (HTTP or cache), of the message body, after
-         * removing any applied content-codings.
-         * @since v18.2.0, v16.17.0
-         */
-        readonly decodedBodySize: number;
-        /**
-         * Returns a `object` that is the JSON representation of the `PerformanceResourceTiming` object
-         * @since v18.2.0, v16.17.0
-         */
-        toJSON(): any;
-    }
     namespace constants {
         const NODE_PERFORMANCE_GC_MAJOR: number;
         const NODE_PERFORMANCE_GC_MINOR: number;
@@ -657,15 +499,10 @@ declare module "perf_hooks" {
     }
     interface Histogram {
         /**
-         * The number of samples recorded by the histogram.
-         * @since v17.4.0, v16.14.0
+         * Returns a `Map` object detailing the accumulated percentile distribution.
+         * @since v11.10.0
          */
-        readonly count: number;
-        /**
-         * The number of samples recorded by the histogram.
-         * v17.4.0, v16.14.0
-         */
-        readonly countBigInt: bigint;
+        readonly percentiles: Map<number, number>;
         /**
          * The number of times the event loop delay exceeded the maximum 1 hour event
          * loop delay threshold.
@@ -673,67 +510,36 @@ declare module "perf_hooks" {
          */
         readonly exceeds: number;
         /**
-         * The number of times the event loop delay exceeded the maximum 1 hour event loop delay threshold.
-         * @since v17.4.0, v16.14.0
+         * The minimum recorded event loop delay.
+         * @since v11.10.0
          */
-        readonly exceedsBigInt: bigint;
+        readonly min: number;
         /**
          * The maximum recorded event loop delay.
          * @since v11.10.0
          */
         readonly max: number;
         /**
-         * The maximum recorded event loop delay.
-         * v17.4.0, v16.14.0
-         */
-        readonly maxBigInt: number;
-        /**
          * The mean of the recorded event loop delays.
          * @since v11.10.0
          */
         readonly mean: number;
         /**
-         * The minimum recorded event loop delay.
+         * The standard deviation of the recorded event loop delays.
          * @since v11.10.0
          */
-        readonly min: number;
-        /**
-         * The minimum recorded event loop delay.
-         * v17.4.0, v16.14.0
-         */
-        readonly minBigInt: bigint;
-        /**
-         * Returns the value at the given percentile.
-         * @since v11.10.0
-         * @param percentile A percentile value in the range (0, 100].
-         */
-        percentile(percentile: number): number;
-        /**
-         * Returns the value at the given percentile.
-         * @since v17.4.0, v16.14.0
-         * @param percentile A percentile value in the range (0, 100].
-         */
-        percentileBigInt(percentile: number): bigint;
-        /**
-         * Returns a `Map` object detailing the accumulated percentile distribution.
-         * @since v11.10.0
-         */
-        readonly percentiles: Map<number, number>;
-        /**
-         * Returns a `Map` object detailing the accumulated percentile distribution.
-         * @since v17.4.0, v16.14.0
-         */
-        readonly percentilesBigInt: Map<bigint, bigint>;
+        readonly stddev: number;
         /**
          * Resets the collected histogram data.
          * @since v11.10.0
          */
         reset(): void;
         /**
-         * The standard deviation of the recorded event loop delays.
+         * Returns the value at the given percentile.
          * @since v11.10.0
+         * @param percentile A percentile value in the range (0, 100].
          */
-        readonly stddev: number;
+        percentile(percentile: number): number;
     }
     interface IntervalHistogram extends Histogram {
         /**
@@ -758,6 +564,8 @@ declare module "perf_hooks" {
         /**
          * Calculates the amount of time (in nanoseconds) that has passed since the
          * previous call to `recordDelta()` and records that amount in the histogram.
+         *
+         * ## Examples
          * @since v15.9.0, v14.18.0
          */
         recordDelta(): void;
@@ -818,79 +626,11 @@ declare module "perf_hooks" {
      * @since v15.9.0, v14.18.0
      */
     function createHistogram(options?: CreateHistogramOptions): RecordableHistogram;
-    import {
-        performance as _performance,
-        PerformanceEntry as _PerformanceEntry,
-        PerformanceMark as _PerformanceMark,
-        PerformanceMeasure as _PerformanceMeasure,
-        PerformanceObserver as _PerformanceObserver,
-        PerformanceObserverEntryList as _PerformanceObserverEntryList,
-        PerformanceResourceTiming as _PerformanceResourceTiming,
-    } from "perf_hooks";
+    import { performance as _performance } from "perf_hooks";
     global {
         /**
-         * `PerformanceEntry` is a global reference for `require('node:perf_hooks').PerformanceEntry`
-         * @see https://nodejs.org/docs/latest-v20.x/api/globals.html#performanceentry
-         * @since v19.0.0
-         */
-        var PerformanceEntry: typeof globalThis extends {
-            onmessage: any;
-            PerformanceEntry: infer T;
-        } ? T
-            : typeof _PerformanceEntry;
-        /**
-         * `PerformanceMark` is a global reference for `require('node:perf_hooks').PerformanceMark`
-         * @see https://nodejs.org/docs/latest-v20.x/api/globals.html#performancemark
-         * @since v19.0.0
-         */
-        var PerformanceMark: typeof globalThis extends {
-            onmessage: any;
-            PerformanceMark: infer T;
-        } ? T
-            : typeof _PerformanceMark;
-        /**
-         * `PerformanceMeasure` is a global reference for `require('node:perf_hooks').PerformanceMeasure`
-         * @see https://nodejs.org/docs/latest-v20.x/api/globals.html#performancemeasure
-         * @since v19.0.0
-         */
-        var PerformanceMeasure: typeof globalThis extends {
-            onmessage: any;
-            PerformanceMeasure: infer T;
-        } ? T
-            : typeof _PerformanceMeasure;
-        /**
-         * `PerformanceObserver` is a global reference for `require('node:perf_hooks').PerformanceObserver`
-         * @see https://nodejs.org/docs/latest-v20.x/api/globals.html#performanceobserver
-         * @since v19.0.0
-         */
-        var PerformanceObserver: typeof globalThis extends {
-            onmessage: any;
-            PerformanceObserver: infer T;
-        } ? T
-            : typeof _PerformanceObserver;
-        /**
-         * `PerformanceObserverEntryList` is a global reference for `require('node:perf_hooks').PerformanceObserverEntryList`
-         * @see https://nodejs.org/docs/latest-v20.x/api/globals.html#performanceobserverentrylist
-         * @since v19.0.0
-         */
-        var PerformanceObserverEntryList: typeof globalThis extends {
-            onmessage: any;
-            PerformanceObserverEntryList: infer T;
-        } ? T
-            : typeof _PerformanceObserverEntryList;
-        /**
-         * `PerformanceResourceTiming` is a global reference for `require('node:perf_hooks').PerformanceResourceTiming`
-         * @see https://nodejs.org/docs/latest-v20.x/api/globals.html#performanceresourcetiming
-         * @since v19.0.0
-         */
-        var PerformanceResourceTiming: typeof globalThis extends {
-            onmessage: any;
-            PerformanceResourceTiming: infer T;
-        } ? T
-            : typeof _PerformanceResourceTiming;
-        /**
-         * `performance` is a global reference for `require('node:perf_hooks').performance`
-         * @see https://nodejs.org/docs/latest-v20.x/api/globals.html#performance
+         * `performance` is a global reference for `require('perf_hooks').performance`
+         * https://nodejs.org/api/globals.html#performance
          * @since v16.0.0
          */
         var performance: typeof globalThis extends {

--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -433,13 +433,13 @@ declare module "process" {
                  * the same execution environment as the parent.
                  *
                  * ```bash
-                 * node --icu-data-dir=./foo --require ./bar.js script.js --version
+                 * node --harmony script.js --version
                  * ```
                  *
                  * Results in `process.execArgv`:
                  *
                  * ```js
-                 * ["--icu-data-dir=./foo", "--require", "./bar.js"]
+                 * ['--harmony']
                  * ```
                  *
                  * And `process.argv`:
@@ -1293,21 +1293,14 @@ declare module "process" {
                 /**
                  * Gets the amount of memory available to the process (in bytes) based on
                  * limits imposed by the OS. If there is no such constraint, or the constraint
-                 * is unknown, `0` is returned.
+                 * is unknown, `undefined` is returned.
                  *
                  * See [`uv_get_constrained_memory`](https://docs.libuv.org/en/v1.x/misc.html#c.uv_get_constrained_memory) for more
                  * information.
                  * @since v19.6.0, v18.15.0
                  * @experimental
                  */
-                constrainedMemory(): number;
-                /**
-                 * Gets the amount of free memory that is still available to the process (in bytes).
-                 * See [`uv_get_available_memory`](https://nodejs.org/docs/latest-v20.x/api/process.html#processavailablememory) for more information.
-                 * @experimental
-                 * @since v20.13.0
-                 */
-                availableMemory(): number;
+                constrainedMemory(): number | undefined;
                 /**
                  * The `process.cpuUsage()` method returns the user and system CPU time usage of
                  * the current process, in an object with properties `user` and `system`, whose

--- a/types/node/punycode.d.ts
+++ b/types/node/punycode.d.ts
@@ -24,7 +24,7 @@
  * made available to developers as a convenience. Fixes or other modifications to
  * the module must be directed to the [Punycode.js](https://github.com/bestiejs/punycode.js) project.
  * @deprecated Since v7.0.0 - Deprecated
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/punycode.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/punycode.js)
  */
 declare module "punycode" {
     /**

--- a/types/node/querystring.d.ts
+++ b/types/node/querystring.d.ts
@@ -9,7 +9,7 @@
  * `querystring` is more performant than `URLSearchParams` but is not a
  * standardized API. Use `URLSearchParams` when performance is not critical or
  * when compatibility with browser code is desirable.
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/querystring.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/querystring.js)
  */
 declare module "querystring" {
     interface StringifyOptions {

--- a/types/node/readline.d.ts
+++ b/types/node/readline.d.ts
@@ -31,7 +31,7 @@
  *
  * Once this code is invoked, the Node.js application will not terminate until the `readline.Interface` is closed because the interface waits for data to be
  * received on the `input` stream.
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/readline.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/readline.js)
  */
 declare module "readline" {
     import { Abortable, EventEmitter } from "node:events";

--- a/types/node/repl.d.ts
+++ b/types/node/repl.d.ts
@@ -6,7 +6,7 @@
  * ```js
  * const repl = require('node:repl');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/repl.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/repl.js)
  */
 declare module "repl" {
     import { AsyncCompleter, Completer, Interface } from "node:readline";

--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -15,7 +15,7 @@
  *
  * The `node:stream` module is useful for creating new types of stream instances.
  * It is usually not necessary to use the `node:stream` module to consume streams.
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/stream.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/stream.js)
  */
 declare module "stream" {
     import { Abortable, EventEmitter } from "node:events";
@@ -272,14 +272,14 @@ declare module "stream" {
          *   });
          * ```
          *
-         * The `readable.resume()` method has no effect if there is a `'readable'` event listener.
+         * The `readable.resume()` method has no effect if there is a `'readable'`event listener.
          * @since v0.9.4
          */
         resume(): this;
         /**
-         * The `readable.isPaused()` method returns the current operating state of the `Readable`.
-         * This is used primarily by the mechanism that underlies the `readable.pipe()` method.
-         * In most typical cases, there will be no reason to use this method directly.
+         * The `readable.isPaused()` method returns the current operating state of the `Readable`. This is
+         * used primarily by the mechanism that underlies the `readable.pipe()` method. In most typical cases,
+         * there will be no reason to use this method directly.
          *
          * ```js
          * const readable = new stream.Readable();
@@ -381,8 +381,8 @@ declare module "stream" {
          * however it is best to simply avoid calling `readable.unshift()` while in the
          * process of performing a read.
          * @since v0.9.11
-         * @param chunk Chunk of data to unshift onto the read queue. For streams not operating in object mode, `chunk` must
-         * be a {string}, {Buffer}, {TypedArray}, {DataView} or `null`. For object mode streams, `chunk` may be any JavaScript value.
+         * @param chunk Chunk of data to unshift onto the read queue. For streams not operating in object mode, `chunk` must be a string, `Buffer`, `Uint8Array`, or `null`. For object mode
+         * streams, `chunk` may be any JavaScript value.
          * @param encoding Encoding of string chunks. Must be a valid `Buffer` encoding, such as `'utf8'` or `'ascii'`.
          */
         unshift(chunk: any, encoding?: BufferEncoding): void;
@@ -782,8 +782,8 @@ declare module "stream" {
          *
          * A `Writable` stream in object mode will always ignore the `encoding` argument.
          * @since v0.9.4
-         * @param chunk Optional data to write. For streams not operating in object mode, `chunk` must be a {string}, {Buffer},
-         * {TypedArray} or {DataView}. For object mode streams, `chunk` may be any JavaScript value other than `null`.
+         * @param chunk Optional data to write. For streams not operating in object mode, `chunk` must be a string, `Buffer` or `Uint8Array`. For object mode streams, `chunk` may be any
+         * JavaScript value other than `null`.
          * @param [encoding='utf8'] The encoding, if `chunk` is a string.
          * @param callback Callback for when this chunk of data is flushed.
          * @return `false` if the stream wishes for the calling code to wait for the `'drain'` event to be emitted before continuing to write additional data; otherwise `true`.
@@ -813,8 +813,8 @@ declare module "stream" {
          * // Writing more now is not allowed!
          * ```
          * @since v0.9.4
-         * @param chunk Optional data to write. For streams not operating in object mode, `chunk` must be a {string}, {Buffer},
-         * {TypedArray} or {DataView}. For object mode streams, `chunk` may be any JavaScript value other than `null`.
+         * @param chunk Optional data to write. For streams not operating in object mode, `chunk` must be a string, `Buffer` or `Uint8Array`. For object mode streams, `chunk` may be any
+         * JavaScript value other than `null`.
          * @param encoding The encoding if `chunk` is a string
          * @param callback Callback for when the stream is finished.
          */
@@ -1300,8 +1300,8 @@ declare module "stream" {
          * Attaches an AbortSignal to a readable or writeable stream. This lets code
          * control stream destruction using an `AbortController`.
          *
-         * Calling `abort` on the `AbortController` corresponding to the passed `AbortSignal` will behave the same way as calling `.destroy(new AbortError())` on the
-         * stream, and `controller.error(new AbortError())` for webstreams.
+         * Calling `abort` on the `AbortController` corresponding to the passed `AbortSignal` will behave the same way as
+         * calling `.destroy(new AbortError())` on the stream, and `controller.error(new AbortError())` for webstreams.
          *
          * ```js
          * const fs = require('node:fs');
@@ -1417,7 +1417,7 @@ declare module "stream" {
          * Especially useful in error handling scenarios where a stream is destroyed
          * prematurely (like an aborted HTTP request), and will not emit `'end'` or `'finish'`.
          *
-         * The `finished` API provides [`promise version`](https://nodejs.org/docs/latest-v20.x/api/stream.html#streamfinishedstream-options).
+         * The `finished` API provides [promise version](https://nodejs.org/docs/latest-v20.x/api/stream.html#streamfinishedstream-options).
          *
          * `stream.finished()` leaves dangling event listeners (in particular `'error'`, `'end'`, `'finish'` and `'close'`) after `callback` has been
          * invoked. The reason for this is so that unexpected `'error'` events (due to
@@ -1505,7 +1505,7 @@ declare module "stream" {
          * );
          * ```
          *
-         * The `pipeline` API provides a [`promise version`](https://nodejs.org/docs/latest-v20.x/api/stream.html#streampipelinesource-transforms-destination-options).
+         * The `pipeline` API provides a [promise version](https://nodejs.org/docs/latest-v20.x/api/stream.html#streampipelinesource-transforms-destination-options).
          *
          * `stream.pipeline()` will call `stream.destroy(err)` on all streams except:
          *

--- a/types/node/string_decoder.d.ts
+++ b/types/node/string_decoder.d.ts
@@ -36,7 +36,7 @@
  * decoder.write(Buffer.from([0x82]));
  * console.log(decoder.end(Buffer.from([0xAC]))); // Prints: €
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/string_decoder.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/string_decoder.js)
  */
 declare module "string_decoder" {
     class StringDecoder {

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -76,7 +76,7 @@
  *
  * If any tests fail, the process exit code is set to `1`.
  * @since v18.0.0, v16.17.0
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/test.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/test.js)
  */
 declare module "node:test" {
     import { Readable } from "node:stream";
@@ -110,7 +110,7 @@ declare module "node:test" {
      * additional diagnostic information, or creating subtests.
      *
      * `test()` returns a `Promise` that fulfills once the test completes.
-     * if `test()` is called within a suite, it fulfills immediately.
+     * if `test()` is called within a `describe()` block, it fulfills immediately.
      * The return value can usually be discarded for top level tests.
      * However, the return value from subtests should be used to prevent the parent
      * test from finishing first and cancelling the subtest
@@ -137,7 +137,7 @@ declare module "node:test" {
      * @param options Configuration options for the test. The following properties are supported:
      * @param [fn='A no-op function'] The function under test. The first argument to this function is a {@link TestContext} object. If the test uses callbacks, the
      * callback function is passed as the second argument.
-     * @return Fulfilled with `undefined` once the test completes, or immediately if the test runs within a suite.
+     * @return Fulfilled with `undefined` once the test completes, or immediately if the test runs within {@link describe}.
      */
     function test(name?: string, fn?: TestFn): Promise<void>;
     function test(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
@@ -147,47 +147,14 @@ declare module "node:test" {
         export { after, afterEach, before, beforeEach, describe, it, mock, only, run, skip, test, todo };
     }
     /**
-     * The `suite()` function is imported from the `node:test` module.
-     * @param name The name of the suite, which is displayed when reporting test results. **Default:** The `name` property of `fn`, or `'<anonymous>'` if `fn` does not have a name.
-     * @param options Optional configuration options for the suite. This supports the same options as `test([name][, options][, fn])`.
-     * @param [fn='A no-op function'] The suite function declaring nested tests and suites. The first argument to this function is a `{@link SuiteContext}` object.
+     * The `describe()` function imported from the `node:test` module. Each
+     * invocation of this function results in the creation of a Subtest.
+     * After invocation of top level `describe` functions,
+     * all top level tests and suites will execute.
+     * @param [name='The name'] The name of the suite, which is displayed when reporting test results.
+     * @param options Configuration options for the suite. supports the same options as `test([name][, options][, fn])`.
+     * @param [fn='A no-op function'] The function under suite declaring all subtests and subsuites. The first argument to this function is a {@link SuiteContext} object.
      * @return Immediately fulfilled with `undefined`.
-     * @since v20.13.0
-     */
-    function suite(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
-    function suite(name?: string, fn?: SuiteFn): Promise<void>;
-    function suite(options?: TestOptions, fn?: SuiteFn): Promise<void>;
-    function suite(fn?: SuiteFn): Promise<void>;
-    namespace suite {
-        /**
-         * Shorthand for skipping a suite. This is the same as [`suite([name], { skip: true }[, fn])`](https://nodejs.org/docs/latest-v20.x/api/test.html#suitename-options-fn).
-         * @since v20.13.0
-         */
-        function skip(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
-        function skip(name?: string, fn?: SuiteFn): Promise<void>;
-        function skip(options?: TestOptions, fn?: SuiteFn): Promise<void>;
-        function skip(fn?: SuiteFn): Promise<void>;
-        /**
-         * Shorthand for marking a suite as `TODO`. This is the same as [`suite([name], { todo: true }[, fn])`](https://nodejs.org/docs/latest-v20.x/api/test.html#suitename-options-fn).
-         * @since v20.13.0
-         */
-        function todo(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
-        function todo(name?: string, fn?: SuiteFn): Promise<void>;
-        function todo(options?: TestOptions, fn?: SuiteFn): Promise<void>;
-        function todo(fn?: SuiteFn): Promise<void>;
-        /**
-         * Shorthand for marking a suite as `only`. This is the same as [`suite([name], { only: true }[, fn])`](https://nodejs.org/docs/latest-v20.x/api/test.html#suitename-options-fn).
-         * @since v20.13.0
-         */
-        function only(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
-        function only(name?: string, fn?: SuiteFn): Promise<void>;
-        function only(options?: TestOptions, fn?: SuiteFn): Promise<void>;
-        function only(fn?: SuiteFn): Promise<void>;
-    }
-    /**
-     * Alias for `{@link suite}`.
-     *
-     * The `describe()` function is imported from the `node:test` module.
      */
     function describe(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
     function describe(name?: string, fn?: SuiteFn): Promise<void>;
@@ -195,23 +162,21 @@ declare module "node:test" {
     function describe(fn?: SuiteFn): Promise<void>;
     namespace describe {
         /**
-         * Shorthand for skipping a suite. This is the same as [`describe([name], { skip: true }[, fn])`](https://nodejs.org/docs/latest-v20.x/api/test.html#describename-options-fn).
-         * @since v18.15.0
+         * Shorthand for skipping a suite, same as `describe([name], { skip: true }[, fn])`.
          */
         function skip(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
         function skip(name?: string, fn?: SuiteFn): Promise<void>;
         function skip(options?: TestOptions, fn?: SuiteFn): Promise<void>;
         function skip(fn?: SuiteFn): Promise<void>;
         /**
-         * Shorthand for marking a suite as `TODO`. This is the same as [`describe([name], { todo: true }[, fn])`](https://nodejs.org/docs/latest-v20.x/api/test.html#describename-options-fn).
-         * @since v18.15.0
+         * Shorthand for marking a suite as `TODO`, same as `describe([name], { todo: true }[, fn])`.
          */
         function todo(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
         function todo(name?: string, fn?: SuiteFn): Promise<void>;
         function todo(options?: TestOptions, fn?: SuiteFn): Promise<void>;
         function todo(fn?: SuiteFn): Promise<void>;
         /**
-         * Shorthand for marking a suite as `only`. This is the same as [`describe([name], { only: true }[, fn])`](https://nodejs.org/docs/latest-v20.x/api/test.html#describename-options-fn).
+         * Shorthand for marking a suite as `only`, same as `describe([name], { only: true }[, fn])`.
          * @since v18.15.0
          */
         function only(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
@@ -220,7 +185,7 @@ declare module "node:test" {
         function only(fn?: SuiteFn): Promise<void>;
     }
     /**
-     * Alias for `test()`.
+     * Shorthand for `test()`.
      *
      * The `it()` function is imported from the `node:test` module.
      * @since v18.6.0, v16.17.0
@@ -365,16 +330,10 @@ declare module "node:test" {
     /**
      * A successful call to `run()` method will return a new `TestsStream` object, streaming a series of events representing the execution of the tests. `TestsStream` will emit events, in the
      * order of the tests definition
-     *
-     * Some of the events are guaranteed to be emitted in the same order as the tests are defined, while others are emitted in the order that the tests execute.
      * @since v18.9.0, v16.19.0
      */
     class TestsStream extends Readable implements NodeJS.ReadableStream {
-        addListener(event: "test:coverage", listener: (data: TestCoverage) => void): this;
-        addListener(event: "test:complete", listener: (data: TestComplete) => void): this;
-        addListener(event: "test:dequeue", listener: (data: TestDequeue) => void): this;
         addListener(event: "test:diagnostic", listener: (data: DiagnosticData) => void): this;
-        addListener(event: "test:enqueue", listener: (data: TestEnqueue) => void): this;
         addListener(event: "test:fail", listener: (data: TestFail) => void): this;
         addListener(event: "test:pass", listener: (data: TestPass) => void): this;
         addListener(event: "test:plan", listener: (data: TestPlan) => void): this;
@@ -382,11 +341,7 @@ declare module "node:test" {
         addListener(event: "test:stderr", listener: (data: TestStderr) => void): this;
         addListener(event: "test:stdout", listener: (data: TestStdout) => void): this;
         addListener(event: string, listener: (...args: any[]) => void): this;
-        emit(event: "test:coverage", data: TestCoverage): boolean;
-        emit(event: "test:complete", data: TestComplete): boolean;
-        emit(event: "test:dequeue", data: TestDequeue): boolean;
         emit(event: "test:diagnostic", data: DiagnosticData): boolean;
-        emit(event: "test:enqueue", data: TestEnqueue): boolean;
         emit(event: "test:fail", data: TestFail): boolean;
         emit(event: "test:pass", data: TestPass): boolean;
         emit(event: "test:plan", data: TestPlan): boolean;
@@ -394,11 +349,7 @@ declare module "node:test" {
         emit(event: "test:stderr", data: TestStderr): boolean;
         emit(event: "test:stdout", data: TestStdout): boolean;
         emit(event: string | symbol, ...args: any[]): boolean;
-        on(event: "test:coverage", listener: (data: TestCoverage) => void): this;
-        on(event: "test:complete", listener: (data: TestComplete) => void): this;
-        on(event: "test:dequeue", listener: (data: TestDequeue) => void): this;
         on(event: "test:diagnostic", listener: (data: DiagnosticData) => void): this;
-        on(event: "test:enqueue", listener: (data: TestEnqueue) => void): this;
         on(event: "test:fail", listener: (data: TestFail) => void): this;
         on(event: "test:pass", listener: (data: TestPass) => void): this;
         on(event: "test:plan", listener: (data: TestPlan) => void): this;
@@ -406,11 +357,7 @@ declare module "node:test" {
         on(event: "test:stderr", listener: (data: TestStderr) => void): this;
         on(event: "test:stdout", listener: (data: TestStdout) => void): this;
         on(event: string, listener: (...args: any[]) => void): this;
-        once(event: "test:coverage", listener: (data: TestCoverage) => void): this;
-        once(event: "test:complete", listener: (data: TestComplete) => void): this;
-        once(event: "test:dequeue", listener: (data: TestDequeue) => void): this;
         once(event: "test:diagnostic", listener: (data: DiagnosticData) => void): this;
-        once(event: "test:enqueue", listener: (data: TestEnqueue) => void): this;
         once(event: "test:fail", listener: (data: TestFail) => void): this;
         once(event: "test:pass", listener: (data: TestPass) => void): this;
         once(event: "test:plan", listener: (data: TestPlan) => void): this;
@@ -418,11 +365,7 @@ declare module "node:test" {
         once(event: "test:stderr", listener: (data: TestStderr) => void): this;
         once(event: "test:stdout", listener: (data: TestStdout) => void): this;
         once(event: string, listener: (...args: any[]) => void): this;
-        prependListener(event: "test:coverage", listener: (data: TestCoverage) => void): this;
-        prependListener(event: "test:complete", listener: (data: TestComplete) => void): this;
-        prependListener(event: "test:dequeue", listener: (data: TestDequeue) => void): this;
         prependListener(event: "test:diagnostic", listener: (data: DiagnosticData) => void): this;
-        prependListener(event: "test:enqueue", listener: (data: TestEnqueue) => void): this;
         prependListener(event: "test:fail", listener: (data: TestFail) => void): this;
         prependListener(event: "test:pass", listener: (data: TestPass) => void): this;
         prependListener(event: "test:plan", listener: (data: TestPlan) => void): this;
@@ -430,11 +373,7 @@ declare module "node:test" {
         prependListener(event: "test:stderr", listener: (data: TestStderr) => void): this;
         prependListener(event: "test:stdout", listener: (data: TestStdout) => void): this;
         prependListener(event: string, listener: (...args: any[]) => void): this;
-        prependOnceListener(event: "test:coverage", listener: (data: TestCoverage) => void): this;
-        prependOnceListener(event: "test:complete", listener: (data: TestComplete) => void): this;
-        prependOnceListener(event: "test:dequeue", listener: (data: TestDequeue) => void): this;
         prependOnceListener(event: "test:diagnostic", listener: (data: DiagnosticData) => void): this;
-        prependOnceListener(event: "test:enqueue", listener: (data: TestEnqueue) => void): this;
         prependOnceListener(event: "test:fail", listener: (data: TestFail) => void): this;
         prependOnceListener(event: "test:pass", listener: (data: TestPass) => void): this;
         prependOnceListener(event: "test:plan", listener: (data: TestPlan) => void): this;
@@ -639,7 +578,7 @@ declare module "node:test" {
         todo?: boolean | string | undefined;
     }
     /**
-     * This function creates a hook that runs before executing a suite.
+     * This function is used to create a hook running before running a suite.
      *
      * ```js
      * describe('tests', async () => {
@@ -655,7 +594,7 @@ declare module "node:test" {
      */
     function before(fn?: HookFn, options?: HookOptions): void;
     /**
-     * This function creates a hook that runs after executing a suite.
+     * This function is used to create a hook running after  running a suite.
      *
      * ```js
      * describe('tests', async () => {
@@ -671,7 +610,8 @@ declare module "node:test" {
      */
     function after(fn?: HookFn, options?: HookOptions): void;
     /**
-     * This function creates a hook that runs before each test in the current suite.
+     * This function is used to create a hook running
+     * before each subtest of the current suite.
      *
      * ```js
      * describe('tests', async () => {
@@ -687,8 +627,8 @@ declare module "node:test" {
      */
     function beforeEach(fn?: HookFn, options?: HookOptions): void;
     /**
-     * This function creates a hook that runs after each test in the current suite.
-     * The `afterEach()` hook is run even if the test fails.
+     * This function is used to create a hook running
+     * after each subtest of the current test.
      *
      * ```js
      * describe('tests', async () => {
@@ -1322,11 +1262,12 @@ interface TestLocationInfo {
      */
     column?: number;
     /**
-     * The path of the test file, `undefined` if test was run through the REPL.
+     * The path of the test file, `undefined` if test is not ran through a file.
      */
     file?: string;
     /**
-     * The line number where the test is defined, or `undefined` if the test was run through the REPL.
+     * The line number where the test is defined, or
+     * `undefined` if the test was run through the REPL.
      */
     line?: number;
 }
@@ -1335,202 +1276,6 @@ interface DiagnosticData extends TestLocationInfo {
      * The diagnostic message.
      */
     message: string;
-    /**
-     * The nesting level of the test.
-     */
-    nesting: number;
-}
-interface TestCoverage {
-    /**
-     * An object containing the coverage report.
-     */
-    summary: {
-        /**
-         * An array of coverage reports for individual files. Each report is an object with the following schema:
-         */
-        files: Array<{
-            /**
-             * The absolute path of the file.
-             */
-            path: string;
-            /**
-             * The total number of lines.
-             */
-            totalLineCount: number;
-            /**
-             * The total number of branches.
-             */
-            totalBranchCount: number;
-            /**
-             * The total number of functions.
-             */
-            totalFunctionCount: number;
-            /**
-             * The number of covered lines.
-             */
-            coveredLineCount: number;
-            /**
-             * The number of covered branches.
-             */
-            coveredBranchCount: number;
-            /**
-             * The number of covered functions.
-             */
-            coveredFunctionCount: number;
-            /**
-             * The percentage of lines covered.
-             */
-            coveredLinePercent: number;
-            /**
-             * The percentage of branches covered.
-             */
-            coveredBranchPercent: number;
-            /**
-             * The percentage of functions covered.
-             */
-            coveredFunctionPercent: number;
-            /**
-             * An array of functions representing function coverage.
-             */
-            functions: Array<{
-                /**
-                 * The name of the function.
-                 */
-                name: string;
-                /**
-                 * The line number where the function is defined.
-                 */
-                line: number;
-                /**
-                 * The number of times the function was called.
-                 */
-                count: number;
-            }>;
-            /**
-             * An array of lines representing line numbers and the number of times they were covered.
-             */
-            lines: Array<{
-                /**
-                 * The line number.
-                 */
-                line: number;
-                /**
-                 * The number of times the line was covered.
-                 */
-                count: number;
-            }>;
-        }>;
-        /**
-         * An object containing a summary of coverage for all files.
-         */
-        totals: {
-            /**
-             * The total number of lines.
-             */
-            totalLineCount: number;
-            /**
-             * The total number of branches.
-             */
-            totalBranchCount: number;
-            /**
-             * The total number of functions.
-             */
-            totalFunctionCount: number;
-            /**
-             * The number of covered lines.
-             */
-            coveredLineCount: number;
-            /**
-             * The number of covered branches.
-             */
-            coveredBranchCount: number;
-            /**
-             * The number of covered functions.
-             */
-            coveredFunctionCount: number;
-            /**
-             * The percentage of lines covered.
-             */
-            coveredLinePercent: number;
-            /**
-             * The percentage of branches covered.
-             */
-            coveredBranchPercent: number;
-            /**
-             * The percentage of functions covered.
-             */
-            coveredFunctionPercent: number;
-        };
-        /**
-         * The working directory when code coverage began. This
-         * is useful for displaying relative path names in case
-         * the tests changed the working directory of the Node.js process.
-         */
-        workingDirectory: string;
-    };
-    /**
-     * The nesting level of the test.
-     */
-    nesting: number;
-}
-interface TestComplete extends TestLocationInfo {
-    /**
-     * Additional execution metadata.
-     */
-    details: {
-        /**
-         * Whether the test passed or not.
-         */
-        passed: boolean;
-        /**
-         * The duration of the test in milliseconds.
-         */
-        duration_ms: number;
-        /**
-         * An error wrapping the error thrown by the test if it did not pass.
-         */
-        error: Error;
-        /**
-         * The type of the test, used to denote whether this is a suite.
-         */
-        type?: "suite";
-    };
-    /**
-     * The test name.
-     */
-    name: string;
-    /**
-     * The nesting level of the test.
-     */
-    nesting: number;
-    /**
-     * The ordinal number of the test.
-     */
-    testNumber: number;
-    /**
-     * Present if `context.todo` is called.
-     */
-    todo?: string | boolean;
-    /**
-     * Present if `context.skip` is called.
-     */
-    skip?: string | boolean;
-}
-interface TestDequeue extends TestLocationInfo {
-    /**
-     * The test name.
-     */
-    name: string;
-    /**
-     * The nesting level of the test.
-     */
-    nesting: number;
-}
-interface TestEnqueue extends TestLocationInfo {
-    /**
-     * The test name.
-     */
-    name: string;
     /**
      * The nesting level of the test.
      */
@@ -1546,12 +1291,12 @@ interface TestFail extends TestLocationInfo {
          */
         duration_ms: number;
         /**
-         * An error wrapping the error thrown by the test if it did not pass.
+         * The error thrown by the test.
          */
         error: Error;
         /**
          * The type of the test, used to denote whether this is a suite.
-         * @since v20.0.0, v19.9.0, v18.17.0
+         * @since 20.0.0, 19.9.0, 18.17.0
          */
         type?: "suite";
     };
@@ -1634,15 +1379,35 @@ interface TestStart extends TestLocationInfo {
 }
 interface TestStderr extends TestLocationInfo {
     /**
-     * The message written to `stderr`.
+     * The message written to `stderr`
      */
     message: string;
 }
 interface TestStdout extends TestLocationInfo {
     /**
-     * The message written to `stdout`.
+     * The message written to `stdout`
      */
     message: string;
+}
+interface TestEnqueue extends TestLocationInfo {
+    /**
+     * The test name
+     */
+    name: string;
+    /**
+     * The nesting level of the test.
+     */
+    nesting: number;
+}
+interface TestDequeue extends TestLocationInfo {
+    /**
+     * The test name
+     */
+    name: string;
+    /**
+     * The nesting level of the test.
+     */
+    nesting: number;
 }
 
 /**
@@ -1660,23 +1425,21 @@ interface TestStdout extends TestLocationInfo {
  * import test from 'test/reporters';
  * ```
  * @since v19.9.0
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/test/reporters.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/test/reporters.js)
  */
 declare module "node:test/reporters" {
     import { Transform, TransformOptions } from "node:stream";
 
     type TestEvent =
-        | { type: "test:coverage"; data: TestCoverage }
-        | { type: "test:complete"; data: TestComplete }
-        | { type: "test:dequeue"; data: TestDequeue }
         | { type: "test:diagnostic"; data: DiagnosticData }
-        | { type: "test:enqueue"; data: TestEnqueue }
         | { type: "test:fail"; data: TestFail }
         | { type: "test:pass"; data: TestPass }
         | { type: "test:plan"; data: TestPlan }
         | { type: "test:start"; data: TestStart }
         | { type: "test:stderr"; data: TestStderr }
         | { type: "test:stdout"; data: TestStdout }
+        | { type: "test:enqueue"; data: TestEnqueue }
+        | { type: "test:dequeue"; data: TestDequeue }
         | { type: "test:watch:drained" };
     type TestEventGenerator = AsyncGenerator<TestEvent, void>;
 
@@ -1697,12 +1460,9 @@ declare module "node:test/reporters" {
         constructor();
     }
     /**
-     * The `junit` reporter outputs test results in a jUnit XML format.
+     * The `junit` reporter outputs test results in a jUnit XML format
      */
     function junit(source: TestEventGenerator): AsyncGenerator<string, void>;
-    /**
-     * The `lcov` reporter outputs test coverage when used with the [`--experimental-test-coverage`](https://nodejs.org/docs/latest-v20.x/api/cli.html#--experimental-test-coverage) flag.
-     */
     class Lcov extends Transform {
         constructor(opts?: TransformOptions);
     }

--- a/types/node/test/child_process.ts
+++ b/types/node/test/child_process.ts
@@ -1,5 +1,4 @@
 import * as childProcess from "node:child_process";
-import * as dgram from "node:dgram";
 import * as fs from "node:fs";
 import * as net from "node:net";
 import assert = require("node:assert");
@@ -339,7 +338,7 @@ async function testPromisify() {
     });
     cp = cp.addListener("message", (message, sendHandle) => {
         const _message: any = message;
-        const _sendHandle: net.Socket | net.Server | dgram.Socket | undefined = sendHandle;
+        const _sendHandle: net.Socket | net.Server = sendHandle;
     });
     cp = cp.addListener("spawn", () => {
     });
@@ -365,7 +364,7 @@ async function testPromisify() {
     });
     cp = cp.on("message", (message, sendHandle) => {
         const _message: any = message;
-        const _sendHandle: net.Socket | net.Server | dgram.Socket | undefined = sendHandle;
+        const _sendHandle: net.Socket | net.Server = sendHandle;
     });
 
     cp = cp.once("close", (code, signal) => {
@@ -382,7 +381,7 @@ async function testPromisify() {
     });
     cp = cp.once("message", (message, sendHandle) => {
         const _message: any = message;
-        const _sendHandle: net.Socket | net.Server | dgram.Socket | undefined = sendHandle;
+        const _sendHandle: net.Socket | net.Server = sendHandle;
     });
 
     cp = cp.prependListener("close", (code, signal) => {
@@ -399,7 +398,7 @@ async function testPromisify() {
     });
     cp = cp.prependListener("message", (message, sendHandle) => {
         const _message: any = message;
-        const _sendHandle: net.Socket | net.Server | dgram.Socket | undefined = sendHandle;
+        const _sendHandle: net.Socket | net.Server = sendHandle;
     });
 
     cp = cp.prependOnceListener("close", (code, signal) => {
@@ -416,7 +415,7 @@ async function testPromisify() {
     });
     cp = cp.prependOnceListener("message", (message, sendHandle) => {
         const _message: any = message;
-        const _sendHandle: net.Socket | net.Server | dgram.Socket | undefined = sendHandle;
+        const _sendHandle: net.Socket | net.Server = sendHandle;
     });
 
     _boolean = cp.kill();

--- a/types/node/test/process.ts
+++ b/types/node/test/process.ts
@@ -201,9 +201,6 @@ process.env.TZ = "test";
         // $ExpectType number
         process.getuid();
     }
-
-    process.constrainedMemory(); // $ExpectType number
-    process.availableMemory(); // $ExpectType number
 }
 
 {

--- a/types/node/test/url.ts
+++ b/types/node/test/url.ts
@@ -187,17 +187,11 @@ import * as url from "node:url";
 
 {
     let path: string = url.fileURLToPath("file://test");
-    path = url.fileURLToPath("file://test", { windows: false });
-    path = url.fileURLToPath("file://test", { windows: true });
     path = url.fileURLToPath(new url.URL("file://test"));
-    path = url.fileURLToPath(new url.URL("file://test"), { windows: false });
-    path = url.fileURLToPath(new url.URL("file://test"), { windows: true });
 }
 
 {
-    let path: url.URL = url.pathToFileURL("file://test");
-    path = url.pathToFileURL("file://test", { windows: false });
-    path = url.pathToFileURL("file://test", { windows: true });
+    const path: url.URL = url.pathToFileURL("file://test");
 }
 
 {

--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -68,9 +68,6 @@ console.log(util.styleText("red", "Error! Error!"));
 console.log(
     util.styleText("underline", util.styleText("italic", "My italic underlined message")),
 );
-console.log(
-    util.styleText(["red", "green"], "text"),
-);
 
 // util.callbackify
 class callbackifyTest {

--- a/types/node/test/v8.ts
+++ b/types/node/test/v8.ts
@@ -72,12 +72,3 @@ v8.startupSnapshot.setDeserializeMainFunction((shelf: BookShelf): void => {
     const name = `${book}.${lang}`;
     console.log(shelf.storage.get(name));
 }, shelf);
-
-class A {
-    foo = "bar";
-}
-v8.queryObjects(A); // $ExpectType number | string[]
-const a = new A();
-v8.queryObjects(A); // $ExpectType number | string[]
-v8.queryObjects(A, { format: "count" }); // $ExpectType number
-v8.queryObjects(A, { format: "summary" }); // $ExpectType string[]

--- a/types/node/timers.d.ts
+++ b/types/node/timers.d.ts
@@ -6,7 +6,7 @@
  * The timer functions within Node.js implement a similar API as the timers API
  * provided by Web Browsers but use a different internal implementation that is
  * built around the Node.js [Event Loop](https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/#setimmediate-vs-settimeout).
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/timers.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/timers.js)
  */
 declare module "timers" {
     import { Abortable } from "node:events";

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -6,7 +6,7 @@
  * ```js
  * const tls = require('node:tls');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/tls.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/tls.js)
  */
 declare module "tls" {
     import { X509Certificate } from "node:crypto";

--- a/types/node/trace_events.d.ts
+++ b/types/node/trace_events.d.ts
@@ -90,7 +90,7 @@
  *
  * The features from this module are not available in [`Worker`](https://nodejs.org/docs/latest-v20.x/api/worker_threads.html#class-worker) threads.
  * @experimental
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/trace_events.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/trace_events.js)
  */
 declare module "trace_events" {
     /**

--- a/types/node/tty.d.ts
+++ b/types/node/tty.d.ts
@@ -21,7 +21,7 @@
  *
  * In most cases, there should be little to no reason for an application to
  * manually create instances of the `tty.ReadStream` and `tty.WriteStream` classes.
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/tty.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/tty.js)
  */
 declare module "tty" {
     import * as net from "node:net";

--- a/types/node/url.d.ts
+++ b/types/node/url.d.ts
@@ -5,7 +5,7 @@
  * ```js
  * import url from 'node:url';
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/url.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/url.js)
  */
 declare module "url" {
     import { Blob as NodeBlob } from "node:buffer";
@@ -46,14 +46,6 @@ declare module "url" {
     interface UrlWithStringQuery extends Url {
         query: string | null;
     }
-    interface FileUrlToPathOptions {
-        /**
-         * `true` if the `path` should be return as a windows filepath, `false` for posix, and `undefined` for the system default.
-         * @default undefined
-         */
-        windows?: boolean | undefined;
-    }
-    interface PathToFileUrlOptions extends FileUrlToPathOptions {}
     /**
      * The `url.parse()` method takes a URL string, parses it, and returns a URL
      * object.
@@ -306,7 +298,7 @@ declare module "url" {
      * @param url The file URL string or URL object to convert to a path.
      * @return The fully-resolved platform-specific Node.js file path.
      */
-    function fileURLToPath(url: string | URL, options?: FileUrlToPathOptions): string;
+    function fileURLToPath(url: string | URL): string;
     /**
      * This function ensures that `path` is resolved absolutely, and that the URL
      * control characters are correctly encoded when converting into a File URL.
@@ -324,7 +316,7 @@ declare module "url" {
      * @param path The path to convert to a File URL.
      * @return The file URL object.
      */
-    function pathToFileURL(path: string, options?: PathToFileUrlOptions): URL;
+    function pathToFileURL(path: string): URL;
     /**
      * This utility function converts a URL object into an ordinary options object as
      * expected by the `http.request()` and `https.request()` APIs.

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -6,7 +6,7 @@
  * ```js
  * const util = require('node:util');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/util.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/util.js)
  */
 declare module "util" {
     import * as types from "node:util/types";
@@ -1256,32 +1256,16 @@ declare module "util" {
      *
      * ```js
      * console.log(
-     *   util.styleText(['underline', 'italic'], 'My italic underlined message'),
-     * );
-     * ```
-     *
-     * When passing an array of formats, the order of the format applied is left to right so the following style
-     * might overwrite the previous one.
-     *
-     * ```js
-     * console.log(
-     *   util.styleText(['red', 'green'], 'text'), // green
+     *   util.styleText('underline', util.styleText('italic', 'My italic underlined message')),
      * );
      * ```
      *
      * The full list of formats can be found in [modifiers](https://nodejs.org/docs/latest-v20.x/api/util.html#modifiers).
-     * @param format A text format or an Array of text formats defined in `util.inspect.colors`.
+     * @param format A text format defined in `util.inspect.colors`.
      * @param text The text to to be formatted.
      * @since v20.12.0
      */
-    export function styleText(
-        format:
-            | ForegroundColors
-            | BackgroundColors
-            | Modifiers
-            | Array<ForegroundColors | BackgroundColors | Modifiers>,
-        text: string,
-    ): string;
+    export function styleText(format: ForegroundColors | BackgroundColors | Modifiers, text: string): string;
     /**
      * An implementation of the [WHATWG Encoding Standard](https://encoding.spec.whatwg.org/) `TextDecoder` API.
      *

--- a/types/node/v8.d.ts
+++ b/types/node/v8.d.ts
@@ -4,7 +4,7 @@
  * ```js
  * const v8 = require('node:v8');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/v8.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/v8.js)
  */
 declare module "v8" {
     import { Readable } from "node:stream";
@@ -183,50 +183,6 @@ declare module "v8" {
      * @since v1.0.0
      */
     function setFlagsFromString(flags: string): void;
-    /**
-     * This is similar to the [`queryObjects()` console API](https://developer.chrome.com/docs/devtools/console/utilities#queryObjects-function)
-     * provided by the Chromium DevTools console. It can be used to search for objects that have the matching constructor on its prototype chain
-     * in the heap after a full garbage collection, which can be useful for memory leak regression tests. To avoid surprising results, users should
-     * avoid using this API on constructors whose implementation they don't control, or on constructors that can be invoked by other parties in the
-     * application.
-     *
-     * To avoid accidental leaks, this API does not return raw references to the objects found. By default, it returns the count of the objects
-     * found. If `options.format` is `'summary'`, it returns an array containing brief string representations for each object. The visibility provided
-     * in this API is similar to what the heap snapshot provides, while users can save the cost of serialization and parsing and directly filter the
-     * target objects during the search.
-     *
-     * Only objects created in the current execution context are included in the results.
-     *
-     * ```js
-     * import { queryObjects } from 'node:v8';
-     * class A { foo = 'bar'; }
-     * console.log(queryObjects(A)); // 0
-     * const a = new A();
-     * console.log(queryObjects(A)); // 1
-     * // [ "A { foo: 'bar' }" ]
-     * console.log(queryObjects(A, { format: 'summary' }));
-     *
-     * class B extends A { bar = 'qux'; }
-     * const b = new B();
-     * console.log(queryObjects(B)); // 1
-     * // [ "B { foo: 'bar', bar: 'qux' }" ]
-     * console.log(queryObjects(B, { format: 'summary' }));
-     *
-     * // Note that, when there are child classes inheriting from a constructor,
-     * // the constructor also shows up in the prototype chain of the child
-     * // classes's prototoype, so the child classes's prototoype would also be
-     * // included in the result.
-     * console.log(queryObjects(A));  // 3
-     * // [ "B { foo: 'bar', bar: 'qux' }", 'A {}', "A { foo: 'bar' }" ]
-     * console.log(queryObjects(A, { format: 'summary' }));
-     * ```
-     * @param ctor The constructor that can be used to search on the prototype chain in order to filter target objects in the heap.
-     * @since v20.13.0
-     * @experimental
-     */
-    function queryObjects(ctor: Function): number | string[];
-    function queryObjects(ctor: Function, options: { format: "count" }): number;
-    function queryObjects(ctor: Function, options: { format: "summary" }): string[];
     /**
      * Generates a snapshot of the current V8 heap and returns a Readable
      * Stream that may be used to read the JSON serialized representation.

--- a/types/node/vm.d.ts
+++ b/types/node/vm.d.ts
@@ -34,7 +34,7 @@
  *
  * console.log(x); // 1; y is not defined.
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/vm.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/vm.js)
  */
 declare module "vm" {
     import { ImportAttributes } from "node:module";
@@ -347,14 +347,11 @@ declare module "vm" {
         sourceMapURL?: string | undefined;
     }
     /**
-     * If given a `contextObject`, the `vm.createContext()` method will
-     * [prepare that object](https://nodejs.org/docs/latest-v20.x/api/vm.html#what-does-it-mean-to-contextify-an-object)
-     * and return a reference to it so that it can be used in `{@link runInContext}` or
-     * [`script.runInContext()`](https://nodejs.org/docs/latest-v20.x/api/vm.html#scriptrunincontextcontextifiedobject-options). Inside such
-     * scripts, the `contextObject` will be the global object, retaining all of its
-     * existing properties but also having the built-in objects and functions any
-     * standard [global object](https://es5.github.io/#x15.1) has. Outside of scripts run by the vm module, global
-     * variables will remain unchanged.
+     * If given a `contextObject`, the `vm.createContext()` method will `prepare
+     * that object` so that it can be used in calls to {@link runInContext} or `script.runInContext()`. Inside such scripts,
+     * the `contextObject` will be the global object, retaining all of its existing
+     * properties but also having the built-in objects and functions any standard [global object](https://es5.github.io/#x15.1) has. Outside of scripts run by the vm module, global variables
+     * will remain unchanged.
      *
      * ```js
      * const vm = require('node:vm');

--- a/types/node/wasi.d.ts
+++ b/types/node/wasi.d.ts
@@ -67,7 +67,7 @@
  * wat2wasm demo.wat
  * ```
  * @experimental
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/wasi.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/wasi.js)
  */
 declare module "wasi" {
     interface WASIOptions {

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -49,7 +49,7 @@
  *
  * Worker threads inherit non-process-specific options by default. Refer to `Worker constructor options` to know how to customize worker thread options,
  * specifically `argv` and `execArgv` options.
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/worker_threads.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/worker_threads.js)
  */
 declare module "worker_threads" {
     import { Blob } from "node:buffer";

--- a/types/node/zlib.d.ts
+++ b/types/node/zlib.d.ts
@@ -89,7 +89,7 @@
  *   });
  * ```
  * @since v0.5.8
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/zlib.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.12.2/lib/zlib.js)
  */
 declare module "zlib" {
     import * as stream from "node:stream";


### PR DESCRIPTION
#69508 was missing the version bump. Revert it so we republish 20.12, then we'll send another PR that reverts this and bumps the version.