### PR TITLE
Fix RmOptions.force JsDoc

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -1662,7 +1662,7 @@ declare module "fs" {
     export function rmdirSync(path: PathLike, options?: RmDirOptions): void;
     export interface RmOptions {
         /**
-         * When `true`, exceptions will be ignored if `path` does not exist.
+         * When `true`, exceptions will be thrown if `path` does not exist.
          * @default false
          */
         force?: boolean | undefined;


### PR DESCRIPTION
Just a little fix in JsDoc.

In `types/node/fs.d.ts`, attribute `force` of `RmOptions` would say that setting it to `true` would ignore exception but it's the opposite.