### PR TITLE
[node] Include `sea` tests

### DIFF
--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -26,6 +26,7 @@ import "./test/process";
 import "./test/querystring";
 import "./test/readline";
 import "./test/repl";
+import "./test/sea";
 import "./test/stream";
 import "./test/string_decoder";
 import "./test/test";

--- a/types/node/v20/node-tests.ts
+++ b/types/node/v20/node-tests.ts
@@ -26,6 +26,7 @@ import "./test/process";
 import "./test/querystring";
 import "./test/readline";
 import "./test/repl";
+import "./test/sea";
 import "./test/stream";
 import "./test/string_decoder";
 import "./test/test";


### PR DESCRIPTION
When the `sea` module definitions were added, the accompanying test suite wasn't added to `node-tests.ts`.