### PR TITLE
[validator] `isUUID` also accepts version 7

### DIFF
--- a/types/validator/index.d.ts
+++ b/types/validator/index.d.ts
@@ -1206,9 +1206,9 @@ declare namespace validator {
      */
     export function isUppercase(str: string): boolean;
 
-    export type UUIDVersion = "1" | "2" | "3" | "4" | "5" | "all" | 1 | 2 | 3 | 4 | 5;
+    export type UUIDVersion = "1" | "2" | "3" | "4" | "5" | "7" | "all" | 1 | 2 | 3 | 4 | 5 | 7;
     /**
-     * Check if the string is a UUID (version 1, 2, 3, 4 or 5).
+     * Check if the string is a UUID (version 1, 2, 3, 4, 5 or 7).
      *
      * @param [version="all"] - UUID version
      */

--- a/types/validator/package.json
+++ b/types/validator/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/validator",
-    "version": "13.12.0",
+    "version": "13.12.9999",
     "projects": [
         "https://github.com/validatorjs/validator.js"
     ],

--- a/types/validator/package.json
+++ b/types/validator/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/validator",
-    "version": "13.11.9999",
+    "version": "13.12.0",
     "projects": [
         "https://github.com/validatorjs/validator.js"
     ],

--- a/types/validator/validator-tests.ts
+++ b/types/validator/validator-tests.ts
@@ -922,8 +922,19 @@ const any: any = null;
     result = validator.isURL("sample", isURLOptions);
 
     result = validator.isUUID("sample");
-    result = validator.isUUID("sample", 5);
     result = validator.isUUID("sample", "all");
+    result = validator.isUUID("sample", "1");
+    result = validator.isUUID("sample", "2");
+    result = validator.isUUID("sample", "3");
+    result = validator.isUUID("sample", "4");
+    result = validator.isUUID("sample", "5");
+    result = validator.isUUID("sample", "7");
+    result = validator.isUUID("sample", 1);
+    result = validator.isUUID("sample", 2);
+    result = validator.isUUID("sample", 3);
+    result = validator.isUUID("sample", 4);
+    result = validator.isUUID("sample", 5);
+    result = validator.isUUID("sample", 7);
 
     result = validator.isUppercase("sample");
 


### PR DESCRIPTION
Updates types to allow `isUUID` to accepts `7` as a `UUID` version in https://github.com/validatorjs/validator.js

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Updated types: 
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/validatorjs/validator.js/pull/2345 with [release `v13.12.0`](https://github.com/validatorjs/validator.js/releases/tag/13.12.0)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
