### PR TITLE
Make challengeName optional in AWS Cognito User Pool DefineAuthChallengeTriggerEvent response.

### DIFF
--- a/types/aws-lambda/test/cognito-tests.ts
+++ b/types/aws-lambda/test/cognito-tests.ts
@@ -124,7 +124,7 @@ const defineAuthChallenge: DefineAuthChallengeTriggerHandler = async (event, _, 
     bool = session.challengeResult;
     boolOrUndefined = request.userNotFound;
 
-    str = response.challengeName;
+    strOrUndefined = response.challengeName;
     bool = response.failAuthentication;
     bool = response.issueTokens;
 

--- a/types/aws-lambda/trigger/cognito-user-pool-trigger/define-auth-challenge.d.ts
+++ b/types/aws-lambda/trigger/cognito-user-pool-trigger/define-auth-challenge.d.ts
@@ -12,7 +12,7 @@ export interface DefineAuthChallengeTriggerEvent extends BaseTriggerEvent<"Defin
         clientMetadata?: StringMap | undefined;
     };
     response: {
-        challengeName: string;
+        challengeName: string | undefined;
         failAuthentication: boolean;
         issueTokens: boolean;
     };

--- a/types/aws-lambda/trigger/cognito-user-pool-trigger/define-auth-challenge.d.ts
+++ b/types/aws-lambda/trigger/cognito-user-pool-trigger/define-auth-challenge.d.ts
@@ -12,7 +12,7 @@ export interface DefineAuthChallengeTriggerEvent extends BaseTriggerEvent<"Defin
         clientMetadata?: StringMap | undefined;
     };
     response: {
-        challengeName: string | undefined;
+        challengeName?: string | undefined;
         failAuthentication: boolean;
         issueTokens: boolean;
     };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-define-auth-challenge.html shows examples of setting the response without a `challengeName`. The `challengeName` is only set when issuing a challenge, not when indicating successful/failed auth.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
