### PR TITLE
[color-rgba] Fix return type

### DIFF
--- a/types/color-rgba/color-rgba-tests.ts
+++ b/types/color-rgba/color-rgba-tests.ts
@@ -1,32 +1,34 @@
 import rgba = require("color-rgba");
 
-// $ExpectType [number, number, number, number] | undefined
+// $ExpectType [number, number, number, number] | []
 rgba("rgb(80, 120, 160)"); // [80, 120, 160, 1]
-// $ExpectType [number, number, number, number] | undefined
+// $ExpectType [number, number, number, number] | []
 rgba("rgba(80, 120, 160, .5)"); // [80, 120, 160, .5]
-// $ExpectType [number, number, number, number] | undefined
+// $ExpectType [number, number, number, number] | []
 rgba("hsla(109, 50%, 50%, .75)"); // [87.125, 191.25, 63.75, .75]
-// $ExpectType [number, number, number, number] | undefined
+// $ExpectType [number, number, number, number] | []
 rgba([10, 20, 30]);
-// $ExpectType [number, number, number, number] | undefined
+// $ExpectType [number, number, number, number] | []
 rgba({
     r: 10,
     g: 20,
     b: 30,
 });
-// $ExpectType [number, number, number, number] | undefined
+// $ExpectType [number, number, number, number] | []
 rgba({
     red: 10,
     green: 0,
     blue: 30,
 });
-// $ExpectType [number, number, number, number] | undefined
+// $ExpectType [number, number, number, number] | []
 rgba({
     h: 10,
     s: 0,
     l: 30,
 });
-// $ExpectType [number, number, number, number] | undefined
+// $ExpectType [number, number, number, number] | []
 rgba("0x00ff00");
-// $ExpectType [number, number, number, number] | undefined
+// $ExpectType [number, number, number, number] | []
 rgba("yellow");
+// $ExpectType [number, number, number, number] | []
+rgba("*garbage*");

--- a/types/color-rgba/index.d.ts
+++ b/types/color-rgba/index.d.ts
@@ -4,7 +4,7 @@
  * `color` can be a CSS color string,
  * an array with channel values, an object etc.,
  */
-declare function rgba(string: ColorValue): [number, number, number, number] | undefined;
+declare function rgba(string: ColorValue): [number, number, number, number] | [];
 
 type ColorValue = string | RGBTuple | RGBColor | RGBKeyedColor | HSL;
 


### PR DESCRIPTION
It returns empty array when an error occurs, not undefined.
This function returns an empty array on failure since version 1.1.0. 
https://github.com/colorjs/color-rgba/commit/dab54c4ff1be914139818450782cfd3da51937ed
The types have been wrong here since the beginning, that's why I did not update the version field.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/colorjs/color-rgba/blob/603560029507dec2cb84a36b4e283155c8d2f78b/index.js#L16
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
