### PR TITLE
[lodash] Add a type predicate to `isObjectLike` and explain why one cannot be added to `isPlainObject`

### DIFF
--- a/types/lodash/common/lang.d.ts
+++ b/types/lodash/common/lang.d.ts
@@ -1097,13 +1097,13 @@ declare module "../index" {
          * _.isObjectLike(null);
          * // => false
          */
-        isObjectLike(value?: any): boolean;
+        isObjectLike(value?: any): value is object;
     }
     interface LoDashImplicitWrapper<TValue> {
         /**
          * @see _.isObjectLike
          */
-        isObjectLike(): boolean;
+        isObjectLike(): this is LoDashImplicitWrapper<object>;
     }
     interface LoDashExplicitWrapper<TValue> {
         /**
@@ -1123,6 +1123,10 @@ declare module "../index" {
          * @return Returns true if value is a plain object, else false.
          */
         isPlainObject(value?: any): boolean;
+
+        // NOTE: The seemingly logical `value is object` type predicate cannot
+        // be added, as it would break the negative version of the type guard.
+        // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69915#pullrequestreview-2143148704
     }
     interface LoDashImplicitWrapper<TValue> {
         /**

--- a/types/lodash/fp.d.ts
+++ b/types/lodash/fp.d.ts
@@ -2004,7 +2004,7 @@ declare namespace _ {
     type LodashIsNull = (value: any) => value is null;
     type LodashIsNumber = (value: any) => value is number;
     type LodashIsObject = (value: any) => value is object;
-    type LodashIsObjectLike = (value: any) => boolean;
+    type LodashIsObjectLike = (value: any) => value is object;
     type LodashIsPlainObject = (value: any) => boolean;
     type LodashIsRegExp = (value: any) => value is RegExp;
     type LodashIsSafeInteger = (value: any) => boolean;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -4495,6 +4495,12 @@ fp.now(); // $ExpectType number
     _(42).isObjectLike(); // $ExpectType boolean
     _.chain([]).isObjectLike(); // $ExpectType PrimitiveChain<boolean>
     fp.isObjectLike(anything); // $ExpectType boolean
+    if (fp.isObjectLike(anything)) {
+        anything; // $ExpectType object
+    }
+    if (_.isObjectLike(anything)) {
+        anything; // $ExpectType object
+    }
 }
 
 // _.isPlainObject


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`isObjectLike`](https://github.com/lodash/lodash/blob/main/src/isObjectLike.ts), [`isPlainObject`](https://github.com/lodash/lodash/blob/main/src/isPlainObject.ts)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
