### PR TITLE
[@types/cloudflare-turnstile] Add "execution" to cloudflare turnstile render params

### DIFF
--- a/types/cloudflare-turnstile/cloudflare-turnstile-tests.ts
+++ b/types/cloudflare-turnstile/cloudflare-turnstile-tests.ts
@@ -35,6 +35,9 @@ const refreshTimeoutNever: Turnstile.RefreshTimeoutMode = "never";
 const refreshTimeoutManual: Turnstile.RefreshTimeoutMode = "manual";
 const refreshTimeoutAuto: Turnstile.RefreshTimeoutMode = "auto";
 
+const executionRender: Turnstile.ExecutionMode = "render";
+const executionExecute: Turnstile.ExecutionMode = "execute";
+
 // @ts-expect-error
 turnstile.ready();
 // $ExpectType void

--- a/types/cloudflare-turnstile/index.d.ts
+++ b/types/cloudflare-turnstile/index.d.ts
@@ -88,6 +88,14 @@ declare namespace Turnstile {
     type RefreshTimeoutMode = "never" | "manual" | "auto";
 
     /**
+     * The execution mode to controls when to obtain the widget token
+     * The default is "render". "render" will make the challenge runs automatically after calling the render() function, while
+     * "execute" will make the challenge runs after the render() function has been called, by invoking the turnstile.execute function separately.
+     * This detaches the appearance and rendering of a widget from its execution.
+     */
+    type ExecutionMode = "render" | "execute";
+
+    /**
      * Parameters for the turnstile.render() method.
      */
     interface RenderParameters {
@@ -219,5 +227,12 @@ declare namespace Turnstile {
          * @default "auto"
          */
         "refresh-timeout"?: RefreshTimeoutMode | undefined;
+
+        /**
+         * Optional
+         * @see ExecutionMode
+         * @default "render"
+         */
+        execution?: ExecutionMode | undefined;
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Cloudflare Turnstile support `execution` in `render()` now](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#execution-modes)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
