### PR TITLE
Add missing parameters to `phoenix`'s `SocketConnectOption` type

### DIFF
--- a/types/phoenix/index.d.ts
+++ b/types/phoenix/index.d.ts
@@ -39,6 +39,7 @@ export interface SocketConnectOption {
     transport: new(endpoint: string) => object;
     timeout: number;
     heartbeatIntervalMs: number;
+    longPollFallbackMs: number;
     longpollerTimeout: number;
     encode: (payload: object, callback: (encoded: any) => void | Promise<void>) => void;
     decode: (payload: string, callback: (decoded: any) => void | Promise<void>) => void;
@@ -46,6 +47,8 @@ export interface SocketConnectOption {
     reconnectAfterMs: (tries: number) => number;
     rejoinAfterMs: (tries: number) => number;
     vsn: string;
+    debug: boolean;
+    sessionStorage: object;
 }
 
 export type MessageRef = string;

--- a/types/phoenix/phoenix-tests.ts
+++ b/types/phoenix/phoenix-tests.ts
@@ -1,12 +1,20 @@
 import { Channel, Presence, Socket, Timer } from "phoenix";
 
 class InMemoryStorage {
-  storage: { [key: string]: any };
+    storage: { [key: string]: any };
 
-  constructor() { this.storage = {} }
-  getItem(keyName: string) { return this.storage[keyName] || null }
-  removeItem(keyName: string) { delete this.storage[keyName] }
-  setItem(keyName: string, keyValue: any) { this.storage[keyName] = keyValue }
+    constructor() {
+        this.storage = {};
+    }
+    getItem(keyName: string) {
+        return this.storage[keyName] || null;
+    }
+    removeItem(keyName: string) {
+        delete this.storage[keyName];
+    }
+    setItem(keyName: string, keyValue: any) {
+        this.storage[keyName] = keyValue;
+    }
 }
 
 function test_socket() {

--- a/types/phoenix/phoenix-tests.ts
+++ b/types/phoenix/phoenix-tests.ts
@@ -1,5 +1,14 @@
 import { Channel, Presence, Socket, Timer } from "phoenix";
 
+class InMemoryStorage {
+  storage: { [key: string]: any };
+
+  constructor() { this.storage = {} }
+  getItem(keyName: string) { return this.storage[keyName] || null }
+  removeItem(keyName: string) { delete this.storage[keyName] }
+  setItem(keyName: string, keyValue: any) { this.storage[keyName] = keyValue }
+}
+
 function test_socket() {
     const socket = new Socket("/ws", {
         binaryType: "arraybuffer",
@@ -7,6 +16,9 @@ function test_socket() {
         reconnectAfterMs: tries => 1000,
         rejoinAfterMs: tries => 1000,
         vsn: "2.0.0",
+        longPollFallbackMs: 10_000,
+        debug: true,
+        sessionStorage: new InMemoryStorage(),
     });
     socket.connect();
 


### PR DESCRIPTION
This PR adds parameters to the type spec here. These parameters have been in Phoenix for a long time, and were simply missing here.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

    The Phoenix [docs](https://hexdocs.pm/phoenix/js/) actually have the wrong types for a few of these. I've submitted a [PR](https://github.com/phoenixframework/phoenix/pull/5846) to correct them based on how these values are used in the code.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
