### PR TITLE
[node] Update typings to v22.3.0

### DIFF
--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -171,6 +171,17 @@ declare module "buffer" {
          */
         arrayBuffer(): Promise<ArrayBuffer>;
         /**
+         * The `blob.bytes()` method returns the byte of the `Blob` object as a `Promise<Uint8Array>`.
+         *
+         * ```js
+         * const blob = new Blob(['hello']);
+         * blob.bytes().then((bytes) => {
+         *   console.log(bytes); // Outputs: Uint8Array(5) [ 104, 101, 108, 108, 111 ]
+         * });
+         * ```
+         */
+        bytes(): Promise<Uint8Array>;
+        /**
          * Creates and returns a new `Blob` containing a subset of this `Blob` objects
          * data. The original `Blob` is not altered.
          * @since v15.7.0, v14.18.0

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -425,6 +425,9 @@ declare global {
         : typeof import("undici-types").WebSocket;
 
     interface EventSource extends _EventSource {}
+    /**
+     * Only available through the [--experimental-eventsource](https://nodejs.org/api/cli.html#--experimental-eventsource) flag.
+     */
     var EventSource: typeof globalThis extends { onmessage: any; EventSource: infer T } ? T
         : typeof import("undici-types").EventSource;
 }

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -7,12 +7,14 @@ type _Request = typeof globalThis extends { onmessage: any } ? {} : import("undi
 type _Response = typeof globalThis extends { onmessage: any } ? {} : import("undici-types").Response;
 type _FormData = typeof globalThis extends { onmessage: any } ? {} : import("undici-types").FormData;
 type _Headers = typeof globalThis extends { onmessage: any } ? {} : import("undici-types").Headers;
+type _MessageEvent = typeof globalThis extends { onmessage: any } ? {} : import("undici-types").MessageEvent;
 type _RequestInit = typeof globalThis extends { onmessage: any } ? {}
     : import("undici-types").RequestInit;
 type _ResponseInit = typeof globalThis extends { onmessage: any } ? {}
     : import("undici-types").ResponseInit;
 type _File = typeof globalThis extends { onmessage: any } ? {} : import("node:buffer").File;
 type _WebSocket = typeof globalThis extends { onmessage: any } ? {} : import("undici-types").WebSocket;
+type _EventSource = typeof globalThis extends { onmessage: any } ? {} : import("undici-types").EventSource;
 // #endregion Fetch and friends
 
 declare global {
@@ -404,6 +406,13 @@ declare global {
     } ? T
         : typeof import("undici-types").Headers;
 
+    interface MessageEvent extends _MessageEvent {}
+    var MessageEvent: typeof globalThis extends {
+        onmessage: any;
+        MessageEvent: infer T;
+    } ? T
+        : typeof import("undici-types").MessageEvent;
+
     interface File extends _File {}
     var File: typeof globalThis extends {
         onmessage: any;
@@ -414,4 +423,8 @@ declare global {
     interface WebSocket extends _WebSocket {}
     var WebSocket: typeof globalThis extends { onmessage: any; WebSocket: infer T } ? T
         : typeof import("undici-types").WebSocket;
+
+    interface EventSource extends _EventSource {}
+    var EventSource: typeof globalThis extends { onmessage: any; EventSource: infer T } ? T
+        : typeof import("undici-types").EventSource;
 }

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "22.2.9999",
+    "version": "22.3.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [
@@ -9,7 +9,7 @@
     ],
     "tsconfigs": ["tsconfig.dom.json", "tsconfig.non-dom.json"],
     "dependencies": {
-        "undici-types": "~6.13.0"
+        "undici-types": "~6.18.2"
     },
     "devDependencies": {
         "@types/node": "workspace:."

--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -1,8 +1,116 @@
 declare module "process" {
-    import * as net from "node:net";
-    import * as os from "node:os";
     import * as tty from "node:tty";
     import { Worker } from "node:worker_threads";
+
+    interface BuiltInModule {
+        "assert": typeof import("assert");
+        "node:assert": typeof import("node:assert");
+        "assert/strict": typeof import("assert/strict");
+        "node:assert/strict": typeof import("node:assert/strict");
+        "async_hooks": typeof import("async_hooks");
+        "node:async_hooks": typeof import("node:async_hooks");
+        "buffer": typeof import("buffer");
+        "node:buffer": typeof import("node:buffer");
+        "child_process": typeof import("child_process");
+        "node:child_process": typeof import("node:child_process");
+        "cluster": typeof import("cluster");
+        "node:cluster": typeof import("node:cluster");
+        "console": typeof import("console");
+        "node:console": typeof import("node:console");
+        "constants": typeof import("constants");
+        "node:constants": typeof import("node:constants");
+        "crypto": typeof import("node:crypto");
+        "node:crypto": typeof import("node:crypto");
+        "dgram": typeof import("node:dgram");
+        "node:dgram": typeof import("node:dgram");
+        "diagnostics_channel": typeof import("node:diagnostics_channel");
+        "node:diagnostics_channel": typeof import("node:diagnostics_channel");
+        "dns": typeof import("node:dns");
+        "node:dns": typeof import("node:dns");
+        "dns/promises": typeof import("dns/promises");
+        "node:dns/promises": typeof import("node:dns/promises");
+        "domain": typeof import("domain");
+        "node:domain": typeof import("node:domain");
+        "events": typeof import("events");
+        "node:events": typeof import("node:events");
+        "fs": typeof import("fs");
+        "node:fs": typeof import("node:fs");
+        "fs/promises": typeof import("fs/promises");
+        "node:fs/promises": typeof import("node:fs/promises");
+        "http": typeof import("http");
+        "node:http": typeof import("node:http");
+        "http2": typeof import("http2");
+        "node:http2": typeof import("node:http2");
+        "https": typeof import("https");
+        "node:https": typeof import("node:https");
+        "inspector": typeof import("inspector");
+        "node:inspector": typeof import("node:inspector");
+        "module": typeof import("module");
+        "node:module": typeof import("node:module");
+        "net": typeof import("net");
+        "node:net": typeof import("node:net");
+        "os": typeof import("os");
+        "node:os": typeof import("node:os");
+        "path": typeof import("path");
+        "node:path": typeof import("node:path");
+        "path/posix": typeof import("path/posix");
+        "node:path/posix": typeof import("node:path/posix");
+        "path/win32": typeof import("path/win32");
+        "node:path/win32": typeof import("node:path/win32");
+        "perf_hooks": typeof import("perf_hooks");
+        "node:perf_hooks": typeof import("node:perf_hooks");
+        "process": typeof import("process");
+        "node:process": typeof import("node:process");
+        "punycode": typeof import("punycode");
+        "node:punycode": typeof import("node:punycode");
+        "querystring": typeof import("querystring");
+        "node:querystring": typeof import("node:querystring");
+        "readline": typeof import("readline");
+        "node:readline": typeof import("node:readline");
+        "readline/promises": typeof import("readline/promises");
+        "node:readline/promises": typeof import("node:readline/promises");
+        "repl": typeof import("repl");
+        "node:repl": typeof import("node:repl");
+        "node:sea": typeof import("node:sea");
+        "stream": typeof import("stream");
+        "node:stream": typeof import("node:stream");
+        "stream/consumers": typeof import("stream/consumers");
+        "node:stream/consumers": typeof import("node:stream/consumers");
+        "stream/promises": typeof import("stream/promises");
+        "node:stream/promises": typeof import("node:stream/promises");
+        "stream/web": typeof import("stream/web");
+        "node:stream/web": typeof import("node:stream/web");
+        "string_decoder": typeof import("string_decoder");
+        "node:string_decoder": typeof import("node:string_decoder");
+        "node:test": typeof import("node:test");
+        "node:test/reporters": typeof import("node:test/reporters");
+        "timers": typeof import("timers");
+        "node:timers": typeof import("node:timers");
+        "timers/promises": typeof import("timers/promises");
+        "node:timers/promises": typeof import("node:timers/promises");
+        "tls": typeof import("tls");
+        "node:tls": typeof import("node:tls");
+        "trace_events": typeof import("trace_events");
+        "node:trace_events": typeof import("node:trace_events");
+        "tty": typeof import("tty");
+        "node:tty": typeof import("node:tty");
+        "url": typeof import("url");
+        "node:url": typeof import("node:url");
+        "util": typeof import("util");
+        "node:util": typeof import("node:util");
+        "util/types": typeof import("util/types");
+        "node:util/types": typeof import("node:util/types");
+        "v8": typeof import("v8");
+        "node:v8": typeof import("node:v8");
+        "vm": typeof import("vm");
+        "node:vm": typeof import("node:vm");
+        "wasi": typeof import("wasi");
+        "node:wasi": typeof import("node:wasi");
+        "worker_threads": typeof import("worker_threads");
+        "node:worker_threads": typeof import("node:worker_threads");
+        "zlib": typeof import("zlib");
+        "node:zlib": typeof import("node:zlib");
+    }
     global {
         var process: NodeJS.Process;
         namespace NodeJS {
@@ -793,6 +901,12 @@ declare module "process" {
                  * @since v17.3.0, v16.14.0
                  */
                 getActiveResourcesInfo(): string[];
+                /**
+                 * Provides a way to load built-in modules in a globally available function.
+                 * @param id ID of the built-in module being requested.
+                 */
+                getBuiltinModule<ID extends keyof BuiltInModule>(id: ID): BuiltInModule[ID];
+                getBuiltinModule(id: string): object | undefined;
                 /**
                  * The `process.getgid()` method returns the numerical group identity of the
                  * process. (See [`getgid(2)`](http://man7.org/linux/man-pages/man2/getgid.2.html).)

--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -19,13 +19,13 @@ declare module "process" {
         "node:console": typeof import("node:console");
         "constants": typeof import("constants");
         "node:constants": typeof import("node:constants");
-        "crypto": typeof import("node:crypto");
+        "crypto": typeof import("crypto");
         "node:crypto": typeof import("node:crypto");
-        "dgram": typeof import("node:dgram");
+        "dgram": typeof import("dgram");
         "node:dgram": typeof import("node:dgram");
-        "diagnostics_channel": typeof import("node:diagnostics_channel");
+        "diagnostics_channel": typeof import("diagnostics_channel");
         "node:diagnostics_channel": typeof import("node:diagnostics_channel");
-        "dns": typeof import("node:dns");
+        "dns": typeof import("dns");
         "node:dns": typeof import("node:dns");
         "dns/promises": typeof import("dns/promises");
         "node:dns/promises": typeof import("node:dns/promises");
@@ -45,6 +45,9 @@ declare module "process" {
         "node:https": typeof import("node:https");
         "inspector": typeof import("inspector");
         "node:inspector": typeof import("node:inspector");
+        // FIXME: module is missed
+        // "inspector/promises": typeof import("inspector/promises");
+        // "node:inspector/promises": typeof import("node:inspector/promises");
         "module": typeof import("module");
         "node:module": typeof import("node:module");
         "net": typeof import("net");
@@ -98,6 +101,8 @@ declare module "process" {
         "node:url": typeof import("node:url");
         "util": typeof import("util");
         "node:util": typeof import("node:util");
+        "sys": typeof import("util");
+        "node:sys": typeof import("node:util");
         "util/types": typeof import("util/types");
         "node:util/types": typeof import("node:util/types");
         "v8": typeof import("v8");

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -728,6 +728,8 @@ declare module "node:test" {
          *   });
          * });
          * ```
+         * 
+         * Only available through the [--experimental-test-snapshots](https://nodejs.org/api/cli.html#--experimental-test-snapshots) flag.
          * @since v22.3.0
          * @experimental
          */
@@ -742,7 +744,7 @@ declare module "node:test" {
          *
          * If no serializers are provided, the test runner's default serializers are used.
          */
-        serializers: ReadonlyArray<((value: any) => any)> | undefined;
+        serializers?: ReadonlyArray<(value: any) => any> | undefined;
     }
 
     /**
@@ -1536,7 +1538,7 @@ declare module "node:test" {
          * @since v22.3.0
          * @param serializers An array of synchronous functions used as the default serializers for snapshot tests.
          */
-        function setDefaultSnapshotSerializers(serializers: ReadonlyArray<((value: any) => any)>): void;
+        function setDefaultSnapshotSerializers(serializers: ReadonlyArray<(value: any) => any>): void;
         /**
          * This function is used to set a custom resolver for the location of the snapshot file used for snapshot testing.
          * By default, the snapshot filename is the same as the entry point filename with `.snapshot` appended.

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -144,7 +144,22 @@ declare module "node:test" {
     function test(options?: TestOptions, fn?: TestFn): Promise<void>;
     function test(fn?: TestFn): Promise<void>;
     namespace test {
-        export { after, afterEach, before, beforeEach, describe, it, mock, only, run, skip, suite, test, todo };
+        export {
+            after,
+            afterEach,
+            before,
+            beforeEach,
+            describe,
+            it,
+            mock,
+            only,
+            run,
+            skip,
+            snapshot,
+            suite,
+            test,
+            todo,
+        };
     }
     /**
      * The `suite()` function is imported from the `node:test` module.
@@ -510,6 +525,11 @@ declare module "node:test" {
          */
         diagnostic(message: string): void;
         /**
+         * The name of the test and each of its ancestors, separated by `>`.
+         * @since v22.3.0
+         */
+        readonly fullName: string;
+        /**
          * The name of the test.
          * @since v18.8.0, v16.18.0
          */
@@ -695,6 +715,34 @@ declare module "node:test" {
          * Identical to the `throws` function from the `node:assert` module, but bound to the test context.
          */
         throws: typeof import("node:assert").throws;
+        /**
+         * This function implements assertions for snapshot testing.
+         * ```js
+         * test('snapshot test with default serialization', (t) => {
+         *   t.assert.snapshot({ value1: 1, value2: 2 });
+         * });
+         *
+         * test('snapshot test with custom serialization', (t) => {
+         *   t.assert.snapshot({ value3: 3, value4: 4 }, {
+         *     serializers: [(value) => JSON.stringify(value)]
+         *   });
+         * });
+         * ```
+         * @since v22.3.0
+         * @experimental
+         */
+        snapshot(value: any, options?: AssertSnapshotOptions): void;
+    }
+    interface AssertSnapshotOptions {
+        /**
+         * An array of synchronous functions used to serialize `value` into a string.
+         * `value` is passed as the only argument to the first serializer function.
+         * The return value of each serializer is passed as input to the next serializer.
+         * Once all serializers have run, the resulting value is coerced to a string.
+         *
+         * If no serializers are provided, the test runner's default serializers are used.
+         */
+        serializers: ReadonlyArray<((value: any) => any)> | undefined;
     }
 
     /**
@@ -879,6 +927,30 @@ declare module "node:test" {
     type FunctionPropertyNames<T> = {
         [K in keyof T]: T[K] extends Function ? K : never;
     }[keyof T];
+    interface MockModuleOptions {
+        /**
+         * If false, each call to `require()` or `import()` generates a new mock module.
+         * If true, subsequent calls will return the same module mock, and the mock module is inserted into the CommonJS cache.
+         * @default false
+         */
+        cache?: boolean | undefined;
+        /**
+         * The value to use as the mocked module's default export.
+         *
+         * If this value is not provided, ESM mocks do not include a default export.
+         * If the mock is a CommonJS or builtin module, this setting is used as the value of `module.exports`.
+         * If this value is not provided, CJS and builtin mocks use an empty object as the value of `module.exports`.
+         */
+        defaultExport?: any;
+        /**
+         * An object whose keys and values are used to create the named exports of the mock module.
+         *
+         * If the mock is a CommonJS or builtin module, these values are copied onto `module.exports`.
+         * Therefore, if a mock is created with both named exports and a non-object default export,
+         * the mock will throw an exception when used as a CJS or builtin module.
+         */
+        namedExports?: object | undefined;
+    }
     /**
      * The `MockTracker` class is used to manage mocking functionality. The test runner
      * module provides a top level `mock` export which is a `MockTracker` instance.
@@ -1043,6 +1115,18 @@ declare module "node:test" {
         ): Mock<((value: MockedObject[MethodName]) => void) | Implementation>;
 
         /**
+         * This function is used to mock the exports of ECMAScript modules, CommonJS modules, and Node.js builtin modules.
+         * Any references to the original module prior to mocking are not impacted.
+         *
+         * Only available through the [--experimental-test-module-mocks](https://nodejs.org/api/cli.html#--experimental-test-module-mocks) flag.
+         * @since v22.3.0
+         * @experimental
+         * @param specifier A string identifying the module to mock.
+         * @param options Optional configuration options for the mock module.
+         */
+        module(specifier: string, options?: MockModuleOptions): MockModuleContext;
+
+        /**
          * This function restores the default behavior of all mocks that were previously
          * created by this `MockTracker` and disassociates the mocks from the `MockTracker` instance. Once disassociated, the mocks can still be used, but the `MockTracker` instance can no longer be
          * used to reset their behavior or
@@ -1198,6 +1282,17 @@ declare module "node:test" {
          * Resets the implementation of the mock function to its original behavior. The
          * mock can still be used after calling this function.
          * @since v19.1.0, v18.13.0
+         */
+        restore(): void;
+    }
+    /**
+     * @since v22.3.0
+     * @experimental
+     */
+    class MockModuleContext {
+        /**
+         * Resets the implementation of the mock module.
+         * @since v22.3.0
          */
         restore(): void;
     }
@@ -1423,6 +1518,35 @@ declare module "node:test" {
          */
         [Symbol.dispose](): void;
     }
+    /**
+     * Only available through the [--experimental-test-snapshots](https://nodejs.org/api/cli.html#--experimental-test-snapshots) flag.
+     * @since v22.3.0
+     * @experimental
+     */
+    namespace snapshot {
+        /**
+         * This function is used to customize the default serialization mechanism used by the test runner.
+         *
+         * By default, the test runner performs serialization by calling `JSON.stringify(value, null, 2)` on the provided value.
+         * `JSON.stringify()` does have limitations regarding circular structures and supported data types.
+         * If a more robust serialization mechanism is required, this function should be used to specify a list of custom serializers.
+         *
+         * Serializers are called in order, with the output of the previous serializer passed as input to the next.
+         * The final result must be a string value.
+         * @since v22.3.0
+         * @param serializers An array of synchronous functions used as the default serializers for snapshot tests.
+         */
+        function setDefaultSnapshotSerializers(serializers: ReadonlyArray<((value: any) => any)>): void;
+        /**
+         * This function is used to set a custom resolver for the location of the snapshot file used for snapshot testing.
+         * By default, the snapshot filename is the same as the entry point filename with `.snapshot` appended.
+         * @since v22.3.0
+         * @param fn A function which returns a string specifying the location of the snapshot file.
+         * The function receives the path of the test file as its only argument.
+         * If `process.argv[1]` is not associated with a file (for example in the REPL), the input is undefined.
+         */
+        function setResolveSnapshotPath(fn: (path: string | undefined) => string): void;
+    }
     export {
         after,
         afterEach,
@@ -1435,6 +1559,7 @@ declare module "node:test" {
         only,
         run,
         skip,
+        snapshot,
         suite,
         SuiteContext,
         test,

--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -504,6 +504,7 @@ declare class NodeFile implements File {
     slice(start?: number, end?: number, type?: string): NodeBlob;
     stream(): ReadableStream;
     arrayBuffer(): Promise<ArrayBuffer>;
+    bytes(): Promise<Uint8Array>;
     text(): Promise<string>;
 }
 

--- a/types/node/test/process.ts
+++ b/types/node/test/process.ts
@@ -211,3 +211,8 @@ process.env.TZ = "test";
         process.setSourceMapsEnabled(true);
     }
 }
+
+{
+    const fs = globalThis.process.getBuiltinModule("fs");
+    fs.constants.F_OK;
+}

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -779,6 +779,7 @@ test("mocks a setter", (t) => {
 });
 
 test("mocks a module", (t) => {
+    // $ExpectType MockModuleContext
     const mock = t.mock.module("node:readline", {
         namedExports: {
             fn() {

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -11,6 +11,7 @@ import {
     only,
     run,
     skip,
+    snapshot,
     suite,
     type SuiteContext,
     test,
@@ -101,7 +102,7 @@ test((t, cb) => {
     cb({ x: "anything" });
 });
 
-// Test the context's methods
+// Test the context's methods/properties
 test(undefined, undefined, t => {
     // $ExpectType void
     t.diagnostic("tap diagnostic");
@@ -123,6 +124,15 @@ test(undefined, undefined, t => {
     t.beforeEach(() => {});
     // $ExpectType void
     t.before(() => {});
+
+    // $ExpectType string
+    t.name;
+    // $ExpectType string
+    t.fullName;
+    // $ExpectType AbortSignal
+    t.signal;
+    // $ExpectType MockTracker
+    t.mock;
 });
 
 // Test the subtest approach.
@@ -768,6 +778,24 @@ test("mocks a setter", (t) => {
     }
 });
 
+test("mocks a module", (t) => {
+    const mock = t.mock.module("node:readline", {
+        namedExports: {
+            fn() {
+                return 42;
+            },
+        },
+        defaultExport: {
+            foo() {
+                return "bar";
+            },
+        },
+        cache: true,
+    });
+    // $ExpectType void
+    mock.restore();
+});
+
 // @ts-expect-error
 dot();
 // $ExpectType AsyncGenerator<"\n" | "." | "X", void, unknown> || AsyncGenerator<"\n" | "." | "X", void, any>
@@ -947,4 +975,32 @@ test("planning with streams", (t: TestContext, done) => {
     stream.on("end", () => {
         done();
     });
+});
+
+// Test snapshot assertion.
+test(t => {
+    // $ExpectType void
+    t.assert.snapshot({ value1: true, value2: false });
+    // $ExpectType void
+    t.assert.snapshot({ value3: "foo", value4: "bar" }, { serializers: [value => JSON.stringify(value)] });
+});
+
+// Snapshot configuration
+// @ts-expect-error
+snapshot.setDefaultSnapshotSerializers();
+// @ts-expect-error
+snapshot.setDefaultSnapshotSerializers((value) => value);
+// $ExpectType void
+snapshot.setDefaultSnapshotSerializers([
+    (value) => {
+        value; // $ExpectType any
+        return value;
+    },
+]);
+// @ts-expect-error
+snapshot.setResolveSnapshotPath();
+// $ExpectType void
+snapshot.setResolveSnapshotPath((path) => {
+    path; // $ExpectType string | undefined
+    return `${path ?? "repl"}.snapshot`;
 });


### PR DESCRIPTION
https://github.com/nodejs/node/releases/tag/v22.3.0

- buffer: add .bytes() method to Blob
- test_runner: add context.fullName
- test_runner: add snapshot testing
- process: add process.getBuiltinModule(id)
- lib: replace MessageEvent with undici's
- lib: add EventSource Client