### PR TITLE
Lazy.js: fix many incorrect types and improve others

### DIFF
--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -1,7 +1,7 @@
 declare namespace LazyJS {
     interface LazyStatic {
         (value: string): StringLikeSequence;
-        <T>(value: T[]): ArrayLikeSequence<T>;
+        <T>(value: readonly T[]): ArrayLikeSequence<T>;
         <T>(value: any): ObjectLikeSequence<T>;
         (value: any): ObjectLikeSequence<any>;
 

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -241,8 +241,7 @@ declare namespace LazyJS {
 
     interface ObjectLikeSequence<T> extends Sequence<T> {
         assign(other: any): ObjectLikeSequence<T>;
-        // throws error
-        // async(): X;
+        async(): never;
         defaults(defaults: any): ObjectLikeSequence<T>;
         functions(): Sequence<T>;
         get(property: string): T | undefined;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -174,7 +174,9 @@ declare namespace LazyJS {
         min(valueFn?: NumberCallback<T>): T;
         none(valueFn?: TestCallback<T, string | number>): boolean;
         pluck<K extends keyof T>(propertyName: K): Sequence<T[K]>;
-        reduce<U>(aggregatorFn: MemoCallback<T, U>, memo?: U): U;
+        reduce(aggregatorFn: (memo: T, value: T) => T): T | undefined;
+        reduce<U>(aggregatorFn: (memo: T | U, value: T) => U): T | U | undefined;
+        reduce<U>(aggregatorFn: MemoCallback<T, U>, memo: U): U;
         reduceRight<U>(aggregatorFn: MemoCallback<T, U>, memo: U): U;
         reject(predicateFn: TestCallback<T, string | number>): Sequence<T>;
         rest(count?: number): Sequence<T>;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -173,7 +173,7 @@ declare namespace LazyJS {
         max(valueFn?: NumberCallback<T>): T;
         min(valueFn?: NumberCallback<T>): T;
         none(valueFn?: TestCallback<T, string | number>): boolean;
-        pluck(propertyName: string): Sequence<any>;
+        pluck<K extends keyof T>(propertyName: K): Sequence<T[K]>;
         reduce<U>(aggregatorFn: MemoCallback<T, U>, memo?: U): U;
         reduceRight<U>(aggregatorFn: MemoCallback<T, U>, memo: U): U;
         reject(predicateFn: TestCallback<T, string | number>): Sequence<T>;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -177,6 +177,8 @@ declare namespace LazyJS {
         reduce(aggregatorFn: (memo: T, value: T) => T): T | undefined;
         reduce<U>(aggregatorFn: (memo: T | U, value: T) => U): T | U | undefined;
         reduce<U>(aggregatorFn: MemoCallback<T, U>, memo: U): U;
+        reduceRight(aggregatorFn: (memo: T, value: T) => T): T | undefined;
+        reduceRight<U>(aggregatorFn: (memo: T | U, value: T) => U): T | U | undefined;
         reduceRight<U>(aggregatorFn: MemoCallback<T, U>, memo: U): U;
         reject(predicateFn: TestCallback<T, string | number>): Sequence<T>;
         rest(count?: number): Sequence<T>;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -176,11 +176,11 @@ declare namespace LazyJS {
         none(valueFn?: TestCallback<T, string | number>): boolean;
         pluck<K extends keyof T>(propertyName: K): Sequence<T[K]>;
         reduce(aggregatorFn: (memo: T, value: T) => T): T | undefined;
-        reduce<U>(aggregatorFn: (memo: T | U, value: T) => U): T | U | undefined;
         reduce<U>(aggregatorFn: MemoCallback<T, U>, memo: U): U;
+        reduce<U>(aggregatorFn: (memo: T | U, value: T) => U): T | U | undefined;
         reduceRight(aggregatorFn: (memo: T, value: T) => T): T | undefined;
-        reduceRight<U>(aggregatorFn: (memo: T | U, value: T) => U): T | U | undefined;
         reduceRight<U>(aggregatorFn: MemoCallback<T, U>, memo: U): U;
+        reduceRight<U>(aggregatorFn: (memo: T | U, value: T) => U): T | U | undefined;
         reject(predicateFn: TestCallback<T, string | number>): Sequence<T>;
         rest(count?: number): Sequence<T>;
         shuffle(): Sequence<T>;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -2,7 +2,7 @@ declare namespace LazyJS {
     interface LazyStatic {
         (value: string): StringLikeSequence;
         <T>(value: readonly T[]): ArrayLikeSequence<T>;
-        <T>(value: Readonly<Record<string, T>>): ObjectLikeSequence<T>;
+        <T, K extends string | number = string | number>(value: Readonly<Record<K, T>>): ObjectLikeSequence<T>;
 
         strict(): LazyStatic;
 

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -111,7 +111,7 @@ declare namespace LazyJS {
 
         last(): T | undefined;
         last(count: number): Sequence<T>;
-        lastIndexOf(value: any): number;
+        lastIndexOf(value: T, equalityFn?: (a: T, b: T) => boolean): number;
 
         reverse(): Sequence<T>;
     }

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -151,7 +151,7 @@ declare namespace LazyJS {
         async(interval?: number): AsyncSequence<T>;
         chunk<N extends number>(size: N): Sequence<Tuple<T, N>>;
         compact(): Sequence<T>;
-        concat(var_args: T[]): Sequence<T>;
+        concat(...var_args: Array<T | T[]>): Sequence<T>;
         consecutive(length: number): Sequence<T>;
         contains(value: T): boolean;
         countBy(keyFn: GetKeyCallback<T>): ObjectLikeSequence<number>;
@@ -209,7 +209,7 @@ declare namespace LazyJS {
 
     interface ArrayLikeSequence<T> extends Sequence<T> {
         // define()X;
-        concat(var_args: T[]): ArrayLikeSequence<T>;
+        concat(...var_args: Array<T | T[]>): ArrayLikeSequence<T>;
         first(): T | undefined;
         first(count?: number): ArrayLikeSequence<T>;
         get(index: number): T | undefined;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -105,7 +105,7 @@ declare namespace LazyJS {
     }
 
     interface SequenceBase<T> extends SequenceBaser<T> {
-        first(): T |  undefined;
+        first(): T | undefined;
         first(count: number): Sequence<T>;
         indexOf(value: T, equalityFn?: (a: T, b: T) => boolean): number;
 

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -148,7 +148,6 @@ declare namespace LazyJS {
     ];
 
     interface SequenceBaser<T> {
-        // TODO improve define() (needs ugly overload)
         async(interval: number): AsyncSequence<T>;
         chunk<N extends number>(size: N): Sequence<Tuple<T, N>>;
         compact(): Sequence<T>;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -2,7 +2,6 @@ declare namespace LazyJS {
     interface LazyStatic {
         (value: string): StringLikeSequence;
         <T>(value: T[]): ArrayLikeSequence<T>;
-        (value: any[]): ArrayLikeSequence<any>;
         <T>(value: any): ObjectLikeSequence<T>;
         (value: any): ObjectLikeSequence<any>;
 

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -105,7 +105,7 @@ declare namespace LazyJS {
     }
 
     interface SequenceBase<T> extends SequenceBaser<T> {
-        first(): any;
+        first(): T |  undefined;
         first(count: number): Sequence<T>;
         indexOf(value: any, startIndex?: number): number;
 
@@ -207,7 +207,7 @@ declare namespace LazyJS {
     interface ArrayLikeSequence<T> extends Sequence<T> {
         // define()X;
         concat(var_args: T[]): ArrayLikeSequence<T>;
-        first(): T;
+        first(): T | undefined;
         first(count?: number): ArrayLikeSequence<T>;
         get(index: number): T;
         length(): number;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -195,7 +195,7 @@ declare namespace LazyJS {
         toObject(): any;
         union(var_args: T[]): Sequence<T>;
         uniq(key?: keyof T): Sequence<T>;
-        where(properties: any): Sequence<T>;
+        where(properties: Partial<T>): Sequence<T>;
         without(...var_args: T[]): Sequence<T>;
         without(var_args: T[]): Sequence<T>;
         zip(var_args: T[]): Sequence<T>;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -160,7 +160,7 @@ declare namespace LazyJS {
         every(predicateFn: TestCallback<T, string | number>): boolean;
         filter(predicateFn: TestCallback<T, string | number>): Sequence<T>;
         find(predicateFn: TestCallback<T, string | number>): T | undefined;
-        findWhere(properties: any): T;
+        findWhere(properties: Partial<T>): T;
         flatten(shallow: true): Sequence<Flatten<T, true>>;
         flatten(shallow?: false): Sequence<Flatten<T, false>>;
         groupBy(keyFn: GetKeyCallback<T>): ObjectLikeSequence<T>;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -254,7 +254,7 @@ declare namespace LazyJS {
         toArray(): T[];
         toObject(): Record<string, T>;
         values(): Sequence<T>;
-        watch(propertyNames: string | string[]): Sequence<{ property: string; value: any }>;
+        watch(propertyNames: string | string[]): Sequence<{ property: string; value: T }>;
 
         dropWhile(predicateFn: TestCallback<T, string>): Sequence<T>;
         every(predicateFn: TestCallback<T, string>): boolean;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -148,7 +148,7 @@ declare namespace LazyJS {
     ];
 
     interface SequenceBaser<T> {
-        async(interval: number): AsyncSequence<T>;
+        async(interval?: number): AsyncSequence<T>;
         chunk<N extends number>(size: N): Sequence<Tuple<T, N>>;
         compact(): Sequence<T>;
         concat(var_args: T[]): Sequence<T>;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -109,7 +109,7 @@ declare namespace LazyJS {
         first(count: number): Sequence<T>;
         indexOf(value: T, equalityFn?: (a: T, b: T) => boolean): number;
 
-        last(): any;
+        last(): T | undefined;
         last(count: number): Sequence<T>;
         lastIndexOf(value: any): number;
 

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -243,7 +243,7 @@ declare namespace LazyJS {
         assign(other: any): ObjectLikeSequence<T>;
         async(): never;
         defaults<U>(defaults: U): ObjectLikeSequence<T | U>;
-        functions(): Sequence<T>;
+        functions(): Sequence<keyof T>;
         get(property: string): T | undefined;
         invert(): ObjectLikeSequence<T>;
         keys(): Sequence<string>;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -71,8 +71,8 @@ declare namespace LazyJS {
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-    interface Iterator<T> {
-        new(sequence: Sequence<T>): Iterator<T>;
+    class Iterator<T> {
+        constructor(sequence: Sequence<T>);
         current(): T;
         moveNext(): boolean;
     }

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -163,7 +163,7 @@ declare namespace LazyJS {
         findWhere(properties: Partial<T>): T;
         flatten(shallow: true): Sequence<Flatten<T, true>>;
         flatten(shallow?: false): Sequence<Flatten<T, false>>;
-        groupBy(keyFn: GetKeyCallback<T>): ObjectLikeSequence<T>;
+        groupBy(keyFn: GetKeyCallback<T>): ObjectLikeSequence<T[]>;
         initial(count?: number): Sequence<T>;
         intersection(var_args: T[]): Sequence<T>;
         invoke(methodName: string): Sequence<unknown>;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -166,7 +166,7 @@ declare namespace LazyJS {
         groupBy(keyFn: GetKeyCallback<T>): ObjectLikeSequence<T>;
         initial(count?: number): Sequence<T>;
         intersection(var_args: T[]): Sequence<T>;
-        invoke(methodName: string): Sequence<T>;
+        invoke(methodName: string): Sequence<unknown>;
         isEmpty(): boolean;
         join(delimiter?: string): string;
         map<U>(mapFn: MapCallback<T, U>): Sequence<U>;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -253,7 +253,7 @@ declare namespace LazyJS {
         pairs(): Sequence<T>;
         pick(properties: string[]): ObjectLikeSequence<T>;
         toArray(): T[];
-        toObject(): any;
+        toObject(): Record<string, T>;
         values(): Sequence<T>;
         watch(propertyNames: string | string[]): Sequence<{ property: string; value: any }>;
 

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -2,7 +2,7 @@ declare namespace LazyJS {
     interface LazyStatic {
         (value: string): StringLikeSequence;
         <T>(value: readonly T[]): ArrayLikeSequence<T>;
-        <T>(value: any): ObjectLikeSequence<T>;
+        <T>(value: Readonly<Record<string, T>>): ObjectLikeSequence<T>;
 
         strict(): LazyStatic;
 

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -194,7 +194,7 @@ declare namespace LazyJS {
         takeWhile(predicateFn: TestCallback<T, string | number>): Sequence<T>;
         toArray(): T[];
         toObject(): any;
-        union(var_args: T[]): Sequence<T>;
+        union(var_args: T | T[] | SequenceBaser<T>): Sequence<T>;
         uniq(key?: keyof T): Sequence<T>;
         where(properties: Partial<T>): Sequence<T>;
         without(...var_args: T[]): Sequence<T>;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -242,7 +242,7 @@ declare namespace LazyJS {
     interface ObjectLikeSequence<T> extends Sequence<T> {
         assign(other: any): ObjectLikeSequence<T>;
         async(): never;
-        defaults(defaults: any): ObjectLikeSequence<T>;
+        defaults<U>(defaults: U): ObjectLikeSequence<T | U>;
         functions(): Sequence<T>;
         get(property: string): T | undefined;
         invert(): ObjectLikeSequence<T>;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -195,6 +195,7 @@ declare namespace LazyJS {
         toArray(): T[];
         toObject(): any;
         union(var_args: T | T[] | SequenceBaser<T>): Sequence<T>;
+        uniq(key: (value: T) => unknown): Sequence<T>;
         uniq(key?: keyof T): Sequence<T>;
         where(properties: Partial<T>): Sequence<T>;
         without(...var_args: T[]): Sequence<T>;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -212,7 +212,7 @@ declare namespace LazyJS {
         concat(var_args: T[]): ArrayLikeSequence<T>;
         first(): T | undefined;
         first(count?: number): ArrayLikeSequence<T>;
-        get(index: number): T;
+        get(index: number): T | undefined;
         length(): number;
         map<U>(mapFn: MapCallback<T, U>): ArrayLikeSequence<U>;
         pop(): ArrayLikeSequence<T>;
@@ -245,7 +245,7 @@ declare namespace LazyJS {
         // async(): X;
         defaults(defaults: any): ObjectLikeSequence<T>;
         functions(): Sequence<T>;
-        get(property: string): any;
+        get(property: string): T | undefined;
         invert(): ObjectLikeSequence<T>;
         keys(): Sequence<string>;
         merge(others: any | ObjectLikeSequence<T>, mergeFn?: Function): ObjectLikeSequence<T>;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -158,6 +158,7 @@ declare namespace LazyJS {
         countBy(propertyName: keyof T): ObjectLikeSequence<number>;
         dropWhile(predicateFn: TestCallback<T, string | number>): Sequence<T>;
         every(predicateFn: TestCallback<T, string | number>): boolean;
+        filter<U extends T>(predicateFn: (value: T, index: string | number) => value is U): Sequence<U>;
         filter(predicateFn: TestCallback<T, string | number>): Sequence<T>;
         find(predicateFn: TestCallback<T, string | number>): T | undefined;
         findWhere(properties: Partial<T>): T;
@@ -225,6 +226,7 @@ declare namespace LazyJS {
 
         dropWhile(predicateFn: TestCallback<T, number>): Sequence<T>;
         every(predicateFn: TestCallback<T, number>): boolean;
+        filter<U extends T>(predicateFn: (value: T, index: number) => value is U): Sequence<U>;
         filter(predicateFn: TestCallback<T, number>): Sequence<T>;
         find(predicateFn: TestCallback<T, number>): T | undefined;
         none(valueFn?: TestCallback<T, number>): boolean;
@@ -258,6 +260,7 @@ declare namespace LazyJS {
 
         dropWhile(predicateFn: TestCallback<T, string>): Sequence<T>;
         every(predicateFn: TestCallback<T, string>): boolean;
+        filter<U extends T>(predicateFn: (value: T, index: string) => value is U): Sequence<U>;
         filter(predicateFn: TestCallback<T, string>): Sequence<T>;
         find(predicateFn: TestCallback<T, string>): T | undefined;
         none(valueFn?: TestCallback<T, string>): boolean;
@@ -295,6 +298,7 @@ declare namespace LazyJS {
 
         dropWhile(predicateFn: TestCallback<string, number>): Sequence<string>;
         every(predicateFn: TestCallback<string, number>): boolean;
+        filter<U extends string>(predicateFn: (value: string, index: number) => value is U): Sequence<U>;
         filter(predicateFn: TestCallback<string, number>): Sequence<string>;
         find(predicateFn: TestCallback<string, number>): string;
         none(valueFn?: TestCallback<string, number>): boolean;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -107,7 +107,7 @@ declare namespace LazyJS {
     interface SequenceBase<T> extends SequenceBaser<T> {
         first(): T |  undefined;
         first(count: number): Sequence<T>;
-        indexOf(value: any, startIndex?: number): number;
+        indexOf(value: T, equalityFn?: (a: T, b: T) => boolean): number;
 
         last(): any;
         last(count: number): Sequence<T>;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -159,7 +159,7 @@ declare namespace LazyJS {
         dropWhile(predicateFn: TestCallback<T, string | number>): Sequence<T>;
         every(predicateFn: TestCallback<T, string | number>): boolean;
         filter(predicateFn: TestCallback<T, string | number>): Sequence<T>;
-        find(predicateFn: TestCallback<T, string | number>): T;
+        find(predicateFn: TestCallback<T, string | number>): T | undefined;
         findWhere(properties: any): T;
         flatten(shallow: true): Sequence<Flatten<T, true>>;
         flatten(shallow?: false): Sequence<Flatten<T, false>>;
@@ -222,7 +222,7 @@ declare namespace LazyJS {
         dropWhile(predicateFn: TestCallback<T, number>): Sequence<T>;
         every(predicateFn: TestCallback<T, number>): boolean;
         filter(predicateFn: TestCallback<T, number>): Sequence<T>;
-        find(predicateFn: TestCallback<T, number>): T;
+        find(predicateFn: TestCallback<T, number>): T | undefined;
         none(valueFn?: TestCallback<T, number>): boolean;
         reject(predicateFn: TestCallback<T, number>): Sequence<T>;
         some(predicateFn?: TestCallback<T, number>): boolean;
@@ -256,7 +256,7 @@ declare namespace LazyJS {
         dropWhile(predicateFn: TestCallback<T, string>): Sequence<T>;
         every(predicateFn: TestCallback<T, string>): boolean;
         filter(predicateFn: TestCallback<T, string>): Sequence<T>;
-        find(predicateFn: TestCallback<T, string>): T;
+        find(predicateFn: TestCallback<T, string>): T | undefined;
         none(valueFn?: TestCallback<T, string>): boolean;
         reject(predicateFn: TestCallback<T, string>): Sequence<T>;
         some(predicateFn?: TestCallback<T, string>): boolean;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -151,7 +151,7 @@ declare namespace LazyJS {
         async(interval?: number): AsyncSequence<T>;
         chunk<N extends number>(size: N): Sequence<Tuple<T, N>>;
         compact(): Sequence<T>;
-        concat(...var_args: Array<T | T[]>): Sequence<T>;
+        concat(...var_args: Array<T | T[] | SequenceBaser<T>>): Sequence<T>;
         consecutive(length: number): Sequence<T>;
         contains(value: T): boolean;
         countBy(keyFn: GetKeyCallback<T>): ObjectLikeSequence<number>;
@@ -210,7 +210,7 @@ declare namespace LazyJS {
 
     interface ArrayLikeSequence<T> extends Sequence<T> {
         // define()X;
-        concat(...var_args: Array<T | T[]>): ArrayLikeSequence<T>;
+        concat(...var_args: Array<T | T[] | SequenceBaser<T>>): ArrayLikeSequence<T>;
         first(): T | undefined;
         first(count?: number): ArrayLikeSequence<T>;
         get(index: number): T | undefined;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -3,7 +3,6 @@ declare namespace LazyJS {
         (value: string): StringLikeSequence;
         <T>(value: readonly T[]): ArrayLikeSequence<T>;
         <T>(value: any): ObjectLikeSequence<T>;
-        (value: any): ObjectLikeSequence<any>;
 
         strict(): LazyStatic;
 

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -71,8 +71,7 @@ declare namespace LazyJS {
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-    class Iterator<T> {
-        constructor(sequence: Sequence<T>);
+    interface Iterator<T> {
         current(): T;
         moveNext(): boolean;
     }

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -16,8 +16,6 @@ declare namespace LazyJS {
 
         repeat<T>(value: T, count?: number): GeneratedSequence<T>;
 
-        on<T>(eventType: string): Sequence<T>;
-
         readFile(path: string): StringLikeSequence;
         makeHttpRequest(path: string): StringLikeSequence;
     }

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -249,7 +249,7 @@ declare namespace LazyJS {
         keys(): Sequence<string>;
         merge(others: any | ObjectLikeSequence<T>, mergeFn?: Function): ObjectLikeSequence<T>;
         omit(properties: string[]): ObjectLikeSequence<T>;
-        pairs(): Sequence<T>;
+        pairs(): Sequence<[string, T]>;
         pick(properties: string[]): ObjectLikeSequence<T>;
         toArray(): T[];
         toObject(): Record<string, T>;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -154,8 +154,8 @@ declare namespace LazyJS {
         concat(var_args: T[]): Sequence<T>;
         consecutive(length: number): Sequence<T>;
         contains(value: T): boolean;
-        countBy(keyFn: GetKeyCallback<T>): ObjectLikeSequence<T>;
-        countBy(propertyName: string): ObjectLikeSequence<T>;
+        countBy(keyFn: GetKeyCallback<T>): ObjectLikeSequence<number>;
+        countBy(propertyName: keyof T): ObjectLikeSequence<number>;
         dropWhile(predicateFn: TestCallback<T, string | number>): Sequence<T>;
         every(predicateFn: TestCallback<T, string | number>): boolean;
         filter(predicateFn: TestCallback<T, string | number>): Sequence<T>;

--- a/types/lazy.js/lazy.js-tests.ts
+++ b/types/lazy.js/lazy.js-tests.ts
@@ -30,7 +30,6 @@ var anyObjectSeq: LazyJS.ObjectLikeSequence<any>;
 var fooAsyncSeq: LazyJS.AsyncSequence<Foo>;
 
 var strSequence: LazyJS.Sequence<string>;
-var anySequence: LazyJS.Sequence<any>;
 var unknownSequence: LazyJS.Sequence<unknown>;
 var stringSeq: LazyJS.StringLikeSequence;
 
@@ -141,7 +140,7 @@ foo = fooSequence.max();
 foo = fooSequence.max(fnNumberCallback);
 foo = fooSequence.min();
 foo = fooSequence.min(fnNumberCallback);
-anySequence = fooSequence.pluck(str);
+strSequence = fooSequence.pluck("key");
 bar = fooSequence.reduce(fnMemoCallback);
 bar = fooSequence.reduce(fnMemoCallback, bar);
 bar = fooSequence.reduceRight(fnMemoCallback, bar);

--- a/types/lazy.js/lazy.js-tests.ts
+++ b/types/lazy.js/lazy.js-tests.ts
@@ -250,7 +250,3 @@ stringSeq = stringSeq.toUpperCase();
 declare var fooSeqSeqSequence: LazyJS.Sequence<LazyJS.Sequence<LazyJS.Sequence<Foo>>>;
 fooSequence = fooSeqSeqSequence.flatten();
 fooSequence = fooSeqSeqSequence.flatten(true).flatten(true);
-
-// Iterator
-
-new LazyJS.Iterator(fooSequence);

--- a/types/lazy.js/lazy.js-tests.ts
+++ b/types/lazy.js/lazy.js-tests.ts
@@ -26,6 +26,7 @@ var fooArraySeq: LazyJS.ArrayLikeSequence<Foo>;
 var barArraySeq: LazyJS.ArrayLikeSequence<Bar>;
 var numObjectSeq: LazyJS.ObjectLikeSequence<number>;
 var fooObjectSeq: LazyJS.ObjectLikeSequence<Foo>;
+var fooBarObjectSeq: LazyJS.ObjectLikeSequence<Foo | Bar>;
 var anyObjectSeq: LazyJS.ObjectLikeSequence<any>;
 var fooAsyncSeq: LazyJS.AsyncSequence<Foo>;
 
@@ -192,7 +193,8 @@ fooArraySeq = fooArraySeq.slice(num, num);
 
 // ObjectLikeSequence
 
-fooObjectSeq = fooObjectSeq.defaults(obj);
+fooObjectSeq = fooObjectSeq.defaults(foo);
+fooBarObjectSeq = fooObjectSeq.defaults(bar);
 fooSequence = fooObjectSeq.functions();
 x = fooObjectSeq.get(str);
 fooObjectSeq = fooObjectSeq.invert();

--- a/types/lazy.js/lazy.js-tests.ts
+++ b/types/lazy.js/lazy.js-tests.ts
@@ -144,6 +144,8 @@ strSequence = fooSequence.pluck("key");
 // $ExpectType Foo | Bar
 fooSequence.reduce(() => bar);
 bar = fooSequence.reduce(fnMemoCallback, bar);
+// $ExpectType Foo | Bar
+fooSequence.reduceRight(() => bar);
 bar = fooSequence.reduceRight(fnMemoCallback, bar);
 fooSequence = fooSequence.reject(fnTestCallback);
 fooSequence = fooSequence.rest(num);

--- a/types/lazy.js/lazy.js-tests.ts
+++ b/types/lazy.js/lazy.js-tests.ts
@@ -141,7 +141,8 @@ foo = fooSequence.max(fnNumberCallback);
 foo = fooSequence.min();
 foo = fooSequence.min(fnNumberCallback);
 strSequence = fooSequence.pluck("key");
-bar = fooSequence.reduce(fnMemoCallback);
+// $ExpectType Foo | Bar
+fooSequence.reduce(() => bar);
 bar = fooSequence.reduce(fnMemoCallback, bar);
 bar = fooSequence.reduceRight(fnMemoCallback, bar);
 fooSequence = fooSequence.reject(fnTestCallback);

--- a/types/lazy.js/lazy.js-tests.ts
+++ b/types/lazy.js/lazy.js-tests.ts
@@ -201,7 +201,8 @@ x = fooObjectSeq.get(str);
 fooObjectSeq = fooObjectSeq.invert();
 strSequence = fooObjectSeq.keys();
 fooObjectSeq = fooObjectSeq.omit(strArr);
-fooSequence = fooObjectSeq.pairs();
+// $ExpectType Sequence<[string, Foo]>
+fooObjectSeq.pairs();
 fooObjectSeq = fooObjectSeq.pick(strArr);
 arr = fooObjectSeq.toArray();
 obj = fooObjectSeq.toObject();

--- a/types/lazy.js/lazy.js-tests.ts
+++ b/types/lazy.js/lazy.js-tests.ts
@@ -10,40 +10,40 @@ interface Bar {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-var foo: Foo;
-var bar: Bar;
+declare var foo: Foo;
+declare var bar: Bar;
 
-var fooArr: Foo[];
-var barArr: Bar[];
+declare var fooArr: Foo[];
+declare var barArr: Bar[];
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-var fooSequence: LazyJS.Sequence<Foo>;
-var fooTupleSequence: LazyJS.Sequence<readonly [Foo, Foo, Foo, Foo, Foo]>;
-var fooArrSequence: LazyJS.Sequence<Foo[]>;
-var barSequence: LazyJS.Sequence<Bar>;
-var fooArraySeq: LazyJS.ArrayLikeSequence<Foo>;
-var barArraySeq: LazyJS.ArrayLikeSequence<Bar>;
-var numObjectSeq: LazyJS.ObjectLikeSequence<number>;
-var fooObjectSeq: LazyJS.ObjectLikeSequence<Foo>;
-var fooBarObjectSeq: LazyJS.ObjectLikeSequence<Foo | Bar>;
-var anyObjectSeq: LazyJS.ObjectLikeSequence<any>;
-var fooAsyncSeq: LazyJS.AsyncSequence<Foo>;
+declare var fooSequence: LazyJS.Sequence<Foo>;
+declare var fooTupleSequence: LazyJS.Sequence<readonly [Foo, Foo, Foo, Foo, Foo]>;
+declare var fooArrSequence: LazyJS.Sequence<Foo[]>;
+declare var barSequence: LazyJS.Sequence<Bar>;
+declare var fooArraySeq: LazyJS.ArrayLikeSequence<Foo>;
+declare var barArraySeq: LazyJS.ArrayLikeSequence<Bar>;
+declare var numObjectSeq: LazyJS.ObjectLikeSequence<number>;
+declare var fooObjectSeq: LazyJS.ObjectLikeSequence<Foo>;
+declare var fooBarObjectSeq: LazyJS.ObjectLikeSequence<Foo | Bar>;
+declare var anyObjectSeq: LazyJS.ObjectLikeSequence<any>;
+declare var fooAsyncSeq: LazyJS.AsyncSequence<Foo>;
 
-var strSequence: LazyJS.Sequence<string>;
-var unknownSequence: LazyJS.Sequence<unknown>;
-var stringSeq: LazyJS.StringLikeSequence;
+declare var strSequence: LazyJS.Sequence<string>;
+declare var unknownSequence: LazyJS.Sequence<unknown>;
+declare var stringSeq: LazyJS.StringLikeSequence;
 
-var obj: Object;
-var bool: boolean;
-var num: number;
-var const5: 5;
-var str: string;
+declare var obj: Object;
+declare var bool: boolean;
+declare var num: number;
+declare var const5: 5;
+declare var str: string;
 var x: any = null;
-var arr: any[];
-var exp: RegExp;
-var strArr: string[];
-var numArr: string[];
+declare var arr: any[];
+declare var exp: RegExp;
+declare var strArr: string[];
+declare var numArr: string[];
 
 function fnCallback(): void {
 }
@@ -114,7 +114,8 @@ fooSequence = fooSequence.dropWhile(fnTestCallback);
 fooSequence = fooSequence.each(fnValueCallback);
 bool = fooSequence.every(fnTestCallback);
 fooSequence = fooSequence.filter(fnTestCallback);
-foo = fooSequence.find(fnTestCallback);
+// $ExpectType Foo | undefined
+fooSequence.find(fnTestCallback);
 foo = fooSequence.findWhere(obj);
 
 x = fooSequence.first();
@@ -133,7 +134,8 @@ bool = fooSequence.isEmpty();
 str = fooSequence.join();
 str = fooSequence.join(str);
 
-foo = fooSequence.last();
+// $ExpectType Foo | undefined
+fooSequence.last();
 fooSequence = fooSequence.last(num);
 
 num = fooSequence.lastIndexOf(foo);
@@ -143,10 +145,10 @@ foo = fooSequence.max(fnNumberCallback);
 foo = fooSequence.min();
 foo = fooSequence.min(fnNumberCallback);
 strSequence = fooSequence.pluck("key");
-// $ExpectType Foo | Bar
+// $ExpectType Foo | Bar | undefined
 fooSequence.reduce(() => bar);
 bar = fooSequence.reduce(fnMemoCallback, bar);
-// $ExpectType Foo | Bar
+// $ExpectType Foo | Bar | undefined
 fooSequence.reduceRight(() => bar);
 bar = fooSequence.reduceRight(fnMemoCallback, bar);
 fooSequence = fooSequence.reject(fnTestCallback);
@@ -181,7 +183,8 @@ obj = fooSequence.toObject();
 fooArraySeq = fooArraySeq.concat(fooArr);
 x = fooArraySeq.first();
 fooArraySeq = fooArraySeq.first(num);
-foo = fooArraySeq.get(num);
+// $ExpectType Foo | undefined
+fooArraySeq.get(num);
 num = fooArraySeq.length();
 barArraySeq = fooArraySeq.map(fnMapCallback);
 fooArraySeq = fooArraySeq.pop();
@@ -241,7 +244,7 @@ stringSeq = stringSeq.toLowerCase();
 stringSeq = stringSeq.toUpperCase();
 
 // flatten
-var fooSeqSeqSequence: LazyJS.Sequence<LazyJS.Sequence<LazyJS.Sequence<Foo>>>;
+declare var fooSeqSeqSequence: LazyJS.Sequence<LazyJS.Sequence<LazyJS.Sequence<Foo>>>;
 fooSequence = fooSeqSeqSequence.flatten();
 fooSequence = fooSeqSeqSequence.flatten(true).flatten(true);
 

--- a/types/lazy.js/lazy.js-tests.ts
+++ b/types/lazy.js/lazy.js-tests.ts
@@ -121,7 +121,8 @@ x = fooSequence.first();
 fooSequence = fooSequence.first(num);
 
 fooSequence = fooSequence.flatten();
-fooObjectSeq = fooSequence.groupBy(fnGetKeyCallback);
+// $ExpectType ObjectLikeSequence<Foo[]>
+fooSequence.groupBy(fnGetKeyCallback);
 num = fooSequence.indexOf(x);
 fooSequence = fooSequence.initial();
 fooSequence = fooSequence.initial(num);

--- a/types/lazy.js/lazy.js-tests.ts
+++ b/types/lazy.js/lazy.js-tests.ts
@@ -1,6 +1,7 @@
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 interface Foo {
+    key: string;
     foo(): string;
 }
 interface Bar {
@@ -23,6 +24,7 @@ var fooArrSequence: LazyJS.Sequence<Foo[]>;
 var barSequence: LazyJS.Sequence<Bar>;
 var fooArraySeq: LazyJS.ArrayLikeSequence<Foo>;
 var barArraySeq: LazyJS.ArrayLikeSequence<Bar>;
+var numObjectSeq: LazyJS.ObjectLikeSequence<number>;
 var fooObjectSeq: LazyJS.ObjectLikeSequence<Foo>;
 var anyObjectSeq: LazyJS.ObjectLikeSequence<any>;
 var fooAsyncSeq: LazyJS.AsyncSequence<Foo>;
@@ -106,8 +108,8 @@ fooSequence = fooSequence.compact();
 fooSequence = fooSequence.concat(arr);
 fooSequence = fooSequence.consecutive(num);
 bool = fooSequence.contains(foo);
-fooSequence = fooSequence.countBy(str);
-fooObjectSeq = fooSequence.countBy(fnGetKeyCallback);
+numObjectSeq = fooSequence.countBy("key");
+numObjectSeq = fooSequence.countBy(fnGetKeyCallback);
 fooSequence = fooSequence.dropWhile(fnTestCallback);
 fooSequence = fooSequence.each(fnValueCallback);
 bool = fooSequence.every(fnTestCallback);

--- a/types/lazy.js/lazy.js-tests.ts
+++ b/types/lazy.js/lazy.js-tests.ts
@@ -44,6 +44,7 @@ declare var arr: any[];
 declare var exp: RegExp;
 declare var strArr: string[];
 declare var numArr: string[];
+declare var fooByNumber: Record<number, Foo>;
 
 function fnCallback(): void {
 }
@@ -91,6 +92,8 @@ function fnGeneratorCallback(index: number): Foo {
 fooArraySeq = Lazy(fooArr);
 fooObjectSeq = Lazy<Foo>({ a: foo, b: foo });
 anyObjectSeq = Lazy<any>({ a: num, b: str });
+// $ExpectType ObjectLikeSequence<Foo>
+Lazy(fooByNumber);
 stringSeq = Lazy(str);
 
 // Strict

--- a/types/lazy.js/lazy.js-tests.ts
+++ b/types/lazy.js/lazy.js-tests.ts
@@ -126,7 +126,8 @@ num = fooSequence.indexOf(x);
 fooSequence = fooSequence.initial();
 fooSequence = fooSequence.initial(num);
 fooSequence = fooSequence.intersection(arr);
-fooSequence = fooSequence.invoke(str);
+// $ExpectType Sequence<unknown>
+fooSequence.invoke(str);
 bool = fooSequence.isEmpty();
 str = fooSequence.join();
 str = fooSequence.join(str);

--- a/types/lazy.js/lazy.js-tests.ts
+++ b/types/lazy.js/lazy.js-tests.ts
@@ -195,7 +195,8 @@ fooArraySeq = fooArraySeq.slice(num, num);
 
 fooObjectSeq = fooObjectSeq.defaults(foo);
 fooBarObjectSeq = fooObjectSeq.defaults(bar);
-fooSequence = fooObjectSeq.functions();
+// $ExpectType Sequence<keyof Foo>
+fooObjectSeq.functions();
 x = fooObjectSeq.get(str);
 fooObjectSeq = fooObjectSeq.invert();
 strSequence = fooObjectSeq.keys();

--- a/types/lazy.js/lazy.js-tests.ts
+++ b/types/lazy.js/lazy.js-tests.ts
@@ -234,3 +234,7 @@ stringSeq = stringSeq.toUpperCase();
 var fooSeqSeqSequence: LazyJS.Sequence<LazyJS.Sequence<LazyJS.Sequence<Foo>>>;
 fooSequence = fooSeqSeqSequence.flatten();
 fooSequence = fooSeqSeqSequence.flatten(true).flatten(true);
+
+// Iterator
+
+new LazyJS.Iterator(fooSequence);

--- a/types/lazy.js/tsconfig.json
+++ b/types/lazy.js/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "types": [],
         "noEmit": true,


### PR DESCRIPTION
I've fixed as many incorrect type definitions as I can (given the time I have available right now), and also added some other improvements.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://danieltao.com/lazy.js/docs/
- [ ] (**N/A**) If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
