### PR TITLE
[@types/aws-lambda] make messageAttributes partial to indicate any key name might not exist

### DIFF
--- a/types/aws-lambda/package.json
+++ b/types/aws-lambda/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/aws-lambda",
-    "version": "9.0.0",
+    "version": "9.0.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "AWS Lambda",
     "projects": [

--- a/types/aws-lambda/package.json
+++ b/types/aws-lambda/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/aws-lambda",
-    "version": "8.10.9999",
+    "version": "9.0.0",
     "nonNpm": "conflict",
     "nonNpmDescription": "AWS Lambda",
     "projects": [

--- a/types/aws-lambda/test/sqs-tests.ts
+++ b/types/aws-lambda/test/sqs-tests.ts
@@ -5,9 +5,16 @@ import { SQSEvent, SQSHandler } from "aws-lambda";
 const handler: SQSHandler = async (event, context, callback) => {
     str = event.Records[0].messageId;
     anyObj = event.Records[0].body;
-    strOrUndefined = event.Records[0].messageAttributes.testAttr.stringValue;
-    strOrUndefined = event.Records[0].messageAttributes.testAttr.binaryValue;
-    str = event.Records[0].messageAttributes.testAttr.dataType;
+
+    // We do a non-null assertion here because we know it's there, based on the type below and to further test deeper properties.
+    let knownAttr = event.Records[0].messageAttributes.testAttr; 
+    if (knownAttr) {
+      strOrUndefined = knownAttr.stringValue;
+      strOrUndefined = knownAttr.binaryValue;
+      str = knownAttr.dataType;
+    }
+
+    objectOrUndefined = event.Records[0].messageAttributes.nonExistingAttr;
 
     callback();
     callback(new Error());

--- a/types/aws-lambda/test/sqs-tests.ts
+++ b/types/aws-lambda/test/sqs-tests.ts
@@ -7,11 +7,11 @@ const handler: SQSHandler = async (event, context, callback) => {
     anyObj = event.Records[0].body;
 
     // We do a non-null assertion here because we know it's there, based on the type below and to further test deeper properties.
-    let knownAttr = event.Records[0].messageAttributes.testAttr; 
+    let knownAttr = event.Records[0].messageAttributes.testAttr;
     if (knownAttr) {
-      strOrUndefined = knownAttr.stringValue;
-      strOrUndefined = knownAttr.binaryValue;
-      str = knownAttr.dataType;
+        strOrUndefined = knownAttr.stringValue;
+        strOrUndefined = knownAttr.binaryValue;
+        str = knownAttr.dataType;
     }
 
     objectOrUndefined = event.Records[0].messageAttributes.nonExistingAttr;

--- a/types/aws-lambda/trigger/sqs.d.ts
+++ b/types/aws-lambda/trigger/sqs.d.ts
@@ -10,7 +10,7 @@ export interface SQSRecord {
     receiptHandle: string;
     body: string;
     attributes: SQSRecordAttributes;
-    messageAttributes: SQSMessageAttributes;
+    messageAttributes: Partial<SQSMessageAttributes>;
     md5OfBody: string;
     eventSource: string;
     eventSourceARN: string;


### PR DESCRIPTION
Please fill in this template.

This change introduces the Partial type to the messageAttributes based on the simple reason, any name you want might not exist, so this forces you as a developer to verify it exists, by either wrapping it in an if statement or using the nullish operator `?`, to access any sub-types.

_The current implementation can lead to flaws in a code base, meaning you might use a name, that does not exist in the SQS message, and therefore start reading on an undefined object, making the application crash_

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-params
- ^^ The docs does not really tell this, but since the type is defined as any key can result in the proper typed object, which is not true and can lead to TypeErrors of trying to read something on undefined, if you use a key that does not exist.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. 
- ^^ _It does not bring it up to date, but rather fix a mistake, so not sure if the major bump is the correct play here, but it does introduce breaking changes_

