### PR TITLE
[@mapbox-sdk]: Restrict `SimpleMarker` coordinates type

### DIFF
--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -1882,7 +1882,7 @@ declare module "@mapbox/mapbox-sdk/services/static" {
     }
 
     interface SimpleMarker {
-        coordinates: LngLatLike;
+        coordinates: [number, number];
         label?: string | undefined;
         color?: string | undefined;
         size?: "large" | "small" | undefined;

--- a/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
+++ b/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
@@ -68,8 +68,7 @@ const drivingDirectionsRequest: MapiRequest = directionsService.getDirections({
     maxWidth: 10,
 });
 
-drivingDirectionsRequest.send().then((response: MapiResponse) => {
-});
+drivingDirectionsRequest.send().then((response: MapiResponse) => {});
 
 const drivingTrafficDirectionsRequest: MapiRequest = directionsService.getDirections({
     profile: "driving-traffic",
@@ -80,8 +79,7 @@ const drivingTrafficDirectionsRequest: MapiRequest = directionsService.getDirect
     maxWidth: 10,
 });
 
-drivingTrafficDirectionsRequest.send().then((response: MapiResponse) => {
-});
+drivingTrafficDirectionsRequest.send().then((response: MapiResponse) => {});
 
 const isochroneService: IsochroneService = Isochrone(client);
 
@@ -154,6 +152,22 @@ staticMapService.getStaticImage({
             geoJson: geoOverlay,
         },
     ],
+});
+
+staticMapService.getStaticImage({
+    width: 16,
+    height: 16,
+    overlays: [
+        {
+            marker: {
+                // @ts-expect-error - Object literal may only specify known properties, and 'lng' does not exist in type '[number, number]'
+                coordinates: { lng: 0, lat: 0 },
+            },
+        },
+    ],
+    position: "auto",
+    ownerId: "owner-id",
+    styleId: "some-style",
 });
 
 staticMapService.getStaticImage({
@@ -239,7 +253,7 @@ geocodeService
     })
     .send()
     .then(({ body }) => {
-        body.features.forEach(feature => {
+        body.features.forEach((feature) => {
             const shortCode = feature.short_code;
         });
     });
@@ -253,7 +267,7 @@ geocodeServiceV6
     })
     .send()
     .then(({ body }) => {
-        body.features.forEach(feature => {
+        body.features.forEach((feature) => {
             const shortCode = feature.properties.context.place?.short_code;
         });
     });
@@ -265,7 +279,7 @@ geocodeServiceV6
     })
     .send()
     .then(({ body }) => {
-        body.features.forEach(feature => {
+        body.features.forEach((feature) => {
             const shortCode = feature.properties.context.place?.short_code;
         });
     });


### PR DESCRIPTION
#### Description

Restricting the type to `[number, number]` on SimpleMarker because the sdk only accepts arrays.

Example output from using other typs in `LngLatLike`:

![image](https://github.com/user-attachments/assets/a1bd8c2f-2f22-4bb0-ae41-ba22e9418b9b)


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
