### PR TITLE
[dockerode] add version option for `buildImage`

### DIFF
--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -315,7 +315,7 @@ docker.buildImage(
     },
 );
 
-docker.buildImage(".", { nocache: true }, (err, response) => {
+docker.buildImage(".", { nocache: true, version: "2" }, (err, response) => {
     // NOOP
 });
 

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -973,6 +973,13 @@ declare namespace Dockerode {
         target?: string | undefined;
         outputs?: string | undefined;
         nocache?: boolean | undefined;
+
+        /**
+         * Version of the builder backend to use.
+         *  - `1` is the first generation classic (deprecated) builder in the Docker daemon (default)
+         *  - `2` is [BuildKit](https://github.com/moby/buildkit)
+         */
+        version?: "1" | "2" | undefined;
     }
 
     interface ImageDistributionOptions {


### PR DESCRIPTION
This PR is related to https://github.com/apocas/dockerode/issues/601, where an upstream change by the moby engine allows `dockerode` to support this PR without internal changes.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: The `version` option was added in the moby engine: https://github.com/moby/moby/commit/0c3b8ccda7fd71a9d90b29848dce4a2010bced7e. The type definition doesn't require changing to support this option as it's a passthrough: https://github.com/apocas/dockerode/blob/master/lib/docker.js#L268
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
