### PR TITLE
[delaunator] Use type parameter correctly on class Delaunator

### DIFF
--- a/types/delaunator/delaunator-tests.ts
+++ b/types/delaunator/delaunator-tests.ts
@@ -3,6 +3,7 @@ import Delaunator from "delaunator";
 // Zipped points [x0, y0, x1, y1, ...]
 const zippedPoints = [168, 180, 168, 178, 168, 179, 168, 181, 168, 183, 167, 183, 167, 184];
 const zipped = new Delaunator(zippedPoints);
+const zippedCoords = zipped.coords; // $ExpectType number[]
 
 // Default [x, y]
 const defaultPoints = [
@@ -45,7 +46,7 @@ Delaunator.from(customPoints, getX, getY);
 const triangles = d.triangles; // $ExpectType Uint32Array
 const halfedges = d.halfedges; // $ExpectType Int32Array
 const hull = d.hull; // $ExpectType Uint32Array
-const coords = d.coords; // $ExpectType ArrayLike<number> | Float64Array
+const coords = d.coords; // $ExpectType Float64Array
 const coordinates: number[][][] = [];
 for (let i = 0; i < triangles.length; i += 3) {
     coordinates.push([defaultPoints[triangles[i]], defaultPoints[triangles[i + 1]], defaultPoints[triangles[i + 2]]]);
@@ -65,5 +66,5 @@ for (let i = 0; i < triangles.length; i += 3) {
 JSON.stringify(coordinates) === JSON.stringify(coordinates2);
 
 // update call
-(zipped.coords as Float64Array)[0] = 1;
+zipped.coords[0] = 1;
 zipped.update();

--- a/types/delaunator/index.d.ts
+++ b/types/delaunator/index.d.ts
@@ -1,4 +1,4 @@
-declare class Delaunator<P> {
+declare class Delaunator {
     /**
      * A Uint32Array array of triangle vertex indices (each group of three numbers forms a triangle).
      * All triangles are directed counterclockwise.

--- a/types/delaunator/index.d.ts
+++ b/types/delaunator/index.d.ts
@@ -39,7 +39,11 @@ declare class Delaunator<A extends ArrayLike<number>> {
      * Constructs a delaunay triangulation object given an array of custom points. Duplicate points are skipped.
      * getX and getY are optional functions for custom point formats. Duplicate points are skipped.
      */
-    static from<P>(points: ArrayLike<P>, getX: (point: P) => number, getY: (point: P) => number): Delaunator<Float64Array>;
+    static from<P>(
+        points: ArrayLike<P>,
+        getX: (point: P) => number,
+        getY: (point: P) => number
+    ): Delaunator<Float64Array>;
 
     /**
      * Updates the triangulation if you modified delaunay.coords values in place, avoiding expensive memory

--- a/types/delaunator/index.d.ts
+++ b/types/delaunator/index.d.ts
@@ -33,13 +33,13 @@ declare class Delaunator {
     /**
      * Constructs a delaunay triangulation object given an array of points ([x, y] by default).
      */
-    static from(points: ArrayLike<ArrayLike<number>>): Delaunator<ArrayLike<number>>;
+    static from(points: ArrayLike<ArrayLike<number>>): Delaunator;
 
     /**
      * Constructs a delaunay triangulation object given an array of custom points. Duplicate points are skipped.
      * getX and getY are optional functions for custom point formats. Duplicate points are skipped.
      */
-    static from<P>(points: ArrayLike<P>, getX: (point: P) => number, getY: (point: P) => number): Delaunator<P>;
+    static from<P>(points: ArrayLike<P>, getX: (point: P) => number, getY: (point: P) => number): Delaunator;
 
     /**
      * Updates the triangulation if you modified delaunay.coords values in place, avoiding expensive memory

--- a/types/delaunator/index.d.ts
+++ b/types/delaunator/index.d.ts
@@ -1,4 +1,4 @@
-declare class Delaunator {
+declare class Delaunator<A extends ArrayLike<number>> {
     /**
      * A Uint32Array array of triangle vertex indices (each group of three numbers forms a triangle).
      * All triangles are directed counterclockwise.
@@ -22,24 +22,24 @@ declare class Delaunator {
     /**
      * An array of input coordinates in the form [x0, y0, x1, y1, ....], of the type provided in the constructor (or Float64Array if you used Delaunator.from).
      */
-    coords: ArrayLike<number> | Float64Array;
+    coords: A;
 
     /**
      * Constructs a delaunay triangulation object given a typed array of point coordinates of the form: [x0, y0, x1, y1, ...].
      * (use a typed array for best performance).
      */
-    constructor(points: ArrayLike<number>);
+    constructor(points: A);
 
     /**
      * Constructs a delaunay triangulation object given an array of points ([x, y] by default).
      */
-    static from(points: ArrayLike<ArrayLike<number>>): Delaunator;
+    static from(points: ArrayLike<ArrayLike<number>>): Delaunator<Float64Array>;
 
     /**
      * Constructs a delaunay triangulation object given an array of custom points. Duplicate points are skipped.
      * getX and getY are optional functions for custom point formats. Duplicate points are skipped.
      */
-    static from<P>(points: ArrayLike<P>, getX: (point: P) => number, getY: (point: P) => number): Delaunator;
+    static from<P>(points: ArrayLike<P>, getX: (point: P) => number, getY: (point: P) => number): Delaunator<Float64Array>;
 
     /**
      * Updates the triangulation if you modified delaunay.coords values in place, avoiding expensive memory


### PR DESCRIPTION
This PR started off removing the `<P>` in `Delaunator<P>`, because it was unused.  (Static methods having a type parameter `<P>` don't count!) Then I realized that the thing to use a type parameter for is the type of the `coords` property, which depends on the constructor (and method of construction).

I suppose this is a breaking change?

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

I'm not sure either of those apply.  Not sure if version number should be bumped because this is technically a breaking change, or what.