### PR TITLE
[node] Update typings to v22.2.0

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -4324,6 +4324,18 @@ declare module "fs" {
          * Function to filter out files/directories. Return true to exclude the item, false to include it.
          */
         exclude?: ((fileName: string) => boolean) | undefined;
+        /**
+         * `true` if the glob should return paths as `Dirent`s, `false` otherwise.
+         * @default false
+         * @since v22.2.0
+         */
+        withFileTypes?: boolean | undefined;
+    }
+    export interface GlobOptionsWithFileTypes extends GlobOptions {
+        withFileTypes: true;
+    }
+    export interface GlobOptionsWithoutFileTypes extends GlobOptions {
+        withFileTypes?: false | undefined;
     }
     /**
      * Retrieves the files matching the specified pattern.
@@ -4334,13 +4346,44 @@ declare module "fs" {
     ): void;
     export function glob(
         pattern: string | string[],
+        options: GlobOptionsWithFileTypes,
+        callback: (
+            err: NodeJS.ErrnoException | null,
+            matches: Dirent[],
+        ) => void,
+    ): void;
+    export function glob(
+        pattern: string | string[],
+        options: GlobOptionsWithoutFileTypes,
+        callback: (
+            err: NodeJS.ErrnoException | null,
+            matches: string[],
+        ) => void,
+    ): void;
+    export function glob(
+        pattern: string | string[],
         options: GlobOptions,
-        callback: (err: NodeJS.ErrnoException | null, matches: string[]) => void,
+        callback: (
+            err: NodeJS.ErrnoException | null,
+            matches: Dirent[] | string[],
+        ) => void,
     ): void;
     /**
      * Retrieves the files matching the specified pattern.
      */
-    export function globSync(pattern: string | string[], options?: GlobOptions): string[];
+    export function globSync(pattern: string | string[]): string[];
+    export function globSync(
+        pattern: string | string[],
+        options: GlobOptionsWithFileTypes,
+    ): Dirent[];
+    export function globSync(
+        pattern: string | string[],
+        options: GlobOptionsWithoutFileTypes,
+    ): string[];
+    export function globSync(
+        pattern: string | string[],
+        options: GlobOptions,
+    ): Dirent[] | string[];
 }
 declare module "node:fs" {
     export * from "fs";

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -21,6 +21,8 @@ declare module "fs/promises" {
         Dir,
         Dirent,
         GlobOptions,
+        GlobOptionsWithFileTypes,
+        GlobOptionsWithoutFileTypes,
         MakeDirectoryOptions,
         Mode,
         ObjectEncodingOptions,
@@ -1243,7 +1245,19 @@ declare module "fs/promises" {
     /**
      * Retrieves the files matching the specified pattern.
      */
-    function glob(pattern: string | string[], options?: GlobOptions): AsyncIterableIterator<string>;
+    function glob(pattern: string | string[]): AsyncIterableIterator<string>;
+    function glob(
+        pattern: string | string[],
+        opt: GlobOptionsWithFileTypes,
+    ): AsyncIterableIterator<Dirent>;
+    function glob(
+        pattern: string | string[],
+        opt: GlobOptionsWithoutFileTypes,
+    ): AsyncIterableIterator<string>;
+    function glob(
+        pattern: string | string[],
+        opt: GlobOptions,
+    ): AsyncIterableIterator<Dirent> | AsyncIterableIterator<string>;
 }
 declare module "node:fs/promises" {
     export * from "fs/promises";

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "22.1.9999",
+    "version": "22.2.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [

--- a/types/node/perf_hooks.d.ts
+++ b/types/node/perf_hooks.d.ts
@@ -271,6 +271,30 @@ declare module "perf_hooks" {
          */
         mark(name: string, options?: MarkOptions): PerformanceMark;
         /**
+         * Creates a new `PerformanceResourceTiming` entry in the Resource Timeline.
+         * A `PerformanceResourceTiming` is a subclass of `PerformanceEntry` whose `performanceEntry.entryType` is always `'resource'`.
+         * Performance resources are used to mark moments in the Resource Timeline.
+         * @param timingInfo [Fetch Timing Info](https://fetch.spec.whatwg.org/#fetch-timing-info)
+         * @param requestedUrl The resource url
+         * @param initiatorType The initiator name, e.g: 'fetch'
+         * @param global 
+         * @param cacheMode The cache mode must be an empty string ('') or 'local'
+         * @param bodyInfo [Fetch Response Body Info](https://fetch.spec.whatwg.org/#response-body-info)
+         * @param responseStatus The response's status code
+         * @param deliveryType The delivery type. Default: ''.
+         * @since v18.2.0, v16.17.0
+         */
+        markResourceTiming(
+            timingInfo: object,
+            requestedUrl: string,
+            initiatorType: string,
+            global: object,
+            cacheMode: "" | "local",
+            bodyInfo: object,
+            responseStatus: number,
+            deliveryType?: string,
+        ): PerformanceResourceTiming;
+        /**
          * Creates a new PerformanceMeasure entry in the Performance Timeline.
          * A PerformanceMeasure is a subclass of PerformanceEntry whose performanceEntry.entryType is always 'measure',
          * and whose performanceEntry.duration measures the number of milliseconds elapsed since startMark and endMark.

--- a/types/node/perf_hooks.d.ts
+++ b/types/node/perf_hooks.d.ts
@@ -277,7 +277,7 @@ declare module "perf_hooks" {
          * @param timingInfo [Fetch Timing Info](https://fetch.spec.whatwg.org/#fetch-timing-info)
          * @param requestedUrl The resource url
          * @param initiatorType The initiator name, e.g: 'fetch'
-         * @param global 
+         * @param global
          * @param cacheMode The cache mode must be an empty string ('') or 'local'
          * @param bodyInfo [Fetch Response Body Info](https://fetch.spec.whatwg.org/#response-body-info)
          * @param responseStatus The response's status code

--- a/types/node/perf_hooks.d.ts
+++ b/types/node/perf_hooks.d.ts
@@ -31,7 +31,17 @@
  */
 declare module "perf_hooks" {
     import { AsyncResource } from "node:async_hooks";
-    type EntryType = "node" | "mark" | "measure" | "gc" | "function" | "http2" | "http" | "dns" | "net";
+    type EntryType =
+        | "dns" // Node.js only
+        | "function" // Node.js only
+        | "gc" // Node.js only
+        | "http2" // Node.js only
+        | "http" // Node.js only
+        | "mark" // available on the Web
+        | "measure" // available on the Web
+        | "net" // Node.js only
+        | "node" // Node.js only
+        | "resource"; // available on the Web
     interface NodeGCPerformanceDetail {
         /**
          * When `performanceEntry.entryType` is equal to 'gc', the `performance.kind` property identifies
@@ -114,6 +124,7 @@ declare module "perf_hooks" {
      * @since v8.5.0
      */
     class PerformanceNodeTiming extends PerformanceEntry {
+        readonly entryType: "node";
         /**
          * The high resolution millisecond timestamp at which the Node.js process
          * completed bootstrapping. If bootstrapping has not yet finished, the property
@@ -567,6 +578,7 @@ declare module "perf_hooks" {
      * @since v18.2.0, v16.17.0
      */
     class PerformanceResourceTiming extends PerformanceEntry {
+        readonly entryType: "resource";
         protected constructor();
         /**
          * The high resolution millisecond timestamp at immediately before dispatching the `fetch`

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -462,6 +462,12 @@ declare module "node:test" {
      */
     class TestContext {
         /**
+         * An object containing assertion methods bound to the test context.
+         * The top-level functions from the `node:assert` module are exposed here for the purpose of creating test plans.
+         * @since v22.2.0
+         */
+        readonly assert: TestContextAssert;
+        /**
          * This function is used to create a hook running before subtest of the current test.
          * @param fn The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
@@ -508,6 +514,42 @@ declare module "node:test" {
          * @since v18.8.0, v16.18.0
          */
         readonly name: string;
+        /**
+         * Used to set the number of assertions and subtests that are expected to run within the test.
+         * If the number of assertions and subtests that run does not match the expected count, the test will fail.
+         *
+         * To make sure assertions are tracked, the assert functions on `context.assert` must be used,
+         * instead of importing from the `node:assert` module.
+         * ```js
+         * test('top level test', (t) => {
+         *   t.plan(2);
+         *   t.assert.ok('some relevant assertion here');
+         *   t.test('subtest', () => {});
+         * });
+         * ```
+         *
+         * When working with asynchronous code, the `plan` function can be used to ensure that the correct number of assertions are run:
+         * ```js
+         * test('planning with streams', (t, done) => {
+         *   function* generate() {
+         *     yield 'a';
+         *     yield 'b';
+         *     yield 'c';
+         *   }
+         *   const expected = ['a', 'b', 'c'];
+         *   t.plan(expected.length);
+         *   const stream = Readable.from(generate());
+         *   stream.on('data', (chunk) => {
+         *     t.assert.strictEqual(chunk, expected.shift());
+         *   });
+         *   stream.on('end', () => {
+         *     done();
+         *   });
+         * });
+         * ```
+         * @since v22.2.0
+         */
+        plan(count: number): void;
         /**
          * If `shouldRunOnlyTests` is truthy, the test context will only run tests that
          * have the `only` option set. Otherwise, all tests are run. If Node.js was not
@@ -584,6 +626,76 @@ declare module "node:test" {
          */
         readonly mock: MockTracker;
     }
+    interface TestContextAssert {
+        /**
+         * Identical to the `deepEqual` function from the `node:assert` module, but bound to the test context.
+         */
+        deepEqual: typeof import("node:assert").deepEqual;
+        /**
+         * Identical to the `deepStrictEqual` function from the `node:assert` module, but bound to the test context.
+         */
+        deepStrictEqual: typeof import("node:assert").deepStrictEqual;
+        /**
+         * Identical to the `doesNotMatch` function from the `node:assert` module, but bound to the test context.
+         */
+        doesNotMatch: typeof import("node:assert").doesNotMatch;
+        /**
+         * Identical to the `doesNotReject` function from the `node:assert` module, but bound to the test context.
+         */
+        doesNotReject: typeof import("node:assert").doesNotReject;
+        /**
+         * Identical to the `doesNotThrow` function from the `node:assert` module, but bound to the test context.
+         */
+        doesNotThrow: typeof import("node:assert").doesNotThrow;
+        /**
+         * Identical to the `equal` function from the `node:assert` module, but bound to the test context.
+         */
+        equal: typeof import("node:assert").equal;
+        /**
+         * Identical to the `fail` function from the `node:assert` module, but bound to the test context.
+         */
+        fail: typeof import("node:assert").fail;
+        /**
+         * Identical to the `ifError` function from the `node:assert` module, but bound to the test context.
+         */
+        ifError: typeof import("node:assert").ifError;
+        /**
+         * Identical to the `match` function from the `node:assert` module, but bound to the test context.
+         */
+        match: typeof import("node:assert").match;
+        /**
+         * Identical to the `notDeepEqual` function from the `node:assert` module, but bound to the test context.
+         */
+        notDeepEqual: typeof import("node:assert").notDeepEqual;
+        /**
+         * Identical to the `notDeepStrictEqual` function from the `node:assert` module, but bound to the test context.
+         */
+        notDeepStrictEqual: typeof import("node:assert").notDeepStrictEqual;
+        /**
+         * Identical to the `notEqual` function from the `node:assert` module, but bound to the test context.
+         */
+        notEqual: typeof import("node:assert").notEqual;
+        /**
+         * Identical to the `notStrictEqual` function from the `node:assert` module, but bound to the test context.
+         */
+        notStrictEqual: typeof import("node:assert").notStrictEqual;
+        /**
+         * Identical to the `ok` function from the `node:assert` module, but bound to the test context.
+         */
+        ok: typeof import("node:assert").ok;
+        /**
+         * Identical to the `rejects` function from the `node:assert` module, but bound to the test context.
+         */
+        rejects: typeof import("node:assert").rejects;
+        /**
+         * Identical to the `strictEqual` function from the `node:assert` module, but bound to the test context.
+         */
+        strictEqual: typeof import("node:assert").strictEqual;
+        /**
+         * Identical to the `throws` function from the `node:assert` module, but bound to the test context.
+         */
+        throws: typeof import("node:assert").throws;
+    }
 
     /**
      * An instance of `SuiteContext` is passed to each suite function in order to
@@ -643,6 +755,14 @@ declare module "node:test" {
          * @default false
          */
         todo?: boolean | string | undefined;
+        /**
+         * The number of assertions and subtests expected to be run in the test.
+         * If the number of assertions run in the test does not match the number
+         * specified in the plan, the test will fail.
+         * @default undefined
+         * @since v22.2.0
+         */
+        plan?: number | undefined;
     }
     /**
      * This function creates a hook that runs before executing a suite.

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -903,6 +903,12 @@ const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Ma
     for await (const entry of globAsync("**/*.js")) {
         entry; // $ExpectType string
     }
+    for await (const entry of globAsync("**/*.js", { withFileTypes: true })) {
+        entry; // $ExpectType Dirent
+    }
+    for await (const entry of globAsync("**/*.js", { withFileTypes: Math.random() > 0.5 })) {
+        entry; // $ExpectType Dirent | string
+    }
 
     glob("**/*.js", (err, matches) => {
         matches; // $ExpectType string[]
@@ -919,11 +925,23 @@ const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Ma
             matches; // $ExpectType string[]
         },
     );
+    glob("**/*.js", { withFileTypes: true }, (err, matches) => {
+        matches; // $ExpectType Dirent[]
+    });
+    glob("**/*.js", { withFileTypes: Math.random() > 0.5 }, (err, matches) => {
+        matches; // $ExpectType Dirent[] | string[]
+    });
 
     for (const entry of globSync("**/*.js")) {
         entry; // $ExpectType string
     }
     for (const entry of globSync("**/*.js", { cwd: "/" })) {
         entry; // $ExpectType string
+    }
+    for (const entry of globSync("**/*.js", { withFileTypes: true })) {
+        entry; // $ExpectType Dirent
+    }
+    for (const entry of globSync("**/*.js", { withFileTypes: Math.random() > 0.5 })) {
+        entry; // $ExpectType Dirent | string
     }
 });

--- a/types/node/test/perf_hooks.ts
+++ b/types/node/test/perf_hooks.ts
@@ -123,3 +123,25 @@ performance.getEntriesByName("test")[0]; // $ExpectType PerformanceEntry
 performance.getEntriesByName("test", "mark")[0]; // $ExpectType PerformanceEntry
 
 performance.getEntriesByType("mark")[0]; // $ExpectType PerformanceEntry
+
+const resource = NodePerf.markResourceTiming({
+    startTime: 0,
+    endTime: 0,
+    finalServiceWorkerStartTime: 0,
+    redirectStartTime: 0,
+    redirectEndTime: 0,
+    postRedirectStartTime: 0,
+    finalConnectionTimingInfo: {
+        domainLookupStartTime: 0,
+        domainLookupEndTime: 0,
+        connectionStartTime: 0,
+        connectionEndTime: 0,
+        secureConnectionStartTime: 0,
+        ALPNNegotiatedProtocol: '',
+    },
+    finalNetworkRequestStartTime: 0,
+    finalNetworkResponseStartTime: 0,
+    encodedBodySize: 0,
+    decodedBodySize: 0,
+}, 'https://nodejs.org', '', global, '', {}, 200, '');
+resource; // $ExpectType PerformanceResourceTiming

--- a/types/node/test/perf_hooks.ts
+++ b/types/node/test/perf_hooks.ts
@@ -124,24 +124,33 @@ performance.getEntriesByName("test", "mark")[0]; // $ExpectType PerformanceEntry
 
 performance.getEntriesByType("mark")[0]; // $ExpectType PerformanceEntry
 
-const resource = NodePerf.markResourceTiming({
-    startTime: 0,
-    endTime: 0,
-    finalServiceWorkerStartTime: 0,
-    redirectStartTime: 0,
-    redirectEndTime: 0,
-    postRedirectStartTime: 0,
-    finalConnectionTimingInfo: {
-        domainLookupStartTime: 0,
-        domainLookupEndTime: 0,
-        connectionStartTime: 0,
-        connectionEndTime: 0,
-        secureConnectionStartTime: 0,
-        ALPNNegotiatedProtocol: '',
+const resource = NodePerf.markResourceTiming(
+    {
+        startTime: 0,
+        endTime: 0,
+        finalServiceWorkerStartTime: 0,
+        redirectStartTime: 0,
+        redirectEndTime: 0,
+        postRedirectStartTime: 0,
+        finalConnectionTimingInfo: {
+            domainLookupStartTime: 0,
+            domainLookupEndTime: 0,
+            connectionStartTime: 0,
+            connectionEndTime: 0,
+            secureConnectionStartTime: 0,
+            ALPNNegotiatedProtocol: "",
+        },
+        finalNetworkRequestStartTime: 0,
+        finalNetworkResponseStartTime: 0,
+        encodedBodySize: 0,
+        decodedBodySize: 0,
     },
-    finalNetworkRequestStartTime: 0,
-    finalNetworkResponseStartTime: 0,
-    encodedBodySize: 0,
-    decodedBodySize: 0,
-}, 'https://nodejs.org', '', global, '', {}, 200, '');
+    "https://nodejs.org",
+    "",
+    global,
+    "",
+    {},
+    200,
+    "",
+);
 resource; // $ExpectType PerformanceResourceTiming

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -930,21 +930,21 @@ const invalidTestContext = new TestContext();
 // @ts-expect-error Should not be able to instantiate a SuiteContext
 const invalidSuiteContext = new SuiteContext();
 
-test('planning with streams', (t: TestContext, done) => {
+test("planning with streams", (t: TestContext, done) => {
     function* generate() {
-      yield 'a';
-      yield 'b';
-      yield 'c';
+        yield "a";
+        yield "b";
+        yield "c";
     }
-    const expected = ['a', 'b', 'c'];
+    const expected = ["a", "b", "c"];
     t.plan(expected.length);
 
     const stream = Readable.from(generate());
-    stream.on('data', (chunk) => {
+    stream.on("data", (chunk) => {
         t.assert.strictEqual(chunk, expected.shift());
     });
-  
-    stream.on('end', () => {
+
+    stream.on("end", () => {
         done();
     });
 });

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -1,4 +1,4 @@
-import { Transform, TransformCallback, TransformOptions } from "node:stream";
+import { Readable, Transform, TransformCallback, TransformOptions } from "node:stream";
 import {
     after,
     afterEach,
@@ -929,3 +929,22 @@ const invalidTestContext = new TestContext();
 
 // @ts-expect-error Should not be able to instantiate a SuiteContext
 const invalidSuiteContext = new SuiteContext();
+
+test('planning with streams', (t: TestContext, done) => {
+    function* generate() {
+      yield 'a';
+      yield 'b';
+      yield 'c';
+    }
+    const expected = ['a', 'b', 'c'];
+    t.plan(expected.length);
+
+    const stream = Readable.from(generate());
+    stream.on('data', (chunk) => {
+        t.assert.strictEqual(chunk, expected.shift());
+    });
+  
+    stream.on('end', () => {
+        done();
+    });
+});

--- a/types/node/test/zlib.ts
+++ b/types/node/test/zlib.ts
@@ -192,9 +192,9 @@ brotliDecompress(
 }
 
 {
-    let crc = crc32('hello');
-    crc = crc32('world', crc); // $ExpectType number
-    
-    crc = crc32(Buffer.from('hello', 'utf16le')); // $ExpectType number
-    crc = crc32(Buffer.from('world', 'utf16le'), crc); // $ExpectType number
+    let crc = crc32("hello");
+    crc = crc32("world", crc); // $ExpectType number
+
+    crc = crc32(Buffer.from("hello", "utf16le")); // $ExpectType number
+    crc = crc32(Buffer.from("world", "utf16le"), crc); // $ExpectType number
 }

--- a/types/node/test/zlib.ts
+++ b/types/node/test/zlib.ts
@@ -7,6 +7,7 @@ import {
     brotliDecompressSync,
     BrotliOptions,
     constants,
+    crc32,
     createBrotliCompress,
     createBrotliDecompress,
     deflate,
@@ -188,4 +189,12 @@ brotliDecompress(
         await pUnzip(Buffer.from("buf")); // $ExpectType Buffer
         await pUnzip(Buffer.from("buf"), { flush: constants.Z_NO_FLUSH }); // $ExpectType Buffer
     })();
+}
+
+{
+    let crc = crc32('hello');
+    crc = crc32('world', crc); // $ExpectType number
+    
+    crc = crc32(Buffer.from('hello', 'utf16le')); // $ExpectType number
+    crc = crc32(Buffer.from('world', 'utf16le'), crc); // $ExpectType number
 }

--- a/types/node/v16/perf_hooks.d.ts
+++ b/types/node/v16/perf_hooks.d.ts
@@ -30,7 +30,17 @@
  */
 declare module "perf_hooks" {
     import { AsyncResource } from "node:async_hooks";
-    type EntryType = "node" | "mark" | "measure" | "gc" | "function" | "http2" | "http" | "dns";
+    type EntryType =
+        | "dns" // Node.js only
+        | "function" // Node.js only
+        | "gc" // Node.js only
+        | "http2" // Node.js only
+        | "http" // Node.js only
+        | "mark" // available on the Web
+        | "measure" // available on the Web
+        | "net" // Node.js only
+        | "node" // Node.js only
+        | "resource"; // available on the Web
     interface NodeGCPerformanceDetail {
         /**
          * When `performanceEntry.entryType` is equal to 'gc', `the performance.kind` property identifies
@@ -462,6 +472,7 @@ declare module "perf_hooks" {
      * @since v16.17.0
      */
     class PerformanceResourceTiming extends PerformanceEntry {
+        readonly entryType: "resource";
         protected constructor();
         /**
          * The high resolution millisecond timestamp at immediately before dispatching the `fetch`

--- a/types/node/v16/perf_hooks.d.ts
+++ b/types/node/v16/perf_hooks.d.ts
@@ -238,7 +238,7 @@ declare module "perf_hooks" {
          * @param timingInfo [Fetch Timing Info](https://fetch.spec.whatwg.org/#fetch-timing-info)
          * @param requestedUrl The resource url
          * @param initiatorType The initiator name, e.g: 'fetch'
-         * @param global 
+         * @param global
          * @param cacheMode The cache mode must be an empty string ('') or 'local'
          * @since v16.17.0
          */

--- a/types/node/v16/perf_hooks.d.ts
+++ b/types/node/v16/perf_hooks.d.ts
@@ -232,6 +232,24 @@ declare module "perf_hooks" {
          */
         mark(name?: string, options?: MarkOptions): void;
         /**
+         * Creates a new `PerformanceResourceTiming` entry in the Resource Timeline.
+         * A `PerformanceResourceTiming` is a subclass of `PerformanceEntry` whose `performanceEntry.entryType` is always `'resource'`.
+         * Performance resources are used to mark moments in the Resource Timeline.
+         * @param timingInfo [Fetch Timing Info](https://fetch.spec.whatwg.org/#fetch-timing-info)
+         * @param requestedUrl The resource url
+         * @param initiatorType The initiator name, e.g: 'fetch'
+         * @param global 
+         * @param cacheMode The cache mode must be an empty string ('') or 'local'
+         * @since v16.17.0
+         */
+        markResourceTiming(
+            timingInfo: object,
+            requestedUrl: string,
+            initiatorType: string,
+            global: object,
+            cacheMode: "" | "local",
+        ): PerformanceResourceTiming;
+        /**
          * Creates a new PerformanceMeasure entry in the Performance Timeline.
          * A PerformanceMeasure is a subclass of PerformanceEntry whose performanceEntry.entryType is always 'measure',
          * and whose performanceEntry.duration measures the number of milliseconds elapsed since startMark and endMark.
@@ -436,6 +454,103 @@ declare module "perf_hooks" {
                     buffered?: boolean | undefined;
                 },
         ): void;
+    }
+    /**
+     * Provides detailed network timing data regarding the loading of an application's resources.
+     *
+     * The constructor of this class is not exposed to users directly.
+     * @since v16.17.0
+     */
+    class PerformanceResourceTiming extends PerformanceEntry {
+        protected constructor();
+        /**
+         * The high resolution millisecond timestamp at immediately before dispatching the `fetch`
+         * request. If the resource is not intercepted by a worker the property will always return 0.
+         * @since v16.17.0
+         */
+        readonly workerStart: number;
+        /**
+         * The high resolution millisecond timestamp that represents the start time of the fetch which
+         * initiates the redirect.
+         * @since v16.17.0
+         */
+        readonly redirectStart: number;
+        /**
+         * The high resolution millisecond timestamp that will be created immediately after receiving
+         * the last byte of the response of the last redirect.
+         * @since v16.17.0
+         */
+        readonly redirectEnd: number;
+        /**
+         * The high resolution millisecond timestamp immediately before the Node.js starts to fetch the resource.
+         * @since v16.17.0
+         */
+        readonly fetchStart: number;
+        /**
+         * The high resolution millisecond timestamp immediately before the Node.js starts the domain name lookup
+         * for the resource.
+         * @since v16.17.0
+         */
+        readonly domainLookupStart: number;
+        /**
+         * The high resolution millisecond timestamp representing the time immediately after the Node.js finished
+         * the domain name lookup for the resource.
+         * @since v16.17.0
+         */
+        readonly domainLookupEnd: number;
+        /**
+         * The high resolution millisecond timestamp representing the time immediately before Node.js starts to
+         * establish the connection to the server to retrieve the resource.
+         * @since v16.17.0
+         */
+        readonly connectStart: number;
+        /**
+         * The high resolution millisecond timestamp representing the time immediately after Node.js finishes
+         * establishing the connection to the server to retrieve the resource.
+         * @since v16.17.0
+         */
+        readonly connectEnd: number;
+        /**
+         * The high resolution millisecond timestamp representing the time immediately before Node.js starts the
+         * handshake process to secure the current connection.
+         * @since v16.17.0
+         */
+        readonly secureConnectionStart: number;
+        /**
+         * The high resolution millisecond timestamp representing the time immediately before Node.js receives the
+         * first byte of the response from the server.
+         * @since v16.17.0
+         */
+        readonly requestStart: number;
+        /**
+         * The high resolution millisecond timestamp representing the time immediately after Node.js receives the
+         * last byte of the resource or immediately before the transport connection is closed, whichever comes first.
+         * @since v16.17.0
+         */
+        readonly responseEnd: number;
+        /**
+         * A number representing the size (in octets) of the fetched resource. The size includes the response header
+         * fields plus the response payload body.
+         * @since v16.17.0
+         */
+        readonly transferSize: number;
+        /**
+         * A number representing the size (in octets) received from the fetch (HTTP or cache), of the payload body, before
+         * removing any applied content-codings.
+         * @since v16.17.0
+         */
+        readonly encodedBodySize: number;
+        /**
+         * A number representing the size (in octets) received from the fetch (HTTP or cache), of the message body, after
+         * removing any applied content-codings.
+         * @since v16.17.0
+         */
+        readonly decodedBodySize: number;
+        /**
+         * Returns a `object` that is the JSON representation of the `PerformanceResourceTiming` object
+         * @since v16.17.0
+         */
+        toJSON(): any;
     }
     namespace constants {
         const NODE_PERFORMANCE_GC_MAJOR: number;

--- a/types/node/v16/test/perf_hooks.ts
+++ b/types/node/v16/test/perf_hooks.ts
@@ -117,3 +117,25 @@ performance.getEntriesByName("test")[0]; // $ExpectType PerformanceEntry
 performance.getEntriesByName("test", "mark")[0]; // $ExpectType PerformanceEntry
 
 performance.getEntriesByType("mark")[0]; // $ExpectType PerformanceEntry
+
+const resource = NodePerf.markResourceTiming({
+    startTime: 0,
+    endTime: 0,
+    finalServiceWorkerStartTime: 0,
+    redirectStartTime: 0,
+    redirectEndTime: 0,
+    postRedirectStartTime: 0,
+    finalConnectionTimingInfo: {
+        domainLookupStartTime: 0,
+        domainLookupEndTime: 0,
+        connectionStartTime: 0,
+        connectionEndTime: 0,
+        secureConnectionStartTime: 0,
+        ALPNNegotiatedProtocol: '',
+    },
+    finalNetworkRequestStartTime: 0,
+    finalNetworkResponseStartTime: 0,
+    encodedBodySize: 0,
+    decodedBodySize: 0,
+}, 'https://nodejs.org', '', global, '');
+resource; // $ExpectType PerformanceResourceTiming

--- a/types/node/v16/test/perf_hooks.ts
+++ b/types/node/v16/test/perf_hooks.ts
@@ -118,24 +118,30 @@ performance.getEntriesByName("test", "mark")[0]; // $ExpectType PerformanceEntry
 
 performance.getEntriesByType("mark")[0]; // $ExpectType PerformanceEntry
 
-const resource = NodePerf.markResourceTiming({
-    startTime: 0,
-    endTime: 0,
-    finalServiceWorkerStartTime: 0,
-    redirectStartTime: 0,
-    redirectEndTime: 0,
-    postRedirectStartTime: 0,
-    finalConnectionTimingInfo: {
-        domainLookupStartTime: 0,
-        domainLookupEndTime: 0,
-        connectionStartTime: 0,
-        connectionEndTime: 0,
-        secureConnectionStartTime: 0,
-        ALPNNegotiatedProtocol: '',
+const resource = NodePerf.markResourceTiming(
+    {
+        startTime: 0,
+        endTime: 0,
+        finalServiceWorkerStartTime: 0,
+        redirectStartTime: 0,
+        redirectEndTime: 0,
+        postRedirectStartTime: 0,
+        finalConnectionTimingInfo: {
+            domainLookupStartTime: 0,
+            domainLookupEndTime: 0,
+            connectionStartTime: 0,
+            connectionEndTime: 0,
+            secureConnectionStartTime: 0,
+            ALPNNegotiatedProtocol: "",
+        },
+        finalNetworkRequestStartTime: 0,
+        finalNetworkResponseStartTime: 0,
+        encodedBodySize: 0,
+        decodedBodySize: 0,
     },
-    finalNetworkRequestStartTime: 0,
-    finalNetworkResponseStartTime: 0,
-    encodedBodySize: 0,
-    decodedBodySize: 0,
-}, 'https://nodejs.org', '', global, '');
+    "https://nodejs.org",
+    "",
+    global,
+    "",
+);
 resource; // $ExpectType PerformanceResourceTiming

--- a/types/node/v18/perf_hooks.d.ts
+++ b/types/node/v18/perf_hooks.d.ts
@@ -30,7 +30,17 @@
  */
 declare module "perf_hooks" {
     import { AsyncResource } from "node:async_hooks";
-    type EntryType = "node" | "mark" | "measure" | "gc" | "function" | "http2" | "http" | "dns";
+    type EntryType =
+        | "dns" // Node.js only
+        | "function" // Node.js only
+        | "gc" // Node.js only
+        | "http2" // Node.js only
+        | "http" // Node.js only
+        | "mark" // available on the Web
+        | "measure" // available on the Web
+        | "net" // Node.js only
+        | "node" // Node.js only
+        | "resource"; // available on the Web
     interface NodeGCPerformanceDetail {
         /**
          * When `performanceEntry.entryType` is equal to 'gc', `the performance.kind` property identifies
@@ -479,6 +489,7 @@ declare module "perf_hooks" {
      * @since v18.2.0, v16.17.0
      */
     class PerformanceResourceTiming extends PerformanceEntry {
+        readonly entryType: "resource";
         protected constructor();
         /**
          * The high resolution millisecond timestamp at immediately before dispatching the `fetch`

--- a/types/node/v18/perf_hooks.d.ts
+++ b/types/node/v18/perf_hooks.d.ts
@@ -247,7 +247,7 @@ declare module "perf_hooks" {
          * @param timingInfo [Fetch Timing Info](https://fetch.spec.whatwg.org/#fetch-timing-info)
          * @param requestedUrl The resource url
          * @param initiatorType The initiator name, e.g: 'fetch'
-         * @param global 
+         * @param global
          * @param cacheMode The cache mode must be an empty string ('') or 'local'
          * @since v18.2.0, v16.17.0
          */

--- a/types/node/v18/perf_hooks.d.ts
+++ b/types/node/v18/perf_hooks.d.ts
@@ -241,6 +241,24 @@ declare module "perf_hooks" {
          */
         mark(name?: string, options?: MarkOptions): PerformanceMark;
         /**
+         * Creates a new `PerformanceResourceTiming` entry in the Resource Timeline.
+         * A `PerformanceResourceTiming` is a subclass of `PerformanceEntry` whose `performanceEntry.entryType` is always `'resource'`.
+         * Performance resources are used to mark moments in the Resource Timeline.
+         * @param timingInfo [Fetch Timing Info](https://fetch.spec.whatwg.org/#fetch-timing-info)
+         * @param requestedUrl The resource url
+         * @param initiatorType The initiator name, e.g: 'fetch'
+         * @param global 
+         * @param cacheMode The cache mode must be an empty string ('') or 'local'
+         * @since v18.2.0, v16.17.0
+         */
+        markResourceTiming(
+            timingInfo: object,
+            requestedUrl: string,
+            initiatorType: string,
+            global: object,
+            cacheMode: "" | "local",
+        ): PerformanceResourceTiming;
+        /**
          * Creates a new PerformanceMeasure entry in the Performance Timeline.
          * A PerformanceMeasure is a subclass of PerformanceEntry whose performanceEntry.entryType is always 'measure',
          * and whose performanceEntry.duration measures the number of milliseconds elapsed since startMark and endMark.
@@ -454,6 +472,104 @@ declare module "perf_hooks" {
                 },
         ): void;
     }
+    /**
+     * Provides detailed network timing data regarding the loading of an application's resources.
+     *
+     * The constructor of this class is not exposed to users directly.
+     * @since v18.2.0, v16.17.0
+     */
+    class PerformanceResourceTiming extends PerformanceEntry {
+        protected constructor();
+        /**
+         * The high resolution millisecond timestamp at immediately before dispatching the `fetch`
+         * request. If the resource is not intercepted by a worker the property will always return 0.
+         * @since v18.2.0, v16.17.0
+         */
+        readonly workerStart: number;
+        /**
+         * The high resolution millisecond timestamp that represents the start time of the fetch which
+         * initiates the redirect.
+         * @since v18.2.0, v16.17.0
+         */
+        readonly redirectStart: number;
+        /**
+         * The high resolution millisecond timestamp that will be created immediately after receiving
+         * the last byte of the response of the last redirect.
+         * @since v18.2.0, v16.17.0
+         */
+        readonly redirectEnd: number;
+        /**
+         * The high resolution millisecond timestamp immediately before the Node.js starts to fetch the resource.
+         * @since v18.2.0, v16.17.0
+         */
+        readonly fetchStart: number;
+        /**
+         * The high resolution millisecond timestamp immediately before the Node.js starts the domain name lookup
+         * for the resource.
+         * @since v18.2.0, v16.17.0
+         */
+        readonly domainLookupStart: number;
+        /**
+         * The high resolution millisecond timestamp representing the time immediately after the Node.js finished
+         * the domain name lookup for the resource.
+         * @since v18.2.0, v16.17.0
+         */
+        readonly domainLookupEnd: number;
+        /**
+         * The high resolution millisecond timestamp representing the time immediately before Node.js starts to
+         * establish the connection to the server to retrieve the resource.
+         * @since v18.2.0, v16.17.0
+         */
+        readonly connectStart: number;
+        /**
+         * The high resolution millisecond timestamp representing the time immediately after Node.js finishes
+         * establishing the connection to the server to retrieve the resource.
+         * @since v18.2.0, v16.17.0
+         */
+        readonly connectEnd: number;
+        /**
+         * The high resolution millisecond timestamp representing the time immediately before Node.js starts the
+         * handshake process to secure the current connection.
+         * @since v18.2.0, v16.17.0
+         */
+        readonly secureConnectionStart: number;
+        /**
+         * The high resolution millisecond timestamp representing the time immediately before Node.js receives the
+         * first byte of the response from the server.
+         * @since v18.2.0, v16.17.0
+         */
+        readonly requestStart: number;
+        /**
+         * The high resolution millisecond timestamp representing the time immediately after Node.js receives the
+         * last byte of the resource or immediately before the transport connection is closed, whichever comes first.
+         * @since v18.2.0, v16.17.0
+         */
+        readonly responseEnd: number;
+        /**
+         * A number representing the size (in octets) of the fetched resource. The size includes the response header
+         * fields plus the response payload body.
+         * @since v18.2.0, v16.17.0
+         */
+        readonly transferSize: number;
+        /**
+         * A number representing the size (in octets) received from the fetch (HTTP or cache), of the payload body, before
+         * removing any applied content-codings.
+         * @since v18.2.0, v16.17.0
+         */
+        readonly encodedBodySize: number;
+        /**
+         * A number representing the size (in octets) received from the fetch (HTTP or cache), of the message body, after
+         * removing any applied content-codings.
+         * @since v18.2.0, v16.17.0
+         */
+        readonly decodedBodySize: number;
+        /**
+         * Returns a `object` that is the JSON representation of the `PerformanceResourceTiming` object
+         * @since v18.2.0, v16.17.0
+         */
+        toJSON(): any;
+    }
+
     namespace constants {
         const NODE_PERFORMANCE_GC_MAJOR: number;
         const NODE_PERFORMANCE_GC_MINOR: number;

--- a/types/node/v18/test/perf_hooks.ts
+++ b/types/node/v18/test/perf_hooks.ts
@@ -124,24 +124,30 @@ performance.getEntriesByName("test", "mark")[0]; // $ExpectType PerformanceEntry
 
 performance.getEntriesByType("mark")[0]; // $ExpectType PerformanceEntry
 
-const resource = NodePerf.markResourceTiming({
-    startTime: 0,
-    endTime: 0,
-    finalServiceWorkerStartTime: 0,
-    redirectStartTime: 0,
-    redirectEndTime: 0,
-    postRedirectStartTime: 0,
-    finalConnectionTimingInfo: {
-        domainLookupStartTime: 0,
-        domainLookupEndTime: 0,
-        connectionStartTime: 0,
-        connectionEndTime: 0,
-        secureConnectionStartTime: 0,
-        ALPNNegotiatedProtocol: '',
+const resource = NodePerf.markResourceTiming(
+    {
+        startTime: 0,
+        endTime: 0,
+        finalServiceWorkerStartTime: 0,
+        redirectStartTime: 0,
+        redirectEndTime: 0,
+        postRedirectStartTime: 0,
+        finalConnectionTimingInfo: {
+            domainLookupStartTime: 0,
+            domainLookupEndTime: 0,
+            connectionStartTime: 0,
+            connectionEndTime: 0,
+            secureConnectionStartTime: 0,
+            ALPNNegotiatedProtocol: "",
+        },
+        finalNetworkRequestStartTime: 0,
+        finalNetworkResponseStartTime: 0,
+        encodedBodySize: 0,
+        decodedBodySize: 0,
     },
-    finalNetworkRequestStartTime: 0,
-    finalNetworkResponseStartTime: 0,
-    encodedBodySize: 0,
-    decodedBodySize: 0,
-}, 'https://nodejs.org', '', global, '');
+    "https://nodejs.org",
+    "",
+    global,
+    "",
+);
 resource; // $ExpectType PerformanceResourceTiming

--- a/types/node/v18/test/perf_hooks.ts
+++ b/types/node/v18/test/perf_hooks.ts
@@ -123,3 +123,25 @@ performance.getEntriesByName("test")[0]; // $ExpectType PerformanceEntry
 performance.getEntriesByName("test", "mark")[0]; // $ExpectType PerformanceEntry
 
 performance.getEntriesByType("mark")[0]; // $ExpectType PerformanceEntry
+
+const resource = NodePerf.markResourceTiming({
+    startTime: 0,
+    endTime: 0,
+    finalServiceWorkerStartTime: 0,
+    redirectStartTime: 0,
+    redirectEndTime: 0,
+    postRedirectStartTime: 0,
+    finalConnectionTimingInfo: {
+        domainLookupStartTime: 0,
+        domainLookupEndTime: 0,
+        connectionStartTime: 0,
+        connectionEndTime: 0,
+        secureConnectionStartTime: 0,
+        ALPNNegotiatedProtocol: '',
+    },
+    finalNetworkRequestStartTime: 0,
+    finalNetworkResponseStartTime: 0,
+    encodedBodySize: 0,
+    decodedBodySize: 0,
+}, 'https://nodejs.org', '', global, '');
+resource; // $ExpectType PerformanceResourceTiming

--- a/types/node/v20/perf_hooks.d.ts
+++ b/types/node/v20/perf_hooks.d.ts
@@ -31,7 +31,17 @@
  */
 declare module "perf_hooks" {
     import { AsyncResource } from "node:async_hooks";
-    type EntryType = "node" | "mark" | "measure" | "gc" | "function" | "http2" | "http" | "dns" | "net";
+    type EntryType =
+        | "dns" // Node.js only
+        | "function" // Node.js only
+        | "gc" // Node.js only
+        | "http2" // Node.js only
+        | "http" // Node.js only
+        | "mark" // available on the Web
+        | "measure" // available on the Web
+        | "net" // Node.js only
+        | "node" // Node.js only
+        | "resource"; // available on the Web
     interface NodeGCPerformanceDetail {
         /**
          * When `performanceEntry.entryType` is equal to 'gc', the `performance.kind` property identifies
@@ -561,6 +571,7 @@ declare module "perf_hooks" {
      * @since v18.2.0, v16.17.0
      */
     class PerformanceResourceTiming extends PerformanceEntry {
+        readonly entryType: "resource";
         protected constructor();
         /**
          * The high resolution millisecond timestamp at immediately before dispatching the `fetch`

--- a/types/node/v20/perf_hooks.d.ts
+++ b/types/node/v20/perf_hooks.d.ts
@@ -277,7 +277,7 @@ declare module "perf_hooks" {
          * @param timingInfo [Fetch Timing Info](https://fetch.spec.whatwg.org/#fetch-timing-info)
          * @param requestedUrl The resource url
          * @param initiatorType The initiator name, e.g: 'fetch'
-         * @param global 
+         * @param global
          * @param cacheMode The cache mode must be an empty string ('') or 'local'
          * @since v18.2.0, v16.17.0
          */

--- a/types/node/v20/perf_hooks.d.ts
+++ b/types/node/v20/perf_hooks.d.ts
@@ -271,6 +271,24 @@ declare module "perf_hooks" {
          */
         mark(name: string, options?: MarkOptions): PerformanceMark;
         /**
+         * Creates a new `PerformanceResourceTiming` entry in the Resource Timeline.
+         * A `PerformanceResourceTiming` is a subclass of `PerformanceEntry` whose `performanceEntry.entryType` is always `'resource'`.
+         * Performance resources are used to mark moments in the Resource Timeline.
+         * @param timingInfo [Fetch Timing Info](https://fetch.spec.whatwg.org/#fetch-timing-info)
+         * @param requestedUrl The resource url
+         * @param initiatorType The initiator name, e.g: 'fetch'
+         * @param global 
+         * @param cacheMode The cache mode must be an empty string ('') or 'local'
+         * @since v18.2.0, v16.17.0
+         */
+        markResourceTiming(
+            timingInfo: object,
+            requestedUrl: string,
+            initiatorType: string,
+            global: object,
+            cacheMode: "" | "local",
+        ): PerformanceResourceTiming;
+        /**
          * Creates a new PerformanceMeasure entry in the Performance Timeline.
          * A PerformanceMeasure is a subclass of PerformanceEntry whose performanceEntry.entryType is always 'measure',
          * and whose performanceEntry.duration measures the number of milliseconds elapsed since startMark and endMark.

--- a/types/node/v20/test/perf_hooks.ts
+++ b/types/node/v20/test/perf_hooks.ts
@@ -124,24 +124,30 @@ performance.getEntriesByName("test", "mark")[0]; // $ExpectType PerformanceEntry
 
 performance.getEntriesByType("mark")[0]; // $ExpectType PerformanceEntry
 
-const resource = NodePerf.markResourceTiming({
-    startTime: 0,
-    endTime: 0,
-    finalServiceWorkerStartTime: 0,
-    redirectStartTime: 0,
-    redirectEndTime: 0,
-    postRedirectStartTime: 0,
-    finalConnectionTimingInfo: {
-        domainLookupStartTime: 0,
-        domainLookupEndTime: 0,
-        connectionStartTime: 0,
-        connectionEndTime: 0,
-        secureConnectionStartTime: 0,
-        ALPNNegotiatedProtocol: '',
+const resource = NodePerf.markResourceTiming(
+    {
+        startTime: 0,
+        endTime: 0,
+        finalServiceWorkerStartTime: 0,
+        redirectStartTime: 0,
+        redirectEndTime: 0,
+        postRedirectStartTime: 0,
+        finalConnectionTimingInfo: {
+            domainLookupStartTime: 0,
+            domainLookupEndTime: 0,
+            connectionStartTime: 0,
+            connectionEndTime: 0,
+            secureConnectionStartTime: 0,
+            ALPNNegotiatedProtocol: "",
+        },
+        finalNetworkRequestStartTime: 0,
+        finalNetworkResponseStartTime: 0,
+        encodedBodySize: 0,
+        decodedBodySize: 0,
     },
-    finalNetworkRequestStartTime: 0,
-    finalNetworkResponseStartTime: 0,
-    encodedBodySize: 0,
-    decodedBodySize: 0,
-}, 'https://nodejs.org', '', global, '');
+    "https://nodejs.org",
+    "",
+    global,
+    "",
+);
 resource; // $ExpectType PerformanceResourceTiming

--- a/types/node/v20/test/perf_hooks.ts
+++ b/types/node/v20/test/perf_hooks.ts
@@ -123,3 +123,25 @@ performance.getEntriesByName("test")[0]; // $ExpectType PerformanceEntry
 performance.getEntriesByName("test", "mark")[0]; // $ExpectType PerformanceEntry
 
 performance.getEntriesByType("mark")[0]; // $ExpectType PerformanceEntry
+
+const resource = NodePerf.markResourceTiming({
+    startTime: 0,
+    endTime: 0,
+    finalServiceWorkerStartTime: 0,
+    redirectStartTime: 0,
+    redirectEndTime: 0,
+    postRedirectStartTime: 0,
+    finalConnectionTimingInfo: {
+        domainLookupStartTime: 0,
+        domainLookupEndTime: 0,
+        connectionStartTime: 0,
+        connectionEndTime: 0,
+        secureConnectionStartTime: 0,
+        ALPNNegotiatedProtocol: '',
+    },
+    finalNetworkRequestStartTime: 0,
+    finalNetworkResponseStartTime: 0,
+    encodedBodySize: 0,
+    decodedBodySize: 0,
+}, 'https://nodejs.org', '', global, '');
+resource; // $ExpectType PerformanceResourceTiming

--- a/types/node/zlib.d.ts
+++ b/types/node/zlib.d.ts
@@ -173,6 +173,15 @@ declare module "zlib" {
     interface InflateRaw extends stream.Transform, Zlib, ZlibReset {}
     interface Unzip extends stream.Transform, Zlib {}
     /**
+     * Computes a 32-bit [Cyclic Redundancy Check](https://en.wikipedia.org/wiki/Cyclic_redundancy_check) checksum of `data`.
+     * If `value` is specified, it is used as the starting value of the checksum, otherwise, 0 is used as the starting value.
+     * @param data When `data` is a string, it will be encoded as UTF-8 before being used for computation.
+     * @param value An optional starting value. It must be a 32-bit unsigned integer. @default 0
+     * @returns A 32-bit unsigned integer containing the checksum.
+     * @since v22.2.0
+     */
+    function crc32(data: string | Buffer | NodeJS.ArrayBufferView, value?: number): number;
+    /**
      * Creates and returns a new `BrotliCompress` object.
      * @since v11.7.0, v10.16.0
      */


### PR DESCRIPTION
https://github.com/nodejs/node/releases/tag/v22.2.0

- fs: allow 'withFileTypes' to be used with globs
- test_runner: support test plans
- zlib: expose zlib.crc32()
- perf_hooks: add deliveryType and responseStatus fields