### PR TITLE
[@npmcli/arborist] Fix Edge.to and Edge.type

### DIFF
--- a/types/npmcli__arborist/index.d.ts
+++ b/types/npmcli__arborist/index.d.ts
@@ -260,7 +260,7 @@ declare namespace Arborist {
          */
         constructor(fields: Pick<Edge, "from" | "type" | "name" | "spec">);
         /** The node that has the dependency. */
-        from: Node;
+        from: Node | null;
         /** The type of dependency. */
         type: SaveType;
         /** The name of the dependency.  Ie, the key in the relevant `package.json` dependencies object. */

--- a/types/npmcli__arborist/index.d.ts
+++ b/types/npmcli__arborist/index.d.ts
@@ -262,7 +262,7 @@ declare namespace Arborist {
         /** The node that has the dependency. */
         from: Node;
         /** The type of dependency. */
-        type: Exclude<SaveType, "peerOptional">;
+        type: SaveType;
         /** The name of the dependency.  Ie, the key in the relevant `package.json` dependencies object. */
         name: string;
         /**
@@ -272,7 +272,7 @@ declare namespace Arborist {
          */
         spec: string;
         /** Automatically set to the node in the tree that matches the `name` field. */
-        to: Node;
+        to: Node | null;
         /** True if `edge.to` satisfies the specifier. */
         valid: boolean;
         invalid: boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   - example of `edge.to` being set to `null`: [edge.js#L279](https://github.com/npm/cli/blob/22731831e22011e32fa0ca12178e242c2ee2b33d/workspaces/arborist/lib/edge.js#L279)
   - example of `edge.from` being set to `null` [edge.js#L281](https://github.com/npm/cli/blob/22731831e22011e32fa0ca12178e242c2ee2b33d/workspaces/arborist/lib/edge.js#L281)
   - no example, but in practice edges of type `peerOptional` exist in my app and cause issues because they are not handled
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.