### PR TITLE
[lodash] fix _.get return type cannot refer to correct type and default type in nested object with optional fields

### DIFF
--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -1140,11 +1140,11 @@ declare module "../index" {
         /**
          * @see _.get
          */
-        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1]>(object: TObject | null | undefined, path: [TKey1, TKey2]): TObject[TKey1][TKey2] | undefined;
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof NonNullable<TObject[TKey1]>>(object: TObject | null | undefined, path: [TKey1, TKey2]): NonNullable<TObject[TKey1]>[TKey2] | undefined;
         /**
          * @see _.get
          */
-        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TDefault>(object: TObject | null | undefined, path: [TKey1, TKey2], defaultValue: TDefault): Exclude<TObject[TKey1][TKey2], undefined> | TDefault;
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof NonNullable<TObject[TKey1]>, TDefault>(object: TObject | null | undefined, path: [TKey1, TKey2], defaultValue: TDefault): Exclude<NonNullable<TObject[TKey1]>[TKey2], undefined> | TDefault;
         /**
          * @see _.get
          */
@@ -1152,11 +1152,11 @@ declare module "../index" {
         /**
          * @see _.get
          */
-        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2]>(object: TObject | null | undefined, path: [TKey1, TKey2, TKey3]): TObject[TKey1][TKey2][TKey3] | undefined;
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof NonNullable<TObject[TKey1]>, TKey3 extends keyof NonNullable<NonNullable<TObject[TKey1]>[TKey2]>>(object: TObject | null | undefined, path: [TKey1, TKey2, TKey3]): NonNullable<NonNullable<TObject[TKey1]>[TKey2]>[TKey3] | undefined;
         /**
          * @see _.get
          */
-        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TDefault>(object: TObject | null | undefined, path: [TKey1, TKey2, TKey3], defaultValue: TDefault): Exclude<TObject[TKey1][TKey2][TKey3], undefined> | TDefault;
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof NonNullable<TObject[TKey1]>, TKey3 extends keyof NonNullable<NonNullable<TObject[TKey1]>[TKey2]>, TDefault>(object: TObject | null | undefined, path: [TKey1, TKey2, TKey3], defaultValue: TDefault): Exclude<NonNullable<NonNullable<TObject[TKey1]>[TKey2]>[TKey3], undefined> | TDefault;
         /**
          * @see _.get
          */
@@ -1164,11 +1164,11 @@ declare module "../index" {
         /**
          * @see _.get
          */
-        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3]>(object: TObject | null | undefined, path: [TKey1, TKey2, TKey3, TKey4]): TObject[TKey1][TKey2][TKey3][TKey4] | undefined;
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof NonNullable<TObject[TKey1]>, TKey3 extends keyof NonNullable<NonNullable<TObject[TKey1]>[TKey2]>, TKey4 extends keyof NonNullable<NonNullable<NonNullable<TObject[TKey1]>[TKey2]>[TKey3]>>(object: TObject | null | undefined, path: [TKey1, TKey2, TKey3, TKey4]): NonNullable<NonNullable<NonNullable<TObject[TKey1]>[TKey2]>[TKey3]>[TKey4] | undefined;
         /**
          * @see _.get
          */
-        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof TObject[TKey1], TKey3 extends keyof TObject[TKey1][TKey2], TKey4 extends keyof TObject[TKey1][TKey2][TKey3], TDefault>(object: TObject | null | undefined, path: [TKey1, TKey2, TKey3, TKey4], defaultValue: TDefault): Exclude<TObject[TKey1][TKey2][TKey3][TKey4], undefined> | TDefault;
+        get<TObject extends object, TKey1 extends keyof TObject, TKey2 extends keyof NonNullable<TObject[TKey1]>, TKey3 extends keyof NonNullable<NonNullable<TObject[TKey1]>[TKey2]>, TKey4 extends keyof NonNullable<NonNullable<NonNullable<TObject[TKey1]>[TKey2]>[TKey3]>, TDefault>(object: TObject | null | undefined, path: [TKey1, TKey2, TKey3, TKey4], defaultValue: TDefault): Exclude<NonNullable<NonNullable<NonNullable<TObject[TKey1]>[TKey2]>[TKey3]>[TKey4], undefined> | TDefault;
         /**
          * @see _.get
          */

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -5357,6 +5357,40 @@ fp.now(); // $ExpectType number
     const value: string | undefined = anything;
     const defaultValue: boolean = anything;
     const objectWithOptionalField: { a?: boolean } = anything;
+    const nestedObjectWithOptionalField: {
+        foo?: {
+            bar: string;
+        } | null;
+        nested?: {
+            with?: {
+                optional: string | null;
+            } | null;
+        } | null;
+        four?: {
+            levels?: {
+                deep?: {
+                    value?: number;
+                } | null;
+            } | null;
+        } | null;
+    } = anything;
+    const nestedObject: {
+        foo: {
+            bar: string;
+        };
+        nested: {
+            with: {
+                optional: string | null;
+            };
+        };
+        four: {
+            levels: {
+                deep: {
+                    value: number;
+                };
+            };
+        };
+    } = anything;
 
     const anyNumber: number = anything;
     const arrayOfNumbers: number[] = anything;
@@ -5416,6 +5450,15 @@ fp.now(); // $ExpectType number
     _.get(complexValue, '0'); // $ExpectType 'Value4' | number
     _.get(complexValue, '1'); // $ExpectType undefined | number
     _.get(complexValue, 'length'); // $ExpectType 'Value5' | number
+    _.get(nestedObject, ['foo', 'bar']); // $ExpectType string
+    _.get(nestedObject, ['nested', 'with', 'optional']); // $ExpectType string | null
+    _.get(nestedObject, ['four', 'levels', 'deep', 'value']); // $ExpectType number
+    _.get(nestedObjectWithOptionalField, ['foo', 'bar'], defaultValue); // $ExpectType string | boolean
+    _.get(nestedObjectWithOptionalField, ['nested', 'with', 'optional'], defaultValue); // $ExpectType string | null | boolean
+    _.get(nestedObjectWithOptionalField, ['four', 'levels', 'deep', 'value'], defaultValue); // $ExpectType number | boolean
+    _.get(nestedObjectWithOptionalField, ['foo', 'bar']); // $ExpectType string | undefined
+    _.get(nestedObjectWithOptionalField, ['nested', 'with', 'optional']); // $ExpectType string | null | undefined
+    _.get(nestedObjectWithOptionalField, ['four', 'levels', 'deep', 'value']); // $ExpectType number | undefined
 
     _("abc").get(1); // $ExpectType string
     _({ a: false }).get("a"); // $ExpectType boolean


### PR DESCRIPTION
### Todos:
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [The sample code](https://replit.com/@ThienNguyen10/AlarmedTemptingGenres#index.ts)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

### Problem:
Imagine when we use _.get to retrieve the deep value in an object, which contains many nested optional fields, then the type returned should be the type of value followed by the path or the type of the default value.
<img width="973" alt="image" src="https://github.com/user-attachments/assets/ac9cdc2a-772e-47f2-ad77-0eac519736e8">

And when we pass the generic path to the function, we cannot retrieve the property if the higher level of that property is optional. In this case, `bar` is optional so TS cannot recognize `baz` property.
<img width="1065" alt="image" src="https://github.com/user-attachments/assets/0de4aecd-b99d-4791-ae7b-5b4d226e8814">

### Solution:
We could wrap the middle-level nested fields with NonNullable, which could remove the `null | undefined`, and then TS could read the type needed, NonNullable will not affect the type of optional value in this case, because we only care about the final result followed by the path, and the default value (Please check the changes for more details).

Please let me know if I missed any cases, thank you guys!