### PR TITLE
[@types/chrome] scripting.StyleOrigin and ExecutionWorld are enums

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -7986,10 +7986,16 @@ declare namespace chrome.runtime {
  */
 declare namespace chrome.scripting {
     /* The CSS style origin for a style change. */
-    export type StyleOrigin = "AUTHOR" | "USER";
+    export enum StyleOrigin {
+        AUTHOR = "AUTHOR",
+        USER = "USER",
+    }
 
     /* The JavaScript world for a script to execute within. */
-    export type ExecutionWorld = "ISOLATED" | "MAIN";
+    export enum ExecutionWorld {
+        ISOLATED = "ISOLATED",
+        MAIN = "MAIN",
+    }
 
     export interface InjectionResult<T extends any = any> {
         /**
@@ -8036,7 +8042,7 @@ declare namespace chrome.scripting {
             /* Details specifying the target into which to inject the script. */
             target: InjectionTarget;
             /* The JavaScript world for a script to execute within. */
-            world?: ExecutionWorld;
+            world?: ExecutionWorld.MAIN | ExecutionWorld.ISOLATED;
             /* Whether the injection should be triggered in the target as soon as possible. Note that this is not a guarantee that injection will occur prior to page load, as the page may have already loaded by the time the script reaches the target. */
             injectImmediately?: boolean;
         }
@@ -13095,7 +13101,7 @@ declare namespace chrome.userScripts {
         /** Specifies when JavaScript files are injected into the web page. The preferred and default value is document_idle */
         runAt?: RunAt;
         /** The JavaScript execution environment to run the script in. The default is `USER_SCRIPT` */
-        world?: ExecutionWorld;
+        world?: ExecutionWorld.MAIN | ExecutionWorld.ISOLATED;
     }
 
     /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/scripting#type-ExecutionWorld and https://developer.chrome.com/docs/extensions/reference/api/scripting#type-StyleOrigin
