### PR TITLE
Added 'alpha' Type for operationsSorter in SwaggerConfigs (@types/swagger-ui-dist)

### DIFF
--- a/types/swagger-ui-dist/index.d.ts
+++ b/types/swagger-ui-dist/index.d.ts
@@ -87,7 +87,7 @@ export interface SwaggerConfigs {
      * It can be 'alpha' (sort by paths alphanumerically), 'method' (sort by HTTP method) or a function (see Array.prototype.sort() to know how sort function works).
      * Default is the order returned by the server unchanged.
      */
-    operationsSorter?: (() => void) | undefined;
+    operationsSorter?: (() => void) | "alpha" | undefined;
 
     /**
      *  Function to intercept remote definition, "Try it out", and OAuth 2.0 requests.

--- a/types/swagger-ui-dist/index.d.ts
+++ b/types/swagger-ui-dist/index.d.ts
@@ -87,7 +87,7 @@ export interface SwaggerConfigs {
      * It can be 'alpha' (sort by paths alphanumerically), 'method' (sort by HTTP method) or a function (see Array.prototype.sort() to know how sort function works).
      * Default is the order returned by the server unchanged.
      */
-    operationsSorter?: (() => void) | "alpha" | undefined;
+    operationsSorter?: (() => void) | "alpha" | "method" | undefined;
 
     /**
      *  Function to intercept remote definition, "Try it out", and OAuth 2.0 requests.


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test swagger-ui-dist`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [SwaggerUI Configuration](https://github.com/swagger-api/swagger-ui/blob/HEAD/docs/usage/configuration.md)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

I've discovered that `operationsSorter` was missing the "alpha" type. Even according to the documentation, this should be allowed.
