### PR TITLE
style: rewrap doc strings for telegram-web-app

### DIFF
--- a/types/telegram-web-app/index.d.ts
+++ b/types/telegram-web-app/index.d.ts
@@ -9,14 +9,14 @@ interface Telegram {
 interface WebApp {
     /**
      * A string with raw data transferred to the Web App, convenient for
-     * validating data. WARNING: Validate data from this field before using it on
-     * the bot's server.
+     * validating data. WARNING: Validate data from this field before using it
+     * on the bot's server.
      */
     initData: string;
     /**
      * An object with input data transferred to the Web App. WARNING: Data from
-     * this field should not be trusted. You should only use data from initData on
-     * the bot's server and only after it has been validated.
+     * this field should not be trusted. You should only use data from initData
+     * on the bot's server and only after it has been validated.
      */
     initDataUnsafe: WebAppInitData;
     /**
@@ -37,9 +37,9 @@ interface WebApp {
      */
     themeParams: ThemeParams;
     /**
-     *  True if the Web App is expanded to the maximum available height. False, if
-     *  the Web App occupies part of the screen and can be expanded to the full
-     *  height using the expand() method.
+     *  True if the Web App is expanded to the maximum available height. False,
+     *  if the Web App occupies part of the screen and can be expanded to the
+     *  full height using the expand() method.
      */
     isExpanded: boolean;
     /**
@@ -47,10 +47,11 @@ interface WebApp {
      * CSS as the variable var(--tg-viewport-height).
      *
      * The application can display just the top part of the Web App, with its
-     * lower part remaining outside the screen area. From this position, the user
-     * can “pull” the Web App to its maximum height, while the bot can do the same
-     * by calling the expand() method. As the position of the Web App changes, the
-     * current height value of the visible area will be updated in real time.
+     * lower part remaining outside the screen area. From this position, the
+     * user can “pull” the Web App to its maximum height, while the bot can do
+     * the same by calling the expand() method. As the position of the Web App
+     * changes, the current height value of the visible area will be updated in
+     * real time.
      *
      * Please note that the refresh rate of this value is not sufficient to
      * smoothly follow the lower border of the window. It should not be used to
@@ -64,17 +65,17 @@ interface WebApp {
      * Also available in CSS as a variable var(--tg-viewport-stable-height).
      *
      * The application can display just the top part of the Web App, with its
-     * lower part remaining outside the screen area. From this position, the user
-     * can “pull” the Web App to its maximum height, while the bot can do the same
-     * by calling the expand() method. Unlike the value of viewportHeight, the
-     * value of viewportStableHeight does not change as the position of the Web
-     * App changes with user gestures or during animations. The value of
-     * viewportStableHeight will be updated after all gestures and animations are
-     * completed and the Web App reaches its final size.
+     * lower part remaining outside the screen area. From this position, the
+     * user can “pull” the Web App to its maximum height, while the bot can do
+     * the same by calling the expand() method. Unlike the value of
+     * viewportHeight, the value of viewportStableHeight does not change as the
+     * position of the Web App changes with user gestures or during animations.
+     * The value of viewportStableHeight will be updated after all gestures and
+     * animations are completed and the Web App reaches its final size.
      *
      * Note the event viewportChanged with the passed parameter
-     * isStateStable=true, which will allow you to track when the stable state of
-     * the height of the visible area changes.
+     * isStateStable=true, which will allow you to track when the stable state
+     * of the height of the visible area changes.
      */
     viewportStableHeight: number;
     /**
@@ -86,8 +87,8 @@ interface WebApp {
      */
     backgroundColor: string;
     /**
-     * True, if the confirmation dialog is enabled while the user is trying to close the Web App.
-     * False, if the confirmation dialog is disabled.
+     * True, if the confirmation dialog is enabled while the user is trying to
+     * close the Web App. False, if the confirmation dialog is disabled.
      */
     isClosingConfirmationEnabled: boolean;
     /**
@@ -101,8 +102,8 @@ interface WebApp {
      */
     MainButton: MainButton;
     /**
-     * An object for controlling the Settings item in the context menu of the Mini App
-     * in the Telegram interface.
+     * An object for controlling the Settings item in the context menu of the
+     * Mini App in the Telegram interface.
      */
     SettingsButton: SettingsButton;
     /**
@@ -123,8 +124,8 @@ interface WebApp {
      */
     isVersionAtLeast(version: string): boolean;
     /**
-     * A method that sets the app header color in the `#RRGGBB` format.
-     * You can also use keywords bg_color and secondary_bg_color.
+     * A method that sets the app header color in the `#RRGGBB` format. You can
+     * also use keywords bg_color and secondary_bg_color.
      */
     // string & {} prevents this from eagerly collapsing into just string
     setHeaderColor(color: "bg_color" | "secondary_bg_color" | (string & {})): void;
@@ -134,11 +135,13 @@ interface WebApp {
      */
     setBackgroundColor(color: "bg_color" | "secondary_bg_color" | (string & {})): void;
     /**
-     * A method that enables a confirmation dialog while the user is trying to close the Web App.
+     * A method that enables a confirmation dialog while the user is trying to
+     * close the Web App.
      */
     enableClosingConfirmation(): void;
     /**
-     * A method that disables the confirmation dialog while the user is trying to close the Web App.
+     * A method that disables the confirmation dialog while the user is trying
+     * to close the Web App.
      */
     disableClosingConfirmation(): void;
     /**
@@ -181,29 +184,33 @@ interface WebApp {
     /**
      * A method used to send data to the bot. When this method is called, a
      * service message is sent to the bot containing the data data of the length
-     * up to 4096 bytes, and the Web App is closed. See the field web_app_data in
-     * the class Message.
+     * up to 4096 bytes, and the Web App is closed. See the field web_app_data
+     * in the class Message.
      *
-     * This method is only available for Web Apps launched via a Keyboard button.
+     * This method is only available for Web Apps launched via a Keyboard
+     * button.
      */
     sendData(data: string): void;
     /**
-     * A method that inserts the bot's username and the specified inline query in the current chat's input field.
-     * Query may be empty, in which case only the bot's username will be inserted.
-     * If an optional choose_chat_types parameter was passed, the client prompts the user to choose a specific chat,
-     * then opens that chat and inserts the bot's username and the specified inline query in the input field.
-     * You can specify which types of chats the user will be able to choose from.
-     * It can be one or more of the following types: users, bots, groups, channels.
+     * A method that inserts the bot's username and the specified inline query
+     * in the current chat's input field. Query may be empty, in which case only
+     * the bot's username will be inserted. If an optional choose_chat_types
+     * parameter was passed, the client prompts the user to choose a specific
+     * chat, then opens that chat and inserts the bot's username and the
+     * specified inline query in the input field. You can specify which types of
+     * chats the user will be able to choose from. It can be one or more of the
+     * following types: users, bots, groups, channels.
      */
     switchInlineQuery(query: string, choose_chat_types?: Array<"users" | "bots" | "groups" | "channels">): void;
     /**
-     * A method that opens a link in an external browser.
-     * The Web App will not be closed.
-     * If the optional options parameter is passed with the field
-     * @param try_instant_view the link will be opened in Instant View mode if possible.
+     * A method that opens a link in an external browser. The Web App will not
+     * be closed. If the optional options parameter is passed with the field
+     * @param try_instant_view the link will be opened in Instant View mode if
+     * possible.
      *
-     * Note that this method can be called only in response to user interaction with
-     * the Web App interface (e.g. a click inside the Web App or on the main button)
+     * Note that this method can be called only in response to user interaction
+     * with the Web App interface (e.g. a click inside the Web App or on the
+     * main button)
      */
     openLink(url: string, options?: { try_instant_view?: boolean }): void;
     /**
@@ -222,44 +229,54 @@ interface WebApp {
         callback: (url: string, status: "paid" | "cancelled" | "failed" | "pending") => void,
     ): void;
     /**
-     * A method that shows a native popup described by the params argument of the type PopupParams.
-     * The Web App will receive the event popupClosed when the popup is closed. If an optional
-     * callback parameter was passed, the callback function will be called and the field id of the
-     * pressed button will be passed as the first argument.
+     * A method that shows a native popup described by the params argument of
+     * the type PopupParams. The Web App will receive the event popupClosed when
+     * the popup is closed. If an optional callback parameter was passed, the
+     * callback function will be called and the field id of the pressed button
+     * will be passed as the first argument.
      */
     showPopup(params: PopupParams, callback?: (button_id: string) => void): void;
     /**
-     * A method that shows message in a simple alert with a 'Close' button. If an optional callback
-     * parameter was passed, the callback function will be called when the popup is closed.
+     * A method that shows message in a simple alert with a 'Close' button. If
+     * an optional callback parameter was passed, the callback function will be
+     * called when the popup is closed.
      */
     showAlert(message: string, callback?: () => void): void;
     /**
-     * A method that shows message in a simple confirmation window with 'OK' and 'Cancel' buttons.
-     * If an optional callback parameter was passed, the callback function will be called when the
-     * popup is closed and the first argument will be a boolean indicating whether the user
-     * pressed the 'OK' button.
+     * A method that shows message in a simple confirmation window with 'OK' and
+     * 'Cancel' buttons. If an optional callback parameter was passed, the
+     * callback function will be called when the popup is closed and the first
+     * argument will be a boolean indicating whether the user pressed the 'OK'
+     * button.
      */
     showConfirm(message: string, callback?: (ok: boolean) => void): void;
     /**
-     * A method that shows a native popup for scanning a QR code described by the params argument of the type ScanQrPopupParams.
-     * The Web App will receive the event qrTextReceived every time the scanner catches a code with text data.
-     * If an optional callback parameter was passed, the callback function will be called and the text from the QR
-     * code will be passed as the first argument. Returning true inside this callback function causes the popup to be closed.
-     * Starting from **Bot API 7.7**, the Mini App will receive the scanQrPopupClosed event if the user closes the native popup for scanning a QR code.
+     * A method that shows a native popup for scanning a QR code described by
+     * the params argument of the type ScanQrPopupParams. The Web App will
+     * receive the event qrTextReceived every time the scanner catches a code
+     * with text data. If an optional callback parameter was passed, the
+     * callback function will be called and the text from the QR code will be
+     * passed as the first argument. Returning true inside this callback
+     * function causes the popup to be closed. Starting from **Bot API 7.7**,
+     * the Mini App will receive the scanQrPopupClosed event if the user closes
+     * the native popup for scanning a QR code.
      */
     showScanQrPopup(params: ScanQrPopupParams, callback?: (data: string) => void): void;
     /**
-     * A method that closes the native popup for scanning a QR code opened with the
-     * showScanQrPopup method. Run it if you received valid data in the event qrTextReceived.
+     * A method that closes the native popup for scanning a QR code opened with
+     * the showScanQrPopup method. Run it if you received valid data in the
+     * event qrTextReceived.
      */
     closeScanQrPopup(): void;
     /**
-     * A method that requests text from the clipboard. The Web App will receive the event clipboardTextReceived.
-     * If an optional callback parameter was passed, the callback function will be
-     * called and the text from the clipboard will be passed as the first argument.
+     * A method that requests text from the clipboard. The Web App will receive
+     * the event clipboardTextReceived. If an optional callback parameter was
+     * passed, the callback function will be called and the text from the
+     * clipboard will be passed as the first argument.
      *
-     * Note: this method can be called only for Web Apps launched from the attachment menu and only
-     * in response to a user interaction with the Web App interface (e.g. a click inside the Web App or on the main button).
+     * Note: this method can be called only for Web Apps launched from the
+     * attachment menu and only in response to a user interaction with the Web
+     * App interface (e.g. a click inside the Web App or on the main button).
      */
     readTextFromClipboard(callback?: (data: string | null) => void): void;
     /**
@@ -278,9 +295,9 @@ interface WebApp {
      *
      * @param callback If an optional callback parameter was passed, the
      * callback function will be called when the popup is closed and the first
-     * argument will be a boolean indicating whether the user shared its
-     * phone number. The second argument, contingent upon success, will be
-     * an object detailing the shared contact information or a cancellation response.
+     * argument will be a boolean indicating whether the user shared its phone
+     * number. The second argument, contingent upon success, will be an object
+     * detailing the shared contact information or a cancellation response.
      */
     requestContact(
         callback?: (success: boolean, response: RequestContactResponse) => void,
@@ -289,33 +306,37 @@ interface WebApp {
      * A method that informs the Telegram app that the Web App is ready to be
      * displayed. It is recommended to call this method as early as possible, as
      * soon as all essential interface elements are loaded. Once this method is
-     * called, the loading placeholder is hidden and the Web App is shown. If the
-     * method is not called, the placeholder will be hidden only when the page is
-     * fully loaded.
+     * called, the loading placeholder is hidden and the Web App is shown. If
+     * the method is not called, the placeholder will be hidden only when the
+     * page is fully loaded.
      */
     ready(): void;
     /**
-     * A method that expands the Web App to the maximum available height. To find
-     * out if the Web App is expanded to the maximum height, refer to the value of
-     * the Telegram.WebApp.isExpanded parameter
+     * A method that expands the Web App to the maximum available height. To
+     * find out if the Web App is expanded to the maximum height, refer to the
+     * value of the Telegram.WebApp.isExpanded parameter
      */
     expand(): void;
     /** A method that closes the Web App. */
     close(): void;
     /**
      * `True`, if vertical swipes to close or minimize the Mini App are enabled.
-     * `False`, if vertical swipes to close or minimize the Mini App are disabled.
-     * In any case, the user will still be able to minimize and close the Mini App by swiping the Mini App's header.
+     * `False`, if vertical swipes to close or minimize the Mini App are
+     * disabled. In any case, the user will still be able to minimize and close
+     * the Mini App by swiping the Mini App's header.
      */
     isVerticalSwipesEnabled: boolean;
     /**
-     * **Bot API 7.7+** A method that enables vertical swipes to close or minimize the Mini App.
-     * For user convenience, it is recommended to always enable swipes unless they conflict with the Mini App's own gestures.
+     * **Bot API 7.7+** A method that enables vertical swipes to close or
+     * minimize the Mini App. For user convenience, it is recommended to always
+     * enable swipes unless they conflict with the Mini App's own gestures.
      */
     enableVerticalSwipes(): void;
     /**
-     * **Bot API 7.7+** A method that disables vertical swipes to close or minimize the Mini App.
-     * This method is useful if your Mini App uses swipe gestures that may conflict with the gestures for minimizing and closing the app.
+     * **Bot API 7.7+** A method that disables vertical swipes to close or
+     * minimize the Mini App. This method is useful if your Mini App uses swipe
+     * gestures that may conflict with the gestures for minimizing and closing
+     * the app.
      */
     disableVerticalSwipes(): void;
 }
@@ -343,74 +364,77 @@ type BiometricTokenUpdatedCallback = (eventData: { isUpdated: boolean }) => void
  */
 interface ThemeParams {
     /**
-     * Background color in the `#RRGGBB` format.
-     * Also available as the CSS variable `var(--tg-theme-bg-color)`.
+     * Background color in the `#RRGGBB` format. Also available as the CSS
+     * variable `var(--tg-theme-bg-color)`.
      */
     bg_color?: string;
     /**
-     * Main text color in the `#RRGGBB` format.
-     * Also available as the CSS variable `var(--tg-theme-text-color)`.
+     * Main text color in the `#RRGGBB` format. Also available as the CSS
+     * variable `var(--tg-theme-text-color)`.
      */
     text_color?: string;
     /**
-     * Hint text color in the `#RRGGBB` format.
-     * Also available as the CSS variable `var(--tg-theme-hint-color)`.
+     * Hint text color in the `#RRGGBB` format. Also available as the CSS
+     * variable `var(--tg-theme-hint-color)`.
      */
     hint_color?: string;
     /**
-     * Link color in the `#RRGGBB` format.
-     * Also available as the CSS variable `var(--tg-theme-link-color)`.
+     * Link color in the `#RRGGBB` format. Also available as the CSS variable
+     * `var(--tg-theme-link-color)`.
      */
     link_color?: string;
     /**
-     * Button color in the `#RRGGBB` format.
-     * Also available as the CSS variable `var(--tg-theme-button-color)`.
+     * Button color in the `#RRGGBB` format. Also available as the CSS variable
+     * `var(--tg-theme-button-color)`.
      */
     button_color?: string;
     /**
-     * Button text color in the `#RRGGBB` format.
-     * Also available as the CSS variable `var(--tg-theme-button-text-color)`.
+     * Button text color in the `#RRGGBB` format. Also available as the CSS
+     * variable `var(--tg-theme-button-text-color)`.
      */
     button_text_color?: string;
     /**
-     * **Bot API 6.1+** Secondary background color in the `#RRGGBB` format.
-     * Also available as the CSS variable `var(--tg-theme-secondary-bg-color)`.
+     * **Bot API 6.1+** Secondary background color in the `#RRGGBB` format. Also
+     * available as the CSS variable `var(--tg-theme-secondary-bg-color)`.
      */
     secondary_bg_color?: string;
     /**
-     * **Bot API 7.0+** Header background color in the `#RRGGBB` format.
-     * Also available as the CSS variable `var(--tg-theme-header-bg-color)`.
+     * **Bot API 7.0+** Header background color in the `#RRGGBB` format. Also
+     * available as the CSS variable `var(--tg-theme-header-bg-color)`.
      */
     header_bg_color?: string;
     /**
-     * **Bot API 7.0+** Accent text color in the `#RRGGBB` format.
-     * Also available as the CSS variable `var(--tg-theme-accent-text-color)`.
+     * **Bot API 7.0+** Accent text color in the `#RRGGBB` format. Also
+     * available as the CSS variable `var(--tg-theme-accent-text-color)`.
      */
     accent_text_color?: string;
     /**
-     * **Bot API 7.0+** Background color for the section in the `#RRGGBB` format. It is
-     * recommended to use this in conjunction with *secondary_bg_color*.
-     * Also available as the CSS variable `var(--tg-theme-section-bg-color)`.
+     * **Bot API 7.0+** Background color for the section in the `#RRGGBB`
+     * format. It is recommended to use this in conjunction with
+     * *secondary_bg_color*. Also available as the CSS variable
+     * `var(--tg-theme-section-bg-color)`.
      */
     section_bg_color?: string;
     /**
-     * **Bot API 7.0+** Header text color for the section in the `#RRGGBB` format.
-     * Also available as the CSS variable `var(--tg-theme-section-header-text-color)`.
+     * **Bot API 7.0+** Header text color for the section in the `#RRGGBB`
+     * format. Also available as the CSS variable
+     * `var(--tg-theme-section-header-text-color)`.
      */
     section_header_text_color?: `#${string}`;
     /**
-     * **Bot API 7.6+** Section separator color in the `#RRGGBB` format.
-     * Also available as the CSS variable `var(--tg-theme-section-separator-color)`.
+     * **Bot API 7.6+** Section separator color in the `#RRGGBB` format. Also
+     * available as the CSS variable `var(--tg-theme-section-separator-color)`.
      */
     section_separator_color?: string;
     /**
-     * **Bot API 7.0+** Subtitle text color in the `#RRGGBB` format.
-     * Also available as the CSS variable `var(--tg-theme-subtitle-text-color)`.
+     * **Bot API 7.0+** Subtitle text color in the `#RRGGBB` format. Also
+     * available as the CSS variable `var(--tg-theme-subtitle-text-color)`.
      */
     subtitle_text_color?: string;
     /**
-     * **Bot API 7.0+** Text color for destructive actions in the `#RRGGBB` format.
-     * Also available as the CSS variable `var(--tg-theme-destructive-text-color)`.
+     * **Bot API 7.0+** Text color for destructive actions in the `#RRGGBB`
+     * format. Also available as the CSS variable
+     * `var(--tg-theme-destructive-text-color)`.
      */
     destructive_text_color?: string;
 }
@@ -428,7 +452,8 @@ interface PopupParams {
      */
     message: string;
     /**
-     * List of buttons to be displayed in the popup, 1-3 buttons. Set to [{“type”:“close”}] by default.
+     * List of buttons to be displayed in the popup, 1-3 buttons. Set to
+     * [{“type”:“close”}] by default.
      */
     buttons?: PopupButton[];
 }
@@ -439,23 +464,25 @@ interface PopupParams {
 type PopupButton =
     & {
         /**
-         * Identifier of the button, 0-64 characters. Set to empty string by default.
-         * If the button is pressed, its id is returned in the callback and the popupClosed event.
+         * Identifier of the button, 0-64 characters. Set to empty string by
+         * default. If the button is pressed, its id is returned in the callback
+         * and the popupClosed event.
          */
         id?: string;
         /**
-         * Type of the button. Set to default by default.
-         * Can be one of these values:
+         * Type of the button. Set to default by default. Can be one of these
+         * values:
          * - `default`, a button with the default style,
          * - `ok`, a button with the localized text “OK”,
          * - `close`, a button with the localized text “Close”,
          * - `cancel`, a button with the localized text “Cancel”,
-         * - `destructive`, a button with a style that indicates a destructive action (e.g. “Remove”, “Delete”, etc.).
+         * - `destructive`, a button with a style that indicates a destructive
+         *   action (e.g. “Remove”, “Delete”, etc.).
          */
         type?: "default" | "ok" | "close" | "cancel" | "destructive";
         /**
-         * The text to be displayed on the button, 0-64 characters.
-         * Required if type is default or destructive. Irrelevant for other types.
+         * The text to be displayed on the button, 0-64 characters. Required if
+         * type is default or destructive. Irrelevant for other types.
          */
         text?: string;
     }
@@ -509,7 +536,8 @@ interface MainButton {
     /** Current button color. Set to themeParams.button_color by default. */
     color: string;
     /**
-     * Current button text color. Set to themeParams.button_text_color by default.
+     * Current button text color. Set to themeParams.button_text_color by
+     * default.
      */
     textColor: string;
     /** Shows whether the button is visible. Set to false by default. */
@@ -528,9 +556,9 @@ interface MainButton {
     /** A method that deletes a previously set handler */
     offClick(callback: () => void): MainButton;
     /**
-     * A method to make the button visible. Note that opening the Web App from the
-     * attachment menu hides the main button until the user interacts with the
-     * Web App interface.
+     * A method to make the button visible. Note that opening the Web App from
+     * the attachment menu hides the main button until the user interacts with
+     * the Web App interface.
      */
     show(): MainButton;
     /** A method to hide the button. */
@@ -574,8 +602,8 @@ interface MainButtonParams {
 }
 
 /**
- * This object controls the Settings item in the context menu of the Mini App in the
- * Telegram interface.
+ * This object controls the Settings item in the context menu of the Mini App in
+ * the Telegram interface.
  */
 interface SettingsButton {
     /**
@@ -583,19 +611,20 @@ interface SettingsButton {
      */
     isVisible: boolean;
     /**
-     * **Bot API 7.0+** A method that sets the press event handler for the Settings item in
-     * the context menu. An alias for
+     * **Bot API 7.0+** A method that sets the press event handler for the
+     * Settings item in the context menu. An alias for
      * `Telegram.WebApp.onEvent('settingsButtonClicked', callback)`
      */
     onClick(callback: () => void): SettingsButton;
     /**
-     * **Bot API 7.0+** A method that removes the press event handler from the Settings item
-     * in the context menu. An alias for
+     * **Bot API 7.0+** A method that removes the press event handler from the
+     * Settings item in the context menu. An alias for
      * `Telegram.WebApp.offEvent('settingsButtonClicked', callback)`
      */
     offClick(callback: () => void): SettingsButton;
     /**
-     * **Bot API 7.0+** A method to make the Settings item in the context menu visible.
+     * **Bot API 7.0+** A method to make the Settings item in the context menu
+     * visible.
      */
     show(): SettingsButton;
     /**
@@ -641,13 +670,13 @@ interface HapticFeedback {
 
 interface CloudStorage {
     /**
-     * A method that stores a value in the cloud storage using the
-     * specified key.
+     * A method that stores a value in the cloud storage using the specified
+     * key.
      *
-     * @param key The key should contain 1-128 characters, only A-Z, a-z, 0-9,
-     * _ and - are allowed.
-     * @param value The value should contain 0-4096 characters. You can store
-     * up to 1024 keys in the cloud storage.
+     * @param key The key should contain 1-128 characters, only A-Z, a-z, 0-9, _
+     * and - are allowed.
+     * @param value The value should contain 0-4096 characters. You can store up
+     * to 1024 keys in the cloud storage.
      * @param callback If an optional callback parameter was passed, the
      * callback function will be called. In case of an error, the first argument
      * will contain the error. In case of success, the first argument will be
@@ -656,15 +685,15 @@ interface CloudStorage {
      */
     setItem(key: string, value: string, callback?: CloudStorageSetItemCallback): CloudStorage;
     /**
-     * A method that receives a value from the cloud storage using
-     * the specified key.
+     * A method that receives a value from the cloud storage using the specified
+     * key.
      *
-     * @param key The key should contain 1-128 characters, only A-Z, a-z, 0-9,
-     * _ and - are allowed.
-     * @param callback In case of an error, the callback function will
-     * be called and the first argument will contain the error. In case of
-     * success, the first argument will be null and the value will be passed
-     * as the second argument.
+     * @param key The key should contain 1-128 characters, only A-Z, a-z, 0-9, _
+     * and - are allowed.
+     * @param callback In case of an error, the callback function will be called
+     * and the first argument will contain the error. In case of success, the
+     * first argument will be null and the value will be passed as the second
+     * argument.
      */
     getItem(key: string, callback?: CloudStorageGetItemCallback): CloudStorage;
     /**
@@ -674,22 +703,22 @@ interface CloudStorage {
      * @param key The keys should contain 1-128 characters, only A-Z, a-z, 0-9,
      * _ and - are allowed.
      * @param callback In case of an error, the callback? function will be
-     * called and the first argument will contain the error. In case of
-     * success, the first argument will be null and the values will be passed
-     * as the second argument.
+     * called and the first argument will contain the error. In case of success,
+     * the first argument will be null and the values will be passed as the
+     * second argument.
      */
     getItems(keys: string[], callback?: CloudStorageGetItemsCallback): CloudStorage;
     /**
      * A method that removes a value from the cloud storage using the specified
      * key.
      *
-     * @param key The key should contain 1-128 characters, only A-Z, a-z, 0-9,
-     * _ and - are allowed.
+     * @param key The key should contain 1-128 characters, only A-Z, a-z, 0-9, _
+     * and - are allowed.
      * @param callback If an optional callback parameter was passed, the
-     * callback function will be called. In case of an error, the first
-     * argument will contain the error. In case of success, the first
-     * argument will be null and the second argument will be a boolean
-     * indicating whether the value was removed.
+     * callback function will be called. In case of an error, the first argument
+     * will contain the error. In case of success, the first argument will be
+     * null and the second argument will be a boolean indicating whether the
+     * value was removed.
      */
     removeItem(key: string, callback?: CloudStorageRemoveItemCallback): CloudStorage;
     /**
@@ -699,10 +728,10 @@ interface CloudStorage {
      * @param key The keys should contain 1-128 characters, only A-Z, a-z, 0-9,
      * _ and - are allowed.
      * @param callback If an optional callback parameter was passed, the
-     * callback function will be called. In case of an error, the first
-     * argument will contain the error. In case of success, the first
-     * argument will be null and the second argument will be a boolean
-     * indicating whether the values were removed.
+     * callback function will be called. In case of an error, the first argument
+     * will contain the error. In case of success, the first argument will be
+     * null and the second argument will be a boolean indicating whether the
+     * values were removed.
      */
     removeItems(keys: string[], callback?: CloudStorageRemoveItemsCallback): CloudStorage;
     /**
@@ -724,8 +753,8 @@ type CloudStorageRemoveItemsCallback = (error: string | null, success: null | tr
 type CloudStorageGetKeysCallback = (error: string | null, keys: null | string[]) => void;
 
 /**
- * This object controls biometrics on the device. Before the first use
- * of this object, it needs to be initialized using the init method.
+ * This object controls biometrics on the device. Before the first use of this
+ * object, it needs to be initialized using the init method.
  */
 interface BiometricManager {
     /**
@@ -737,7 +766,8 @@ interface BiometricManager {
      */
     isBiometricAvailable: boolean;
     /**
-     * The type of biometrics currently available on the device. Can be one of these values:
+     * The type of biometrics currently available on the device. Can be one of
+     * these values:
      * - finger, fingerprint-based biometrics,
      * - face, face-based biometrics,
      * - unknown, biometrics of an unknown type.
@@ -756,30 +786,34 @@ interface BiometricManager {
      */
     isBiometricTokenSaved: boolean;
     /**
-     * A unique device identifier that can be used to match the token to the device.
+     * A unique device identifier that can be used to match the token to the
+     * device.
      */
     deviceId: string;
     /**
-     * A method that initializes the BiometricManager object. It should be called before
-     * the object's first use. If an optional callback parameter was passed, the callback
-     * function will be called when the object is initialized.
+     * A method that initializes the BiometricManager object. It should be
+     * called before the object's first use. If an optional callback parameter
+     * was passed, the callback function will be called when the object is
+     * initialized.
      */
     init: (callback?: () => void) => BiometricManager;
     /**
-     * A method that requests permission to use biometrics according to the params
-     * argument of type BiometricRequestAccessParams. If an optional callback
-     * parameter was passed, the callback function will be called and the first argument
-     * will be a boolean indicating whether the user granted access.
+     * A method that requests permission to use biometrics according to the
+     * params argument of type BiometricRequestAccessParams. If an optional
+     * callback parameter was passed, the callback function will be called and
+     * the first argument will be a boolean indicating whether the user granted
+     * access.
      */
     requestAccess: (
         params: BiometricRequestAccessParams,
         callback?: BiometricRequestAccessCallback,
     ) => BiometricManager;
     /**
-     * A method that authenticates the user using biometrics according to the params
-     * argument of type BiometricAuthenticateParams. If an optional callback parameter
-     * was passed, the callback function will be called and the first argument will be
-     * a boolean indicating whether the user authenticated successfully.
+     * A method that authenticates the user using biometrics according to the
+     * params argument of type BiometricAuthenticateParams. If an optional
+     * callback parameter was passed, the callback function will be called and
+     * the first argument will be a boolean indicating whether the user
+     * authenticated successfully.
      *
      * If so, the second argument will be a biometric token.
      */
@@ -788,21 +822,24 @@ interface BiometricManager {
         callback?: BiometricAuthenticateCallback,
     ) => BiometricManager;
     /**
-     * A method that updates the biometric token in secure storage on the device.
-     * To remove the token, pass an empty string. If an optional callback parameter
-     * was passed, the callback function will be called and the first argument will be
-     * a boolean indicating whether the token was updated.
+     * A method that updates the biometric token in secure storage on the
+     * device. To remove the token, pass an empty string. If an optional
+     * callback parameter was passed, the callback function will be called and
+     * the first argument will be a boolean indicating whether the token was
+     * updated.
      */
     updateBiometricToken: (
         token: string,
         callback?: BiometricUpdateBiometricTokenCallback,
     ) => BiometricManager;
     /**
-     * A method that opens the biometric access settings for bots. Useful when you
-     * need to request biometrics access to users who haven't granted it yet.
+     * A method that opens the biometric access settings for bots. Useful when
+     * you need to request biometrics access to users who haven't granted it
+     * yet.
      *
-     * Note that this method can be called only in response to user interaction with
-     * the Mini App interface (e.g. a click inside the Mini App or on the main button)
+     * Note that this method can be called only in response to user interaction
+     * with the Mini App interface (e.g. a click inside the Mini App or on the
+     * main button)
      */
     openSettings: () => BiometricManager;
 }
@@ -812,24 +849,26 @@ type BiometricAuthenticateCallback = (isAuthenticated: boolean, biometricToken?:
 type BiometricUpdateBiometricTokenCallback = (applied: boolean) => void;
 
 /**
- * This object describes the native popup for requesting permission to use biometrics.
+ * This object describes the native popup for requesting permission to use
+ * biometrics.
  */
 interface BiometricRequestAccessParams {
     /**
-     * The text to be displayed to a user in the popup describing why the bot needs
-     * access to biometrics, 0-128 characters.
+     * The text to be displayed to a user in the popup describing why the bot
+     * needs access to biometrics, 0-128 characters.
      */
     reason?: string;
 }
 
 /**
- * This object describes the native popup for authenticating the user using biometrics.
+ * This object describes the native popup for authenticating the user using
+ * biometrics.
  */
 interface BiometricAuthenticateParams {
     /**
-     * The text to be displayed to a user in the popup describing why you are asking them
-     * to authenticate and what action you will be taking based on that authentication,
-     * 0-128 characters.
+     * The text to be displayed to a user in the popup describing why you are
+     * asking them to authenticate and what action you will be taking based on
+     * that authentication, 0-128 characters.
      */
     reason?: string;
 }
@@ -840,16 +879,16 @@ interface BiometricAuthenticateParams {
  */
 interface WebAppInitData {
     /**
-     * A unique identifier for the Web App session, required for sending messages
-     * via the answerWebAppQuery method.
+     * A unique identifier for the Web App session, required for sending
+     * messages via the answerWebAppQuery method.
      */
     query_id?: string;
     /** An object containing data about the current user. */
     user?: WebAppUser;
     /**
-     * An object containing data about the chat partner of the current user in the
-     * chat where the bot was launched via the attachment menu. Returned only for
-     * Web Apps launched via the attachment menu.
+     * An object containing data about the chat partner of the current user in
+     * the chat where the bot was launched via the attachment menu. Returned
+     * only for Web Apps launched via the attachment menu.
      */
     receiver?: WebAppUser;
     /**
@@ -859,21 +898,21 @@ interface WebAppInitData {
      */
     chat?: WebAppChat;
     /**
-     * Type of the chat from which the Web App was opened.
-     * Can be either “sender” for a private chat with the user opening the link,
-     * “private”, “group”, “supergroup”, or “channel”.
-     * Returned only for Web Apps launched from direct links.
+     * Type of the chat from which the Web App was opened. Can be either
+     * “sender” for a private chat with the user opening the link, “private”,
+     * “group”, “supergroup”, or “channel”. Returned only for Web Apps launched
+     * from direct links.
      */
     chat_type?: "sender" | "private" | "group" | "supergroup" | "channel";
     /**
-     * Global identifier, uniquely corresponding to the chat from which the Web App was opened.
-     * Returned only for Web Apps launched from a direct link.
+     * Global identifier, uniquely corresponding to the chat from which the Web
+     * App was opened. Returned only for Web Apps launched from a direct link.
      */
     chat_instance?: string;
     /**
-     * The value of the startattach parameter, passed via link. Only returned for
-     * Web Apps when launched from the attachment menu via link. The value of the
-     * start_param parameter will also be passed in the GET-parameter
+     * The value of the startattach parameter, passed via link. Only returned
+     * for Web Apps when launched from the attachment menu via link. The value
+     * of the start_param parameter will also be passed in the GET-parameter
      * tgWebAppStartParam, so the Web App can load the correct interface right
      * away.
      */
@@ -895,11 +934,11 @@ interface WebAppInitData {
 /** This object contains the data of the Web App user. */
 interface WebAppUser {
     /**
-     * A unique identifier for the user or bot. This number may have more than 32
-     * significant bits and some programming languages may have difficulty/silent
-     * defects in interpreting it. It has at most 52 significant bits, so a 64-bit
-     * integer or a double-precision float type is safe for storing this
-     * identifier.
+     * A unique identifier for the user or bot. This number may have more than
+     * 32 significant bits and some programming languages may have
+     * difficulty/silent defects in interpreting it. It has at most 52
+     * significant bits, so a 64-bit integer or a double-precision float type is
+     * safe for storing this identifier.
      */
     id: number;
     /** True, if this user is a bot. Returns in the receiver field only. */
@@ -919,8 +958,8 @@ interface WebAppUser {
     /** True, if this user allowed the bot to message them. */
     allows_write_to_pm?: true;
     /**
-     * URL of the user’s profile photo. The photo can be in .jpeg or .svg formats.
-     * Only returned for Web Apps launched from the attachment menu.
+     * URL of the user’s profile photo. The photo can be in .jpeg or .svg
+     * formats. Only returned for Web Apps launched from the attachment menu.
      */
     photo_url?: string;
 }
@@ -967,16 +1006,17 @@ interface ScanQrPopupParams {
 }
 
 /**
- * This object describes contact information shared when requestContact was approved by the user.
+ * This object describes contact information shared when requestContact was
+ * approved by the user.
  */
 interface RequestContactResponseSent {
     /** Status 'sent' indicates that contact information has been shared. */
     status: "sent";
     /** A status message or result as a string. */
     response: string;
-    /** Contains sensitive information shared upon user consent. WARNING: Data from
-     * this field should not be trusted. You should only use data from `response` on
-     * the bot's server and only after it has been validated. */
+    /** Contains sensitive information shared upon user consent. WARNING: Data
+     * from this field should not be trusted. You should only use data from
+     * `response` on the bot's server and only after it has been validated. */
     responseUnsafe: {
         /** Authorization date for sharing contact information. */
         auth_date: string;
@@ -1000,7 +1040,8 @@ interface RequestContactResponseSent {
  * This object only contains a status to indicate the cancellation.
  */
 interface RequestContactResponseCancelled {
-    /** Status 'cancelled', indicates that user cancelled the contact share request. */
+    /** Status 'cancelled', indicates that user cancelled the contact share
+     * request. */
     status: "cancelled";
 }
 

--- a/types/telegram-web-app/telegram-web-app-tests.ts
+++ b/types/telegram-web-app/telegram-web-app-tests.ts
@@ -14,7 +14,7 @@ btn.onClick(() => {
     app.close();
 });
 
-app.onEvent("viewportChanged", e => {
+app.onEvent("viewportChanged", (e) => {
     if (e.isStateStable) console.log("Done at", app.viewportHeight);
     else console.log("Changing, currently at ", app.viewportHeight);
 });
@@ -24,10 +24,10 @@ app.showPopup(
         message: "Hello",
         buttons: [{ type: "default", text: "Button text", id: "btn_id" }],
     },
-    btn_id => console.log(btn_id),
+    (btn_id) => console.log(btn_id),
 );
 
-app.onEvent("popupClosed", e => {
+app.onEvent("popupClosed", (e) => {
     console.log(e.button_id);
 });
 
@@ -64,7 +64,7 @@ app.CloudStorage.getKeys((err, keys) => {
     }
 });
 
-app.requestWriteAccess(success => {
+app.requestWriteAccess((success) => {
     const test = success; // $ExpectType boolean
 });
 


### PR DESCRIPTION
This pull requests applies uniform formatting for the JSDoc tags. They have evolved to vary a lot in length, with inconsistent word wrapping all over the place.

Fortunately, there is https://marketplace.visualstudio.com/items?itemName=stkb.rewrap: an extension that can automatically rewrap text in comments. I simply applied this extension to the entire file.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://marketplace.visualstudio.com/items?itemName=stkb.rewrap