### PR TITLE
FBInstant Games

### DIFF
--- a/types/facebook-instant-games/index.d.ts
+++ b/types/facebook-instant-games/index.d.ts
@@ -873,6 +873,7 @@ declare namespace FBInstant {
          * this will reject. Otherwise, the promise will resolve when the game has switched into the specified context.
          *
          * @param id ID of the desired context.
+         * @param switchSilentlyIfSolo If switching into a solo context, set this to true to switch silently, with no confirmation dialog or toast. This only has an effect when switching into a solo context. (optional, default false)
          * @returns A promise that resolves when the game has switched into the specified context, or rejects otherwise.
          * @throws INVALID_PARAM
          * @throws SAME_CONTEXT
@@ -881,7 +882,7 @@ declare namespace FBInstant {
          * @throws PENDING_REQUEST
          * @throws CLIENT_UNSUPPORTED_OPERATION
          */
-        switchAsync(id: string): Promise<void>;
+        switchAsync(id: string, switchSilentlyIfSolo?:boolean): Promise<void>;
 
         /**
          * Opens a context selection dialog for the player. If the player selects an available context, the client will attempt to switch into that context,
@@ -1407,10 +1408,6 @@ declare namespace FBInstant {
      * Represents content to be shared by the user.
      */
     interface SharePayload {
-        /**
-         * Indicates the intent of the share.
-         */
-        intent: Intent;
 
         /**
          * A base64 encoded image to be shared.
@@ -1431,6 +1428,11 @@ declare namespace FBInstant {
          * A blob of data to attach to the share. All game sessions launched from the share will be able to access this blob through FBInstant.getEntryPointData().
          */
         data?: any;
+
+        /**
+         * An optional array to set sharing destinations in the share dialog. If not specified all available sharing destinations will be displayed
+         */
+        shareDestination?: ShareDestination[];
 
         /**
          * A flag indicating whether to switch the user into the new context created on sharing
@@ -2120,6 +2122,16 @@ declare namespace FBInstant {
      * "LEADERBOARD": An update associated with an Instant Game leaderboard.
      */
     type UpdateAction = "CUSTOM" | "LEADERBOARD";
+    
+    /**
+     * A parameter that may be applied to a Share Async operation
+     * 
+     * "NEWSFEED" - Enable share to newsfeed option
+     * "GROUP" - Enable share to official game group option.
+     * "COPY_LINK" - Enable copy the game link in clipboard 
+     * "MESSENGER" - Enable share game to messenger option
+    */
+    type ShareDestination = "NEWSFEED" | "GROUP" | "COPY_LINK" | "MESSENGER";
 
     /**
      * Represents the current platform that the user is playing on.


### PR DESCRIPTION
Reflects documentation of SDK https://developers.facebook.com/docs/games/instant-games/sdk/fbinstant7.1

Added parameter 'shareDestination' to SharePayload (used by shareAsync).
Removed deprecated 'intent' from same object.

Added 'switchSilentlyIfSolo' to switchAsync
