### PR TITLE
Add MathML Support to `@types/react`

### DIFF
--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -170,6 +170,7 @@ interface MathMLMsqrtElement extends MathMLElement {}
 interface MathMLMstyleElement extends MathMLElement {}
 interface MathMLMsubElement extends MathMLElement {}
 interface MathMLMsubsupElement extends MathMLElement {}
+interface MathMLMsupElement extends MathMLElement {}
 
 interface FormData {}
 interface Text {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -171,6 +171,7 @@ interface MathMLMstyleElement extends MathMLElement {}
 interface MathMLMsubElement extends MathMLElement {}
 interface MathMLMsubsupElement extends MathMLElement {}
 interface MathMLMsupElement extends MathMLElement {}
+interface MathMLMtableElement extends MathMLElement {}
 
 interface FormData {}
 interface Text {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -153,6 +153,7 @@ interface SVGViewElement extends SVGElement {}
 
 interface MathMLElement extends Element {}
 interface MathMLMathElement extends MathMLElement {}
+interface MathMLMErrorElement extends MathMLElement {}
 
 interface FormData {}
 interface Text {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -154,6 +154,7 @@ interface SVGViewElement extends SVGElement {}
 interface MathMLElement extends Element {}
 interface MathMLMathElement extends MathMLElement {}
 interface MathMLMErrorElement extends MathMLElement {}
+interface MathMLMFracElement extends MathMLElement {}
 
 interface FormData {}
 interface Text {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -174,6 +174,8 @@ interface MathMLMsupElement extends MathMLElement {}
 interface MathMLMtableElement extends MathMLElement {}
 interface MathMLMtdElement extends MathMLElement {}
 interface MathMLMtextElement extends MathMLElement {}
+interface MathMLMtrElement extends MathMLElement {}
+interface MathMLMunderElement extends MathMLElement {}
 
 interface FormData {}
 interface Text {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -156,7 +156,8 @@ interface MathMLMathElement extends MathMLElement {}
 interface MathMLMErrorElement extends MathMLElement {}
 interface MathMLMFracElement extends MathMLElement {}
 interface MathMLMIElement extends MathMLElement {}
-interface MathMLMMultiScriptsElement extends MathMLElement{}
+interface MathMLMMultiScriptsElement extends MathMLElement {}
+interface MathMLMNElement extends MathMLElement {}
 
 interface FormData {}
 interface Text {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -153,12 +153,12 @@ interface SVGViewElement extends SVGElement {}
 
 interface MathMLElement extends Element {}
 interface MathMLMathElement extends MathMLElement {}
-interface MathMLMErrorElement extends MathMLElement {}
-interface MathMLMFracElement extends MathMLElement {}
-interface MathMLMIElement extends MathMLElement {}
-interface MathMLMMultiScriptsElement extends MathMLElement {}
-interface MathMLMNElement extends MathMLElement {}
-interface MathMLMOElement extends MathMLElement {}
+interface MathMLMerrorElement extends MathMLElement {}
+interface MathMLMfracElement extends MathMLElement {}
+interface MathMLMiElement extends MathMLElement {}
+interface MathMLMmultiscriptsElement extends MathMLElement {}
+interface MathMLMnElement extends MathMLElement {}
+interface MathMLMoElement extends MathMLElement {}
 
 interface FormData {}
 interface Text {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -164,6 +164,7 @@ interface MathMLMpaddedElement extends MathMLElement {}
 interface MathMLMphantomElement extends MathMLElement {}
 interface MathMLMrootElement extends MathMLElement {}
 interface MathMLMrowElement extends MathMLElement {}
+interface MathMLMsElement extends MathMLElement {}
 
 interface FormData {}
 interface Text {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -172,6 +172,7 @@ interface MathMLMsubElement extends MathMLElement {}
 interface MathMLMsubsupElement extends MathMLElement {}
 interface MathMLMsupElement extends MathMLElement {}
 interface MathMLMtableElement extends MathMLElement {}
+interface MathMLMtdElement extends MathMLElement {}
 
 interface FormData {}
 interface Text {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -165,6 +165,7 @@ interface MathMLMphantomElement extends MathMLElement {}
 interface MathMLMrootElement extends MathMLElement {}
 interface MathMLMrowElement extends MathMLElement {}
 interface MathMLMsElement extends MathMLElement {}
+interface MathMLMspaceElement extends MathMLElement {}
 
 interface FormData {}
 interface Text {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -162,6 +162,7 @@ interface MathMLMoElement extends MathMLElement {}
 interface MathMLMoverElement extends MathMLElement {}
 interface MathMLMpaddedElement extends MathMLElement {}
 interface MathMLMphantomElement extends MathMLElement {}
+interface MathMLMprescriptsElement extends MathMLElement {}
 interface MathMLMrootElement extends MathMLElement {}
 interface MathMLMrowElement extends MathMLElement {}
 interface MathMLMsElement extends MathMLElement {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -166,6 +166,7 @@ interface MathMLMrootElement extends MathMLElement {}
 interface MathMLMrowElement extends MathMLElement {}
 interface MathMLMsElement extends MathMLElement {}
 interface MathMLMspaceElement extends MathMLElement {}
+interface MathMLMsqrtElement extends MathMLElement {}
 
 interface FormData {}
 interface Text {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -177,6 +177,10 @@ interface MathMLMtextElement extends MathMLElement {}
 interface MathMLMtrElement extends MathMLElement {}
 interface MathMLMunderElement extends MathMLElement {}
 interface MathMLMunderoverElement extends MathMLElement {}
+interface MathMLSemanticsElement extends MathMLElement {}
+
+interface MathMLAnnotationElement extends MathMLElement {}
+interface MathMLAnnotationXmlElement extends MathMLElement {}
 
 interface FormData {}
 interface Text {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -167,6 +167,7 @@ interface MathMLMrowElement extends MathMLElement {}
 interface MathMLMsElement extends MathMLElement {}
 interface MathMLMspaceElement extends MathMLElement {}
 interface MathMLMsqrtElement extends MathMLElement {}
+interface MathMLMstyleElement extends MathMLElement {}
 
 interface FormData {}
 interface Text {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -162,6 +162,7 @@ interface MathMLMoElement extends MathMLElement {}
 interface MathMLMoverElement extends MathMLElement {}
 interface MathMLMpaddedElement extends MathMLElement {}
 interface MathMLMphantomElement extends MathMLElement {}
+interface MathMLMrootElement extends MathMLElement {}
 
 interface FormData {}
 interface Text {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -168,6 +168,7 @@ interface MathMLMsElement extends MathMLElement {}
 interface MathMLMspaceElement extends MathMLElement {}
 interface MathMLMsqrtElement extends MathMLElement {}
 interface MathMLMstyleElement extends MathMLElement {}
+interface MathMLMsubElement extends MathMLElement {}
 
 interface FormData {}
 interface Text {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -159,6 +159,7 @@ interface MathMLMiElement extends MathMLElement {}
 interface MathMLMmultiscriptsElement extends MathMLElement {}
 interface MathMLMnElement extends MathMLElement {}
 interface MathMLMoElement extends MathMLElement {}
+interface MathMLMoverElement extends MathMLElement {}
 
 interface FormData {}
 interface Text {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -163,6 +163,7 @@ interface MathMLMoverElement extends MathMLElement {}
 interface MathMLMpaddedElement extends MathMLElement {}
 interface MathMLMphantomElement extends MathMLElement {}
 interface MathMLMrootElement extends MathMLElement {}
+interface MathMLMrowElement extends MathMLElement {}
 
 interface FormData {}
 interface Text {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -169,6 +169,7 @@ interface MathMLMspaceElement extends MathMLElement {}
 interface MathMLMsqrtElement extends MathMLElement {}
 interface MathMLMstyleElement extends MathMLElement {}
 interface MathMLMsubElement extends MathMLElement {}
+interface MathMLMsubsupElement extends MathMLElement {}
 
 interface FormData {}
 interface Text {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -161,6 +161,7 @@ interface MathMLMnElement extends MathMLElement {}
 interface MathMLMoElement extends MathMLElement {}
 interface MathMLMoverElement extends MathMLElement {}
 interface MathMLMpaddedElement extends MathMLElement {}
+interface MathMLMphantomElement extends MathMLElement {}
 
 interface FormData {}
 interface Text {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -160,6 +160,7 @@ interface MathMLMmultiscriptsElement extends MathMLElement {}
 interface MathMLMnElement extends MathMLElement {}
 interface MathMLMoElement extends MathMLElement {}
 interface MathMLMoverElement extends MathMLElement {}
+interface MathMLMpaddedElement extends MathMLElement {}
 
 interface FormData {}
 interface Text {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -158,6 +158,7 @@ interface MathMLMFracElement extends MathMLElement {}
 interface MathMLMIElement extends MathMLElement {}
 interface MathMLMMultiScriptsElement extends MathMLElement {}
 interface MathMLMNElement extends MathMLElement {}
+interface MathMLMOElement extends MathMLElement {}
 
 interface FormData {}
 interface Text {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -151,6 +151,9 @@ interface SVGTSpanElement extends SVGElement {}
 interface SVGUseElement extends SVGElement {}
 interface SVGViewElement extends SVGElement {}
 
+interface MathMLElement extends Element {}
+interface MathMLMathElement extends MathMLElement {}
+
 interface FormData {}
 interface Text {}
 interface TouchList {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -155,6 +155,7 @@ interface MathMLElement extends Element {}
 interface MathMLMathElement extends MathMLElement {}
 interface MathMLMErrorElement extends MathMLElement {}
 interface MathMLMFracElement extends MathMLElement {}
+interface MathMLMIElement extends MathMLElement {}
 
 interface FormData {}
 interface Text {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -173,6 +173,7 @@ interface MathMLMsubsupElement extends MathMLElement {}
 interface MathMLMsupElement extends MathMLElement {}
 interface MathMLMtableElement extends MathMLElement {}
 interface MathMLMtdElement extends MathMLElement {}
+interface MathMLMtextElement extends MathMLElement {}
 
 interface FormData {}
 interface Text {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -176,6 +176,7 @@ interface MathMLMtdElement extends MathMLElement {}
 interface MathMLMtextElement extends MathMLElement {}
 interface MathMLMtrElement extends MathMLElement {}
 interface MathMLMunderElement extends MathMLElement {}
+interface MathMLMunderoverElement extends MathMLElement {}
 
 interface FormData {}
 interface Text {}

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -156,6 +156,7 @@ interface MathMLMathElement extends MathMLElement {}
 interface MathMLMErrorElement extends MathMLElement {}
 interface MathMLMFracElement extends MathMLElement {}
 interface MathMLMIElement extends MathMLElement {}
+interface MathMLMMultiScriptsElement extends MathMLElement{}
 
 interface FormData {}
 interface Text {}

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3955,6 +3955,7 @@ declare namespace React {
         mathvariant: 'normal';
     }
     interface MathMLMMultiScriptsElement extends MathMLAttributes<MathMLMMultiScriptsElement> {}
+    interface MathMLMNElement extends MathMLAttributes<MathMLMNElement> {}
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
@@ -4557,6 +4558,7 @@ declare global {
             mfrac: React.MathMLProps<MathMLMFracElement>;
             mi: React.MathMLProps<MathMLMIElement>;
             mmultiscripts: React.MathMLProps<MathMLMMultiScriptsElement>;
+            mn: React.MathMLProps<MathMLMNElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2375,7 +2375,7 @@ declare namespace React {
     interface SVGLineElementAttributes<T> extends SVGProps<T> {}
     interface SVGTextElementAttributes<T> extends SVGProps<T> {}
 
-    interface MathMLProps<T extends MathMLElement> extends MathMLAttributes<T> {}
+    type MathMLProps<E extends MathMLAttributes<T>, T> = ClassAttributes<T> & E;
 
     interface DOMAttributes<T> {
         children?: ReactNode | undefined;
@@ -3925,7 +3925,7 @@ declare namespace React {
     }
 
     // https://developer.mozilla.org/en-US/docs/Web/MathML/Global_attributes
-    interface MathMLAttributes<T extends MathMLElement> extends DOMAttributes<T> {
+    interface MathMLAttributes<T> extends DOMAttributes<T> {
         className?: string | undefined;
         dir?: 'ltr' | 'rtl' | undefined;
         displaystyle?: boolean | undefined;
@@ -3948,15 +3948,15 @@ declare namespace React {
         display?: 'block' | 'inline' | undefined;
     }
     interface MathMLMerrorAttributes extends MathMLAttributes<MathMLMerrorAttributes> {}
-    interface MathMLMfracElement extends MathMLAttributes<MathMLMfracElement> {
+    interface MathMLMfracAttributes extends MathMLAttributes<MathMLMfracElement> {
         linethickness?: string | undefined;
     }
-    interface MathMLMiElement extends MathMLAttributes<MathMLMiElement> {
+    interface MathMLMiAttributes extends MathMLAttributes<MathMLMiElement> {
         mathvariant?: 'normal' | undefined;
     }
-    interface MathMLMmultiscriptsElement extends MathMLAttributes<MathMLMmultiscriptsElement> {}
-    interface MathMLMnElement extends MathMLAttributes<MathMLMnElement> {}
-    interface MathMLMoElement extends MathMLAttributes<MathMLMoElement> {
+    interface MathMLMmultiscriptsAttributes extends MathMLAttributes<MathMLMmultiscriptsElement> {}
+    interface MathMLMnAttributes extends MathMLAttributes<MathMLMnElement> {}
+    interface MathMLMoAttributes extends MathMLAttributes<MathMLMoElement> {
         /* This attribute is non-standard. */
         accent?: boolean | undefined;
         fence?: boolean | undefined;
@@ -3970,34 +3970,34 @@ declare namespace React {
         stretchy?: boolean | undefined;
         symmetric?: boolean | undefined;
     }
-    interface MathMLMoverElement extends MathMLAttributes<MathMLMoverElement> {
+    interface MathMLMoverAttributes extends MathMLAttributes<MathMLMoverElement> {
         accent?: boolean | undefined;
     }
-    interface MathMLMpaddedElement extends MathMLAttributes<MathMLMpaddedElement> {
+    interface MathMLMpaddedAttributes extends MathMLAttributes<MathMLMpaddedElement> {
         depth?: string | undefined;
         height?: string | undefined;
         lspace?: string | undefined;
         voffset?: string | undefined;
         width?: string | undefined;
     }
-    interface MathMLMphantomElement extends MathMLAttributes<MathMLMphantomElement> {}
-    interface MathMLMrootElement extends MathMLAttributes<MathMLMrootElement> {}
-    interface MathMLMrowElement extends MathMLAttributes<MathMLMrowElement> {}
-    interface MathMLMsElement extends MathMLAttributes<MathMLMrowElement> {
+    interface MathMLMphantomAttributes extends MathMLAttributes<MathMLMphantomElement> {}
+    interface MathMLMrootAttributes extends MathMLAttributes<MathMLMrootElement> {}
+    interface MathMLMrowAttributes extends MathMLAttributes<MathMLMrowElement> {}
+    interface MathMLMsAttributes extends MathMLAttributes<MathMLMrowElement> {
         lquote?: string | undefined;
         rquote?: string | undefined;
     }
-    interface MathMLMspaceElement extends MathMLAttributes<MathMLMspaceElement> {
+    interface MathMLMspaceAttributes extends MathMLAttributes<MathMLMspaceElement> {
         depth?: string | undefined;
         height?: string | undefined;
         width?: string | undefined;
     }
-    interface MathMLMsqrtElement extends MathMLAttributes<MathMLMsqrtElement> {}
-    interface MathMLMstyleElement extends MathMLAttributes<MathMLMstyleElement> {}
-    interface MathMLMsubElement extends MathMLAttributes<MathMLMsubElement> {}
-    interface MathMLMsubsupElement extends MathMLAttributes<MathMLMsubsupElement> {}
-    interface MathMLMsupElement extends MathMLAttributes<MathMLMsupElement> {}
-    interface MathMLMtableElement extends MathMLAttributes<MathMLMtableElement> {
+    interface MathMLMsqrtAttributes extends MathMLAttributes<MathMLMsqrtElement> {}
+    interface MathMLMstyleAttributes extends MathMLAttributes<MathMLMstyleElement> {}
+    interface MathMLMsubAttributes extends MathMLAttributes<MathMLMsubElement> {}
+    interface MathMLMsubsupAttributes extends MathMLAttributes<MathMLMsubsupElement> {}
+    interface MathMLMsupAttributes extends MathMLAttributes<MathMLMsupElement> {}
+    interface MathMLMtableAttributes extends MathMLAttributes<MathMLMtableElement> {
         /* This attribute is non-standard. */
         align?: string | undefined;
         /* This attribute is non-standard. */
@@ -4019,7 +4019,7 @@ declare namespace React {
         /* This attribute is non-standard. */
         width?: string | undefined;
     }
-    interface MathMLMtdElement extends MathMLAttributes<MathMLMtdElement> {
+    interface MathMLMtdAttributes extends MathMLAttributes<MathMLMtdElement> {
         /* This attribute is non-standard. */
         columnalign?: 'left' | 'center' | 'right' | undefined;
         columnspan?: number | string | undefined;
@@ -4027,34 +4027,34 @@ declare namespace React {
         rowalign?: 'axis' | 'baseline' | 'bottom' | 'center' | 'top' | undefined;
         rowspan?: number | string | undefined;
     }
-    interface MathMLMtextElement extends MathMLAttributes<MathMLMtextElement> {}
-    interface MathMLMtrElement extends MathMLAttributes<MathMLMtrElement> {
+    interface MathMLMtextAttributes extends MathMLAttributes<MathMLMtextElement> {}
+    interface MathMLMtrAttributes extends MathMLAttributes<MathMLMtrElement> {
         /* This attribute is non-standard. */
         columnalign?: 'left' | 'center' | 'right' | undefined;
         /* This attribute is non-standard. */
         rowalign?: 'axis' | 'baseline' | 'bottom' | 'center' | 'top' | undefined;
     }
-    interface MathMLMunderElement extends MathMLAttributes<MathMLMunderElement> {
+    interface MathMLMunderAttributes extends MathMLAttributes<MathMLMunderElement> {
         accentunder?: boolean | undefined;
     }
-    interface MathMLMunderoverElement extends MathMLAttributes<MathMLElement> {
+    interface MathMLMunderoverAttributes extends MathMLAttributes<MathMLElement> {
         accent?: boolean | undefined;
         accentunder?: boolean | undefined;
     }
     /**
      * @see https://w3c.github.io/mathml-core/#semantics-and-presentation
     */
-    interface MathMLSemanticsElement extends MathMLAttributes<MathMLSemanticsElement> {}
+    interface MathMLSemanticsAttributes extends MathMLAttributes<MathMLSemanticsElement> {}
     /**
      * @see https://w3c.github.io/mathml-core/#semantics-and-presentation
     */
-    interface MathMLAnnotationElement extends MathMLAttributes<MathMLAnnotationElement> {
+    interface MathMLAnnotationAttributes extends MathMLAttributes<MathMLAnnotationElement> {
         encoding?: string | undefined;
     }
     /**
      * @see https://w3c.github.io/mathml-core/#semantics-and-presentation
     */
-    interface MathMLAnnotationXmlElement extends MathMLAttributes<MathMLAnnotationXmlElement> {
+    interface MathMLAnnotationXmlAttributes extends MathMLAttributes<MathMLAnnotationXmlElement> {
         encoding?: string | undefined;
     }
 
@@ -4654,35 +4654,35 @@ declare global {
             view: React.SVGProps<SVGViewElement>;
 
             // MathML
-            math: React.MathMLProps<MathMLMathElement>;
-            merror: React.MathMLProps<MathMLMerrorElement>;
-            mfrac: React.MathMLProps<MathMLMfracElement>;
-            mi: React.MathMLProps<MathMLMiElement>;
-            mmultiscripts: React.MathMLProps<MathMLMmultiscriptsElement>;
-            mn: React.MathMLProps<MathMLMnElement>;
-            mo: React.MathMLProps<MathMLMoElement>;
-            mover: React.MathMLProps<MathMLMoverElement>;
-            mpadded: React.MathMLProps<MathMLMpaddedElement>;
-            mphantom: React.MathMLProps<MathMLMphantomElement>;
-            mroot: React.MathMLProps<MathMLMrootElement>;
-            mrow: React.MathMLProps<MathMLMrowElement>;
-            ms: React.MathMLProps<MathMLMsElement>;
-            mspace: React.MathMLProps<MathMLMspaceElement>;
-            msqrt: React.MathMLProps<MathMLMsqrtElement>;
-            mstyle: React.MathMLProps<MathMLMstyleElement>;
-            msub: React.MathMLProps<MathMLMsubElement>;
-            msubsup: React.MathMLProps<MathMLMsubsupElement>;
-            msup: React.MathMLProps<MathMLMsupElement>;
-            mtable: React.MathMLProps<MathMLMtableElement>;
-            mtd: React.MathMLProps<MathMLMtdElement>;
-            mtext: React.MathMLProps<MathMLMtextElement>;
-            mtr: React.MathMLProps<MathMLMtrElement>;
-            munder: React.MathMLProps<MathMLMunderElement>;
-            munderover: React.MathMLProps<MathMLMunderoverElement>;
-            semantics: React.MathMLProps<MathMLSemanticsElement>;
+            math: React.MathMLProps<React.MathMLMathAttributes, MathMLMathElement>;
+            merror: React.MathMLProps<React.MathMLMerrorAttributes, MathMLMerrorElement>;
+            mfrac: React.MathMLProps<React.MathMLMfracAttributes, MathMLMfracElement>;
+            mi: React.MathMLProps<React.MathMLMiAttributes, MathMLMiElement>;
+            mmultiscripts: React.MathMLProps<React.MathMLMmultiscriptsAttributes, MathMLMmultiscriptsElement>;
+            mn: React.MathMLProps<React.MathMLMnAttributes, MathMLMnElement>;
+            mo: React.MathMLProps<React.MathMLMoAttributes, MathMLMoElement>;
+            mover: React.MathMLProps<React.MathMLMoverAttributes, MathMLMoverElement>;
+            mpadded: React.MathMLProps<React.MathMLMpaddedAttributes, MathMLMpaddedElement>;
+            mphantom: React.MathMLProps<React.MathMLMphantomAttributes, MathMLMphantomElement>;
+            mroot: React.MathMLProps<React.MathMLMrootAttributes, MathMLMrootElement>;
+            mrow: React.MathMLProps<React.MathMLMrowAttributes, MathMLMrowElement>;
+            ms: React.MathMLProps<React.MathMLMsAttributes, MathMLMsElement>;
+            mspace: React.MathMLProps<React.MathMLMspaceAttributes, MathMLMspaceElement>;
+            msqrt: React.MathMLProps<React.MathMLMsqrtAttributes, MathMLMsqrtElement>;
+            mstyle: React.MathMLProps<React.MathMLMstyleAttributes, MathMLMstyleElement>;
+            msub: React.MathMLProps<React.MathMLMsubAttributes, MathMLMsubElement>;
+            msubsup: React.MathMLProps<React.MathMLMsubsupAttributes, MathMLMsubsupElement>;
+            msup: React.MathMLProps<React.MathMLMsupAttributes, MathMLMsupElement>;
+            mtable: React.MathMLProps<React.MathMLMtableAttributes, MathMLMtableElement>;
+            mtd: React.MathMLProps<React.MathMLMtdAttributes, MathMLMtdElement>;
+            mtext: React.MathMLProps<React.MathMLMtextAttributes, MathMLMtextElement>;
+            mtr: React.MathMLProps<React.MathMLMtrAttributes, MathMLMtrElement>;
+            munder: React.MathMLProps<React.MathMLMunderAttributes, MathMLMunderElement>;
+            munderover: React.MathMLProps<React.MathMLMoverAttributes, MathMLMoverElement>;
+            semantics: React.MathMLProps<React.MathMLSemanticsAttributes, MathMLSemanticsElement>;
             // MathML semantic annotations
-            annotation: React.MathMLProps<MathMLAnnotationElement>;
-            'annotation-xml': React.MathMLProps<MathMLAnnotationXmlElement>;
+            annotation: React.MathMLProps<React.MathMLAnnotationAttributes, MathMLAnnotationElement>;
+            'annotation-xml': React.MathMLProps<React.MathMLAnnotationXmlAttributes, MathMLAnnotationXmlElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -4041,7 +4041,22 @@ declare namespace React {
         accent?: boolean | undefined;
         accentunder?: boolean | undefined;
     }
+    /**
+     * @see https://w3c.github.io/mathml-core/#semantics-and-presentation
+    */
     interface MathMLSemanticsElement extends MathMLAttributes<MathMLSemanticsElement> {}
+    /**
+     * @see https://w3c.github.io/mathml-core/#semantics-and-presentation
+    */
+    interface MathMLAnnotationElement extends MathMLAttributes<MathMLAnnotationElement> {
+        encoding?: string | undefined;
+    }
+    /**
+     * @see https://w3c.github.io/mathml-core/#semantics-and-presentation
+    */
+    interface MathMLAnnotationXmlElement extends MathMLAttributes<MathMLAnnotationXmlElement> {
+        encoding?: string | undefined;
+    }
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
@@ -4664,6 +4679,10 @@ declare global {
             mtr: React.MathMLProps<MathMLMtrElement>;
             munder: React.MathMLProps<MathMLMunderElement>;
             munderover: React.MathMLProps<MathMLMunderoverElement>;
+            semantics: React.MathMLProps<MathMLSemanticsElement>;
+            // MathML semantic annotations
+            annotation: React.MathMLProps<MathMLAnnotationElement>;
+            'annotation-xml': React.MathMLProps<MathMLAnnotationXmlElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3968,6 +3968,9 @@ declare namespace React {
         stretchy?: boolean | undefined;
         symmetric?: boolean | undefined;
     }
+    interface MathMLMoverElement extends MathMLAttributes<MathMLMoverElement> {
+        accent?: boolean | undefined;
+    }
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
@@ -4572,6 +4575,7 @@ declare global {
             mmultiscripts: React.MathMLProps<MathMLMmultiscriptsElement>;
             mn: React.MathMLProps<MathMLMnElement>;
             mo: React.MathMLProps<MathMLMoElement>;
+            mover: React.MathMLProps<MathMLMoverElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -4005,6 +4005,10 @@ declare namespace React {
     interface MathMLMunderElement extends MathMLAttributes<MathMLMunderElement> {
         accentunder?: boolean | undefined;
     }
+    interface MathMLMunderoverElement extends MathMLAttributes<MathMLElement> {
+        accent?: boolean | undefined;
+        accentunder?: boolean | undefined;
+    }
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
@@ -4626,6 +4630,7 @@ declare global {
             mtext: React.MathMLProps<MathMLMtextElement>;
             mtr: React.MathMLProps<MathMLMtrElement>;
             munder: React.MathMLProps<MathMLMunderElement>;
+            munderover: React.MathMLProps<MathMLMunderoverElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3995,6 +3995,7 @@ declare namespace React {
     interface MathMLMsubElement extends MathMLAttributes<MathMLMsubElement> {}
     interface MathMLMsubsupElement extends MathMLAttributes<MathMLMsubsupElement> {}
     interface MathMLMsupElement extends MathMLAttributes<MathMLMsupElement> {}
+    interface MathMLMtableElement extends MathMLAttributes<MathMLMtableElement> {}
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
@@ -4611,6 +4612,7 @@ declare global {
             msub: React.MathMLProps<MathMLMsubElement>;
             msubsup: React.MathMLProps<MathMLMsubsupElement>;
             msup: React.MathMLProps<MathMLMsupElement>;
+            mtable: React.MathMLProps<MathMLMtableElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3948,6 +3948,9 @@ declare namespace React {
         display?: 'block' | 'inline'
     }
     interface MathMLMErrorAttributes extends MathMLAttributes<MathMLMErrorAttributes> {}
+    interface MathMLMFracElement extends MathMLAttributes<MathMLMFracElement> {
+        linethickness: string;
+    }
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
@@ -4547,6 +4550,7 @@ declare global {
             // MathML
             math: React.MathMLProps<MathMLMathElement>;
             merror: React.MathMLProps<MathMLMErrorElement>;
+            mfrac: React.MathMLProps<MathMLMFracElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3971,6 +3971,13 @@ declare namespace React {
     interface MathMLMoverElement extends MathMLAttributes<MathMLMoverElement> {
         accent?: boolean | undefined;
     }
+    interface MathMLMpaddedElement extends MathMLAttributes<MathMLMpaddedElement> {
+        depth?: string | undefined;
+        height?: string | undefined;
+        lspace?: string | undefined;
+        voffset?: string | undefined;
+        width?: string | undefined;
+    }
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
@@ -4576,6 +4583,7 @@ declare global {
             mn: React.MathMLProps<MathMLMnElement>;
             mo: React.MathMLProps<MathMLMoElement>;
             mover: React.MathMLProps<MathMLMoverElement>;
+            mpadded: React.MathMLProps<MathMLMpaddedElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3978,7 +3978,8 @@ declare namespace React {
         voffset?: string | undefined;
         width?: string | undefined;
     }
-    interface MathMLMphantomElement extends MathMLAttributes<MathMLMphantomElement>;
+    interface MathMLMphantomElement extends MathMLAttributes<MathMLMphantomElement> {}
+    interface MathMLMrootElement extends MathMLAttributes<MathMLMrootElement> {}
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
@@ -4586,6 +4587,7 @@ declare global {
             mover: React.MathMLProps<MathMLMoverElement>;
             mpadded: React.MathMLProps<MathMLMpaddedElement>;
             mphantom: React.MathMLProps<MathMLMphantomElement>;
+            mroot: React.MathMLProps<MathMLMrootElement>
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3947,7 +3947,7 @@ declare namespace React {
     interface MathMLMathAttributes extends MathMLAttributes<MathMLMathElement> {
         display?: 'block' | 'inline'
     }
-
+    interface MathMLMErrorAttributes extends MathMLAttributes<MathMLMErrorAttributes> {}
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
@@ -4546,6 +4546,7 @@ declare global {
 
             // MathML
             math: React.MathMLProps<MathMLMathElement>;
+            merror: React.MathMLProps<MathMLMErrorElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -4001,6 +4001,10 @@ declare namespace React {
         rowspan?: number | string | undefined;
     }
     interface MathMLMtextElement extends MathMLAttributes<MathMLMtextElement> {}
+    interface MathMLMtrElement extends MathMLAttributes<MathMLMtrElement> {}
+    interface MathMLMunderElement extends MathMLAttributes<MathMLMunderElement> {
+        accentunder?: boolean | undefined;
+    }
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
@@ -4620,6 +4624,8 @@ declare global {
             mtable: React.MathMLProps<MathMLMtableElement>;
             mtd: React.MathMLProps<MathMLMtdElement>;
             mtext: React.MathMLProps<MathMLMtextElement>;
+            mtr: React.MathMLProps<MathMLMtrElement>;
+            munder: React.MathMLProps<MathMLMunderElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3994,6 +3994,7 @@ declare namespace React {
     interface MathMLMstyleElement extends MathMLAttributes<MathMLMstyleElement> {}
     interface MathMLMsubElement extends MathMLAttributes<MathMLMsubElement> {}
     interface MathMLMsubsupElement extends MathMLAttributes<MathMLMsubsupElement> {}
+    interface MathMLMsupElement extends MathMLAttributes<MathMLMsupElement> {}
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
@@ -4609,6 +4610,7 @@ declare global {
             mstyle: React.MathMLProps<MathMLMstyleElement>;
             msub: React.MathMLProps<MathMLMsubElement>;
             msubsup: React.MathMLProps<MathMLMsubsupElement>;
+            msup: React.MathMLProps<MathMLMsupElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3996,6 +3996,10 @@ declare namespace React {
     interface MathMLMsubsupElement extends MathMLAttributes<MathMLMsubsupElement> {}
     interface MathMLMsupElement extends MathMLAttributes<MathMLMsupElement> {}
     interface MathMLMtableElement extends MathMLAttributes<MathMLMtableElement> {}
+    interface MathMLMtdElement extends MathMLAttributes<MathMLMtdElement> {
+        columnspan?: number | string | undefined;
+        rowspan?: number | string | undefined;
+    }
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
@@ -4613,6 +4617,7 @@ declare global {
             msubsup: React.MathMLProps<MathMLMsubsupElement>;
             msup: React.MathMLProps<MathMLMsupElement>;
             mtable: React.MathMLProps<MathMLMtableElement>;
+            mtd: React.MathMLProps<MathMLMtdElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -4000,6 +4000,7 @@ declare namespace React {
         columnspan?: number | string | undefined;
         rowspan?: number | string | undefined;
     }
+    interface MathMLMtextElement extends MathMLAttributes<MathMLMtextElement> {}
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
@@ -4618,6 +4619,7 @@ declare global {
             msup: React.MathMLProps<MathMLMsupElement>;
             mtable: React.MathMLProps<MathMLMtableElement>;
             mtd: React.MathMLProps<MathMLMtdElement>;
+            mtext: React.MathMLProps<MathMLMtextElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -4009,6 +4009,7 @@ declare namespace React {
         accent?: boolean | undefined;
         accentunder?: boolean | undefined;
     }
+    interface MathMLSemanticsElement extends MathMLAttributes<MathMLSemanticsElement> {}
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3990,6 +3990,7 @@ declare namespace React {
         height?: string | undefined;
         width?: string | undefined;
     }
+    interface MathMLMsqrtElement extends MathMLAttributes<MathMLMsqrtElement> {}
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
@@ -4601,6 +4602,7 @@ declare global {
             mrow: React.MathMLProps<MathMLMrowElement>;
             ms: React.MathMLProps<MathMLMsElement>;
             mspace: React.MathMLProps<MathMLMspaceElement>;
+            msqrt: React.MathMLProps<MathMLMsqrtElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3954,6 +3954,7 @@ declare namespace React {
     interface MathMLMIElement extends MathMLAttributes<MathMLMIElement> {
         mathvariant: 'normal';
     }
+    interface MathMLMMultiScriptsElement extends MathMLAttributes<MathMLMMultiScriptsElement> {}
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
@@ -4555,6 +4556,7 @@ declare global {
             merror: React.MathMLProps<MathMLMErrorElement>;
             mfrac: React.MathMLProps<MathMLMFracElement>;
             mi: React.MathMLProps<MathMLMIElement>;
+            mmultiscripts: React.MathMLProps<MathMLMMultiScriptsElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3980,6 +3980,7 @@ declare namespace React {
     }
     interface MathMLMphantomElement extends MathMLAttributes<MathMLMphantomElement> {}
     interface MathMLMrootElement extends MathMLAttributes<MathMLMrootElement> {}
+    interface MathMLMrowElement extends MathMLAttributes<MathMLMrowElement> {}
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
@@ -4587,7 +4588,8 @@ declare global {
             mover: React.MathMLProps<MathMLMoverElement>;
             mpadded: React.MathMLProps<MathMLMpaddedElement>;
             mphantom: React.MathMLProps<MathMLMphantomElement>;
-            mroot: React.MathMLProps<MathMLMrootElement>
+            mroot: React.MathMLProps<MathMLMrootElement>;
+            mrow: React.MathMLProps<MathMLMrowElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3991,6 +3991,7 @@ declare namespace React {
         width?: string | undefined;
     }
     interface MathMLMsqrtElement extends MathMLAttributes<MathMLMsqrtElement> {}
+    interface MathMLMstyleElement extends MathMLAttributes<MathMLMstyleElement> {}
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
@@ -4603,6 +4604,7 @@ declare global {
             ms: React.MathMLProps<MathMLMsElement>;
             mspace: React.MathMLProps<MathMLMspaceElement>;
             msqrt: React.MathMLProps<MathMLMsqrtElement>;
+            mstyle: React.MathMLProps<MathMLMstyleElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2375,7 +2375,7 @@ declare namespace React {
     interface SVGLineElementAttributes<T> extends SVGProps<T> {}
     interface SVGTextElementAttributes<T> extends SVGProps<T> {}
 
-    interface MathMLProps<T> extends MathMLAttributes<T> {}
+    interface MathMLProps<T extends MathMLElement> extends MathMLAttributes<T> {}
 
     interface DOMAttributes<T> {
         children?: ReactNode | undefined;
@@ -3925,7 +3925,7 @@ declare namespace React {
     }
 
     // https://developer.mozilla.org/en-US/docs/Web/MathML/Global_attributes
-    interface MathMLAttributes<T> extends DOMAttributes<T> {
+    interface MathMLAttributes<T extends MathMLElement> extends DOMAttributes<T> {
         className?: string | undefined;
         dir?: 'ltr' | 'rtl' | undefined;
         displaystyle?: boolean | undefined;
@@ -3939,6 +3939,15 @@ declare namespace React {
         style?: CSSProperties | undefined;
         tabindex?: number | undefined;
     }
+
+    // Individual MathML elements are described here:
+    //
+    // https://developer.mozilla.org/en-US/docs/Web/MathML/Element/math
+    //
+    interface MathMLMathAttributes extends MathMLAttributes<MathMLMathElement> {
+        display?: 'block' | 'inline'
+    }
+
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
@@ -4536,7 +4545,7 @@ declare global {
             view: React.SVGProps<SVGViewElement>;
 
             // MathML
-            match: 
+            math: React.MathMLProps<MathMLMathElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2375,6 +2375,8 @@ declare namespace React {
     interface SVGLineElementAttributes<T> extends SVGProps<T> {}
     interface SVGTextElementAttributes<T> extends SVGProps<T> {}
 
+    interface MathMLProps<T> extends MathMLAttributes<T> {}
+
     interface DOMAttributes<T> {
         children?: ReactNode | undefined;
         dangerouslySetInnerHTML?: {
@@ -3922,6 +3924,22 @@ declare namespace React {
         zoomAndPan?: string | undefined;
     }
 
+    // https://developer.mozilla.org/en-US/docs/Web/MathML/Global_attributes
+    interface MathMLAttributes<T> extends DOMAttributes<T> {
+        className?: string | undefined;
+        dir?: 'ltr' | 'rtl' | undefined;
+        displaystyle?: boolean | undefined;
+        href?: string | undefined;
+        id?: string | undefined;
+        mathbackground?: string | undefined;
+        mathcolor?: string | undefined;
+        mathsize?: string | undefined;
+        nonce?: string | undefined;
+        scriptlevel?: string | undefined;
+        style?: CSSProperties | undefined;
+        tabindex?: number | undefined;
+    }
+
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
         allowpopups?: boolean | undefined;
@@ -4516,6 +4534,9 @@ declare global {
             tspan: React.SVGProps<SVGTSpanElement>;
             use: React.SVGProps<SVGUseElement>;
             view: React.SVGProps<SVGViewElement>;
+
+            // MathML
+            match: 
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3978,6 +3978,7 @@ declare namespace React {
         voffset?: string | undefined;
         width?: string | undefined;
     }
+    interface MathMLMphantomElement extends MathMLAttributes<MathMLMphantomElement>;
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
@@ -4584,6 +4585,7 @@ declare global {
             mo: React.MathMLProps<MathMLMoElement>;
             mover: React.MathMLProps<MathMLMoverElement>;
             mpadded: React.MathMLProps<MathMLMpaddedElement>;
+            mphantom: React.MathMLProps<MathMLMphantomElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3947,16 +3947,16 @@ declare namespace React {
     interface MathMLMathAttributes extends MathMLAttributes<MathMLMathElement> {
         display?: 'block' | 'inline' | undefined;
     }
-    interface MathMLMErrorAttributes extends MathMLAttributes<MathMLMErrorAttributes> {}
-    interface MathMLMFracElement extends MathMLAttributes<MathMLMFracElement> {
+    interface MathMLMerrorAttributes extends MathMLAttributes<MathMLMerrorAttributes> {}
+    interface MathMLMfracElement extends MathMLAttributes<MathMLMfracElement> {
         linethickness?: string | undefined;
     }
-    interface MathMLMIElement extends MathMLAttributes<MathMLMIElement> {
+    interface MathMLMiElement extends MathMLAttributes<MathMLMiElement> {
         mathvariant?: 'normal' | undefined;
     }
-    interface MathMLMMultiScriptsElement extends MathMLAttributes<MathMLMMultiScriptsElement> {}
-    interface MathMLMNElement extends MathMLAttributes<MathMLMNElement> {}
-    interface MathMLMOElement extends MathMLAttributes<MathMLMNElement> {
+    interface MathMLMmultiscriptsElement extends MathMLAttributes<MathMLMmultiscriptsElement> {}
+    interface MathMLMnElement extends MathMLAttributes<MathMLMnElement> {}
+    interface MathMLMoElement extends MathMLAttributes<MathMLMoElement> {
         fence?: boolean | undefined;
         largeop?: boolean | undefined;
         lspace?: string | undefined;
@@ -4566,12 +4566,12 @@ declare global {
 
             // MathML
             math: React.MathMLProps<MathMLMathElement>;
-            merror: React.MathMLProps<MathMLMErrorElement>;
-            mfrac: React.MathMLProps<MathMLMFracElement>;
-            mi: React.MathMLProps<MathMLMIElement>;
-            mmultiscripts: React.MathMLProps<MathMLMMultiScriptsElement>;
-            mn: React.MathMLProps<MathMLMNElement>;
-            mo: React.MathMLProps<MathMLMOElement>;
+            merror: React.MathMLProps<MathMLMerrorElement>;
+            mfrac: React.MathMLProps<MathMLMfracElement>;
+            mi: React.MathMLProps<MathMLMiElement>;
+            mmultiscripts: React.MathMLProps<MathMLMmultiscriptsElement>;
+            mn: React.MathMLProps<MathMLMnElement>;
+            mo: React.MathMLProps<MathMLMoElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3981,6 +3981,10 @@ declare namespace React {
     interface MathMLMphantomElement extends MathMLAttributes<MathMLMphantomElement> {}
     interface MathMLMrootElement extends MathMLAttributes<MathMLMrootElement> {}
     interface MathMLMrowElement extends MathMLAttributes<MathMLMrowElement> {}
+    interface MathMLMsElement extends MathMLAttributes<MathMLMrowElement> {
+        lquote?: string | undefined;
+        rquote?: string | undefined;
+    }
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
@@ -4590,6 +4594,7 @@ declare global {
             mphantom: React.MathMLProps<MathMLMphantomElement>;
             mroot: React.MathMLProps<MathMLMrootElement>;
             mrow: React.MathMLProps<MathMLMrowElement>;
+            ms: React.MathMLProps<MathMLMsElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3927,7 +3927,7 @@ declare namespace React {
     // https://developer.mozilla.org/en-US/docs/Web/MathML/Global_attributes
     interface MathMLAttributes<T> extends DOMAttributes<T> {
         className?: string | undefined;
-        dir?: 'ltr' | 'rtl' | undefined;
+        dir?: "ltr" | "rtl" | undefined;
         displaystyle?: boolean | undefined;
         href?: string | undefined;
         id?: string | undefined;
@@ -3945,14 +3945,14 @@ declare namespace React {
     // https://developer.mozilla.org/en-US/docs/Web/MathML/Element/math
     //
     interface MathMLMathAttributes extends MathMLAttributes<MathMLMathElement> {
-        display?: 'block' | 'inline' | undefined;
+        display?: "block" | "inline" | undefined;
     }
     interface MathMLMerrorAttributes extends MathMLAttributes<MathMLMerrorAttributes> {}
     interface MathMLMfracAttributes extends MathMLAttributes<MathMLMfracElement> {
         linethickness?: string | undefined;
     }
     interface MathMLMiAttributes extends MathMLAttributes<MathMLMiElement> {
-        mathvariant?: 'normal' | undefined;
+        mathvariant?: "normal" | undefined;
     }
     interface MathMLMmultiscriptsAttributes extends MathMLAttributes<MathMLMmultiscriptsElement> {}
     interface MathMLMnAttributes extends MathMLAttributes<MathMLMnElement> {}
@@ -4012,7 +4012,7 @@ declare namespace React {
         /* This attribute is non-standard. */
         columnspacing?: string | undefined;
         /* This attribute is non-standard. */
-        frame?: 'none' | 'solid' | 'dashed' | undefined;
+        frame?: "none" | "solid" | "dashed" | undefined;
         /* This attribute is non-standard. */
         framespacing?: string | undefined;
         /* This attribute is non-standard. */
@@ -4026,18 +4026,18 @@ declare namespace React {
     }
     interface MathMLMtdAttributes extends MathMLAttributes<MathMLMtdElement> {
         /* This attribute is non-standard. */
-        columnalign?: 'left' | 'center' | 'right' | undefined;
+        columnalign?: "left" | "center" | "right" | undefined;
         columnspan?: number | string | undefined;
         /* This attribute is non-standard. */
-        rowalign?: 'axis' | 'baseline' | 'bottom' | 'center' | 'top' | undefined;
+        rowalign?: "axis" | "baseline" | "bottom" | "center" | "top" | undefined;
         rowspan?: number | string | undefined;
     }
     interface MathMLMtextAttributes extends MathMLAttributes<MathMLMtextElement> {}
     interface MathMLMtrAttributes extends MathMLAttributes<MathMLMtrElement> {
         /* This attribute is non-standard. */
-        columnalign?: 'left' | 'center' | 'right' | undefined;
+        columnalign?: "left" | "center" | "right" | undefined;
         /* This attribute is non-standard. */
-        rowalign?: 'axis' | 'baseline' | 'bottom' | 'center' | 'top' | undefined;
+        rowalign?: "axis" | "baseline" | "bottom" | "center" | "top" | undefined;
     }
     interface MathMLMunderAttributes extends MathMLAttributes<MathMLMunderElement> {
         accentunder?: boolean | undefined;
@@ -4048,17 +4048,17 @@ declare namespace React {
     }
     /**
      * @see https://w3c.github.io/mathml-core/#semantics-and-presentation
-    */
+     */
     interface MathMLSemanticsAttributes extends MathMLAttributes<MathMLSemanticsElement> {}
     /**
      * @see https://w3c.github.io/mathml-core/#semantics-and-presentation
-    */
+     */
     interface MathMLAnnotationAttributes extends MathMLAttributes<MathMLAnnotationElement> {
         encoding?: string | undefined;
     }
     /**
      * @see https://w3c.github.io/mathml-core/#semantics-and-presentation
-    */
+     */
     interface MathMLAnnotationXmlAttributes extends MathMLAttributes<MathMLAnnotationXmlElement> {
         encoding?: string | undefined;
     }
@@ -4688,7 +4688,7 @@ declare global {
             semantics: React.MathMLProps<React.MathMLSemanticsAttributes, MathMLSemanticsElement>;
             // MathML semantic annotations
             annotation: React.MathMLProps<React.MathMLAnnotationAttributes, MathMLAnnotationElement>;
-            'annotation-xml': React.MathMLProps<React.MathMLAnnotationXmlAttributes, MathMLAnnotationXmlElement>;
+            "annotation-xml": React.MathMLProps<React.MathMLAnnotationXmlAttributes, MathMLAnnotationXmlElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3992,6 +3992,7 @@ declare namespace React {
     }
     interface MathMLMsqrtElement extends MathMLAttributes<MathMLMsqrtElement> {}
     interface MathMLMstyleElement extends MathMLAttributes<MathMLMstyleElement> {}
+    interface MathMLMsubElement extends MathMLAttributes<MathMLMsubElement> {}
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
@@ -4605,6 +4606,7 @@ declare global {
             mspace: React.MathMLProps<MathMLMspaceElement>;
             msqrt: React.MathMLProps<MathMLMsqrtElement>;
             mstyle: React.MathMLProps<MathMLMstyleElement>;
+            msub: React.MathMLProps<MathMLMsubElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3993,6 +3993,7 @@ declare namespace React {
     interface MathMLMsqrtElement extends MathMLAttributes<MathMLMsqrtElement> {}
     interface MathMLMstyleElement extends MathMLAttributes<MathMLMstyleElement> {}
     interface MathMLMsubElement extends MathMLAttributes<MathMLMsubElement> {}
+    interface MathMLMsubsupElement extends MathMLAttributes<MathMLMsubsupElement> {}
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
@@ -4607,6 +4608,7 @@ declare global {
             msqrt: React.MathMLProps<MathMLMsqrtElement>;
             mstyle: React.MathMLProps<MathMLMstyleElement>;
             msub: React.MathMLProps<MathMLMsubElement>;
+            msubsup: React.MathMLProps<MathMLMsubsupElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3957,6 +3957,8 @@ declare namespace React {
     interface MathMLMmultiscriptsElement extends MathMLAttributes<MathMLMmultiscriptsElement> {}
     interface MathMLMnElement extends MathMLAttributes<MathMLMnElement> {}
     interface MathMLMoElement extends MathMLAttributes<MathMLMoElement> {
+        /* This attribute is non-standard. */
+        accent?: boolean | undefined;
         fence?: boolean | undefined;
         largeop?: boolean | undefined;
         lspace?: string | undefined;
@@ -3995,13 +3997,43 @@ declare namespace React {
     interface MathMLMsubElement extends MathMLAttributes<MathMLMsubElement> {}
     interface MathMLMsubsupElement extends MathMLAttributes<MathMLMsubsupElement> {}
     interface MathMLMsupElement extends MathMLAttributes<MathMLMsupElement> {}
-    interface MathMLMtableElement extends MathMLAttributes<MathMLMtableElement> {}
+    interface MathMLMtableElement extends MathMLAttributes<MathMLMtableElement> {
+        /* This attribute is non-standard. */
+        align?: string | undefined;
+        /* This attribute is non-standard. */
+        columnalign?: string | undefined;
+        /* This attribute is non-standard. */
+        columnlines?: string | undefined;
+        /* This attribute is non-standard. */
+        columnspacing?: string | undefined;
+        /* This attribute is non-standard. */
+        frame?: 'none' | 'solid' | 'dashed' | undefined;
+        /* This attribute is non-standard. */
+        framespacing?: string | undefined;
+        /* This attribute is non-standard. */
+        rowalign?: string | undefined;
+        /* This attribute is non-standard. */
+        rowlines?: string | undefined;
+        /* This attribute is non-standard. */
+        rowspacing?: string | undefined;
+        /* This attribute is non-standard. */
+        width?: string | undefined;
+    }
     interface MathMLMtdElement extends MathMLAttributes<MathMLMtdElement> {
+        /* This attribute is non-standard. */
+        columnalign?: 'left' | 'center' | 'right' | undefined;
         columnspan?: number | string | undefined;
+        /* This attribute is non-standard. */
+        rowalign?: 'axis' | 'baseline' | 'bottom' | 'center' | 'top' | undefined;
         rowspan?: number | string | undefined;
     }
     interface MathMLMtextElement extends MathMLAttributes<MathMLMtextElement> {}
-    interface MathMLMtrElement extends MathMLAttributes<MathMLMtrElement> {}
+    interface MathMLMtrElement extends MathMLAttributes<MathMLMtrElement> {
+        /* This attribute is non-standard. */
+        columnalign?: 'left' | 'center' | 'right' | undefined;
+        /* This attribute is non-standard. */
+        rowalign?: 'axis' | 'baseline' | 'bottom' | 'center' | 'top' | undefined;
+    }
     interface MathMLMunderElement extends MathMLAttributes<MathMLMunderElement> {
         accentunder?: boolean | undefined;
     }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3945,17 +3945,29 @@ declare namespace React {
     // https://developer.mozilla.org/en-US/docs/Web/MathML/Element/math
     //
     interface MathMLMathAttributes extends MathMLAttributes<MathMLMathElement> {
-        display?: 'block' | 'inline';
+        display?: 'block' | 'inline' | undefined;
     }
     interface MathMLMErrorAttributes extends MathMLAttributes<MathMLMErrorAttributes> {}
     interface MathMLMFracElement extends MathMLAttributes<MathMLMFracElement> {
-        linethickness: string;
+        linethickness?: string | undefined;
     }
     interface MathMLMIElement extends MathMLAttributes<MathMLMIElement> {
-        mathvariant: 'normal';
+        mathvariant?: 'normal' | undefined;
     }
     interface MathMLMMultiScriptsElement extends MathMLAttributes<MathMLMMultiScriptsElement> {}
     interface MathMLMNElement extends MathMLAttributes<MathMLMNElement> {}
+    interface MathMLMOElement extends MathMLAttributes<MathMLMNElement> {
+        fence?: boolean | undefined;
+        largeop?: boolean | undefined;
+        lspace?: string | undefined;
+        maxsize?: string | undefined;
+        minsize?: string | undefined;
+        movablelimits?: boolean | undefined;
+        rspace?: string | undefined;
+        separator?: boolean | undefined;
+        stretchy?: boolean | undefined;
+        symmetric?: boolean | undefined;
+    }
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
@@ -4559,6 +4571,7 @@ declare global {
             mi: React.MathMLProps<MathMLMIElement>;
             mmultiscripts: React.MathMLProps<MathMLMMultiScriptsElement>;
             mn: React.MathMLProps<MathMLMNElement>;
+            mo: React.MathMLProps<MathMLMOElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3945,11 +3945,14 @@ declare namespace React {
     // https://developer.mozilla.org/en-US/docs/Web/MathML/Element/math
     //
     interface MathMLMathAttributes extends MathMLAttributes<MathMLMathElement> {
-        display?: 'block' | 'inline'
+        display?: 'block' | 'inline';
     }
     interface MathMLMErrorAttributes extends MathMLAttributes<MathMLMErrorAttributes> {}
     interface MathMLMFracElement extends MathMLAttributes<MathMLMFracElement> {
         linethickness: string;
+    }
+    interface MathMLMIElement extends MathMLAttributes<MathMLMIElement> {
+        mathvariant: 'normal';
     }
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
@@ -4551,6 +4554,7 @@ declare global {
             math: React.MathMLProps<MathMLMathElement>;
             merror: React.MathMLProps<MathMLMErrorElement>;
             mfrac: React.MathMLProps<MathMLMFracElement>;
+            mi: React.MathMLProps<MathMLMIElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3985,6 +3985,11 @@ declare namespace React {
         lquote?: string | undefined;
         rquote?: string | undefined;
     }
+    interface MathMLMspaceElement extends MathMLAttributes<MathMLMspaceElement> {
+        depth?: string | undefined;
+        height?: string | undefined;
+        width?: string | undefined;
+    }
 
     interface WebViewHTMLAttributes<T> extends HTMLAttributes<T> {
         allowFullScreen?: boolean | undefined;
@@ -4595,6 +4600,7 @@ declare global {
             mroot: React.MathMLProps<MathMLMrootElement>;
             mrow: React.MathMLProps<MathMLMrowElement>;
             ms: React.MathMLProps<MathMLMsElement>;
+            mspace: React.MathMLProps<MathMLMspaceElement>;
         }
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3981,6 +3981,11 @@ declare namespace React {
         width?: string | undefined;
     }
     interface MathMLMphantomAttributes extends MathMLAttributes<MathMLMphantomElement> {}
+    // Described in relation to <mmultiscripts /> here:
+    //
+    // https://developer.mozilla.org/en-US/docs/Web/MathML/Element/mmultiscripts#using_mprescripts
+    //
+    interface MathMLMprescriptsAttributes extends MathMLAttributes<MathMLMprescriptsElement> {}
     interface MathMLMrootAttributes extends MathMLAttributes<MathMLMrootElement> {}
     interface MathMLMrowAttributes extends MathMLAttributes<MathMLMrowElement> {}
     interface MathMLMsAttributes extends MathMLAttributes<MathMLMrowElement> {
@@ -4664,6 +4669,7 @@ declare global {
             mover: React.MathMLProps<React.MathMLMoverAttributes, MathMLMoverElement>;
             mpadded: React.MathMLProps<React.MathMLMpaddedAttributes, MathMLMpaddedElement>;
             mphantom: React.MathMLProps<React.MathMLMphantomAttributes, MathMLMphantomElement>;
+            mprescripts: React.MathMLProps<React.MathMLMprescriptsAttributes, MathMLMprescriptsElement>;
             mroot: React.MathMLProps<React.MathMLMrootAttributes, MathMLMrootElement>;
             mrow: React.MathMLProps<React.MathMLMrowAttributes, MathMLMrowElement>;
             ms: React.MathMLProps<React.MathMLMsAttributes, MathMLMsElement>;
@@ -4678,7 +4684,7 @@ declare global {
             mtext: React.MathMLProps<React.MathMLMtextAttributes, MathMLMtextElement>;
             mtr: React.MathMLProps<React.MathMLMtrAttributes, MathMLMtrElement>;
             munder: React.MathMLProps<React.MathMLMunderAttributes, MathMLMunderElement>;
-            munderover: React.MathMLProps<React.MathMLMoverAttributes, MathMLMoverElement>;
+            munderover: React.MathMLProps<React.MathMLMunderoverAttributes, MathMLMunderoverElement>;
             semantics: React.MathMLProps<React.MathMLSemanticsAttributes, MathMLSemanticsElement>;
             // MathML semantic annotations
             annotation: React.MathMLProps<React.MathMLAnnotationAttributes, MathMLAnnotationElement>;

--- a/types/react/test/elementAttributes.tsx
+++ b/types/react/test/elementAttributes.tsx
@@ -90,6 +90,148 @@ const testCases = [
     </dialog>,
     <link nonce="8IBTHwOdqNKAWeKl7plt8g==" />,
     <center></center>,
+    // MathML test cases
+    <math display="block"></math>,
+    <math display="inline"></math>,
+    // @ts-expect-error
+    <math display="whoops"></math>,
+    <mfrac></mfrac>,
+    <mfrac linethickness="2px"></mfrac>,
+    <mi></mi>,
+    <mi mathvariant="normal"></mi>,
+    // @ts-expect-error
+    <mi mathvariant="whoops"></mi>,
+    <mmultiscripts></mmultiscripts>,
+    <mprescripts />,
+    <mn>1</mn>,
+    <mo>+</mo>,
+    <mo
+      accent
+      fence
+      largeop
+      lspace="2px"
+      maxsize="14px"
+      minsize="12px"
+      movablelimits
+      rspace="2px"
+      separator
+      stretchy
+      symmetric
+      >+</mo>,
+    <mover></mover>,
+    <mover accent></mover>,
+    <mpadded></mpadded>,
+    <mpadded
+      depth="1px"
+      height="1px"
+      lspace="1px"
+      voffset="1px"
+      width="1px"
+      ></mpadded>,
+    <mphantom></mphantom>,
+    <mroot></mroot>,
+    <mrow></mrow>,
+    <ms></ms>,
+    <ms lquote="&quot;" rquote="&quot;"></ms>,
+    <mspace></mspace>,
+    <mspace
+      depth="1px"
+      height="1px"
+      width="1px"
+      ></mspace>,
+    <msqrt></msqrt>,
+    <mstyle displaystyle={false} mathcolor="teal"></mstyle>,
+    <msub></msub>,
+    <msubsup></msubsup>,
+    <msup></msup>,
+    <mtable></mtable>,
+    <mtable
+      align="top"
+      columnalign="left"
+      columnlines="solid"
+      columnspacing="2em"
+      frame="solid"
+      framespacing="2px"
+      rowalign="top"
+      rowspacing="1em"
+      width="100%"
+      ></mtable>,
+    // @ts-expect-error
+    <mtable frame="whoops"></mtable>,
+    <mtext></mtext>,
+    <mtd></mtd>,
+    <mtd
+      columnalign="left"
+      columnspan={1}
+      rowalign="top"
+      rowspan={2}
+      ></mtd>,
+    <mtd
+      // @ts-expect-error
+      columnalign="whoops"
+      columnspan="1"
+      // @ts-expect-error
+      rowalign="whoops"
+      rowspan="2"
+      ></mtd>,
+    <mtr></mtr>,
+    <mtr
+      columnalign="left"
+      rowalign="top"
+      ></mtr>,
+    <mtr
+      // @ts-expect-error
+      columnalign="whoops"
+      // @ts-expect-error
+      rowalign="whoops"
+      ></mtr>,
+    <munder></munder>,
+    <munder accentunder></munder>,
+    <munderover></munderover>,
+    <munderover accent accentunder></munderover>,
+    <semantics></semantics>,
+    <annotation></annotation>,
+    <annotation-xml></annotation-xml>,
+    // Example from MDN:
+    //
+    // https://developer.mozilla.org/en-US/docs/Web/MathML/Element/math#examples
+    //
+    <p>
+        The infinite sum
+        <math display="block">
+            <mrow>
+            <munderover>
+                <mo>∑</mo>
+                <mrow>
+                <mi>n</mi>
+                <mo>=</mo>
+                <mn>1</mn>
+                </mrow>
+                <mrow>
+                <mo>+</mo>
+                <mn>∞</mn>
+                </mrow>
+            </munderover>
+            <mfrac>
+                <mn>1</mn>
+                <msup>
+                <mi>n</mi>
+                <mn>2</mn>
+                </msup>
+            </mfrac>
+            </mrow>
+        </math>
+        is equal to the real number
+        <math display="inline">
+            <mfrac>
+            <msup>
+                <mi>π</mi>
+                <mn>2</mn>
+            </msup>
+            <mn>6</mn>
+            </mfrac>
+        </math>.
+    </p>
 ];
 
 // Needed to check these HTML elements in event callbacks.

--- a/types/react/test/elementAttributes.tsx
+++ b/types/react/test/elementAttributes.tsx
@@ -106,28 +106,31 @@ const testCases = [
     <mn>1</mn>,
     <mo>+</mo>,
     <mo
-      accent
-      fence
-      largeop
-      lspace="2px"
-      maxsize="14px"
-      minsize="12px"
-      movablelimits
-      rspace="2px"
-      separator
-      stretchy
-      symmetric
-      >+</mo>,
+        accent
+        fence
+        largeop
+        lspace="2px"
+        maxsize="14px"
+        minsize="12px"
+        movablelimits
+        rspace="2px"
+        separator
+        stretchy
+        symmetric
+    >
+        +
+    </mo>,
     <mover></mover>,
     <mover accent></mover>,
     <mpadded></mpadded>,
     <mpadded
-      depth="1px"
-      height="1px"
-      lspace="1px"
-      voffset="1px"
-      width="1px"
-      ></mpadded>,
+        depth="1px"
+        height="1px"
+        lspace="1px"
+        voffset="1px"
+        width="1px"
+    >
+    </mpadded>,
     <mphantom></mphantom>,
     <mroot></mroot>,
     <mrow></mrow>,
@@ -135,10 +138,11 @@ const testCases = [
     <ms lquote="&quot;" rquote="&quot;"></ms>,
     <mspace></mspace>,
     <mspace
-      depth="1px"
-      height="1px"
-      width="1px"
-      ></mspace>,
+        depth="1px"
+        height="1px"
+        width="1px"
+    >
+    </mspace>,
     <msqrt></msqrt>,
     <mstyle displaystyle={false} mathcolor="teal"></mstyle>,
     <msub></msub>,
@@ -146,45 +150,50 @@ const testCases = [
     <msup></msup>,
     <mtable></mtable>,
     <mtable
-      align="top"
-      columnalign="left"
-      columnlines="solid"
-      columnspacing="2em"
-      frame="solid"
-      framespacing="2px"
-      rowalign="top"
-      rowspacing="1em"
-      width="100%"
-      ></mtable>,
+        align="top"
+        columnalign="left"
+        columnlines="solid"
+        columnspacing="2em"
+        frame="solid"
+        framespacing="2px"
+        rowalign="top"
+        rowspacing="1em"
+        width="100%"
+    >
+    </mtable>,
     // @ts-expect-error
     <mtable frame="whoops"></mtable>,
     <mtext></mtext>,
     <mtd></mtd>,
     <mtd
-      columnalign="left"
-      columnspan={1}
-      rowalign="top"
-      rowspan={2}
-      ></mtd>,
+        columnalign="left"
+        columnspan={1}
+        rowalign="top"
+        rowspan={2}
+    >
+    </mtd>,
     <mtd
-      // @ts-expect-error
-      columnalign="whoops"
-      columnspan="1"
-      // @ts-expect-error
-      rowalign="whoops"
-      rowspan="2"
-      ></mtd>,
+        // @ts-expect-error
+        columnalign="whoops"
+        columnspan="1"
+        // @ts-expect-error
+        rowalign="whoops"
+        rowspan="2"
+    >
+    </mtd>,
     <mtr></mtr>,
     <mtr
-      columnalign="left"
-      rowalign="top"
-      ></mtr>,
+        columnalign="left"
+        rowalign="top"
+    >
+    </mtr>,
     <mtr
-      // @ts-expect-error
-      columnalign="whoops"
-      // @ts-expect-error
-      rowalign="whoops"
-      ></mtr>,
+        // @ts-expect-error
+        columnalign="whoops"
+        // @ts-expect-error
+        rowalign="whoops"
+    >
+    </mtr>,
     <munder></munder>,
     <munder accentunder></munder>,
     <munderover></munderover>,
@@ -200,38 +209,38 @@ const testCases = [
         The infinite sum
         <math display="block">
             <mrow>
-            <munderover>
-                <mo>∑</mo>
-                <mrow>
-                <mi>n</mi>
-                <mo>=</mo>
-                <mn>1</mn>
-                </mrow>
-                <mrow>
-                <mo>+</mo>
-                <mn>∞</mn>
-                </mrow>
-            </munderover>
-            <mfrac>
-                <mn>1</mn>
-                <msup>
-                <mi>n</mi>
-                <mn>2</mn>
-                </msup>
-            </mfrac>
+                <munderover>
+                    <mo>∑</mo>
+                    <mrow>
+                        <mi>n</mi>
+                        <mo>=</mo>
+                        <mn>1</mn>
+                    </mrow>
+                    <mrow>
+                        <mo>+</mo>
+                        <mn>∞</mn>
+                    </mrow>
+                </munderover>
+                <mfrac>
+                    <mn>1</mn>
+                    <msup>
+                        <mi>n</mi>
+                        <mn>2</mn>
+                    </msup>
+                </mfrac>
             </mrow>
         </math>
         is equal to the real number
         <math display="inline">
             <mfrac>
-            <msup>
-                <mi>π</mi>
-                <mn>2</mn>
-            </msup>
-            <mn>6</mn>
+                <msup>
+                    <mi>π</mi>
+                    <mn>2</mn>
+                </msup>
+                <mn>6</mn>
             </mfrac>
         </math>.
-    </p>
+    </p>,
 ];
 
 // Needed to check these HTML elements in event callbacks.


### PR DESCRIPTION
This adds support to React for [MathML](https://developer.mozilla.org/en-US/docs/Web/MathML) as [discussed previously](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69884).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/docs/Web/MathML
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

## Notes

In initial discussion, it was brought up that:

> If it works at runtime, we should support it with types.

MathML is still [newly supported by modern browsers](https://caniuse.com/mathml). As a result, the browser support for some elements – and especially for some element attributes – is mixed. In some cases, elements have been deprecated and/or have had support removed. In other cases, the support across browsers is "non-standard", as MDN puts it. For example, various alignment and styling attributes on the `mtable` element are not supported in Chrome (v126 at the time of this writing), but are supported in Firefox. This can be seen by [previewing the example from MDN](https://developer.mozilla.org/en-US/docs/Web/MathML/Element/mtable#alignment_with_row_number):

```html
<mtable frame="solid" rowlines="solid" align="axis 3">
```

(Chrome): 
<img width="117" alt="Screenshot 2024-07-06 at 3 21 09 PM" src="https://github.com/DefinitelyTyped/DefinitelyTyped/assets/7310102/4df6d7e3-cee3-4267-8f0e-8edc07d1c52b">

(Firefox): 
<img width="125" alt="Screenshot 2024-07-06 at 3 21 30 PM" src="https://github.com/DefinitelyTyped/DefinitelyTyped/assets/7310102/c56a5e47-8462-425f-9de3-d3ba7f88960a">

~~In regards to the spectrum of support, the approach initially taken in this PR is as follows:~~

* ~~All elements MDN lists, except for those marked as deprecated and/or non-standard, have relevant types added in this PR.~~
* ~~All attributes MDN lists for a given element, except for those marked as deprecated, have relevant types added in this PR. Note that types for  "non-standard" attributes have been added in this PR.~~

~~This approach was taken to reduce the initial blast radius of the initial MathML support with the intent that more detailed elements/attributes with further afield support could be added if the community finds a need to reach for them. That being said, I'm happy to discuss this more and adjust to whatever the maintainers of these types see as the best approach.~~

The difference in seems to come from the difference between MathML and MathML Core from the Math WG:

* [MathML 3 specification](https://www.w3.org/TR/MathML3/)
* [MathML Core specification](https://www.w3.org/TR/mathml-core/)

As MDN puts summarizes:

> MDN uses [MathML Core](https://w3c.github.io/mathml-core/) as a reference specification but, due to an erratic standardization history, legacy MathML features may still show up in existing implementations and web content.

and

> Note: It is highly recommended that developers and authors switch to MathML Core, perhaps relying on other web technologies to cover missing use cases. The Math WG is maintaining a set of [MathML polyfills](https://github.com/mathml-refresh/mathml-polyfills) to facilitate that transition.

The approach taken in this PR is to use the MathML Core specification. **Note: Updates still need to be made to fully support this specification**.