### PR TITLE
[plotly.js] Make width/height nullable in Plotly.toImage / Plotly.downloadImage

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -302,7 +302,7 @@ export interface ToImgopts {
     height: number | null;
     scale?: number | undefined;
 }
-   
+
 export interface DownloadImgopts {
     format: "jpeg" | "png" | "webp" | "svg";
     /**

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -292,15 +292,27 @@ export interface PlotlyHTMLElement extends HTMLElement {
 
 export interface ToImgopts {
     format: "jpeg" | "png" | "webp" | "svg";
-    width: number;
-    height: number;
+    /**
+     * If null, uses current graph width
+     */
+    width: number | null;
+    /**
+     * If null, uses current graph height
+     */
+    height: number | null;
     scale?: number | undefined;
 }
-
+   
 export interface DownloadImgopts {
     format: "jpeg" | "png" | "webp" | "svg";
-    width: number;
-    height: number;
+    /**
+     * If null, uses current graph width
+     */
+    width: number | null;
+    /**
+     * If null, uses current graph height
+     */
+    height: number | null;
     filename: string;
 }
 

--- a/types/plotly.js/test/core-tests.ts
+++ b/types/plotly.js/test/core-tests.ts
@@ -715,6 +715,17 @@ function rand() {
 //////////////////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////////////////
+// Plotly.toImage with null dimensions
+(() => {
+    // Plotly.toImage will turn the plot in the given div into a data URL string
+    // toImage takes the div as the first argument and an object specifying image properties as the other
+    Plotly.toImage(graphDiv, { format: "png", width: null, height: null, scale: 2 }).then(dataUrl => {
+        // use the dataUrl
+    });
+})();
+//////////////////////////////////////////////////////////////////////
+
+//////////////////////////////////////////////////////////////////////
 // Plotly.toImage + scale parameter
 (() => {
     // Plotly.toImage will turn the plot in the given div into a data URL string
@@ -741,6 +752,14 @@ function rand() {
 (() => {
     // downloadImage will accept the div as the first argument and an object specifying image properties as the other
     Plotly.downloadImage(graphDiv, { format: "png", width: 800, height: 600, filename: "newplot" });
+})();
+//////////////////////////////////////////////////////////////////////
+
+//////////////////////////////////////////////////////////////////////
+// Plotly.downloadImage with null dimensions
+(() => {
+    // downloadImage will accept the div as the first argument and an object specifying image properties as the other
+    Plotly.downloadImage(graphDiv, { format: "png", width: null, height: null, filename: "newplot" });
 })();
 //////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/plotly/plotly.js/pull/3746
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. 

Context: `width`/`height` in the opts argument of `Plotly.toImage` and `Plotly.downloadImage` were made nullable in v1.47.0 (PR linked above).
