### PR TITLE
Fix `sass-loader` Callback arguments (missing `content`)

### DIFF
--- a/types/sass-loader/interfaces.d.ts
+++ b/types/sass-loader/interfaces.d.ts
@@ -435,7 +435,7 @@ export interface LoaderOptions {
 }
 
 export namespace LoaderOptions {
-    type Callback<T> = (loaderContext: Webpack.loader.LoaderContext) => T;
+    type Callback<T> = (content: string | Buffer, loaderContext: Webpack.loader.LoaderContext) => T;
 
     type SassOptions = NodeSass.Options | Sass.LegacyOptions<"sync">;
 }

--- a/types/sass-loader/sass-loader-tests.ts
+++ b/types/sass-loader/sass-loader-tests.ts
@@ -16,3 +16,15 @@ const loaderOptions: SassLoader.Options = {
     },
     webpackImporter: true,
 };
+
+const loaderOptionsWithCallback: SassLoader.Options = {
+    additionalData: (content, _loaderContext) => {
+        return `$env: \"development\";${content}`;
+    },
+    warnRuleAsWarning: true,
+    sourceMap: true,
+    sassOptions: {
+        sourceMap: true,
+    },
+    webpackImporter: true,
+};


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack-contrib/sass-loader?tab=readme-ov-file#additionaldata
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
