### PR TITLE
fix(karma-webpack): make webpackMiddleware optional

### DIFF
--- a/types/karma-webpack/index.d.ts
+++ b/types/karma-webpack/index.d.ts
@@ -30,6 +30,6 @@ declare module "karma" {
 
     interface ConfigOptions {
         webpack: Webpack.Configuration;
-        webpackMiddleware: KarmaWebpackMiddlewareOptions;
+        webpackMiddleware?: KarmaWebpackMiddlewareOptions;
     }
 }

--- a/types/karma-webpack/karma-webpack-tests.ts
+++ b/types/karma-webpack/karma-webpack-tests.ts
@@ -11,4 +11,15 @@ export default function(config: karma.Config): void {
         webpackMiddleware: { noInfo: true },
         reporters: ["spec"],
     });
+
+    // optional webpackMiddleware
+    config.set({
+        files: ["src/index.spec.ts"],
+        browsers: ["ChromeHeadless"],
+        singleRun: true,
+        frameworks: ["jasmine"],
+        preprocessors: { "src/index.spec.ts": ["webpack", "sourcemap"] },
+        webpack: { entry: "test.js" },
+        reporters: ["spec"],
+    });
 }

--- a/types/karma-webpack/package.json
+++ b/types/karma-webpack/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/karma-webpack",
-    "version": "2.0.9999",
+    "version": "4.0.9999",
     "projects": [
         "https://github.com/webpack-contrib/karma-webpack"
     ],


### PR DESCRIPTION
make webpackMiddleware optional as per codymikol/karma-webpack#418 change and 4.0.2 release https://github.com/codymikol/karma-webpack/releases/tag/v4.0.2

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
