### PR TITLE
feat(ws): Enable `addEventListener`/`removeEventListener` to Work with Unions of Event Types

### DIFF
--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -112,31 +112,15 @@ declare class WebSocket extends EventEmitter {
     resume(): void;
 
     // HTML5 WebSocket events
-    addEventListener(
-        method: "message",
-        cb: (event: WebSocket.MessageEvent) => void,
+    addEventListener<K extends keyof WebSocket.WebSocketEventMap>(
+        type: K,
+        listener: (event: WebSocket.WebSocketEventMap[K]) => void,
         options?: WebSocket.EventListenerOptions,
     ): void;
-    addEventListener(
-        method: "close",
-        cb: (event: WebSocket.CloseEvent) => void,
-        options?: WebSocket.EventListenerOptions,
+    removeEventListener<K extends keyof WebSocket.WebSocketEventMap>(
+        type: K,
+        listener: (event: WebSocket.WebSocketEventMap[K]) => void,
     ): void;
-    addEventListener(
-        method: "error",
-        cb: (event: WebSocket.ErrorEvent) => void,
-        options?: WebSocket.EventListenerOptions,
-    ): void;
-    addEventListener(
-        method: "open",
-        cb: (event: WebSocket.Event) => void,
-        options?: WebSocket.EventListenerOptions,
-    ): void;
-
-    removeEventListener(method: "message", cb: (event: WebSocket.MessageEvent) => void): void;
-    removeEventListener(method: "close", cb: (event: WebSocket.CloseEvent) => void): void;
-    removeEventListener(method: "error", cb: (event: WebSocket.ErrorEvent) => void): void;
-    removeEventListener(method: "open", cb: (event: WebSocket.Event) => void): void;
 
     // Events
     on(event: "close", listener: (this: WebSocket, code: number, reason: Buffer) => void): this;
@@ -305,6 +289,13 @@ declare namespace WebSocket {
         data: Data;
         type: string;
         target: WebSocket;
+    }
+
+    interface WebSocketEventMap {
+        open: Event;
+        error: ErrorEvent;
+        close: CloseEvent;
+        message: MessageEvent;
     }
 
     interface EventListenerOptions {

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -201,17 +201,18 @@ import * as wslib from "ws";
     const ws = new WebSocket("ws://www.host.com/path");
     // @ts-expect-error
     ws.addEventListener("other", () => {});
+    // @ts-expect-error
+    ws.removeEventListener("other", () => {});
 }
 
 {
     const ws = new WebSocket("ws://www.host.com/path");
-    ws.addEventListener(
-        "message",
-        (event: WebSocket.MessageEvent) => {
-            console.log(event.data, event.target, event.type);
-        },
-        { once: true },
-    );
+    const listener = (event: WebSocket.MessageEvent) => console.log(event.data, event.target, event.type);
+    ws.addEventListener("message", listener, { once: true });
+    ws.removeEventListener("message", listener);
+
+    ws.addEventListener("open" as "open" | "close" | "error" | "message", console.log);
+    ws.removeEventListener("open" as "open" | "close" | "error" | "message", console.log);
 }
 
 {


### PR DESCRIPTION
This follows after the standardized `document.addEventListener` method defined in `lib.dom.d.ts`. See:
https://github.com/microsoft/TypeScript/blob/main/src/lib/dom.generated.d.ts

With this approach, the following code becomes legal in TypeScript:

```ts
import { WebSocket } from "ws";

const websocket = new WebSocket("ws://localhost:3000");
const event = "open" as "open" | "close";

// The bottom two lines would previously throw an error in TypeScript
websocket.addEventListener(event, console.log);
websocket.removeEventListener(event, console.log);
```

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   - Docs: https://github.com/websockets/ws/blob/master/doc/ws.md
   - Inspiration: https://github.com/microsoft/TypeScript/blob/main/src/lib/dom.generated.d.ts
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. (**N/A**)