### PR TITLE
Update dprint to pick up comment bugfix

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -50,10 +50,10 @@
     },
     // NOTE: if extending this list, also update settings.template.json.
     "plugins": [
-        "https://plugins.dprint.dev/typescript-0.89.3.wasm",
-        "https://plugins.dprint.dev/json-0.19.2.wasm",
-        "https://plugins.dprint.dev/markdown-0.16.4.wasm",
-        "https://plugins.dprint.dev/prettier-0.39.0.json@896b70f29ef8213c1b0ba81a93cee9c2d4f39ac2194040313cd433906db7bc7c"
+        "https://plugins.dprint.dev/typescript-0.91.4.wasm",
+        "https://plugins.dprint.dev/json-0.19.3.wasm",
+        "https://plugins.dprint.dev/markdown-0.17.1.wasm",
+        "https://plugins.dprint.dev/prettier-0.40.0.json@68c668863ec834d4be0f6f5ccaab415df75336a992aceb7eeeb14fdf096a9e9c"
     ],
     "indentWidth": 4,
     "lineWidth": 120,


### PR DESCRIPTION
This pulls in a bugfix that would have formatted comments on parameters (like `/** @deferred */`) incorrectly.