### PR TITLE
[`mapbox__mapbox-sdk`] - Add types for missing `@mapbox/mapbox-sdk` and `isochrone` service

### DIFF
--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -1,6 +1,14 @@
 /// <reference types="node" />
 
 // eslint-disable-next-line @definitelytyped/no-declare-current-package
+declare module "@mapbox/mapbox-sdk" {
+    // eslint-disable-next-line @definitelytyped/no-self-import
+    import MapiClient, { SdkConfig } from "@mapbox/mapbox-sdk/lib/classes/mapi-client";
+
+    export default function createNodeClient(config: SdkConfig): MapiClient;
+}
+
+// eslint-disable-next-line @definitelytyped/no-declare-current-package
 declare module "@mapbox/mapbox-sdk/lib/classes/mapi-client" {
     // eslint-disable-next-line @definitelytyped/no-self-import
     import { MapiRequest, MapiRequestOptions } from "@mapbox/mapbox-sdk/lib/classes/mapi-request";

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -1236,6 +1236,100 @@ declare module "@mapbox/mapbox-sdk/services/geocoding-v6" {
 }
 
 // eslint-disable-next-line @definitelytyped/no-declare-current-package
+declare module "@mapbox/mapbox-sdk/services/isochrone" {
+    import * as GeoJSON from "geojson";
+    // eslint-disable-next-line @definitelytyped/no-self-import
+    import MapiClient, { SdkConfig } from "@mapbox/mapbox-sdk/lib/classes/mapi-client";
+    // eslint-disable-next-line @definitelytyped/no-self-import
+    import { MapiRequest } from "@mapbox/mapbox-sdk/lib/classes/mapi-request";
+
+    export default function Isochrone(config: SdkConfig | MapiClient): IsochroneService;
+
+    interface IsochroneService {
+        getContours(
+            request: IsochroneRequest<false | undefined>,
+        ): MapiRequest<GeoJSON.FeatureCollection<GeoJSON.LineString>>;
+        getContours(
+            request: IsochroneRequest<true>,
+        ): MapiRequest<GeoJSON.FeatureCollection<GeoJSON.Polygon>>;
+    }
+
+    interface IsochroneDistance {
+        /**
+         * The times in minutes to use for each isochrone contour. You can specify up to four contours.
+         * Times must be in increasing order. The maximum time that can be specified is 60 minutes.
+         * Setting minutes and meters in the same time is an error.
+         */
+        minutes?: never;
+        /**
+         * The distances in meters to use for each isochrone contour. You can specify up to four contours.
+         * Distances must be in increasing order. The maximum distance that can be specified is
+         * 100000 meters. Setting minutes and meters in the same time is an error.
+         */
+        meters: [number, number?, number?, number?];
+    }
+
+    interface IsochroneTime {
+        /**
+         * The times in minutes to use for each isochrone contour. You can specify up to four contours.
+         * Times must be in increasing order. The maximum time that can be specified is 60 minutes.
+         * Setting minutes and meters in the same time is an error.
+         */
+        minutes: [number, number?, number?, number?];
+        /**
+         * The distances in meters to use for each isochrone contour. You can specify up to four contours.
+         * Distances must be in increasing order. The maximum distance that can be specified is
+         * 100000 meters. Setting minutes and meters in the same time is an error.
+         */
+        meters?: never;
+    }
+
+    type IsochroneRequest<T extends boolean | undefined = false> = (IsochroneDistance | IsochroneTime) & {
+        /**
+         * The colors to use for each isochrone contour, specified as hex values without a leading
+         * `#`(for example, `ff0000` for red). If this parameter is used, there must be the same
+         * number of colors as there are entries in contours_minutes or contours_meters. If no
+         * colors are specified, the Isochrone API will assign a default rainbow color scheme to
+         * the output.
+         */
+        colors?: [string?, string?, string?, string?];
+        /** A {longitude,latitude} coordinate pair around which to center the isochrone lines. */
+        coordinates: [number, number];
+        /**
+         * A floating point value from 0.0 to 1.0 that can be used to remove smaller contours. The
+         * default is 1.0. A value of 1.0 will only return the largest contour for a given time
+         * value. A value of 0.5 drops any contours that are less than half the area of the largest
+         * contour in the set of contours for that same time value.
+         *
+         * @default 1.0
+         */
+        denoise?: number;
+        /**
+         *  A positive floating point value in meters used as the tolerance for Douglas-Peucker
+         * generalization. There is no upper bound. If no value is specified in the request, the
+         * Isochrone API will choose the most optimized generalization to use for the request.
+         * Note that the generalization of contours can lead to self-intersections, as well as
+         * intersections of adjacent contours.
+         */
+        generalize?: number;
+        /**
+         * Specify whether to return the contours as GeoJSON polygons (`true`) or linestrings
+         * (`false`, default). When polygons=`true`, any contour that forms a ring is returned as a
+         * polygon.
+         *
+         * @default false
+         */
+        polygons?: T;
+        /**
+         * A Mapbox Directions routing profile ID.
+         *
+         * @default 'driving'
+         */
+        profile?: "driving" | "driving-traffic" | "walking" | "cycling";
+    };
+}
+
+// eslint-disable-next-line @definitelytyped/no-declare-current-package
 declare module "@mapbox/mapbox-sdk/services/geocoding" {
     import { LngLatLike } from "mapbox-gl";
     // eslint-disable-next-line @definitelytyped/no-self-import

--- a/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
+++ b/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
@@ -1,4 +1,5 @@
-import MapiClient, { SdkConfig } from "@mapbox/mapbox-sdk/lib/classes/mapi-client";
+import mbxClient from '@mapbox/mapbox-sdk'
+import { SdkConfig } from "@mapbox/mapbox-sdk/lib/classes/mapi-client";
 import { MapiRequest } from "@mapbox/mapbox-sdk/lib/classes/mapi-request";
 import { MapiResponse } from "@mapbox/mapbox-sdk/lib/classes/mapi-response";
 import Directions, { DirectionsResponse, DirectionsService } from "@mapbox/mapbox-sdk/services/directions";
@@ -13,7 +14,7 @@ import { LineString } from "geojson";
 const config: SdkConfig = {
     accessToken: "access-token",
 };
-const client = new MapiClient(config);
+const client = mbxClient(config);
 
 const directionsService: DirectionsService = Directions(client);
 

--- a/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
+++ b/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
@@ -1,4 +1,4 @@
-import mbxClient from '@mapbox/mapbox-sdk'
+import mbxClient from "@mapbox/mapbox-sdk";
 import { SdkConfig } from "@mapbox/mapbox-sdk/lib/classes/mapi-client";
 import { MapiRequest } from "@mapbox/mapbox-sdk/lib/classes/mapi-request";
 import { MapiResponse } from "@mapbox/mapbox-sdk/lib/classes/mapi-response";

--- a/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
+++ b/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
@@ -5,6 +5,7 @@ import { MapiResponse } from "@mapbox/mapbox-sdk/lib/classes/mapi-response";
 import Directions, { DirectionsResponse, DirectionsService } from "@mapbox/mapbox-sdk/services/directions";
 import Geocoding, { GeocodeService } from "@mapbox/mapbox-sdk/services/geocoding";
 import GeocodingV6, { GeocodeService as GeocodeServiceV6 } from "@mapbox/mapbox-sdk/services/geocoding-v6";
+import Isochrone, { IsochroneService } from "@mapbox/mapbox-sdk/services/isochrone";
 import MapMatching, { MapMatchingResponse, MapMatchingService } from "@mapbox/mapbox-sdk/services/map-matching";
 import Optimization, { OptimizationService } from "@mapbox/mapbox-sdk/services/optimization";
 import StaticMap, { StaticMapService } from "@mapbox/mapbox-sdk/services/static";
@@ -80,6 +81,32 @@ const drivingTrafficDirectionsRequest: MapiRequest = directionsService.getDirect
 });
 
 drivingTrafficDirectionsRequest.send().then((response: MapiResponse) => {
+});
+
+const isochroneService: IsochroneService = Isochrone(client);
+
+const isochroneRequestLine = isochroneService.getContours({ coordinates: [-3.599431, 54.507913], minutes: [20, 40] });
+
+const isochroneRequestPoly = isochroneService.getContours({
+    coordinates: [-3.599431, 54.507913],
+    minutes: [20, 40],
+    polygons: true,
+});
+
+isochroneRequestLine.send().then((response) => {
+    const body = response.body;
+    const features = body.features;
+    features.map((feature) => {
+        feature.geometry.type === "LineString";
+    });
+});
+
+isochroneRequestPoly.send().then((response) => {
+    const body = response.body;
+    const features = body.features;
+    features.map((feature) => {
+        feature.geometry.type === "Polygon";
+    });
 });
 
 const mapMatchingService: MapMatchingService = MapMatching(client);

--- a/types/mapbox__mapbox-sdk/package.json
+++ b/types/mapbox__mapbox-sdk/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/mapbox__mapbox-sdk",
-    "version": "0.14.9999",
+    "version": "0.15.9999",
     "projects": [
         "https://github.com/mapbox/mapbox-sdk-js"
     ],


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Main Export](https://github.com/mapbox/mapbox-sdk-js/blob/v0.15.16/lib/node/node-client.js) / [Docs for using the import](https://github.com/mapbox/mapbox-sdk-js/blob/v0.15.16/lib/node/node-client.js)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Fixes `File '*/node_modules/@types/mapbox__mapbox-sdk/index.d.ts' is not a module.` error when following documentation:

```js
const mbxClient = require('@mapbox/mapbox-sdk');
const mbxStyles = require('@mapbox/mapbox-sdk/services/styles');
const mbxTilesets = require('@mapbox/mapbox-sdk/services/tilesets');

const baseClient = mbxClient({ accessToken: MY_ACCESS_TOKEN });
const stylesService = mbxStyles(baseClient);
const tilesetsService = mbxTilesets(baseClient);
```