### PR TITLE
[shimmer] Remove global `Function` modification

### DIFF
--- a/types/shimmer/index.d.ts
+++ b/types/shimmer/index.d.ts
@@ -1,9 +1,3 @@
-declare global {
-    interface Function {
-        __wrapped?: boolean | undefined;
-    }
-}
-
 declare const shimmer: {
     (options: { logger?(msg: string): void }): void;
     wrap<Nodule extends object, FieldName extends keyof Nodule>(

--- a/types/shimmer/package.json
+++ b/types/shimmer/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/shimmer",
-    "version": "1.0.9999",
+    "version": "1.2.9999",
     "projects": [
         "https://github.com/othiym23/shimmer"
     ],

--- a/types/shimmer/shimmer-tests.ts
+++ b/types/shimmer/shimmer-tests.ts
@@ -22,3 +22,12 @@ shimmer.massWrap([fish, turtle], ["age"], (originalAge) => {
 shimmer.unwrap(fish, "name");
 
 shimmer.massUnwrap([fish, turtle], ["age"]);
+
+// The following may look weird and unrelated to the package but shimmer had a global type definition that broke the following code:
+// https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69966
+function randomFunction() {}
+// eslint-disable-next-line @typescript-eslint/ban-types
+function randomFunctionThatTakesFunction(f: Required<Function>) {
+    return f;
+}
+randomFunctionThatTakesFunction(randomFunction);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/getsentry/sentry-javascript/issues/12682
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

This PR updates the `shimmer` types which contained a rather painful global override for the `Function` interface which resulted in incompatibilies in certain situations. See: https://github.com/getsentry/sentry-javascript/issues/12682

Also brings the package version up to date with the packages current versions as the DT readme suggests.