### PR TITLE
[tabulator-tables] Update for new export maps upstream

### DIFF
--- a/types/tabulator-tables/index.d.mts
+++ b/types/tabulator-tables/index.d.mts
@@ -1,0 +1,1 @@
+export * from "./index.js";

--- a/types/tabulator-tables/package.json
+++ b/types/tabulator-tables/package.json
@@ -8,6 +8,12 @@
     "devDependencies": {
         "@types/tabulator-tables": "workspace:."
     },
+    "exports": {
+        ".": {
+            "require": "./index.d.ts",
+            "import": "./index.d.mts"
+        }
+    },
     "owners": [
         {
             "name": "Josh Harris",


### PR DESCRIPTION
https://github.com/olifolkerd/tabulator/pull/4490 changed the package upstream in a technically breaking way (adding an export map should realistically always be a major bump); fix the DT package to also contain an export map, along with an mts file which just reexports the main entrypoint.