### PR TITLE
[@types/chrome] Fix Window type in ExtensionSidebarPaneShownEvent

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2622,9 +2622,7 @@ declare namespace chrome.devtools.panels {
         onSelectionChanged: SelectionChangedEvent;
     }
 
-    export interface ExtensionSidebarPaneShownEvent
-        extends chrome.events.Event<(window: Window) => void>
-    {}
+    export interface ExtensionSidebarPaneShownEvent extends chrome.events.Event<(window: Window) => void> {}
 
     export interface ExtensionSidebarPaneHiddenEvent extends chrome.events.Event<() => void> {}
 

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2623,7 +2623,7 @@ declare namespace chrome.devtools.panels {
     }
 
     export interface ExtensionSidebarPaneShownEvent
-        extends chrome.events.Event<(window: chrome.windows.Window) => void>
+        extends chrome.events.Event<(window: Window) => void>
     {}
 
     export interface ExtensionSidebarPaneHiddenEvent extends chrome.events.Event<() => void> {}


### PR DESCRIPTION
Very similar to a previous fix: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/23979
The same issue exists in the sidebar pane onShown (this API is not very commonly used).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/devtools/panels#type-ExtensionSidebarPane
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
