### PR TITLE
fix(http-proxy): Add missing 'method' server option

### DIFF
--- a/types/http-proxy/http-proxy-tests.ts
+++ b/types/http-proxy/http-proxy-tests.ts
@@ -37,6 +37,11 @@ const newProxyUrl = HttpProxy.createProxyServer({
     target: "http://localhost:9015",
 });
 
+const newProxyKnownMethod = HttpProxy.createProxyServer({
+    target: "http://localhost:9015",
+    method: "POST",
+});
+
 const newProxyComplete = HttpProxy.createProxyServer({
     target: {
         protocol: "http:",

--- a/types/http-proxy/index.d.ts
+++ b/types/http-proxy/index.d.ts
@@ -193,6 +193,8 @@ declare namespace Server {
         selfHandleResponse?: boolean | undefined;
         /** Buffer */
         buffer?: stream.Stream | undefined;
+        /** Explicitly set the method type of the ProxyReq */
+        method?: string | undefined;
     }
 
     type StartCallback<TIncomingMessage = http.IncomingMessage, TServerResponse = http.ServerResponse> = (


### PR DESCRIPTION
The http-proxy library supports explicitly setting the ProxyReq method via an option called 'method'. Thius is not currently reflected in the type but it does indeed work. The library simply does `outgoing.method = options.method || req.method;` in https://github.com/http-party/node-http-proxy/blob/master/lib/http-proxy/common.js.

This PR therefore just adds the key to the server options.

I did originally implement the type as an enum of the established HTTP method types, but as the node http 'method' is just typed as string I decided to do the same here.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [usage in src](https://github.com/http-party/node-http-proxy/blob/master/lib/http-proxy/common.js)


