### PR TITLE
[ads-client] Allow `null` as `Settings` properties

### DIFF
--- a/types/ads-client/ads-client-tests.ts
+++ b/types/ads-client/ads-client-tests.ts
@@ -3,6 +3,10 @@ import * as ads from "ads-client";
 const client = new ads.Client({
     targetAmsNetId: "localhost",
     targetAdsPort: 851,
+    localAddress: null,
+    localTcpPort: null,
+    localAmsNetId: null,
+    localAdsPort: null,
 });
 
 async function usage() {

--- a/types/ads-client/index.d.ts
+++ b/types/ads-client/index.d.ts
@@ -5,26 +5,26 @@ import EventEmitter = require("events");
 export interface Settings {
     targetAmsNetId: string;
     targetAdsPort: number;
-    objectifyEnumerations?: boolean | null;
-    convertDatesToJavascript?: boolean | null;
-    readAndCacheSymbols?: boolean | null;
-    readAndCacheDataTypes?: boolean | null;
-    disableSymbolVersionMonitoring?: boolean | null;
-    routerTcpPort?: number | null;
-    routerAddress?: string | null;
-    localAddress?: string | null;
-    localTcpPort?: number | null;
-    localAmsNetId?: string | null;
-    localAdsPort?: number | null;
-    timeoutDelay?: number | null;
-    hideConsoleWarnings?: boolean | null;
-    autoReconnect?: boolean | null;
-    reconnectInterval?: number | null;
-    checkStateInterval?: number | null;
-    connectionDownDelay?: number | null;
-    allowHalfOpen?: boolean | null;
-    disableBigInt?: boolean | null;
-    bareClient?: boolean | null;
+    objectifyEnumerations?: boolean | null | undefined;
+    convertDatesToJavascript?: boolean | null | undefined;
+    readAndCacheSymbols?: boolean | null | undefined;
+    readAndCacheDataTypes?: boolean | null | undefined;
+    disableSymbolVersionMonitoring?: boolean | null | undefined;
+    routerTcpPort?: number | null | undefined;
+    routerAddress?: string | null | undefined;
+    localAddress?: string | null | undefined;
+    localTcpPort?: number | null | undefined;
+    localAmsNetId?: string | null | undefined;
+    localAdsPort?: number | null | undefined;
+    timeoutDelay?: number | null | undefined;
+    hideConsoleWarnings?: boolean | null | undefined;
+    autoReconnect?: boolean | null | undefined;
+    reconnectInterval?: number | null | undefined;
+    checkStateInterval?: number | null | undefined;
+    connectionDownDelay?: number | null | undefined;
+    allowHalfOpen?: boolean | null | undefined;
+    disableBigInt?: boolean | null | undefined;
+    bareClient?: boolean | null | undefined;
 }
 
 export interface Metadata {

--- a/types/ads-client/index.d.ts
+++ b/types/ads-client/index.d.ts
@@ -5,26 +5,26 @@ import EventEmitter = require("events");
 export interface Settings {
     targetAmsNetId: string;
     targetAdsPort: number;
-    objectifyEnumerations?: boolean;
-    convertDatesToJavascript?: boolean;
-    readAndCacheSymbols?: boolean;
-    readAndCacheDataTypes?: boolean;
-    disableSymbolVersionMonitoring?: boolean;
-    routerTcpPort?: number;
-    routerAddress?: string;
-    localAddress?: string;
-    localTcpPort?: number;
-    localAmsNetId?: string;
-    localAdsPort?: number;
-    timeoutDelay?: number;
-    hideConsoleWarnings?: boolean;
-    autoReconnect?: boolean;
-    reconnectInterval?: number;
-    checkStateInterval?: number;
-    connectionDownDelay?: number;
-    allowHalfOpen?: boolean;
-    disableBigInt?: boolean;
-    bareClient?: boolean;
+    objectifyEnumerations?: boolean | null;
+    convertDatesToJavascript?: boolean | null;
+    readAndCacheSymbols?: boolean | null;
+    readAndCacheDataTypes?: boolean | null;
+    disableSymbolVersionMonitoring?: boolean | null;
+    routerTcpPort?: number | null;
+    routerAddress?: string | null;
+    localAddress?: string | null;
+    localTcpPort?: number | null;
+    localAmsNetId?: string | null;
+    localAdsPort?: number | null;
+    timeoutDelay?: number | null;
+    hideConsoleWarnings?: boolean | null;
+    autoReconnect?: boolean | null;
+    reconnectInterval?: number | null;
+    checkStateInterval?: number | null;
+    connectionDownDelay?: number | null;
+    allowHalfOpen?: boolean | null;
+    disableBigInt?: boolean | null;
+    bareClient?: boolean | null;
 }
 
 export interface Metadata {


### PR DESCRIPTION
Upstream library allows `null` for optional properties in `Settings`, but the type definitions didn't reflect this.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jisotalo/ads-client/blob/1a88b8a02917ccf63874fe20cabb792b558b2dd1/src/ads-client.js#L86