### PR TITLE
Chai's AssertionArgs should not require the 4th param

### DIFF
--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -1202,6 +1202,19 @@ function use() {
         }
     }
 
+    function testAssertionPrototypeArgs(chai: Chai.ChaiStatic, utils: Chai.ChaiUtils) {
+        const Assertion = chai.Assertion;
+
+        Assertion.addMethod("testAssertion", function(expected: Object) {
+            this.assert(
+                true,
+                "expected message",
+                "negated expected message",
+                // 4th and subsequent args are optional
+            );
+        });
+    }
+
     chai.use(chaiSubset);
 }
 

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -99,16 +99,12 @@ declare namespace Chai {
 
     // chai.Assertion.prototype.assert arguments
     type AssertionArgs = [
-        // 'expression to be tested'
-        // This parameter is unused and the docs list its type as
-        // 'Philosophical', which is mentioned nowhere else in the source. Do
-        // with that what you will!
-        any,
-        Message, // message if value fails
-        Message, // message if negated value fails
-        any, // expected value
+        any, // expression to be tested
+        Message, // message or function that returns message to display if expression fails
+        Message, // negatedMessage or function that returns negatedMessage to display if expression fails
+        any?, // expected value
         any?, // actual value
-        boolean?, // showDiff
+        boolean?, // showDiff, when set to `true`, assert will display a diff in addition to the message if expression fails
     ];
 
     export interface AssertionPrototype {


### PR DESCRIPTION
[Chai `Assertion.prototype.assert` does not require 4th arg](https://github.com/chaijs/chai/blob/v4.3.10/lib/chai/assertion.js#L132-L145)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Chai `Assertion.prototype.assert` does not require 4th arg](https://github.com/chaijs/chai/blob/v4.3.10/lib/chai/assertion.js#L132-L145)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
