### PR TITLE
add back my user as an owner

### DIFF
--- a/types/arc4/package.json
+++ b/types/arc4/package.json
@@ -11,5 +11,10 @@
     "dependencies": {
         "@types/node": "*"
     },
-    "owners": []
+    "owners": [
+        {
+            "name": "Maximilian Hofmann",
+            "githubUsername": "maxiicodes"
+        }
+    ]
 }

--- a/types/exaroton/package.json
+++ b/types/exaroton/package.json
@@ -13,5 +13,10 @@
     "devDependencies": {
         "@types/exaroton": "workspace:."
     },
-    "owners": []
+    "owners": [
+        {
+            "name": "Maximilian Hofmann",
+            "githubUsername": "maxiicodes"
+        }
+    ]
 }


### PR DESCRIPTION
I changed my GitHub username from hofmmaxi to maxiicodes a couple of weeks ago. This adds my new username as an owner to the packages I created.