### PR TITLE
[node] events: improve static methods, fix broken reversion

### DIFF
--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -80,39 +80,24 @@ declare module "events" {
          * Can be used to cancel awaiting events.
          */
         signal?: AbortSignal | undefined;
-        /**
-         * Names of events that will end the iteration.
-         */
-        close?: string[] | undefined;
-        /**
-         * The high watermark. The emitter is paused every time the size
-         * of events being buffered is higher than it. Supported only
-         * on emitters implementing `pause()` and `resume()` methods.
-         * @default `Number.MAX_SAFE_INTEGER`
-         */
-        highWaterMark?: number | undefined;
-        /**
-         * The low watermark. The emitter is resumed every time the size of events being buffered
-         * is lower than it. Supported only on emitters implementing `pause()` and `resume()` methods.
-         * @default 1
-         */
-        lowWaterMark?: number | undefined;
     }
     interface StaticEventEmitterIteratorOptions extends StaticEventEmitterOptions {
         /**
          * Names of events that will end the iteration.
          */
-        close?: string[];
+        close?: string[] | undefined;
         /**
-         * The emitter is paused every time the size of events being buffered is higher than it. Supported only on emitters implementing pause() and resume() methods.
+         * The high watermark. The emitter is paused every time the size of events being buffered is higher than it.
+         * Supported only on emitters implementing `pause()` and `resume()` methods.
          * @default Number.MAX_SAFE_INTEGER
          */
-        highWaterMark?: number;
+        highWaterMark?: number | undefined;
         /**
-         * The emitter is resumed every time the size of events being buffered is lower than it. Supported only on emitters implementing pause() and resume() methods.
+         * The low watermark. The emitter is resumed every time the size of events being buffered is lower than it.
+         * Supported only on emitters implementing `pause()` and `resume()` methods.
          * @default 1
          */
-        lowWaterMark?: number;
+        lowWaterMark?: number | undefined;
     }
     interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
     type EventMap<T> = Record<keyof T, any[]> | DefaultEventMap;
@@ -232,7 +217,7 @@ declare module "events" {
         static once(
             emitter: NodeJS.EventEmitter,
             eventName: string | symbol,
-            options?: Pick<StaticEventEmitterOptions, "signal">,
+            options?: StaticEventEmitterOptions,
         ): Promise<any[]>;
         static once(emitter: EventTarget, eventName: string, options?: StaticEventEmitterOptions): Promise<any[]>;
         /**
@@ -319,7 +304,7 @@ declare module "events" {
         static on(
             emitter: NodeJS.EventEmitter,
             eventName: string | symbol,
-            options?: StaticEventEmitterOptions,
+            options?: StaticEventEmitterIteratorOptions,
         ): AsyncIterableIterator<any>;
         static on(
             emitter: EventTarget,

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -305,12 +305,12 @@ declare module "events" {
             emitter: NodeJS.EventEmitter,
             eventName: string | symbol,
             options?: StaticEventEmitterIteratorOptions,
-        ): AsyncIterableIterator<any>;
+        ): AsyncIterableIterator<any[]>;
         static on(
             emitter: EventTarget,
             eventName: string,
             options?: StaticEventEmitterIteratorOptions,
-        ): AsyncIterableIterator<any>;
+        ): AsyncIterableIterator<any[]>;
         /**
          * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
          *

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -298,7 +298,6 @@ declare module "events" {
          * console.log('done'); // prints 'done'
          * ```
          * @since v13.6.0, v12.16.0
-         * @param eventName The name of the event being listened for
          * @return An `AsyncIterator` that iterates `eventName` events emitted by the `emitter`
          */
         static on(

--- a/types/node/test/events.ts
+++ b/types/node/test/events.ts
@@ -97,7 +97,7 @@ declare const any: any;
 
 async function test() {
     for await (const e of events.on(new events.EventEmitter(), "test")) {
-        console.log(e);
+        console.log(e.length);
     }
     events.on(new events.EventEmitter(), "test", { signal: new AbortController().signal });
     events.on(new events.EventEmitter(), "test", { close: ["close"] });
@@ -107,7 +107,7 @@ async function test() {
 
 async function testWithSymbol() {
     for await (const e of events.on(new events.EventEmitter(), Symbol("test"))) {
-        console.log(e);
+        console.log(e.length);
     }
     events.on(new events.EventEmitter(), Symbol("test"), { signal: new AbortController().signal });
 }


### PR DESCRIPTION
- The revert commit at 5ef2885af75f1a3dc160c53c70a2d2567c4af314 resulted in a Frankenmerge with the changes introduced by #69684. This patches the affected definitions to a well-merged state.
- The iteration type of the AsyncIterator returned by the static method `events.on()` is defined as an array of event arguments, the same as the Promise resolution type of `events.once()`. It should therefore also be typed as `any[]`.
- Removed an isolated JSDoc annotation for a self-documenting parameter.

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [node:events](https://nodejs.org/docs/latest/api/events.html#eventsonemitter-eventname-options)
  > The `value` returned by each iteration is an array composed of the emitted event arguments.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
