### PR TITLE
[@types/picomatch] Fix `expandRange` options field

### DIFF
--- a/types/picomatch/lib/picomatch.d.ts
+++ b/types/picomatch/lib/picomatch.d.ts
@@ -84,8 +84,7 @@ declare namespace picomatch {
          * The function receives the range values as two arguments, and it must return a string to be used in the generated regex.
          * It's recommended that returned strings be wrapped in parentheses.
          */
-        expandRange?: ((from: string, to: string, options: PicomatchOptions) => string) | undefined;
-        expandRange?: ((from: string, to: string, step: string, options: PicomatchOptions) => string) | undefined;
+        expandRange?: ((from: string, to: string, options: PicomatchOptions) => string) | ((from: string, to: string, step: string, options: PicomatchOptions) => string) | undefined;
         /**
          * Throws an error if no matches are found. Based on the bash option of the same name.
          */

--- a/types/picomatch/lib/picomatch.d.ts
+++ b/types/picomatch/lib/picomatch.d.ts
@@ -30,6 +30,9 @@ declare function picomatch<T extends true | false = false>(
 declare namespace picomatch {
     type Glob = string | string[];
 
+    function expandRange(from: string, to: string, options: PicomatchOptions): string;
+    function expandRange(from: string, to: string, step: string, options: PicomatchOptions): string;
+
     interface Matcher {
         (test: string): boolean;
     }
@@ -84,10 +87,7 @@ declare namespace picomatch {
          * The function receives the range values as two arguments, and it must return a string to be used in the generated regex.
          * It's recommended that returned strings be wrapped in parentheses.
          */
-        expandRange?:
-            | ((from: string, to: string, options: PicomatchOptions) => string)
-            | ((from: string, to: string, step: string, options: PicomatchOptions) => string)
-            | undefined;
+        expandRange?: typeof expandRange | undefined;
         /**
          * Throws an error if no matches are found. Based on the bash option of the same name.
          */

--- a/types/picomatch/lib/picomatch.d.ts
+++ b/types/picomatch/lib/picomatch.d.ts
@@ -84,7 +84,10 @@ declare namespace picomatch {
          * The function receives the range values as two arguments, and it must return a string to be used in the generated regex.
          * It's recommended that returned strings be wrapped in parentheses.
          */
-        expandRange?: ((from: string, to: string, options: PicomatchOptions) => string) | ((from: string, to: string, step: string, options: PicomatchOptions) => string) | undefined;
+        expandRange?:
+            | ((from: string, to: string, options: PicomatchOptions) => string)
+            | ((from: string, to: string, step: string, options: PicomatchOptions) => string)
+            | undefined;
         /**
          * Throws an error if no matches are found. Based on the bash option of the same name.
          */

--- a/types/picomatch/lib/picomatch.d.ts
+++ b/types/picomatch/lib/picomatch.d.ts
@@ -84,7 +84,8 @@ declare namespace picomatch {
          * The function receives the range values as two arguments, and it must return a string to be used in the generated regex.
          * It's recommended that returned strings be wrapped in parentheses.
          */
-        expandRange?: ((a: string, b: string) => string) | undefined;
+        expandRange?: ((from: string, to: string, options: PicomatchOptions) => string) | undefined;
+        expandRange?: ((from: string, to: string, step: string, options: PicomatchOptions) => string) | undefined;
         /**
          * Throws an error if no matches are found. Based on the bash option of the same name.
          */

--- a/types/picomatch/lib/picomatch.d.ts
+++ b/types/picomatch/lib/picomatch.d.ts
@@ -30,9 +30,6 @@ declare function picomatch<T extends true | false = false>(
 declare namespace picomatch {
     type Glob = string | string[];
 
-    function expandRange(from: string, to: string, options: PicomatchOptions): string;
-    function expandRange(from: string, to: string, step: string, options: PicomatchOptions): string;
-
     interface Matcher {
         (test: string): boolean;
     }
@@ -87,7 +84,8 @@ declare namespace picomatch {
          * The function receives the range values as two arguments, and it must return a string to be used in the generated regex.
          * It's recommended that returned strings be wrapped in parentheses.
          */
-        expandRange?: typeof expandRange | undefined;
+        expandRange?(from: string, to: string, options: PicomatchOptions): string;
+        expandRange?(from: string, to: string, step: string, options: PicomatchOptions): string;
         /**
          * Throws an error if no matches are found. Based on the bash option of the same name.
          */

--- a/types/picomatch/picomatch-tests.ts
+++ b/types/picomatch/picomatch-tests.ts
@@ -52,7 +52,7 @@ pm.makeRe("foo/{01..25}/bar", {
     },
 });
 pm.makeRe("foo/{01..25..5}/bar", {
-    expandRange(from: string, to: string, step: string) {
+    expandRange(from: string, to: string, step: string | pm.PicomatchOptions) {
         return `(<fill-range output>)`;
     },
 });

--- a/types/picomatch/picomatch-tests.ts
+++ b/types/picomatch/picomatch-tests.ts
@@ -47,12 +47,12 @@ pm.scan("!./foo/*.js", { tokens: true });
 
 pm.makeRe("foo/*.js").test("foo/bar.js");
 pm.makeRe("foo/{01..25}/bar", {
-    expandRange(from, to) {
+    expandRange(from: string, to: string) {
         return `(<fill-range output>)`;
     },
 });
 pm.makeRe("foo/{01..25..5}/bar", {
-    expandRange(from, to, step) {
+    expandRange(from: string, to: string, step: string) {
         return `(<fill-range output>)`;
     },
 });

--- a/types/picomatch/picomatch-tests.ts
+++ b/types/picomatch/picomatch-tests.ts
@@ -47,7 +47,12 @@ pm.scan("!./foo/*.js", { tokens: true });
 
 pm.makeRe("foo/*.js").test("foo/bar.js");
 pm.makeRe("foo/{01..25}/bar", {
-    expandRange(a, b) {
+    expandRange(from, to) {
+        return `(<fill-range output>)`;
+    },
+});
+pm.makeRe("foo/{01..25..5}/bar", {
+    expandRange(from, to, step) {
         return `(<fill-range output>)`;
     },
 });


### PR DESCRIPTION
Add options parameter - https://github.com/micromatch/picomatch/blob/master/lib/parse.js#L24
Support more than 2 range parameters - https://github.com/micromatch/picomatch/blob/master/lib/parse.js#L576, https://en.wikipedia.org/wiki/Bash_(Unix_shell)#Brace_expansion (picomatch support step parameter)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see commit description start.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.