### PR TITLE
Cytoscape closeness centrality normalized result

### DIFF
--- a/types/cytoscape/cytoscape-tests.ts
+++ b/types/cytoscape/cytoscape-tests.ts
@@ -1076,3 +1076,6 @@ const coseAllOptions: CoseLayoutOptions = {
     minTemp: 10.0,
 };
 cy.layout(coseAllOptions);
+
+const ccn = cy.nodes().closenessCentralityNormalized({directed: false});
+ccn.closeness(cy.nodes()[0]);

--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -3413,9 +3413,12 @@ declare namespace cytoscape {
         harmonic?: boolean | undefined;
     }
     /**
-     * http://js.cytoscape.org/#eles.closenessCentralityNormalized
-     * trivial
+     * http://js.cytoscape.org/#eles.closenessCentrality
      */
+    interface SearchClosenessCentralityNormalizedResult {
+        /** the normalised closeness centrality of the specified node */
+        closeness(node: NodeSingular): any;
+    }
 
     /**
      * http://js.cytoscape.org/#eles.betweennessCentrality
@@ -3600,7 +3603,7 @@ declare namespace cytoscape {
          */
         closenessCentralityNormalized(
             options: SearchClosenessCentralityNormalizedOptions,
-        ): SearchDegreeCentralityNormalizedResultDirected | SearchDegreeCentralityNormalizedResultUndirected;
+        ): SearchClosenessCentralityNormalizedResult;
         /**
          * Considering only the elements in the calling collection,
          * calculate the betweenness centrality of the nodes.

--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -3413,7 +3413,7 @@ declare namespace cytoscape {
         harmonic?: boolean | undefined;
     }
     /**
-     * http://js.cytoscape.org/#eles.closenessCentrality
+     * http://js.cytoscape.org/#eles.closenessCentralityNormalized
      */
     interface SearchClosenessCentralityNormalizedResult {
         /** the normalised closeness centrality of the specified node */


### PR DESCRIPTION
The function `closenessCentralityNormalized` returns a different result type than `degreeCentralityNormalized`. Defines a new interface type and uses it as return type.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [cytoscape.js closenessCentralityNormalized](https://js.cytoscape.org/#eles.closenessCentralityNormalized)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
