### PR TITLE
Preemptively fix broken ExpectTypes

### DIFF
--- a/types/alpinejs/alpinejs-tests.ts
+++ b/types/alpinejs/alpinejs-tests.ts
@@ -322,9 +322,9 @@ import Alpine, {
 
     const el = document.body;
 
-    // $ExpectType: () => void
+    // $ExpectType () => void
     Alpine.setStyles(el, "visibility: hidden");
-    // $ExpectType: () => void
+    // $ExpectType () => void
     Alpine.setStyles(el, { visibility: "hidden" });
 }
 
@@ -492,7 +492,7 @@ import Alpine, {
         alpine.magic("foo", () => {});
     };
 
-    // $ExpectType: void
+    // $ExpectType void
     Alpine.plugin(MyAlpinePlugin);
 }
 

--- a/types/antlr4/test/atn.ts
+++ b/types/antlr4/test/atn.ts
@@ -227,7 +227,7 @@ LexerActionType.TYPE; // $ExpectType LexerActionType.TYPE
 const lexerAtnConfigInstance = new LexerATNConfig(atnStateInstance, atnConfigInstance);
 lexerAtnConfigInstance.lexerActionExecutor; // $ExpectType LexerActionExecutor | null
 lexerAtnConfigInstance.passedThroughNonGreedyDecision; // $ExpectType boolean
-lexerAtnConfigInstance.checkNonGreedyDecision(atnConfigInstance, atnStateInstance); // $ExpectType
+lexerAtnConfigInstance.checkNonGreedyDecision(atnConfigInstance, atnStateInstance); // $ExpectType boolean
 
 // LexerATNSimulator
 const dfaInstance = new DFA(atnInstance, 0);
@@ -426,7 +426,7 @@ PredictionMode.hasConflictingAltSet(bitsetCollection); // $ExpectType boolean
 PredictionMode.allSubsetsEqual(bitsetCollection); // $ExpectType boolean
 PredictionMode.getUniqueAlt(bitsetCollection); // $ExpectType number
 PredictionMode.getAlts(bitsetCollection); // $ExpectType BitSet
-PredictionMode.getConflictingAltSubsets(atnConfigSetInstance); // $ExpectType
+PredictionMode.getConflictingAltSubsets(atnConfigSetInstance); // $ExpectType BitSet[]
 PredictionMode.getStateToAltMap(atnConfigSetInstance); // $ExpectType AltDict
 PredictionMode.hasStateAssociatedWithOneAlt(atnConfigSetInstance); // $ExpectType boolean
 PredictionMode.getSingleViableAlt(bitsetCollection); // $ExpectType number

--- a/types/css-mediaquery/css-mediaquery-tests.ts
+++ b/types/css-mediaquery/css-mediaquery-tests.ts
@@ -2,7 +2,7 @@ import { Expression, match, parse } from "css-mediaquery";
 
 // @ts-expect-error
 match("(min-width: 800)");
-// $ExpectType
+// $ExpectType boolean
 match("(min-width: 800)", {});
 match("(min-width: 800)", { width: 300 });
 match("(min-width: 800)", { width: "300px" });

--- a/types/d3-array/d3-array-tests.ts
+++ b/types/d3-array/d3-array-tests.ts
@@ -2603,7 +2603,7 @@ const p1: Array<number | string | Date | number[]> = d3Array.permute(testObject,
     "when" as "when",
     "more" as "more",
 ]);
-// $ExpectType: Array<Date | number[]>
+// $ExpectType (Date | number[])[]
 const p2 = d3Array.permute(testObject, ["when" as "when", "more" as "more"]);
 // @ts-expect-error
 const p3 = d3Array.permute(testObject, ["when" as "when", "unknown" as "unknown"]);

--- a/types/d3-array/v2/d3-array-tests.ts
+++ b/types/d3-array/v2/d3-array-tests.ts
@@ -974,7 +974,7 @@ const p1: Array<number | string | Date | number[]> = d3Array.permute(testObject,
     "when" as "when",
     "more" as "more",
 ]);
-// $ExpectType: Array<Date | number[]>
+// $ExpectType (Date | number[])[]
 const p2 = d3Array.permute(testObject, ["when" as "when", "more" as "more"]);
 // @ts-expect-error
 const p3 = d3Array.permute(testObject, ["when" as "when", "unknown" as "unknown"]);

--- a/types/ember-data__adapter/test/error.ts
+++ b/types/ember-data__adapter/test/error.ts
@@ -24,7 +24,7 @@ class MyInvalid extends InvalidError {
 
 const invalid = new MyInvalid();
 
-const isInvalid = invalid instanceof AdapterError; // $ExpectType<boolean>
+const isInvalid = invalid instanceof AdapterError; // $ExpectType boolean
 
-errorsHashToArray({}); // $ExpectType<any[]>
-errorsArrayToHash([]); // $ExpectType<{}>
+errorsHashToArray({}); // $ExpectType any[]
+errorsArrayToHash([]); // $ExpectType {}

--- a/types/ember-data__adapter/v3/test/error.ts
+++ b/types/ember-data__adapter/v3/test/error.ts
@@ -24,7 +24,7 @@ class MyInvalid extends InvalidError {
 
 const invalid = new MyInvalid();
 
-const isInvalid = invalid instanceof AdapterError; // $ExpectType<boolean>
+const isInvalid = invalid instanceof AdapterError; // $ExpectType boolean
 
-errorsHashToArray({}); // $ExpectType<any[]>
-errorsArrayToHash([]); // $ExpectType<{}>
+errorsHashToArray({}); // $ExpectType any[]
+errorsArrayToHash([]); // $ExpectType {}

--- a/types/ember-data__store/ember-data__store-tests.ts
+++ b/types/ember-data__store/ember-data__store-tests.ts
@@ -26,7 +26,7 @@ declare module "ember-data/types/registries/model" {
 }
 
 // -- actual tests
-Store; // $ExpectType<DS.Store>
-Snapshot; // $ExpectType<DS.Snapshot>
-normalizeModelName("post"); // $ExpectType<string>
-normalizeModelName("post-comment"); // $ExpectType<string>
+Store; // $ExpectType typeof Store
+Snapshot; // $ExpectType typeof Snapshot
+normalizeModelName("post"); // $ExpectType string
+normalizeModelName("post-comment"); // $ExpectType string

--- a/types/ember-data__store/v3/ember-data__store-tests.ts
+++ b/types/ember-data__store/v3/ember-data__store-tests.ts
@@ -26,6 +26,6 @@ declare module "ember-data/types/registries/model" {
 }
 
 // -- actual tests
-Store; // $ExpectType<DS.Store>
-normalizeModelName("post"); // $ExpectType<string>
-normalizeModelName("post-comment"); // $ExpectType<string>
+Store; // $ExpectType typeof Store
+normalizeModelName("post"); // $ExpectType string
+normalizeModelName("post-comment"); // $ExpectType string

--- a/types/es-aggregate-error/es-aggregate-error-tests.ts
+++ b/types/es-aggregate-error/es-aggregate-error-tests.ts
@@ -21,19 +21,19 @@ const explicitError: AggregateError = new AggregateError([oneError, otherError],
 
 AggregateError.prototype; // $ExpectType AggregateError
 AggregateError.shim; // $ExpectType () => typeof AggregateError
-AggregateError.shim(); // $ExpectType: AggregateError
+AggregateError.shim(); // $ExpectType typeof AggregateError
 
-implicitError.errors; // $ExpectType: Array<unknown>
-implicitError.message; // $ExpectType: string
-implicitError.name; // $ExpectType: "AggregateError"
+implicitError.errors; // $ExpectType ReadonlyArray<any>
+implicitError.message; // $ExpectType string
+implicitError.name; // $ExpectType "AggregateError"
 
 // @ts-expect-error
 implicitError.name = "something else";
 
 const err = new Error("test");
 if (err instanceof AggregateError) {
-    const aggregateErr: AggregateError = err; // $ExpectType: AggregateError
+    const aggregateErr: AggregateError = err; // $ExpectType AggregateError
     // @ts-expect-error
     const notAggregateErr: typeof AggregateError = err;
-    aggregateErr.name; // $ExpectType: "AggregateError"
+    aggregateErr.name; // $ExpectType "AggregateError"
 }

--- a/types/fernet/fernet-tests.ts
+++ b/types/fernet/fernet-tests.ts
@@ -32,12 +32,12 @@ fInst.ttl; // $ExpectType number
 fInst.versionHex; // $ExpectType string
 fInst.ivHex; // $ExpectType string
 fInst.iv; // $ExpectType WordArray
-fInst.secret; // $ExpectType: Secret | undefined
+fInst.secret; // $ExpectType Secret | undefined
 fernet.ttl; // $ExpectType number
 fernet.versionHex; // $ExpectType string
 fernet.ivHex; // $ExpectType string
 fernet.iv; // $ExpectType WordArray
-fernet.secret; // $ExpectType: Secret | undefined
+fernet.secret; // $ExpectType Secret | undefined
 
 fInst.parseHex("123"); // $ExpectType number
 fInst.decode64toHex("123"); // $ExpectType string

--- a/types/firstline/firstline-tests.ts
+++ b/types/firstline/firstline-tests.ts
@@ -1,10 +1,10 @@
 import firstline = require("firstline");
 
-// $ExpectType: Promise<string>
+// $ExpectType Promise<string>
 firstline("./my-file.txt");
-// $ExpectType: Promise<string>
+// $ExpectType Promise<string>
 firstline("./my-file.txt", { lineEnding: "\r" });
-// $ExpectType: Promise<string>
+// $ExpectType Promise<string>
 firstline("./my-file.txt", { lineEnding: "\r", encoding: "ascii" });
 // @ts-expect-error
 firstline("./my-file.txt", { lineEnding: "\r", encoding: "utf88" });

--- a/types/floreal/floreal-tests.ts
+++ b/types/floreal/floreal-tests.ts
@@ -5,8 +5,8 @@ const fd2 = new Floreal("1799-11-09"); // $ExpectType FlorealDate
 const fd3 = new Floreal(Date.now()); // $ExpectType FlorealDate
 const fd4 = new Floreal(new Date()); // $ExpectType FlorealDate
 
-fd1.dayName(); // $ExpectType: string
-fd2.firstDayOfYear(); // $ExpectType: Date
+fd1.dayName(); // $ExpectType string
+fd2.firstDayOfYear(); // $ExpectType Date
 // @ts-expect-error
 fd1.foo();
 fd1.setYear("XII");

--- a/types/moonjs/moonjs-tests.ts
+++ b/types/moonjs/moonjs-tests.ts
@@ -79,7 +79,7 @@ const componentConstructor = Moon.component("my-component", {
     methods: {
         halfFoo() {
             const currentFoo = this.get("foo");
-            currentFoo; // $ExpectType: number
+            currentFoo; // $ExpectType number
             return currentFoo / 2;
         },
         bothProps(): [any, any] {

--- a/types/oojs-ui/oojs-ui-tests.ts
+++ b/types/oojs-ui/oojs-ui-tests.ts
@@ -934,11 +934,11 @@
         editable: false,
     });
 
-    instance.focus(); // $ExpectType
+    instance.focus(); // $ExpectType void
 
-    instance.focus(1); // $ExpectType
+    instance.focus(1); // $ExpectType void
 
-    instance.focusFirstFocusable(); // $ExpectType
+    instance.focusFirstFocusable(); // $ExpectType void
 
     instance.isOutlined(); // $ExpectType boolean
 

--- a/types/shelljs.exec/shelljs.exec-tests.ts
+++ b/types/shelljs.exec/shelljs.exec-tests.ts
@@ -8,7 +8,7 @@ exec("echo test with options", {
 exec("echo test without options");
 
 const results = exec("echo test with return");
-results.code; // $ExpectType<number>
-results.stdout; // $ExpectType<string>
+results.code; // $ExpectType number
+results.stdout; // $ExpectType string
 // @ts-expect-error
 results.silent;

--- a/types/systemjs/systemjs-tests.ts
+++ b/types/systemjs/systemjs-tests.ts
@@ -67,7 +67,7 @@ System.set("https://example.com/d.js", {
 });
 
 for (const entry of System.entries()) {
-    // $ExpectType: string
+    // $ExpectType string
     const moduleId = entry[0];
     const module = entry[1];
 }

--- a/types/vk-openapi/vk-openapi-tests.ts
+++ b/types/vk-openapi/vk-openapi-tests.ts
@@ -832,7 +832,7 @@ VK.Widgets.CommunityMessages("test", 123, {});
 
 VK.Widgets.CommunityMessages("test", 123, {
     onCanNotWrite: reason => {
-        // $ExpectType: 'offline' | 'no_access' | 'disabled_messages' | 'cant_write'
+        // $ExpectType OnCanNotWriteReason
         reason;
     },
     welcomeScreen: 0,

--- a/types/yargs/v15/yargs-tests.ts
+++ b/types/yargs/v15/yargs-tests.ts
@@ -381,13 +381,13 @@ function Argv$commandModule() {
 
     const CommandTwo: yargs.CommandModule<{ a: string }, { b: number }> = {
         builder: yargs => {
-            // $ExpectType: string
+            // $ExpectType string
             yargs.argv.a;
             return yargs.number("b").default("b", parseInt(yargs.argv.a, 10));
         },
 
         handler: argv => {
-            // $ExpectType: number
+            // $ExpectType number
             argv.b;
         },
     };
@@ -443,7 +443,7 @@ function Argv$commandModule() {
 
     const commandArgs = builder(yargs).argv;
 
-    // $ExpectType: { [x: string]: unknown; file: unknown; cleanDestination: boolean | undefined; _: (string | number)[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; file: unknown; cleanDestination: boolean | undefined; _: (string | number)[]; $0: string; }
     commandArgs;
 
     // Backwards compatibility with older types

--- a/types/yargs/v16/yargs-tests.ts
+++ b/types/yargs/v16/yargs-tests.ts
@@ -382,13 +382,13 @@ function Argv$commandModule() {
 
     const CommandTwo: yargs.CommandModule<{ a: string }, { b: number }> = {
         builder: yargs => {
-            // $ExpectType: string
+            // $ExpectType string
             yargs.argv.a;
             return yargs.number("b").default("b", parseInt(yargs.argv.a, 10));
         },
 
         handler: argv => {
-            // $ExpectType: number
+            // $ExpectType number
             argv.b;
         },
     };
@@ -444,7 +444,7 @@ function Argv$commandModule() {
 
     const commandArgs = builder(yargs).argv;
 
-    // $ExpectType: { [x: string]: unknown; file: unknown; cleanDestination: boolean | undefined; _: (string | number)[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; file: unknown; cleanDestination: boolean | undefined; _: (string | number)[]; $0: string; }
     commandArgs;
 
     // Backwards compatibility with older types

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -401,13 +401,13 @@ async function Argv$commandModule() {
 
     const CommandTwo: yargs.CommandModule<{ a: string }, { b: number }> = {
         builder: async yargs => {
-            // $ExpectType: string
+            // $ExpectType string
             (await yargs.argv).a;
             return yargs.number("b").default("b", parseInt((await yargs.argv).a, 10));
         },
 
         handler: argv => {
-            // $ExpectType: number
+            // $ExpectType number
             argv.b;
         },
     };
@@ -463,7 +463,7 @@ async function Argv$commandModule() {
 
     const commandArgs = builder(yargs).argv;
 
-    // $ExpectType: { [x: string]: unknown; file: unknown; cleanDestination: boolean | undefined; _: (string | number)[]; $0: string; }
+    // $ExpectType { [x: string]: unknown; file: unknown; cleanDestination: boolean | undefined; _: (string | number)[]; $0: string; } | Promise<{ [x: string]: unknown; file: unknown; cleanDestination: boolean | undefined; _: (string | number)[]; $0: string; }>
     commandArgs;
 
     // Backwards compatibility with older types


### PR DESCRIPTION
These are all invalid, but not caught by the lint rule. That bug will be fixed in https://github.com/microsoft/DefinitelyTyped-tools/pull/1016, causing errors here. So, fix these now.