### PR TITLE
[@types/critters-webpack-plugin] Update critters-webpack-plugin to 3.0.2

### DIFF
--- a/types/critters-webpack-plugin/critters-webpack-plugin-tests.ts
+++ b/types/critters-webpack-plugin/critters-webpack-plugin-tests.ts
@@ -1,16 +1,18 @@
 import Critters from "critters-webpack-plugin";
 import { Configuration } from "webpack";
 
-const critters: Configuration["plugins"] = [new Critters({
-    compress: true,
-    external: true,
-    inlineFonts: false,
-    preloadFonts: true,
-    keyframes: "critical",
-    noscriptFallback: true,
-    inlineThreshold: 0,
-    mergeStylesheets: true,
-    additionalStylesheets: ["./base.css"],
-    pruneSource: true,
-    minimumExternalSize: 0,
-})];
+const critters: Configuration["plugins"] = [
+    new Critters({
+        compress: true,
+        external: true,
+        inlineFonts: false,
+        preloadFonts: true,
+        keyframes: "critical",
+        noscriptFallback: true,
+        inlineThreshold: 0,
+        mergeStylesheets: true,
+        additionalStylesheets: ["./base.css"],
+        pruneSource: true,
+        minimumExternalSize: 0,
+    }),
+];

--- a/types/critters-webpack-plugin/critters-webpack-plugin-tests.ts
+++ b/types/critters-webpack-plugin/critters-webpack-plugin-tests.ts
@@ -1,6 +1,7 @@
 import Critters from "critters-webpack-plugin";
+import { Configuration } from "webpack";
 
-new Critters({
+const critters: Configuration["plugins"] = [new Critters({
     compress: true,
     external: true,
     inlineFonts: false,
@@ -12,4 +13,4 @@ new Critters({
     additionalStylesheets: ["./base.css"],
     pruneSource: true,
     minimumExternalSize: 0,
-});
+})];

--- a/types/critters-webpack-plugin/index.d.ts
+++ b/types/critters-webpack-plugin/index.d.ts
@@ -1,8 +1,13 @@
-import { Plugin } from "webpack";
+import { Compiler, WebpackPluginInstance } from "webpack";
 
 export default Critters;
-declare class Critters extends Plugin {
+declare class Critters implements WebpackPluginInstance {
     constructor(options?: Critters.CrittersOptions);
+    apply: (compiler: Compiler) => void;
+    getCssAsset(href: any, style: any ): Promise<any>;
+    checkInlineThreshold(link: any, style: any , sheet: any): boolean;
+    embedAdditionalStylesheet(document: any): Promise<void>;
+    pruneSource(style: any, before: any, sheetInverse: any): boolean
 }
 
 declare namespace Critters {

--- a/types/critters-webpack-plugin/index.d.ts
+++ b/types/critters-webpack-plugin/index.d.ts
@@ -4,10 +4,10 @@ export default Critters;
 declare class Critters implements WebpackPluginInstance {
     constructor(options?: Critters.CrittersOptions);
     apply: (compiler: Compiler) => void;
-    getCssAsset(href: any, style: any ): Promise<any>;
-    checkInlineThreshold(link: any, style: any , sheet: any): boolean;
+    getCssAsset(href: any, style: any): Promise<any>;
+    checkInlineThreshold(link: any, style: any, sheet: any): boolean;
     embedAdditionalStylesheet(document: any): Promise<void>;
-    pruneSource(style: any, before: any, sheetInverse: any): boolean
+    pruneSource(style: any, before: any, sheetInverse: any): boolean;
 }
 
 declare namespace Critters {

--- a/types/critters-webpack-plugin/package.json
+++ b/types/critters-webpack-plugin/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/critters-webpack-plugin",
-    "version": "3.0.2",
+    "version": "3.0.9999",
     "projects": [
         "https://github.com/GoogleChromeLabs/critters"
     ],

--- a/types/critters-webpack-plugin/package.json
+++ b/types/critters-webpack-plugin/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/critters-webpack-plugin",
-    "version": "3.1.9999",
+    "version": "3.0.2",
     "projects": [
         "https://github.com/GoogleChromeLabs/critters"
     ],

--- a/types/critters-webpack-plugin/package.json
+++ b/types/critters-webpack-plugin/package.json
@@ -1,12 +1,12 @@
 {
     "private": true,
     "name": "@types/critters-webpack-plugin",
-    "version": "2.5.9999",
+    "version": "3.1.9999",
     "projects": [
         "https://github.com/GoogleChromeLabs/critters"
     ],
     "dependencies": {
-        "@types/webpack": "^4"
+        "@types/webpack": "^5"
     },
     "devDependencies": {
         "@types/critters-webpack-plugin": "workspace:."


### PR DESCRIPTION
Update type to support plugin type for webpack v5.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

