### PR TITLE
[@types/set-cookie-parser] Revert updated `sameSite` typings

### DIFF
--- a/types/set-cookie-parser/index.d.ts
+++ b/types/set-cookie-parser/index.d.ts
@@ -85,7 +85,7 @@ declare namespace parse {
         /**
          * indicates a cookie ought not to be sent along with cross-site requests
          */
-        sameSite?: true | false | "lax" | "strict" | "none" | undefined;
+        sameSite?: string | undefined;
     }
 
     interface CookieMap {

--- a/types/set-cookie-parser/set-cookie-parser-tests.ts
+++ b/types/set-cookie-parser/set-cookie-parser-tests.ts
@@ -19,7 +19,7 @@ assert.strictEqual(cookies[0].value, "bar");
 
 // Optional properties included test
 const optionalIncluded =
-    "foo=bar; Max-Age=1000; Domain=.example.com; Path=/; Expires=Tue, 01 Jul 2025 10:01:11 GMT; HttpOnly; Secure; SameSite=strict";
+    "foo=bar; Max-Age=1000; Domain=.example.com; Path=/; Expires=Tue, 01 Jul 2025 10:01:11 GMT; HttpOnly; Secure; SameSite=Strict";
 cookies = setCookie(optionalIncluded);
 assert.strictEqual(cookies.length, 1);
 assert.strictEqual(cookies[0].name, "foo");
@@ -30,7 +30,7 @@ assert.deepStrictEqual(cookies[0].expires, new Date("Tue Jul 01 2025 06:01:11 GM
 assert.strictEqual(cookies[0].maxAge, 1000);
 assert.strictEqual(cookies[0].httpOnly, true);
 assert.strictEqual(cookies[0].secure, true);
-assert.strictEqual(cookies[0].sameSite, "strict");
+assert.strictEqual(cookies[0].sameSite, "Strict");
 
 // Array of strings test
 const arrayOfCookies = ["bam=baz", "foo=bar"];
@@ -125,7 +125,7 @@ assert.deepStrictEqual(cookiesMap, expectedCookiesMap);
 
 // Call parseString function
 const individualSetCookieHeader =
-    "user=%D0%98%D0%BB%D1%8C%D1%8F%20%D0%97%D0%B0%D0%B9%D1%86%D0%B5%D0%B2; Max-Age=1000; Domain=.example.com; Path=/; Expires=Tue, 01 Jul 2025 10:01:11 GMT; HttpOnly; Secure; SameSite=strict";
+    "user=%D0%98%D0%BB%D1%8C%D1%8F%20%D0%97%D0%B0%D0%B9%D1%86%D0%B5%D0%B2; Max-Age=1000; Domain=.example.com; Path=/; Expires=Tue, 01 Jul 2025 10:01:11 GMT; HttpOnly; Secure; SameSite=Strict";
 const decodedValueCookie = setCookie.parseString(individualSetCookieHeader);
 const notDecodedValueCookie = setCookie.parseString(individualSetCookieHeader, { decodeValues: false });
 const expectedCookie: setCookie.Cookie = {
@@ -137,7 +137,7 @@ const expectedCookie: setCookie.Cookie = {
     expires: new Date("Tue, 01 Jul 2025 10:01:11 GMT"),
     httpOnly: true,
     secure: true,
-    sameSite: "strict",
+    sameSite: "Strict",
 };
 assert.deepStrictEqual(decodedValueCookie, expectedCookie);
 assert.strictEqual(notDecodedValueCookie.value, "%D0%98%D0%BB%D1%8C%D1%8F%20%D0%97%D0%B0%D0%B9%D1%86%D0%B5%D0%B2");


### PR DESCRIPTION
This reverts commit 4dfd3f058adc3694bfe01123629b4c6b4ad19813 (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69734).

Note that the implementation in `set-cookie-parser` does not do any case adjustments or other normalization for cookie attributes, so it will return them exactly as they appear in the original string:

https://github.com/nfriedly/set-cookie-parser/blob/0b05cf2d6c370fbf20c47cc7387d2e340a949980/lib/set-cookie.js#L54

Making the types claim that `sameSite` sill only have lowercase values, or indeed that it cannot have arbitrary values, doesn't match the implementation.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
