### PR TITLE
[@types/encoding-japanese] Fix convert return type

### DIFF
--- a/types/encoding-japanese/index.d.ts
+++ b/types/encoding-japanese/index.d.ts
@@ -64,7 +64,7 @@ export function detect(data: IntArrayType | string, encodings?: Encoding | Encod
 export function convert(data: IntArrayType, to: Encoding, from?: Encoding): number[];
 export function convert(data: string, to: Encoding, from?: Encoding): string;
 export function convert(data: IntArrayType | string, options: ConvertStringOptions): string;
-export function convert(data: IntArrayType | string, options: ConvertArrayBufferOptions): ArrayBuffer;
+export function convert(data: IntArrayType | string, options: ConvertArrayBufferOptions): Uint16Array;
 export function convert(data: IntArrayType | string, options: ConvertArrayOptions): number[];
 export function convert(data: string, options: ConvertUnknownOptions): string;
 export function convert(data: IntArrayType, options: ConvertUnknownOptions): number[];

--- a/types/encoding-japanese/test/encoding-japanese-tests.cjs.ts
+++ b/types/encoding-japanese/test/encoding-japanese-tests.cjs.ts
@@ -116,7 +116,7 @@ const utf16Array3 = Encoding.convert(utf8Array, {
     type: "arraybuffer",
     bom: true, // With BOM
 });
-utf16Array3; // $ExpectType ArrayBuffer
+utf16Array3; // $ExpectType Uint16Array
 
 const utf16Array4 = Encoding.convert(utf8Array, {
     to: "UTF16", // to_encoding


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/polygonplanet/encoding.js?tab=readme-ov-file#specify-the-return-type-by-the-type-option
  > arraybuffer : Return as an ArrayBuffer (Actually returns a Uint16Array due to historical reasons).
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
