### PR TITLE
fix(sparqljs): inaccurate types of INSERT/DELETE operations

### DIFF
--- a/types/sparqljs/index.d.ts
+++ b/types/sparqljs/index.d.ts
@@ -124,14 +124,14 @@ export type InsertDeleteOperation =
     }
     | {
         updateType: "insertdelete";
-        graph?: GraphOrDefault;
-        insert?: Quads[];
-        delete?: Quads[];
+        graph?: IriTerm;
+        insert: Quads[];
+        delete: Quads[];
         using?: {
             default: IriTerm[];
             named: IriTerm[];
         };
-        where?: Pattern[];
+        where: Pattern[];
     }
     | {
         updateType: "deletewhere";

--- a/types/sparqljs/sparqljs-tests.ts
+++ b/types/sparqljs/sparqljs-tests.ts
@@ -144,10 +144,7 @@ function updateQueries() {
         updates: [
             {
                 updateType: "insertdelete",
-                graph: {
-                    type: "graph",
-                    name: DataFactory.namedNode("http://example.com/foo"),
-                },
+                graph: DataFactory.namedNode("http://example.com/foo"),
                 insert: [bgp],
                 delete: [bgp],
                 where: [],


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/RubenVerborgh/SPARQL.js/blob/main/lib/SparqlGenerator.js#L378-L383>
   - `graph` is used with `this.toEntity` which expects an instance of `Term`
   - `insert` and `delete` must be arrays
   - `where` is passed to `this.group` which doesnot handle undefined
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
