### PR TITLE
rails__actioncable update createConsumer type to accept function which returns string

### DIFF
--- a/types/rails__actioncable/index.d.ts
+++ b/types/rails__actioncable/index.d.ts
@@ -225,6 +225,6 @@ export const logger: {
 /**
  * @see https://github.com/rails/rails/blob/main/actioncable/app/javascript/action_cable/index.js
  */
-export function createConsumer(url?: string): Consumer;
+export function createConsumer(url?: string | (() => string)): Consumer;
 // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 export function getConfig(name: string): string | void;

--- a/types/rails__actioncable/rails__actioncable-tests.ts
+++ b/types/rails__actioncable/rails__actioncable-tests.ts
@@ -30,6 +30,7 @@ logger.enabled = true;
  */
 const consumer = new Consumer("url"); // $ExpectType Consumer
 createConsumer("url"); // $ExpectType Consumer
+createConsumer(() => "url"); // $ExpectType Consumer
 
 consumer.url; // $ExpectType string
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  https://github.com/rails/rails/blob/main/actioncable/app/assets/javascripts/action_cable.js#L472
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. - I believe this is just something missed not due to a version change so I believe we leave it the same?


### Explanation of why it takes `() => string`

`createConsumer()` passes the url to the [consumer initializer](https://github.com/rails/rails/blob/main/actioncable/app/javascript/action_cable/index.js). Within the consumer the url is parsed via `createWebSocketURL(url)`. This function checks if the url is a function. If it is a function it calls the it and then sets the url to the return of the function. https://github.com/rails/rails/blob/main/actioncable/app/assets/javascripts/action_cable.js#L472

Also see rails documentation: https://guides.rubyonrails.org/action_cable_overview.html#connect-consumer

```js
// Use a function to dynamically generate the URL
createConsumer(getWebSocketURL)

function getWebSocketURL() {
  const token = localStorage.get('auth-token')
  return `wss://example.com/cable?token=${token}`
}
```