### PR TITLE
Fix documentation of default `strength` value of d3-force's `ForceCollide<T>` interface

### DIFF
--- a/types/d3-force/index.d.ts
+++ b/types/d3-force/index.d.ts
@@ -465,7 +465,7 @@ export interface ForceCollide<NodeDatum extends SimulationNodeDatum> extends For
     strength(): number;
     /**
      * Set the force strength to the specified number in the range [0,1] and return this force.
-     * The default strength is 0.7.
+     * The default strength is 1.
      *
      * Overlapping nodes are resolved through iterative relaxation.
      * For each node, the other nodes that are anticipated to overlap at the next tick (using the anticipated positions [x + vx,y + vy]) are determined;


### PR DESCRIPTION
The default used to be `0.7` but was [changed to `1.0` on May 4th 2016](https://github.com/d3/d3-force/commit/f15a5adad7428479d208e660a4930d843e2ac4d9).

```typescript
export default function(radius) {
  var nodes,
      radii,
      random,
      strength = 1,
      iterations = 1;

  // ...
}
```

Relevant code section: [src/collide.js#L17](https://github.com/d3/d3-force/blob/c3e73cf641813c1d6490e6acc8b8f5aa3c239ea9/src/collide.js#L17)

The documentation of the corresponding getter `strength()` already uses the correct value of `1`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/d3/d3-force/blob/c3e73cf641813c1d6490e6acc8b8f5aa3c239ea9/src/collide.js#L17
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
