### PR TITLE
youtube: assume type from event name on (add|remove)EventHandler

### DIFF
--- a/types/youtube/index.d.ts
+++ b/types/youtube/index.d.ts
@@ -979,7 +979,10 @@ declare namespace YT {
          * @param eventName   Name of the event.
          * @param listener   Handler for the event.
          */
-        addEventListener<TEvent extends PlayerEvent>(eventName: keyof Events, listener: (event: TEvent) => void): void;
+        addEventListener<EventName extends keyof Events>(
+            eventName: EventName,
+            listener: NonNullable<Events[EventName]>,
+        ): void;
 
         /**
          * Remove an event listener for the specified event.
@@ -987,9 +990,9 @@ declare namespace YT {
          * @param eventName   Name of the event.
          * @param listener   Handler for the event.
          */
-        removeEventListener<TEvent extends PlayerEvent>(
-            eventName: keyof Events,
-            listener: (event: TEvent) => void,
+        removeEventListener<EventName extends keyof Events>(
+            eventName: EventName,
+            listener: NonNullable<Events[EventName]>,
         ): void;
 
         /**

--- a/types/youtube/package.json
+++ b/types/youtube/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/youtube",
-    "version": "0.0.9999",
+    "version": "0.1.9999",
     "projects": [
         "https://developers.google.com/youtube/"
     ],

--- a/types/youtube/youtube-tests.ts
+++ b/types/youtube/youtube-tests.ts
@@ -281,6 +281,10 @@ player.addEventListener("onPlaybackRateChange", (event: YT.OnPlaybackRateChangeE
 player.addEventListener("onError", (event: YT.OnErrorEvent) => {});
 player.addEventListener("onApiChange", (event: YT.PlayerEvent) => {});
 
+player.addEventListener("onStateChange", (event) => {
+    ensureNumeric<typeof event.data>();
+});
+
 const frame: HTMLIFrameElement = player.getIframe();
 
 const sphericalProperties: YT.SphericalProperties = player.getSphericalProperties();


### PR DESCRIPTION

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---
With the current `@types/youtube`, if a user wants to use `player.addEventListener`, they need to specify the actual type manually, not just the event name.

For example:

```typescript
player.addEventListener("onStateChange", (event: YT.OnStateChangeEvent) => {});
// or
player.addEventListener<YT.OnStateChangeEvent>("onStateChange", (event) => {});
```

This patch resolves that issue. Now the user only needs to write the event name.

```typescript
player.addEventListener("onStateChange", (event) => {
    // now `event` is `YT.OnStateChangeEvent`, whereas previously it defaulted to `YT.PlayerEvent`
});
```

Additionally, it protects against incompatible event types:

```typescript
player.addEventListener("onStateChange", (event: YT.OnPlaybackQualityChangeEvent) => {
});

/*
Argument of type '(event: YT.OnPlaybackQualityChangeEvent) => void' is not assignable to parameter of type 'PlayerEventHandler<OnStateChangeEvent>'.
  Types of parameters 'event' and 'event' are incompatible.
    Type 'OnStateChangeEvent' is not assignable to type 'OnPlaybackQualityChangeEvent'.
      Types of property 'data' are incompatible.
        Type 'YT.PlayerState' is not assignable to type 'string'.
*/
```

---

Note: This patch breaks code that uses generics for specifying event types (e.g. `player.addEventListener<YT.OnStateChangeEvent>(...)`).

I think we need to bump up the major version because it is a breaking change. However, I'm not sure if it is enough to increase `x` of `0.x.y` for a v0.x package. Bumping to v1.0 might suggest that it is ready for production use, but I'm not certain we have the quality for that.