### PR TITLE
Add missing type definitions for package `probe-image-size` deep import `lib/parse_sync/png.js`.

### DIFF
--- a/types/probe-image-size/index.d.ts
+++ b/types/probe-image-size/index.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="node" />
+/// <reference path="./lib/parse_sync/png.js/index.d.ts" />
 
 import needle = require("needle");
 import { Transform } from "stream";

--- a/types/probe-image-size/lib/parse_sync/png.js/index.d.ts
+++ b/types/probe-image-size/lib/parse_sync/png.js/index.d.ts
@@ -1,0 +1,14 @@
+/// <reference types="node" />
+
+declare function parsePng(data: Buffer):
+    | {
+        width: number;
+        height: number;
+        type: "png";
+        mime: "image/png";
+        wUnits: "px";
+        hUnits: "px";
+    }
+    | undefined;
+
+export = parsePng;

--- a/types/probe-image-size/probe-image-size-tests.ts
+++ b/types/probe-image-size/probe-image-size-tests.ts
@@ -29,3 +29,22 @@ const data = fs.readFileSync("image.jpg");
     new probe.Error("Error", "ECONTENT"); // $ExpectType ProbeError
     new probe.Error("Error", "ECONTENT", 404); // $ExpectType ProbeError
 })();
+
+
+// Tests for deep imports.
+
+// -- /lib/parse_sync/png.js
+
+import parsePng from "probe-image-size/lib/parse_sync/png.js";
+
+/** The smallest PNG that will pass `parsePng` checks. */
+const testPngMinimal = '\x89PNG\r\n\x1a\n' +
+    '\x00\x00\x00\x0D' + // IHDR chunk length: 13 bytes
+    'IHDR' +
+    '\x00\x00\x00\x01' + // Width: 1
+    '\x00\x00\x00\x01';  // Height: 1
+
+// @ts-expect-error - not a Buffer.
+parsePng(testPngMinimal);
+
+parsePng(Buffer.from(testPngMinimal)); // $ExpectType { width: number; height: number; type: "png"; mime: "image/png"; wUnits: "px"; hUnits: "px"; } | undefined

--- a/types/probe-image-size/tsconfig.json
+++ b/types/probe-image-size/tsconfig.json
@@ -14,6 +14,7 @@
     },
     "files": [
         "index.d.ts",
-        "probe-image-size-tests.ts"
+        "probe-image-size-tests.ts",
+        "lib/parse_sync/png.js/index.d.ts"
     ]
 }


### PR DESCRIPTION
# What's changed?

When directly deep importing the PNG parsing function from `probe-image-size/lib/parse_sync/png.js`, TypeScript does not infer narrow enough types for the argument or return type.

This PR adds a type definition for the function, and ensures a return type that is more narrow.

Also added some test cases to `probe-image-size-tests.ts`.

# Checklist

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

# If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodeca/probe-image-size/blob/master/lib/parse_sync/png.js
- [N/A] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
