### PR TITLE
[new-relic-browser] Mark as conflicting with npm package, now that it's a security holding package

### DIFF
--- a/types/new-relic-browser/package.json
+++ b/types/new-relic-browser/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "@types/new-relic-browser",
     "version": "1.230.9999",
-    "nonNpm": true,
+    "nonNpm": "conflict",
     "nonNpmDescription": "NewRelicBrowser",
     "projects": [
         "https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api"


### PR DESCRIPTION
See:

- https://github.com/DefinitelyTyped/DefinitelyTyped/actions/runs/10318896268/job/28566235129#step:12:2508
- https://www.npmjs.com/package/new-relic-browser