### PR TITLE
[itowns] Fix event map for View

### DIFF
--- a/types/itowns/src/Core/View.d.ts
+++ b/types/itowns/src/Core/View.d.ts
@@ -13,6 +13,23 @@ export enum VIEW_EVENTS {
     CAMERA_MOVED = "camera-moved",
 }
 
+export interface ViewEventMap {
+    "layers-initialized": {};
+    "layer-removed": { layerId: string };
+    "layer-added": { layerId: string };
+    "initialized": {};
+    "layers-order-changed": {
+        previous: { sequence: string[]; }
+        new: { sequence: string[]; }
+    };
+    "camera-moved": {
+        coord: Coordinates;
+        range: number;
+        heading: number;
+        tilt: number;
+    };
+}
+
 export interface RendererOptions {
     antialias?: boolean;
     alpha?: boolean;
@@ -34,7 +51,7 @@ export interface ViewOptions {
 export type FrameRequester = (dt: number, updateLoopRestarted: boolean, ...args: any) => void;
 
 // TODO: Define public API
-export default class View extends THREE.EventDispatcher<THREE.Event> {
+export default class View extends THREE.EventDispatcher<ViewEventMap> {
     constructor(crs: string, viewerDiv: HTMLElement, options?: ViewOptions);
 
     domElement: HTMLElement;

--- a/types/itowns/src/Core/View.d.ts
+++ b/types/itowns/src/Core/View.d.ts
@@ -19,8 +19,8 @@ export interface ViewEventMap {
     "layer-added": { layerId: string };
     "initialized": {};
     "layers-order-changed": {
-        previous: { sequence: string[]; }
-        new: { sequence: string[]; }
+        previous: { sequence: string[] };
+        new: { sequence: string[] };
     };
     "camera-moved": {
         coord: Coordinates;

--- a/types/itowns/test/SourceFileFromFormat.ts
+++ b/types/itowns/test/SourceFileFromFormat.ts
@@ -54,3 +54,8 @@ view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, () => {
     // Move the camera to visualize all data.
     view.controls?.lookAtCoordinate(sourceFromFormat.extent, false);
 });
+
+view.addEventListener(itowns.GLOBE_VIEW_EVENTS.COLOR_LAYERS_ORDER_CHANGED, (event) => {
+    event.previous.sequence; // $ExpectType string[]
+    event.new.sequence; // $ExpectType string[]
+});

--- a/types/itowns/test/SourceFileFromMethods.ts
+++ b/types/itowns/test/SourceFileFromMethods.ts
@@ -56,3 +56,8 @@ view.addEventListener(itowns.GLOBE_VIEW_EVENTS.GLOBE_INITIALIZED, () => {
     // Move the camera to visualize all data.
     view.controls?.lookAtCoordinate(sourceFromFetcherAndParser.extent, false);
 });
+
+view.addEventListener(itowns.VIEW_EVENTS.COLOR_LAYERS_ORDER_CHANGED, (event) => {
+    event.previous.sequence; // $ExpectType string[]
+    event.new.sequence; // $ExpectType string[]
+});


### PR DESCRIPTION
I'm working on [improving the typing for event listeners](https://github.com/three-types/three-ts-types/pull/1145) in `@types/three`, however currently the `View` class does not have its event map set up correctly. This PR corrects that so that we can move forward with the change in `@types/three`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/three-types/three-ts-types/pull/1145
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
