### PR TITLE
Fix of "The file '@types/favico.js/index.d.ts' is not a module.ts(2306)"

### DIFF
--- a/types/favico.js/index.d.ts
+++ b/types/favico.js/index.d.ts
@@ -1,3 +1,4 @@
+
 declare namespace favicojs {
     interface FavicoJsStatic {
         new(opt?: FavicoJsOptions): Favico;
@@ -30,5 +31,6 @@ declare namespace favicojs {
         webcam(): void;
     }
 }
+declare module "favico.js";
 
 declare var Favico: favicojs.FavicoJsStatic;


### PR DESCRIPTION
Error fixed adding declare module "favico.js" line.

The file '~/app/node_modules/@types/favico.js/index.d.ts' is not a module.ts(2306) favico.js -  0.3.10
Node - v20.15.0
NPM - 10.8.1

![image](https://github.com/DefinitelyTyped/DefinitelyTyped/assets/88730920/03d2b227-cf07-420e-b902-2110ddb8fddf)