### PR TITLE
Don't use github search in publisher watchdog

### DIFF
--- a/scripts/watchdog-publisher.js
+++ b/scripts/watchdog-publisher.js
@@ -35,7 +35,7 @@ async function getTopFiveMerged(sort) {
         per_page: 100,
         direction: "desc",
         sort,
-    })
+    });
 
     const result = [];
 

--- a/scripts/watchdog-publisher.js
+++ b/scripts/watchdog-publisher.js
@@ -180,8 +180,6 @@ function parseNpmInfo(info) {
     }
 }
 main().catch(error => {
-
-
     console.error(error && (error.stack || error.message || error));
     process.exit(1);
 });


### PR DESCRIPTION
This script (and all others) just use the GHA GITHUB_TOKEN. However, by using the search API, we are effectively making unauthenticated requests.

Instead of using the search API, directly iterate over the pull requests searching for the merged ones; this action should be covered by our token as repo-scoped and not rate limit.

The PRs checked before and after are identical:

```console
$ GITHUB_TOKEN=$(gh auth token) node ./watchdog-publisher.js
search for 5 most recently created PRs
search for 5 most recently updated PRs
get merge_at date for PR 70093
list first 100 files for PR 70093
get merge_at date for PR 70092
list first 100 files for PR 70092
get merge_at date for PR 70085
list first 100 files for PR 70085
get merge_at date for PR 70081
list first 100 files for PR 70081
get merge_at date for PR 70080
list first 100 files for PR 70080
get merge_at date for PR 70093
list first 100 files for PR 70093
get merge_at date for PR 70054
list first 100 files for PR 70054
get merge_at date for PR 65463
list first 100 files for PR 65463
get merge_at date for PR 70092
list first 100 files for PR 70092
get merge_at date for PR 70085
list first 100 files for PR 70085


## Interesting PRs ##
git 

## Longest publish latency ##
No unpublished PRs found: 0
```
```console
$ git switch fix-watchdog   
Switched to branch 'fix-watchdog'
Your branch is up to date with 'origin/fix-watchdog'.

$ GITHUB_TOKEN=$(gh auth token) node ./watchdog-publisher.js
search for 5 most recently created PRs
search for 5 most recently updated PRs
get merge_at date for PR 70093
list first 100 files for PR 70093
get merge_at date for PR 70092
list first 100 files for PR 70092
get merge_at date for PR 70085
list first 100 files for PR 70085
get merge_at date for PR 70081
list first 100 files for PR 70081
get merge_at date for PR 70080
list first 100 files for PR 70080
get merge_at date for PR 70093
list first 100 files for PR 70093
get merge_at date for PR 70054
list first 100 files for PR 70054
get merge_at date for PR 65463
list first 100 files for PR 65463
get merge_at date for PR 70092
list first 100 files for PR 70092
get merge_at date for PR 70085
list first 100 files for PR 70085


## Interesting PRs ##


## Longest publish latency ##
No unpublished PRs found: 0
```