### PR TITLE
Allows arrays for background image style properties

### DIFF
--- a/types/cytoscape/cytoscape-tests.ts
+++ b/types/cytoscape/cytoscape-tests.ts
@@ -99,7 +99,7 @@ const showAllStyle: cytoscape.Stylesheet[] = [
             "background-offset-y": [10, 10],
             "background-width-relative-to": ["inner", "include-padding"],
             "background-height-relative-to": ["inner", "include-padding"],
-            "background-clip": ["clipped", "none"],
+            "background-clip": ["node", "none"],
         },
     },
     {

--- a/types/cytoscape/cytoscape-tests.ts
+++ b/types/cytoscape/cytoscape-tests.ts
@@ -76,8 +76,14 @@ const showAllStyle: cytoscape.Stylesheet[] = [
         selector: "node .background-multi-image",
         style: {
             "background-image": [
-                "data:image/svg+xml;utf8," + encodeURIComponent(`<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg><svg xmlns='' version='1.1'></svg>`),
-                "data:image/svg+xml;utf8," + encodeURIComponent(`<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg><svg xmlns='' version='1.1'></svg>`)
+                "data:image/svg+xml;utf8,"
+                + encodeURIComponent(
+                    `<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg><svg xmlns='' version='1.1'></svg>`,
+                ),
+                "data:image/svg+xml;utf8,"
+                + encodeURIComponent(
+                    `<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg><svg xmlns='' version='1.1'></svg>`,
+                ),
             ],
             "background-image-opacity": [0.5, 1.0],
             "background-image-crossorigin": ["anonymous", "use-credentials"],
@@ -93,8 +99,8 @@ const showAllStyle: cytoscape.Stylesheet[] = [
             "background-offset-y": [10, 10],
             "background-width-relative-to": ["inner", "include-padding"],
             "background-height-relative-to": ["inner", "include-padding"],
-            "background-clip": ["clipped", "none"]
-        }
+            "background-clip": ["clipped", "none"],
+        },
     },
     {
         selector: "$node > node",

--- a/types/cytoscape/cytoscape-tests.ts
+++ b/types/cytoscape/cytoscape-tests.ts
@@ -73,6 +73,30 @@ const showAllStyle: cytoscape.Stylesheet[] = [
         },
     },
     {
+        selector: "node .background-multi-image",
+        style: {
+            "background-image": [
+                "data:image/svg+xml;utf8," + encodeURIComponent(`<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg><svg xmlns='' version='1.1'></svg>`),
+                "data:image/svg+xml;utf8," + encodeURIComponent(`<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg><svg xmlns='' version='1.1'></svg>`)
+            ],
+            "background-image-opacity": [0.5, 1.0],
+            "background-image-crossorigin": ["anonymous", "use-credentials"],
+            "background-image-smoothing": ["yes", "no"],
+            "background-image-containment": ["inside", "over"],
+            "background-width": [24, "60%"],
+            "background-height": ["60%", 24],
+            "background-fit": ["contain", "cover"],
+            "background-repeat": ["repeat-x", "repeat-y"],
+            "background-position-x": [24, 24],
+            "background-position-y": [0, 10],
+            "background-offset-x": [0, 0],
+            "background-offset-y": [10, 10],
+            "background-width-relative-to": ["inner", "include-padding"],
+            "background-height-relative-to": ["inner", "include-padding"],
+            "background-clip": ["clipped", "none"]
+        }
+    },
+    {
         selector: "$node > node",
         css: parentCSS,
     },

--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -4051,8 +4051,8 @@ declare namespace cytoscape {
              * may be node for clipped to node shape or none for no clipping.
              */
             "background-clip"?:
-                | PropertyValueNode<"clipped" | "none">
-                | PropertyValueNode<Array<"clipped" | "none">>
+                | PropertyValueNode<"node" | "none">
+                | PropertyValueNode<Array<"node" | "none">>
                 | undefined;
             /**
              * Specifies a padding size (e.g. 20) that expands the bounding box of the node in

--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -3936,7 +3936,9 @@ declare namespace cytoscape {
              *
              * The default is set to `anonymous`.
              */
-            "background-image-crossorigin"?: PropertyValueNode<"anonymous" | "use-credentials"> | PropertyValueNode<Array<"anonymous" | "use-credentials">>;
+            "background-image-crossorigin"?:
+                | PropertyValueNode<"anonymous" | "use-credentials">
+                | PropertyValueNode<Array<"anonymous" | "use-credentials">>;
             /**
              * The opacity of the background image. [0 1]
              */
@@ -3953,7 +3955,9 @@ declare namespace cytoscape {
              *
              * The default is set to `inside`.
              */
-            "background-image-containment"?: PropertyValueNode<"inside" | "over"> | PropertyValueNode<Array<"inside" | "over">>;
+            "background-image-containment"?:
+                | PropertyValueNode<"inside" | "over">
+                | PropertyValueNode<Array<"inside" | "over">>;
             /**
              * Specifies the width of the image.
              * A percent value (e.g. 50%) may be used to set
@@ -3963,7 +3967,10 @@ declare namespace cytoscape {
              * in calculating the fitting — thereby overriding the aspect ratio.
              * The auto value is used by default, which uses the width of the image.
              */
-            "background-width"?: PropertyValueNode<number | string> | PropertyValueNode<Array<number | string>> | undefined;
+            "background-width"?:
+                | PropertyValueNode<number | string>
+                | PropertyValueNode<Array<number | string>>
+                | undefined;
             /**
              * Specifies the height of the image.
              * A percent value (e.g. 50%) may be used to set the image
@@ -3973,29 +3980,44 @@ declare namespace cytoscape {
              * the fitting — thereby overriding the aspect ratio.
              * The auto value is used by default, which uses the height of the image.
              */
-            "background-height"?: PropertyValueNode<number | string> | PropertyValueNode<Array<number | string>> | undefined;
+            "background-height"?:
+                | PropertyValueNode<number | string>
+                | PropertyValueNode<Array<number | string>>
+                | undefined;
             /**
              * How the background image is fit to the node;
              * may be none for original size,
              * contain to fit inside node,
              * or cover to cover the node.
              */
-            "background-fit"?: PropertyValueNode<"none" | "contain" | "cover"> | PropertyValueNode<Array<"none" | "contain" | "cover">> | undefined;
+            "background-fit"?:
+                | PropertyValueNode<"none" | "contain" | "cover">
+                | PropertyValueNode<Array<"none" | "contain" | "cover">>
+                | undefined;
             /**
              * Whether to repeat the background image;
              * may be no-repeat, repeat-x, repeat-y, or repeat.
              */
-            "background-repeat"?: PropertyValueNode<"no-repeat" | "repeat-x" | "repeat-y" | "repeat"> | PropertyValueNode<Array<"no-repeat" | "repeat-x" | "repeat-y" | "repeat">> | undefined;
+            "background-repeat"?:
+                | PropertyValueNode<"no-repeat" | "repeat-x" | "repeat-y" | "repeat">
+                | PropertyValueNode<Array<"no-repeat" | "repeat-x" | "repeat-y" | "repeat">>
+                | undefined;
             /**
              * The x position of the background image,
              * measured in percent(e.g. `'50%'`) or pixels (e.g. `'10px'`).
              */
-            "background-position-x"?: PropertyValueNode<number | string> | PropertyValueNode<Array<number | string>> | undefined;
+            "background-position-x"?:
+                | PropertyValueNode<number | string>
+                | PropertyValueNode<Array<number | string>>
+                | undefined;
             /**
              * The y position of the background image,
              * measured in percent(e.g. `'50%'`) or pixels (e.g. `'10px'`).
              */
-            "background-position-y"?: PropertyValueNode<number | string> | PropertyValueNode<Array<number | string>> | undefined;
+            "background-position-y"?:
+                | PropertyValueNode<number | string>
+                | PropertyValueNode<Array<number | string>>
+                | undefined;
             /**
              * The x offset of the background image,
              * measured in percent(e.g. `'50%'`) or pixels (e.g. `'10px'`).
@@ -4012,19 +4034,26 @@ declare namespace cytoscape {
              *
              * If not specified, include-padding is used by default.
              */
-            "background-width-relative-to"?: PropertyValueNode<"inner" | "include-padding"> | PropertyValueNode<Array<"inner" | "include-padding">>;
+            "background-width-relative-to"?:
+                | PropertyValueNode<"inner" | "include-padding">
+                | PropertyValueNode<Array<"inner" | "include-padding">>;
             /**
              * Changes whether the height is calculated relative to the height of the node or
              * the height in addition to the padding; may be `inner` or `include-padding`.
              *
              * If not specified, `include-padding` is used by default.
              */
-            "background-height-relative-to"?: PropertyValueNode<"inner" | "include-padding"> | PropertyValueNode<Array<"inner" | "include-padding">>;
+            "background-height-relative-to"?:
+                | PropertyValueNode<"inner" | "include-padding">
+                | PropertyValueNode<Array<"inner" | "include-padding">>;
             /**
              * How background image clipping is handled;
              * may be node for clipped to node shape or none for no clipping.
              */
-            "background-clip"?: PropertyValueNode<"clipped" | "none"> | PropertyValueNode<Array<"clipped" | "none">> | undefined;
+            "background-clip"?:
+                | PropertyValueNode<"clipped" | "none">
+                | PropertyValueNode<Array<"clipped" | "none">>
+                | undefined;
             /**
              * Specifies a padding size (e.g. 20) that expands the bounding box of the node in
              * all directions. This allows for images to be drawn outside of the normal bounding

--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -3929,31 +3929,31 @@ declare namespace cytoscape {
              * You may use a data URI to use embedded images,
              * thereby saving a HTTP request.
              */
-            "background-image"?: PropertyValueNode<string> | undefined;
+            "background-image"?: PropertyValueNode<string> | PropertyValueNode<string[]> | undefined;
             /**
              * All images are loaded with a crossorigin attribute which may be `anonymous` or
              * `use-credentials`.
              *
              * The default is set to `anonymous`.
              */
-            "background-image-crossorigin"?: PropertyValueNode<"anonymous" | "use-credentials">;
+            "background-image-crossorigin"?: PropertyValueNode<"anonymous" | "use-credentials"> | PropertyValueNode<Array<"anonymous" | "use-credentials">>;
             /**
              * The opacity of the background image. [0 1]
              */
-            "background-image-opacity"?: PropertyValueNode<number> | undefined;
+            "background-image-opacity"?: PropertyValueNode<number> | PropertyValueNode<number[]> | undefined;
             /**
              * Determines whether background image is smoothed (`yes`, default) or not (`no`).
              * This is only a hint, and the browser may or may not respect the
              * value set for this property.
              */
-            "background-image-smoothing"?: PropertyValueNode<"yes" | "no">;
+            "background-image-smoothing"?: PropertyValueNode<"yes" | "no"> | PropertyValueNode<Array<"yes" | "no">>;
             /**
              * Determines whether background image is within (`inside`)
              * or over top of the node (`over`).
              *
              * The default is set to `inside`.
              */
-            "background-image-containment"?: PropertyValueNode<"inside" | "over">;
+            "background-image-containment"?: PropertyValueNode<"inside" | "over"> | PropertyValueNode<Array<"inside" | "over">>;
             /**
              * Specifies the width of the image.
              * A percent value (e.g. 50%) may be used to set
@@ -3963,7 +3963,7 @@ declare namespace cytoscape {
              * in calculating the fitting — thereby overriding the aspect ratio.
              * The auto value is used by default, which uses the width of the image.
              */
-            "background-width"?: PropertyValueNode<number | string> | undefined;
+            "background-width"?: PropertyValueNode<number | string> | PropertyValueNode<Array<number | string>> | undefined;
             /**
              * Specifies the height of the image.
              * A percent value (e.g. 50%) may be used to set the image
@@ -3973,58 +3973,58 @@ declare namespace cytoscape {
              * the fitting — thereby overriding the aspect ratio.
              * The auto value is used by default, which uses the height of the image.
              */
-            "background-height"?: PropertyValueNode<number | string> | undefined;
+            "background-height"?: PropertyValueNode<number | string> | PropertyValueNode<Array<number | string>> | undefined;
             /**
              * How the background image is fit to the node;
              * may be none for original size,
              * contain to fit inside node,
              * or cover to cover the node.
              */
-            "background-fit"?: PropertyValueNode<"none" | "contain" | "cover"> | undefined;
+            "background-fit"?: PropertyValueNode<"none" | "contain" | "cover"> | PropertyValueNode<Array<"none" | "contain" | "cover">> | undefined;
             /**
              * Whether to repeat the background image;
              * may be no-repeat, repeat-x, repeat-y, or repeat.
              */
-            "background-repeat"?: PropertyValueNode<"no-repeat" | "repeat-x" | "repeat-y" | "repeat"> | undefined;
+            "background-repeat"?: PropertyValueNode<"no-repeat" | "repeat-x" | "repeat-y" | "repeat"> | PropertyValueNode<Array<"no-repeat" | "repeat-x" | "repeat-y" | "repeat">> | undefined;
             /**
              * The x position of the background image,
              * measured in percent(e.g. `'50%'`) or pixels (e.g. `'10px'`).
              */
-            "background-position-x"?: PropertyValueNode<number | string> | undefined;
+            "background-position-x"?: PropertyValueNode<number | string> | PropertyValueNode<Array<number | string>> | undefined;
             /**
              * The y position of the background image,
              * measured in percent(e.g. `'50%'`) or pixels (e.g. `'10px'`).
              */
-            "background-position-y"?: PropertyValueNode<number | string> | undefined;
+            "background-position-y"?: PropertyValueNode<number | string> | PropertyValueNode<Array<number | string>> | undefined;
             /**
              * The x offset of the background image,
              * measured in percent(e.g. `'50%'`) or pixels (e.g. `'10px'`).
              */
-            "background-offset-x"?: PropertyValueNode<number | string>;
+            "background-offset-x"?: PropertyValueNode<number | string> | PropertyValueNode<Array<number | string>>;
             /**
              * The y offset of the background image,
              * measured in percent(e.g. `'50%'`) or pixels (e.g. `'10px'`).
              */
-            "background-offset-y"?: PropertyValueNode<number | string>;
+            "background-offset-y"?: PropertyValueNode<number | string> | PropertyValueNode<Array<number | string>>;
             /**
              * Changes whether the width is calculated relative to the width of the node or
              * the width in addition to the padding; may be inner or include-padding.
              *
              * If not specified, include-padding is used by default.
              */
-            "background-width-relative-to"?: PropertyValueNode<"inner" | "include-padding">;
+            "background-width-relative-to"?: PropertyValueNode<"inner" | "include-padding"> | PropertyValueNode<Array<"inner" | "include-padding">>;
             /**
              * Changes whether the height is calculated relative to the height of the node or
              * the height in addition to the padding; may be `inner` or `include-padding`.
              *
              * If not specified, `include-padding` is used by default.
              */
-            "background-height-relative-to"?: PropertyValueNode<"inner" | "include-padding">;
+            "background-height-relative-to"?: PropertyValueNode<"inner" | "include-padding"> | PropertyValueNode<Array<"inner" | "include-padding">>;
             /**
              * How background image clipping is handled;
              * may be node for clipped to node shape or none for no clipping.
              */
-            "background-clip"?: PropertyValueNode<"clipped" | "none"> | undefined;
+            "background-clip"?: PropertyValueNode<"clipped" | "none"> | PropertyValueNode<Array<"clipped" | "none">> | undefined;
             /**
              * Specifies a padding size (e.g. 20) that expands the bounding box of the node in
              * all directions. This allows for images to be drawn outside of the normal bounding


### PR DESCRIPTION
Cytoscape allows multiple background images by passing arrays (of the same length) for the relevant style properties.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://js.cytoscape.org/#style/background-image
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
