### PR TITLE
[sharedb] Add emitter types to `MilestoneDB`

### DIFF
--- a/types/sharedb/index.d.ts
+++ b/types/sharedb/index.d.ts
@@ -221,7 +221,12 @@ declare namespace sharedb {
         private _removeStream(channel, stream): void;
     }
 
-    abstract class MilestoneDB {
+    interface MilestoneDBEventMap {
+        "error": (error: Error) => void;
+        "save": (collection: string, snapshot: Snapshot) => void;
+    }
+
+    abstract class MilestoneDB extends ShareDB.TypedEmitter<MilestoneDBEventMap> {
         close(callback?: BasicCallback): void;
         getMilestoneSnapshot(collection: string, id: string, version: number, callback?: BasicCallback): void;
         saveMilestoneSnapshot(collection: string, snapshot: Snapshot, callback?: BasicCallback): void;

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -80,6 +80,11 @@ backend.on("someCustomEvent", (arg0: string, arg1: number) => {});
 backend.db.getOps("someCollection", "someId", null, null, {}, () => {});
 backend.db.getSnapshotBulk("someCollection", ["id1", "id2"], null, null, () => {});
 
+backend.milestoneDb.once("save", (collection, snapshot) => {
+    console.log(collection, snapshot.data);
+});
+backend.milestoneDb.on("error", (error) => console.error(error.message));
+
 console.log(backend.pubsub);
 console.log(backend.extraDbs);
 


### PR DESCRIPTION
The `MilestoneDB` [extends `EventEmitter`][1], and exposes these events:

 - [`'save'`][2]
 - [`'error'`][3]

[1]: https://github.com/share/sharedb/blob/10ba551013138a0031fff632d587d3002e45b781/lib/milestone-db/index.js#L14
[2]: https://github.com/share/sharedb/blob/10ba551013138a0031fff632d587d3002e45b781/lib/milestone-db/memory.js#L40
[3]: https://github.com/share/sharedb/blob/10ba551013138a0031fff632d587d3002e45b781/lib/milestone-db/memory.js#L39

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.