### PR TITLE
[node] Add generics to static members of `EventEmitter`

### DIFF
--- a/types/imap/index.d.ts
+++ b/types/imap/index.d.ts
@@ -267,18 +267,6 @@ declare namespace Connection {
 declare class Connection extends EventEmitter implements Connection.MessageFunctions {
     constructor(config: Connection.Config);
 
-    // from NodeJS.EventEmitter
-    addListener(event: string, listener: Function): this;
-    on(event: string, listener: Function): this;
-    once(event: string, listener: Function): this;
-    removeListener(event: string, listener: Function): this;
-    removeAllListeners(event?: string): this;
-    setMaxListeners(n: number): this;
-    getMaxListeners(): number;
-    listeners(event: string): Function[];
-    emit(event: string, ...args: any[]): boolean;
-    listenerCount(type: string): number;
-
     // from MessageFunctions
     /** Searches the currently open mailbox for messages using given criteria. criteria is a list describing what you want to find. For criteria types that require arguments, use an array instead of just the string criteria type name (e.g. ['FROM', 'foo@bar.com']). Prefix criteria types with an "!" to negate. */
     search(criteria: any[], callback: (error: Error, uids: number[]) => void): void;

--- a/types/jake/index.d.ts
+++ b/types/jake/index.d.ts
@@ -241,16 +241,6 @@ declare global {
              */
             reenable(): void;
 
-            addListener(event: string, listener: Function): this;
-            on(event: string, listener: Function): this;
-            once(event: string, listener: Function): this;
-            removeListener(event: string, listener: Function): this;
-            removeAllListeners(event?: string): this;
-            setMaxListeners(n: number): this;
-            getMaxListeners(): number;
-            listeners(event: string): Function[];
-            emit(event: string, ...args: any[]): boolean;
-            listenerCount(type: string): number;
             complete(value?: any): void;
             value: any;
 

--- a/types/newman/newman-tests.ts
+++ b/types/newman/newman-tests.ts
@@ -23,7 +23,7 @@ const workingDir = "path/to/working/directory";
 const insecureFileRead = true;
 const requestAgent = new http.Agent();
 
-// $ExpectType EventEmitter<DefaultEventMap>
+// $ExpectType EventEmitter<{}>
 run(
     {
         collection,

--- a/types/node-red/node-red-tests.ts
+++ b/types/node-red/node-red-tests.ts
@@ -23,7 +23,7 @@ async function REDTests() {
     // $ExpectType Util
     RED.util;
 
-    // $ExpectType EventEmitter<DefaultEventMap>
+    // $ExpectType EventEmitter<{}>
     RED.events;
 
     // $ExpectType Hooks

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -1,5 +1,3 @@
-declare const internalTypeOnlyBrandSymbol: unique symbol;
-
 /**
  * Much of the Node.js core API is built around an idiomatic asynchronous
  * event-driven architecture in which certain kinds of objects (called "emitters")
@@ -139,6 +137,11 @@ declare module "events" {
      */
     class EventEmitter<Events extends EventMap<Events> = {}> {
         constructor(options?: EventEmitterOptions);
+
+        // This "property" is used to brand a specific instance of the EventEmitter class with its Event map, which is needed
+        // in order to infer the map if we have a chain like `class A extends EventEmitter<{}>` (or many levels deep)
+        // It is also marked as possibly undefined in order to allow something like `const t: NodeJS.EventEmitter<{}> = { <insert implementation here> };`
+        readonly #internalTypeOnlyBrand?: Events;
 
         [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
             error: Error,
@@ -644,11 +647,6 @@ declare module "events" {
     global {
         namespace NodeJS {
             interface EventEmitter<Events extends EventMap<Events> = {}> {
-                // This "property" is used to brand a specific instance of the EventEmitter class with its Event map, which is needed
-                // in order to infer the map if we have a chain like `class A extends EventEmitter<{}>` (or many levels deep)
-                // It is also marked as possibly undefined in order to allow something like `const t: NodeJS.EventEmitter<{}> = { <insert implementation here> };`
-                readonly [internalTypeOnlyBrandSymbol]?: Events;
-
                 [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
                     error: Error,
                     event: EventName,

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -99,24 +99,27 @@ declare module "events" {
          */
         lowWaterMark?: number | undefined;
     }
-    interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
-    type EventMap<T> = Record<keyof T, any[]> | DefaultEventMap;
-    type DefaultEventMap = [never];
-    type AnyRest = [...args: any[]];
-    type Args<K, T> = T extends DefaultEventMap ? AnyRest : (
-        K extends keyof T ? T[K] : never
-    );
-    type Key<K, T> = T extends DefaultEventMap ? string | symbol : K | keyof T;
-    type Key2<K, T> = T extends DefaultEventMap ? string | symbol : K & keyof T;
-    type Listener<K, T, F> = T extends DefaultEventMap ? F : (
-        K extends keyof T ? (
-                T[K] extends unknown[] ? (...args: T[K]) => void : never
-            )
-            : never
-    );
-    type Listener1<K, T> = Listener<K, T, (...args: any[]) => void>;
-    type Listener2<K, T> = Listener<K, T, Function>;
-
+    interface EventEmitter<Events extends EventMap<Events> = {}> extends NodeJS.EventEmitter<Events> {}
+    type EventMap<Events> = Record<keyof Events, unknown[]>;
+    type Args<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ? (
+            | Events[EventName]
+            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
+                : never)
+        )
+        : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+            ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
+            : any[]);
+    type EventNames<Events extends EventMap<Events>> = {} extends Events ? (string | symbol)
+        : (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap);
+    type Listener<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ?
+            | ((...args: Events[EventName]) => void)
+            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
+                : never)
+        : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+            ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
+            : (...args: any[]) => void);
     /**
      * The `EventEmitter` class is defined and exposed by the `node:events` module:
      *
@@ -130,10 +133,15 @@ declare module "events" {
      * It supports the following option:
      * @since v0.1.26
      */
-    class EventEmitter<T extends EventMap<T> = DefaultEventMap> {
+    class EventEmitter<Events extends EventMap<Events> = {}> {
         constructor(options?: EventEmitterOptions);
 
-        [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
+        [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
+            error: Error,
+            event: EventName,
+            ...args: Args<Events, EventName>
+        ): void;
+        [EventEmitter.captureRejectionSymbol]?(error: Error, event: string | symbol, ...args: any[]): void;
 
         /**
          * Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
@@ -214,6 +222,11 @@ declare module "events" {
          * ```
          * @since v11.13.0, v10.16.0
          */
+        static once<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            eventName: EventName,
+            options?: StaticEventEmitterOptions,
+        ): Promise<Args<Events, EventName>>;
         static once(
             emitter: NodeJS.EventEmitter,
             eventName: string | symbol,
@@ -300,6 +313,11 @@ declare module "events" {
          * @since v13.6.0, v12.16.0
          * @return An `AsyncIterator` that iterates `eventName` events emitted by the `emitter`
          */
+        static on<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            eventName: EventName,
+            options?: StaticEventEmitterIteratorOptions,
+        ): NodeJS.AsyncIterator<Args<Events, EventName>>;
         static on(
             emitter: NodeJS.EventEmitter,
             eventName: string | symbol,
@@ -310,6 +328,27 @@ declare module "events" {
             eventName: string,
             options?: StaticEventEmitterIteratorOptions,
         ): NodeJS.AsyncIterator<any[]>;
+        /**
+         * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
+         *
+         * ```js
+         * import { EventEmitter, listenerCount } from 'node:events';
+         *
+         * const myEmitter = new EventEmitter();
+         * myEmitter.on('event', () => {});
+         * myEmitter.on('event', () => {});
+         * console.log(listenerCount(myEmitter, 'event'));
+         * // Prints: 2
+         * ```
+         * @since v0.9.12
+         * @deprecated Since v3.2.0 - Use `listenerCount` instead.
+         * @param emitter The emitter to query
+         * @param eventName The event name
+         */
+        static listenerCount<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            eventName: EventName,
+        ): number;
         /**
          * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
          *
@@ -355,7 +394,14 @@ declare module "events" {
          * ```
          * @since v15.2.0, v14.17.0
          */
-        static getEventListeners(emitter: EventTarget | NodeJS.EventEmitter, name: string | symbol): Function[];
+        static getEventListeners<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            name: EventName,
+        ): Array<Listener<Events, EventName>>;
+        static getEventListeners(
+            emitter: EventTarget | NodeJS.EventEmitter,
+            name: string | symbol,
+        ): Function[];
         /**
          * Returns the currently set max amount of listeners.
          *
@@ -585,16 +631,37 @@ declare module "events" {
              */
             readonly asyncResource: EventEmitterReferencingAsyncResource;
         }
+
+        export interface EventEmitterBuiltInEventMap {
+            newListener: [eventName: string | symbol, listener: Function];
+            removeListener: [eventName: string | symbol, listener: Function];
+        }
     }
     global {
         namespace NodeJS {
-            interface EventEmitter<T extends EventMap<T> = DefaultEventMap> {
-                [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
+            interface EventEmitter<Events extends EventMap<Events> = {}> {
+                [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
+                    error: Error,
+                    event: EventName,
+                    ...args: Args<Events, EventName>
+                ): void;
+                [EventEmitter.captureRejectionSymbol]?<EventName extends string | symbol>(
+                    error: Error,
+                    event: EventName,
+                    ...args: Args<Events, EventName>
+                ): void;
                 /**
                  * Alias for `emitter.on(eventName, listener)`.
                  * @since v0.1.26
                  */
-                addListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                addListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                addListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Adds the `listener` function to the end of the listeners array for the event
                  * named `eventName`. No checks are made to see if the `listener` has already
@@ -626,7 +693,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                on<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                on<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                on<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Adds a **one-time** `listener` function for the event named `eventName`. The
                  * next time `eventName` is triggered, this listener is removed and then invoked.
@@ -656,7 +730,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                once<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                once<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                once<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Removes the specified `listener` from the listener array for the event named `eventName`.
                  *
@@ -739,12 +820,26 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                removeListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                removeListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Alias for `emitter.removeListener()`.
                  * @since v10.0.0
                  */
-                off<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                off<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                off<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Removes all listeners, or those of the specified `eventName`.
                  *
@@ -755,7 +850,10 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeAllListeners(eventName?: Key<unknown, T>): this;
+                /* eslint-disable @definitelytyped/no-unnecessary-generics */
+                removeAllListeners<EventName extends EventNames<Events>>(eventName: EventName): this;
+                removeAllListeners<EventName extends string | symbol>(eventName?: EventName): this;
+                /* eslint-enable @definitelytyped/no-unnecessary-generics */
                 /**
                  * By default `EventEmitter`s will print a warning if more than `10` listeners are
                  * added for a particular event. This is a useful default that helps finding
@@ -784,7 +882,12 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                listeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
+                listeners<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
+                listeners<EventName extends string | symbol>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
                  * including any wrappers (such as those created by `.once()`).
@@ -815,7 +918,12 @@ declare module "events" {
                  * ```
                  * @since v9.4.0
                  */
-                rawListeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
+                rawListeners<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
+                rawListeners<EventName extends string | symbol>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
                 /**
                  * Synchronously calls each of the listeners registered for the event named `eventName`, in the order they were registered, passing the supplied arguments
                  * to each.
@@ -856,7 +964,14 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                emit<K>(eventName: Key<K, T>, ...args: Args<K, T>): boolean;
+                emit<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    ...args: Args<Events, EventName>
+                ): boolean;
+                emit<EventName extends string | symbol>(
+                    eventName: EventName,
+                    ...args: Args<Events, EventName>
+                ): boolean;
                 /**
                  * Returns the number of listeners listening for the event named `eventName`.
                  * If `listener` is provided, it will return how many times the listener is found
@@ -865,7 +980,14 @@ declare module "events" {
                  * @param eventName The name of the event being listened for
                  * @param listener The event handler function
                  */
-                listenerCount<K>(eventName: Key<K, T>, listener?: Listener2<K, T>): number;
+                listenerCount<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener?: Listener<Events, EventName>,
+                ): number;
+                listenerCount<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener?: Listener<Events, EventName>,
+                ): number;
                 /**
                  * Adds the `listener` function to the _beginning_ of the listeners array for the
                  * event named `eventName`. No checks are made to see if the `listener` has
@@ -883,7 +1005,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                prependListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                prependListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Adds a **one-time**`listener` function for the event named `eventName` to the _beginning_ of the listeners array. The next time `eventName` is triggered, this
                  * listener is removed, and then invoked.
@@ -899,7 +1028,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependOnceListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                prependOnceListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                prependOnceListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Returns an array listing the events for which the emitter has registered
                  * listeners. The values in the array are strings or `Symbol`s.
@@ -919,7 +1055,7 @@ declare module "events" {
                  * ```
                  * @since v6.0.0
                  */
-                eventNames(): Array<(string | symbol) & Key2<unknown, T>>;
+                eventNames(): Array<(string | symbol)> & Array<EventNames<Events>>;
             }
         }
     }

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -1,3 +1,5 @@
+declare const internalTypeOnlyBrandSymbol: unique symbol;
+
 /**
  * Much of the Node.js core API is built around an idiomatic asynchronous
  * event-driven architecture in which certain kinds of objects (called "emitters")
@@ -34,6 +36,7 @@
  * ```
  * @see [source](https://github.com/nodejs/node/blob/v22.x/lib/events.js)
  */
+
 declare module "events" {
     import { AsyncResource, AsyncResourceOptions } from "node:async_hooks";
     // NOTE: This class is in the docs but is **not actually exported** by Node.
@@ -120,6 +123,7 @@ declare module "events" {
         : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
             ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
             : (...args: any[]) => void);
+
     /**
      * The `EventEmitter` class is defined and exposed by the `node:events` module:
      *
@@ -640,6 +644,11 @@ declare module "events" {
     global {
         namespace NodeJS {
             interface EventEmitter<Events extends EventMap<Events> = {}> {
+                // This "property" is used to brand a specific instance of the EventEmitter class with its Event map, which is needed
+                // in order to infer the map if we have a chain like `class A extends EventEmitter<{}>` (or many levels deep)
+                // It is also marked as possibly undefined in order to allow something like `const t: NodeJS.EventEmitter<{}> = { <insert implementation here> };`
+                readonly [internalTypeOnlyBrandSymbol]?: Events;
+
                 [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
                     error: Error,
                     event: EventName,

--- a/types/node/test/events.ts
+++ b/types/node/test/events.ts
@@ -31,7 +31,7 @@ declare const any: any;
     result = emitter.getMaxListeners();
     result = emitter.listenerCount(event);
 
-    const handler: Function = () => {};
+    const handler = () => {};
     result = emitter.listenerCount(event, handler);
 }
 
@@ -141,7 +141,7 @@ async function testEventTarget() {
     captureRejectionSymbol2 = events.captureRejectionSymbol;
 
     const emitter = new events.EventEmitter();
-    emitter[events.captureRejectionSymbol] = (err: Error, name: string, ...args: any[]) => {};
+    emitter[events.captureRejectionSymbol] = (err: Error, name: string | symbol, ...args: any[]) => {};
 }
 
 {
@@ -193,16 +193,16 @@ async function testEventTarget() {
 
 {
     class MyEmitter extends events.EventEmitter {
-        addListener(event: string, listener: () => void): this {
+        addListener(event: string | symbol, listener: () => void): this {
             return this;
         }
-        listeners(event: string): Array<() => void> {
+        listeners(event: string | symbol): Array<() => void> {
             return [];
         }
-        emit(event: string, ...args: any[]): boolean {
+        emit(event: string | symbol, ...args: any[]): boolean {
             return true;
         }
-        listenerCount(type: string): number {
+        listenerCount(type: string | symbol): number {
             return 0;
         }
     }

--- a/types/node/test/events_generic.ts
+++ b/types/node/test/events_generic.ts
@@ -299,4 +299,18 @@ declare const event5: "event5";
 
     events.on(doubleExtended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
     events.once(doubleExtended, "unknown"); // $ExpectType Promise<any[]>
+
+    extended.addListener(event1, (a: string, b: number | boolean): number => 1);
+    doubleExtended.addListener(event1, (a: string, b: number | boolean): number => 1);
+    // @ts-expect-error
+    extended.addListener(event1, (a: string, b: boolean): number => 1);
+    // @ts-expect-error
+    doubleExtended.addListener(event1, (a: string, b: boolean): number => 1);
+
+    extended.emit("event1", "hello", 42);
+    doubleExtended.emit("event1", "hello", 42);
+    // @ts-expect-error
+    extended.emit("event1", 123);
+    // @ts-expect-error
+    doubleExtended.emit("event1", 123);
 }

--- a/types/node/test/events_generic.ts
+++ b/types/node/test/events_generic.ts
@@ -110,13 +110,17 @@ declare const event5: "event5";
 }
 
 {
-    let result: Promise<number[]>;
+    let result1: Promise<T["event1"]>;
+    let result2: Promise<T["event2"]>;
+    let result3: Promise<T["event3"]>;
+    let result4: Promise<T["event4"]>;
+    let result5: Promise<T["event5"]>;
 
-    result = events.once(emitter, event1);
-    result = events.once(emitter, event2);
-    result = events.once(emitter, event3);
-    result = events.once(emitter, event4);
-    result = events.once(emitter, event5);
+    result1 = events.once(emitter, event1);
+    result2 = events.once(emitter, event2);
+    result3 = events.once(emitter, event3);
+    result4 = events.once(emitter, event4);
+    result5 = events.once(emitter, event5);
 
     emitter.emit("event1", "hello", 42);
     emitter.emit("event2", true);
@@ -146,7 +150,7 @@ declare const event5: "event5";
 }
 
 {
-    let result: Array<keyof T>;
+    let result: Array<keyof T | keyof events.EventEmitterBuiltInEventMap>;
 
     result = emitter.eventNames();
 }
@@ -157,12 +161,12 @@ declare const event5: "event5";
         )
         : never;
 
-    function on1<K>(event: K, listener: Listener<K>): void {
+    function on1<K extends keyof T>(event: K, listener: Listener<K>): void {
         emitter.on(event, listener);
     }
 
     // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-    function on2<K>(...args: Parameters<typeof emitter.on<K>>): void {
+    function on2<K extends keyof T>(...args: Parameters<typeof emitter.on<K>>): void {
         emitter.on(...args);
     }
 
@@ -204,7 +208,6 @@ declare const event5: "event5";
     emitter.emit("abc", "hello", 123);
     // @ts-expect-error
     emitter.emit("abc", 123, false);
-    // @ts-expect-error
     emitter.emit("def", "hello", 123);
 }
 
@@ -226,7 +229,6 @@ declare const event5: "event5";
     emitter.emit(s1, "hello", 123);
     // @ts-expect-error
     emitter.emit(s1, 123, false);
-    // @ts-expect-error
     emitter.emit(s2, "hello", 123);
 }
 
@@ -244,6 +246,36 @@ declare const event5: "event5";
     emitter.emit(789, 123, false);
     // @ts-expect-error
     emitter.emit(s1, "hello", false);
-    // @ts-expect-error
     emitter.emit(s2, "hello", false);
+}
+
+{
+    const promise1: Promise<[string, number]> = events.once(new events.EventEmitter<T>(), "event1");
+    const promise2: Promise<[boolean]> = events.once(new events.EventEmitter<T>(), "event2");
+    const promise3: Promise<[]> = events.once(new events.EventEmitter<T>(), "event3");
+    const promise4: Promise<string[]> = events.once(new events.EventEmitter<T>(), "event4");
+    const promise5: Promise<unknown[]> = events.once(new events.EventEmitter<T>(), "event5");
+    // @ts-expect-error
+    const promise6: Promise<[string, string]> = events.once(new events.EventEmitter<T>(), "event1");
+    const promise7: Promise<any[]> = events.once(new events.EventEmitter<T>(), "event");
+
+    const iterable1: NodeJS.AsyncIterator<[string, number]> = events.on(new events.EventEmitter<T>(), "event1");
+    const iterable2: NodeJS.AsyncIterator<[boolean]> = events.on(new events.EventEmitter<T>(), "event2");
+    const iterable3: NodeJS.AsyncIterator<[]> = events.on(new events.EventEmitter<T>(), "event3");
+    const iterable4: NodeJS.AsyncIterator<string[]> = events.on(new events.EventEmitter<T>(), "event4");
+    const iterable5: NodeJS.AsyncIterator<unknown[]> = events.on(new events.EventEmitter<T>(), "event5");
+    // @ts-expect-error
+    const iterable6: NodeJS.AsyncIterator<[string, string]> = events.on(new events.EventEmitter<T>(), "event1");
+    const iterable7: NodeJS.AsyncIterator<any[]> = events.on(new events.EventEmitter<T>(), "event");
+}
+
+{
+    function acceptsEventEmitterInterface(eventEmitter: NodeJS.EventEmitter) {
+    }
+
+    function acceptsEventEmitterClass(eventEmitter: events.EventEmitter) {
+    }
+
+    acceptsEventEmitterInterface(emitter);
+    acceptsEventEmitterClass(emitter);
 }

--- a/types/node/test/events_generic.ts
+++ b/types/node/test/events_generic.ts
@@ -279,3 +279,24 @@ declare const event5: "event5";
     acceptsEventEmitterInterface(emitter);
     acceptsEventEmitterClass(emitter);
 }
+
+{
+    class Extended extends events.EventEmitter<T> {}
+
+    class DoubleExtension extends Extended {}
+
+    const extended = new Extended();
+    const doubleExtended = new DoubleExtension();
+
+    events.on(extended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
+    events.once(extended, "event1"); // $ExpectType Promise<[string, number]>
+
+    events.on(extended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
+    events.once(extended, "unknown"); // $ExpectType Promise<any[]>
+
+    events.on(doubleExtended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
+    events.once(doubleExtended, "event1"); // $ExpectType Promise<[string, number]>
+
+    events.on(doubleExtended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
+    events.once(doubleExtended, "unknown"); // $ExpectType Promise<any[]>
+}

--- a/types/node/v16/events.d.ts
+++ b/types/node/v16/events.d.ts
@@ -1,3 +1,5 @@
+declare const internalTypeOnlyBrandSymbol: unique symbol;
+
 /**
  * Much of the Node.js core API is built around an idiomatic asynchronous
  * event-driven architecture in which certain kinds of objects (called "emitters")
@@ -34,6 +36,7 @@
  * ```
  * @see [source](https://github.com/nodejs/node/blob/v16.9.0/lib/events.js)
  */
+
 declare module "events" {
     import { AsyncResource, AsyncResourceOptions } from "node:async_hooks";
 
@@ -56,6 +59,9 @@ declare module "events" {
         ): any;
     }
     interface StaticEventEmitterOptions {
+        /**
+         * Can be used to cancel awaiting events.
+         */
         signal?: AbortSignal | undefined;
     }
     interface EventEmitter<Events extends EventMap<Events> = {}> extends NodeJS.EventEmitter<Events> {}
@@ -79,7 +85,7 @@ declare module "events" {
         : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
             ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
             : (...args: any[]) => void);
-    /**
+
     /**
      * The `EventEmitter` class is defined and exposed by the `events` module:
      *
@@ -140,7 +146,7 @@ declare module "events" {
          * run();
          * ```
          *
-         * The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
+         * The special handling of the `'error'` event is only used when `events.once()` is used to wait for another event. If `events.once()` is used to wait for the
          * '`error'` event itself, then it is treated as any other kind of event without
          * special handling:
          *
@@ -151,7 +157,7 @@ declare module "events" {
          *
          * once(ee, 'error')
          *   .then(([err]) => console.log('ok', err.message))
-         *   .catch((err) => console.log('error', err.message));
+         *   .catch((err) => console.error('error', err.message));
          *
          * ee.emit('error', new Error('boom'));
          *
@@ -188,7 +194,7 @@ declare module "events" {
         static once<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
             emitter: EventEmitter<Events>,
             eventName: EventName,
-            options?: Pick<StaticEventEmitterOptions, "signal">,
+            options?: StaticEventEmitterOptions,
         ): Promise<Args<Events, EventName>>;
         static once(
             emitter: NodeEventTarget,
@@ -251,8 +257,7 @@ declare module "events" {
          * process.nextTick(() => ac.abort());
          * ```
          * @since v13.6.0, v12.16.0
-         * @param eventName The name of the event being listened for
-         * @return that iterates `eventName` events emitted by the `emitter`
+         * @return An `AsyncIterator` that iterates `eventName` events emitted by the `emitter`
          */
         static on<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
             emitter: EventEmitter<Events>,
@@ -261,11 +266,11 @@ declare module "events" {
         ): NodeJS.AsyncIterator<Args<Events, EventName>>;
         static on(
             emitter: NodeJS.EventEmitter,
-            eventName: string,
+            eventName: string | symbol,
             options?: StaticEventEmitterOptions,
-        ): NodeJS.AsyncIterator<any>;
+        ): NodeJS.AsyncIterator<any[]>;
         /**
-         * A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
+         * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
          *
          * ```js
          * import { EventEmitter, listenerCount } from 'node:events';
@@ -285,10 +290,11 @@ declare module "events" {
             eventName: EventName,
         ): number;
         /**
-         * A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
+         * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
          *
          * ```js
          * const { EventEmitter, listenerCount } = require('events');
+         *
          * const myEmitter = new EventEmitter();
          * myEmitter.on('event', () => {});
          * myEmitter.on('event', () => {});
@@ -317,16 +323,16 @@ declare module "events" {
          *   const ee = new EventEmitter();
          *   const listener = () => console.log('Events are fun');
          *   ee.on('foo', listener);
-         *   getEventListeners(ee, 'foo'); // [listener]
+         *   console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
          * }
          * {
          *   const et = new EventTarget();
          *   const listener = () => console.log('Events are fun');
          *   et.addEventListener('foo', listener);
-         *   getEventListeners(et, 'foo'); // [listener]
+         *   console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
          * }
          * ```
-         * @since v15.2.0
+         * @since v15.2.0, v14.17.0
          */
         static getEventListeners<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
             emitter: EventEmitter<Events>,
@@ -352,21 +358,65 @@ declare module "events" {
          */
         static setMaxListeners(n?: number, ...eventTargets: Array<DOMEventTarget | NodeJS.EventEmitter>): void;
         /**
-         * This symbol shall be used to install a listener for only monitoring `'error'`
-         * events. Listeners installed using this symbol are called before the regular
-         * `'error'` listeners are called.
+         * This symbol shall be used to install a listener for only monitoring `'error'` events. Listeners installed using this symbol are called before the regular `'error'` listeners are called.
          *
-         * Installing a listener using this symbol does not change the behavior once an
-         * `'error'` event is emitted, therefore the process will still crash if no
+         * Installing a listener using this symbol does not change the behavior once an `'error'` event is emitted. Therefore, the process will still crash if no
          * regular `'error'` listener is installed.
+         * @since v13.6.0, v12.17.0
          */
         static readonly errorMonitor: unique symbol;
+        /**
+         * Value: `Symbol.for('nodejs.rejection')`
+         *
+         * See how to write a custom `rejection handler`.
+         * @since v13.4.0, v12.16.0
+         */
         static readonly captureRejectionSymbol: unique symbol;
         /**
-         * Sets or gets the default captureRejection value for all emitters.
+         * Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+         *
+         * Change the default `captureRejections` option on all new `EventEmitter` objects.
+         * @since v13.4.0, v12.16.0
          */
-        // TODO: These should be described using static getter/setter pairs:
         static captureRejections: boolean;
+        /**
+         * By default, a maximum of `10` listeners can be registered for any single
+         * event. This limit can be changed for individual `EventEmitter` instances
+         * using the `emitter.setMaxListeners(n)` method. To change the default
+         * for _all_`EventEmitter` instances, the `events.defaultMaxListeners` property
+         * can be used. If this value is not a positive number, a `RangeError` is thrown.
+         *
+         * Take caution when setting the `events.defaultMaxListeners` because the
+         * change affects _all_ `EventEmitter` instances, including those created before
+         * the change is made. However, calling `emitter.setMaxListeners(n)` still has
+         * precedence over `events.defaultMaxListeners`.
+         *
+         * This is not a hard limit. The `EventEmitter` instance will allow
+         * more listeners to be added but will output a trace warning to stderr indicating
+         * that a "possible EventEmitter memory leak" has been detected. For any single
+         * `EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()` methods can be used to
+         * temporarily avoid this warning:
+         *
+         * ```js
+         * const EventEmitter = require('events');
+         * const emitter = new EventEmitter();
+         * emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+         * emitter.once('event', () => {
+         *   // do stuff
+         *   emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+         * });
+         * ```
+         *
+         * The `--trace-warnings` command-line flag can be used to display the
+         * stack trace for such warnings.
+         *
+         * The emitted warning can be inspected with `process.on('warning')` and will
+         * have the additional `emitter`, `type`, and `count` properties, referring to
+         * the event emitter instance, the event's name and the number of attached
+         * listeners, respectively.
+         * Its `name` property is set to `'MaxListenersExceededWarning'`.
+         * @since v0.11.2
+         */
         static defaultMaxListeners: number;
     }
     import internal = require("node:events");
@@ -394,13 +444,41 @@ declare module "events" {
         }
 
         /**
-         * Integrates `EventEmitter` with `AsyncResource` for `EventEmitter`s that require
-         * manual async tracking. Specifically, all events emitted by instances of
-         * `EventEmitterAsyncResource` will run within its async context.
+         * Integrates `EventEmitter` with `AsyncResource` for `EventEmitter`s that
+         * require manual async tracking. Specifically, all events emitted by instances
+         * of `events.EventEmitterAsyncResource` will run within its `async context`.
          *
-         * The EventEmitterAsyncResource class has the same methods and takes the
-         * same options as EventEmitter and AsyncResource themselves.
-         * @throws if `options.name` is not provided when instantiated directly.
+         * ```js
+         * const { EventEmitterAsyncResource, EventEmitter } = require('events');
+         * const { notStrictEqual, strictEqual } = require('assert');
+         * const { executionAsyncId, triggerAsyncId } = require('async_hooks');
+         *
+         * // Async tracking tooling will identify this as 'Q'.
+         * const ee1 = new EventEmitterAsyncResource({ name: 'Q' });
+         *
+         * // 'foo' listeners will run in the EventEmitters async context.
+         * ee1.on('foo', () => {
+         *   strictEqual(executionAsyncId(), ee1.asyncId);
+         *   strictEqual(triggerAsyncId(), ee1.triggerAsyncId);
+         * });
+         *
+         * const ee2 = new EventEmitter();
+         *
+         * // 'foo' listeners on ordinary EventEmitters that do not track async
+         * // context, however, run in the same async context as the emit().
+         * ee2.on('foo', () => {
+         *   notStrictEqual(executionAsyncId(), ee2.asyncId);
+         *   notStrictEqual(triggerAsyncId(), ee2.triggerAsyncId);
+         * });
+         *
+         * Promise.resolve().then(() => {
+         *   ee1.emit('foo');
+         *   ee2.emit('foo');
+         * });
+         * ```
+         *
+         * The `EventEmitterAsyncResource` class has the same methods and takes the
+         * same options as `EventEmitter` and `AsyncResource` themselves.
          * @since v17.4.0, v16.14.0
          */
         export class EventEmitterAsyncResource extends EventEmitter {
@@ -409,17 +487,24 @@ declare module "events" {
              */
             constructor(options?: EventEmitterAsyncResourceOptions);
             /**
-             * Call all destroy hooks. This should only ever be called once. An
-             * error will be thrown if it is called more than once. This must be
-             * manually called. If the resource is left to be collected by the GC then
-             * the destroy hooks will never be called.
+             * Call all `destroy` hooks. This should only ever be called once. An error will
+             * be thrown if it is called more than once. This **must** be manually called. If
+             * the resource is left to be collected by the GC then the `destroy` hooks will
+             * never be called.
              */
             emitDestroy(): void;
-            /** The unique asyncId assigned to the resource. */
+            /**
+             * The unique `asyncId` assigned to the resource.
+             */
             readonly asyncId: number;
-            /** The same triggerAsyncId that is passed to the AsyncResource constructor. */
+            /**
+             * The same triggerAsyncId that is passed to the AsyncResource constructor.
+             */
             readonly triggerAsyncId: number;
-            /** The underlying AsyncResource */
+            /**
+             * The returned `AsyncResource` object has an additional `eventEmitter` property
+             * that provides a reference to this `EventEmitterAsyncResource`.
+             */
             readonly asyncResource: EventEmitterReferencingAsyncResource;
         }
 
@@ -431,6 +516,11 @@ declare module "events" {
     global {
         namespace NodeJS {
             interface EventEmitter<Events extends EventMap<Events> = {}> {
+                // This "property" is used to brand a specific instance of the EventEmitter class with its Event map, which is needed
+                // in order to infer the map if we have a chain like `class A extends EventEmitter<{}>` (or many levels deep)
+                // It is also marked as possibly undefined in order to allow something like `const t: NodeJS.EventEmitter<{}> = { <insert implementation here> };`
+                readonly [internalTypeOnlyBrandSymbol]?: Events;
+
                 [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
                     error: Error,
                     event: EventName,
@@ -454,10 +544,10 @@ declare module "events" {
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
-                 * Adds the `listener` function to the end of the listeners array for the
-                 * event named `eventName`. No checks are made to see if the `listener` has
-                 * already been added. Multiple calls passing the same combination of `eventName` and `listener` will result in the `listener` being added, and called, multiple
-                 * times.
+                 * Adds the `listener` function to the end of the listeners array for the event
+                 * named `eventName`. No checks are made to see if the `listener` has already
+                 * been added. Multiple calls passing the same combination of `eventName` and
+                 * `listener` will result in the `listener` being added, and called, multiple times.
                  *
                  * ```js
                  * server.on('connection', (stream) => {
@@ -467,10 +557,11 @@ declare module "events" {
                  *
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  *
-                 * By default, event listeners are invoked in the order they are added. The`emitter.prependListener()` method can be used as an alternative to add the
+                 * By default, event listeners are invoked in the order they are added. The `emitter.prependListener()` method can be used as an alternative to add the
                  * event listener to the beginning of the listeners array.
                  *
                  * ```js
+                 * const EventEmitter = require('events');
                  * const myEE = new EventEmitter();
                  * myEE.on('foo', () => console.log('a'));
                  * myEE.prependListener('foo', () => console.log('b'));
@@ -492,7 +583,7 @@ declare module "events" {
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
-                 * Adds a **one-time**`listener` function for the event named `eventName`. The
+                 * Adds a **one-time** `listener` function for the event named `eventName`. The
                  * next time `eventName` is triggered, this listener is removed and then invoked.
                  *
                  * ```js
@@ -503,10 +594,11 @@ declare module "events" {
                  *
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  *
-                 * By default, event listeners are invoked in the order they are added. The`emitter.prependOnceListener()` method can be used as an alternative to add the
+                 * By default, event listeners are invoked in the order they are added. The `emitter.prependOnceListener()` method can be used as an alternative to add the
                  * event listener to the beginning of the listeners array.
                  *
                  * ```js
+                 * const EventEmitter = require('events');
                  * const myEE = new EventEmitter();
                  * myEE.once('foo', () => console.log('a'));
                  * myEE.prependOnceListener('foo', () => console.log('b'));
@@ -528,7 +620,7 @@ declare module "events" {
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
-                 * Removes the specified `listener` from the listener array for the event named`eventName`.
+                 * Removes the specified `listener` from the listener array for the event named `eventName`.
                  *
                  * ```js
                  * const callback = (stream) => {
@@ -545,10 +637,12 @@ declare module "events" {
                  * called multiple times to remove each instance.
                  *
                  * Once an event is emitted, all listeners attached to it at the
-                 * time of emitting are called in order. This implies that any`removeListener()` or `removeAllListeners()` calls _after_ emitting and_before_ the last listener finishes execution will
-                 * not remove them from`emit()` in progress. Subsequent events behave as expected.
+                 * time of emitting are called in order. This implies that any `removeListener()` or `removeAllListeners()` calls _after_ emitting and _before_ the last listener finishes execution
+                 * will not remove them from`emit()` in progress. Subsequent events behave as expected.
                  *
                  * ```js
+                 * const EventEmitter = require('events');
+                 * class MyEmitter extends EventEmitter {}
                  * const myEmitter = new MyEmitter();
                  *
                  * const callbackA = () => {
@@ -586,9 +680,10 @@ declare module "events" {
                  *
                  * When a single function has been added as a handler multiple times for a single
                  * event (as in the example below), `removeListener()` will remove the most
-                 * recently added instance. In the example the `once('ping')`listener is removed:
+                 * recently added instance. In the example the `once('ping')` listener is removed:
                  *
                  * ```js
+                 * const EventEmitter = require('events');
                  * const ee = new EventEmitter();
                  *
                  * function pong() {
@@ -644,7 +739,7 @@ declare module "events" {
                  * By default `EventEmitter`s will print a warning if more than `10` listeners are
                  * added for a particular event. This is a useful default that helps finding
                  * memory leaks. The `emitter.setMaxListeners()` method allows the limit to be
-                 * modified for this specific `EventEmitter` instance. The value can be set to`Infinity` (or `0`) to indicate an unlimited number of listeners.
+                 * modified for this specific `EventEmitter` instance. The value can be set to `Infinity` (or `0`) to indicate an unlimited number of listeners.
                  *
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.3.5
@@ -679,6 +774,7 @@ declare module "events" {
                  * including any wrappers (such as those created by `.once()`).
                  *
                  * ```js
+                 * const EventEmitter = require('events');
                  * const emitter = new EventEmitter();
                  * emitter.once('log', () => console.log('log once'));
                  *
@@ -710,7 +806,7 @@ declare module "events" {
                     eventName: EventName,
                 ): Array<Listener<Events, EventName>>;
                 /**
-                 * Synchronously calls each of the listeners registered for the event named`eventName`, in the order they were registered, passing the supplied arguments
+                 * Synchronously calls each of the listeners registered for the event named `eventName`, in the order they were registered, passing the supplied arguments
                  * to each.
                  *
                  * Returns `true` if the event had listeners, `false` otherwise.
@@ -758,9 +854,12 @@ declare module "events" {
                     ...args: Args<Events, EventName>
                 ): boolean;
                 /**
-                 * Returns the number of listeners listening to the event named `eventName`.
+                 * Returns the number of listeners listening for the event named `eventName`.
+                 * If `listener` is provided, it will return how many times the listener is found
+                 * in the list of the listeners of the event.
                  * @since v3.2.0
                  * @param eventName The name of the event being listened for
+                 * @param listener The event handler function
                  */
                 listenerCount<EventName extends EventNames<Events>>(
                     eventName: EventName,
@@ -773,8 +872,8 @@ declare module "events" {
                 /**
                  * Adds the `listener` function to the _beginning_ of the listeners array for the
                  * event named `eventName`. No checks are made to see if the `listener` has
-                 * already been added. Multiple calls passing the same combination of `eventName` and `listener` will result in the `listener` being added, and called, multiple
-                 * times.
+                 * already been added. Multiple calls passing the same combination of `eventName`
+                 * and `listener` will result in the `listener` being added, and called, multiple times.
                  *
                  * ```js
                  * server.prependListener('connection', (stream) => {
@@ -796,7 +895,7 @@ declare module "events" {
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
-                 * Adds a **one-time**`listener` function for the event named `eventName` to the_beginning_ of the listeners array. The next time `eventName` is triggered, this
+                 * Adds a **one-time**`listener` function for the event named `eventName` to the _beginning_ of the listeners array. The next time `eventName` is triggered, this
                  * listener is removed, and then invoked.
                  *
                  * ```js

--- a/types/node/v16/events.d.ts
+++ b/types/node/v16/events.d.ts
@@ -58,23 +58,28 @@ declare module "events" {
     interface StaticEventEmitterOptions {
         signal?: AbortSignal | undefined;
     }
-    interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
-    type EventMap<T> = Record<keyof T, any[]> | DefaultEventMap;
-    type DefaultEventMap = [never];
-    type AnyRest = [...args: any[]];
-    type Args<K, T> = T extends DefaultEventMap ? AnyRest : (
-        K extends keyof T ? T[K] : never
-    );
-    type Key<K, T> = T extends DefaultEventMap ? string | symbol : K | keyof T;
-    type Key2<K, T> = T extends DefaultEventMap ? string | symbol : K & keyof T;
-    type Listener<K, T, F> = T extends DefaultEventMap ? F : (
-        K extends keyof T ? (
-                T[K] extends unknown[] ? (...args: T[K]) => void : never
-            )
-            : never
-    );
-    type Listener1<K, T> = Listener<K, T, (...args: any[]) => void>;
-    type Listener2<K, T> = Listener<K, T, Function>;
+    interface EventEmitter<Events extends EventMap<Events> = {}> extends NodeJS.EventEmitter<Events> {}
+    type EventMap<Events> = Record<keyof Events, unknown[]>;
+    type Args<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ? (
+            | Events[EventName]
+            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
+                : never)
+        )
+        : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+            ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
+            : any[]);
+    type EventNames<Events extends EventMap<Events>> = {} extends Events ? (string | symbol)
+        : (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap);
+    type Listener<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ?
+            | ((...args: Events[EventName]) => void)
+            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
+                : never)
+        : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+            ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
+            : (...args: any[]) => void);
+    /**
     /**
      * The `EventEmitter` class is defined and exposed by the `events` module:
      *
@@ -88,10 +93,15 @@ declare module "events" {
      * It supports the following option:
      * @since v0.1.26
      */
-    class EventEmitter<T extends EventMap<T> = DefaultEventMap> {
+    class EventEmitter<Events extends EventMap<Events> = {}> {
         constructor(options?: EventEmitterOptions);
 
-        [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
+        [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
+            error: Error,
+            event: EventName,
+            ...args: Args<Events, EventName>
+        ): void;
+        [EventEmitter.captureRejectionSymbol]?(error: Error, event: string | symbol, ...args: any[]): void;
 
         /**
          * Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
@@ -175,6 +185,11 @@ declare module "events" {
          * ```
          * @since v11.13.0, v10.16.0
          */
+        static once<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            eventName: EventName,
+            options?: Pick<StaticEventEmitterOptions, "signal">,
+        ): Promise<Args<Events, EventName>>;
         static once(
             emitter: NodeEventTarget,
             eventName: string | symbol,
@@ -239,6 +254,11 @@ declare module "events" {
          * @param eventName The name of the event being listened for
          * @return that iterates `eventName` events emitted by the `emitter`
          */
+        static on<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            eventName: EventName,
+            options?: StaticEventEmitterOptions,
+        ): NodeJS.AsyncIterator<Args<Events, EventName>>;
         static on(
             emitter: NodeJS.EventEmitter,
             eventName: string,
@@ -249,6 +269,26 @@ declare module "events" {
          *
          * ```js
          * import { EventEmitter, listenerCount } from 'node:events';
+         * const myEmitter = new EventEmitter();
+         * myEmitter.on('event', () => {});
+         * myEmitter.on('event', () => {});
+         * console.log(listenerCount(myEmitter, 'event'));
+         * // Prints: 2
+         * ```
+         * @since v0.9.12
+         * @deprecated Since v3.2.0 - Use `listenerCount` instead.
+         * @param emitter The emitter to query
+         * @param eventName The event name
+         */
+        static listenerCount<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            eventName: EventName,
+        ): number;
+        /**
+         * A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
+         *
+         * ```js
+         * const { EventEmitter, listenerCount } = require('events');
          * const myEmitter = new EventEmitter();
          * myEmitter.on('event', () => {});
          * myEmitter.on('event', () => {});
@@ -288,6 +328,10 @@ declare module "events" {
          * ```
          * @since v15.2.0
          */
+        static getEventListeners<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            name: EventName,
+        ): Array<Listener<Events, EventName>>;
         static getEventListeners(emitter: DOMEventTarget | NodeJS.EventEmitter, name: string | symbol): Function[];
         /**
          * ```js
@@ -378,16 +422,37 @@ declare module "events" {
             /** The underlying AsyncResource */
             readonly asyncResource: EventEmitterReferencingAsyncResource;
         }
+
+        export interface EventEmitterBuiltInEventMap {
+            newListener: [eventName: string | symbol, listener: Function];
+            removeListener: [eventName: string | symbol, listener: Function];
+        }
     }
     global {
         namespace NodeJS {
-            interface EventEmitter<T extends EventMap<T> = DefaultEventMap> {
-                [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
+            interface EventEmitter<Events extends EventMap<Events> = {}> {
+                [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
+                    error: Error,
+                    event: EventName,
+                    ...args: Args<Events, EventName>
+                ): void;
+                [EventEmitter.captureRejectionSymbol]?<EventName extends string | symbol>(
+                    error: Error,
+                    event: EventName,
+                    ...args: Args<Events, EventName>
+                ): void;
                 /**
                  * Alias for `emitter.on(eventName, listener)`.
                  * @since v0.1.26
                  */
-                addListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                addListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                addListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Adds the `listener` function to the end of the listeners array for the
                  * event named `eventName`. No checks are made to see if the `listener` has
@@ -418,7 +483,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                on<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                on<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                on<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Adds a **one-time**`listener` function for the event named `eventName`. The
                  * next time `eventName` is triggered, this listener is removed and then invoked.
@@ -447,7 +519,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                once<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                once<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                once<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Removes the specified `listener` from the listener array for the event named`eventName`.
                  *
@@ -527,12 +606,26 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                removeListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                removeListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Alias for `emitter.removeListener()`.
                  * @since v10.0.0
                  */
-                off<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                off<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                off<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Removes all listeners, or those of the specified `eventName`.
                  *
@@ -543,7 +636,10 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeAllListeners(event?: Key<unknown, T>): this;
+                /* eslint-disable @definitelytyped/no-unnecessary-generics */
+                removeAllListeners<EventName extends EventNames<Events>>(eventName: EventName): this;
+                removeAllListeners<EventName extends string | symbol>(eventName?: EventName): this;
+                /* eslint-enable @definitelytyped/no-unnecessary-generics */
                 /**
                  * By default `EventEmitter`s will print a warning if more than `10` listeners are
                  * added for a particular event. This is a useful default that helps finding
@@ -572,7 +668,12 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                listeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
+                listeners<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
+                listeners<EventName extends string | symbol>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
                  * including any wrappers (such as those created by `.once()`).
@@ -602,7 +703,12 @@ declare module "events" {
                  * ```
                  * @since v9.4.0
                  */
-                rawListeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
+                rawListeners<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
+                rawListeners<EventName extends string | symbol>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
                 /**
                  * Synchronously calls each of the listeners registered for the event named`eventName`, in the order they were registered, passing the supplied arguments
                  * to each.
@@ -643,13 +749,27 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                emit<K>(eventName: Key<K, T>, ...args: Args<K, T>): boolean;
+                emit<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    ...args: Args<Events, EventName>
+                ): boolean;
+                emit<EventName extends string | symbol>(
+                    eventName: EventName,
+                    ...args: Args<Events, EventName>
+                ): boolean;
                 /**
                  * Returns the number of listeners listening to the event named `eventName`.
                  * @since v3.2.0
                  * @param eventName The name of the event being listened for
                  */
-                listenerCount<K>(eventName: Key<K, T>, listener?: Listener2<K, T>): number;
+                listenerCount<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener?: Listener<Events, EventName>,
+                ): number;
+                listenerCount<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener?: Listener<Events, EventName>,
+                ): number;
                 /**
                  * Adds the `listener` function to the _beginning_ of the listeners array for the
                  * event named `eventName`. No checks are made to see if the `listener` has
@@ -667,7 +787,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                prependListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                prependListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Adds a **one-time**`listener` function for the event named `eventName` to the_beginning_ of the listeners array. The next time `eventName` is triggered, this
                  * listener is removed, and then invoked.
@@ -683,7 +810,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependOnceListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                prependOnceListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                prependOnceListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Returns an array listing the events for which the emitter has registered
                  * listeners. The values in the array are strings or `Symbol`s.
@@ -702,7 +836,7 @@ declare module "events" {
                  * ```
                  * @since v6.0.0
                  */
-                eventNames(): Array<(string | symbol) & Key2<unknown, T>>;
+                eventNames(): Array<(string | symbol)> & Array<EventNames<Events>>;
             }
         }
     }

--- a/types/node/v16/events.d.ts
+++ b/types/node/v16/events.d.ts
@@ -1,5 +1,3 @@
-declare const internalTypeOnlyBrandSymbol: unique symbol;
-
 /**
  * Much of the Node.js core API is built around an idiomatic asynchronous
  * event-driven architecture in which certain kinds of objects (called "emitters")
@@ -101,6 +99,11 @@ declare module "events" {
      */
     class EventEmitter<Events extends EventMap<Events> = {}> {
         constructor(options?: EventEmitterOptions);
+
+        // This "property" is used to brand a specific instance of the EventEmitter class with its Event map, which is needed
+        // in order to infer the map if we have a chain like `class A extends EventEmitter<{}>` (or many levels deep)
+        // It is also marked as possibly undefined in order to allow something like `const t: NodeJS.EventEmitter<{}> = { <insert implementation here> };`
+        readonly #internalTypeOnlyBrand?: Events;
 
         [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
             error: Error,
@@ -516,11 +519,6 @@ declare module "events" {
     global {
         namespace NodeJS {
             interface EventEmitter<Events extends EventMap<Events> = {}> {
-                // This "property" is used to brand a specific instance of the EventEmitter class with its Event map, which is needed
-                // in order to infer the map if we have a chain like `class A extends EventEmitter<{}>` (or many levels deep)
-                // It is also marked as possibly undefined in order to allow something like `const t: NodeJS.EventEmitter<{}> = { <insert implementation here> };`
-                readonly [internalTypeOnlyBrandSymbol]?: Events;
-
                 [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
                     error: Error,
                     event: EventName,

--- a/types/node/v16/test/events_generic.ts
+++ b/types/node/v16/test/events_generic.ts
@@ -299,4 +299,18 @@ declare const event5: "event5";
 
     events.on(doubleExtended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
     events.once(doubleExtended, "unknown"); // $ExpectType Promise<any[]>
+
+    extended.addListener(event1, (a: string, b: number | boolean): number => 1);
+    doubleExtended.addListener(event1, (a: string, b: number | boolean): number => 1);
+    // @ts-expect-error
+    extended.addListener(event1, (a: string, b: boolean): number => 1);
+    // @ts-expect-error
+    doubleExtended.addListener(event1, (a: string, b: boolean): number => 1);
+
+    extended.emit("event1", "hello", 42);
+    doubleExtended.emit("event1", "hello", 42);
+    // @ts-expect-error
+    extended.emit("event1", 123);
+    // @ts-expect-error
+    doubleExtended.emit("event1", 123);
 }

--- a/types/node/v16/test/events_generic.ts
+++ b/types/node/v16/test/events_generic.ts
@@ -248,3 +248,55 @@ declare const event5: "event5";
     emitter.emit(s1, "hello", false);
     emitter.emit(s2, "hello", false);
 }
+
+{
+    const promise1: Promise<[string, number]> = events.once(new events.EventEmitter<T>(), "event1");
+    const promise2: Promise<[boolean]> = events.once(new events.EventEmitter<T>(), "event2");
+    const promise3: Promise<[]> = events.once(new events.EventEmitter<T>(), "event3");
+    const promise4: Promise<string[]> = events.once(new events.EventEmitter<T>(), "event4");
+    const promise5: Promise<unknown[]> = events.once(new events.EventEmitter<T>(), "event5");
+    // @ts-expect-error
+    const promise6: Promise<[string, string]> = events.once(new events.EventEmitter<T>(), "event1");
+    const promise7: Promise<any[]> = events.once(new events.EventEmitter<T>(), "event");
+
+    const iterable1: NodeJS.AsyncIterator<[string, number]> = events.on(new events.EventEmitter<T>(), "event1");
+    const iterable2: NodeJS.AsyncIterator<[boolean]> = events.on(new events.EventEmitter<T>(), "event2");
+    const iterable3: NodeJS.AsyncIterator<[]> = events.on(new events.EventEmitter<T>(), "event3");
+    const iterable4: NodeJS.AsyncIterator<string[]> = events.on(new events.EventEmitter<T>(), "event4");
+    const iterable5: NodeJS.AsyncIterator<unknown[]> = events.on(new events.EventEmitter<T>(), "event5");
+    // @ts-expect-error
+    const iterable6: NodeJS.AsyncIterator<[string, string]> = events.on(new events.EventEmitter<T>(), "event1");
+    const iterable7: NodeJS.AsyncIterator<any[]> = events.on(new events.EventEmitter<T>(), "event");
+}
+
+{
+    function acceptsEventEmitterInterface(eventEmitter: NodeJS.EventEmitter) {
+    }
+
+    function acceptsEventEmitterClass(eventEmitter: events.EventEmitter) {
+    }
+
+    acceptsEventEmitterInterface(emitter);
+    acceptsEventEmitterClass(emitter);
+}
+
+{
+    class Extended extends events.EventEmitter<T> {}
+
+    class DoubleExtension extends Extended {}
+
+    const extended = new Extended();
+    const doubleExtended = new DoubleExtension();
+
+    events.on(extended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
+    events.once(extended, "event1"); // $ExpectType Promise<[string, number]>
+
+    events.on(extended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
+    events.once(extended, "unknown"); // $ExpectType Promise<any[]>
+
+    events.on(doubleExtended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
+    events.once(doubleExtended, "event1"); // $ExpectType Promise<[string, number]>
+
+    events.on(doubleExtended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
+    events.once(doubleExtended, "unknown"); // $ExpectType Promise<any[]>
+}

--- a/types/node/v16/test/events_generic.ts
+++ b/types/node/v16/test/events_generic.ts
@@ -110,13 +110,17 @@ declare const event5: "event5";
 }
 
 {
-    let result: Promise<number[]>;
+    let result1: Promise<T["event1"]>;
+    let result2: Promise<T["event2"]>;
+    let result3: Promise<T["event3"]>;
+    let result4: Promise<T["event4"]>;
+    let result5: Promise<T["event5"]>;
 
-    result = events.once(emitter, event1);
-    result = events.once(emitter, event2);
-    result = events.once(emitter, event3);
-    result = events.once(emitter, event4);
-    result = events.once(emitter, event5);
+    result1 = events.once(emitter, event1);
+    result2 = events.once(emitter, event2);
+    result3 = events.once(emitter, event3);
+    result4 = events.once(emitter, event4);
+    result5 = events.once(emitter, event5);
 
     emitter.emit("event1", "hello", 42);
     emitter.emit("event2", true);
@@ -146,7 +150,7 @@ declare const event5: "event5";
 }
 
 {
-    let result: Array<keyof T>;
+    let result: Array<keyof T | keyof events.EventEmitterBuiltInEventMap>;
 
     result = emitter.eventNames();
 }
@@ -157,12 +161,12 @@ declare const event5: "event5";
         )
         : never;
 
-    function on1<K>(event: K, listener: Listener<K>): void {
+    function on1<K extends keyof T>(event: K, listener: Listener<K>): void {
         emitter.on(event, listener);
     }
 
     // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-    function on2<K>(...args: Parameters<typeof emitter.on<K>>): void {
+    function on2<K extends keyof T>(...args: Parameters<typeof emitter.on<K>>): void {
         emitter.on(...args);
     }
 
@@ -204,7 +208,6 @@ declare const event5: "event5";
     emitter.emit("abc", "hello", 123);
     // @ts-expect-error
     emitter.emit("abc", 123, false);
-    // @ts-expect-error
     emitter.emit("def", "hello", 123);
 }
 
@@ -226,7 +229,6 @@ declare const event5: "event5";
     emitter.emit(s1, "hello", 123);
     // @ts-expect-error
     emitter.emit(s1, 123, false);
-    // @ts-expect-error
     emitter.emit(s2, "hello", 123);
 }
 
@@ -244,6 +246,5 @@ declare const event5: "event5";
     emitter.emit(789, 123, false);
     // @ts-expect-error
     emitter.emit(s1, "hello", false);
-    // @ts-expect-error
     emitter.emit(s2, "hello", false);
 }

--- a/types/node/v18/events.d.ts
+++ b/types/node/v18/events.d.ts
@@ -1,3 +1,5 @@
+declare const internalTypeOnlyBrandSymbol: unique symbol;
+
 /**
  * Much of the Node.js core API is built around an idiomatic asynchronous
  * event-driven architecture in which certain kinds of objects (called "emitters")
@@ -34,13 +36,12 @@
  * ```
  * @see [source](https://github.com/nodejs/node/blob/v18.0.0/lib/events.js)
  */
+
 declare module "events" {
     import { AsyncResource, AsyncResourceOptions } from "node:async_hooks";
-
     // NOTE: This class is in the docs but is **not actually exported** by Node.
     // If https://github.com/nodejs/node/issues/39903 gets resolved and Node
     // actually starts exporting the class, uncomment below.
-
     // import { EventListener, EventListenerObject } from '__dom-events';
     // /** The NodeEventTarget is a Node.js-specific extension to EventTarget that emulates a subset of the EventEmitter API. */
     // interface NodeEventTarget extends EventTarget {
@@ -71,7 +72,6 @@ declare module "events" {
     //      */
     //     removeListener(type: string, listener: EventListener | EventListenerObject): this;
     // }
-
     interface EventEmitterOptions {
         /**
          * Enables automatic capturing of promise rejection.
@@ -93,6 +93,9 @@ declare module "events" {
         ): any;
     }
     interface StaticEventEmitterOptions {
+        /**
+         * Can be used to cancel awaiting events.
+         */
         signal?: AbortSignal | undefined;
     }
     interface EventEmitter<Events extends EventMap<Events> = {}> extends NodeJS.EventEmitter<Events> {}
@@ -116,6 +119,7 @@ declare module "events" {
         : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
             ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
             : (...args: any[]) => void);
+
     /**
      * The `EventEmitter` class is defined and exposed by the `events` module:
      *
@@ -224,7 +228,7 @@ declare module "events" {
         static once<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
             emitter: EventEmitter<Events>,
             eventName: EventName,
-            options?: Pick<StaticEventEmitterOptions, "signal">,
+            options?: StaticEventEmitterOptions,
         ): Promise<Args<Events, EventName>>;
         static once(
             emitter: _NodeEventTarget,
@@ -287,8 +291,7 @@ declare module "events" {
          * process.nextTick(() => ac.abort());
          * ```
          * @since v13.6.0, v12.16.0
-         * @param eventName The name of the event being listened for
-         * @return that iterates `eventName` events emitted by the `emitter`
+         * @return An `AsyncIterator` that iterates `eventName` events emitted by the `emitter`
          */
         static on<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
             emitter: EventEmitter<Events>,
@@ -297,11 +300,11 @@ declare module "events" {
         ): NodeJS.AsyncIterator<Args<Events, EventName>>;
         static on(
             emitter: NodeJS.EventEmitter,
-            eventName: string,
+            eventName: string | symbol,
             options?: StaticEventEmitterOptions,
-        ): NodeJS.AsyncIterator<any>;
+        ): NodeJS.AsyncIterator<any[]>;
         /**
-         * A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
+         * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
          *
          * ```js
          * import { EventEmitter, listenerCount } from 'node:events';
@@ -321,10 +324,11 @@ declare module "events" {
             eventName: EventName,
         ): number;
         /**
-         * A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
+         * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
          *
          * ```js
          * const { EventEmitter, listenerCount } = require('events');
+         *
          * const myEmitter = new EventEmitter();
          * myEmitter.on('event', () => {});
          * myEmitter.on('event', () => {});
@@ -353,13 +357,13 @@ declare module "events" {
          *   const ee = new EventEmitter();
          *   const listener = () => console.log('Events are fun');
          *   ee.on('foo', listener);
-         *   getEventListeners(ee, 'foo'); // [listener]
+         *   console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
          * }
          * {
          *   const et = new EventTarget();
          *   const listener = () => console.log('Events are fun');
          *   et.addEventListener('foo', listener);
-         *   getEventListeners(et, 'foo'); // [listener]
+         *   console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
          * }
          * ```
          * @since v15.2.0, v14.17.0
@@ -380,7 +384,7 @@ declare module "events" {
          * the max set, the EventTarget will print a warning.
          *
          * ```js
-         * import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
+         * const { getMaxListeners, setMaxListeners, EventEmitter } = require('events');
          *
          * {
          *   const ee = new EventEmitter();
@@ -432,7 +436,7 @@ declare module "events" {
          * Returns a disposable so that it may be unsubscribed from more easily.
          *
          * ```js
-         * import { addAbortListener } from 'node:events';
+         * const { addAbortListener } = require('events');
          *
          * function example(signal) {
          *   let disposable;
@@ -461,12 +465,58 @@ declare module "events" {
          * regular `'error'` listener is installed.
          */
         static readonly errorMonitor: unique symbol;
+        /**
+         * Value: `Symbol.for('nodejs.rejection')`
+         *
+         * See how to write a custom `rejection handler`.
+         * @since v13.4.0, v12.16.0
+         */
         static readonly captureRejectionSymbol: unique symbol;
         /**
-         * Sets or gets the default captureRejection value for all emitters.
+         * Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+         *
+         * Change the default `captureRejections` option on all new `EventEmitter` objects.
+         * @since v13.4.0, v12.16.0
          */
-        // TODO: These should be described using static getter/setter pairs:
         static captureRejections: boolean;
+        /**
+         * By default, a maximum of `10` listeners can be registered for any single
+         * event. This limit can be changed for individual `EventEmitter` instances
+         * using the `emitter.setMaxListeners(n)` method. To change the default
+         * for _all_`EventEmitter` instances, the `events.defaultMaxListeners` property
+         * can be used. If this value is not a positive number, a `RangeError` is thrown.
+         *
+         * Take caution when setting the `events.defaultMaxListeners` because the
+         * change affects _all_ `EventEmitter` instances, including those created before
+         * the change is made. However, calling `emitter.setMaxListeners(n)` still has
+         * precedence over `events.defaultMaxListeners`.
+         *
+         * This is not a hard limit. The `EventEmitter` instance will allow
+         * more listeners to be added but will output a trace warning to stderr indicating
+         * that a "possible EventEmitter memory leak" has been detected. For any single
+         * `EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()` methods can be used to
+         * temporarily avoid this warning:
+         *
+         * ```js
+         * const EventEmitter = require('events');
+         * const emitter = new EventEmitter();
+         * emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+         * emitter.once('event', () => {
+         *   // do stuff
+         *   emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+         * });
+         * ```
+         *
+         * The `--trace-warnings` command-line flag can be used to display the
+         * stack trace for such warnings.
+         *
+         * The emitted warning can be inspected with `process.on('warning')` and will
+         * have the additional `emitter`, `type`, and `count` properties, referring to
+         * the event emitter instance, the event's name and the number of attached
+         * listeners, respectively.
+         * Its `name` property is set to `'MaxListenersExceededWarning'`.
+         * @since v0.11.2
+         */
         static defaultMaxListeners: number;
     }
     import internal = require("node:events");
@@ -494,13 +544,41 @@ declare module "events" {
         }
 
         /**
-         * Integrates `EventEmitter` with `AsyncResource` for `EventEmitter`s that require
-         * manual async tracking. Specifically, all events emitted by instances of
-         * `EventEmitterAsyncResource` will run within its async context.
+         * Integrates `EventEmitter` with `AsyncResource` for `EventEmitter`s that
+         * require manual async tracking. Specifically, all events emitted by instances
+         * of `events.EventEmitterAsyncResource` will run within its `async context`.
          *
-         * The EventEmitterAsyncResource class has the same methods and takes the
-         * same options as EventEmitter and AsyncResource themselves.
-         * @throws if `options.name` is not provided when instantiated directly.
+         * ```js
+         * const { EventEmitterAsyncResource, EventEmitter } = require('events');
+         * const { notStrictEqual, strictEqual } = require('assert');
+         * const { executionAsyncId, triggerAsyncId } = require('async_hooks');
+         *
+         * // Async tracking tooling will identify this as 'Q'.
+         * const ee1 = new EventEmitterAsyncResource({ name: 'Q' });
+         *
+         * // 'foo' listeners will run in the EventEmitters async context.
+         * ee1.on('foo', () => {
+         *   strictEqual(executionAsyncId(), ee1.asyncId);
+         *   strictEqual(triggerAsyncId(), ee1.triggerAsyncId);
+         * });
+         *
+         * const ee2 = new EventEmitter();
+         *
+         * // 'foo' listeners on ordinary EventEmitters that do not track async
+         * // context, however, run in the same async context as the emit().
+         * ee2.on('foo', () => {
+         *   notStrictEqual(executionAsyncId(), ee2.asyncId);
+         *   notStrictEqual(triggerAsyncId(), ee2.triggerAsyncId);
+         * });
+         *
+         * Promise.resolve().then(() => {
+         *   ee1.emit('foo');
+         *   ee2.emit('foo');
+         * });
+         * ```
+         *
+         * The `EventEmitterAsyncResource` class has the same methods and takes the
+         * same options as `EventEmitter` and `AsyncResource` themselves.
          * @since v17.4.0, v16.14.0
          */
         export class EventEmitterAsyncResource extends EventEmitter {
@@ -509,17 +587,24 @@ declare module "events" {
              */
             constructor(options?: EventEmitterAsyncResourceOptions);
             /**
-             * Call all destroy hooks. This should only ever be called once. An
-             * error will be thrown if it is called more than once. This must be
-             * manually called. If the resource is left to be collected by the GC then
-             * the destroy hooks will never be called.
+             * Call all `destroy` hooks. This should only ever be called once. An error will
+             * be thrown if it is called more than once. This **must** be manually called. If
+             * the resource is left to be collected by the GC then the `destroy` hooks will
+             * never be called.
              */
             emitDestroy(): void;
-            /** The unique asyncId assigned to the resource. */
+            /**
+             * The unique `asyncId` assigned to the resource.
+             */
             readonly asyncId: number;
-            /** The same triggerAsyncId that is passed to the AsyncResource constructor. */
+            /**
+             * The same triggerAsyncId that is passed to the AsyncResource constructor.
+             */
             readonly triggerAsyncId: number;
-            /** The underlying AsyncResource */
+            /**
+             * The returned `AsyncResource` object has an additional `eventEmitter` property
+             * that provides a reference to this `EventEmitterAsyncResource`.
+             */
             readonly asyncResource: EventEmitterReferencingAsyncResource;
         }
 
@@ -531,6 +616,11 @@ declare module "events" {
     global {
         namespace NodeJS {
             interface EventEmitter<Events extends EventMap<Events> = {}> {
+                // This "property" is used to brand a specific instance of the EventEmitter class with its Event map, which is needed
+                // in order to infer the map if we have a chain like `class A extends EventEmitter<{}>` (or many levels deep)
+                // It is also marked as possibly undefined in order to allow something like `const t: NodeJS.EventEmitter<{}> = { <insert implementation here> };`
+                readonly [internalTypeOnlyBrandSymbol]?: Events;
+
                 [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
                     error: Error,
                     event: EventName,
@@ -554,10 +644,10 @@ declare module "events" {
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
-                 * Adds the `listener` function to the end of the listeners array for the
-                 * event named `eventName`. No checks are made to see if the `listener` has
-                 * already been added. Multiple calls passing the same combination of `eventName` and `listener` will result in the `listener` being added, and called, multiple
-                 * times.
+                 * Adds the `listener` function to the end of the listeners array for the event
+                 * named `eventName`. No checks are made to see if the `listener` has already
+                 * been added. Multiple calls passing the same combination of `eventName` and
+                 * `listener` will result in the `listener` being added, and called, multiple times.
                  *
                  * ```js
                  * server.on('connection', (stream) => {
@@ -567,10 +657,11 @@ declare module "events" {
                  *
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  *
-                 * By default, event listeners are invoked in the order they are added. The`emitter.prependListener()` method can be used as an alternative to add the
+                 * By default, event listeners are invoked in the order they are added. The `emitter.prependListener()` method can be used as an alternative to add the
                  * event listener to the beginning of the listeners array.
                  *
                  * ```js
+                 * const EventEmitter = require('events');
                  * const myEE = new EventEmitter();
                  * myEE.on('foo', () => console.log('a'));
                  * myEE.prependListener('foo', () => console.log('b'));
@@ -592,7 +683,7 @@ declare module "events" {
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
-                 * Adds a **one-time**`listener` function for the event named `eventName`. The
+                 * Adds a **one-time** `listener` function for the event named `eventName`. The
                  * next time `eventName` is triggered, this listener is removed and then invoked.
                  *
                  * ```js
@@ -603,10 +694,11 @@ declare module "events" {
                  *
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  *
-                 * By default, event listeners are invoked in the order they are added. The`emitter.prependOnceListener()` method can be used as an alternative to add the
+                 * By default, event listeners are invoked in the order they are added. The `emitter.prependOnceListener()` method can be used as an alternative to add the
                  * event listener to the beginning of the listeners array.
                  *
                  * ```js
+                 * const EventEmitter = require('events');
                  * const myEE = new EventEmitter();
                  * myEE.once('foo', () => console.log('a'));
                  * myEE.prependOnceListener('foo', () => console.log('b'));
@@ -628,7 +720,7 @@ declare module "events" {
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
-                 * Removes the specified `listener` from the listener array for the event named`eventName`.
+                 * Removes the specified `listener` from the listener array for the event named `eventName`.
                  *
                  * ```js
                  * const callback = (stream) => {
@@ -645,10 +737,12 @@ declare module "events" {
                  * called multiple times to remove each instance.
                  *
                  * Once an event is emitted, all listeners attached to it at the
-                 * time of emitting are called in order. This implies that any`removeListener()` or `removeAllListeners()` calls _after_ emitting and _before_ the last listener finishes execution
+                 * time of emitting are called in order. This implies that any `removeListener()` or `removeAllListeners()` calls _after_ emitting and _before_ the last listener finishes execution
                  * will not remove them from`emit()` in progress. Subsequent events behave as expected.
                  *
                  * ```js
+                 * const EventEmitter = require('events');
+                 * class MyEmitter extends EventEmitter {}
                  * const myEmitter = new MyEmitter();
                  *
                  * const callbackA = () => {
@@ -686,9 +780,10 @@ declare module "events" {
                  *
                  * When a single function has been added as a handler multiple times for a single
                  * event (as in the example below), `removeListener()` will remove the most
-                 * recently added instance. In the example the `once('ping')`listener is removed:
+                 * recently added instance. In the example the `once('ping')` listener is removed:
                  *
                  * ```js
+                 * const EventEmitter = require('events');
                  * const ee = new EventEmitter();
                  *
                  * function pong() {
@@ -744,7 +839,7 @@ declare module "events" {
                  * By default `EventEmitter`s will print a warning if more than `10` listeners are
                  * added for a particular event. This is a useful default that helps finding
                  * memory leaks. The `emitter.setMaxListeners()` method allows the limit to be
-                 * modified for this specific `EventEmitter` instance. The value can be set to`Infinity` (or `0`) to indicate an unlimited number of listeners.
+                 * modified for this specific `EventEmitter` instance. The value can be set to `Infinity` (or `0`) to indicate an unlimited number of listeners.
                  *
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.3.5
@@ -779,6 +874,7 @@ declare module "events" {
                  * including any wrappers (such as those created by `.once()`).
                  *
                  * ```js
+                 * const EventEmitter = require('events');
                  * const emitter = new EventEmitter();
                  * emitter.once('log', () => console.log('log once'));
                  *
@@ -810,7 +906,7 @@ declare module "events" {
                     eventName: EventName,
                 ): Array<Listener<Events, EventName>>;
                 /**
-                 * Synchronously calls each of the listeners registered for the event named`eventName`, in the order they were registered, passing the supplied arguments
+                 * Synchronously calls each of the listeners registered for the event named `eventName`, in the order they were registered, passing the supplied arguments
                  * to each.
                  *
                  * Returns `true` if the event had listeners, `false` otherwise.
@@ -858,10 +954,9 @@ declare module "events" {
                     ...args: Args<Events, EventName>
                 ): boolean;
                 /**
-                 * Returns the number of listeners listening to the event named `eventName`.
-                 *
-                 * If `listener` is provided, it will return how many times the listener
-                 * is found in the list of the listeners of the event.
+                 * Returns the number of listeners listening for the event named `eventName`.
+                 * If `listener` is provided, it will return how many times the listener is found
+                 * in the list of the listeners of the event.
                  * @since v3.2.0
                  * @param eventName The name of the event being listened for
                  * @param listener The event handler function
@@ -877,8 +972,8 @@ declare module "events" {
                 /**
                  * Adds the `listener` function to the _beginning_ of the listeners array for the
                  * event named `eventName`. No checks are made to see if the `listener` has
-                 * already been added. Multiple calls passing the same combination of `eventName` and `listener` will result in the `listener` being added, and called, multiple
-                 * times.
+                 * already been added. Multiple calls passing the same combination of `eventName`
+                 * and `listener` will result in the `listener` being added, and called, multiple times.
                  *
                  * ```js
                  * server.prependListener('connection', (stream) => {

--- a/types/node/v18/events.d.ts
+++ b/types/node/v18/events.d.ts
@@ -1,5 +1,3 @@
-declare const internalTypeOnlyBrandSymbol: unique symbol;
-
 /**
  * Much of the Node.js core API is built around an idiomatic asynchronous
  * event-driven architecture in which certain kinds of objects (called "emitters")
@@ -135,6 +133,11 @@ declare module "events" {
      */
     class EventEmitter<Events extends EventMap<Events> = {}> {
         constructor(options?: EventEmitterOptions);
+
+        // This "property" is used to brand a specific instance of the EventEmitter class with its Event map, which is needed
+        // in order to infer the map if we have a chain like `class A extends EventEmitter<{}>` (or many levels deep)
+        // It is also marked as possibly undefined in order to allow something like `const t: NodeJS.EventEmitter<{}> = { <insert implementation here> };`
+        readonly #internalTypeOnlyBrand?: Events;
 
         [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
             error: Error,
@@ -616,11 +619,6 @@ declare module "events" {
     global {
         namespace NodeJS {
             interface EventEmitter<Events extends EventMap<Events> = {}> {
-                // This "property" is used to brand a specific instance of the EventEmitter class with its Event map, which is needed
-                // in order to infer the map if we have a chain like `class A extends EventEmitter<{}>` (or many levels deep)
-                // It is also marked as possibly undefined in order to allow something like `const t: NodeJS.EventEmitter<{}> = { <insert implementation here> };`
-                readonly [internalTypeOnlyBrandSymbol]?: Events;
-
                 [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
                     error: Error,
                     event: EventName,

--- a/types/node/v18/events.d.ts
+++ b/types/node/v18/events.d.ts
@@ -95,23 +95,27 @@ declare module "events" {
     interface StaticEventEmitterOptions {
         signal?: AbortSignal | undefined;
     }
-    interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
-    type EventMap<T> = Record<keyof T, any[]> | DefaultEventMap;
-    type DefaultEventMap = [never];
-    type AnyRest = [...args: any[]];
-    type Args<K, T> = T extends DefaultEventMap ? AnyRest : (
-        K extends keyof T ? T[K] : never
-    );
-    type Key<K, T> = T extends DefaultEventMap ? string | symbol : K | keyof T;
-    type Key2<K, T> = T extends DefaultEventMap ? string | symbol : K & keyof T;
-    type Listener<K, T, F> = T extends DefaultEventMap ? F : (
-        K extends keyof T ? (
-                T[K] extends unknown[] ? (...args: T[K]) => void : never
-            )
-            : never
-    );
-    type Listener1<K, T> = Listener<K, T, (...args: any[]) => void>;
-    type Listener2<K, T> = Listener<K, T, Function>;
+    interface EventEmitter<Events extends EventMap<Events> = {}> extends NodeJS.EventEmitter<Events> {}
+    type EventMap<Events> = Record<keyof Events, unknown[]>;
+    type Args<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ? (
+            | Events[EventName]
+            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
+                : never)
+        )
+        : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+            ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
+            : any[]);
+    type EventNames<Events extends EventMap<Events>> = {} extends Events ? (string | symbol)
+        : (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap);
+    type Listener<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ?
+            | ((...args: Events[EventName]) => void)
+            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
+                : never)
+        : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+            ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
+            : (...args: any[]) => void);
     /**
      * The `EventEmitter` class is defined and exposed by the `events` module:
      *
@@ -125,10 +129,15 @@ declare module "events" {
      * It supports the following option:
      * @since v0.1.26
      */
-    class EventEmitter<T extends EventMap<T> = DefaultEventMap> {
+    class EventEmitter<Events extends EventMap<Events> = {}> {
         constructor(options?: EventEmitterOptions);
 
-        [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
+        [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
+            error: Error,
+            event: EventName,
+            ...args: Args<Events, EventName>
+        ): void;
+        [EventEmitter.captureRejectionSymbol]?(error: Error, event: string | symbol, ...args: any[]): void;
 
         /**
          * Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
@@ -212,6 +221,11 @@ declare module "events" {
          * ```
          * @since v11.13.0, v10.16.0
          */
+        static once<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            eventName: EventName,
+            options?: Pick<StaticEventEmitterOptions, "signal">,
+        ): Promise<Args<Events, EventName>>;
         static once(
             emitter: _NodeEventTarget,
             eventName: string | symbol,
@@ -276,6 +290,11 @@ declare module "events" {
          * @param eventName The name of the event being listened for
          * @return that iterates `eventName` events emitted by the `emitter`
          */
+        static on<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            eventName: EventName,
+            options?: StaticEventEmitterOptions,
+        ): NodeJS.AsyncIterator<Args<Events, EventName>>;
         static on(
             emitter: NodeJS.EventEmitter,
             eventName: string,
@@ -286,6 +305,26 @@ declare module "events" {
          *
          * ```js
          * import { EventEmitter, listenerCount } from 'node:events';
+         * const myEmitter = new EventEmitter();
+         * myEmitter.on('event', () => {});
+         * myEmitter.on('event', () => {});
+         * console.log(listenerCount(myEmitter, 'event'));
+         * // Prints: 2
+         * ```
+         * @since v0.9.12
+         * @deprecated Since v3.2.0 - Use `listenerCount` instead.
+         * @param emitter The emitter to query
+         * @param eventName The event name
+         */
+        static listenerCount<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            eventName: EventName,
+        ): number;
+        /**
+         * A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
+         *
+         * ```js
+         * const { EventEmitter, listenerCount } = require('events');
          * const myEmitter = new EventEmitter();
          * myEmitter.on('event', () => {});
          * myEmitter.on('event', () => {});
@@ -325,6 +364,10 @@ declare module "events" {
          * ```
          * @since v15.2.0, v14.17.0
          */
+        static getEventListeners<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            name: EventName,
+        ): Array<Listener<Events, EventName>>;
         static getEventListeners(emitter: _DOMEventTarget | NodeJS.EventEmitter, name: string | symbol): Function[];
         /**
          * Returns the currently set max amount of listeners.
@@ -479,16 +522,37 @@ declare module "events" {
             /** The underlying AsyncResource */
             readonly asyncResource: EventEmitterReferencingAsyncResource;
         }
+
+        export interface EventEmitterBuiltInEventMap {
+            newListener: [eventName: string | symbol, listener: Function];
+            removeListener: [eventName: string | symbol, listener: Function];
+        }
     }
     global {
         namespace NodeJS {
-            interface EventEmitter<T extends EventMap<T> = DefaultEventMap> {
-                [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
+            interface EventEmitter<Events extends EventMap<Events> = {}> {
+                [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
+                    error: Error,
+                    event: EventName,
+                    ...args: Args<Events, EventName>
+                ): void;
+                [EventEmitter.captureRejectionSymbol]?<EventName extends string | symbol>(
+                    error: Error,
+                    event: EventName,
+                    ...args: Args<Events, EventName>
+                ): void;
                 /**
                  * Alias for `emitter.on(eventName, listener)`.
                  * @since v0.1.26
                  */
-                addListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                addListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                addListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Adds the `listener` function to the end of the listeners array for the
                  * event named `eventName`. No checks are made to see if the `listener` has
@@ -519,7 +583,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                on<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                on<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                on<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Adds a **one-time**`listener` function for the event named `eventName`. The
                  * next time `eventName` is triggered, this listener is removed and then invoked.
@@ -548,7 +619,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                once<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                once<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                once<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Removes the specified `listener` from the listener array for the event named`eventName`.
                  *
@@ -628,12 +706,26 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                removeListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                removeListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Alias for `emitter.removeListener()`.
                  * @since v10.0.0
                  */
-                off<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                off<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                off<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Removes all listeners, or those of the specified `eventName`.
                  *
@@ -644,7 +736,10 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeAllListeners(event?: Key<unknown, T>): this;
+                /* eslint-disable @definitelytyped/no-unnecessary-generics */
+                removeAllListeners<EventName extends EventNames<Events>>(eventName: EventName): this;
+                removeAllListeners<EventName extends string | symbol>(eventName?: EventName): this;
+                /* eslint-enable @definitelytyped/no-unnecessary-generics */
                 /**
                  * By default `EventEmitter`s will print a warning if more than `10` listeners are
                  * added for a particular event. This is a useful default that helps finding
@@ -673,7 +768,12 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                listeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
+                listeners<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
+                listeners<EventName extends string | symbol>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
                  * including any wrappers (such as those created by `.once()`).
@@ -703,7 +803,12 @@ declare module "events" {
                  * ```
                  * @since v9.4.0
                  */
-                rawListeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
+                rawListeners<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
+                rawListeners<EventName extends string | symbol>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
                 /**
                  * Synchronously calls each of the listeners registered for the event named`eventName`, in the order they were registered, passing the supplied arguments
                  * to each.
@@ -744,7 +849,14 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                emit<K>(eventName: Key<K, T>, ...args: Args<K, T>): boolean;
+                emit<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    ...args: Args<Events, EventName>
+                ): boolean;
+                emit<EventName extends string | symbol>(
+                    eventName: EventName,
+                    ...args: Args<Events, EventName>
+                ): boolean;
                 /**
                  * Returns the number of listeners listening to the event named `eventName`.
                  *
@@ -754,7 +866,14 @@ declare module "events" {
                  * @param eventName The name of the event being listened for
                  * @param listener The event handler function
                  */
-                listenerCount<K>(eventName: Key<K, T>, listener?: Listener2<K, T>): number;
+                listenerCount<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener?: Listener<Events, EventName>,
+                ): number;
+                listenerCount<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener?: Listener<Events, EventName>,
+                ): number;
                 /**
                  * Adds the `listener` function to the _beginning_ of the listeners array for the
                  * event named `eventName`. No checks are made to see if the `listener` has
@@ -772,7 +891,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                prependListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                prependListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Adds a **one-time**`listener` function for the event named `eventName` to the _beginning_ of the listeners array. The next time `eventName` is triggered, this
                  * listener is removed, and then invoked.
@@ -788,7 +914,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependOnceListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                prependOnceListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                prependOnceListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Returns an array listing the events for which the emitter has registered
                  * listeners. The values in the array are strings or `Symbol`s.
@@ -807,7 +940,7 @@ declare module "events" {
                  * ```
                  * @since v6.0.0
                  */
-                eventNames(): Array<(string | symbol) & Key2<unknown, T>>;
+                eventNames(): Array<(string | symbol)> & Array<EventNames<Events>>;
             }
         }
     }

--- a/types/node/v18/test/events.ts
+++ b/types/node/v18/test/events.ts
@@ -31,7 +31,7 @@ declare const any: any;
     result = emitter.getMaxListeners();
     result = emitter.listenerCount(event);
 
-    const handler: Function = () => {};
+    const handler = () => {};
     result = emitter.listenerCount(event, handler);
 }
 

--- a/types/node/v18/test/events_generic.ts
+++ b/types/node/v18/test/events_generic.ts
@@ -299,4 +299,18 @@ declare const event5: "event5";
 
     events.on(doubleExtended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
     events.once(doubleExtended, "unknown"); // $ExpectType Promise<any[]>
+
+    extended.addListener(event1, (a: string, b: number | boolean): number => 1);
+    doubleExtended.addListener(event1, (a: string, b: number | boolean): number => 1);
+    // @ts-expect-error
+    extended.addListener(event1, (a: string, b: boolean): number => 1);
+    // @ts-expect-error
+    doubleExtended.addListener(event1, (a: string, b: boolean): number => 1);
+
+    extended.emit("event1", "hello", 42);
+    doubleExtended.emit("event1", "hello", 42);
+    // @ts-expect-error
+    extended.emit("event1", 123);
+    // @ts-expect-error
+    doubleExtended.emit("event1", 123);
 }

--- a/types/node/v18/test/events_generic.ts
+++ b/types/node/v18/test/events_generic.ts
@@ -248,3 +248,55 @@ declare const event5: "event5";
     emitter.emit(s1, "hello", false);
     emitter.emit(s2, "hello", false);
 }
+
+{
+    const promise1: Promise<[string, number]> = events.once(new events.EventEmitter<T>(), "event1");
+    const promise2: Promise<[boolean]> = events.once(new events.EventEmitter<T>(), "event2");
+    const promise3: Promise<[]> = events.once(new events.EventEmitter<T>(), "event3");
+    const promise4: Promise<string[]> = events.once(new events.EventEmitter<T>(), "event4");
+    const promise5: Promise<unknown[]> = events.once(new events.EventEmitter<T>(), "event5");
+    // @ts-expect-error
+    const promise6: Promise<[string, string]> = events.once(new events.EventEmitter<T>(), "event1");
+    const promise7: Promise<any[]> = events.once(new events.EventEmitter<T>(), "event");
+
+    const iterable1: NodeJS.AsyncIterator<[string, number]> = events.on(new events.EventEmitter<T>(), "event1");
+    const iterable2: NodeJS.AsyncIterator<[boolean]> = events.on(new events.EventEmitter<T>(), "event2");
+    const iterable3: NodeJS.AsyncIterator<[]> = events.on(new events.EventEmitter<T>(), "event3");
+    const iterable4: NodeJS.AsyncIterator<string[]> = events.on(new events.EventEmitter<T>(), "event4");
+    const iterable5: NodeJS.AsyncIterator<unknown[]> = events.on(new events.EventEmitter<T>(), "event5");
+    // @ts-expect-error
+    const iterable6: NodeJS.AsyncIterator<[string, string]> = events.on(new events.EventEmitter<T>(), "event1");
+    const iterable7: NodeJS.AsyncIterator<any[]> = events.on(new events.EventEmitter<T>(), "event");
+}
+
+{
+    function acceptsEventEmitterInterface(eventEmitter: NodeJS.EventEmitter) {
+    }
+
+    function acceptsEventEmitterClass(eventEmitter: events.EventEmitter) {
+    }
+
+    acceptsEventEmitterInterface(emitter);
+    acceptsEventEmitterClass(emitter);
+}
+
+{
+    class Extended extends events.EventEmitter<T> {}
+
+    class DoubleExtension extends Extended {}
+
+    const extended = new Extended();
+    const doubleExtended = new DoubleExtension();
+
+    events.on(extended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
+    events.once(extended, "event1"); // $ExpectType Promise<[string, number]>
+
+    events.on(extended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
+    events.once(extended, "unknown"); // $ExpectType Promise<any[]>
+
+    events.on(doubleExtended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
+    events.once(doubleExtended, "event1"); // $ExpectType Promise<[string, number]>
+
+    events.on(doubleExtended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
+    events.once(doubleExtended, "unknown"); // $ExpectType Promise<any[]>
+}

--- a/types/node/v18/test/events_generic.ts
+++ b/types/node/v18/test/events_generic.ts
@@ -110,13 +110,17 @@ declare const event5: "event5";
 }
 
 {
-    let result: Promise<number[]>;
+    let result1: Promise<T["event1"]>;
+    let result2: Promise<T["event2"]>;
+    let result3: Promise<T["event3"]>;
+    let result4: Promise<T["event4"]>;
+    let result5: Promise<T["event5"]>;
 
-    result = events.once(emitter, event1);
-    result = events.once(emitter, event2);
-    result = events.once(emitter, event3);
-    result = events.once(emitter, event4);
-    result = events.once(emitter, event5);
+    result1 = events.once(emitter, event1);
+    result2 = events.once(emitter, event2);
+    result3 = events.once(emitter, event3);
+    result4 = events.once(emitter, event4);
+    result5 = events.once(emitter, event5);
 
     emitter.emit("event1", "hello", 42);
     emitter.emit("event2", true);
@@ -146,7 +150,7 @@ declare const event5: "event5";
 }
 
 {
-    let result: Array<keyof T>;
+    let result: Array<keyof T | keyof events.EventEmitterBuiltInEventMap>;
 
     result = emitter.eventNames();
 }
@@ -157,12 +161,12 @@ declare const event5: "event5";
         )
         : never;
 
-    function on1<K>(event: K, listener: Listener<K>): void {
+    function on1<K extends keyof T>(event: K, listener: Listener<K>): void {
         emitter.on(event, listener);
     }
 
     // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-    function on2<K>(...args: Parameters<typeof emitter.on<K>>): void {
+    function on2<K extends keyof T>(...args: Parameters<typeof emitter.on<K>>): void {
         emitter.on(...args);
     }
 
@@ -204,7 +208,6 @@ declare const event5: "event5";
     emitter.emit("abc", "hello", 123);
     // @ts-expect-error
     emitter.emit("abc", 123, false);
-    // @ts-expect-error
     emitter.emit("def", "hello", 123);
 }
 
@@ -226,7 +229,6 @@ declare const event5: "event5";
     emitter.emit(s1, "hello", 123);
     // @ts-expect-error
     emitter.emit(s1, 123, false);
-    // @ts-expect-error
     emitter.emit(s2, "hello", 123);
 }
 
@@ -244,6 +246,5 @@ declare const event5: "event5";
     emitter.emit(789, 123, false);
     // @ts-expect-error
     emitter.emit(s1, "hello", false);
-    // @ts-expect-error
     emitter.emit(s2, "hello", false);
 }

--- a/types/node/v20/events.d.ts
+++ b/types/node/v20/events.d.ts
@@ -1,5 +1,3 @@
-declare const internalTypeOnlyBrandSymbol: unique symbol;
-
 /**
  * Much of the Node.js core API is built around an idiomatic asynchronous
  * event-driven architecture in which certain kinds of objects (called "emitters")
@@ -139,6 +137,11 @@ declare module "events" {
      */
     class EventEmitter<Events extends EventMap<Events> = {}> {
         constructor(options?: EventEmitterOptions);
+
+        // This "property" is used to brand a specific instance of the EventEmitter class with its Event map, which is needed
+        // in order to infer the map if we have a chain like `class A extends EventEmitter<{}>` (or many levels deep)
+        // It is also marked as possibly undefined in order to allow something like `const t: NodeJS.EventEmitter<{}> = { <insert implementation here> };`
+        readonly #internalTypeOnlyBrand?: Events;
 
         [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
             error: Error,
@@ -644,11 +647,6 @@ declare module "events" {
     global {
         namespace NodeJS {
             interface EventEmitter<Events extends EventMap<Events> = {}> {
-                // This "property" is used to brand a specific instance of the EventEmitter class with its Event map, which is needed
-                // in order to infer the map if we have a chain like `class A extends EventEmitter<{}>` (or many levels deep)
-                // It is also marked as possibly undefined in order to allow something like `const t: NodeJS.EventEmitter<{}> = { <insert implementation here> };`
-                readonly [internalTypeOnlyBrandSymbol]?: Events;
-
                 [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
                     error: Error,
                     event: EventName,

--- a/types/node/v20/events.d.ts
+++ b/types/node/v20/events.d.ts
@@ -1,3 +1,5 @@
+declare const internalTypeOnlyBrandSymbol: unique symbol;
+
 /**
  * Much of the Node.js core API is built around an idiomatic asynchronous
  * event-driven architecture in which certain kinds of objects (called "emitters")
@@ -34,6 +36,7 @@
  * ```
  * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/events.js)
  */
+
 declare module "events" {
     import { AsyncResource, AsyncResourceOptions } from "node:async_hooks";
     // NOTE: This class is in the docs but is **not actually exported** by Node.
@@ -120,6 +123,7 @@ declare module "events" {
         : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
             ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
             : (...args: any[]) => void);
+
     /**
      * The `EventEmitter` class is defined and exposed by the `node:events` module:
      *
@@ -640,6 +644,11 @@ declare module "events" {
     global {
         namespace NodeJS {
             interface EventEmitter<Events extends EventMap<Events> = {}> {
+                // This "property" is used to brand a specific instance of the EventEmitter class with its Event map, which is needed
+                // in order to infer the map if we have a chain like `class A extends EventEmitter<{}>` (or many levels deep)
+                // It is also marked as possibly undefined in order to allow something like `const t: NodeJS.EventEmitter<{}> = { <insert implementation here> };`
+                readonly [internalTypeOnlyBrandSymbol]?: Events;
+
                 [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
                     error: Error,
                     event: EventName,

--- a/types/node/v20/events.d.ts
+++ b/types/node/v20/events.d.ts
@@ -99,24 +99,27 @@ declare module "events" {
          */
         lowWaterMark?: number | undefined;
     }
-    interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
-    type EventMap<T> = Record<keyof T, any[]> | DefaultEventMap;
-    type DefaultEventMap = [never];
-    type AnyRest = [...args: any[]];
-    type Args<K, T> = T extends DefaultEventMap ? AnyRest : (
-        K extends keyof T ? T[K] : never
-    );
-    type Key<K, T> = T extends DefaultEventMap ? string | symbol : K | keyof T;
-    type Key2<K, T> = T extends DefaultEventMap ? string | symbol : K & keyof T;
-    type Listener<K, T, F> = T extends DefaultEventMap ? F : (
-        K extends keyof T ? (
-                T[K] extends unknown[] ? (...args: T[K]) => void : never
-            )
-            : never
-    );
-    type Listener1<K, T> = Listener<K, T, (...args: any[]) => void>;
-    type Listener2<K, T> = Listener<K, T, Function>;
-
+    interface EventEmitter<Events extends EventMap<Events> = {}> extends NodeJS.EventEmitter<Events> {}
+    type EventMap<Events> = Record<keyof Events, unknown[]>;
+    type Args<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ? (
+            | Events[EventName]
+            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
+                : never)
+        )
+        : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+            ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
+            : any[]);
+    type EventNames<Events extends EventMap<Events>> = {} extends Events ? (string | symbol)
+        : (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap);
+    type Listener<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ?
+            | ((...args: Events[EventName]) => void)
+            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
+                : never)
+        : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+            ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
+            : (...args: any[]) => void);
     /**
      * The `EventEmitter` class is defined and exposed by the `node:events` module:
      *
@@ -130,10 +133,15 @@ declare module "events" {
      * It supports the following option:
      * @since v0.1.26
      */
-    class EventEmitter<T extends EventMap<T> = DefaultEventMap> {
+    class EventEmitter<Events extends EventMap<Events> = {}> {
         constructor(options?: EventEmitterOptions);
 
-        [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
+        [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
+            error: Error,
+            event: EventName,
+            ...args: Args<Events, EventName>
+        ): void;
+        [EventEmitter.captureRejectionSymbol]?(error: Error, event: string | symbol, ...args: any[]): void;
 
         /**
          * Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
@@ -214,6 +222,11 @@ declare module "events" {
          * ```
          * @since v11.13.0, v10.16.0
          */
+        static once<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            eventName: EventName,
+            options?: StaticEventEmitterOptions,
+        ): Promise<Args<Events, EventName>>;
         static once(
             emitter: NodeJS.EventEmitter,
             eventName: string | symbol,
@@ -300,6 +313,11 @@ declare module "events" {
          * @since v13.6.0, v12.16.0
          * @return An `AsyncIterator` that iterates `eventName` events emitted by the `emitter`
          */
+        static on<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            eventName: EventName,
+            options?: StaticEventEmitterIteratorOptions,
+        ): NodeJS.AsyncIterator<Args<Events, EventName>>;
         static on(
             emitter: NodeJS.EventEmitter,
             eventName: string | symbol,
@@ -310,6 +328,27 @@ declare module "events" {
             eventName: string,
             options?: StaticEventEmitterIteratorOptions,
         ): NodeJS.AsyncIterator<any[]>;
+        /**
+         * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
+         *
+         * ```js
+         * import { EventEmitter, listenerCount } from 'node:events';
+         *
+         * const myEmitter = new EventEmitter();
+         * myEmitter.on('event', () => {});
+         * myEmitter.on('event', () => {});
+         * console.log(listenerCount(myEmitter, 'event'));
+         * // Prints: 2
+         * ```
+         * @since v0.9.12
+         * @deprecated Since v3.2.0 - Use `listenerCount` instead.
+         * @param emitter The emitter to query
+         * @param eventName The event name
+         */
+        static listenerCount<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            eventName: EventName,
+        ): number;
         /**
          * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
          *
@@ -355,7 +394,14 @@ declare module "events" {
          * ```
          * @since v15.2.0, v14.17.0
          */
-        static getEventListeners(emitter: EventTarget | NodeJS.EventEmitter, name: string | symbol): Function[];
+        static getEventListeners<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            name: EventName,
+        ): Array<Listener<Events, EventName>>;
+        static getEventListeners(
+            emitter: EventTarget | NodeJS.EventEmitter,
+            name: string | symbol,
+        ): Function[];
         /**
          * Returns the currently set max amount of listeners.
          *
@@ -585,16 +631,37 @@ declare module "events" {
              */
             readonly asyncResource: EventEmitterReferencingAsyncResource;
         }
+
+        export interface EventEmitterBuiltInEventMap {
+            newListener: [eventName: string | symbol, listener: Function];
+            removeListener: [eventName: string | symbol, listener: Function];
+        }
     }
     global {
         namespace NodeJS {
-            interface EventEmitter<T extends EventMap<T> = DefaultEventMap> {
-                [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
+            interface EventEmitter<Events extends EventMap<Events> = {}> {
+                [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
+                    error: Error,
+                    event: EventName,
+                    ...args: Args<Events, EventName>
+                ): void;
+                [EventEmitter.captureRejectionSymbol]?<EventName extends string | symbol>(
+                    error: Error,
+                    event: EventName,
+                    ...args: Args<Events, EventName>
+                ): void;
                 /**
                  * Alias for `emitter.on(eventName, listener)`.
                  * @since v0.1.26
                  */
-                addListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                addListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                addListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Adds the `listener` function to the end of the listeners array for the event
                  * named `eventName`. No checks are made to see if the `listener` has already
@@ -626,7 +693,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                on<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                on<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                on<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Adds a **one-time** `listener` function for the event named `eventName`. The
                  * next time `eventName` is triggered, this listener is removed and then invoked.
@@ -656,7 +730,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                once<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                once<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                once<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Removes the specified `listener` from the listener array for the event named `eventName`.
                  *
@@ -739,12 +820,26 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                removeListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                removeListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Alias for `emitter.removeListener()`.
                  * @since v10.0.0
                  */
-                off<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                off<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                off<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Removes all listeners, or those of the specified `eventName`.
                  *
@@ -755,7 +850,10 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeAllListeners(eventName?: Key<unknown, T>): this;
+                /* eslint-disable @definitelytyped/no-unnecessary-generics */
+                removeAllListeners<EventName extends EventNames<Events>>(eventName: EventName): this;
+                removeAllListeners<EventName extends string | symbol>(eventName?: EventName): this;
+                /* eslint-enable @definitelytyped/no-unnecessary-generics */
                 /**
                  * By default `EventEmitter`s will print a warning if more than `10` listeners are
                  * added for a particular event. This is a useful default that helps finding
@@ -784,7 +882,12 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                listeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
+                listeners<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
+                listeners<EventName extends string | symbol>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
                  * including any wrappers (such as those created by `.once()`).
@@ -815,7 +918,12 @@ declare module "events" {
                  * ```
                  * @since v9.4.0
                  */
-                rawListeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
+                rawListeners<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
+                rawListeners<EventName extends string | symbol>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
                 /**
                  * Synchronously calls each of the listeners registered for the event named `eventName`, in the order they were registered, passing the supplied arguments
                  * to each.
@@ -856,7 +964,14 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                emit<K>(eventName: Key<K, T>, ...args: Args<K, T>): boolean;
+                emit<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    ...args: Args<Events, EventName>
+                ): boolean;
+                emit<EventName extends string | symbol>(
+                    eventName: EventName,
+                    ...args: Args<Events, EventName>
+                ): boolean;
                 /**
                  * Returns the number of listeners listening for the event named `eventName`.
                  * If `listener` is provided, it will return how many times the listener is found
@@ -865,7 +980,14 @@ declare module "events" {
                  * @param eventName The name of the event being listened for
                  * @param listener The event handler function
                  */
-                listenerCount<K>(eventName: Key<K, T>, listener?: Listener2<K, T>): number;
+                listenerCount<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener?: Listener<Events, EventName>,
+                ): number;
+                listenerCount<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener?: Listener<Events, EventName>,
+                ): number;
                 /**
                  * Adds the `listener` function to the _beginning_ of the listeners array for the
                  * event named `eventName`. No checks are made to see if the `listener` has
@@ -883,7 +1005,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                prependListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                prependListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Adds a **one-time**`listener` function for the event named `eventName` to the _beginning_ of the listeners array. The next time `eventName` is triggered, this
                  * listener is removed, and then invoked.
@@ -899,7 +1028,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependOnceListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                prependOnceListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                prependOnceListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Returns an array listing the events for which the emitter has registered
                  * listeners. The values in the array are strings or `Symbol`s.
@@ -919,7 +1055,7 @@ declare module "events" {
                  * ```
                  * @since v6.0.0
                  */
-                eventNames(): Array<(string | symbol) & Key2<unknown, T>>;
+                eventNames(): Array<(string | symbol)> & Array<EventNames<Events>>;
             }
         }
     }

--- a/types/node/v20/test/events.ts
+++ b/types/node/v20/test/events.ts
@@ -31,7 +31,7 @@ declare const any: any;
     result = emitter.getMaxListeners();
     result = emitter.listenerCount(event);
 
-    const handler: Function = () => {};
+    const handler = () => {};
     result = emitter.listenerCount(event, handler);
 }
 
@@ -141,7 +141,7 @@ async function testEventTarget() {
     captureRejectionSymbol2 = events.captureRejectionSymbol;
 
     const emitter = new events.EventEmitter();
-    emitter[events.captureRejectionSymbol] = (err: Error, name: string, ...args: any[]) => {};
+    emitter[events.captureRejectionSymbol] = (err: Error, name: string | symbol, ...args: any[]) => {};
 }
 
 {
@@ -193,16 +193,16 @@ async function testEventTarget() {
 
 {
     class MyEmitter extends events.EventEmitter {
-        addListener(event: string, listener: () => void): this {
+        addListener(event: string | symbol, listener: () => void): this {
             return this;
         }
-        listeners(event: string): Array<() => void> {
+        listeners(event: string | symbol): Array<() => void> {
             return [];
         }
-        emit(event: string, ...args: any[]): boolean {
+        emit(event: string | symbol, ...args: any[]): boolean {
             return true;
         }
-        listenerCount(type: string): number {
+        listenerCount(type: string | symbol): number {
             return 0;
         }
     }

--- a/types/node/v20/test/events_generic.ts
+++ b/types/node/v20/test/events_generic.ts
@@ -299,4 +299,18 @@ declare const event5: "event5";
 
     events.on(doubleExtended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
     events.once(doubleExtended, "unknown"); // $ExpectType Promise<any[]>
+
+    extended.addListener(event1, (a: string, b: number | boolean): number => 1);
+    doubleExtended.addListener(event1, (a: string, b: number | boolean): number => 1);
+    // @ts-expect-error
+    extended.addListener(event1, (a: string, b: boolean): number => 1);
+    // @ts-expect-error
+    doubleExtended.addListener(event1, (a: string, b: boolean): number => 1);
+
+    extended.emit("event1", "hello", 42);
+    doubleExtended.emit("event1", "hello", 42);
+    // @ts-expect-error
+    extended.emit("event1", 123);
+    // @ts-expect-error
+    doubleExtended.emit("event1", 123);
 }

--- a/types/node/v20/test/events_generic.ts
+++ b/types/node/v20/test/events_generic.ts
@@ -110,13 +110,17 @@ declare const event5: "event5";
 }
 
 {
-    let result: Promise<number[]>;
+    let result1: Promise<T["event1"]>;
+    let result2: Promise<T["event2"]>;
+    let result3: Promise<T["event3"]>;
+    let result4: Promise<T["event4"]>;
+    let result5: Promise<T["event5"]>;
 
-    result = events.once(emitter, event1);
-    result = events.once(emitter, event2);
-    result = events.once(emitter, event3);
-    result = events.once(emitter, event4);
-    result = events.once(emitter, event5);
+    result1 = events.once(emitter, event1);
+    result2 = events.once(emitter, event2);
+    result3 = events.once(emitter, event3);
+    result4 = events.once(emitter, event4);
+    result5 = events.once(emitter, event5);
 
     emitter.emit("event1", "hello", 42);
     emitter.emit("event2", true);
@@ -146,7 +150,7 @@ declare const event5: "event5";
 }
 
 {
-    let result: Array<keyof T>;
+    let result: Array<keyof T | keyof events.EventEmitterBuiltInEventMap>;
 
     result = emitter.eventNames();
 }
@@ -157,12 +161,12 @@ declare const event5: "event5";
         )
         : never;
 
-    function on1<K>(event: K, listener: Listener<K>): void {
+    function on1<K extends keyof T>(event: K, listener: Listener<K>): void {
         emitter.on(event, listener);
     }
 
     // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-    function on2<K>(...args: Parameters<typeof emitter.on<K>>): void {
+    function on2<K extends keyof T>(...args: Parameters<typeof emitter.on<K>>): void {
         emitter.on(...args);
     }
 
@@ -204,7 +208,6 @@ declare const event5: "event5";
     emitter.emit("abc", "hello", 123);
     // @ts-expect-error
     emitter.emit("abc", 123, false);
-    // @ts-expect-error
     emitter.emit("def", "hello", 123);
 }
 
@@ -226,7 +229,6 @@ declare const event5: "event5";
     emitter.emit(s1, "hello", 123);
     // @ts-expect-error
     emitter.emit(s1, 123, false);
-    // @ts-expect-error
     emitter.emit(s2, "hello", 123);
 }
 
@@ -244,6 +246,36 @@ declare const event5: "event5";
     emitter.emit(789, 123, false);
     // @ts-expect-error
     emitter.emit(s1, "hello", false);
-    // @ts-expect-error
     emitter.emit(s2, "hello", false);
+}
+
+{
+    const promise1: Promise<[string, number]> = events.once(new events.EventEmitter<T>(), "event1");
+    const promise2: Promise<[boolean]> = events.once(new events.EventEmitter<T>(), "event2");
+    const promise3: Promise<[]> = events.once(new events.EventEmitter<T>(), "event3");
+    const promise4: Promise<string[]> = events.once(new events.EventEmitter<T>(), "event4");
+    const promise5: Promise<unknown[]> = events.once(new events.EventEmitter<T>(), "event5");
+    // @ts-expect-error
+    const promise6: Promise<[string, string]> = events.once(new events.EventEmitter<T>(), "event1");
+    const promise7: Promise<any[]> = events.once(new events.EventEmitter<T>(), "event");
+
+    const iterable1: NodeJS.AsyncIterator<[string, number]> = events.on(new events.EventEmitter<T>(), "event1");
+    const iterable2: NodeJS.AsyncIterator<[boolean]> = events.on(new events.EventEmitter<T>(), "event2");
+    const iterable3: NodeJS.AsyncIterator<[]> = events.on(new events.EventEmitter<T>(), "event3");
+    const iterable4: NodeJS.AsyncIterator<string[]> = events.on(new events.EventEmitter<T>(), "event4");
+    const iterable5: NodeJS.AsyncIterator<unknown[]> = events.on(new events.EventEmitter<T>(), "event5");
+    // @ts-expect-error
+    const iterable6: NodeJS.AsyncIterator<[string, string]> = events.on(new events.EventEmitter<T>(), "event1");
+    const iterable7: NodeJS.AsyncIterator<any[]> = events.on(new events.EventEmitter<T>(), "event");
+}
+
+{
+    function acceptsEventEmitterInterface(eventEmitter: NodeJS.EventEmitter) {
+    }
+
+    function acceptsEventEmitterClass(eventEmitter: events.EventEmitter) {
+    }
+
+    acceptsEventEmitterInterface(emitter);
+    acceptsEventEmitterClass(emitter);
 }

--- a/types/node/v20/test/events_generic.ts
+++ b/types/node/v20/test/events_generic.ts
@@ -279,3 +279,24 @@ declare const event5: "event5";
     acceptsEventEmitterInterface(emitter);
     acceptsEventEmitterClass(emitter);
 }
+
+{
+    class Extended extends events.EventEmitter<T> {}
+
+    class DoubleExtension extends Extended {}
+
+    const extended = new Extended();
+    const doubleExtended = new DoubleExtension();
+
+    events.on(extended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
+    events.once(extended, "event1"); // $ExpectType Promise<[string, number]>
+
+    events.on(extended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
+    events.once(extended, "unknown"); // $ExpectType Promise<any[]>
+
+    events.on(doubleExtended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
+    events.once(doubleExtended, "event1"); // $ExpectType Promise<[string, number]>
+
+    events.on(doubleExtended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
+    events.once(doubleExtended, "unknown"); // $ExpectType Promise<any[]>
+}

--- a/types/opossum/opossum-tests.ts
+++ b/types/opossum/opossum-tests.ts
@@ -142,7 +142,7 @@ const options: CircuitBreaker.Options = {
     resetTimeout: 30000, // After 30 seconds, try again.
 };
 options.enableSnapshots; // $ExpectType boolean | undefined
-options.rotateBucketController; // $ExpectType EventEmitter<DefaultEventMap> | undefined
+options.rotateBucketController; // $ExpectType EventEmitter<{}> | undefined
 breaker = new CircuitBreaker(asyncFunctionThatCouldFail, options);
 
 breaker

--- a/types/rdf-store-fs/rdf-store-fs-tests.ts
+++ b/types/rdf-store-fs/rdf-store-fs-tests.ts
@@ -45,20 +45,20 @@ function store_match() {
 
 function store_import() {
     const stream: Stream = <any> {};
-    // $ExpectType EventEmitter<DefaultEventMap>
+    // $ExpectType EventEmitter<{}>
     let imported = flatStore.import(stream);
     imported = flatStore.import(stream, { truncate: true });
 }
 
 function store_remove() {
     const stream: Stream = <any> {};
-    // $ExpectType EventEmitter<DefaultEventMap>
+    // $ExpectType EventEmitter<{}>
     const event = flatStore.remove(stream);
 }
 
 function store_removeMatches() {
     const term: Term = <any> {};
-    // $ExpectType EventEmitter<DefaultEventMap>
+    // $ExpectType EventEmitter<{}>
     let event = flatStore.removeMatches();
     event = flatStore.removeMatches(term);
     event = flatStore.removeMatches(term, term);
@@ -68,7 +68,7 @@ function store_removeMatches() {
 
 function store_deleteGraph() {
     const graph: Quad_Graph = <any> {};
-    // $ExpectType EventEmitter<DefaultEventMap>
+    // $ExpectType EventEmitter<{}>
     const event = flatStore.deleteGraph(graph);
 }
 

--- a/types/readable-stream/index.d.ts
+++ b/types/readable-stream/index.d.ts
@@ -209,10 +209,8 @@ declare class _Readable extends NoAsyncDispose implements _IReadable {
     off(eventName: string | symbol, listener: (...args: any[]) => void): this;
     setMaxListeners(n: number): this;
     getMaxListeners(): number;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    listeners(eventName: string | symbol): Function[];
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    rawListeners(eventName: string | symbol): Function[];
+    listeners(eventName: string | symbol): Array<(...args: any[]) => void>;
+    rawListeners(eventName: string | symbol): Array<(...args: any[]) => void>;
     listenerCount(eventName: string | symbol): number;
     eventNames(): Array<string | symbol>;
 

--- a/types/sane/index.d.ts
+++ b/types/sane/index.d.ts
@@ -80,8 +80,7 @@ declare class SaneWatcher extends EventEmitter {
     removeListener(event: "add" | "change", listener: (path: string, root: string, stat: Stats) => void): this;
     removeListener(event: "delete", listener: (path: string, root: string) => void): this;
     removeAllListeners(event?: EventType): this;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    listeners(event: EventType): Function[];
+    listeners(event: EventType): Array<(...args: any[]) => void>;
     emit(event: "ready"): boolean;
     emit(event: "error", error: Error): boolean;
     emit(event: "all", eventType: AllEventType, path: string, root: string, stat?: Stats): boolean;

--- a/types/sse/sse-tests.ts
+++ b/types/sse/sse-tests.ts
@@ -17,7 +17,7 @@ new SSE(expressApp, options); // $ExpectType SSE
 const sse = new SSE(expressApp); // $ExpectType SSE
 sse.handleRequest(expressApp.request, expressApp.response, "query"); // $ExpectType void
 sse.matchesPath("/sse", "/sse"); // $ExpectType boolean
-sse.server; // $ExpectType EventEmitter<DefaultEventMap>
+sse.server; // $ExpectType EventEmitter<{}>
 
 SSE.Client; // $ExpectType typeof Client
 const sseClient = new SSE.Client(expressApp.request, expressApp.response); // $ExpectType Client

--- a/types/steam/index.d.ts
+++ b/types/steam/index.d.ts
@@ -44,17 +44,5 @@ declare namespace Steam {
 
         setPersonaState(state: EPersonaState): void;
         setPersonaName(name: string): void;
-
-        // Event emitter
-        addListener(event: string, listener: Function): this;
-        on(event: string, listener: Function): this;
-        once(event: string, listener: Function): this;
-        removeListener(event: string, listener: Function): this;
-        removeAllListeners(event?: string): this;
-        setMaxListeners(n: number): this;
-        getMaxListeners(): number;
-        listeners(event: string): Function[];
-        emit(event: string, ...args: any[]): boolean;
-        listenerCount(type: string): number;
     }
 }

--- a/types/twitter/twitter-tests.ts
+++ b/types/twitter/twitter-tests.ts
@@ -53,7 +53,7 @@ stream.on("error", error => {
 });
 
 client.stream("statuses/filter", { track: "javascript" }, stream => {
-    // $ExpectType EventEmitter<DefaultEventMap>
+    // $ExpectType EventEmitter<{}>
     stream;
 
     stream.on("data", (event: any) => {
@@ -65,6 +65,6 @@ client.stream("statuses/filter", { track: "javascript" }, stream => {
     });
 });
 client.stream("statuses/filter", stream => {
-    // $ExpectType EventEmitter<DefaultEventMap>
+    // $ExpectType EventEmitter<{}>
     stream;
 });

--- a/types/umzug/index.d.ts
+++ b/types/umzug/index.d.ts
@@ -231,15 +231,15 @@ declare namespace umzug {
 
         on(
             eventName: "migrating" | "reverting" | "migrated" | "reverted",
-            cb?: (name: string, migration: Migration) => void,
+            cb: (name: string, migration: Migration) => void,
         ): this;
         addListener(
             eventName: "migrating" | "reverting" | "migrated" | "reverted",
-            cb?: (name: string, migration: Migration) => void,
+            cb: (name: string, migration: Migration) => void,
         ): this;
         removeListener(
             eventName: "migrating" | "reverting" | "migrated" | "reverted",
-            cb?: (name: string, migration: Migration) => void,
+            cb: (name: string, migration: Migration) => void,
         ): this;
     }
 

--- a/types/xml-flow/xml-flow-tests.ts
+++ b/types/xml-flow/xml-flow-tests.ts
@@ -8,7 +8,7 @@ fs.writeFileSync("./test.xml", "<head><childOne>text</childOne><childTwo>text</c
 const readStreamOne = fs.createReadStream("./test.xml", "utf8");
 const readStreamTwo = fs.createReadStream("./test.xml", "utf8");
 
-// $ExpectType EventEmitter<DefaultEventMap>
+// $ExpectType EventEmitter<{}>
 const myFlow = flow(readStreamOne);
 
 const myOptions = {
@@ -22,7 +22,7 @@ const myOptions = {
     strict: true,
 };
 
-// $ExpectType EventEmitter<DefaultEventMap>
+// $ExpectType EventEmitter<{}>
 const myFlowWithOptions = flow(readStreamTwo, myOptions);
 
 // Create object to xml-ise


### PR DESCRIPTION
While I originally set out to just add generics to static members of `EventEmitter`, I discovered a few quirks and bugs in the existing generic code that made it very hard to do well. In order to make the static members work I had to fix these bugs, which ends up being possibly a little clearer to understand.

The original PR used T, K, etc... for type param ids, which I have expanded in my cleanup process to better help understand what said generics did. I think this would be helpful for everyone, so I've left it, but wasn't sure if it was a stylistic choice.

The biggest change worth noting here (of the bug fixes) is that the types will now still allow you to emit, listen, etc... arbitrary events. It maintains type safety for events you specify as having strict types but prefers to more strictly match the runtime when straying outside those events.

The change from `Function` to a function signature is the only slight breaking change. It notably brought to light some packages that were overriding the built-in types of `EventEmitter` from the days when they were still implementing the interface instead of extending the class.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68313#issuecomment-2186088773
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.