### PR TITLE
[node] test/reporters: correct exported reporter class types

### DIFF
--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -1833,31 +1833,47 @@ declare module "node:test/reporters" {
         | { type: "test:watch:drained"; data: undefined };
     type TestEventGenerator = AsyncGenerator<TestEvent, void>;
 
+    interface ReporterConstructorWrapper<T extends new (...args: any[]) => Transform> {
+        new (...args: ConstructorParameters<T>): InstanceType<T>;
+        (...args: ConstructorParameters<T>): InstanceType<T>;
+    }
+
     /**
      * The `dot` reporter outputs the test results in a compact format,
      * where each passing test is represented by a `.`,
      * and each failing test is represented by a `X`.
+     * @since v20.0.0
      */
     function dot(source: TestEventGenerator): AsyncGenerator<"\n" | "." | "X", void>;
     /**
      * The `tap` reporter outputs the test results in the [TAP](https://testanything.org/) format.
+     * @since v20.0.0
      */
     function tap(source: TestEventGenerator): AsyncGenerator<string, void>;
-    /**
-     * The `spec` reporter outputs the test results in a human-readable format.
-     */
-    class Spec extends Transform {
+    class SpecReporter extends Transform {
         constructor();
     }
     /**
+     * The `spec` reporter outputs the test results in a human-readable format.
+     * @since v20.0.0
+     */
+    const spec: ReporterConstructorWrapper<typeof SpecReporter>;
+    /**
      * The `junit` reporter outputs test results in a jUnit XML format.
+     * @since v21.0.0
      */
     function junit(source: TestEventGenerator): AsyncGenerator<string, void>;
-    /**
-     * The `lcov` reporter outputs test coverage when used with the [`--experimental-test-coverage`](https://nodejs.org/docs/latest-v22.x/api/cli.html#--experimental-test-coverage) flag.
-     */
-    class Lcov extends Transform {
-        constructor(opts?: TransformOptions);
+    class LcovReporter extends Transform {
+        constructor(opts?: Omit<TransformOptions, "writableObjectMode">);
     }
-    export { dot, junit, Lcov as lcov, Spec as spec, tap, TestEvent };
+    /**
+     * The `lcov` reporter outputs test coverage when used with the
+     * [`--experimental-test-coverage`](https://nodejs.org/docs/latest-v22.x/api/cli.html#--experimental-test-coverage) flag.
+     * @since v22.0.0
+     */
+    // TODO: change the export to a wrapper function once node@0db38f0 is merged (breaking change)
+    // const lcov: ReporterConstructorWrapper<typeof LcovReporter>;
+    const lcov: LcovReporter;
+
+    export { dot, junit, lcov, spec, tap, TestEvent };
 }

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -1833,8 +1833,8 @@ declare module "node:test/reporters" {
         | { type: "test:watch:drained"; data: undefined };
     type TestEventGenerator = AsyncGenerator<TestEvent, void>;
 
-    interface ReporterConstructorWrapper<T extends new (...args: any[]) => Transform> {
-        new (...args: ConstructorParameters<T>): InstanceType<T>;
+    interface ReporterConstructorWrapper<T extends new(...args: any[]) => Transform> {
+        new(...args: ConstructorParameters<T>): InstanceType<T>;
         (...args: ConstructorParameters<T>): InstanceType<T>;
     }
 

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -776,13 +776,17 @@ dot("" as any);
 tap();
 // $ExpectType AsyncGenerator<string, void, unknown> || AsyncGenerator<string, void, any>
 tap("" as any);
-// $ExpectType Spec
+// $ExpectType SpecReporter
 new spec();
+// $ExpectType SpecReporter
+spec();
 // @ts-expect-error
 junit();
 // $ExpectType AsyncGenerator<string, void, unknown> || AsyncGenerator<string, void, any>
 junit("" as any);
-// $ExpectType Lcov
+// @ts-expect-error (TODO: change to expect type LcovReporter once lcov is a wrapper function)
+lcov();
+// @ts-expect-error (TODO: change to expect type LcovReporter once lcov is a wrapper function)
 new lcov();
 
 describe("Mock Timers Test Suite", () => {

--- a/types/node/v20/test.d.ts
+++ b/types/node/v20/test.d.ts
@@ -1706,27 +1706,35 @@ declare module "node:test/reporters" {
      * The `dot` reporter outputs the test results in a compact format,
      * where each passing test is represented by a `.`,
      * and each failing test is represented by a `X`.
+     * @since v20.0.0
      */
     function dot(source: TestEventGenerator): AsyncGenerator<"\n" | "." | "X", void>;
     /**
      * The `tap` reporter outputs the test results in the [TAP](https://testanything.org/) format.
+     * @since v20.0.0
      */
     function tap(source: TestEventGenerator): AsyncGenerator<string, void>;
     /**
      * The `spec` reporter outputs the test results in a human-readable format.
+     * @since v20.0.0
      */
-    class Spec extends Transform {
+    class SpecReporter extends Transform {
         constructor();
     }
     /**
      * The `junit` reporter outputs test results in a jUnit XML format.
+     * @since v21.0.0
      */
     function junit(source: TestEventGenerator): AsyncGenerator<string, void>;
-    /**
-     * The `lcov` reporter outputs test coverage when used with the [`--experimental-test-coverage`](https://nodejs.org/docs/latest-v20.x/api/cli.html#--experimental-test-coverage) flag.
-     */
-    class Lcov extends Transform {
-        constructor(opts?: TransformOptions);
+    class LcovReporter extends Transform {
+        constructor(opts?: Omit<TransformOptions, "writableObjectMode">);
     }
-    export { dot, junit, Lcov as lcov, Spec as spec, tap, TestEvent };
+    /**
+     * The `lcov` reporter outputs test coverage when used with the
+     * [`--experimental-test-coverage`](https://nodejs.org/docs/latest-v20.x/api/cli.html#--experimental-test-coverage) flag.
+     * @since v22.0.0
+     */
+    const lcov: LcovReporter;
+
+    export { dot, junit, lcov, SpecReporter as spec, tap, TestEvent };
 }

--- a/types/node/v20/test/test.ts
+++ b/types/node/v20/test/test.ts
@@ -772,14 +772,16 @@ dot("" as any);
 tap();
 // $ExpectType AsyncGenerator<string, void, unknown> || AsyncGenerator<string, void, any>
 tap("" as any);
-// $ExpectType Spec
+// $ExpectType SpecReporter
 new spec();
+// @ts-expect-error
+spec();
 // @ts-expect-error
 junit();
 // $ExpectType AsyncGenerator<string, void, unknown> || AsyncGenerator<string, void, any>
 junit("" as any);
-// $ExpectType Lcov
-new lcov();
+// $ExpectType LcovReporter
+lcov;
 
 describe("Mock Timers Test Suite", () => {
     it((t) => {


### PR DESCRIPTION
Fixes some type annoyances with exported reporter classes in `test/reporters`.

- In v20, the `spec` export was simply the `SpecReporter` class itself, which then needed to be constructed with `new` before use.
- From v21, the `spec` export was changed to be a wrapper function, which could be called with or without `new`.
- v22 added the `lcov` export, which was originally (and is currently) an _instance_ of the `LcovReporter` class.
  - This is going to be changed to export a wrapper function similar to `spec` (nodejs/node@0db38f0f9994e519f6a4abb60bd3170ca0eae5cd), but this hasn't landed in a release yet.

This PR fixes the v20 and v22 package definitions accordingly. (`lcov` was already included in the v20 package prior to the new version branch, so I have updated it there for completeness.)

Resolves #69289.

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/blob/main/lib/test/reporters.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
