### PR TITLE
[react] Explicitly allow async Form Actions

### DIFF
--- a/types/react/canary.d.ts
+++ b/types/react/canary.d.ts
@@ -67,7 +67,7 @@ declare module "." {
     export function unstable_useCacheRefresh(): () => void;
 
     interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS {
-        functions: (formData: FormData) => void;
+        functions: (formData: FormData) => void | Promise<void>;
     }
 
     export interface TransitionStartFunction {

--- a/types/react/test/canary.tsx
+++ b/types/react/test/canary.tsx
@@ -127,6 +127,20 @@ function formActionsTest() {
             Delete
         </button>
     </form>;
+
+    <form
+        action={async (formData) => {
+            // $ExpectType FormData
+            formData;
+        }}
+    />;
+
+    <form
+        // @ts-expect-error -- Type 'Promise<number>' is not assignable to type 'Promise<void>'
+        action={async () => {
+            return 1;
+        }}
+    />;
 }
 
 const useOptimistic = React.useOptimistic;

--- a/types/react/ts5.0/canary.d.ts
+++ b/types/react/ts5.0/canary.d.ts
@@ -67,7 +67,7 @@ declare module "." {
     export function unstable_useCacheRefresh(): () => void;
 
     interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS {
-        functions: (formData: FormData) => void;
+        functions: (formData: FormData) => void | Promise<void>;
     }
 
     export interface TransitionStartFunction {

--- a/types/react/ts5.0/test/canary.tsx
+++ b/types/react/ts5.0/test/canary.tsx
@@ -127,6 +127,20 @@ function formActionsTest() {
             Delete
         </button>
     </form>;
+
+    <form
+        action={async (formData) => {
+            // $ExpectType FormData
+            formData;
+        }}
+    />;
+
+    <form
+        // @ts-expect-error -- Type 'Promise<number>' is not assignable to type 'Promise<void>'
+        action={async () => {
+            return 1;
+        }}
+    />;
 }
 
 const useOptimistic = React.useOptimistic;


### PR DESCRIPTION
This was implicitly enabled by TypeScript allowing any return type if the return type of an expected function is `void`. But this is not generally behavior we want in React so we should not relly on it.

It's also problematic since certain type-aware ESLint rules may issue violations since it looks like Form Actions can't be async.

We now explicitly codify support of async Form Actions. This also means return anything else will now issue type errors

Closes https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64451#discussioncomment-10163634
