### PR TITLE
[mongoose-delete] Raise minimum TS version to 4.9

### DIFF
--- a/types/mongoose-delete/package.json
+++ b/types/mongoose-delete/package.json
@@ -5,6 +5,7 @@
     "projects": [
         "https://github.com/dsanel/mongoose-delete"
     ],
+    "minimumTypeScriptVersion": "4.9",
     "dependencies": {
         "@types/node": "*",
         "mongoose": "^5.11 || ^6 || ^7 || ^8"


### PR DESCRIPTION
It looks like the upstream mongoose types have started doing things which make TS 4.8 unhappy. Raise the minimum to unblock CI.