### PR TITLE
Makes @types/ssh2-sftp-client depends on 1.x versions of @types/ssh2

### DIFF
--- a/types/ssh2-sftp-client/package.json
+++ b/types/ssh2-sftp-client/package.json
@@ -6,7 +6,7 @@
         "https://github.com/theophilusx/ssh2-sftp-client"
     ],
     "dependencies": {
-        "@types/ssh2": "*"
+        "@types/ssh2": "^1.0.0"
     },
     "devDependencies": {
         "@types/node": "*",


### PR DESCRIPTION
Version 9 of @types/ssh2-sftp-client is not compatbile with @types/ssh2 version 0.x. Since the dependency is currently set to `*`, @types/ssh2 0.x will be installed due to other dependencies, breaking @types/ssh-sftp-client

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.