### PR TITLE
[node] Update typings to v22.1.0

### DIFF
--- a/types/node/dns.d.ts
+++ b/types/node/dns.d.ts
@@ -81,10 +81,20 @@ declare module "dns" {
          */
         all?: boolean | undefined;
         /**
+         * When `verbatim`, the resolved addresses are return unsorted. When `ipv4first`, the resolved addresses are sorted
+         * by placing IPv4 addresses before IPv6 addresses. When `ipv6first`, the resolved addresses are sorted by placing IPv6
+         * addresses before IPv4 addresses. Default value is configurable using
+         * {@link setDefaultResultOrder} or [`--dns-result-order`](https://nodejs.org/docs/latest-v22.x/api/cli.html#--dns-result-orderorder).
+         * @default `verbatim` (addresses are not reordered)
+         * @since v22.1.0
+         */
+        order?: "ipv4first" | "ipv6first" | "verbatim" | undefined;
+        /**
          * When `true`, the callback receives IPv4 and IPv6 addresses in the order the DNS resolver returned them. When `false`, IPv4
-         * addresses are placed before IPv6 addresses. Default value is configurable using {@link setDefaultResultOrder}
-         * or [`--dns-result-order`](https://nodejs.org/docs/latest-v22.x/api/cli.html#--dns-result-orderorder).
-         * @default true
+         * addresses are placed before IPv6 addresses. This option will be deprecated in favor of `order`. When both are specified,
+         * `order` has higher precedence. New code should only use `order`. Default value is configurable using {@link setDefaultResultOrder}
+         * @default true (addresses are not reordered)
+         * @deprecated Please use `order` option
          */
         verbatim?: boolean | undefined;
     }
@@ -663,14 +673,15 @@ declare module "dns" {
         callback: (err: NodeJS.ErrnoException | null, hostnames: string[]) => void,
     ): void;
     /**
-     * Get the default value for `verbatim` in {@link lookup} and [`dnsPromises.lookup()`](https://nodejs.org/docs/latest-v22.x/api/dns.html#dnspromiseslookuphostname-options).
+     * Get the default value for `order` in {@link lookup} and [`dnsPromises.lookup()`](https://nodejs.org/docs/latest-v22.x/api/dns.html#dnspromiseslookuphostname-options).
      * The value could be:
      *
-     * * `ipv4first`: for `verbatim` defaulting to `false`.
-     * * `verbatim`: for `verbatim` defaulting to `true`.
+     * * `ipv4first`: for `order` defaulting to `ipv4first`.
+     * * `ipv6first`: for `order` defaulting to `ipv6first`.
+     * * `verbatim`: for `order` defaulting to `verbatim`.
      * @since v18.17.0
      */
-    export function getDefaultResultOrder(): "ipv4first" | "verbatim";
+    export function getDefaultResultOrder(): "ipv4first" | "ipv6first" | "verbatim";
     /**
      * Sets the IP address and port of servers to be used when performing DNS
      * resolution. The `servers` argument is an array of [RFC 5952](https://tools.ietf.org/html/rfc5952#section-6) formatted
@@ -717,19 +728,21 @@ declare module "dns" {
      */
     export function getServers(): string[];
     /**
-     * Set the default value of `verbatim` in {@link lookup} and [`dnsPromises.lookup()`](https://nodejs.org/docs/latest-v22.x/api/dns.html#dnspromiseslookuphostname-options).
+     * Set the default value of `order` in {@link lookup} and [`dnsPromises.lookup()`](https://nodejs.org/docs/latest-v22.x/api/dns.html#dnspromiseslookuphostname-options).
      * The value could be:
      *
-     * * `ipv4first`: sets default `verbatim` to `false`.
-     * * `verbatim`: sets default `verbatim` to `true`.
+     * * `ipv4first`: sets default `order` to `ipv4first`.
+     * * `ipv6first`: sets default `order` to `ipv6first`.
+     * * `verbatim`: sets default `order` to `verbatim`.
      *
      * The default is `verbatim` and {@link setDefaultResultOrder} have higher
      * priority than [`--dns-result-order`](https://nodejs.org/docs/latest-v22.x/api/cli.html#--dns-result-orderorder). When using
      * [worker threads](https://nodejs.org/docs/latest-v22.x/api/worker_threads.html), {@link setDefaultResultOrder} from the main
      * thread won't affect the default dns orders in workers.
      * @since v16.4.0, v14.18.0
+     * @param order must be `'ipv4first'`, `'ipv6first'` or `'verbatim'`.
      */
-    export function setDefaultResultOrder(order: "ipv4first" | "verbatim"): void;
+    export function setDefaultResultOrder(order: "ipv4first" | "ipv6first" | "verbatim"): void;
     // Error codes
     export const NODATA: "ENODATA";
     export const FORMERR: "EFORMERR";

--- a/types/node/dns/promises.d.ts
+++ b/types/node/dns/promises.d.ts
@@ -346,20 +346,20 @@ declare module "dns/promises" {
      */
     function setServers(servers: readonly string[]): void;
     /**
-     * Set the default value of `verbatim` in {@link lookup} and [`dnsPromises.lookup()`](https://nodejs.org/docs/latest-v22.x/api/dns.html#dnspromiseslookuphostname-options).
-     * The value could be:
+     * Set the default value of `order` in `dns.lookup()` and `{@link lookup}`. The value could be:
      *
-     * * `ipv4first`: sets default `verbatim` to `false`.
-     * * `verbatim`: sets default `verbatim` to `true`.
+     * * `ipv4first`: sets default `order` to `ipv4first`.
+     * * `ipv6first`: sets default `order` to `ipv6first`.
+     * * `verbatim`: sets default `order` to `verbatim`.
      *
-     * The default is `verbatim` and {@link setDefaultResultOrder} have higher
-     * priority than [`--dns-result-order`](https://nodejs.org/docs/latest-v22.x/api/cli.html#--dns-result-orderorder). When using
-     * [worker threads](https://nodejs.org/docs/latest-v22.x/api/worker_threads.html), {@link setDefaultResultOrder} from the main
-     * thread won't affect the default dns orders in workers.
+     * The default is `verbatim` and [dnsPromises.setDefaultResultOrder()](https://nodejs.org/docs/latest-v20.x/api/dns.html#dnspromisessetdefaultresultorderorder)
+     * have higher priority than [`--dns-result-order`](https://nodejs.org/docs/latest-v20.x/api/cli.html#--dns-result-orderorder).
+     * When using [worker threads](https://nodejs.org/docs/latest-v20.x/api/worker_threads.html), [`dnsPromises.setDefaultResultOrder()`](https://nodejs.org/docs/latest-v20.x/api/dns.html#dnspromisessetdefaultresultorderorder)
+     * from the main thread won't affect the default dns orders in workers.
      * @since v16.4.0, v14.18.0
-     * @param order must be `'ipv4first'` or `'verbatim'`.
+     * @param order must be `'ipv4first'`, `'ipv6first'` or `'verbatim'`.
      */
-    function setDefaultResultOrder(order: "ipv4first" | "verbatim"): void;
+    function setDefaultResultOrder(order: "ipv4first" | "ipv6first" | "verbatim"): void;
     // Error codes
     const NODATA: "ENODATA";
     const FORMERR: "EFORMERR";

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "22.0.9999",
+    "version": "22.1.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [
@@ -9,7 +9,7 @@
     ],
     "tsconfigs": ["tsconfig.dom.json", "tsconfig.non-dom.json"],
     "dependencies": {
-        "undici-types": "~6.11.1"
+        "undici-types": "~6.13.0"
     },
     "devDependencies": {
         "@types/node": "workspace:."

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -343,6 +343,15 @@ declare module "node:test" {
          */
         testNamePatterns?: string | RegExp | ReadonlyArray<string | RegExp> | undefined;
         /**
+         * A String, RegExp or a RegExp Array, that can be used to exclude running tests whose
+         * name matches the provided pattern. Test name patterns are interpreted as JavaScript
+         * regular expressions. For each test that is executed, any corresponding test hooks,
+         * such as `beforeEach()`, are also run.
+         * @default undefined
+         * @since v22.1.0
+         */
+        testSkipPatterns?: string | RegExp | ReadonlyArray<string | RegExp> | undefined;
+        /**
          * The number of milliseconds after which the test execution will fail.
          * If unspecified, subtests inherit this value from their parent.
          * @default Infinity

--- a/types/node/test/dns.ts
+++ b/types/node/test/dns.ts
@@ -77,7 +77,7 @@ lookup("nodejs.org", { all: true }, (err, addresses) => {
     const _err: NodeJS.ErrnoException | null = err;
     const _address: LookupAddress[] = addresses;
 });
-lookup("nodejs.org", { all: true, verbatim: true }, (err, addresses) => {
+lookup("nodejs.org", { all: true, order: "ipv6first" }, (err, addresses) => {
     const _err: NodeJS.ErrnoException | null = err;
     const _address: LookupAddress[] = addresses;
 });

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -38,6 +38,7 @@ run({
     timeout: 100,
     inspectPort: () => 8081,
     testNamePatterns: ["executed", /^core-/],
+    testSkipPatterns: ["excluded", /^lib-/],
     only: true,
     setup: (reporter) => {
         // $ExpectType TestsStream

--- a/types/node/test/url.ts
+++ b/types/node/test/url.ts
@@ -187,11 +187,17 @@ import * as url from "node:url";
 
 {
     let path: string = url.fileURLToPath("file://test");
+    path = url.fileURLToPath("file://test", { windows: false });
+    path = url.fileURLToPath("file://test", { windows: true });
     path = url.fileURLToPath(new url.URL("file://test"));
+    path = url.fileURLToPath(new url.URL("file://test"), { windows: false });
+    path = url.fileURLToPath(new url.URL("file://test"), { windows: true });
 }
 
 {
     let path: url.URL = url.pathToFileURL("file://test");
+    path = url.pathToFileURL("file://test", { windows: false });
+    path = url.pathToFileURL("file://test", { windows: true });
 }
 
 {
@@ -205,4 +211,12 @@ import * as url from "node:url";
     const dataUrl2: url.URL = new URL("file://test");
     const urlSearchParams1: URLSearchParams = new url.URLSearchParams();
     const urlSearchParams2: url.URLSearchParams = new URLSearchParams();
+}
+
+{
+    const isValid = url.URL.canParse('/foo', 'https://example.org/');
+    isValid; // $ExpectType boolean
+
+    const parsedUrl = url.URL.parse('/foo', 'https://example.org/');
+    parsedUrl; // $ExpectType URL | null
 }

--- a/types/node/url.d.ts
+++ b/types/node/url.d.ts
@@ -46,6 +46,22 @@ declare module "url" {
     interface UrlWithStringQuery extends Url {
         query: string | null;
     }
+    interface FileUrlToPathOptions {
+        /**
+         * `true` if the `path` should be return as a windows filepath, `false` for posix, and `undefined` for the system default.
+         * @default undefined
+         * @since v22.1.0
+         */
+        windows?: boolean | undefined;
+    }
+    interface PathToFileUrlOptions {
+        /**
+         * `true` if the `path` should be return as a windows filepath, `false` for posix, and `undefined` for the system default.
+         * @default undefined
+         * @since v22.1.0
+         */
+        windows?: boolean | undefined;
+    }
     /**
      * The `url.parse()` method takes a URL string, parses it, and returns a URL
      * object.
@@ -298,7 +314,7 @@ declare module "url" {
      * @param url The file URL string or URL object to convert to a path.
      * @return The fully-resolved platform-specific Node.js file path.
      */
-    function fileURLToPath(url: string | URL): string;
+    function fileURLToPath(url: string | URL, options?: FileUrlToPathOptions): string;
     /**
      * This function ensures that `path` is resolved absolutely, and that the URL
      * control characters are correctly encoded when converting into a File URL.
@@ -316,7 +332,7 @@ declare module "url" {
      * @param path The path to convert to a File URL.
      * @return The file URL object.
      */
-    function pathToFileURL(path: string): URL;
+    function pathToFileURL(path: string, options?: PathToFileUrlOptions): URL;
     /**
      * This utility function converts a URL object into an ordinary options object as
      * expected by the `http.request()` and `https.request()` APIs.
@@ -429,6 +445,15 @@ declare module "url" {
          * @param base The base URL to resolve against if the `input` is not absolute. If `base` is not a string, it is `converted to a string` first.
          */
         static canParse(input: string, base?: string): boolean;
+        /**
+         * Parses a string as a URL. If `base` is provided, it will be used as the base URL for the purpose of resolving non-absolute `input` URLs.
+         * Returns `null` if `input` is not a valid.
+         * @param input The absolute or relative input URL to parse. If `input` is relative, then `base` is required. If `input` is absolute, the `base` is ignored. If `input` is not a string, it is
+         * `converted to a string` first.
+         * @param base The base URL to resolve against if the `input` is not absolute. If `base` is not a string, it is `converted to a string` first.
+         * @since v22.1.0
+         */
+        static parse(input: string, base?: string): URL | null;
         constructor(input: string | { toString: () => string }, base?: string | URL);
         /**
          * Gets and sets the fragment portion of the URL.


### PR DESCRIPTION
https://github.com/nodejs/node/releases/tag/v22.1.0

- dns: add order option and support ipv6first
- lib, url: add a windows option to path parsing
- test_runner: add --test-skip-pattern cli option
- url: implement parse method for safer URL parsing
- deps: update undici to 6.13.0
