### PR TITLE
Update iterator types to align with microsoft/TypeScript#59506

### DIFF
--- a/types/call-bind/test/callBound.test.ts
+++ b/types/call-bind/test/callBound.test.ts
@@ -1,8 +1,8 @@
 import callBound = require("call-bind/callBound");
 
-callBound("%ArrayProto_keys%"); // $ExpectType (thisArg: unknown) => IterableIterator<number> || (thisArg: unknown) => BuiltinIterator<number, any, any>
-callBound("%ArrayProto_values%"); // $ExpectType (thisArg: unknown) => IterableIterator<any> || (thisArg: unknown) => BuiltinIterator<any, any, any>
-callBound("%ArrayProto_entries%"); // $ExpectType (thisArg: unknown) => IterableIterator<[number, any]> || (thisArg: unknown) => BuiltinIterator<[number, any], any, any>
+callBound("%ArrayProto_keys%"); // $ExpectType (thisArg: unknown) => IterableIterator<number> || (thisArg: unknown) => ArrayIterator<number>
+callBound("%ArrayProto_values%"); // $ExpectType (thisArg: unknown) => IterableIterator<any> || (thisArg: unknown) => ArrayIterator<any>
+callBound("%ArrayProto_entries%"); // $ExpectType (thisArg: unknown) => IterableIterator<[number, any]> || (thisArg: unknown) => ArrayIterator<[number, any]>
 callBound("%ArrayProto_forEach%"); // $ExpectType (thisArg: unknown, callbackfn: (value: any, index: number, array: any[]) => void, thisArg?: any) => void
 
 callBound("%ObjProto_toString%"); // $ExpectType (thisArg: unknown) => string

--- a/types/es-abstract/test/es2015.test.ts
+++ b/types/es-abstract/test/es2015.test.ts
@@ -46,7 +46,7 @@ ES2015.Call<bigint, readonly [], string>(Object.prototype.toString, BigInt(Numbe
 ES2015.Call(Object.prototype.hasOwnProperty, [], ["length"] as const); // $ExpectType boolean
 ES2015.Call(Object.prototype.hasOwnProperty, any, args as IArguments & [PropertyKey]); // $ExpectType boolean
 
-// $ExpectType IterableIterator<number> || BuiltinIterator<number, any, any>
+// $ExpectType IterableIterator<number> || ArrayIterator<number>
 ES2015.GetIterator([1, 2, 3]);
 
 function* generable() {

--- a/types/es-abstract/test/helpers/callBound.test.ts
+++ b/types/es-abstract/test/helpers/callBound.test.ts
@@ -1,8 +1,8 @@
 import callBound = require("es-abstract/helpers/callBound");
 
-callBound("%ArrayProto_keys%"); // $ExpectType (thisArg: unknown) => IterableIterator<number> || (thisArg: unknown) => BuiltinIterator<number, any, any>
-callBound("%ArrayProto_values%"); // $ExpectType (thisArg: unknown) => IterableIterator<any> || (thisArg: unknown) => BuiltinIterator<any, any, any>
-callBound("%ArrayProto_entries%"); // $ExpectType (thisArg: unknown) => IterableIterator<[number, any]> || (thisArg: unknown) => BuiltinIterator<[number, any], any, any>
+callBound("%ArrayProto_keys%"); // $ExpectType (thisArg: unknown) => IterableIterator<number> || (thisArg: unknown) => ArrayIterator<number>
+callBound("%ArrayProto_values%"); // $ExpectType (thisArg: unknown) => IterableIterator<any> || (thisArg: unknown) => ArrayIterator<any>
+callBound("%ArrayProto_entries%"); // $ExpectType (thisArg: unknown) => IterableIterator<[number, any]> || (thisArg: unknown) => ArrayIterator<[number, any]>
 callBound("%ArrayProto_forEach%"); // $ExpectType (thisArg: unknown, callbackfn: (value: any, index: number, array: any[]) => void, thisArg?: any) => void
 
 callBound("%ObjProto_toString%"); // $ExpectType (thisArg: unknown) => string

--- a/types/es-get-iterator/es-get-iterator-tests.ts
+++ b/types/es-get-iterator/es-get-iterator-tests.ts
@@ -36,7 +36,7 @@ declare const ARGUMENTS: IArguments;
 getIterator(ARGUMENTS);
 
 declare const ITERABLE_UNION: number[] | Set<Date>;
-// $ExpectType Iterator<number, any, undefined> | Iterator<Date, any, undefined> || Iterator<number, any, any> | Iterator<Date, any, unknown>
+// $ExpectType Iterator<number, any, undefined> | Iterator<Date, any, undefined> || Iterator<number, any, unknown> | Iterator<Date, any, unknown>
 getIterator(ITERABLE_UNION);
 
 declare const ITERABLE_OR_OTHERS_UNION: Map<Error, DataView> | ArrayBuffer;

--- a/types/es-get-iterator/es-get-iterator-tests.ts
+++ b/types/es-get-iterator/es-get-iterator-tests.ts
@@ -1,21 +1,21 @@
 import getIterator = require("es-get-iterator");
 
-// $ExpectType Iterator<string, any, undefined> || Iterator<string, any, any>
+// $ExpectType Iterator<string, any, undefined> || Iterator<string, any, unknown>
 getIterator("foo");
 
-// $ExpectType Iterator<never, any, undefined> || Iterator<never, any, any>
+// $ExpectType Iterator<never, any, undefined> || Iterator<never, any, unknown>
 getIterator([]);
 
-// $ExpectType Iterator<number, any, undefined> || Iterator<number, any, any>
+// $ExpectType Iterator<number, any, undefined> || Iterator<number, any, unknown>
 getIterator([0, 1, 2, 3, 4]);
 
-// $ExpectType Iterator<string | number | boolean | undefined, any, undefined> || Iterator<string | number | boolean | undefined, any, any>
+// $ExpectType Iterator<string | number | boolean | undefined, any, undefined> || Iterator<string | number | boolean | undefined, any, unknown>
 getIterator([undefined, true, "bar", 0]);
 
-// $ExpectType Iterator<[symbol, unknown], any, undefined> || Iterator<[symbol, unknown], any, any>
+// $ExpectType Iterator<[symbol, unknown], any, undefined> || Iterator<[symbol, unknown], any, unknown>
 getIterator(new Map<symbol, unknown>());
 
-// $ExpectType Iterator<boolean, any, undefined> || Iterator<boolean, any, any>
+// $ExpectType Iterator<boolean, any, undefined> || Iterator<boolean, any, unknown>
 getIterator(new Set<boolean>());
 
 // $ExpectType Iterator<"foo" | "bar", void, unknown> || Iterator<"foo" | "bar", void, any>
@@ -32,15 +32,15 @@ getIterator((function*() {
 })());
 
 declare const ARGUMENTS: IArguments;
-// $ExpectType Iterator<any, any, undefined> || Iterator<any, any, any>
+// $ExpectType Iterator<any, any, undefined> || Iterator<any, any, unknown>
 getIterator(ARGUMENTS);
 
 declare const ITERABLE_UNION: number[] | Set<Date>;
-// $ExpectType Iterator<number, any, undefined> | Iterator<Date, any, undefined> || Iterator<number, any, any> | Iterator<Date, any, any>
+// $ExpectType Iterator<number, any, undefined> | Iterator<Date, any, undefined> || Iterator<number, any, any> | Iterator<Date, any, unknown>
 getIterator(ITERABLE_UNION);
 
 declare const ITERABLE_OR_OTHERS_UNION: Map<Error, DataView> | ArrayBuffer;
-// $ExpectType Iterator<[Error, DataView], any, undefined> | undefined || Iterator<[Error, DataView], any, any> | undefined
+// $ExpectType Iterator<[Error, DataView], any, undefined> | undefined || Iterator<[Error, DataView], any, unknown> | undefined
 getIterator(ITERABLE_OR_OTHERS_UNION);
 
 declare const UNKNOWN: unknown;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -5514,9 +5514,9 @@ fp.now(); // $ExpectType number
     _.chain(objectWithOptionalField).get("a", defaultValue); // $ExpectType PrimitiveChain<false> | PrimitiveChain<true>
     _.chain({}).get("a", defaultValue); // $ExpectType PrimitiveChain<false> | PrimitiveChain<true>
 
-    fp.get(Symbol.iterator, []); // $ExpectType any || () => IterableIterator<never> || () => BuiltinIterator<never, any, any>
-    fp.get(Symbol.iterator)([]); // $ExpectType any || () => IterableIterator<never> || () => BuiltinIterator<never>
-    fp.get([Symbol.iterator], []); // $ExpectType any || () => IterableIterator<never> || () => BuiltinIterator<never, any, any>
+    fp.get(Symbol.iterator, []); // $ExpectType any || () => IterableIterator<never> || () => ArrayIterator<never>
+    fp.get(Symbol.iterator)([]); // $ExpectType any || () => IterableIterator<never> || () => ArrayIterator<never>
+    fp.get([Symbol.iterator], []); // $ExpectType any || () => IterableIterator<never> || () => ArrayIterator<never>
     fp.get(1)("abc"); // $ExpectType string
     fp.get("1")("abc"); // $ExpectType any
     fp.get("a", { a: { b: true } }); // $ExpectType { b: boolean; }
@@ -7289,7 +7289,7 @@ fp.now(); // $ExpectType number
     _.chain("a.b[0]").property<SampleObject, number>(); // $ExpectType FunctionChain<(obj: SampleObject) => number>
     _.chain(["a", "b", 0]).property<SampleObject, number>(); // $ExpectType FunctionChain<(obj: SampleObject) => number>
     fp.property(Symbol.iterator)([]); // $ExpectType any
-    fp.property([Symbol.iterator], []); // $ExpectType any || () => IterableIterator<never> || () => BuiltinIterator<never, any, any>
+    fp.property([Symbol.iterator], []); // $ExpectType any || () => IterableIterator<never> || () => ArrayIterator<never>
     fp.property(1)("abc"); // $ExpectType string
 }
 
@@ -7300,7 +7300,7 @@ fp.now(); // $ExpectType number
     _.chain({}).propertyOf() as _.LoDashExplicitWrapper<(path: _.Many<_.PropertyName>) => any>;
 
     fp.propertyOf(Symbol.iterator)([]); // $ExpectType any
-    fp.propertyOf([Symbol.iterator], []); // $ExpectType any || () => IterableIterator<never> || () => BuiltinIterator<never, any, any>
+    fp.propertyOf([Symbol.iterator], []); // $ExpectType any || () => IterableIterator<never> || () => ArrayIterator<never>
     fp.propertyOf(1)("abc"); // $ExpectType string
 }
 

--- a/types/regenerator-runtime/regenerator-runtime-tests.ts
+++ b/types/regenerator-runtime/regenerator-runtime-tests.ts
@@ -13,7 +13,7 @@ declare const anyIterable: Iterable<object>;
 declare const anyIterableIterator: IterableIterator<object>;
 declare const anyGenerator: Generator<object, object, object>;
 
-regenerator.values(anyArray); // $ExpectType IterableIterator<object> || BuiltinIterator<object, any, any>
+regenerator.values(anyArray); // $ExpectType IterableIterator<object> || ArrayIterator<object>
 expectType<Iterator<object>>(regenerator.values(anyIterable));
 regenerator.values(anyIterableIterator); // $ExpectType IterableIterator<object>
 regenerator.values(anyGenerator); // $ExpectType Generator<object, object, object>

--- a/types/string.prototype.matchall/string.prototype.matchall-tests.ts
+++ b/types/string.prototype.matchall/string.prototype.matchall-tests.ts
@@ -8,5 +8,5 @@ matchAll(str, nonRegexStr); // $ExpectType IterableIterator<RegExpExecArray>
 matchAll(str, new RegExp(nonRegexStr, "g")); // $ExpectType IterableIterator<RegExpExecArray>
 matchAll(str, globalRegex); // $ExpectType IterableIterator<RegExpExecArray>
 matchAll.shim(); // $ExpectType void
-str.matchAll(globalRegex); // $ExpectType IterableIterator<RegExpExecArray> || BuiltinIterator<RegExpExecArray, any, any>
-str.matchAll(new RegExp(nonRegexStr, "g")); // $ExpectType IterableIterator<RegExpExecArray> || BuiltinIterator<RegExpExecArray, any, any>
+str.matchAll(globalRegex); // $ExpectType IterableIterator<RegExpExecArray> || RegExpStringIterator<RegExpExecArray>
+str.matchAll(new RegExp(nonRegexStr, "g")); // $ExpectType IterableIterator<RegExpExecArray> || RegExpStringIterator<RegExpExecArray>


### PR DESCRIPTION
This updates various libraries to align with the changes in microsoft/TypeScript#59506 which renames `BuiltinIterator` to `IteratorObject` and introduces specific `IteratorObject` subtypes for built-ins such as `ArrayIterator`, `MapIterator`, `SetIterator`, etc..

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://github.com/microsoft/TypeScript/pull/59506)
