### PR TITLE
Add missing type definition for `http-link-header` package `toString()` method.

### DIFF
--- a/types/http-link-header/index.d.ts
+++ b/types/http-link-header/index.d.ts
@@ -55,6 +55,11 @@ declare class Link {
      * @return The calling instance
      */
     parse(value: string, offset?: number): Link;
+    /**
+     * Get a string representation of the link header instance
+     * @return A string representation of the link header instance
+     */
+    toString(): string;
 }
 
 declare namespace Link {


### PR DESCRIPTION
# What's changed?
Add missing type definition for `http-link-header` package `toString()` method.

This resolves a typescript error when `@typescript-eslint/no-base-to-string` is enabled:

<img width="614" alt="image" src="https://github.com/DefinitelyTyped/DefinitelyTyped/assets/37989995/46345904-3252-4b96-afda-ed27a2a40783">

## Testing
There was an existing test which happened to be passing already, since calling `.toString()` on an object calls the method from the Object prototype.

# Checklist

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [N/A] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

# Changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jhermsmeier/node-http-link-header/blob/master/lib/link.js#L272-L289
- [N/A] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
