### PR TITLE
Fix of "The file '@types/favico.js/index.d.ts' is not a module.ts(2306)"

### DIFF
--- a/types/favico.js/index.d.ts
+++ b/types/favico.js/index.d.ts
@@ -1,4 +1,4 @@
-declare namespace favicojs {
+declare module "favico.js" {
     interface FavicoJsStatic {
         new(opt?: FavicoJsOptions): Favico;
     }
@@ -16,7 +16,8 @@ declare namespace favicojs {
         dataUrl?: ((url: string) => any) | undefined;
     }
 
-    interface Favico {
+    class Favico {
+        constructor(options?: FavicoOptions);
         badge(number: number): void;
         badge(number: number, animation: string): void;
         badge(number: number, opts: FavicoJsOptions): void;


### PR DESCRIPTION
Error fixed

The file '~/app/node_modules/@types/favico.js/index.d.ts' is not a module.ts(2306)
favico.js -  0.3.10
Node - v20.15.0
NPM - 10.8.1

![image](https://github.com/DefinitelyTyped/DefinitelyTyped/assets/88730920/03d2b227-cf07-420e-b902-2110ddb8fddf)
