### PR TITLE
[draft-js] Update getComponentForKey to return a DraftDecoratorComponent

### DIFF
--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -438,7 +438,7 @@ declare namespace Draft {
              *
              * See `CompositeDraftDecorator` for the most common use case.
              */
-            interface DraftDecoratorType {
+            interface DraftDecoratorType<P = {}> {
                 /**
                  * Given a `ContentBlock`, return an immutable List of decorator keys.
                  */
@@ -448,7 +448,7 @@ declare namespace Draft {
                  * Given a decorator key, return the component to use when rendering
                  * this decorated range.
                  */
-                getComponentForKey(key: string): Function;
+                getComponentForKey(key: string): DraftDecoratorComponent<P>;
 
                 /**
                  * Given a decorator key, optionally return the props to use when rendering
@@ -456,6 +456,14 @@ declare namespace Draft {
                  */
                 getPropsForKey(key: string): any;
             }
+
+            /**
+             * DraftDecoratorComponent is the component that will be used to render the "decorated" section of text.
+             */
+            type DraftDecoratorComponent<P = {}> =
+                | React.Component
+                | React.ComponentClass<any>
+                | ((props: DraftDecoratorComponentProps & P) => React.ReactNode);
 
             /**
              * DraftDecoratorComponentProps are the core set of props that will be
@@ -497,16 +505,13 @@ declare namespace Draft {
              *   - "props": Props to be passed into the React component that will be used
              *     merged with DraftDecoratorComponentProps
              */
-            interface DraftDecorator<P = any> {
+            interface DraftDecorator<P = {}> {
                 strategy: (
                     block: ContentBlock,
                     callback: (start: number, end: number) => void,
                     contentState: ContentState,
                 ) => void;
-                component:
-                    | React.Component
-                    | React.ComponentClass<any>
-                    | ((props: DraftDecoratorComponentProps & P) => React.ReactNode);
+                component: DraftDecoratorComponent;
                 props?: P | undefined;
             }
 
@@ -533,7 +538,7 @@ declare namespace Draft {
                 constructor(decorators: DraftDecorator[]);
 
                 getDecorations(block: ContentBlock, contentState: ContentState): Immutable.List<string>;
-                getComponentForKey(key: string): Function;
+                getComponentForKey<P = {}>(key: string): DraftDecoratorComponent<P>;
                 getPropsForKey(key: string): Object;
             }
         }
@@ -1125,6 +1130,7 @@ import EditorState = Draft.Model.ImmutableData.EditorState;
 import EditorChangeType = Draft.Model.ImmutableData.EditorChangeType;
 import EditorCommand = Draft.Component.Base.EditorCommand;
 
+import DraftDecoratorComponent = Draft.Model.Decorators.DraftDecoratorComponent;
 import DraftDecoratorComponentProps = Draft.Model.Decorators.DraftDecoratorComponentProps;
 import DraftDecoratorType = Draft.Model.Decorators.DraftDecoratorType;
 import DraftDecorator = Draft.Model.Decorators.DraftDecorator;
@@ -1195,6 +1201,7 @@ export {
     DraftBlockType,
     DraftComponent,
     DraftDecorator,
+    DraftDecoratorComponent,
     DraftDecoratorComponentProps,
     DraftDecoratorType,
     DraftDragType,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Relates to #65555 

Since the added code in the [DraftDecorator](https://github.com/IlyaGerasimets/DefinitelyTyped/blob/458dc34f60724aa1a017bc1f196bfadfbb21c57b/types/draft-js/index.d.ts#L534) changes the type of component, the functions `getComponentForKey` from [DraftDecoratorType](https://github.com/IlyaGerasimets/DefinitelyTyped/blob/458dc34f60724aa1a017bc1f196bfadfbb21c57b/types/draft-js/index.d.ts#L479) and at [CompositeDraftDecorator](https://github.com/IlyaGerasimets/DefinitelyTyped/blob/458dc34f60724aa1a017bc1f196bfadfbb21c57b/types/draft-js/index.d.ts#L559C19-L559C42) must be returning the same type of component that is named `DraftDecoratorComponent`.