### PR TITLE
[cannon] fix typo `isFronmtWheel` to `isFrontWheel`

### DIFF
--- a/types/cannon/cannon-tests.ts
+++ b/types/cannon/cannon-tests.ts
@@ -3,3 +3,9 @@ import cannon = require("cannon");
 var aabb = new cannon.AABB();
 
 aabb.setFromPoints([new cannon.Vec3(1, 2, 3)]);
+
+var vehicle = new CANNON.RaycastVehicle()
+
+vehicle.addWheel({
+  isFrontWheel: true,
+})

--- a/types/cannon/index.d.ts
+++ b/types/cannon/index.d.ts
@@ -511,7 +511,7 @@ declare namespace CANNON {
         deltaRotation?: number | undefined;
         rollInfluence?: number | undefined;
         maxSuspensionForce?: number | undefined;
-        isFronmtWheel?: boolean | undefined;
+        isFrontWheel?: boolean | undefined;
         clippedInvContactDotSuspension?: number | undefined;
         suspensionRelativeVelocity?: number | undefined;
         suspensionForce?: number | undefined;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://schteppe.github.io/cannon.js/docs/classes/WheelInfo.html#:~:text=%5B-,isFrontWheel,-%3Dtrue%5D%20Boolean](https://schteppe.github.io/cannon.js/docs/classes/WheelInfo.html#:~:text=%5B-,isFrontWheel,-%3Dtrue%5D%20Boolean)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Fix typo `isFronmtWheel` to `isFrontWheel`