### PR TITLE
[npm-package-arg] Restructure Result to Discriminated Union

### DIFF
--- a/types/npm-package-arg/index.d.ts
+++ b/types/npm-package-arg/index.d.ts
@@ -15,34 +15,9 @@ declare namespace npa {
      * Something like: 1.2, ^1.7.17, http://x.com/foo.tgz, git+https://github.com/user/foo, bitbucket:user/foo, file:foo.tar.gz or file:../foo/bar/. If not included then the default is latest.
      * @param where Optionally the path to resolve file paths relative to. Defaults to process.cwd()
      */
-    function resolve(name: string, spec: string, where?: string):
-        | FileResult
-        | HostedGitResult
-        | URLResult
-        | AliasResult
-        | RegistryResult;
+    function resolve(name: string, spec: string, where?: string): Result;
 
-    class Result {
-        /**
-         * One of the following strings:
-         * * git - A git repo
-         * * tag - A tagged version, like "foo@latest"
-         * * version - A specific version number, like "foo@1.2.3"
-         * * range - A version range, like "foo@2.x"
-         * * file - A local .tar.gz, .tar or .tgz file.
-         * * directory - A local directory.
-         * * remote - An http url (presumably to a tgz)
-         */
-        type:
-            | "git"
-            | "tag"
-            | "version"
-            | "range"
-            | "file"
-            | "directory"
-            | "remote"
-            | "alias";
-
+    class BaseResult {
         /** If true this specifier refers to a resource hosted on a registry. This is true for tag, version and range types. */
         registry: boolean;
 
@@ -77,14 +52,16 @@ declare namespace npa {
         raw: string;
     }
 
-    interface FileResult extends Result {
+    type Result = FileResult | HostedGitResult | URLResult | AliasResult | RegistryResult;
+
+    interface FileResult extends BaseResult {
         type: "file" | "directory";
         where: string;
         saveSpec: string;
         fetchSpec: null | string;
     }
 
-    interface HostedGitResult extends Result {
+    interface HostedGitResult extends BaseResult {
         type: "git";
         hosted: HostedGit;
         saveSpec: string;
@@ -93,7 +70,7 @@ declare namespace npa {
         gitCommittish: undefined | string;
     }
 
-    interface URLResult extends Result {
+    interface URLResult extends BaseResult {
         saveSpec: string;
         type: "git" | "remote";
         fetchSpec: string;
@@ -101,7 +78,7 @@ declare namespace npa {
         gitRange: string | undefined;
     }
 
-    interface AliasResult extends Result {
+    interface AliasResult extends BaseResult {
         subSpec: Result;
         registry: true;
         type: "alias";
@@ -109,7 +86,7 @@ declare namespace npa {
         fetchSpec: null;
     }
 
-    interface RegistryResult extends Result {
+    interface RegistryResult extends BaseResult {
         registry: true;
         type: "version" | "range" | "tag";
         saveSpec: null;

--- a/types/npm-package-arg/npm-package-arg-tests.ts
+++ b/types/npm-package-arg/npm-package-arg-tests.ts
@@ -2,5 +2,34 @@ import npa = require("npm-package-arg");
 
 const result1 = npa("npm-package-arg@5.1");
 const result2 = npa("npm-package-arg@5.1", "..");
+switch (result2.type) {
+    case "file":
+        result2; // $ExpectType FileResult
+        break;
+    case "directory":
+        result2; // $ExpectType FileResult
+        break;
+    case "git":
+        result2; // $ExpectType HostedGitResult | URLResult
+        break;
+    case "remote":
+        result2; // $ExpectType URLResult
+        break;
+    case "alias":
+        result2; // $ExpectType AliasResult
+        break;
+    case "version":
+        result2; // $ExpectType RegistryResult
+        break;
+    case "range":
+        result2; // $ExpectType RegistryResult
+        break;
+    case "tag":
+        result2; // $ExpectType RegistryResult
+        break;
+    default:
+        result2; // $ExpectType never
+}
+
 const result3 = npa.resolve("npm-package-arg", "^5.1.0");
 const result4 = npa.resolve("npm-package-arg", "^5.1.0", "..");


### PR DESCRIPTION
Restructure the Result type such that:

* It is a discriminated union of various Result sub-types
* It is returned directly by both `resolve()` and `npa()`
* The original Result class, minus type `type` field, is now `BaseResult`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`npa()` returns the same type as `resolve()`](https://github.com/npm/npm-package-arg/blob/74d06ae66df6b8a91f5b5e4b8ff001a887cf4851/lib/npa.js#L53)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.