### PR TITLE
[@types/express-serve-static-core] 🏷️ Add `Promise<void>` to `RequestHandler`'s return type

### DIFF
--- a/types/architect__functions/test/http-tests.ts
+++ b/types/architect__functions/test/http-tests.ts
@@ -22,8 +22,8 @@ import express = require("express");
 
 const app = express();
 
-app.get("/", (req, res) => res.send("Hello World!"));
-app.get("/cool", (req, res) => res.send("very cool"));
+app.get("/", (req, res) => void res.send("Hello World!"));
+app.get("/cool", (req, res) => void res.send("very cool"));
 
 ////////////////////
 // tests for arc.http.helpers: https://github.com/architect/functions/blob/master/src/http/index.js#L21-L26

--- a/types/create-test-server/create-test-server-tests.ts
+++ b/types/create-test-server/create-test-server-tests.ts
@@ -19,7 +19,7 @@ const server = createTestServer().then((server) => {
     });
 
     // You can return a body directly too
-    server.get("/foo", () => "bar");
+    server.get("/foo", () => void "bar");
     server.get("/foo", "bar");
 
     return server;

--- a/types/express-brute-memcached/express-brute-memcached-tests.ts
+++ b/types/express-brute-memcached/express-brute-memcached-tests.ts
@@ -8,7 +8,7 @@ var bruteforce = new ExpressBrute(store);
 
 app.post(
     "/auth",
-    bruteforce.prevent, // error 403 if we hit this route too often
+    (req, res, next) => void bruteforce.prevent(req, res, next), // error 403 if we hit this route too often
     function(req, res, next) {
         res.send("Success!");
     },

--- a/types/express-brute-mongo/express-brute-mongo-tests.ts
+++ b/types/express-brute-mongo/express-brute-mongo-tests.ts
@@ -18,6 +18,6 @@ const store = new MongoStore(ready => {
 const app = express();
 const bruteforce = new ExpressBrute(store);
 
-app.post("/auth", bruteforce.prevent, (req, res, next) => {
+app.post("/auth", (req, res, next) => void bruteforce.prevent(req, res, next), (req, res, next) => {
     res.send("Success!");
 });

--- a/types/express-brute/express-brute-tests.ts
+++ b/types/express-brute/express-brute-tests.ts
@@ -9,7 +9,7 @@ store.reset("key", (error: any) => {});
 
 var app = express();
 var bruteforce = new ExpressBrute(store);
-app.post("/auth", bruteforce.prevent, (req, res, next) => {
+app.post("/auth", (res, req, next) => void bruteforce.prevent(res, req, next), (req, res, next) => {
     res.send("Success!");
 });
 

--- a/types/express-oauth-server/express-oauth-server-tests.ts
+++ b/types/express-oauth-server/express-oauth-server-tests.ts
@@ -72,17 +72,19 @@ resultingAuthorizationCodeMiddleware = expressOAuthServer.authorize();
 
 const expressApp = express();
 
+const authenticatePath = expressOAuthServer.authenticate();
 expressApp.all(
     "/path",
-    expressOAuthServer.authenticate(),
+    (res, req, next) => void authenticatePath(res, req, next),
     (req: express.Request, res: express.Response, next: express.NextFunction) => {
         res.json({ message: "Secure data" });
     },
 );
 
+const authenticateProfile = expressOAuthServer.authenticate({ scope: "profile" });
 expressApp.get(
     "/profile",
-    expressOAuthServer.authenticate({ scope: "profile" }),
+    (res, req, next) => void authenticateProfile(res, req, next),
     (
         req: express.Request & { user?: OAuth2Server.Token | undefined },
         res: express.Response,

--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -323,3 +323,8 @@ app.get("/:readonly", req => {
     // @ts-expect-error
     req.xhr = true;
 });
+
+// Starting with Express 5, route handlers and middleware that return a
+// `Promise` will call `next(value)` automatically when they reject or throw an
+// error.
+app.get("/async", Promise.resolve);

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -61,7 +61,7 @@ export interface RequestHandler<
         req: Request<P, ResBody, ReqBody, ReqQuery, LocalsObj>,
         res: Response<ResBody, LocalsObj>,
         next: NextFunction,
-    ): void;
+    ): void | Promise<void>;
 }
 
 export type ErrorRequestHandler<
@@ -75,7 +75,7 @@ export type ErrorRequestHandler<
     req: Request<P, ResBody, ReqBody, ReqQuery, LocalsObj>,
     res: Response<ResBody, LocalsObj>,
     next: NextFunction,
-) => void;
+) => void | Promise<void>;
 
 export type PathParams = string | RegExp | Array<string | RegExp>;
 

--- a/types/express-serve-static-core/package.json
+++ b/types/express-serve-static-core/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/express-serve-static-core",
-    "version": "4.19.9999",
+    "version": "5.0.9999",
     "projects": [
         "http://expressjs.com"
     ],

--- a/types/express-ua-middleware/express-ua-middleware-tests.ts
+++ b/types/express-ua-middleware/express-ua-middleware-tests.ts
@@ -3,7 +3,7 @@ import express = require("express");
 
 const server = express();
 
-server.use(userAgent);
+server.use(userAgent());
 server.get("/", (req, res) => {
     req.userAgent; // $ExpectType UserAgent & UserAgentRaw
 });

--- a/types/feathersjs__express/feathersjs__express-tests.ts
+++ b/types/feathersjs__express/feathersjs__express-tests.ts
@@ -1,5 +1,5 @@
 import feathersExpress, * as express from "@feathersjs/express";
-import feathers, { Application } from "@feathersjs/feathers";
+import feathers from "@feathersjs/feathers";
 
 const app = feathersExpress(feathers());
 
@@ -13,7 +13,7 @@ const feathersServiceDummy = {
 };
 const expressMiddlewareDummy = (req: express.Request, res: express.Response, next: express.NextFunction) => {
     next();
-    return app;
+    app;
 };
 
 app.use(express.json());

--- a/types/forest-express-mongoose/forest-express-mongoose-tests.ts
+++ b/types/forest-express-mongoose/forest-express-mongoose-tests.ts
@@ -235,5 +235,5 @@ collection("complexCollection", complexCollectionOptions);
 const app = express();
 
 app.get("/", (request) => {
-    return recordsGetter.getIdsFromRequest(request);
+    recordsGetter.getIdsFromRequest(request);
 });

--- a/types/forest-express-sequelize/forest-express-sequelize-tests.ts
+++ b/types/forest-express-sequelize/forest-express-sequelize-tests.ts
@@ -235,5 +235,5 @@ collection("complexCollection", complexCollectionOptions);
 const app = express();
 
 app.get("/", (request) => {
-    return recordsGetter.getIdsFromRequest(request);
+    recordsGetter.getIdsFromRequest(request);
 });

--- a/types/fusebit__oauth-connector/fusebit__oauth-connector-tests.ts
+++ b/types/fusebit__oauth-connector/fusebit__oauth-connector-tests.ts
@@ -42,7 +42,7 @@ class MyConnector extends conn.OAuthConnector {
     }
 
     authorize(params: conn.AuthorizeParams): express.RequestHandler {
-        return (req: express.Request, res: express.Response, next: express.NextFunction) => next;
+        return (req: express.Request, res: express.Response, next: express.NextFunction) => void next;
     }
 
     onNewUser(

--- a/types/logfmt/logfmt-tests.ts
+++ b/types/logfmt/logfmt-tests.ts
@@ -43,7 +43,7 @@ http.createServer((req, res) => {
 const app = express();
 app.use(logfmt.bodyParserStream());
 app.post("/logs", (req, res) => {
-    if (!req.body) return res.send("OK");
+    if (!req.body) return void res.send("OK");
 
     req.body.pipe(through((line) => {
         console.dir(line);

--- a/types/mock-req-res/mock-req-res-tests.ts
+++ b/types/mock-req-res/mock-req-res-tests.ts
@@ -2,7 +2,7 @@ import { Request, RequestHandler, Response } from "express";
 import { mockRequest, mockResponse } from "mock-req-res";
 
 const handler: RequestHandler = (req: Request, res: Response) => {
-    return res.status(200).json(`Hello from handler with an originalUrl value of '${req.originalUrl}'`);
+    return void res.status(200).json(`Hello from handler with an originalUrl value of '${req.originalUrl}'`);
 };
 
 const req = mockRequest({ originalUrl: "/" });

--- a/types/mongoose-aggregate-paginate-v2/mongoose-aggregate-paginate-v2-tests.ts
+++ b/types/mongoose-aggregate-paginate-v2/mongoose-aggregate-paginate-v2-tests.ts
@@ -3,9 +3,9 @@
  * Adapted to mongoose-aggregate-paginate-v2 by Alexandre Croteau <https://github.com/acrilex1>
  */
 
+import { Request, Response, Router } from "express";
 import { Aggregate, AggregatePaginateModel, AggregatePaginateResult, model, PaginateOptions, Schema } from "mongoose";
 import mongooseAggregatePaginate = require("mongoose-aggregate-paginate-v2");
-import { Request, Response, Router } from "express";
 
 // #region Test Models
 interface User {
@@ -65,10 +65,10 @@ router.get("/users.json", async (req: Request, res: Response) => {
         console.log("offset: " + value.offset);
         console.log("docs: ");
         console.dir(value.docsCustom);
-        return res.json(value);
+        return void res.json(value);
     } catch (err) {
         console.log(err);
-        return res.status(500).send(err);
+        return void res.status(500).send(err);
     }
 });
 
@@ -90,10 +90,10 @@ router.get("/stats/hobbies.json", async (req: Request, res: Response) => {
 
     try {
         const value: AggregatePaginateResult<HobbyStats> = await UserModel.aggregatePaginate(aggregate, options);
-        return res.json(value);
+        return void res.json(value);
     } catch (err) {
         console.log(err);
-        return res.status(500).send(err);
+        return void res.status(500).send(err);
     }
 });
 
@@ -117,10 +117,10 @@ router.get("/stats/hobbies.json", async (req: Request, res: Response) => {
 
     try {
         const value: AggregatePaginateResult<HobbyStats> = await UserModel.aggregatePaginate(aggregate, options);
-        return res.json(value);
+        return void res.json(value);
     } catch (err) {
         console.log(err);
-        return res.status(500).send(err);
+        return void res.status(500).send(err);
     }
 });
 // #endregion

--- a/types/swaggerize-express/swaggerize-express-tests.ts
+++ b/types/swaggerize-express/swaggerize-express-tests.ts
@@ -27,7 +27,7 @@ app.use(swaggerize({
         "api": {
             "v1": {
                 "version": {
-                    "$get": (req: express.Request, res: express.Response) => res.send("v1"),
+                    "$get": (req: express.Request, res: express.Response) => void res.send("v1"),
                 },
             },
         },


### PR DESCRIPTION
* Fixes #50871
* Adds `@typescript-eslint/no-misused-promises` to `@types/express-serve-static-core`'s ESLint config
* Fixes tests that returns something from an Express handler, something that's not supposed to be possible in the first place as handlers are supposed to return `void` (and now `void | Promise<void>`)
* Closes https://github.com/coderabbitai/DefinitelyTyped/pull/2
* Follow-up to https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69660#issuecomment-2179314113