### PR TITLE
Add EventEmitter to Client in chrome-remote-interface

### DIFF
--- a/types/chrome-remote-interface/chrome-remote-interface-tests.ts
+++ b/types/chrome-remote-interface/chrome-remote-interface-tests.ts
@@ -11,6 +11,8 @@ function assertType<T>(value: T): T {
         const cdpPort = { port: 9223 };
         client = await CDP(cdpPort);
         client.on("disconnect", () => {});
+        client.once("disconnect", () => {});
+        client.off("disconnect");
         client.on("Network.requestWillBeSent", (params) => {
             params.documentURL;
         });

--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 import EventEmitter from 'events';
 import type ProtocolMappingApi from "devtools-protocol/types/protocol-mapping";
 import type ProtocolProxyApi from "devtools-protocol/types/protocol-proxy-api";

--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -277,6 +277,13 @@ declare namespace CDP {
             ): void;
             // '<domain>.<method>.<sessionId>' i.e. Network.requestWillBeSent.abc123
             on(event: string, callback: (params: object, sessionId?: string) => void): void;
+            once(event: "event", callback: (message: EventMessage) => void): void;
+            once(event: "ready" | "disconnect", callback: () => void): void;
+            once<T extends keyof ProtocolMappingApi.Events>(
+                event: T,
+                callback: (params: ProtocolMappingApi.Events[T][0], sessionId?: string) => void,
+            ): void;
+            once(event: string, callback: (params: object, sessionId?: string) => void): void;
             // client.send(method, [params], [sessionId], [callback])
             send<T extends keyof ProtocolMappingApi.Commands>(event: T, callback: SendCallback<T>): void;
             send<T extends keyof ProtocolMappingApi.Commands>(

--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -1,3 +1,4 @@
+import EventEmitter from 'events';
 import type ProtocolMappingApi from "devtools-protocol/types/protocol-mapping";
 import type ProtocolProxyApi from "devtools-protocol/types/protocol-proxy-api";
 
@@ -297,7 +298,8 @@ declare namespace CDP {
         }
         & EventPromises<ProtocolMappingApi.Events>
         & EventCallbacks<ProtocolMappingApi.Events>
-        & ImproveAPI<AllDomains>;
+        & ImproveAPI<AllDomains>
+        & EventEmitter;
 
     // '<domain>.<event>' i.e. Page.loadEventFired
     type EventPromises<T extends ProtocolMappingApi.Events> = {


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cyrus-and/chrome-remote-interface/blob/master/lib/chrome.js#L27

I'm not sure how to make it depend on the `events` module from Node
