### PR TITLE
[react-bootstrap] Ensure forwards compatiblity with React 19

### DIFF
--- a/types/react-bootstrap/lib/NavItem.d.ts
+++ b/types/react-bootstrap/lib/NavItem.d.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 import { SelectCallback, Sizes } from "react-bootstrap";
 
 declare namespace NavItem {
-    export interface NavItemProps extends React.HTMLProps<NavItem> {
+    export interface NavItemProps extends Omit<React.HTMLProps<NavItem>, "onToggle"> {
         active?: boolean | undefined;
         brand?: any; // TODO: Add more specific type
         bsSize?: Sizes | undefined;

--- a/types/react-bootstrap/lib/Navbar.d.ts
+++ b/types/react-bootstrap/lib/Navbar.d.ts
@@ -6,7 +6,7 @@ import NavbarHeader = require("./NavbarHeader");
 import NavbarToggle = require("./NavbarToggle");
 
 declare namespace Navbar {
-    export interface NavbarProps extends React.HTMLProps<Navbar> {
+    export interface NavbarProps extends Omit<React.HTMLProps<Navbar>, "onToggle"> {
         brand?: any; // TODO: Add more specific type
         bsSize?: Sizes | undefined;
         bsStyle?: string | undefined;


### PR DESCRIPTION
In React 19, `onToggle` will move to `DOMAttributes` due to support of the Popover API. Libraries extending `DOMAttributes` with their custom `onToggle` will have their types broken since extending an interface means all properties need to be compatible. But oftentimes the custom `onToggle` has nothing in common with the native `onToggle`.

We can already make this change now so that we have a release of those libraries ready by the time React 19 is release.

Cherry-picked from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69022