### PR TITLE
[eslint]: add `LegacyConfig` type

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -1072,6 +1072,9 @@ const eslintConfig3: Linter.Config<ESLintRules & TSLinterRules> = eslintConfig2;
 eslintConfig3.rules; // $ExpectType Partial<ESLintRules & TSLinterRules> | undefined
 eslintConfig3.overrides?.[1].rules; // $ExpectType Partial<ESLintRules & TSLinterRules> | undefined
 
+let legacyConfig: Linter.LegacyConfig = eslintConfig;
+eslintConfig = legacyConfig;
+
 // #endregion
 
 // #region RuleTester

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -1054,6 +1054,11 @@ export namespace Linter {
     }
 
     /**
+     * An alias for `Config` for interoperability with `@types/eslint@9`.
+     */
+    type LegacyConfig = Config;
+
+    /**
      * Parser options.
      *
      * @see [Specifying Parser Options](https://eslint.org/docs/user-guide/configuring/language-options#specifying-parser-options)


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69957#discussion_r1678383797
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

This PR adds `Linter.LegacyConfig` as an alias for `Linter.Config`. `Linter.LegacyConfig` will represent the type for an eslintrc config object in both `@types/eslint@8` and `@types/eslint@9`.

The `Linter.Config` type represents the default config object type for the targeted version of ESLint, which ist eslintrc config for v8 and flat config for v9. In `@types/eslint@9`, the eslintrc config type will be only be accessible as `Linter.LegacyConfig`.