### PR TITLE
[@npmcli/arborist] Fix Node.edgesOut and Define Node.isWorkspace

### DIFF
--- a/types/npmcli__arborist/index.d.ts
+++ b/types/npmcli__arborist/index.d.ts
@@ -202,7 +202,7 @@ declare namespace Arborist {
          * Edges in the dependency graph indicating nodes that this node depends
          * on, which resolve its dependencies.
          */
-        edgesOut: Edge[];
+        edgesOut: Map<string, Edge>;
         /** Edges in the dependency graph indicating nodes that depend on this node. */
         edgesIn: Edge[];
 
@@ -215,6 +215,8 @@ declare namespace Arborist {
         get pkgid(): string;
 
         get inBundle(): boolean;
+
+        get isWorkspace(): boolean;
 
         /** Errors encountered while parsing package.json or version specifiers. */
         errors: Error[];

--- a/types/npmcli__arborist/npmcli__arborist-tests.ts
+++ b/types/npmcli__arborist/npmcli__arborist-tests.ts
@@ -18,6 +18,8 @@ const arb = new Arborist({
 
 arb.loadActual().then(tree => {
     tree; // $ExpectType Node
+    tree.isWorkspace; // $ExpectType boolean
+    tree.edgesOut; // $ExpectType Map<string, Edge>
 });
 
 arb.loadVirtual().then(tree => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  * `edgesOut`: https://github.com/npm/cli/blob/22731831e22011e32fa0ca12178e242c2ee2b33d/workspaces/arborist/lib/node.js#L200
  * `isWorkspace`: https://github.com/npm/cli/blob/22731831e22011e32fa0ca12178e242c2ee2b33d/workspaces/arborist/lib/node.js#L522-L529
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.