### PR TITLE
Fix incomplete argument type decoration for 'express-ws'

### DIFF
--- a/types/express-ws/index.d.ts
+++ b/types/express-ws/index.d.ts
@@ -34,7 +34,7 @@ declare namespace expressWs {
         getWss(): ws.Server;
     }
 
-    type WebsocketRequestHandler = (ws: ws, req: express.Request, next: express.NextFunction) => void;
+    type WebsocketRequestHandler = (ws: ws.WebSocket, req: express.Request, next: express.NextFunction) => void;
     type WebsocketMethod<T> = (route: core.PathParams, ...middlewares: WebsocketRequestHandler[]) => T;
 
     interface WithWebsocketMethod {


### PR DESCRIPTION
Based on context, ws.WebSocket should be here instead, since it should be possible to call ".on" on the ws (a method of ws.WebSocket)

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [see any examples here...](https://www.npmjs.com/package/express-ws)
