### PR TITLE
Update react-resizable index.d.ts to allow axis to be 'none'

### DIFF
--- a/types/react-resizable/index.d.ts
+++ b/types/react-resizable/index.d.ts
@@ -62,6 +62,11 @@ export type ResizableProps =
             height: number;
             axis?: "both";
         }
+        | {
+            width?: number | undefined;
+            height?: number | undefined;
+            axis?: "none";
+        }
     );
 
 export class Resizable extends React.Component<ResizableProps, ResizableState> {}

--- a/types/react-resizable/react-resizable-tests.tsx
+++ b/types/react-resizable/react-resizable-tests.tsx
@@ -127,3 +127,27 @@ class TestXYResizableComponent extends React.Component<{ children?: React.ReactN
         );
     }
 }
+
+class TestXYResizableComponent extends React.Component<{ children?: React.ReactNode }> {
+    render() {
+        return (
+            <Resizable
+                width={10}
+                height={20}
+                axis="none"
+                className={"foobar"}
+                minConstraints={[20, 20]}
+                maxConstraints={[42, 42]}
+                handleSize={[5, 5]}
+                lockAspectRatio={false}
+                draggableOpts={{ opaque: true }}
+                onResizeStart={resizeCallback}
+                onResizeStop={resizeCallback}
+                onResize={resizeCallback}
+                transformScale={1}
+            >
+                <div>{this.props.children}</div>
+            </Resizable>
+        );
+    }
+}

--- a/types/react-resizable/react-resizable-tests.tsx
+++ b/types/react-resizable/react-resizable-tests.tsx
@@ -128,7 +128,7 @@ class TestXYResizableComponent extends React.Component<{ children?: React.ReactN
     }
 }
 
-class TestXYResizableComponent extends React.Component<{ children?: React.ReactNode }> {
+class TestNoneResizableComponent extends React.Component<{ children?: React.ReactNode }> {
     render() {
         return (
             <Resizable


### PR DESCRIPTION
Currently, Resizable and ResizableBox will not accept 'none' as a type for axis. https://github.com/react-grid-layout/react-resizable/discussions/239

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
Cannot provide URL to code where I experience this bug since it is proprietary for my work.  Basically, I have a component with a state that will set the axis to 'x' or 'none' depending on if I want it to be resizable or not.  When I try to set the axis prop to 'none', I get an error that 'none' is not a valid type.
