### PR TITLE
feat(relay-test-utils): update types to match latest version and add option for stricter typing for resolvers

### DIFF
--- a/types/relay-test-utils/lib/RelayMockPayloadGenerator.d.ts
+++ b/types/relay-test-utils/lib/RelayMockPayloadGenerator.d.ts
@@ -8,29 +8,28 @@ export interface MockResolverContext {
     readonly args: Record<string, unknown> | null | undefined;
 }
 
-export type DeepPartial<T> = T extends object
-  ? {
-      [P in keyof T]?: DeepPartial<T[P]>;
+export type DeepPartial<T> = T extends object ? {
+        [P in keyof T]?: DeepPartial<T[P]>;
     }
-  : T;
+    : T;
 
 export type MockResolver<T = unknown> = (
-  context: MockResolverContext,
-  generateId: () => number,
+    context: MockResolverContext,
+    generateId: () => number,
 ) => DeepPartial<T> | undefined;
 
 export type DefaultMockResolvers = Partial<{
-  ID: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
-  [key: string]: unknown;
+    ID: string;
+    Boolean: boolean;
+    Int: number;
+    Float: number;
+    [key: string]: unknown;
 }>;
 
 export type MockResolvers<
-  TypeMap extends DefaultMockResolvers = DefaultMockResolvers,
+    TypeMap extends DefaultMockResolvers = DefaultMockResolvers,
 > = {
-  [K in keyof TypeMap]?: MockResolver<TypeMap[K]>;
+    [K in keyof TypeMap]?: MockResolver<TypeMap[K]>;
 };
 
 export function generate(
@@ -42,5 +41,5 @@ export function generate(
 export function generateWithDefer(
     operation: OperationDescriptor,
     mockResolvers?: MockResolvers | null,
-    options?: { mockClientData?: boolean, generateDeferredPayload?: boolean } | null,
-): GraphQLResponse
+    options?: { mockClientData?: boolean; generateDeferredPayload?: boolean } | null,
+): GraphQLResponse;

--- a/types/relay-test-utils/lib/RelayMockPayloadGenerator.d.ts
+++ b/types/relay-test-utils/lib/RelayMockPayloadGenerator.d.ts
@@ -1,4 +1,4 @@
-import { GraphQLSingularResponse, OperationDescriptor } from "relay-runtime";
+import { GraphQLResponse, GraphQLSingularResponse, OperationDescriptor } from "relay-runtime";
 
 export interface MockResolverContext {
     readonly parentType: string | null | undefined;
@@ -8,14 +8,39 @@ export interface MockResolverContext {
     readonly args: Record<string, unknown> | null | undefined;
 }
 
-export type MockResolver = (context: MockResolverContext, generateId: () => number) => unknown;
+export type DeepPartial<T> = T extends object
+  ? {
+      [P in keyof T]?: DeepPartial<T[P]>;
+    }
+  : T;
 
-export interface MockResolvers {
-    [typeName: string]: MockResolver;
-}
+export type MockResolver<T = unknown> = (
+  context: MockResolverContext,
+  generateId: () => number,
+) => DeepPartial<T> | undefined;
+
+export type DefaultMockResolvers = Partial<{
+  ID: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+  [key: string]: unknown;
+}>;
+
+export type MockResolvers<
+  TypeMap extends DefaultMockResolvers = DefaultMockResolvers,
+> = {
+  [K in keyof TypeMap]?: MockResolver<TypeMap[K]>;
+};
 
 export function generate(
     operation: OperationDescriptor,
     mockResolvers?: MockResolvers | null,
     options?: { mockClientData?: boolean } | null,
 ): GraphQLSingularResponse;
+
+export function generateWithDefer(
+    operation: OperationDescriptor,
+    mockResolvers?: MockResolvers | null,
+    options?: { mockClientData?: boolean, generateDeferredPayload?: boolean } | null,
+): GraphQLResponse

--- a/types/relay-test-utils/lib/RelayModernMockEnvironment.d.ts
+++ b/types/relay-test-utils/lib/RelayModernMockEnvironment.d.ts
@@ -27,7 +27,7 @@ export interface MockFunctions {
     reject: (request: ConcreteRequest | OperationDescriptor, error: Error | string) => void;
     nextValue: (request: ConcreteRequest | OperationDescriptor, payload: GraphQLSingularResponse) => void;
     complete: (request: ConcreteRequest | OperationDescriptor) => void;
-    resolve: (request: ConcreteRequest | OperationDescriptor, payload: GraphQLSingularResponse) => void;
+    resolve: (request: ConcreteRequest | OperationDescriptor, payload: GraphQLSingularResponse | readonly GraphQLSingularResponse[]) => void;
     getAllOperations: () => readonly OperationDescriptor[];
     findOperation: (findFn: (operation: OperationDescriptor) => boolean) => OperationDescriptor;
     queuePendingOperation: (query: GraphQLTaggedNode, variables: Variables) => void;
@@ -44,7 +44,7 @@ interface MockEnvironment {
     mockClear: () => void;
 }
 
-export interface RelayMockEnvironment extends MockEnvironment, IEnvironment {}
+export interface RelayMockEnvironment extends MockEnvironment, IEnvironment { }
 
 /**
  * Creates an instance of the `Environment` interface defined in
@@ -84,4 +84,4 @@ export interface RelayMockEnvironment extends MockEnvironment, IEnvironment {}
  */
 export function createMockEnvironment(config?: Partial<EnvironmentConfig>): RelayMockEnvironment;
 
-export {};
+export { };

--- a/types/relay-test-utils/lib/RelayModernMockEnvironment.d.ts
+++ b/types/relay-test-utils/lib/RelayModernMockEnvironment.d.ts
@@ -27,7 +27,10 @@ export interface MockFunctions {
     reject: (request: ConcreteRequest | OperationDescriptor, error: Error | string) => void;
     nextValue: (request: ConcreteRequest | OperationDescriptor, payload: GraphQLSingularResponse) => void;
     complete: (request: ConcreteRequest | OperationDescriptor) => void;
-    resolve: (request: ConcreteRequest | OperationDescriptor, payload: GraphQLSingularResponse | readonly GraphQLSingularResponse[]) => void;
+    resolve: (
+        request: ConcreteRequest | OperationDescriptor,
+        payload: GraphQLSingularResponse | readonly GraphQLSingularResponse[],
+    ) => void;
     getAllOperations: () => readonly OperationDescriptor[];
     findOperation: (findFn: (operation: OperationDescriptor) => boolean) => OperationDescriptor;
     queuePendingOperation: (query: GraphQLTaggedNode, variables: Variables) => void;
@@ -44,7 +47,7 @@ interface MockEnvironment {
     mockClear: () => void;
 }
 
-export interface RelayMockEnvironment extends MockEnvironment, IEnvironment { }
+export interface RelayMockEnvironment extends MockEnvironment, IEnvironment {}
 
 /**
  * Creates an instance of the `Environment` interface defined in
@@ -84,4 +87,4 @@ export interface RelayMockEnvironment extends MockEnvironment, IEnvironment { }
  */
 export function createMockEnvironment(config?: Partial<EnvironmentConfig>): RelayMockEnvironment;
 
-export { };
+export {};

--- a/types/relay-test-utils/lib/index.d.ts
+++ b/types/relay-test-utils/lib/index.d.ts
@@ -1,4 +1,5 @@
 import * as MockPayloadGenerator from "./RelayMockPayloadGenerator";
+export { MockResolver, MockResolvers, DefaultMockResolvers } from "./RelayMockPayloadGenerator";
 export { RelayMockEnvironment as MockEnvironment } from "./RelayModernMockEnvironment";
 export { MockPayloadGenerator };
 export { createMockEnvironment } from "./RelayModernMockEnvironment";

--- a/types/relay-test-utils/lib/index.d.ts
+++ b/types/relay-test-utils/lib/index.d.ts
@@ -1,5 +1,5 @@
 import * as MockPayloadGenerator from "./RelayMockPayloadGenerator";
-export { MockResolver, MockResolvers, DefaultMockResolvers } from "./RelayMockPayloadGenerator";
+export { DefaultMockResolvers, MockResolver, MockResolvers } from "./RelayMockPayloadGenerator";
 export { RelayMockEnvironment as MockEnvironment } from "./RelayModernMockEnvironment";
 export { MockPayloadGenerator };
 export { createMockEnvironment } from "./RelayModernMockEnvironment";

--- a/types/relay-test-utils/package.json
+++ b/types/relay-test-utils/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/relay-test-utils",
-    "version": "14.1.9999",
+    "version": "17.0.9999",
     "projects": [
         "https://relay.dev"
     ],

--- a/types/relay-test-utils/test/classical.tsx
+++ b/types/relay-test-utils/test/classical.tsx
@@ -37,3 +37,47 @@ function TestQueryRenderer() {
         />
     );
 }
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+type User = {
+    __typename?: "User",
+    id: string,
+    displayName?: string,
+}
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+type TypeMap = {
+    ID: string;
+    Boolean: boolean;
+    Int: number;
+    Float: number;
+    User: User;
+}
+
+type MockResolvers = MockPayloadGenerator.MockResolvers<TypeMap>;
+type UserMockResolver = MockResolvers["User"];
+
+const userResolver: UserMockResolver = (context, generateId) => {
+    const id = generateId();
+
+    return {
+        id: (context.name || "") + String(id),
+        displayName: "User " + id,
+    };
+}
+
+const mockResolvers: MockResolvers = {
+    User: userResolver,
+};
+
+const rawMockResolvers: MockPayloadGenerator.MockResolvers = {
+    Int: () => 42,
+};
+
+environment.mock.resolveMostRecentOperation(operation =>
+    MockPayloadGenerator.generate(operation, mockResolvers, { mockClientData: true })
+);
+
+environment.mock.resolveMostRecentOperation(operation =>
+    MockPayloadGenerator.generate(operation, rawMockResolvers, { mockClientData: true })
+);

--- a/types/relay-test-utils/test/classical.tsx
+++ b/types/relay-test-utils/test/classical.tsx
@@ -40,10 +40,10 @@ function TestQueryRenderer() {
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type User = {
-    __typename?: "User",
-    id: string,
-    displayName?: string,
-}
+    __typename?: "User";
+    id: string;
+    displayName?: string;
+};
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type TypeMap = {
@@ -52,7 +52,7 @@ type TypeMap = {
     Int: number;
     Float: number;
     User: User;
-}
+};
 
 type MockResolvers = MockPayloadGenerator.MockResolvers<TypeMap>;
 type UserMockResolver = MockResolvers["User"];
@@ -64,7 +64,7 @@ const userResolver: UserMockResolver = (context, generateId) => {
         id: (context.name || "") + String(id),
         displayName: "User " + id,
     };
-}
+};
 
 const mockResolvers: MockResolvers = {
     User: userResolver,

--- a/types/relay-test-utils/test/index.tsx
+++ b/types/relay-test-utils/test/index.tsx
@@ -122,7 +122,13 @@ function environmentTests() {
     // @ExpectType OperationDescriptor
     const newOperation = environment.mock.getMostRecentOperation();
 
-    environment.mock.resolve(operation, MockPayloadGenerator.generateWithDefer(newOperation, null, { generateDeferredPayload: true, mockClientData: true }))
+    environment.mock.resolve(
+        operation,
+        MockPayloadGenerator.generateWithDefer(newOperation, null, {
+            generateDeferredPayload: true,
+            mockClientData: true,
+        }),
+    );
 }
 
 function testResolverTests() {

--- a/types/relay-test-utils/test/index.tsx
+++ b/types/relay-test-utils/test/index.tsx
@@ -118,6 +118,11 @@ function environmentTests() {
     environment.mock.nextValue(operation, { data: {} });
     environment.mock.resolve(operation, { data: {} });
     environment.mock.queuePendingOperation(userQuery, {});
+
+    // @ExpectType OperationDescriptor
+    const newOperation = environment.mock.getMostRecentOperation();
+
+    environment.mock.resolve(operation, MockPayloadGenerator.generateWithDefer(newOperation, null, { generateDeferredPayload: true, mockClientData: true }))
 }
 
 function testResolverTests() {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/relay/blob/6479b71e4b1d94be596444e141832afa9dc90f09/packages/relay-test-utils/RelayMockPayloadGenerator.js#L1031
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

In scope of this PR we:
* add definition for `generateWithDefer`  that exists on MockPayloadGenerator
* align type of `resolve` from RelayModernMockEnvironment which can now also accept array of response
* add generic argument to MockResolver and MockResolvers type which allows to strongly type mock resolver and have autocomplete when writing tests/storybook relying on resolver (this is inspired by @alloy code in [custom payload generator](https://github.com/microsoft/graphitation/blob/main/packages/graphql-js-operation-payload-generator/src/index.ts))
* even tough this is not a breaking change we bump the version to 17.0.0 as that is the latest of `relay-test-utils`

As for testing, I copied the new types and added them to our internal monorepo to check correctness