### PR TITLE
[readable-stream] fix signature of pipe in Duplex class

### DIFF
--- a/types/readable-stream/index.d.ts
+++ b/types/readable-stream/index.d.ts
@@ -352,7 +352,7 @@ declare namespace _Readable {
         ): Promise<T>;
         _destroy(err: Error | null, callback: (error: Error | null) => void): void;
         destroy(err?: Error, callback?: (error: Error | null) => void): this;
-        pipe<S extends _IWritable>(dest: S, pipeOpts?: { end?: boolean | undefined }): S;
+        pipe<S extends NodeJS.WritableStream>(dest: S, pipeOpts?: { end?: boolean | undefined }): S;
         addListener(ev: string | symbol, fn: (...args: any[]) => void): this;
         on(ev: string | symbol, fn: (...args: any[]) => void): this;
 


### PR DESCRIPTION
In the context of https://github.com/eclipse-thingweb/node-wot/pull/1297, we noticed that the `readable-stream` types can cause transpilation issues when depending on them due to an apparent bug in the signature of the `pipe` method of the `Duplex` class. This problem was seemingly introduced by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69218, which changed the signature of some `pipe` methods but forgot the `Duplex` class which implements `_Readable`. This caused a signature mismatch and transpilation to fail in some circumstances. Applying the change proposed here, in any case, fixed the issue we experienced in our project.

I hope that this is the correct fix for the issue – if you have any feedback or if anything should be changed, let me know :)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
