### PR TITLE
fix: WS server address can be null

### DIFF
--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -341,7 +341,7 @@ declare namespace WebSocket {
 
         constructor(options?: ServerOptions<T, U>, callback?: () => void);
 
-        address(): AddressInfo | string;
+        address(): AddressInfo | string | null;
         close(cb?: (err?: Error) => void): void;
         handleUpgrade(
             request: InstanceType<U>,

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -120,6 +120,13 @@ import * as wslib from "ws";
     });
 
     wss.close();
+
+    const addr = wss.address();
+
+    if (addr === null) {
+        // $ExpectType null
+        addr;
+    }
 }
 
 {


### PR DESCRIPTION
The return type from the `.address()` method can be `null` if the server is not running.

See [this line](https://github.com/websockets/ws/blob/019f28ff1ffddfcdc428d1de5ecd98648057a2ab/lib/websocket-server.js#L148) in the ws source code.

Refs: https://github.com/alanshaw/it-ws/issues/114

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
