### PR TITLE
[node] Add missing typings for MessagePort in worker_threads

### DIFF
--- a/types/node/test/worker_threads.ts
+++ b/types/node/test/worker_threads.ts
@@ -147,3 +147,64 @@ import { createContext } from "node:vm";
     const mp1 = new workerThreads.MessagePort();
     const mp2 = new MessagePort();
 }
+
+{
+    // Test addEventListener, removeEventListener and dispatchEvent
+    if (workerThreads.isMainThread) {
+        const worker = new workerThreads.Worker(__filename);
+        const { port1, port2 } = new workerThreads.MessageChannel();
+        const events: string[] = [];
+
+        const customEvent = (event: Event) => events.push(event.type);
+
+        // addEventListener
+        port1.addEventListener("message", (event) => events.push(event.type));
+        port1.addEventListener("close", (event) => events.push(event.type));
+        port1.addEventListener("dispatch", (event) => events.push(event.type));
+        port1.addEventListener("custom_event", customEvent);
+
+        // emit custom_event
+        port1.emit("custom_event", "test");
+
+        // removeEventListener
+        port1.removeEventListener("custom_event", customEvent);
+        port1.emit("custom_event", "It won't emit as it has been removed");
+
+        // emit dispatch event
+        port1.dispatchEvent(new Event("dispatch"));
+
+        // emit message event
+        worker.postMessage({ port: port2 }, [port2]);
+        port1.postMessage("From main to parent");
+
+        // close event
+        setTimeout(() => {
+            port1.close();
+            port2.close();
+
+            assert.deepStrictEqual(events, [
+                "custom_event",
+                "dispatch",
+                "message",
+                "close",
+            ], "Main Events");
+        }, 250);
+    } else if (workerThreads.parentPort) {
+        const events: string[] = [];
+
+        workerThreads.parentPort.once("message", ({ port: parentPort }) => {
+            const port: workerThreads.MessagePort = parentPort;
+
+            port.addEventListener("message", (event) => {
+                events.push(event.type);
+                port.postMessage("From parent to main");
+            });
+
+            setTimeout(() => {
+                port.close();
+
+                assert.deepStrictEqual(events, ["message"], "Parent Events");
+            }, 125);
+        });
+    }
+}

--- a/types/node/v16/worker_threads.d.ts
+++ b/types/node/v16/worker_threads.d.ts
@@ -237,6 +237,9 @@ declare module "worker_threads" {
         off(event: "message", listener: (value: any) => void): this;
         off(event: "messageerror", listener: (error: Error) => void): this;
         off(event: string | symbol, listener: (...args: any[]) => void): this;
+        addEventListener: EventTarget["addEventListener"];
+        dispatchEvent: EventTarget["dispatchEvent"];
+        removeEventListener: EventTarget["removeEventListener"];
     }
     interface WorkerOptions {
         /**

--- a/types/node/v18/test/worker_threads.ts
+++ b/types/node/v18/test/worker_threads.ts
@@ -147,3 +147,64 @@ import { createContext } from "node:vm";
     const mp1 = new workerThreads.MessagePort();
     const mp2 = new MessagePort();
 }
+
+{
+    // Test addEventListener, removeEventListener and dispatchEvent
+    if (workerThreads.isMainThread) {
+        const worker = new workerThreads.Worker(__filename);
+        const { port1, port2 } = new workerThreads.MessageChannel();
+        const events: string[] = [];
+
+        const customEvent = (event: Event) => events.push(event.type);
+
+        // addEventListener
+        port1.addEventListener("message", (event) => events.push(event.type));
+        port1.addEventListener("close", (event) => events.push(event.type));
+        port1.addEventListener("dispatch", (event) => events.push(event.type));
+        port1.addEventListener("custom_event", customEvent);
+
+        // emit custom_event
+        port1.emit("custom_event", "test");
+
+        // removeEventListener
+        port1.removeEventListener("custom_event", customEvent);
+        port1.emit("custom_event", "It won't emit as it has been removed");
+
+        // emit dispatch event
+        port1.dispatchEvent(new Event("dispatch"));
+
+        // emit message event
+        worker.postMessage({ port: port2 }, [port2]);
+        port1.postMessage("From main to parent");
+
+        // close event
+        setTimeout(() => {
+            port1.close();
+            port2.close();
+
+            assert.deepStrictEqual(events, [
+                "custom_event",
+                "dispatch",
+                "message",
+                "close",
+            ], "Main Events");
+        }, 250);
+    } else if (workerThreads.parentPort) {
+        const events: string[] = [];
+
+        workerThreads.parentPort.once("message", ({ port: parentPort }) => {
+            const port: workerThreads.MessagePort = parentPort;
+
+            port.addEventListener("message", (event) => {
+                events.push(event.type);
+                port.postMessage("From parent to main");
+            });
+
+            setTimeout(() => {
+                port.close();
+
+                assert.deepStrictEqual(events, ["message"], "Parent Events");
+            }, 125);
+        });
+    }
+}

--- a/types/node/v18/worker_threads.d.ts
+++ b/types/node/v18/worker_threads.d.ts
@@ -237,6 +237,9 @@ declare module "worker_threads" {
         off(event: "message", listener: (value: any) => void): this;
         off(event: "messageerror", listener: (error: Error) => void): this;
         off(event: string | symbol, listener: (...args: any[]) => void): this;
+        addEventListener: EventTarget["addEventListener"];
+        dispatchEvent: EventTarget["dispatchEvent"];
+        removeEventListener: EventTarget["removeEventListener"];
     }
     interface WorkerOptions {
         /**

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -237,6 +237,9 @@ declare module "worker_threads" {
         off(event: "message", listener: (value: any) => void): this;
         off(event: "messageerror", listener: (error: Error) => void): this;
         off(event: string | symbol, listener: (...args: any[]) => void): this;
+        addEventListener: EventTarget["addEventListener"];
+        dispatchEvent: EventTarget["dispatchEvent"];
+        removeEventListener: EventTarget["removeEventListener"];
     }
     interface WorkerOptions {
         /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:



- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v15.x/docs/api/worker_threads.html#worker_threads_class_messageport

> I haven't found documentation that explicitly states this usage method. So, I'll provide a complete minimal reproduction using native **JavaScript** (**Node.js**).

Closes #52340.

---

The `workerThreads.MessagePort` supports the use of `addEventListener`, `removeEventListener`, and `dispatchEvent`. However, I noticed the absence of these options in **@types/node**.

The proposed approach is to preserve the current state, by _just_ adding the `addEventListener`, `removeEventListener` and `dispatchEvent` options to `MessagePort` without the need to repeat types or _breaking changes_.

---

Here is a complete and functional example demonstrating all the options mentioned working:

<details>
<summary>
test.js <i>(click to show)</i>
</summary>

```js
'use strict';

const workerThreads = require('node:worker_threads');

if (workerThreads.isMainThread) {
    const worker = new workerThreads.Worker(__filename);
    const { port1, port2 } = new workerThreads.MessageChannel();
    const events = [];

    const customEvent = (event) => events.push(event.type);

    // addEventListener
    port1.addEventListener('message', (event) => events.push(event.type));
    port1.addEventListener('close', (event) => events.push(event.type));
    port1.addEventListener('dispatch', (event) => events.push(event.type));
    port1.addEventListener('custom_event', customEvent);

    // emit custom_event
    port1.emit('custom_event', 'test');

    // removeEventListener
    port1.removeEventListener('custom_event', customEvent);
    port1.emit('custom_event', "It won't emit as it has been removed");

    // emit dispatch event
    port1.dispatchEvent(new Event('dispatch'));

    // emit message event
    worker.postMessage({ port: port2 }, [port2]);
    port1.postMessage('From main to parent');

    // close event
    setTimeout(() => {
        port1.close();
        port2.close();

        console.log('Main Events:', events);
    }, 500);
} else if (workerThreads.parentPort) {
    const events = [];

    workerThreads.parentPort.once('message', ({ port: parentPort }) => {
        const port = parentPort;

        port.addEventListener('message', (event) => {
            events.push(event.type);
            port.postMessage('From parent to main');
        });

        setTimeout(() => {
            port.close();

            console.log('Parent Events:', events);
        }, 250);
    });
}
```

</details>

Then:

```sh
node test.js
```

Output:

```
Parent Events: [ 'message' ]
Main Events: [ 'custom_event', 'dispatch', 'message', 'close' ]
```

- Note that the `custom_event` was emitted twice, but appears only once due to the `removeEventListener` 🙋🏻‍♂️

---

<details open>
<summary>
How it is without these changes if the same is done with <b>TypeScript</b>:
</summary>

<img width="659" alt="Screenshot 2024-06-02 at 17 40 25" src="https://github.com/DefinitelyTyped/DefinitelyTyped/assets/46850407/497ab5bf-7003-486f-be3b-3f73967ad9cf">

</details>

---

To ensure that the changes work across different **Node.js** versions, I used the official **Docker** image for each version that was modified:

<details>
<summary>
See detailed results
</summary>

> _docker-compose.yml_

```yml
# version: '3.9'
services:
  node-16:
    image: node:16-alpine
    working_dir: /usr/app
    volumes:
      - ./:/usr/app
    command: node test.js
  node-18:
    image: node:18-alpine
    working_dir: /usr/app
    volumes:
      - ./:/usr/app
    command: node test.js
  node-20:
    image: node:20-alpine
    working_dir: /usr/app
    volumes:
      - ./:/usr/app
    command: node test.js
  node-22:
    image: node:22-alpine
    working_dir: /usr/app
    volumes:
      - ./:/usr/app
    command: node test.js
```

Then

```sh
docker compose up
```

Output

<img width="569" alt="Screenshot 2024-06-02 at 17 07 18" src="https://github.com/DefinitelyTyped/DefinitelyTyped/assets/46850407/e4f346fa-c345-4098-a9ff-f0968b6d7fb5">

</details>
