### PR TITLE
fix: typescript compilation error in lib/webdriver.d.ts

### DIFF
--- a/types/selenium-webdriver/lib/webdriver.d.ts
+++ b/types/selenium-webdriver/lib/webdriver.d.ts
@@ -286,7 +286,7 @@ export class WebDriver {
     quit(): Promise<void>;
 
     /** @override */
-    actions(options: { async: boolean | undefined; bridge: boolean | undefined }): Actions;
+    actions(options?: { async: boolean; bridge: boolean } | { async: boolean } | { bridge: boolean }): Actions;
 
     /**
      * Executes a snippet of JavaScript in the context of the currently selected

--- a/types/selenium-webdriver/lib/webdriver.d.ts
+++ b/types/selenium-webdriver/lib/webdriver.d.ts
@@ -286,7 +286,7 @@ export class WebDriver {
     quit(): Promise<void>;
 
     /** @override */
-    actions(options?: { async: boolean; bridge: boolean } | { async: boolean } | { bridge: boolean }): Actions;
+    actions(options?: { async?: boolean; bridge?: boolean }): Actions;
 
     /**
      * Executes a snippet of JavaScript in the context of the currently selected

--- a/types/selenium-webdriver/lib/webdriver.d.ts
+++ b/types/selenium-webdriver/lib/webdriver.d.ts
@@ -286,7 +286,7 @@ export class WebDriver {
     quit(): Promise<void>;
 
     /** @override */
-    actions(options?: { async?: boolean; bridge?: boolean }): Actions;
+    actions(options?: { async?: boolean | undefined; bridge?: boolean | undefined }): Actions;
 
     /**
      * Executes a snippet of JavaScript in the context of the currently selected

--- a/types/selenium-webdriver/test/index.ts
+++ b/types/selenium-webdriver/test/index.ts
@@ -480,6 +480,13 @@ async function TestWebDriver() {
     let wsUrl: string = await driver.getWsUrl("TargetAddress", "target", await driver.getCapabilities());
 
     driver = webdriver.WebDriver.createSession(executor, webdriver.Capabilities.chrome());
+    
+    //actions api
+    let actions = await driver.actions();
+    actions = driver.actions({async:true});
+    actions = driver.actions({bridge: true});
+    actions = driver.actions({async:true, bridge: true});
+    actions.clear()
 }
 
 declare const serializable: webdriver.Serializable<string>;


### PR DESCRIPTION
To avoid typescript error

```
TS2345: Argument of type '{ bridge: true; }' is not assignable to parameter of type '{ async: boolean; bridge: boolean; }'.
  Property 'async' is missing in type '{ bridge: true; }' but required in type '{ async: boolean; bridge: boolean; }'
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
