### PR TITLE
[react] Add failing tests for returning `ReactNode` from an async Component

### DIFF
--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -772,6 +772,15 @@ function elementTypeTests() {
         }
     }
 
+    const ReturnPromiseReactNode = async ({ children }: { children?: React.ReactNode }) => children;
+    const FCPromiseReactNode: React.FC = ReturnReactNode;
+    class RenderPromiseReactNode extends React.Component<{ children?: React.ReactNode }> {
+        // @ts-expect-error class components cannot render async
+        async render() {
+            return this.props.children;
+        }
+    }
+
     const ReturnWithLegacyContext = (props: { foo: string }, context: { bar: number }) => {
         return (
             <div>
@@ -864,6 +873,13 @@ function elementTypeTests() {
     <RenderPromise />;
     // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
     React.createElement(RenderPromise);
+
+    // @ts-expect-error See https://github.com/microsoft/TypeScript/issues/59111
+    <ReturnPromiseReactNode />;
+    // @ts-expect-error See https://github.com/microsoft/TypeScript/issues/59111
+    React.createElement(ReturnPromiseReactNode);
+    <FCPromiseReactNode />;
+    React.createElement(FCPromiseReactNode);
 
     <ReturnWithLegacyContext foo="one" />;
     React.createElement(ReturnWithLegacyContext, { foo: "one" });

--- a/types/react/ts5.0/test/tsx.tsx
+++ b/types/react/ts5.0/test/tsx.tsx
@@ -761,6 +761,16 @@ function elementTypeTests() {
         }
     }
 
+    const ReturnPromiseReactNode = async ({ children }: { children?: React.ReactNode }) => children;
+    // @ts-expect-error experimental release channel only
+    const FCPromiseReactNode: React.FC = ReturnReactNode;
+    class RenderPromiseReactNode extends React.Component<{ children?: React.ReactNode }> {
+        // @ts-expect-error class components cannot render async
+        async render() {
+            return this.props.children;
+        }
+    }
+
     const ReturnWithLegacyContext = (props: { foo: string }, context: { bar: number }) => {
         return (
             <div>
@@ -864,6 +874,13 @@ function elementTypeTests() {
     <RenderPromise />;
     // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
     React.createElement(RenderPromise);
+
+    // @ts-expect-error See https://github.com/microsoft/TypeScript/issues/59111
+    <ReturnPromiseReactNode />;
+    // @ts-expect-error See https://github.com/microsoft/TypeScript/issues/59111
+    React.createElement(ReturnPromiseReactNode);
+    <FCPromiseReactNode />;
+    React.createElement(FCPromiseReactNode);
 
     <ReturnWithLegacyContext foo="one" />;
     React.createElement(ReturnWithLegacyContext, { foo: "one" });


### PR DESCRIPTION
Originally flagged in https://github.com/vercel/next.js/discussions/67365
Related:  https://github.com/microsoft/TypeScript/issues/59111