### PR TITLE
add 'on' for FfmpegCommand

### DIFF
--- a/types/fluent-ffmpeg/index.d.ts
+++ b/types/fluent-ffmpeg/index.d.ts
@@ -396,7 +396,7 @@ declare namespace Ffmpeg {
         mergeToFile(target: string | stream.Writable, tmpFolder: string): FfmpegCommand;
         concatenate(target: string | stream.Writable, options?: { end?: boolean | undefined }): FfmpegCommand;
         concat(target: string | stream.Writable, options?: { end?: boolean | undefined }): FfmpegCommand;
-        on(status: string, callback: (value: any) => void): FfmpegCommand;
+        on<K extends string | symbol>(eventName: K, listener: (...args: any[]) => void): this;
         clone(): FfmpegCommand;
         run(): void;
     }

--- a/types/fluent-ffmpeg/index.d.ts
+++ b/types/fluent-ffmpeg/index.d.ts
@@ -396,6 +396,7 @@ declare namespace Ffmpeg {
         mergeToFile(target: string | stream.Writable, tmpFolder: string): FfmpegCommand;
         concatenate(target: string | stream.Writable, options?: { end?: boolean | undefined }): FfmpegCommand;
         concat(target: string | stream.Writable, options?: { end?: boolean | undefined }): FfmpegCommand;
+        on(status: string, callback: (value: any) => void): FfmpegCommand;
         clone(): FfmpegCommand;
         run(): void;
     }


### PR DESCRIPTION
I'm having an issue with TypeScript when I run an FFmpeg command using the fluent-ffmpeg library. The class is missing the method `on` in the declaration file. I'm submitting this PR to add the type and prevent typing errors while using the library with TypeScript. I will provider a link in the fluent-ffmpeg docs that show a use of the method `on` <<https://github.com/fluent-ffmpeg/node-fluent-ffmpeg#:~:text=.on(>>


![Screenshot_371](https://github.com/user-attachments/assets/74729ed2-3d15-4871-80e9-dab7b5369dd4)


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/fluent-ffmpeg/node-fluent-ffmpeg#:~:text=.on(>>
