### PR TITLE
[@types/react]: improve useState type-check usage with functions

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1925,8 +1925,8 @@ declare namespace React {
      * @see {@link https://react.dev/reference/react/useState}
      */
     function useState<S>(initialState: SetStateInitialState<S>): [S, Dispatch<SetStateAction<S>>];
-
-    // typechecker overload when storing a function or a class.
+    // Because we need to check both, the state initializer and the dispatcher, we need this
+    // overload to check function-wide when S is a function or a class.
     /**
      * Returns a stateful value, and a function to update it.
      *
@@ -1936,13 +1936,13 @@ declare namespace React {
     function useState<S extends StateFunctionOrClass>(
         initialState: SetStateInitializer<S>,
     ): [S, Dispatch<SetStateFunctionAction<S>>];
+    // convenience overload when first argument is omitted.
     /**
      * Returns a stateful value, and a function to update it.
      *
      * @version 16.8.0
      * @see {@link https://react.dev/reference/react/useState}
      */
-    // convenience overload when first argument is omitted, but the generic is used.
     function useState<S = undefined>(): [
         S | undefined,
         Dispatch<SetStateWithUndefinedAction<S>>,

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -251,8 +251,14 @@ function useEveryHook(ref: React.Ref<{ id: number }> | undefined): () => boolean
 
     // useState convenience overload
     // default to undefined only (not that useful, but type-safe -- no {} or unknown!)
-    // $ExpectType undefined
-    React.useState()[0];
+    {
+        const [state, setState] = React.useState();
+        // $ExpectType undefined
+        state;
+        // Allow void calls when storing undefined
+        setState();
+    }
+
     // $ExpectType number | undefined
     React.useState<number>()[0];
     // default overload
@@ -270,18 +276,31 @@ function useEveryHook(ref: React.Ref<{ id: number }> | undefined): () => boolean
     // make sure setState accepts a function
     setToggle(r => !r);
 
-    // Undesired
-    // Should not type-check since `number` will be `number` at runtime but `() => number` in the type-checker
-    const [number, setNumber] = React.useState<() => number>(() => 0);
-    // Should be `number`
-    // $EpectType () => number
+    // $ExpectType number
+    React.useState(() => 0)[0];
+    // $ExpectType string
+    React.useState(() => "")[0];
+
+    React.useState();
+
+    // make sure optional functions signatures works as expected
+    const [number, setNumber] = React.useState<() => number>();
+    // $ExpectType (() => number) | undefined
     number;
+    setNumber();
+    // When storing a function, don't allow direct input to update the state
+    // @ts-expect-error
+    setNumber(() => 0);
+    setNumber(() => () => 0);
+    // When storing a function, don't allow direct input to initialize the state
+    // @ts-expect-error
+    React.useState<() => number>(() => 0);
 
     const [numFunc, setNumFunc] = React.useState<() => number>(() => () => 0);
     // $ExpectType () => number
     numFunc;
-    // Undesired
-    // Should not typecheck since that would update the state to `number` when the type-checker would still consider the state to be `() => number`
+    // When storing a function, don't allow direct input to update the state
+    // @ts-expect-error
     setNumFunc(() => 42);
     // this is the correct way to set a function in state
     setNumFunc(() => () => 42);
@@ -296,20 +315,33 @@ function useEveryHook(ref: React.Ref<{ id: number }> | undefined): () => boolean
     // $ExpectType () => number
     React.useState(() => () => 0)[0];
 
-    // Undesired
     // Classes should only be accepted as a return value of state initializer/updater functions not direct input.
     // React would call the constructor causing a TypeError.
+    // @ts-expect-error
     React.useState(class {});
     // This is the correct way to store classes in state.
     // $ExpectType typeof A
     React.useState(() => class A {})[0];
 
     const [_, setClass] = React.useState(() => class {});
-    // Undesired
     // Classes should only be accepted as a return value of state initializer/updater functions not direct input.
     // React would call the constructor causing a TypeError,
+    // @ts-expect-error
     setClass(class {});
     setClass(() => class {});
+
+    {
+        class A {}
+
+        const [_, setClass] = React.useState<typeof A>();
+
+        // Classes should only be accepted as a return value of state initializer/updater functions not direct input.
+        // React would call the constructor causing a TypeError,
+        // @ts-expect-error
+        setClass(class {});
+        setClass(() => class {});
+        setClass();
+    }
 
     // useReducer convenience overload
 

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -343,6 +343,10 @@ function useEveryHook(ref: React.Ref<{ id: number }> | undefined): () => boolean
         setClass();
     }
 
+    // Should allow generic any
+    // $ExpectType any
+    React.useState<any>()[0];
+
     // useReducer convenience overload
 
     return React.useCallback(() => didLayout.current, []);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react.dev/reference/react/useState#im-trying-to-set-state-to-a-function-but-it-gets-called-instead
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---
I open a discussion about this here: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/70228. There have been some PRs to address this, and if this can't solve the issue, at least I would like to know what you think about the `void` overload to `undefined` hooks to allow void setState calls. As I mentioned, instead of having conditional type aliases, I created several signature overloads to discriminate when the hook is storing a function (or an undefined value, as was my original intention). I tried with conditional type aliases, but I've found that the signature overloads are more reliable. 

I updated the tests covering the undesired behavior and created more to cover other cases that I considered useful.

Let me know if there is anything else I can do to help. 

Thanks!