### PR TITLE
[mapbox__mapbox-gl-draw] compatibility with MapBox GL js 3.5+ native types

### DIFF
--- a/types/mapbox__mapbox-gl-draw/index.d.ts
+++ b/types/mapbox__mapbox-gl-draw/index.d.ts
@@ -1,11 +1,12 @@
 import { BBox, Feature, FeatureCollection, GeoJSON, GeoJsonTypes, Geometry, Point, Position } from "geojson";
 import {
-    CircleLayer,
-    FillLayer,
+    CircleLayerSpecification,
+    ControlPosition,
+    FillLayerSpecification,
     IControl,
-    LineLayer,
+    LineLayerSpecification,
     Map,
-    MapboxEvent,
+    MapEvent,
     MapMouseEvent as MapboxMapMouseEvent,
     MapTouchEvent as MapboxMapTouchEvent,
 } from "mapbox-gl";
@@ -13,19 +14,37 @@ import {
 export = MapboxDraw;
 export as namespace MapboxDraw;
 
+type EventOf<T extends MapboxDraw.DrawEventType, Target = unknown> = keyof MapboxDraw.DrawEvents[T] extends never ? {
+        type: T;
+        target: Target;
+    }
+    : {
+        type: T;
+        target: Target;
+    } & MapboxDraw.DrawEvents[T];
+
+declare module "mapbox-gl" {
+    interface Map {
+        on<T extends MapboxDraw.DrawEventType>(type: T, listener: (event: EventOf<T>) => void): this;
+        off<T extends MapboxDraw.DrawEventType>(type: T, listener: (event: EventOf<T>) => void): this;
+    }
+}
+
 declare namespace MapboxDraw {
     type DrawMode = DrawModes[keyof DrawModes];
 
-    type DrawEventType =
-        | "draw.create"
-        | "draw.delete"
-        | "draw.update"
-        | "draw.render"
-        | "draw.combine"
-        | "draw.uncombine"
-        | "draw.modechange"
-        | "draw.actionable"
-        | "draw.selectionchange";
+    interface DrawEvents {
+        "draw.create": MapboxDraw.DrawCreateEvent;
+        "draw.delete": MapboxDraw.DrawDeleteEvent;
+        "draw.update": MapboxDraw.DrawUpdateEvent;
+        "draw.selectionchange": MapboxDraw.DrawSelectionChangeEvent;
+        "draw.render": MapboxDraw.DrawRenderEvent;
+        "draw.combine": MapboxDraw.DrawCombineEvent;
+        "draw.uncombine": MapboxDraw.DrawUncombineEvent;
+        "draw.modechange": MapboxDraw.DrawModeChangeEvent;
+        "draw.actionable": MapboxDraw.DrawActionableEvent;
+    }
+    type DrawEventType = keyof DrawEvents;
 
     interface DrawModes {
         DRAW_LINE_STRING: "draw_line_string";
@@ -178,7 +197,7 @@ declare namespace MapboxDraw {
     }
 
     interface DrawCustomModeThis {
-        map: mapboxgl.Map;
+        map: Map;
 
         drawConfig: MapboxDrawOptions;
 
@@ -389,13 +408,13 @@ declare namespace MapboxDraw {
             isOfMetaType: (
                 type: Constants["meta"][keyof Constants["meta"]],
             ) => (e: MapMouseEvent | MapTouchEvent) => boolean;
-            isShiftMousedown: (e: MapboxEvent) => boolean;
+            isShiftMousedown: (e: MapEvent) => boolean;
             isActiveFeature: (e: MapMouseEvent | MapTouchEvent) => boolean;
             isInactiveFeature: (e: MapMouseEvent | MapTouchEvent) => boolean;
             noTarget: (e: MapMouseEvent | MapTouchEvent) => boolean;
             isFeature: (e: MapMouseEvent | MapTouchEvent) => boolean;
             isVertex: (e: MapMouseEvent | MapTouchEvent) => boolean;
-            isShiftDown: (e: MapboxEvent) => boolean;
+            isShiftDown: (e: MapEvent) => boolean;
             isEscapeKey: (e: KeyboardEvent) => boolean;
             isEnterKey: (e: KeyboardEvent) => boolean;
             isTrue: () => boolean;
@@ -503,7 +522,9 @@ declare namespace MapboxDraw {
 
         StringSet(items?: Array<string | number>): StringSet;
 
-        theme: Array<(FillLayer | LineLayer | CircleLayer) & { id: ThemeLayerId }>;
+        theme: Array<
+            (FillLayerSpecification | LineLayerSpecification | CircleLayerSpecification) & { id: ThemeLayerId }
+        >;
 
         /**
          * Derive a dense array (no `undefined`s) from a single value or array.
@@ -552,7 +573,7 @@ declare class MapboxDraw implements IControl {
 
     modes: MapboxDraw.DrawModes;
 
-    getDefaultPosition: () => string;
+    getDefaultPosition: () => ControlPosition;
 
     constructor(options?: MapboxDraw.MapboxDrawOptions);
 
@@ -595,7 +616,7 @@ declare class MapboxDraw implements IControl {
 
     setFeatureProperty(featureId: string, property: string, value: any): this;
 
-    onAdd(map: mapboxgl.Map): HTMLElement;
+    onAdd(map: Map): HTMLElement;
 
-    onRemove(map: mapboxgl.Map): any;
+    onRemove(map: Map): any;
 }

--- a/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
+++ b/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
@@ -89,7 +89,7 @@ const customMode: CustomMode = {
         // $ExpectType DrawFeature
         e.featureTarget;
 
-        // $ExpectType Map
+        // $ExpectType Map$1
         this.map;
 
         // $ExpectType boolean | undefined
@@ -169,7 +169,7 @@ const customMode: CustomMode = {
         // $ExpectType StringSet
         lib.StringSet(["1", 2]);
 
-        const FabricDrawingManagerStyles: Lib["theme"] = [
+        const FabricDrawingManagerStyles: Array<Partial<Lib["theme"][number]>> = [
             {
                 id: "gl-draw-polygon-fill-inactive",
                 type: "fill",

--- a/types/mapbox__mapbox-gl-draw/package.json
+++ b/types/mapbox__mapbox-gl-draw/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/geojson": "*",
-        "@types/mapbox-gl": "*"
+        "mapbox-gl": "*"
     },
     "devDependencies": {
         "@types/mapbox__mapbox-gl-draw": "workspace:."
@@ -24,6 +24,10 @@
         {
             "name": "Joel Daros",
             "githubUsername": "joel-daros"
+        },
+        {
+            "name": "Brook Jordan",
+            "githubUsername": "brookjordan"
         }
     ]
 }


### PR DESCRIPTION
This allows `map.on` to work correctly with, and updates deprecated types from, the new natively typed `mapbox-gl`

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://github.com/mapbox/mapbox-gl-js/releases/tag/v3.5.0)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
