### PR TITLE
Update encoding-japanese for v2.2.0

### DIFF
--- a/types/encoding-japanese/index.d.ts
+++ b/types/encoding-japanese/index.d.ts
@@ -33,7 +33,7 @@ export interface ConvertStringOptions {
     to: Encoding;
     from?: Encoding | undefined;
     type: "string";
-    fallback?: "html-entity" | "html-entity-hex";
+    fallback?: "html-entity" | "html-entity-hex" | "ignore" | "error";
     bom?: boolean | string | undefined;
 }
 
@@ -41,7 +41,7 @@ export interface ConvertArrayBufferOptions {
     to: Encoding;
     from?: Encoding | undefined;
     type: "arraybuffer";
-    fallback?: "html-entity" | "html-entity-hex";
+    fallback?: "html-entity" | "html-entity-hex" | "ignore" | "error";
     bom?: boolean | string | undefined;
 }
 
@@ -49,14 +49,14 @@ export interface ConvertArrayOptions {
     to: Encoding;
     from?: Encoding | undefined;
     type: "array";
-    fallback?: "html-entity" | "html-entity-hex";
+    fallback?: "html-entity" | "html-entity-hex" | "ignore" | "error";
     bom?: boolean | string | undefined;
 }
 
 export interface ConvertUnknownOptions {
     to: Encoding;
     from?: Encoding | undefined;
-    fallback?: "html-entity" | "html-entity-hex";
+    fallback?: "html-entity" | "html-entity-hex" | "ignore" | "error";
     bom?: boolean | string | undefined;
 }
 

--- a/types/encoding-japanese/package.json
+++ b/types/encoding-japanese/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/encoding-japanese",
-    "version": "2.0.9999",
+    "version": "2.2.9999",
     "projects": [
         "https://github.com/polygonplanet/encoding.js"
     ],

--- a/types/encoding-japanese/test/encoding-japanese-tests.cjs.ts
+++ b/types/encoding-japanese/test/encoding-japanese-tests.cjs.ts
@@ -50,6 +50,24 @@ const sjisArray4 = Encoding.convert("🐙", {
 sjisArray4; // $ExpectType string
 // fallback: '&#128025;'
 
+const sjisArray5 = Encoding.convert("🐙", {
+    to: "SJIS", // to_encoding
+    from: "UTF8", // from_encoding
+    type: "string",
+    fallback: "ignore",
+});
+sjisArray5; // $ExpectType string
+// fallback: ''
+
+const sjisArray6 = Encoding.convert("🐙", {
+    to: "SJIS", // to_encoding
+    from: "UTF8", // from_encoding
+    type: "string",
+    fallback: "error",
+});
+sjisArray6; // $ExpectType string
+// throws error: `Character cannot be represented`
+
 const utf8String = "ã\u0081\u0093ã\u0082\u0093ã\u0081«ã\u0081¡ã\u0081¯";
 const unicodeString = Encoding.convert(utf8String, {
     to: "UNICODE",
@@ -120,7 +138,7 @@ if (isSJIS) {
     // Encoding is SJIS'
 }
 
-const sjisArray5 = [
+const sjisArray7 = [
     130,
     177,
     130,
@@ -145,7 +163,7 @@ const sjisArray5 = [
     230,
 ];
 
-const encoded = Encoding.urlEncode(sjisArray5); // $ExpectType string
+const encoded = Encoding.urlEncode(sjisArray7); // $ExpectType string
 // encoded: '%82%B1%82%F1%82%C9%82%BF%82%CD%81A%82%D9%82%B0%81%99%82%D2%82%E6'
 
 const decoded = Encoding.urlDecode(encoded); // $ExpectType number[]
@@ -154,8 +172,8 @@ const decoded = Encoding.urlDecode(encoded); // $ExpectType number[]
 //    65, 130, 217, 130, 176, 129, 153, 130, 210, 130, 230
 // ]
 
-const sjisArray6 = [130, 177, 130, 241, 130, 201, 130, 191, 130, 205];
-const encoded2 = Encoding.base64Encode(sjisArray6); // $ExpectType string
+const sjisArray8 = [130, 177, 130, 241, 130, 201, 130, 191, 130, 205];
+const encoded2 = Encoding.base64Encode(sjisArray8); // $ExpectType string
 // encoded2: 'grGC8YLJgr+CzQ=='
 
 const decoded2 = Encoding.base64Decode(encoded2); // $ExpectType number[]


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
   - Release: https://github.com/polygonplanet/encoding.js/releases/tag/2.2.0
   - ignore fallback option: https://github.com/polygonplanet/encoding.js?tab=readme-ov-file#ignoring-characters-when-they-cannot-be-represented
   - error fallback option: https://github.com/polygonplanet/encoding.js?tab=readme-ov-file#throwing-an-error-when-they-cannot-be-represented
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

