### PR TITLE
[node] Update typings to v22.4.0

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -103,6 +103,84 @@ declare global {
         };
     // #endregion borrowed
 
+    // #region Storage
+    /**
+     * This Web Storage API interface provides access to a particular domain's session or local storage. It allows, for example, the addition, modification, or deletion of stored data items.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage)
+     */
+    interface Storage {
+        /**
+         * Returns the number of key/value pairs.
+         *
+         * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/length)
+         */
+        readonly length: number;
+        /**
+         * Removes all key/value pairs, if there are any.
+         *
+         * Dispatches a storage event on Window objects holding an equivalent Storage object.
+         *
+         * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/clear)
+         */
+        clear(): void;
+        /**
+         * Returns the current value associated with the given key, or null if the given key does not exist.
+         *
+         * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/getItem)
+         */
+        getItem(key: string): string | null;
+        /**
+         * Returns the name of the nth key, or null if n is greater than or equal to the number of key/value pairs.
+         *
+         * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/key)
+         */
+        key(index: number): string | null;
+        /**
+         * Removes the key/value pair with the given key, if a key/value pair with the given key exists.
+         *
+         * Dispatches a storage event on Window objects holding an equivalent Storage object.
+         *
+         * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/removeItem)
+         */
+        removeItem(key: string): void;
+        /**
+         * Sets the value of the pair identified by key to value, creating a new key/value pair if none existed for key previously.
+         *
+         * Throws a "QuotaExceededError" DOMException exception if the new value couldn't be set. (Setting could fail if, e.g., the user has disabled storage for the site, or if the quota has been exceeded.)
+         *
+         * Dispatches a storage event on Window objects holding an equivalent Storage object.
+         *
+         * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/setItem)
+         */
+        setItem(key: string, value: string): void;
+    }
+
+    var Storage: typeof globalThis extends { onmessage: any; Storage: infer T } ? T
+        : {
+            prototype: Storage;
+            new(): Storage;
+        };
+
+    /**
+     * A browser-compatible implementation of [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage).
+     * Data is stored unencrypted in the file specified by the `--localstorage-file` CLI flag.
+     * Any modification of this data outside of the Web Storage API is not supported.
+     * Enable this API with the `--experimental-webstorage` CLI flag.
+     * @since v22.4.0
+     */
+    var localStorage: Storage;
+
+    /**
+     * A browser-compatible implementation of [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage).
+     * Data is stored in memory, with a storage quota of 10 MB.
+     * Any modification of this data outside of the Web Storage API is not supported.
+     * Enable this API with the `--experimental-webstorage` CLI flag.
+     * @since v22.4.0
+     */
+    var sessionStorage: Storage;
+    // #endregion Storage
+
     // #region Disposable
     interface SymbolConstructor {
         /**

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "22.3.9999",
+    "version": "22.4.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [
@@ -9,7 +9,7 @@
     ],
     "tsconfigs": ["tsconfig.dom.json", "tsconfig.non-dom.json"],
     "dependencies": {
-        "undici-types": "~6.18.2"
+        "undici-types": "~6.19.2"
     },
     "devDependencies": {
         "@types/node": "workspace:."

--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -337,6 +337,58 @@ access("file/that/does/not/exist", (err) => {
 }
 
 {
+    // args are passed `type: "boolean"` and allow negative options
+    const result = util.parseArgs({
+        args: ["--no-alpha"],
+        options: {
+            alpha: { type: "boolean" },
+        },
+        allowNegative: true,
+    });
+    // $ExpectType boolean | undefined
+    result.values.alpha; // false
+}
+
+{
+    // args are passed `default: "true"` and allow negative options
+    const result = util.parseArgs({
+        args: ["--no-alpha"],
+        options: {
+            alpha: { type: "boolean", default: true },
+        },
+        allowNegative: true,
+    });
+    // $ExpectType boolean | undefined
+    result.values.alpha; // false
+}
+
+{
+    // allow negative options and multiple as true
+    const result = util.parseArgs({
+        args: ["--no-alpha", "--alpha", "--no-alpha"],
+        options: {
+            alpha: { type: "boolean", multiple: true },
+        },
+        allowNegative: true,
+    });
+    // $ExpectType boolean[] | undefined
+    result.values.alpha; // [false, true, false]
+}
+
+{
+    // allow negative options and passed multiple arguments
+    const result = util.parseArgs({
+        args: ["--no-alpha", "--alpha"],
+        options: {
+            alpha: { type: "boolean" },
+        },
+        allowNegative: true,
+    });
+    // $ExpectType boolean | undefined
+    result.values.alpha; // true
+}
+
+{
     const controller: AbortController = util.transferableAbortController();
     const signal: AbortSignal = util.transferableAbortSignal(controller.signal);
     util.aborted(signal, {}).then(() => {});

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -843,6 +843,7 @@ declare module "tls" {
         ciphers?: string | undefined;
         /**
          * Name of an OpenSSL engine which can provide the client certificate.
+         * @deprecated
          */
         clientCertEngine?: string | undefined;
         /**
@@ -885,12 +886,14 @@ declare module "tls" {
         /**
          * Name of an OpenSSL engine to get private key from. Should be used
          * together with privateKeyIdentifier.
+         * @deprecated
          */
         privateKeyEngine?: string | undefined;
         /**
          * Identifier of a private key managed by an OpenSSL engine. Should be
          * used together with privateKeyEngine. Should not be set together with
          * key, because both options define a private key in different ways.
+         * @deprecated
          */
         privateKeyIdentifier?: string | undefined;
         /**

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -1481,6 +1481,12 @@ declare module "util" {
          */
         allowPositionals?: boolean | undefined;
         /**
+         * If `true`, allows explicitly setting boolean options to `false` by prefixing the option name with `--no-`.
+         * @default false
+         * @since v22.4.0
+         */
+        allowNegative?: boolean | undefined;
+        /**
          * Return the parsed tokens. This is useful for extending the built-in behavior,
          * from adding additional checks through to reprocessing the tokens in different ways.
          * @default false


### PR DESCRIPTION
https://github.com/nodejs/node/releases/tag/v22.4.0

- deps,lib,src: add experimental web storage
- doc: doc-only deprecate OpenSSL engine-based APIs
- util: support --no- for argument with boolean type for parseArgs

---------------

Fix https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/70056