### PR TITLE
[@types/react-instantsearch-dom] Add onFocus to SearchBoxProps

### DIFF
--- a/types/react-instantsearch-dom/index.d.ts
+++ b/types/react-instantsearch-dom/index.d.ts
@@ -127,6 +127,7 @@ export interface SearchBoxProps extends CommonWidgetProps {
     onReset?: ((event: React.SyntheticEvent<HTMLFormElement>) => any) | undefined;
     onChange?: ((event: React.SyntheticEvent<HTMLInputElement>) => any) | undefined;
     onKeyDown?: ((event: React.KeyboardEvent<HTMLInputElement>) => any) | undefined;
+    onFocus?: ((event: React.FocusEvent<HTMLInputElement>) => any) | undefined;
 }
 /**
  * The SearchBox component displays a search box that lets the user search for a specific query.

--- a/types/react-instantsearch-dom/react-instantsearch-dom-tests.tsx
+++ b/types/react-instantsearch-dom/react-instantsearch-dom-tests.tsx
@@ -215,6 +215,8 @@ import {
 
     function onSearchBoxKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {}
 
+    function onSearchBoxFocus(event: React.FocusEvent<HTMLInputElement>) {}
+
     function onSearchBoxReset(event: React.SyntheticEvent<HTMLFormElement>) {}
 
     function onSearchBoxSubmit(event: React.SyntheticEvent<HTMLFormElement>) {}
@@ -222,6 +224,7 @@ import {
     <SearchBox
         onChange={onSearchBoxChange}
         onKeyDown={onSearchBoxKeyDown}
+        onFocus={onSearchBoxFocus}
         onReset={onSearchBoxReset}
         onSubmit={onSearchBoxSubmit}
         submit={<></>}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - The component's `propTypes` doesn't include `onFocus`: https://github.com/algolia/react-instantsearch/blob/master/packages/react-instantsearch-dom/src/components/SearchBox.js#L61
  - However, the implementation allows event handlers: https://github.com/algolia/react-instantsearch/blob/master/packages/react-instantsearch-dom/src/components/SearchBox.js#L239-L249
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
