### PR TITLE
[react-transition-group] Add missed TransitionActions properties to BaseTransitionProps

### DIFF
--- a/types/react-transition-group/Transition.d.ts
+++ b/types/react-transition-group/Transition.d.ts
@@ -50,7 +50,7 @@ export interface TransitionActions {
     exit?: boolean | undefined;
 }
 
-interface BaseTransitionProps<RefElement extends undefined | HTMLElement> {
+interface BaseTransitionProps<RefElement extends undefined | HTMLElement> extends TransitionActions {
     /**
      * Show the component; triggers the enter or exit states
      */

--- a/types/react-transition-group/react-transition-group-tests.tsx
+++ b/types/react-transition-group/react-transition-group-tests.tsx
@@ -223,6 +223,30 @@ const Test: React.FunctionComponent = () => {
                 <CSSTransition timeout={500} nodeRef={nodeRef} onEnter={handleEnterNoNode}>
                     <div ref={nodeRef}>{"test"}</div>
                 </CSSTransition>
+
+                <Transition
+                    // @ts-expect-error
+                    appear="test"
+                    timeout={500}
+                >
+                    <div>{"test"}</div>
+                </Transition>
+
+                <Transition
+                    // @ts-expect-error
+                    enter={null}
+                    timeout={500}
+                >
+                    <div>{"test"}</div>
+                </Transition>
+
+                <CSSTransition
+                    // @ts-expect-error
+                    exit={2}
+                    timeout={500}
+                >
+                    <div>{"test"}</div>
+                </CSSTransition>
             </TransitionGroup>
         </>
     );


### PR DESCRIPTION
Currently, the `TransitionActions` interface is only exported, but is not used for the `Transition` and `CSSTransition` component props. This results in properties from this interface not being prompted, and also any value (not just `boolean`) can be passed there (because of the index signature of the components props)

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reactjs/react-transition-group/blob/master/src/Transition.js#L478 (PropTypes for `Transition` component with actions)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
