### PR TITLE
[@types/chromecast-caf-receiver] Extensible customData types

### DIFF
--- a/types/chromecast-caf-receiver/cast.framework.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.d.ts
@@ -568,7 +568,12 @@ export class PlayerManager {
     /**
      * Sends a media status message to all senders (broadcast). Applications use this to send a custom state change.
      */
-    broadcastStatus(includeMedia?: boolean, requestId?: number, customData?: any, includeQueueItems?: boolean): void;
+    broadcastStatus(
+        includeMedia?: boolean,
+        requestId?: number,
+        customData?: messages.MediaStatusCustomData | null,
+        includeQueueItems?: boolean,
+    ): void;
 
     /**
      * Convert media time to absolute time.
@@ -736,7 +741,7 @@ export class PlayerManager {
         requestId: number,
         type: messages.ErrorType,
         reason?: messages.ErrorReason,
-        customData?: any,
+        customData?: unknown,
     ): void;
 
     /**
@@ -751,7 +756,7 @@ export class PlayerManager {
         senderId: string,
         requestId: number,
         includeMedia?: boolean,
-        customData?: any,
+        customData?: messages.MediaStatusCustomData | null,
         includeQueueItems?: boolean,
     ): void;
 

--- a/types/chromecast-caf-receiver/cast.framework.messages.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.messages.d.ts
@@ -610,6 +610,18 @@ export class AudioTrackInfo {
      */
     spatialAudio?: boolean | undefined;
 }
+
+/**
+ * Custom data set by the receiver application.
+ *
+ * @remarks
+ *
+ * Augment this interface in custom receivers.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface TrackCustomData {
+}
+
 /**
  * Describes track metadata information.
  * @see https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.Track
@@ -625,7 +637,7 @@ export class Track {
     /**
      * Custom data set by the receiver application.
      */
-    customData?: any;
+    customData?: TrackCustomData;
 
     /**
      * Indicate track is in-band and not side-loaded track. Relevant only for text tracks.
@@ -684,6 +696,17 @@ export class Track {
 }
 
 /**
+ * Custom data set by the receiver application.
+ *
+ * @remarks
+ *
+ * Augment this interface in custom receivers.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface TextTrackStyleCustomData {
+}
+
+/**
  * Describes style information for a text track.
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages.TextTrackStyle
  */
@@ -696,7 +719,7 @@ export class TextTrackStyle {
     /**
      * Custom data set by the receiver application.
      */
-    customData?: any;
+    customData?: TextTrackStyleCustomData;
 
     /**
      * RGBA color for the edge; this value will be ignored if edgeType is NONE.
@@ -819,6 +842,17 @@ export class SetCredentialsRequestData extends RequestData {
 }
 
 /**
+ * Customizable object for storing session state.
+ *
+ * @remarks
+ *
+ * Augment this interface in custom receivers.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface SessionStateCustomData {
+}
+
+/**
  * A state object containing all data to be stored in StoreSession and to be
  * recovered in ResumeSession.
  * @see https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.SessionState
@@ -829,7 +863,7 @@ export class SessionState {
     /**
      * Customizable object for storing the state.
      */
-    customData?: any;
+    customData?: SessionStateCustomData;
 
     loadRequestData?: LoadRequestData | undefined;
 }
@@ -1104,6 +1138,17 @@ export class QueueLoadRequestData extends RequestData {
 }
 
 /**
+ * The application can define any extra queue item information needed.
+ *
+ * @remarks
+ *
+ * Augment this interface in custom receivers.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface QueueItemCustomData {
+}
+
+/**
  * Queue item information. Application developers may need to create a QueueItem to
  * insert a queue element using InsertQueueItems. In this case they should not
  * provide an itemId (as the actual itemId will be assigned when the item is inserted
@@ -1128,7 +1173,7 @@ export class QueueItem {
     /**
      * The application can define any extra queue item information needed.
      */
-    customData?: any;
+    customData?: QueueItemCustomData;
 
     /**
      * Unique identifier of the item in the queue.
@@ -1638,6 +1683,17 @@ export class MovieMediaMetadata {
 }
 
 /**
+ * Applicaiton-specific media status.
+ *
+ * @remarks
+ *
+ * Augment this interface in custom receivers.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface MediaStatusCustomData {
+}
+
+/**
  * Represents the status of a media session.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages.MediaStatus}
  */
@@ -1668,7 +1724,7 @@ export class MediaStatus {
     /**
      * Application-specific media status.
      */
-    customData?: any;
+    customData?: MediaStatusCustomData;
 
     /**
      * Extended media status information.
@@ -1805,6 +1861,17 @@ export class MediaMetadata {
 }
 
 /**
+ * Application-specific media information.
+ *
+ * @remarks
+ *
+ * Augment this interface in custom receivers.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface MediaInformationCustomData {
+}
+
+/**
  * Represents the media information.
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages.MediaInformation
  */
@@ -1841,7 +1908,7 @@ export class MediaInformation {
     /**
      * Application-specific media information.
      */
-    customData?: any;
+    customData?: MediaInformationCustomData;
 
     /**
      * The media duration.
@@ -2384,6 +2451,17 @@ export class BreakStatus {
 }
 
 /**
+ * Application-specific break clip data.
+ *
+ * @remarks
+ *
+ * Augment this interface in custom receivers.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface BreakClipCustomData {
+}
+
+/**
  * Represents break clip (e.g. a clip of ad during ad break)
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages.BreakClip
  */
@@ -2411,7 +2489,7 @@ export class BreakClip {
     /**
      * Application-specific break clip data.
      */
-    customData?: any;
+    customData?: BreakClipCustomData;
     /**
      * Duration of break clip in sec.
      */

--- a/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
+++ b/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
@@ -283,3 +283,47 @@ tracksInfo.activeTrackIds = [1, 2];
 tracksInfo.language = "en";
 tracksInfo.textTrackStyle = new cast.framework.messages.TextTrackStyle();
 tracksInfo.tracks = [new cast.framework.messages.Track(1, cast.framework.messages.TrackType.AUDIO)];
+
+// You can extend the types of some customData fields via declaration merging, so that
+// custom data passed between your custom receiver and CAF remains statically typed.
+
+declare module "./cast.framework.messages" {
+    interface TrackCustomData {
+        dialect?: string;
+    }
+
+    interface TextTrackStyleCustomData {
+        lineHeight?: number;
+    }
+
+    interface SessionStateCustomData {
+        userId?: string;
+    }
+
+    interface QueueItemCustomData {
+        priority?: number;
+    }
+
+    interface MediaStatusCustomData {
+        description?: string;
+    }
+
+    interface MediaInformationCustomData {
+        environment: "production" | "staging";
+    }
+
+    interface BreakClipCustomData {
+        advertiser?: string;
+    }
+}
+
+const sessionState = new cast.framework.messages.SessionState();
+const mediaStatus = new cast.framework.messages.MediaStatus();
+
+track.customData = { dialect: "关中话" };
+tracksInfo.textTrackStyle!.customData = { lineHeight: 1.5 };
+sessionState.customData = { userId: "1234" };
+mediaStatus.customData = { description: "Lorem ipsum" };
+queueItem.customData = { priority: 1 };
+queueItem.media.customData = { environment: "production" };
+breakClip.customData = { advertiser: "Umbrella Corporation" };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [`cast.framework.messages.Track#customData`](https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages.Track#customData)
  - [`cast.framework.messages.TextTrackStyle#customData`](https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages.TextTrackStyle#customData)
  - [`cast.framework.messages.SessionState#customData`](https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages.SessionState#customData)
  - [`cast.framework.messages.QueueItem#customData`](https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages.QueueItem#customData)
  - [`cast.framework.messages.MediaStatus#customData`](https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages.MediaStatus#customData)
  - [`cast.framework.messages.MediaInformation#customData`](https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages.MediaInformation#customData)
  - [`cast.framework.messages.BreakClip#customData`](https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages.BreakClip#customData)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.