### PR TITLE
Add typing for https://v4.webpack.js.org/api/compiler-hooks/#assetemi…

### DIFF
--- a/types/webpack/v4/index.d.ts
+++ b/types/webpack/v4/index.d.ts
@@ -1450,6 +1450,7 @@ declare namespace webpack {
             afterPlugins: SyncHook<Compiler>;
             afterResolvers: SyncHook<Compiler>;
             entryOption: SyncBailHook;
+            assetEmitted: AsyncSeriesHook<string, string>;
         }
 
         interface MultiStats {


### PR DESCRIPTION
https://v4.webpack.js.org/api/compiler-hooks/#assetemitted

This hook definition was missing from the webpack typings. There's probably more but I need this one exactly.