### PR TITLE
[@types/jquery.validation] Adding customElements to ValidationOptions

### DIFF
--- a/types/jquery.validation/index.d.ts
+++ b/types/jquery.validation/index.d.ts
@@ -18,6 +18,13 @@ declare namespace JQueryValidation {
          */
         debug?: boolean | undefined;
         /**
+         * Use this to register additional elements to be validatable. Main use case is for validating web components.
+         * By default, only the following elements are supported: "input", "select", "textarea", "[contenteditable]"
+         * 
+         * default: []
+         */
+        customElements?: string[] | undefined;
+        /**
          * Use this class to create error labels, to look for existing error labels and to add it to invalid elements.
          *
          * default: "error"

--- a/types/jquery.validation/jquery.validation-tests.ts
+++ b/types/jquery.validation/jquery.validation-tests.ts
@@ -192,6 +192,9 @@ function test_validate() {
         onkeyup: () => {},
         onclick: elt => 2,
     });
+    $(".selector").validate({
+        customElements: ["my-custom-element"]
+    });
 }
 
 function test_methods() {

--- a/types/jquery.validation/package.json
+++ b/types/jquery.validation/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/jquery.validation",
-    "version": "1.16.9999",
+    "version": "1.17.9999",
     "nonNpm": true,
     "nonNpmDescription": "jquery.validation",
     "projects": [


### PR DESCRIPTION
jquery.validation 1.21.0 (https://github.com/jquery-validation/jquery-validation/releases/tag/1.21.0) has added support for registering additional elements to be validatable (for example web components)

This PR adds this customElements to ValidationOptions

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jquery-validation/jquery-validation/pull/2493
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

