### PR TITLE
Update scripts target to es2023

### DIFF
--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es2019",
+        "target": "es2023",
         "module": "nodenext",
         "strict": true,
         "allowJs": true,


### PR DESCRIPTION
Corresponds to node 18. Required by a minor update from octokit/webhooks.