### PR TITLE
[node] Remove post-22.0 features from v22.0.x package

### DIFF
--- a/types/node/dns.d.ts
+++ b/types/node/dns.d.ts
@@ -81,19 +81,10 @@ declare module "dns" {
          */
         all?: boolean | undefined;
         /**
-         * When `verbatim`, the resolved addresses are return unsorted. When `ipv4first`, the resolved addresses are sorted
-         * by placing IPv4 addresses before IPv6 addresses. When `ipv6first`, the resolved addresses are sorted by placing IPv6
-         * addresses before IPv4 addresses. Default value is configurable using
-         * {@link setDefaultResultOrder} or [`--dns-result-order`](https://nodejs.org/docs/latest-v22.x/api/cli.html#--dns-result-orderorder).
-         * @default `verbatim` (addresses are not reordered)
-         */
-        order?: "ipv4first" | "ipv6first" | "verbatim" | undefined;
-        /**
          * When `true`, the callback receives IPv4 and IPv6 addresses in the order the DNS resolver returned them. When `false`, IPv4
-         * addresses are placed before IPv6 addresses. This option will be deprecated in favor of `order`. When both are specified,
-         * `order` has higher precedence. New code should only use `order`. Default value is configurable using {@link setDefaultResultOrder}
+         * addresses are placed before IPv6 addresses. Default value is configurable using {@link setDefaultResultOrder}
          * or [`--dns-result-order`](https://nodejs.org/docs/latest-v22.x/api/cli.html#--dns-result-orderorder).
-         * @default true (addresses are not reordered)
+         * @default true
          */
         verbatim?: boolean | undefined;
     }
@@ -672,15 +663,14 @@ declare module "dns" {
         callback: (err: NodeJS.ErrnoException | null, hostnames: string[]) => void,
     ): void;
     /**
-     * Get the default value for `order` in {@link lookup} and [`dnsPromises.lookup()`](https://nodejs.org/docs/latest-v22.x/api/dns.html#dnspromiseslookuphostname-options).
+     * Get the default value for `verbatim` in {@link lookup} and [`dnsPromises.lookup()`](https://nodejs.org/docs/latest-v22.x/api/dns.html#dnspromiseslookuphostname-options).
      * The value could be:
      *
-     * * `ipv4first`: for `order` defaulting to `ipv4first`.
-     * * `ipv6first`: for `order` defaulting to `ipv6first`.
-     * * `verbatim`: for `order` defaulting to `verbatim`.
+     * * `ipv4first`: for `verbatim` defaulting to `false`.
+     * * `verbatim`: for `verbatim` defaulting to `true`.
      * @since v18.17.0
      */
-    export function getDefaultResultOrder(): "ipv4first" | "ipv6first" | "verbatim";
+    export function getDefaultResultOrder(): "ipv4first" | "verbatim";
     /**
      * Sets the IP address and port of servers to be used when performing DNS
      * resolution. The `servers` argument is an array of [RFC 5952](https://tools.ietf.org/html/rfc5952#section-6) formatted
@@ -727,21 +717,19 @@ declare module "dns" {
      */
     export function getServers(): string[];
     /**
-     * Set the default value of `order` in {@link lookup} and [`dnsPromises.lookup()`](https://nodejs.org/docs/latest-v22.x/api/dns.html#dnspromiseslookuphostname-options).
+     * Set the default value of `verbatim` in {@link lookup} and [`dnsPromises.lookup()`](https://nodejs.org/docs/latest-v22.x/api/dns.html#dnspromiseslookuphostname-options).
      * The value could be:
      *
-     * * `ipv4first`: sets default `order` to `ipv4first`.
-     * * `ipv6first`: sets default `order` to `ipv6first`.
-     * * `verbatim`: sets default `order` to `verbatim`.
+     * * `ipv4first`: sets default `verbatim` to `false`.
+     * * `verbatim`: sets default `verbatim` to `true`.
      *
      * The default is `verbatim` and {@link setDefaultResultOrder} have higher
      * priority than [`--dns-result-order`](https://nodejs.org/docs/latest-v22.x/api/cli.html#--dns-result-orderorder). When using
      * [worker threads](https://nodejs.org/docs/latest-v22.x/api/worker_threads.html), {@link setDefaultResultOrder} from the main
      * thread won't affect the default dns orders in workers.
      * @since v16.4.0, v14.18.0
-     * @param order must be `'ipv4first'`, `'ipv6first'` or `'verbatim'`.
      */
-    export function setDefaultResultOrder(order: "ipv4first" | "ipv6first" | "verbatim"): void;
+    export function setDefaultResultOrder(order: "ipv4first" | "verbatim"): void;
     // Error codes
     export const NODATA: "ENODATA";
     export const FORMERR: "EFORMERR";

--- a/types/node/dns/promises.d.ts
+++ b/types/node/dns/promises.d.ts
@@ -346,20 +346,20 @@ declare module "dns/promises" {
      */
     function setServers(servers: readonly string[]): void;
     /**
-     * Set the default value of `order` in `dns.lookup()` and `{@link lookup}`. The value could be:
+     * Set the default value of `verbatim` in {@link lookup} and [`dnsPromises.lookup()`](https://nodejs.org/docs/latest-v22.x/api/dns.html#dnspromiseslookuphostname-options).
+     * The value could be:
      *
-     * * `ipv4first`: sets default `order` to `ipv4first`.
-     * * `ipv6first`: sets default `order` to `ipv6first`.
-     * * `verbatim`: sets default `order` to `verbatim`.
+     * * `ipv4first`: sets default `verbatim` to `false`.
+     * * `verbatim`: sets default `verbatim` to `true`.
      *
-     * The default is `verbatim` and [dnsPromises.setDefaultResultOrder()](https://nodejs.org/docs/latest-v20.x/api/dns.html#dnspromisessetdefaultresultorderorder)
-     * have higher priority than [`--dns-result-order`](https://nodejs.org/docs/latest-v20.x/api/cli.html#--dns-result-orderorder).
-     * When using [worker threads](https://nodejs.org/docs/latest-v20.x/api/worker_threads.html), [`dnsPromises.setDefaultResultOrder()`](https://nodejs.org/docs/latest-v20.x/api/dns.html#dnspromisessetdefaultresultorderorder)
-     * from the main thread won't affect the default dns orders in workers.
+     * The default is `verbatim` and {@link setDefaultResultOrder} have higher
+     * priority than [`--dns-result-order`](https://nodejs.org/docs/latest-v22.x/api/cli.html#--dns-result-orderorder). When using
+     * [worker threads](https://nodejs.org/docs/latest-v22.x/api/worker_threads.html), {@link setDefaultResultOrder} from the main
+     * thread won't affect the default dns orders in workers.
      * @since v16.4.0, v14.18.0
-     * @param order must be `'ipv4first'`, `'ipv6first'` or `'verbatim'`.
+     * @param order must be `'ipv4first'` or `'verbatim'`.
      */
-    function setDefaultResultOrder(order: "ipv4first" | "ipv6first" | "verbatim"): void;
+    function setDefaultResultOrder(order: "ipv4first" | "verbatim"): void;
     // Error codes
     const NODATA: "ENODATA";
     const FORMERR: "EFORMERR";

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -4324,17 +4324,6 @@ declare module "fs" {
          * Function to filter out files/directories. Return true to exclude the item, false to include it.
          */
         exclude?: ((fileName: string) => boolean) | undefined;
-        /**
-         * `true` if the glob should return paths as `Dirent`s, `false` otherwise.
-         * @default false
-         */
-        withFileTypes?: boolean | undefined;
-    }
-    export interface GlobOptionsWithFileTypes extends GlobOptions {
-        withFileTypes: true;
-    }
-    export interface GlobOptionsWithoutFileTypes extends GlobOptions {
-        withFileTypes?: false | undefined;
     }
     /**
      * Retrieves the files matching the specified pattern.
@@ -4343,32 +4332,15 @@ declare module "fs" {
         pattern: string | string[],
         callback: (err: NodeJS.ErrnoException | null, matches: string[]) => void,
     ): void;
-    /**
-     * Retrieves the files matching the specified pattern.
-     */
-    export function glob<Options extends GlobOptions>(
+    export function glob(
         pattern: string | string[],
-        options: Options,
-        callback: (
-            err: NodeJS.ErrnoException | null,
-            matches: Options extends GlobOptionsWithFileTypes ? Dirent[]
-                : Options extends GlobOptionsWithoutFileTypes ? string[]
-                : Dirent[] | string[],
-        ) => void,
+        options: GlobOptions,
+        callback: (err: NodeJS.ErrnoException | null, matches: string[]) => void,
     ): void;
     /**
      * Retrieves the files matching the specified pattern.
      */
-    export function globSync(pattern: string | string[]): string[];
-    /**
-     * Retrieves the files matching the specified pattern.
-     */
-    export function globSync<Options extends GlobOptions>(
-        pattern: string | string[],
-        options: Options,
-    ): Options extends GlobOptionsWithFileTypes ? Dirent[]
-        : Options extends GlobOptionsWithoutFileTypes ? string[]
-        : Dirent[] | string[];
+    export function globSync(pattern: string | string[], options?: GlobOptions): string[];
 }
 declare module "node:fs" {
     export * from "fs";

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -21,8 +21,6 @@ declare module "fs/promises" {
         Dir,
         Dirent,
         GlobOptions,
-        GlobOptionsWithFileTypes,
-        GlobOptionsWithoutFileTypes,
         MakeDirectoryOptions,
         Mode,
         ObjectEncodingOptions,
@@ -1245,16 +1243,7 @@ declare module "fs/promises" {
     /**
      * Retrieves the files matching the specified pattern.
      */
-    function glob(pattern: string | string[]): AsyncIterableIterator<string>;
-    /**
-     * Retrieves the files matching the specified pattern.
-     */
-    function glob<Options extends GlobOptions>(
-        pattern: string | string[],
-        opt: Options,
-    ): Options extends GlobOptionsWithFileTypes ? AsyncIterableIterator<Dirent>
-        : Options extends GlobOptionsWithoutFileTypes ? AsyncIterableIterator<string>
-        : AsyncIterableIterator<Dirent> | AsyncIterableIterator<string>;
+    function glob(pattern: string | string[], options?: GlobOptions): AsyncIterableIterator<string>;
 }
 declare module "node:fs/promises" {
     export * from "fs/promises";

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -941,17 +941,6 @@ declare module "node:test" {
          * @since v19.1.0, v18.13.0
          */
         restoreAll(): void;
-        /**
-         * This function is used to mock the exports of ECMAScript modules,
-         * CommonJS modules, and Node.js builtin modules. Any references to
-         * the original module prior to mocking are not impacted
-         * @since v22.3.0
-         */
-        module(speficier: string, options?: {
-            cache?: boolean;
-            defaultExport?: any;
-            namedExports?: object;
-        }): { restore: () => void };
         timers: MockTimers;
     }
     const mock: MockTracker;

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -903,12 +903,6 @@ const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Ma
     for await (const entry of globAsync("**/*.js")) {
         entry; // $ExpectType string
     }
-    for await (const entry of globAsync("**/*.js", { withFileTypes: true })) {
-        entry; // $ExpectType Dirent
-    }
-    for await (const entry of globAsync("**/*.js", { withFileTypes: Math.random() > 0.5 })) {
-        entry; // $ExpectType Dirent | string
-    }
 
     glob("**/*.js", (err, matches) => {
         matches; // $ExpectType string[]
@@ -925,23 +919,11 @@ const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Ma
             matches; // $ExpectType string[]
         },
     );
-    glob("**/*.js", { withFileTypes: true }, (err, matches) => {
-        matches; // $ExpectType Dirent[]
-    });
-    glob("**/*.js", { withFileTypes: Math.random() > 0.5 }, (err, matches) => {
-        matches; // $ExpectType Dirent[] | string[]
-    });
 
     for (const entry of globSync("**/*.js")) {
         entry; // $ExpectType string
     }
     for (const entry of globSync("**/*.js", { cwd: "/" })) {
         entry; // $ExpectType string
-    }
-    for (const entry of globSync("**/*.js", { withFileTypes: true })) {
-        entry; // $ExpectType Dirent
-    }
-    for (const entry of globSync("**/*.js", { withFileTypes: Math.random() > 0.5 })) {
-        entry; // $ExpectType Dirent | string
     }
 });

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -496,22 +496,6 @@ test("mocks a counting function", (t) => {
     const fn = t.mock.fn(addOne, addTwo, { times: 2 });
     // $ExpectType number
     fn();
-
-    const mock = t.mock.module("node:readline", {
-        namedExports: {
-            fn() {
-                return 42;
-            },
-        },
-        defaultExport: {
-            foo() {
-                return "bar";
-            },
-        },
-        cache: true,
-    });
-    // $ExpectType void
-    mock.restore();
 });
 
 test("spies on an object method", (t) => {

--- a/types/node/test/url.ts
+++ b/types/node/test/url.ts
@@ -187,17 +187,11 @@ import * as url from "node:url";
 
 {
     let path: string = url.fileURLToPath("file://test");
-    path = url.fileURLToPath("file://test", { windows: false });
-    path = url.fileURLToPath("file://test", { windows: true });
     path = url.fileURLToPath(new url.URL("file://test"));
-    path = url.fileURLToPath(new url.URL("file://test"), { windows: false });
-    path = url.fileURLToPath(new url.URL("file://test"), { windows: true });
 }
 
 {
     let path: url.URL = url.pathToFileURL("file://test");
-    path = url.pathToFileURL("file://test", { windows: false });
-    path = url.pathToFileURL("file://test", { windows: true });
 }
 
 {

--- a/types/node/url.d.ts
+++ b/types/node/url.d.ts
@@ -46,14 +46,6 @@ declare module "url" {
     interface UrlWithStringQuery extends Url {
         query: string | null;
     }
-    interface FileUrlToPathOptions {
-        /**
-         * `true` if the `path` should be return as a windows filepath, `false` for posix, and `undefined` for the system default.
-         * @default undefined
-         */
-        windows?: boolean | undefined;
-    }
-    interface PathToFileUrlOptions extends FileUrlToPathOptions {}
     /**
      * The `url.parse()` method takes a URL string, parses it, and returns a URL
      * object.
@@ -306,7 +298,7 @@ declare module "url" {
      * @param url The file URL string or URL object to convert to a path.
      * @return The fully-resolved platform-specific Node.js file path.
      */
-    function fileURLToPath(url: string | URL, options?: FileUrlToPathOptions): string;
+    function fileURLToPath(url: string | URL): string;
     /**
      * This function ensures that `path` is resolved absolutely, and that the URL
      * control characters are correctly encoded when converting into a File URL.
@@ -324,7 +316,7 @@ declare module "url" {
      * @param path The path to convert to a File URL.
      * @return The file URL object.
      */
-    function pathToFileURL(path: string, options?: PathToFileUrlOptions): URL;
+    function pathToFileURL(path: string): URL;
     /**
      * This utility function converts a URL object into an ordinary options object as
      * expected by the `http.request()` and `https.request()` APIs.


### PR DESCRIPTION
Because @types/node was only branched to v22 after Node had already released v22.5, there were quite a few features added to what was the main (v20) branch at the time that didn't exist at the time of v22.0's release. The net result is that the new v22.0.x @types/node package is contaminated with definitions that didn't exist in Node v22.0.

While the package version stands at v22.0.x, it seems like the time to take the opportunity to remove these definitions. The intention would then be to iterate upwards with definition PRs for v22.1, v22.2 etc. in standard fashion.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V22.md
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
