### PR TITLE
Fix always-truthy errors

### DIFF
--- a/types/ember/test/component.ts
+++ b/types/ember/test/component.ts
@@ -102,7 +102,7 @@ Component.extend({
     tagName: "input",
     attributeBindings: ["disabled"],
     disabled: computed(() => {
-        if ("someLogic") {
+        if ("bogus" > "logic") {
             return true;
         } else {
             return false;

--- a/types/ember/v2/test/component.ts
+++ b/types/ember/v2/test/component.ts
@@ -102,7 +102,7 @@ Component.extend({
     tagName: "input",
     attributeBindings: ["disabled"],
     disabled: computed(() => {
-        if ("someLogic") {
+        if ("bogus" > "logic") {
             return true;
         } else {
             return false;

--- a/types/ember/v3/test/component.ts
+++ b/types/ember/v3/test/component.ts
@@ -102,7 +102,7 @@ Component.extend({
     tagName: "input",
     attributeBindings: ["disabled"],
     disabled: computed(() => {
-        if ("someLogic") {
+        if ("bogus" > "logic") {
             return true;
         } else {
             return false;

--- a/types/ember__component/test/component.ts
+++ b/types/ember__component/test/component.ts
@@ -101,7 +101,7 @@ Component.extend({
     tagName: "input",
     attributeBindings: ["disabled"],
     disabled: computed(() => {
-        if ("someLogic") {
+        if ("bogus" > "logic") {
             return true;
         } else {
             return false;

--- a/types/ember__component/v3/test/component.ts
+++ b/types/ember__component/v3/test/component.ts
@@ -101,7 +101,7 @@ Component.extend({
     tagName: "input",
     attributeBindings: ["disabled"],
     disabled: computed(() => {
-        if ("someLogic") {
+        if ("bogus" > "logic") {
             return true;
         } else {
             return false;

--- a/types/hapi__joi/hapi__joi-tests.ts
+++ b/types/hapi__joi/hapi__joi-tests.ts
@@ -49,7 +49,8 @@ validOpts = { stripUnknown: bool };
 validOpts = { stripUnknown: { arrays: bool } };
 validOpts = { stripUnknown: { objects: bool } };
 validOpts = { stripUnknown: { arrays: bool, objects: bool } };
-validOpts = { presence: "optional" || "required" || "forbidden" };
+declare const presence: "optional" | "required" | "forbidden" | undefined;
+validOpts = { presence };
 validOpts = { context: obj };
 validOpts = { noDefaults: bool };
 validOpts = {

--- a/types/karma-browserstack-launcher/karma-browserstack-launcher-tests.ts
+++ b/types/karma-browserstack-launcher/karma-browserstack-launcher-tests.ts
@@ -6,8 +6,8 @@ const test = (config: karma.Config) => {
     config.set({
         // global config of your BrowserStack account
         browserStack: {
-            username: "jamesbond" || process.env.BROWSERSTACK_USERNAME,
-            accessKey: "007" || process.env.BROWSERSTACK_ACCESS_KEY,
+            username: process.env.BROWSERSTACK_USERNAME,
+            accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
             build: process.env.BUILD_NUMBER,
             captureTimeout: 100,
             forcelocal: true,

--- a/types/react-native-joi/react-native-joi-tests.ts
+++ b/types/react-native-joi/react-native-joi-tests.ts
@@ -50,7 +50,8 @@ validOpts = { stripUnknown: bool };
 validOpts = { stripUnknown: { arrays: bool } };
 validOpts = { stripUnknown: { objects: bool } };
 validOpts = { stripUnknown: { arrays: bool, objects: bool } };
-validOpts = { presence: "optional" || "required" || "forbidden" };
+declare const presence: "optional" | "required" | "forbidden" | undefined;
+validOpts = { presence };
 validOpts = { context: obj };
 validOpts = { noDefaults: bool };
 validOpts = {

--- a/types/rsvp/rsvp-tests.ts
+++ b/types/rsvp/rsvp-tests.ts
@@ -101,7 +101,7 @@ function testAllSettled() {
     const resolved2 = RSVP.resolve("wat");
     const rejected = RSVP.reject(new Error("oh teh noes"));
     const pending = new RSVP.Promise<{ neato: string }>((resolve, reject) => {
-        if ("something") {
+        if ("bogus" > "logic") {
             resolve({ neato: "yay" });
         } else {
             reject("nay");


### PR DESCRIPTION
From a recent TS PR : https://github.com/microsoft/TypeScript/pull/59217

This only changes tests:
- One case was testing types, so I switched to a `declare const` that declares the types directly.
- The others used an always-truthy check in a conditional, so I switched it to more complex (but still bogus) check.