### PR TITLE
Add typings for fluent-ffmpeg filenames event

### DIFF
--- a/types/fluent-ffmpeg/fluent-ffmpeg-tests.ts
+++ b/types/fluent-ffmpeg/fluent-ffmpeg-tests.ts
@@ -128,3 +128,16 @@ ffmpeg("/path/to/file.avi")
     .on("end", () => {
         console.log("Transcoding succeeded !");
     });
+
+
+ffmpeg("/path/to/file.avi")
+    .on("filenames", (filenames) => {
+        console.log("Created screenshots " + filenames.join(", "));
+    })
+    .on("end", () => {
+        console.log("Transcoding succeeded !");
+    })
+    .screenshots({
+      timestamps: [0, 1, 2],
+      folder: "/path/to/output",
+    });

--- a/types/fluent-ffmpeg/fluent-ffmpeg-tests.ts
+++ b/types/fluent-ffmpeg/fluent-ffmpeg-tests.ts
@@ -129,7 +129,6 @@ ffmpeg("/path/to/file.avi")
         console.log("Transcoding succeeded !");
     });
 
-
 ffmpeg("/path/to/file.avi")
     .on("filenames", (filenames) => {
         console.log("Created screenshots " + filenames.join(", "));
@@ -138,6 +137,6 @@ ffmpeg("/path/to/file.avi")
         console.log("Transcoding succeeded !");
     })
     .screenshots({
-      timestamps: [0, 1, 2],
-      folder: "/path/to/output",
+        timestamps: [0, 1, 2],
+        folder: "/path/to/output",
     });

--- a/types/fluent-ffmpeg/index.d.ts
+++ b/types/fluent-ffmpeg/index.d.ts
@@ -456,13 +456,21 @@ declare namespace Ffmpeg {
         on(event: "error", listener: (error: Error, stdout: string | null, stderr: string | null) => void): this;
 
         /**
+         * Emitted when a taking screenshots
+         *
+         * @event FfmpegCommand#filenames
+         * @param {Array} [filenames] generated filenames when taking screenshots
+         */
+        on(event: "filenames", listener: (filenames: string[]) => void): this;
+
+        /**
          * Emitted when a command finishes processing
          *
          * @event FfmpegCommand#end
-         * @param {Array|String|null} [filenames|stdout] generated filenames when taking screenshots, ffmpeg stdout when not outputting to a stream, null otherwise
+         * @param {String|null} stdout ffmpeg stdout when not outputting to a stream, null otherwise
          * @param {String|null} stderr ffmpeg stderr
          */
-        on(event: "end", listener: (filenames: string[] | string | null, stderr: string | null) => void): this;
+        on(event: "end", listener: (stdout: string | null, stderr: string | null) => void): this;
 
         // recipes
         saveToFile(output: string): FfmpegCommand;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [fluent-ffmpeg documentation](https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/blob/fafb8d3a66f91485907145d776cc14272e402f48/README.md#screenshotsoptions-dirname-generate-thumbnails)

Context:
- fixes #70198 
- the [fluent-ffmpeg documentation](https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/blob/fafb8d3a66f91485907145d776cc14272e402f48/README.md#screenshotsoptions-dirname-generate-thumbnails) mentions a `filenames` event which is triggered when taking screenshots with `fluent-ffmpeg`
- this PR adds support for this event
- this PR also udpates the `end` event with the correct types based on the implementation in [their source code](https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/blob/fafb8d3a66f91485907145d776cc14272e402f48/lib/processor.js#L417)
