### PR TITLE
[dns2] Add `type` property to `udp` ListenOptions

### DIFF
--- a/types/dns2/dns2-tests.ts
+++ b/types/dns2/dns2-tests.ts
@@ -139,6 +139,49 @@ serverOnAddress.listen({
     },
 });
 
+const serverOnAddressWithUdpType = DNS.createServer({
+    udp: true,
+    handle: (request, send, rinfo) => {
+        const response = Packet.createResponseFromRequest(request);
+        const [question] = request.questions;
+        const { name } = question;
+        response.answers.push({
+            name,
+            type: Packet.TYPE.A,
+            class: Packet.CLASS.IN,
+            ttl: 300,
+            address: "8.8.8.8",
+        });
+        response.answers.push({
+            name,
+            type: Packet.TYPE.CNAME,
+            class: Packet.CLASS.IN,
+            ttl: 300,
+            domain: "another-name.example.com",
+        });
+        response.answers.push({
+            name,
+            type: Packet.TYPE.TXT,
+            class: Packet.CLASS.IN,
+            ttl: 60,
+            data: "dnslink=/ipfs/123abc",
+        });
+        send(response);
+    },
+});
+
+serverOnAddressWithUdpType.on("request", (request, response, rinfo) => {
+    console.log(request.header.id, request.questions[0]);
+});
+
+serverOnAddressWithUdpType.listen({
+    udp: {
+        port: 5355,
+        address: "0.0.0.0",
+        type: 'udp4'
+    },
+});
+
 const udpServer = new DNS.UDPServer((request, send, rinfo) => {
     const response = Packet.createResponseFromRequest(request);
     send(response);

--- a/types/dns2/dns2-tests.ts
+++ b/types/dns2/dns2-tests.ts
@@ -178,7 +178,7 @@ serverOnAddressWithUdpType.listen({
     udp: {
         port: 5355,
         address: "0.0.0.0",
-        type: 'udp4'
+        type: "udp4",
     },
 });
 

--- a/types/dns2/index.d.ts
+++ b/types/dns2/index.d.ts
@@ -84,8 +84,10 @@ declare namespace DNS {
         type: "udp4" | "udp6";
     }
 
+    type UdpListenOptions = ListenOptions & UdpDnsServerOptions;
+
     interface DnsServerListenOptions {
-        udp?: ListenOptions;
+        udp?: UdpListenOptions;
         tcp?: ListenOptions;
         doh?: ListenOptions;
     }
@@ -101,6 +103,7 @@ declare namespace DNS {
     type ListenOptions = number | {
         port: number;
         address: string;
+        type: "udp4" | "udp6"
     };
 }
 

--- a/types/dns2/index.d.ts
+++ b/types/dns2/index.d.ts
@@ -84,7 +84,9 @@ declare namespace DNS {
         type: "udp4" | "udp6";
     }
 
-    type UdpListenOptions = ListenOptions & UdpDnsServerOptions;
+    type UdpListenOptions = ListenOptions & {
+        type?: "udp4" | "udp6"
+    }
 
     interface DnsServerListenOptions {
         udp?: UdpListenOptions;

--- a/types/dns2/index.d.ts
+++ b/types/dns2/index.d.ts
@@ -85,8 +85,8 @@ declare namespace DNS {
     }
 
     type UdpListenOptions = ListenOptions & {
-        type?: "udp4" | "udp6"
-    }
+        type?: "udp4" | "udp6";
+    };
 
     interface DnsServerListenOptions {
         udp?: UdpListenOptions;

--- a/types/dns2/index.d.ts
+++ b/types/dns2/index.d.ts
@@ -103,7 +103,6 @@ declare namespace DNS {
     type ListenOptions = number | {
         port: number;
         address: string;
-        type: "udp4" | "udp6"
     };
 }
 


### PR DESCRIPTION
The source code for the `dns2` package, as stated in its README, accepts an optional `type` property in the UDP listen options. This PR adds them.

- [Original package source code for accepting `type`](https://github.com/song940/node-dns/blob/master/server/udp.js#L13)
- [Original package README stating it accepts `type`](https://github.com/song940/node-dns/tree/master?tab=readme-ov-file#example-server)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
