### PR TITLE
[@types/jiff] Correct the return type for patchInPlace

### DIFF
--- a/types/jiff/index.d.ts
+++ b/types/jiff/index.d.ts
@@ -57,7 +57,7 @@ declare var jiff: {
      *  x is a value, the new value will be returned.
      */
     patch(changes: jiff.JSONPatch, x: jiff.JSONValue, options?: jiff.PatchOptions): jiff.JSONValue;
-    patchInPlace(patch: jiff.JSONPatch, a: jiff.JSONValue, options?: jiff.PatchOptions): void;
+    patchInPlace(patch: jiff.JSONPatch, a: jiff.JSONValue, options?: jiff.PatchOptions): jiff.JSONValue;
 };
 
 export = jiff;

--- a/types/jiff/jiff-tests.ts
+++ b/types/jiff/jiff-tests.ts
@@ -7,22 +7,22 @@ const patch: jiff.JSONPatch = jiff.diff(a, b);
 
 const c = jiff.patch(patch, a);
 
-jiff.patchInPlace(patch, a);
+const d = jiff.patchInPlace(patch, a);
 
-const d: jiff.JSONObject = {
+const e: jiff.JSONObject = {
     list: [
         { id: "1", value: "original" },
         { id: "2", value: "original2" },
     ],
 };
-const e: jiff.JSONPatch = [{ op: "replace", path: "/list/2/value", value: "replaced", context: "2" }];
-const f = jiff.patch(e, d, {
+const f: jiff.JSONPatch = [{ op: "replace", path: "/list/2/value", value: "replaced", context: "2" }];
+const g = jiff.patch(f, e, {
     findContext(index, array, context) {
         return array.findIndex((value, index, array) => value["id"] === context);
     },
 });
 
-jiff.patchInPlace(e, d, {
+const h = jiff.patchInPlace(f, e, {
     findContext(index, array, context) {
         return array.findIndex((value, index, array) => value["id"] === context);
     },


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cujojs/jiff/blob/880de3bfc2c496d42cac8c609858874059515b85/lib/jsonPatch.js#L55
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

patchInPlace method while it does mutate the input, it also returns the new value, this is an important distinction as when replacing the root with another value e.g. `{op: "replace", path: "", value: null}`, we are actually not returning the original reference but instead a new reference which holds the value null. This behaviour is defined in the source method, but was not reflected in the type definitions
