### PR TITLE
feat(heic-convert): add type definitions for 2.1.0 version

### DIFF
--- a/types/heic-convert/browser.d.ts
+++ b/types/heic-convert/browser.d.ts
@@ -1,0 +1,28 @@
+interface ConversionOptions {
+    /**
+     * the HEIC file buffer
+     */
+    buffer: ArrayBufferLike;
+    /**
+     * output format
+     */
+    format: "JPEG" | "PNG";
+    /**
+     * the JPEG compression quality, between 0 and 1
+     * @default 0.92
+     */
+    quality?: number;
+}
+
+interface Convertible {
+    convert(): Promise<ArrayBuffer>;
+}
+
+/** @async */
+declare function convert(image: ConversionOptions): Promise<ArrayBuffer>;
+declare namespace convert {
+    /** @async */
+    function all(image: ConversionOptions): Promise<Convertible[]>;
+}
+
+export = convert;

--- a/types/heic-convert/heic-convert-tests.mts
+++ b/types/heic-convert/heic-convert-tests.mts
@@ -1,0 +1,22 @@
+import convert from "heic-convert";
+import convertBrowser from "heic-convert/browser";
+
+// $ExpectType Promise<ArrayBuffer>
+convert({ buffer: new ArrayBuffer(10), format: "PNG" });
+// $ExpectType Promise<ArrayBuffer>
+convertBrowser({ buffer: new ArrayBuffer(10), format: "PNG" });
+
+// $ExpectType Promise<ArrayBuffer>
+convert({ buffer: new ArrayBuffer(10), format: "JPEG", quality: 0.4 });
+// $ExpectType Promise<ArrayBuffer>
+convertBrowser({ buffer: new ArrayBuffer(10), format: "JPEG", quality: 0.4 });
+
+// $ExpectType Promise<Convertible[]>
+convert.all({ buffer: new ArrayBuffer(10), format: "PNG" });
+// $ExpectType Promise<Convertible[]>
+convertBrowser.all({ buffer: new ArrayBuffer(10), format: "PNG" });
+
+// $ExpectType Promise<Convertible[]>
+convert.all({ buffer: new ArrayBuffer(10), format: "JPEG", quality: 0.4 });
+// $ExpectType Promise<Convertible[]>
+convertBrowser.all({ buffer: new ArrayBuffer(10), format: "JPEG", quality: 0.4 });

--- a/types/heic-convert/heic-convert-tests.ts
+++ b/types/heic-convert/heic-convert-tests.ts
@@ -1,13 +1,22 @@
 import convert = require("heic-convert");
+import convertBrowser = require("heic-convert/browser");
 
 // $ExpectType Promise<ArrayBuffer>
 convert({ buffer: new ArrayBuffer(10), format: "PNG" });
+// $ExpectType Promise<ArrayBuffer>
+convertBrowser({ buffer: new ArrayBuffer(10), format: "PNG" });
 
 // $ExpectType Promise<ArrayBuffer>
 convert({ buffer: new ArrayBuffer(10), format: "JPEG", quality: 0.4 });
+// $ExpectType Promise<ArrayBuffer>
+convertBrowser({ buffer: new ArrayBuffer(10), format: "JPEG", quality: 0.4 });
 
 // $ExpectType Promise<Convertible[]>
 convert.all({ buffer: new ArrayBuffer(10), format: "PNG" });
+// $ExpectType Promise<Convertible[]>
+convertBrowser.all({ buffer: new ArrayBuffer(10), format: "PNG" });
 
 // $ExpectType Promise<Convertible[]>
 convert.all({ buffer: new ArrayBuffer(10), format: "JPEG", quality: 0.4 });
+// $ExpectType Promise<Convertible[]>
+convertBrowser.all({ buffer: new ArrayBuffer(10), format: "JPEG", quality: 0.4 });

--- a/types/heic-convert/package.json
+++ b/types/heic-convert/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/heic-convert",
-    "version": "1.2.9999",
+    "version": "2.1.9999",
     "projects": [
         "https://github.com/catdad-experiments/heic-convert"
     ],
@@ -13,5 +13,15 @@
             "name": "Tregan",
             "githubUsername": "treemmett"
         }
-    ]
+    ],
+    "exports": {
+        ".": {
+            "import": "./index.d.ts",
+            "require": "./index.d.ts"
+        },
+        "./browser": {
+            "import": "./browser.d.ts",
+            "require": "./browser.d.ts"
+        }
+    }
 }

--- a/types/heic-convert/package.json
+++ b/types/heic-convert/package.json
@@ -15,13 +15,7 @@
         }
     ],
     "exports": {
-        ".": {
-            "import": "./index.d.ts",
-            "require": "./index.d.ts"
-        },
-        "./browser": {
-            "import": "./browser.d.ts",
-            "require": "./browser.d.ts"
-        }
+        ".": "./index.d.ts",
+        "./browser": "./browser.d.ts"
     }
 }

--- a/types/heic-convert/tsconfig.json
+++ b/types/heic-convert/tsconfig.json
@@ -14,6 +14,7 @@
     },
     "files": [
         "index.d.ts",
-        "heic-convert-tests.ts"
+        "heic-convert-tests.ts",
+        "heic-convert-tests.mts"
     ]
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`heic-convert` docs](https://github.com/catdad-experiments/heic-convert/blob/master/browser.js)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

