### PR TITLE
fix(node/structuredClone): allow writability of structuredClone typings

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -146,6 +146,33 @@ declare global {
     interface BigUint64Array extends RelativeIndexable<bigint> {}
     // #endregion ArrayLike.at() end
 
+    type IsAny<Type> = 0 extends 1 & Type ? true : false;
+    type Primitive = string | number | boolean | bigint | symbol | undefined | null;
+    type Builtin = Primitive | Function | Date | Error | RegExp;
+    type IsUnknown<Type> = IsAny<Type> extends true ? false : unknown extends Type ? true : false;
+
+    type DeepWritable<Type> = Type extends Exclude<Builtin, Error>
+        ? Type
+        : Type extends Map<infer Key, infer Value>
+        ? Map<DeepWritable<Key>, DeepWritable<Value>>
+        : Type extends ReadonlyMap<infer Key, infer Value>
+        ? Map<DeepWritable<Key>, DeepWritable<Value>>
+        : Type extends WeakMap<infer Key, infer Value>
+        ? WeakMap<DeepWritable<Key>, DeepWritable<Value>>
+        : Type extends Set<infer Values>
+        ? Set<DeepWritable<Values>>
+        : Type extends ReadonlySet<infer Values>
+        ? Set<DeepWritable<Values>>
+        : Type extends WeakSet<infer Values>
+        ? WeakSet<DeepWritable<Values>>
+        : Type extends Promise<infer Value>
+        ? Promise<DeepWritable<Value>>
+        : Type extends {}
+        ? { -readonly [Key in keyof Type]: DeepWritable<Type[Key]> }
+        : IsUnknown<Type> extends true
+        ? unknown
+        : Type;
+
     /**
      * @since v17.0.0
      *
@@ -154,7 +181,7 @@ declare global {
     function structuredClone<T>(
         value: T,
         transfer?: { transfer: ReadonlyArray<import("worker_threads").TransferListItem> },
-    ): T;
+    ): DeepWritable<T>;
 
     /*----------------------------------------------*
     *                                               *

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -146,6 +146,7 @@ declare global {
     interface BigUint64Array extends RelativeIndexable<bigint> {}
     // #endregion ArrayLike.at() end
 
+    // DeepWritable and types from https://github.com/ts-essentials/ts-essentials/blob/365612c0de7f32d203552861d8431986c0d291c4/lib/deep-writable/index.ts
     type IsAny<Type> = 0 extends 1 & Type ? true : false;
     type Primitive = string | number | boolean | bigint | symbol | undefined | null;
     type Builtin = Primitive | Function | Date | Error | RegExp;

--- a/types/node/test/globals.ts
+++ b/types/node/test/globals.ts
@@ -36,6 +36,8 @@ declare var RANDOM_GLOBAL_VARIABLE: true;
 
     const arrayBuffer = new ArrayBuffer(0);
     structuredClone({ test: arrayBuffer }, { transfer: [arrayBuffer] }); // $ExpectType { test: ArrayBuffer; }
+
+    structuredClone(Object.freeze({ test: arrayBuffer })); // $ExpectType { test: ArrayBuffer; }
 }
 
 // Array.prototype.at()


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

`structuredClone` removes the immutability usually presented by the `readonly` operator by functions like `Object.freeze`. ([see playground](https://www.typescriptlang.org/play/?#code/MYewdgzgLgBARjAvDaAnArsK7UFMAmAwgDbi4AUA8nAFa5YB0AZnrgF4UDeMAHgFwwAjAF8AlKIBQcBjyQwAzACYJoSCGK4GpAObk4ogNwSgA))

**This PR is NOT ready.** While it isn't marked as draft (for it is able to work), the types are from [ts-essentials](https://github.com/ts-essentials/ts-essentials/blob/365612c0de7f32d203552861d8431986c0d291c4/lib/deep-writable/index.ts) after realizing that the one I could write did not cover every edge case. However, presumably, I'm unsure if the library should be imported and reused (but given `@types/node`s prevalence, I don't think that's such a good idea), inlined, or perhaps added as an in-built maintained type to TypeScript? I'm mainly opening this up for future discussion.