### PR TITLE
Add testEnvironment option to ConstructorOptions in node-telegram-bot-api

### DIFF
--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -117,6 +117,7 @@ declare namespace TelegramBot {
         request?: Options | undefined;
         baseApiUrl?: string | undefined;
         filepath?: boolean | undefined;
+        testEnvironment?: boolean | undefined;
     }
 
     interface StartPollingOptions extends ConstructorOptions {


### PR DESCRIPTION
**Description:**
This PR introduces a new `testEnvironment` option to the `ConstructorOptions` interface for the `node-telegram-bot-api` type definitions. This option is intended to facilitate better control during testing, allowing developers to specify if the environment is a test environment, which can affect various internal behaviors of the library.

**Type of change:**
Adding a new property to an existing interface.

**Justification:**
The underlying library `node-telegram-bot-api` supports a variety of configurations that can be beneficial during development and testing. By exposing `testEnvironment` in the TypeScript definitions, developers can take advantage of static typing to manage configurations specific to testing environments more effectively.

**Checklist:**
- [x] I have tested the changes in my own code (compile and run).
- [x] I have added or edited the necessary tests in my fork to reflect these changes.
- [x] I have read the guidelines in the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] I have followed common TypeScript and DefinitelyTyped [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes) guidelines.
- [x] I have run `pnpm test node-telegram-bot-api` and all tests pass without new failures.

**Documentation or source code reference:**
- (Provide a URL or description where this new configuration is discussed or used in the source library if applicable. If the feature is not documented yet, please mention that.)

**Note:**
If the `testEnvironment` option is not currently documented in the node-telegram-bot-api's official documentation, it might be beneficial to add a note here about how this change aligns with any upcoming features or internal API adjustments that are planned but not yet published.
