### PR TITLE
add types (tabGroups and tab.group) to webextension-polyfill 

### DIFF
--- a/types/webextension-polyfill/index.d.ts
+++ b/types/webextension-polyfill/index.d.ts
@@ -49,6 +49,7 @@ import { Sessions as ImportedSessions } from "./namespaces/sessions";
 import { SidebarAction as ImportedSidebarAction } from "./namespaces/sidebarAction";
 import { Storage as ImportedStorage } from "./namespaces/storage";
 import { Tabs as ImportedTabs } from "./namespaces/tabs";
+import { TabGroups as ImportedTabGroups } from "./namespaces/tabGroups";
 import { Theme as ImportedTheme } from "./namespaces/theme";
 import { TopSites as ImportedTopSites } from "./namespaces/topSites";
 import { Types as ImportedTypes } from "./namespaces/types";
@@ -106,6 +107,7 @@ declare namespace Browser {
     const sidebarAction: SidebarAction.Static;
     const storage: Storage.Static;
     const tabs: Tabs.Static;
+    const tabGroups: TabGroups.Static;
     const theme: Theme.Static;
     const topSites: TopSites.Static;
     const types: Types.Static;
@@ -163,6 +165,7 @@ declare namespace Browser {
         sidebarAction: SidebarAction.Static;
         storage: Storage.Static;
         tabs: Tabs.Static;
+        tabGroups: TabGroups.Static;
         theme: Theme.Static;
         topSites: TopSites.Static;
         types: Types.Static;
@@ -221,6 +224,7 @@ declare namespace Browser {
     export import SidebarAction = ImportedSidebarAction;
     export import Storage = ImportedStorage;
     export import Tabs = ImportedTabs;
+    export import TabGroups = ImportedTabGroups;
     export import Theme = ImportedTheme;
     export import TopSites = ImportedTopSites;
     export import Types = ImportedTypes;

--- a/types/webextension-polyfill/namespaces/tabGroups.d.ts
+++ b/types/webextension-polyfill/namespaces/tabGroups.d.ts
@@ -1,0 +1,176 @@
+//////////////////////////////////////////////////////
+// BEWARE: DO NOT EDIT MANUALLY! Changes will be lost!
+//////////////////////////////////////////////////////
+
+/**
+ * Namespace: browser.tabGroups
+ *
+ * Use the <code>chrome.tabGroups</code> API to interact with the browser's tab grouping system. You can use this API to modify,
+ * and rearrange tab groups in the browser.
+ * To group and ungroup tabs, or to query what tabs are in groups, use the <code>browser.tabs</code> API.
+ *
+ * Comments found in source JSON schema files:
+ * Copyright (c) 2012 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+import { Events } from "./events";
+
+export namespace TabGroups {
+    type ColorEnum = "grey" | "blue" | "red" | "yellow" | "green" | "pink" | "purple" | "cyan" | "orange";
+
+    interface TabGroup {
+        /**
+         * Whether the group is collapsed. A collapsed group is one whose tabs are hidden.
+         */
+        collapsed: boolean;
+
+        /**
+         * The group's color.
+         */
+        color: ColorEnum;
+
+        /**
+         * The ID of the group. Group IDs are unique within a browser session.
+         */
+        id: number;
+
+        /**
+         * The title of the group.
+         * Optional.
+         */
+        title?: string;
+
+        /**
+         * The ID of the window that contains the group.
+         */
+        windowId: number;
+    }
+
+    interface MoveMovePropertiesType {
+        /**
+         * The position to move the group to. Use -1 to place the group at the end of the window.
+         */
+        index: number;
+
+        /**
+         * The window to move the group to. Defaults to the window the group is currently in.
+         * Optional.
+         */
+        windowId?: number;
+    }
+
+    interface QueryQueryInfoType {
+        /**
+         * Whether the groups are collapsed.
+         * Optional.
+         */
+        collapsed?: boolean;
+
+        /**
+         * The color of the groups.
+         * Optional.
+         */
+        color?: boolean;
+
+        /**
+         * Match group titles against a pattern.
+         * Optional.
+         */
+        title?: boolean;
+
+        /**
+         * The ID of the parent window, or windows.WINDOW_ID_CURRENT for the current window.
+         * Optional.
+         */
+        windowId?: boolean;
+    }
+
+    interface UpdateUpdatePropertiesType {
+        /**
+         * Whether the group should be collapsed.
+         * Optional.
+         */
+        collapsed?: boolean;
+
+        /**
+         * The color of the group.
+         * Optional.
+         */
+        color?: boolean;
+
+        /**
+         * The title of the group.
+         * Optional.
+         */
+        title?: boolean;
+    }
+
+    interface Static {
+        /**
+         * Retrieves details about the specified group.
+         *
+         * @param groupId
+         */
+        get(groupId: number): Promise<TabGroup>;
+
+        /**
+         * Moves the group and all its tabs within its window, or to a new window.
+         *
+         * @param groupId The ID of the group to move.
+         * @param moveProperties
+         */
+        move(groupId: number, moveProperties: MoveMovePropertiesType): Promise<TabGroup | undefined>;
+
+        /**
+         * Gets all groups that have the specified properties, or all groups if no properties are specified.
+         *
+         * @param queryInfo
+         */
+        query(queryInfo: QueryQueryInfoType): Promise<TabGroup[]>;
+
+        /**
+         * Modifies the properties of a group. Properties that are not specified in <var>updateProperties</var> are not modified.
+         *
+         * @param groupId The ID of the group to modify.
+         * @param updateProperties
+         */
+        update(groupId: number, updateProperties: UpdateUpdatePropertiesType): Promise<TabGroup | undefined>;
+
+        /**
+         * Fired when a group is created.
+         *
+         * @param group Details of the tabGroup that was created.
+         */
+        onCreated: Events.Event<(group: TabGroup) => void>;
+
+        /**
+         * Fired when a group is moved within a window.
+         * Move events are still fired for the individual tabs within the group, as well as for the group itself.
+         * This event is not fired when a group is moved between windows;
+         * instead, it will be removed from one window and created in another.
+         *
+         * @param group Details of the tabGroup that was moved.
+         */
+        onMoved: Events.Event<(group: TabGroup) => void>;
+
+        /**
+         * Fired when a group is closed, either directly by the user or automatically because it contained zero tabs.
+         *
+         * @param group Details of the tabGroup that was removed.
+         */
+        onRemoved: Events.Event<(group: TabGroup) => void>;
+
+        /**
+         * Fired when a group is updated.
+         *
+         * @param group Details of the tabGroup that was updated.
+         */
+        onUpdated: Events.Event<(group: TabGroup) => void>;
+
+        /**
+         * An ID that represents the absence of a group.
+         */
+        TAB_GROUP_ID_NONE: -1;
+    }
+}

--- a/types/webextension-polyfill/namespaces/tabGroups.d.ts
+++ b/types/webextension-polyfill/namespaces/tabGroups.d.ts
@@ -71,19 +71,19 @@ export namespace TabGroups {
          * The color of the groups.
          * Optional.
          */
-        color?: boolean;
+        color?: ColorEnum;
 
         /**
          * Match group titles against a pattern.
          * Optional.
          */
-        title?: boolean;
+        title?: string;
 
         /**
          * The ID of the parent window, or windows.WINDOW_ID_CURRENT for the current window.
          * Optional.
          */
-        windowId?: boolean;
+        windowId?: number;
     }
 
     interface UpdateUpdatePropertiesType {
@@ -97,13 +97,13 @@ export namespace TabGroups {
          * The color of the group.
          * Optional.
          */
-        color?: boolean;
+        color?: ColorEnum;
 
         /**
          * The title of the group.
          * Optional.
          */
-        title?: boolean;
+        title?: string;
     }
 
     interface Static {

--- a/types/webextension-polyfill/namespaces/tabs.d.ts
+++ b/types/webextension-polyfill/namespaces/tabs.d.ts
@@ -244,6 +244,12 @@ export namespace Tabs {
          * Optional.
          */
         pendingUrl?: string;
+
+        /**
+         * The ID of the group that the tab belongs to.
+         * Optional.
+         */
+        groupId?: number;
     }
 
     /**
@@ -860,6 +866,31 @@ export namespace Tabs {
         insert?: boolean;
     }
 
+    interface GroupOptionsType {
+        /**
+         * Configurations for creating a group. Cannot be used if groupId is already specified.
+         * Optional.
+         */
+        createProperties?: {
+            /**
+             * The window of the new group. Defaults to the current window.
+             * Optional.
+             */
+            windowId?: number;
+        };
+
+        /**
+         * The ID of the group to add the tabs to. If not specified, a new group will be created.
+         * Optional.
+         */
+        groupId?: number;
+
+        /**
+         * The tab ID or list of tab IDs to add to the specified group.
+         */
+        tabIds: number[] | number;
+    }
+
     /**
      * Lists the changes to the state of the tab that was updated.
      */
@@ -1365,6 +1396,14 @@ export namespace Tabs {
          * @param tabId Optional. The ID of the tab to navigate backward.
          */
         goBack(tabId?: number): Promise<void>;
+
+        /**
+         * Adds one or more tabs to a specified group, or if no group is specified, adds the given tabs to a newly created group.
+         *
+         * @param options The options to add the tab(s) to a group.
+         * @returns The ID of the group that the tabs were added to.
+         */
+        group(options: GroupOptionsType): Promise<number>;
 
         /**
          * Fired when a tab is created. Note that the tab's URL may not be set at the time this event fired,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [chrome.tabGroups](https://developer.chrome.com/docs/extensions/reference/api/tabGroups)
  - [chrome.tabs.group](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-group)
