### PR TITLE
[@types/selenium-webdriver] Fix missing default exports error

### DIFF
--- a/types/selenium-webdriver/chromium.d.ts
+++ b/types/selenium-webdriver/chromium.d.ts
@@ -1,4 +1,4 @@
-import http from "./http";
+import { Executor } from "./http";
 import * as webdriver from "./index";
 import * as remote from "./remote";
 
@@ -340,7 +340,7 @@ export class ChromiumWebDriver extends webdriver.WebDriver {
      * Creates a new session with the WebDriver server.
      *
      * @param {(Capabilities|Options)=} caps The configuration options.
-     * @param {(remote.DriverService|http.Executor)=} opt_serviceExecutor Either
+     * @param {(remote.DriverService|Executor)=} opt_serviceExecutor Either
      *     a  DriverService to use for the remote end, or a preconfigured executor
      *     for an externally managed endpoint. If neither is provided, the
      *     {@linkplain ##getDefaultService default service} will be used by
@@ -351,7 +351,7 @@ export class ChromiumWebDriver extends webdriver.WebDriver {
      */
     static createSession(
         caps?: webdriver.Capabilities | Options,
-        opt_serviceExecutor?: remote.DriverService | http.Executor,
+        opt_serviceExecutor?: remote.DriverService | Executor,
         vendorPrefix?: string,
         vendorCapabilityKey?: string,
     ): ChromiumWebDriver;

--- a/types/selenium-webdriver/lib/webdriver.d.ts
+++ b/types/selenium-webdriver/lib/webdriver.d.ts
@@ -12,7 +12,7 @@ import {
     Window,
 } from "..";
 import { HttpResponse } from "../devtools/networkinterceptor";
-import command, { Command } from "./command";
+import { Command, Executor } from "./command";
 import { FileDetector } from "./input";
 export {};
 
@@ -233,12 +233,12 @@ export class WebDriver {
     /**
      * @param {!(./session.Session|IThenable<!./session.Session>)} session Either
      *     a known session or a promise that will be resolved to a session.
-     * @param {!command.Executor} executor The executor to use when sending
+     * @param {!Executor} executor The executor to use when sending
      *     commands to the browser.
      * @param {(function(this: void): ?)=} onQuit A function to call, if any,
      *     when the session is terminated.
      */
-    constructor(session: Session | Promise<Session>, executor: command.Executor, onQuit?: (this: void) => any);
+    constructor(session: Session | Promise<Session>, executor: Executor, onQuit?: (this: void) => any);
 
     /**
      * Creates a new WebDriver session.
@@ -256,7 +256,7 @@ export class WebDriver {
      *     // also fail, propagating the creation failure.
      *     driver.get('http://www.google.com').catch(e => console.log(e));
      *
-     * @param {!command.Executor} executor The executor to create the new session
+     * @param {!Executor} executor The executor to create the new session
      *     with.
      * @param {!Capabilities} capabilities The desired capabilities for the new
      *     session.
@@ -268,13 +268,13 @@ export class WebDriver {
     static createSession(...var_args: any[]): WebDriver;
 
     /** @override */
-    execute(command: command.Command): Promise<void>;
+    execute(command: Command): Promise<void>;
 
     /** @override */
     setFileDetector(detector: FileDetector): void;
 
     /** @override */
-    getExecutor(): command.Executor;
+    getExecutor(): Executor;
 
     /** @override */
     getSession(): Promise<Session>;
@@ -945,7 +945,7 @@ export class ShadowRoot implements Serializable<IWebElementId> {
      * instance. Will ensure this element's ID is included in the command
      * parameters under the "id" key.
      *
-     * @param {!command.Command} command The command to schedule.
+     * @param {!Command} command The command to schedule.
      * @return {!Promise<T>} A promise that will be resolved with the result.
      * @template T
      * @see WebDriver#schedule


### PR DESCRIPTION
- both [lib/command](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/selenium-webdriver/lib/command.d.ts) and [http](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/selenium-webdriver/http.d.ts) do not have default exports
- `chromium.d.ts` and `lib/webdriver.d.ts` try to import defaults, causing the TS1192 "Module has no default exports" error
- This PR just explicitly specifies the imports to fix that issue

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
