### PR TITLE
[geojson] Bring type definition of Position more in to line with the official spec

### DIFF
--- a/types/geojson/geojson-tests.ts
+++ b/types/geojson/geojson-tests.ts
@@ -131,8 +131,9 @@ const n4 = [1, 2, 3, 4, 5];
 const pc4: Position = n4;
 
 // From typescript 4.9 can use satisfies as a safer alternative to "as"
-const n5 = [1, 2, 3, 4, 5] satisfies Position;
-const pc5: Position = n5;
+// Disabling temporarily as dependent CI projects not requiring TS 4.9 just yet
+// const n5 = [1, 2, 3, 4, 5] satisfies Position;
+// const pc5: Position = n5;
 
 const point: Point = {
     type: "Point",

--- a/types/geojson/geojson-tests.ts
+++ b/types/geojson/geojson-tests.ts
@@ -11,6 +11,7 @@ import {
     MultiPolygon,
     Point,
     Polygon,
+    Position,
 } from "geojson";
 
 let featureCollection: FeatureCollection = {
@@ -100,7 +101,38 @@ const featureWithPolygon: Feature<Polygon> = {
 featureWithPolygon.type; // $ExpectType "Feature"
 featureWithPolygon.geometry; // $ExpectType Polygon
 featureWithPolygon.geometry.type; // $ExpectType "Polygon"
-featureWithPolygon.geometry.coordinates; // $ExpectType number[][][] || Position[][]
+featureWithPolygon.geometry.coordinates; // $ExpectType Position[][]
+
+// @ts-expect-error need minimum of two number elements
+const p1: Position = [];
+// @ts-expect-error need minimum of two number elements 
+const p2: Position = [1];
+const p3: Position = [1, 2];
+const p4: Position = [1, 2, 3];
+const p5: Position = [1, 2, 3, 4];
+const p6: Position = [1, 2, 3, 4, 5, 6, 7, 8];
+// @ts-expect-error third element not a number
+const p7: Position = [1, 2, "foo"];
+
+// Legacy code i.e. Turf will need to update any coord definitions like this
+// e.g. number[][] to Position[]
+const n1: number[] = [1, 2];
+// @ts-expect-error insufficiently strict type
+const pc1: Position = n1;
+
+const n2: [number, number] = [1, 2];
+const pc2: Position = n2;
+
+const n3: [number, number, number] = [1, 2, 3];
+const pc3: Position = n3;
+
+const n4 = [1, 2, 3, 4, 5];
+// @ts-expect-error only infers number[], not good enough
+const pc4: Position = n4;
+
+// From typescript 4.9 can use satisfies as a safer alternative to "as"
+const n5 = [1, 2, 3, 4, 5] satisfies Position;
+const pc5: Position = n5;
 
 const point: Point = {
     type: "Point",

--- a/types/geojson/index.d.ts
+++ b/types/geojson/index.d.ts
@@ -24,11 +24,16 @@ export type BBox = [number, number, number, number] | [number, number, number, n
 /**
  * A Position is an array of coordinates.
  * https://tools.ietf.org/html/rfc7946#section-3.1.1
- * Array should contain between two and three elements.
- * The previous GeoJSON specification allowed more elements (e.g., which could be used to represent M values),
- * but the current specification only allows X, Y, and (optionally) Z to be defined.
+ * Array must contain two or more number elements.
+ * The previous GeoJSON specification allowed more elements (e.g., which could 
+ * be used to represent M values). However the current specification allows for
+ * an optional third element, and strongly suggests implementations "SHOULD NOT"
+ * go beyond that.
+ * For that reason the type guarantees a minimum of two elements (longitude and
+ * latitude) while allowing users to include any additional elements if they
+ * choose to.
  */
-export type Position = number[]; // [number, number] | [number, number, number];
+export type Position = [number, number, ...number[]];
 
 /**
  * The base GeoJSON object.

--- a/types/geojson/package.json
+++ b/types/geojson/package.json
@@ -4,7 +4,6 @@
     "version": "8000.0.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "geojson",
-    "minimumTypeScriptVersion": "4.9",
     "projects": [
         "https://geojson.org/"
     ],

--- a/types/geojson/package.json
+++ b/types/geojson/package.json
@@ -1,9 +1,10 @@
 {
     "private": true,
     "name": "@types/geojson",
-    "version": "7946.0.9999",
+    "version": "8000.0.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "geojson",
+    "minimumTypeScriptVersion": "4.9",
     "projects": [
         "https://geojson.org/"
     ],


### PR DESCRIPTION
This PR aims to bring the definition of the geojson Position type more in to line with the [official spec](https://www.rfc-editor.org/rfc/rfc7946).

Rather than a Position being a number array of no particular size (including empty), the revised type mandates a minimum of two elements while allowing additional elements if desired. This seems to be the best trade off between strictness, and not limiting legacy implementations.

This change will allow GeoJSON types to be used without casting workarounds when using libraries that type their interfaces strictly. Libraries that only expect number[] should also be happy to accept the more exacting Position type.

Some notes:

This change _will_ cause type errors in client code where Position coordinates have simply be defined as number[] e.g.

```
const n: number[] = [1, 2]
function f(p: Position) {
  // whatever
}

// not happy
f(n)
```

Presuming the implementation adheres to the GeoJSON spec though and includes at least two elements at runtime, it should be safe to replace number[] with Position.

Due to the above this would be a major semver bump. While the current release helpfully defines the version as the same as the GeoJSON RFC (7946) incrementing to 7947 might prove confusing. So fast forwarding to 8000 for a clean break. Maybe I'm being pedantic though.

A few previous attempts to refine this type have fallen by the wayside. I think this approach addresses all the counter arguments and concerns raised previously. In the interests of rigour am including those below and tagging some people that may have a POV. Firmly believe this will improve the utility of the typedef and help produce more robust GeoJSON aware code.

Previous PRs

* #21590
* #60732

Discussions
* #56182
* #67773
* #58642

@michaeloliverx @oddvarogreid @thw0rted @DenisCarriere @tomwanzek @Ledragon @gustavderdrache

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: this PR, plus previous discussions 
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.