### PR TITLE
[react-autocomplete]: add default for `autoHighlight` prop

### DIFF
--- a/types/react-autocomplete/index.d.ts
+++ b/types/react-autocomplete/index.d.ts
@@ -116,8 +116,10 @@ declare namespace Autocomplete {
         /**
          * Whether or not to automatically highlight the top match in the dropdown
          * menu.
+         *
+         * @default true
          */
-        autoHighlight?: true | undefined;
+        autoHighlight?: boolean | undefined;
         /**
          * Whether or not to automatically select the highlighted item when the
          * `<input>` loses focus.

--- a/types/react-autocomplete/index.d.ts
+++ b/types/react-autocomplete/index.d.ts
@@ -117,7 +117,7 @@ declare namespace Autocomplete {
          * Whether or not to automatically highlight the top match in the dropdown
          * menu.
          */
-        autoHighlight?: boolean | undefined;
+        autoHighlight?: true | undefined;
         /**
          * Whether or not to automatically select the highlighted item when the
          * `<input>` loses focus.

--- a/types/react-autocomplete/react-autocomplete-tests.tsx
+++ b/types/react-autocomplete/react-autocomplete-tests.tsx
@@ -9,6 +9,7 @@ const items = ["hello", "world"];
     getItemValue={(item) => item}
     renderItem={(item) => <div key={item}>{item}</div>}
     value={items[0]}
+    autoHighlight={false}
 />;
 
 // @ts-expect-error


### PR DESCRIPTION
### Rationale

Noticed the `autoHighlight` typings were missing the default `true` when I tried to reference them in https://github.com/argoproj/argo-ui/pull/560#issuecomment-2155872347

#### Source

See the default upstream in `react-autocomplete`:
- [docs](https://github.com/reactjs/react-autocomplete/tree/41388f7d7760bf6cf38e7946e43d4fddd9c7c176?tab=readme-ov-file#autohighlight-boolean-optional)
- [source code](https://github.com/reactjs/react-autocomplete/blob/41388f7d7760bf6cf38e7946e43d4fddd9c7c176/lib/Autocomplete.js#L188)

### Notes to Reviewers

I'm not sure what the convention is for defaults exactly, please let me know if JSDoc `@default` is preferred or something and feel free to modify.

Also let me know if there's a better or preferred way to test this than the prop addition I made to the one existing smoke test

### Checklist

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
    - the existing test seems to just be a smoke test? I added the prop as another smoke, but there wasn't a place I could add another test case
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reactjs/react-autocomplete/blob/41388f7d7760bf6cf38e7946e43d4fddd9c7c176/lib/Autocomplete.js#L188
