### PR TITLE
relay-runtime - Improve type-safety of RecordProxy#getOrCreateLinkedRecord

### DIFF
--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -354,6 +354,7 @@ export interface RecordProxy<T = {}> {
     ): [H] extends [never] ? RecordProxy[] | null
         : NonNullable<H> extends Array<infer U> ? Array<RecordProxy<U>> | (H extends null ? null : never)
         : never;
+    getOrCreateLinkedRecord<K extends keyof T>(name: T, typeName: string, args?: Variables | null): RecordProxy<NonNullable<T[K]>>;
     getOrCreateLinkedRecord(name: string, typeName: string, args?: Variables | null): RecordProxy<T>;
     getType(): string;
     getValue<K extends keyof T>(name: K, args?: Variables | null): T[K];

--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -354,7 +354,7 @@ export interface RecordProxy<T = {}> {
     ): [H] extends [never] ? RecordProxy[] | null
         : NonNullable<H> extends Array<infer U> ? Array<RecordProxy<U>> | (H extends null ? null : never)
         : never;
-    getOrCreateLinkedRecord<K extends keyof T>(name: T, typeName: string, args?: Variables | null): RecordProxy<NonNullable<T[K]>>;
+    getOrCreateLinkedRecord<K extends keyof T>(name: K, typeName: string, args?: Variables | null): RecordProxy<NonNullable<T[K]>>;
     getOrCreateLinkedRecord(name: string, typeName: string, args?: Variables | null): RecordProxy<T>;
     getType(): string;
     getValue<K extends keyof T>(name: K, args?: Variables | null): T[K];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://relay.dev/docs/api-reference/store/#getorcreatelinkedrecordname-string-typename-string-arguments-object
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.



This is mostly a RFC, this seems to be working well from some testing I did, and in theory is not a breaking change as the previous definition is kept as an overload. The previous type is actually wrong, as this will not return a record proxy of the same type every time, it depends on the field itself.

It is missing tests, but I am not sure what is the best way to add these, the method is currently not being tested.