### PR TITLE
[carbon-components-react] Ensure forwards compatiblity with React 19

### DIFF
--- a/types/carbon-components-react/lib/components/Toggle/Toggle.d.ts
+++ b/types/carbon-components-react/lib/components/Toggle/Toggle.d.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ReactInputAttr } from "../../../typings/shared";
 
-type ExcludedAttributes = "aria-labelledby" | "id" | "onChange" | "onKeyUp" | "size" | "type";
+type ExcludedAttributes = "aria-labelledby" | "id" | "onChange" | "onKeyUp" | "onToggle" | "size" | "type";
 
 export interface ToggleProps extends Omit<ReactInputAttr, ExcludedAttributes> {
     defaultToggled?: boolean | undefined;

--- a/types/carbon-components-react/lib/components/ToggleSmall/ToggleSmall.d.ts
+++ b/types/carbon-components-react/lib/components/ToggleSmall/ToggleSmall.d.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ReactInputAttr } from "../../../typings/shared";
 
-type ExcludedAttributes = "aria-label" | "id" | "onChange" | "onKeyUp" | "ref" | "type";
+type ExcludedAttributes = "aria-label" | "id" | "onChange" | "onKeyUp" | "onToggle" | "ref" | "type";
 
 export interface ToggleSmallProps extends Omit<ReactInputAttr, ExcludedAttributes> {
     "aria-label": string;

--- a/types/carbon-components-react/lib/components/TreeView/TreeNode.d.ts
+++ b/types/carbon-components-react/lib/components/TreeView/TreeNode.d.ts
@@ -1,7 +1,9 @@
 import * as React from "react";
 import { ReactLIAttr } from "../../../typings/shared";
 
-export interface TreeNodeStandaloneProps extends Omit<ReactLIAttr, "aria-expanded" | "onClick" | "onSelect"> {
+export interface TreeNodeStandaloneProps
+    extends Omit<ReactLIAttr, "aria-expanded" | "onClick" | "onSelect" | "onToggle">
+{
     active?: number | string | undefined;
     depth?: number | undefined;
     isExpanded?: boolean | undefined;

--- a/types/carbon-components-react/lib/components/UIShell/SideNav.d.ts
+++ b/types/carbon-components-react/lib/components/UIShell/SideNav.d.ts
@@ -3,7 +3,7 @@ import { ForwardRefReturn, InternationalProps, ReactAttr } from "../../../typing
 
 export type SideNavTranslationKey = "carbon.sidenav.state.closed" | "carbon.sidenav.state.open";
 
-export interface SideNavProps extends ReactAttr, InternationalProps<SideNavTranslationKey> {
+export interface SideNavProps extends Omit<ReactAttr, "onToggle">, InternationalProps<SideNavTranslationKey> {
     addFocusListeners?: boolean | undefined;
     addMouseListeners?: boolean | undefined;
     defaultExpanded?: boolean | undefined;


### PR DESCRIPTION
In React 19, `onToggle` will move to `DOMAttributes` due to support of the Popover API. Libraries extending `DOMAttributes` with their custom `onToggle` will have their types broken since extending an interface means all properties need to be compatible. But oftentimes the custom `onToggle` has nothing in common with the native `onToggle`.

We can already make this change now so that we have a release of those libraries ready by the time React 19 is release.

Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69022