### PR TITLE
[node] Fix `http.createServer` signature

### DIFF
--- a/types/node-red__registry/node-red__registry-tests.ts
+++ b/types/node-red__registry/node-red__registry-tests.ts
@@ -1,4 +1,5 @@
 import registry = require("@node-red/registry");
+import http = require("node:http")
 
 function registryTests() {
     interface ExtendedNodeRedSettings extends registry.NodeAPISettingsWithData {
@@ -165,8 +166,8 @@ function registryTests() {
             RED.httpNode;
             // $ExpectType Express
             RED.httpAdmin;
-            // $ExpectType Server<typeof IncomingMessage, typeof ServerResponse>
-            RED.server;
+
+            const server: http.Server<typeof http.IncomingMessage, typeof http.ServerResponse> = RED.server;
 
             // $ExpectType string
             RED._("myNode.label");

--- a/types/node-red__registry/node-red__registry-tests.ts
+++ b/types/node-red__registry/node-red__registry-tests.ts
@@ -1,5 +1,5 @@
 import registry = require("@node-red/registry");
-import http = require("node:http")
+import http = require("node:http");
 
 function registryTests() {
     interface ExtendedNodeRedSettings extends registry.NodeAPISettingsWithData {

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -1557,7 +1557,7 @@ declare module "http" {
     >(requestListener?: RequestListener<Request, Response>): Server<Request, Response>;
     function createServer<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Response extends typeof ServerResponse<InstanceType<Request>> = typeof ServerResponse<InstanceType<Request>>
+        Response extends typeof ServerResponse<InstanceType<Request>> = typeof ServerResponse<InstanceType<Request>>,
     >(
         options: ServerOptions<Request, Response>,
         requestListener?: RequestListener<Request, Response>,

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -231,7 +231,7 @@ declare module "http" {
     }
     interface ServerOptions<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Response extends typeof ServerResponse = typeof ServerResponse,
+        Response extends typeof ServerResponse<InstanceType<Request>> = typeof ServerResponse<InstanceType<Request>>,
     > {
         /**
          * Specifies the `IncomingMessage` class to be used. Useful for extending the original `IncomingMessage`.
@@ -315,14 +315,14 @@ declare module "http" {
     }
     type RequestListener<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Response extends typeof ServerResponse = typeof ServerResponse,
+        Response extends typeof ServerResponse<InstanceType<Request>> = typeof ServerResponse<InstanceType<Request>>,
     > = (req: InstanceType<Request>, res: InstanceType<Response> & { req: InstanceType<Request> }) => void;
     /**
      * @since v0.1.17
      */
     class Server<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Response extends typeof ServerResponse = typeof ServerResponse,
+        Response extends typeof ServerResponse<InstanceType<Request>> = typeof ServerResponse<InstanceType<Request>>,
     > extends NetServer {
         constructor(requestListener?: RequestListener<Request, Response>);
         constructor(options: ServerOptions<Request, Response>, requestListener?: RequestListener<Request, Response>);
@@ -1553,11 +1553,11 @@ declare module "http" {
      */
     function createServer<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Response extends typeof ServerResponse = typeof ServerResponse,
+        Response extends typeof ServerResponse<InstanceType<Request>> = typeof ServerResponse<InstanceType<Request>>,
     >(requestListener?: RequestListener<Request, Response>): Server<Request, Response>;
     function createServer<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Response extends typeof ServerResponse = typeof ServerResponse,
+        Response extends typeof ServerResponse<InstanceType<Request>> = typeof ServerResponse<InstanceType<Request>>
     >(
         options: ServerOptions<Request, Response>,
         requestListener?: RequestListener<Request, Response>,

--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -1050,11 +1050,17 @@ declare module "http2" {
     }
     export interface ServerHttp2Session<
         Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<InstanceType<Http1Request>>,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
         Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
-        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<InstanceType<Http2Request>>
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
     > extends Http2Session {
-        readonly server: Http2Server<Http1Request, Http1Response, Http2Request, Http2Response> | Http2SecureServer<Http1Request, Http1Response, Http2Request, Http2Response>;
+        readonly server:
+            | Http2Server<Http1Request, Http1Response, Http2Request, Http2Response>
+            | Http2SecureServer<Http1Request, Http1Response, Http2Request, Http2Response>;
         /**
          * Submits an `ALTSVC` frame (as defined by [RFC 7838](https://tools.ietf.org/html/rfc7838)) to the connected client.
          *
@@ -1149,17 +1155,30 @@ declare module "http2" {
         ): void;
         addListener(
             event: "connect",
-            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>, socket: net.Socket | tls.TLSSocket) => void,
+            listener: (
+                session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+                socket: net.Socket | tls.TLSSocket,
+            ) => void,
         ): this;
         addListener(
             event: "stream",
             listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void,
         ): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        emit(event: "connect", session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>, socket: net.Socket | tls.TLSSocket): boolean;
+        emit(
+            event: "connect",
+            session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+            socket: net.Socket | tls.TLSSocket,
+        ): boolean;
         emit(event: "stream", stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
         emit(event: string | symbol, ...args: any[]): boolean;
-        on(event: "connect", listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>, socket: net.Socket | tls.TLSSocket) => void): this;
+        on(
+            event: "connect",
+            listener: (
+                session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+                socket: net.Socket | tls.TLSSocket,
+            ) => void,
+        ): this;
         on(
             event: "stream",
             listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void,
@@ -1167,7 +1186,10 @@ declare module "http2" {
         on(event: string | symbol, listener: (...args: any[]) => void): this;
         once(
             event: "connect",
-            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>, socket: net.Socket | tls.TLSSocket) => void,
+            listener: (
+                session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+                socket: net.Socket | tls.TLSSocket,
+            ) => void,
         ): this;
         once(
             event: "stream",
@@ -1176,7 +1198,10 @@ declare module "http2" {
         once(event: string | symbol, listener: (...args: any[]) => void): this;
         prependListener(
             event: "connect",
-            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>, socket: net.Socket | tls.TLSSocket) => void,
+            listener: (
+                session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+                socket: net.Socket | tls.TLSSocket,
+            ) => void,
         ): this;
         prependListener(
             event: "stream",
@@ -1185,7 +1210,10 @@ declare module "http2" {
         prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
         prependOnceListener(
             event: "connect",
-            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>, socket: net.Socket | tls.TLSSocket) => void,
+            listener: (
+                session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+                socket: net.Socket | tls.TLSSocket,
+            ) => void,
         ): this;
         prependOnceListener(
             event: "stream",
@@ -1220,9 +1248,13 @@ declare module "http2" {
     }
     export interface ServerSessionOptions<
         Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<InstanceType<Http1Request>>,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
         Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
-        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<InstanceType<Http2Request>>
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
     > extends SessionOptions {
         Http1IncomingMessage?: Http1Request | undefined;
         Http1ServerResponse?: Http1Response | undefined;
@@ -1232,21 +1264,33 @@ declare module "http2" {
     export interface SecureClientSessionOptions extends ClientSessionOptions, tls.ConnectionOptions {}
     export interface SecureServerSessionOptions<
         Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<InstanceType<Http1Request>>,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
         Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
-        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<InstanceType<Http2Request>>
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
     > extends ServerSessionOptions<Http1Request, Http1Response, Http2Request, Http2Response>, tls.TlsOptions {}
     export interface ServerOptions<
         Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<InstanceType<Http1Request>>,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
         Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
-        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<InstanceType<Http2Request>>
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
     > extends ServerSessionOptions<Http1Request, Http1Response, Http2Request, Http2Response> {}
     export interface SecureServerOptions<
         Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<InstanceType<Http1Request>>,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
         Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
-        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<InstanceType<Http2Request>>
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
     > extends SecureServerSessionOptions<Http1Request, Http1Response, Http2Request, Http2Response> {
         allowHTTP1?: boolean | undefined;
         origins?: string[] | undefined;
@@ -1261,9 +1305,13 @@ declare module "http2" {
     }
     export interface Http2Server<
         Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<InstanceType<Http1Request>>,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
         Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
-        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<InstanceType<Http2Request>>
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
     > extends net.Server, HTTP2ServerCommon {
         addListener(
             event: "checkContinue",
@@ -1273,7 +1321,10 @@ declare module "http2" {
             event: "request",
             listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        addListener(event: "session", listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void): this;
+        addListener(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         addListener(event: "sessionError", listener: (err: Error) => void): this;
         addListener(
             event: "stream",
@@ -1281,9 +1332,16 @@ declare module "http2" {
         ): this;
         addListener(event: "timeout", listener: () => void): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        emit(event: "checkContinue", request: InstanceType<Http2Request>, response: InstanceType<Http2Response>): boolean;
+        emit(
+            event: "checkContinue",
+            request: InstanceType<Http2Request>,
+            response: InstanceType<Http2Response>,
+        ): boolean;
         emit(event: "request", request: InstanceType<Http2Request>, response: InstanceType<Http2Response>): boolean;
-        emit(event: "session", session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>): boolean;
+        emit(
+            event: "session",
+            session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+        ): boolean;
         emit(event: "sessionError", err: Error): boolean;
         emit(event: "stream", stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
         emit(event: "timeout"): boolean;
@@ -1292,8 +1350,14 @@ declare module "http2" {
             event: "checkContinue",
             listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        on(event: "request", listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void): this;
-        on(event: "session", listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void): this;
+        on(
+            event: "request",
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
+        ): this;
+        on(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         on(event: "sessionError", listener: (err: Error) => void): this;
         on(
             event: "stream",
@@ -1305,8 +1369,14 @@ declare module "http2" {
             event: "checkContinue",
             listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        once(event: "request", listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void): this;
-        once(event: "session", listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void): this;
+        once(
+            event: "request",
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
+        ): this;
+        once(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         once(event: "sessionError", listener: (err: Error) => void): this;
         once(
             event: "stream",
@@ -1322,7 +1392,10 @@ declare module "http2" {
             event: "request",
             listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        prependListener(event: "session", listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void): this;
+        prependListener(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         prependListener(event: "sessionError", listener: (err: Error) => void): this;
         prependListener(
             event: "stream",
@@ -1338,7 +1411,10 @@ declare module "http2" {
             event: "request",
             listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        prependOnceListener(event: "session", listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void): this;
+        prependOnceListener(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         prependOnceListener(event: "sessionError", listener: (err: Error) => void): this;
         prependOnceListener(
             event: "stream",
@@ -1349,9 +1425,13 @@ declare module "http2" {
     }
     export interface Http2SecureServer<
         Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<InstanceType<Http1Request>>,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
         Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
-        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<InstanceType<Http2Request>>
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
     > extends tls.Server, HTTP2ServerCommon {
         addListener(
             event: "checkContinue",
@@ -1361,7 +1441,10 @@ declare module "http2" {
             event: "request",
             listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        addListener(event: "session", listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void): this;
+        addListener(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         addListener(event: "sessionError", listener: (err: Error) => void): this;
         addListener(
             event: "stream",
@@ -1370,9 +1453,16 @@ declare module "http2" {
         addListener(event: "timeout", listener: () => void): this;
         addListener(event: "unknownProtocol", listener: (socket: tls.TLSSocket) => void): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        emit(event: "checkContinue", request: InstanceType<Http2Request>, response: InstanceType<Http2Response>): boolean;
+        emit(
+            event: "checkContinue",
+            request: InstanceType<Http2Request>,
+            response: InstanceType<Http2Response>,
+        ): boolean;
         emit(event: "request", request: InstanceType<Http2Request>, response: InstanceType<Http2Response>): boolean;
-        emit(event: "session", session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>): boolean;
+        emit(
+            event: "session",
+            session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+        ): boolean;
         emit(event: "sessionError", err: Error): boolean;
         emit(event: "stream", stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
         emit(event: "timeout"): boolean;
@@ -1382,8 +1472,14 @@ declare module "http2" {
             event: "checkContinue",
             listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        on(event: "request", listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void): this;
-        on(event: "session", listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void): this;
+        on(
+            event: "request",
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
+        ): this;
+        on(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         on(event: "sessionError", listener: (err: Error) => void): this;
         on(
             event: "stream",
@@ -1396,8 +1492,14 @@ declare module "http2" {
             event: "checkContinue",
             listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        once(event: "request", listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void): this;
-        once(event: "session", listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void): this;
+        once(
+            event: "request",
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
+        ): this;
+        once(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         once(event: "sessionError", listener: (err: Error) => void): this;
         once(
             event: "stream",
@@ -1414,7 +1516,10 @@ declare module "http2" {
             event: "request",
             listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        prependListener(event: "session", listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void): this;
+        prependListener(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         prependListener(event: "sessionError", listener: (err: Error) => void): this;
         prependListener(
             event: "stream",
@@ -1431,7 +1536,10 @@ declare module "http2" {
             event: "request",
             listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        prependOnceListener(event: "session", listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void): this;
+        prependOnceListener(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         prependOnceListener(event: "sessionError", listener: (err: Error) => void): this;
         prependOnceListener(
             event: "stream",
@@ -2378,9 +2486,13 @@ declare module "http2" {
     ): Http2Server;
     export function createServer<
         Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<InstanceType<Http1Request>>,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
         Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
-        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<InstanceType<Http2Request>>
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
     >(
         options: ServerOptions<Http1Request, Http1Response, Http2Request, Http2Response>,
         onRequestHandler?: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
@@ -2418,9 +2530,13 @@ declare module "http2" {
     ): Http2SecureServer;
     export function createSecureServer<
         Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<InstanceType<Http1Request>>,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
         Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
-        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<InstanceType<Http2Request>>
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
     >(
         options: SecureServerOptions<Http1Request, Http1Response, Http2Request, Http2Response>,
         onRequestHandler?: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
@@ -2458,9 +2574,13 @@ declare module "http2" {
      */
     export function performServerHandshake<
         Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<InstanceType<Http1Request>>,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
         Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
-        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<InstanceType<Http2Request>>
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
     >(
         socket: stream.Duplex,
         options?: ServerOptions<Http1Request, Http1Response, Http2Request, Http2Response>,

--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -408,9 +408,9 @@ declare module "http2" {
          * });
          * ```
          *
-         * Initiates a response. When the `options.waitForTrailers` option is set, the`'wantTrailers'` event will be emitted immediately after queuing the last chunk
-         * of payload data to be sent. The `http2stream.sendTrailers()` method can then be
-         * used to sent trailing header fields to the peer.
+         * Initiates a response. When the `options.waitForTrailers` option is set, the `'wantTrailers'` event
+         * will be emitted immediately after queuing the last chunk of payload data to be sent.
+         * The `http2stream.sendTrailers()` method can then be used to send trailing header fields to the peer.
          *
          * When `options.waitForTrailers` is set, the `Http2Stream` will not automatically
          * close when the final `DATA` frame is transmitted. User code must call either `http2stream.sendTrailers()` or `http2stream.close()` to close the `Http2Stream`.
@@ -459,8 +459,8 @@ declare module "http2" {
          *
          * The optional `options.statCheck` function may be specified to give user code
          * an opportunity to set additional content headers based on the `fs.Stat` details
-         * of the given fd. If the `statCheck` function is provided, the `http2stream.respondWithFD()` method will perform an `fs.fstat()` call to
-         * collect details on the provided file descriptor.
+         * of the given fd. If the `statCheck` function is provided, the `http2stream.respondWithFD()` method will
+         * perform an `fs.fstat()` call to collect details on the provided file descriptor.
          *
          * The `offset` and `length` options may be used to limit the response to a
          * specific range subset. This can be used, for instance, to support HTTP Range
@@ -478,7 +478,8 @@ declare module "http2" {
          * header fields to the peer.
          *
          * When `options.waitForTrailers` is set, the `Http2Stream` will not automatically
-         * close when the final `DATA` frame is transmitted. User code _must_ call either `http2stream.sendTrailers()` or `http2stream.close()` to close the `Http2Stream`.
+         * close when the final `DATA` frame is transmitted. User code _must_ call either `http2stream.sendTrailers()`
+         * or `http2stream.close()` to close the `Http2Stream`.
          *
          * ```js
          * const http2 = require('node:http2');
@@ -521,9 +522,9 @@ declare module "http2" {
          * an opportunity to set additional content headers based on the `fs.Stat` details
          * of the given file:
          *
-         * If an error occurs while attempting to read the file data, the `Http2Stream` will be closed using an `RST_STREAM` frame using the standard `INTERNAL_ERROR` code. If the `onError` callback is
-         * defined, then it will be called. Otherwise
-         * the stream will be destroyed.
+         * If an error occurs while attempting to read the file data, the `Http2Stream` will be closed using an
+         * `RST_STREAM` frame using the standard `INTERNAL_ERROR` code.
+         * If the `onError` callback is defined, then it will be called. Otherwise, the stream will be destroyed.
          *
          * Example using a file path:
          *
@@ -677,7 +678,8 @@ declare module "http2" {
          */
         readonly encrypted?: boolean | undefined;
         /**
-         * A prototype-less object describing the current local settings of this `Http2Session`. The local settings are local to _this_`Http2Session` instance.
+         * A prototype-less object describing the current local settings of this `Http2Session`.
+         * The local settings are local to _this_`Http2Session` instance.
          * @since v8.4.0
          */
         readonly localSettings: Settings;
@@ -692,12 +694,14 @@ declare module "http2" {
         readonly originSet?: string[] | undefined;
         /**
          * Indicates whether the `Http2Session` is currently waiting for acknowledgment of
-         * a sent `SETTINGS` frame. Will be `true` after calling the `http2session.settings()` method. Will be `false` once all sent `SETTINGS` frames have been acknowledged.
+         * a sent `SETTINGS` frame. Will be `true` after calling the `http2session.settings()` method.
+         * Will be `false` once all sent `SETTINGS` frames have been acknowledged.
          * @since v8.4.0
          */
         readonly pendingSettingsAck: boolean;
         /**
-         * A prototype-less object describing the current remote settings of this`Http2Session`. The remote settings are set by the _connected_ HTTP/2 peer.
+         * A prototype-less object describing the current remote settings of this`Http2Session`.
+         * The remote settings are set by the _connected_ HTTP/2 peer.
          * @since v8.4.0
          */
         readonly remoteSettings: Settings;

--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -1048,8 +1048,13 @@ declare module "http2" {
     export interface AlternativeServiceOptions {
         origin: number | string | url.URL;
     }
-    export interface ServerHttp2Session extends Http2Session {
-        readonly server: Http2Server | Http2SecureServer;
+    export interface ServerHttp2Session<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<InstanceType<Http1Request>>,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<InstanceType<Http2Request>>
+    > extends Http2Session {
+        readonly server: Http2Server<Http1Request, Http1Response, Http2Request, Http2Response> | Http2SecureServer<Http1Request, Http1Response, Http2Request, Http2Response>;
         /**
          * Submits an `ALTSVC` frame (as defined by [RFC 7838](https://tools.ietf.org/html/rfc7838)) to the connected client.
          *
@@ -1144,17 +1149,17 @@ declare module "http2" {
         ): void;
         addListener(
             event: "connect",
-            listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void,
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>, socket: net.Socket | tls.TLSSocket) => void,
         ): this;
         addListener(
             event: "stream",
             listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void,
         ): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        emit(event: "connect", session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket): boolean;
+        emit(event: "connect", session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>, socket: net.Socket | tls.TLSSocket): boolean;
         emit(event: "stream", stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
         emit(event: string | symbol, ...args: any[]): boolean;
-        on(event: "connect", listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void): this;
+        on(event: "connect", listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>, socket: net.Socket | tls.TLSSocket) => void): this;
         on(
             event: "stream",
             listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void,
@@ -1162,7 +1167,7 @@ declare module "http2" {
         on(event: string | symbol, listener: (...args: any[]) => void): this;
         once(
             event: "connect",
-            listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void,
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>, socket: net.Socket | tls.TLSSocket) => void,
         ): this;
         once(
             event: "stream",
@@ -1171,7 +1176,7 @@ declare module "http2" {
         once(event: string | symbol, listener: (...args: any[]) => void): this;
         prependListener(
             event: "connect",
-            listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void,
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>, socket: net.Socket | tls.TLSSocket) => void,
         ): this;
         prependListener(
             event: "stream",
@@ -1180,7 +1185,7 @@ declare module "http2" {
         prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
         prependOnceListener(
             event: "connect",
-            listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void,
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>, socket: net.Socket | tls.TLSSocket) => void,
         ): this;
         prependOnceListener(
             event: "stream",
@@ -1213,16 +1218,36 @@ declare module "http2" {
         createConnection?: ((authority: url.URL, option: SessionOptions) => stream.Duplex) | undefined;
         protocol?: "http:" | "https:" | undefined;
     }
-    export interface ServerSessionOptions extends SessionOptions {
-        Http1IncomingMessage?: typeof IncomingMessage | undefined;
-        Http1ServerResponse?: typeof ServerResponse | undefined;
-        Http2ServerRequest?: typeof Http2ServerRequest | undefined;
-        Http2ServerResponse?: typeof Http2ServerResponse | undefined;
+    export interface ServerSessionOptions<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<InstanceType<Http1Request>>,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<InstanceType<Http2Request>>
+    > extends SessionOptions {
+        Http1IncomingMessage?: Http1Request | undefined;
+        Http1ServerResponse?: Http1Response | undefined;
+        Http2ServerRequest?: Http2Request | undefined;
+        Http2ServerResponse?: Http2Response | undefined;
     }
     export interface SecureClientSessionOptions extends ClientSessionOptions, tls.ConnectionOptions {}
-    export interface SecureServerSessionOptions extends ServerSessionOptions, tls.TlsOptions {}
-    export interface ServerOptions extends ServerSessionOptions {}
-    export interface SecureServerOptions extends SecureServerSessionOptions {
+    export interface SecureServerSessionOptions<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<InstanceType<Http1Request>>,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<InstanceType<Http2Request>>
+    > extends ServerSessionOptions<Http1Request, Http1Response, Http2Request, Http2Response>, tls.TlsOptions {}
+    export interface ServerOptions<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<InstanceType<Http1Request>>,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<InstanceType<Http2Request>>
+    > extends ServerSessionOptions<Http1Request, Http1Response, Http2Request, Http2Response> {}
+    export interface SecureServerOptions<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<InstanceType<Http1Request>>,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<InstanceType<Http2Request>>
+    > extends SecureServerSessionOptions<Http1Request, Http1Response, Http2Request, Http2Response> {
         allowHTTP1?: boolean | undefined;
         origins?: string[] | undefined;
     }
@@ -1234,16 +1259,21 @@ declare module "http2" {
          */
         updateSettings(settings: Settings): void;
     }
-    export interface Http2Server extends net.Server, HTTP2ServerCommon {
+    export interface Http2Server<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<InstanceType<Http1Request>>,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<InstanceType<Http2Request>>
+    > extends net.Server, HTTP2ServerCommon {
         addListener(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
         addListener(
             event: "request",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        addListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        addListener(event: "session", listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void): this;
         addListener(event: "sessionError", listener: (err: Error) => void): this;
         addListener(
             event: "stream",
@@ -1251,19 +1281,19 @@ declare module "http2" {
         ): this;
         addListener(event: "timeout", listener: () => void): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        emit(event: "checkContinue", request: Http2ServerRequest, response: Http2ServerResponse): boolean;
-        emit(event: "request", request: Http2ServerRequest, response: Http2ServerResponse): boolean;
-        emit(event: "session", session: ServerHttp2Session): boolean;
+        emit(event: "checkContinue", request: InstanceType<Http2Request>, response: InstanceType<Http2Response>): boolean;
+        emit(event: "request", request: InstanceType<Http2Request>, response: InstanceType<Http2Response>): boolean;
+        emit(event: "session", session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>): boolean;
         emit(event: "sessionError", err: Error): boolean;
         emit(event: "stream", stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
         emit(event: "timeout"): boolean;
         emit(event: string | symbol, ...args: any[]): boolean;
         on(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        on(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        on(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        on(event: "request", listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void): this;
+        on(event: "session", listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void): this;
         on(event: "sessionError", listener: (err: Error) => void): this;
         on(
             event: "stream",
@@ -1273,10 +1303,10 @@ declare module "http2" {
         on(event: string | symbol, listener: (...args: any[]) => void): this;
         once(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        once(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        once(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        once(event: "request", listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void): this;
+        once(event: "session", listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void): this;
         once(event: "sessionError", listener: (err: Error) => void): this;
         once(
             event: "stream",
@@ -1286,13 +1316,13 @@ declare module "http2" {
         once(event: string | symbol, listener: (...args: any[]) => void): this;
         prependListener(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
         prependListener(
             event: "request",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        prependListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        prependListener(event: "session", listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void): this;
         prependListener(event: "sessionError", listener: (err: Error) => void): this;
         prependListener(
             event: "stream",
@@ -1302,13 +1332,13 @@ declare module "http2" {
         prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
         prependOnceListener(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
         prependOnceListener(
             event: "request",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        prependOnceListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        prependOnceListener(event: "session", listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void): this;
         prependOnceListener(event: "sessionError", listener: (err: Error) => void): this;
         prependOnceListener(
             event: "stream",
@@ -1317,16 +1347,21 @@ declare module "http2" {
         prependOnceListener(event: "timeout", listener: () => void): this;
         prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
     }
-    export interface Http2SecureServer extends tls.Server, HTTP2ServerCommon {
+    export interface Http2SecureServer<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<InstanceType<Http1Request>>,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<InstanceType<Http2Request>>
+    > extends tls.Server, HTTP2ServerCommon {
         addListener(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
         addListener(
             event: "request",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        addListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        addListener(event: "session", listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void): this;
         addListener(event: "sessionError", listener: (err: Error) => void): this;
         addListener(
             event: "stream",
@@ -1335,9 +1370,9 @@ declare module "http2" {
         addListener(event: "timeout", listener: () => void): this;
         addListener(event: "unknownProtocol", listener: (socket: tls.TLSSocket) => void): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        emit(event: "checkContinue", request: Http2ServerRequest, response: Http2ServerResponse): boolean;
-        emit(event: "request", request: Http2ServerRequest, response: Http2ServerResponse): boolean;
-        emit(event: "session", session: ServerHttp2Session): boolean;
+        emit(event: "checkContinue", request: InstanceType<Http2Request>, response: InstanceType<Http2Response>): boolean;
+        emit(event: "request", request: InstanceType<Http2Request>, response: InstanceType<Http2Response>): boolean;
+        emit(event: "session", session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>): boolean;
         emit(event: "sessionError", err: Error): boolean;
         emit(event: "stream", stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
         emit(event: "timeout"): boolean;
@@ -1345,10 +1380,10 @@ declare module "http2" {
         emit(event: string | symbol, ...args: any[]): boolean;
         on(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        on(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        on(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        on(event: "request", listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void): this;
+        on(event: "session", listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void): this;
         on(event: "sessionError", listener: (err: Error) => void): this;
         on(
             event: "stream",
@@ -1359,10 +1394,10 @@ declare module "http2" {
         on(event: string | symbol, listener: (...args: any[]) => void): this;
         once(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        once(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        once(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        once(event: "request", listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void): this;
+        once(event: "session", listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void): this;
         once(event: "sessionError", listener: (err: Error) => void): this;
         once(
             event: "stream",
@@ -1373,13 +1408,13 @@ declare module "http2" {
         once(event: string | symbol, listener: (...args: any[]) => void): this;
         prependListener(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
         prependListener(
             event: "request",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        prependListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        prependListener(event: "session", listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void): this;
         prependListener(event: "sessionError", listener: (err: Error) => void): this;
         prependListener(
             event: "stream",
@@ -1390,13 +1425,13 @@ declare module "http2" {
         prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
         prependOnceListener(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
         prependOnceListener(
             event: "request",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        prependOnceListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        prependOnceListener(event: "session", listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void): this;
         prependOnceListener(event: "sessionError", listener: (err: Error) => void): this;
         prependOnceListener(
             event: "stream",
@@ -1652,7 +1687,7 @@ declare module "http2" {
      * passed as the second parameter to the `'request'` event.
      * @since v8.4.0
      */
-    export class Http2ServerResponse extends stream.Writable {
+    export class Http2ServerResponse<Request extends Http2ServerRequest = Http2ServerRequest> extends stream.Writable {
         constructor(stream: ServerHttp2Stream);
         /**
          * See `response.socket`.
@@ -1698,7 +1733,7 @@ declare module "http2" {
          * A reference to the original HTTP2 `request` object.
          * @since v15.7.0
          */
-        readonly req: Http2ServerRequest;
+        readonly req: Request;
         /**
          * Returns a `Proxy` object that acts as a `net.Socket` (or `tls.TLSSocket`) but
          * applies getters, setters, and methods based on HTTP/2 logic.
@@ -2341,10 +2376,15 @@ declare module "http2" {
     export function createServer(
         onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
     ): Http2Server;
-    export function createServer(
-        options: ServerOptions,
-        onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
-    ): Http2Server;
+    export function createServer<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<InstanceType<Http1Request>>,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<InstanceType<Http2Request>>
+    >(
+        options: ServerOptions<Http1Request, Http1Response, Http2Request, Http2Response>,
+        onRequestHandler?: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
+    ): Http2Server<Http1Request, Http1Response, Http2Request, Http2Response>;
     /**
      * Returns a `tls.Server` instance that creates and manages `Http2Session` instances.
      *
@@ -2376,10 +2416,15 @@ declare module "http2" {
     export function createSecureServer(
         onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
     ): Http2SecureServer;
-    export function createSecureServer(
-        options: SecureServerOptions,
-        onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
-    ): Http2SecureServer;
+    export function createSecureServer<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<InstanceType<Http1Request>>,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<InstanceType<Http2Request>>
+    >(
+        options: SecureServerOptions<Http1Request, Http1Response, Http2Request, Http2Response>,
+        onRequestHandler?: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
+    ): Http2SecureServer<Http1Request, Http1Response, Http2Request, Http2Response>;
     /**
      * Returns a `ClientHttp2Session` instance.
      *
@@ -2411,7 +2456,15 @@ declare module "http2" {
      * @param options Any `{@link createServer}` options can be provided.
      * @since v20.12.0
      */
-    export function performServerHandshake(socket: stream.Duplex, options?: ServerOptions): ServerHttp2Session;
+    export function performServerHandshake<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<InstanceType<Http1Request>>,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<InstanceType<Http2Request>>
+    >(
+        socket: stream.Duplex,
+        options?: ServerOptions<Http1Request, Http1Response, Http2Request, Http2Response>,
+    ): ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>;
 }
 declare module "node:http2" {
     export * from "http2";

--- a/types/node/https.d.ts
+++ b/types/node/https.d.ts
@@ -10,7 +10,9 @@ declare module "https" {
     import { URL } from "node:url";
     type ServerOptions<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<
+            InstanceType<Request>
+        >,
     > = tls.SecureContextOptions & tls.TlsOptions & http.ServerOptions<Request, Response>;
     type RequestOptions =
         & http.RequestOptions
@@ -34,7 +36,9 @@ declare module "https" {
     }
     interface Server<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<
+            InstanceType<Request>
+        >,
     > extends http.Server<Request, Response> {}
     /**
      * See `http.Server` for more information.
@@ -42,7 +46,9 @@ declare module "https" {
      */
     class Server<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<
+            InstanceType<Request>
+        >,
     > extends tls.Server {
         constructor(requestListener?: http.RequestListener<Request, Response>);
         constructor(
@@ -306,11 +312,15 @@ declare module "https" {
      */
     function createServer<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<
+            InstanceType<Request>
+        >,
     >(requestListener?: http.RequestListener<Request, Response>): Server<Request, Response>;
     function createServer<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<
+            InstanceType<Request>
+        >,
     >(
         options: ServerOptions<Request, Response>,
         requestListener?: http.RequestListener<Request, Response>,

--- a/types/node/https.d.ts
+++ b/types/node/https.d.ts
@@ -10,7 +10,7 @@ declare module "https" {
     import { URL } from "node:url";
     type ServerOptions<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse = typeof http.ServerResponse,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
     > = tls.SecureContextOptions & tls.TlsOptions & http.ServerOptions<Request, Response>;
     type RequestOptions =
         & http.RequestOptions
@@ -34,7 +34,7 @@ declare module "https" {
     }
     interface Server<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse = typeof http.ServerResponse,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
     > extends http.Server<Request, Response> {}
     /**
      * See `http.Server` for more information.
@@ -42,7 +42,7 @@ declare module "https" {
      */
     class Server<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse = typeof http.ServerResponse,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
     > extends tls.Server {
         constructor(requestListener?: http.RequestListener<Request, Response>);
         constructor(
@@ -119,25 +119,19 @@ declare module "https" {
         emit(
             event: "checkContinue",
             req: InstanceType<Request>,
-            res: InstanceType<Response> & {
-                req: InstanceType<Request>;
-            },
+            res: InstanceType<Response>,
         ): boolean;
         emit(
             event: "checkExpectation",
             req: InstanceType<Request>,
-            res: InstanceType<Response> & {
-                req: InstanceType<Request>;
-            },
+            res: InstanceType<Response>,
         ): boolean;
         emit(event: "clientError", err: Error, socket: Duplex): boolean;
         emit(event: "connect", req: InstanceType<Request>, socket: Duplex, head: Buffer): boolean;
         emit(
             event: "request",
             req: InstanceType<Request>,
-            res: InstanceType<Response> & {
-                req: InstanceType<Request>;
-            },
+            res: InstanceType<Response>,
         ): boolean;
         emit(event: "upgrade", req: InstanceType<Request>, socket: Duplex, head: Buffer): boolean;
         on(event: string, listener: (...args: any[]) => void): this;
@@ -312,11 +306,11 @@ declare module "https" {
      */
     function createServer<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse = typeof http.ServerResponse,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
     >(requestListener?: http.RequestListener<Request, Response>): Server<Request, Response>;
     function createServer<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse = typeof http.ServerResponse,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
     >(
         options: ServerOptions<Request, Response>,
         requestListener?: http.RequestListener<Request, Response>,

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -63,9 +63,13 @@ import * as url from "node:url";
     }
 
     class MyServerResponse<
-        Request extends http.IncomingMessage = http.IncomingMessage,
+        Request extends MyIncomingMessage = MyIncomingMessage,
     > extends http.ServerResponse<Request> {
         bar: typeof bar;
+
+        getFoo() {
+            return this.req.foo
+        }
     }
 
     function reqListener(req: MyIncomingMessage, res: MyServerResponse): void {}
@@ -75,6 +79,7 @@ import * as url from "node:url";
         foo = req.foo;
         bar = res.bar;
         foo = res.req.foo;
+        foo = res.getFoo();
     });
     server = new http.Server({ IncomingMessage: MyIncomingMessage, ServerResponse: MyServerResponse }, reqListener);
 

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -68,7 +68,7 @@ import * as url from "node:url";
         bar: typeof bar;
 
         getFoo() {
-            return this.req.foo
+            return this.req.foo;
         }
     }
 

--- a/types/node/test/http2.ts
+++ b/types/node/test/http2.ts
@@ -485,7 +485,7 @@ import { URL } from "node:url";
     const http2Stream: Http2Stream = {} as any;
     const duplex: Duplex = http2Stream;
 
-    performServerHandshake(duplex, serverOptions); // $ExpectType ServerHttp2Session
+    const session: ServerHttp2Session = performServerHandshake(duplex, serverOptions);
 }
 
 // constants

--- a/types/node/test/http2.ts
+++ b/types/node/test/http2.ts
@@ -421,7 +421,9 @@ import { URL } from "node:url";
         foo: number;
     }
 
-    class MyHttp2ServerResponse<Request extends Http2ServerRequest = Http2ServerRequest> extends Http2ServerResponse<Request> {
+    class MyHttp2ServerResponse<Request extends Http2ServerRequest = Http2ServerRequest>
+        extends Http2ServerResponse<Request>
+    {
         bar: string;
     }
 

--- a/types/node/test/http2.ts
+++ b/types/node/test/http2.ts
@@ -421,7 +421,7 @@ import { URL } from "node:url";
         foo: number;
     }
 
-    class MyHttp2ServerResponse extends Http2ServerResponse {
+    class MyHttp2ServerResponse<Request extends Http2ServerRequest = Http2ServerRequest> extends Http2ServerResponse<Request> {
         bar: string;
     }
 

--- a/types/node/v16/http.d.ts
+++ b/types/node/v16/http.d.ts
@@ -225,7 +225,7 @@ declare module "http" {
     }
     interface ServerOptions<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Response extends typeof ServerResponse = typeof ServerResponse,
+        Response extends typeof ServerResponse<InstanceType<Request>> = typeof ServerResponse<InstanceType<Request>>,
     > {
         IncomingMessage?: Request | undefined;
         ServerResponse?: Response | undefined;
@@ -265,14 +265,14 @@ declare module "http" {
     }
     type RequestListener<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Response extends typeof ServerResponse = typeof ServerResponse,
+        Response extends typeof ServerResponse<InstanceType<Request>> = typeof ServerResponse<InstanceType<Request>>,
     > = (req: InstanceType<Request>, res: InstanceType<Response> & { req: InstanceType<Request> }) => void;
     /**
      * @since v0.1.17
      */
     class Server<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Response extends typeof ServerResponse = typeof ServerResponse,
+        Response extends typeof ServerResponse<InstanceType<Request>> = typeof ServerResponse<InstanceType<Request>>,
     > extends NetServer {
         constructor(requestListener?: RequestListener<Request, Response>);
         constructor(options: ServerOptions<Request, Response>, requestListener?: RequestListener<Request, Response>);
@@ -1287,12 +1287,12 @@ declare module "http" {
      */
     function createServer<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Response extends typeof ServerResponse = typeof ServerResponse,
+        Response extends typeof ServerResponse<InstanceType<Request>> = typeof ServerResponse<InstanceType<Request>>,
     >(requestListener?: RequestListener<Request, Response>): Server<Request, Response>;
     function createServer<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Response extends typeof ServerResponse = typeof ServerResponse,
-    >(options: ServerOptions, requestListener?: RequestListener<Request, Response>): Server<Request, Response>;
+        Response extends typeof ServerResponse<InstanceType<Request>> = typeof ServerResponse<InstanceType<Request>>,
+    >(options: ServerOptions<Request, Response>, requestListener?: RequestListener<Request, Response>): Server<Request, Response>;
     // although RequestOptions are passed as ClientRequestArgs to ClientRequest directly,
     // create interface RequestOptions would make the naming more clear to developers
     interface RequestOptions extends ClientRequestArgs {}

--- a/types/node/v16/http.d.ts
+++ b/types/node/v16/http.d.ts
@@ -1292,7 +1292,10 @@ declare module "http" {
     function createServer<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
         Response extends typeof ServerResponse<InstanceType<Request>> = typeof ServerResponse<InstanceType<Request>>,
-    >(options: ServerOptions<Request, Response>, requestListener?: RequestListener<Request, Response>): Server<Request, Response>;
+    >(
+        options: ServerOptions<Request, Response>,
+        requestListener?: RequestListener<Request, Response>,
+    ): Server<Request, Response>;
     // although RequestOptions are passed as ClientRequestArgs to ClientRequest directly,
     // create interface RequestOptions would make the naming more clear to developers
     interface RequestOptions extends ClientRequestArgs {}

--- a/types/node/v16/http2.d.ts
+++ b/types/node/v16/http2.d.ts
@@ -1,6 +1,6 @@
 /**
- * The `http2` module provides an implementation of the [HTTP/2](https://tools.ietf.org/html/rfc7540) protocol. It
- * can be accessed using:
+ * The `http2` module provides an implementation of the [HTTP/2](https://tools.ietf.org/html/rfc7540) protocol.
+ * It can be accessed using:
  *
  * ```js
  * const http2 = require('http2');
@@ -96,7 +96,7 @@ declare module "http2" {
          */
         readonly endAfterHeaders: boolean;
         /**
-         * The numeric stream identifier of this `Http2Stream` instance. Set to `undefined`if the stream identifier has not yet been assigned.
+         * The numeric stream identifier of this `Http2Stream` instance. Set to `undefined` if the stream identifier has not yet been assigned.
          * @since v8.4.0
          */
         readonly id?: number | undefined;
@@ -109,7 +109,7 @@ declare module "http2" {
         /**
          * Set to the `RST_STREAM` `error code` reported when the `Http2Stream` is
          * destroyed after either receiving an `RST_STREAM` frame from the connected peer,
-         * calling `http2stream.close()`, or `http2stream.destroy()`. Will be`undefined` if the `Http2Stream` has not been closed.
+         * calling `http2stream.close()`, or `http2stream.destroy()`. Will be `undefined` if the `Http2Stream` has not been closed.
          * @since v8.4.0
          */
         readonly rstCode: number;
@@ -136,7 +136,7 @@ declare module "http2" {
          */
         readonly session: Http2Session | undefined;
         /**
-         * Provides miscellaneous information about the current state of the`Http2Stream`.
+         * Provides miscellaneous information about the current state of the `Http2Stream`.
          *
          * A current state of this `Http2Stream`.
          * @since v8.4.0
@@ -355,7 +355,7 @@ declare module "http2" {
         /**
          * Read-only property mapped to the `SETTINGS_ENABLE_PUSH` flag of the remote
          * client's most recent `SETTINGS` frame. Will be `true` if the remote peer
-         * accepts push streams, `false` otherwise. Settings are the same for every`Http2Stream` in the same `Http2Session`.
+         * accepts push streams, `false` otherwise. Settings are the same for every `Http2Stream` in the same `Http2Session`.
          * @since v8.4.0
          */
         readonly pushAllowed: boolean;
@@ -365,7 +365,7 @@ declare module "http2" {
          */
         additionalHeaders(headers: OutgoingHttpHeaders): void;
         /**
-         * Initiates a push stream. The callback is invoked with the new `Http2Stream`instance created for the push stream passed as the second argument, or an`Error` passed as the first argument.
+         * Initiates a push stream. The callback is invoked with the new `Http2Stream` instance created for the push stream passed as the second argument, or an `Error` passed as the first argument.
          *
          * ```js
          * const http2 = require('http2');
@@ -382,7 +382,7 @@ declare module "http2" {
          * ```
          *
          * Setting the weight of a push stream is not allowed in the `HEADERS` frame. Pass
-         * a `weight` value to `http2stream.priority` with the `silent` option set to`true` to enable server-side bandwidth balancing between concurrent streams.
+         * a `weight` value to `http2stream.priority` with the `silent` option set to `true` to enable server-side bandwidth balancing between concurrent streams.
          *
          * Calling `http2stream.pushStream()` from within a pushed stream is not permitted
          * and will throw an error.
@@ -408,13 +408,12 @@ declare module "http2" {
          * });
          * ```
          *
-         * When the `options.waitForTrailers` option is set, the `'wantTrailers'` event
-         * will be emitted immediately after queuing the last chunk of payload data to be
-         * sent. The `http2stream.sendTrailers()` method can then be used to sent trailing
-         * header fields to the peer.
+         * Initiates a response. When the `options.waitForTrailers` option is set, the `'wantTrailers'` event
+         * will be emitted immediately after queuing the last chunk of payload data to be sent.
+         * The `http2stream.sendTrailers()` method can then be used to send trailing header fields to the peer.
          *
          * When `options.waitForTrailers` is set, the `Http2Stream` will not automatically
-         * close when the final `DATA` frame is transmitted. User code must call either`http2stream.sendTrailers()` or `http2stream.close()` to close the`Http2Stream`.
+         * close when the final `DATA` frame is transmitted. User code must call either `http2stream.sendTrailers()` or `http2stream.close()` to close the `Http2Stream`.
          *
          * ```js
          * const http2 = require('http2');
@@ -451,7 +450,7 @@ declare module "http2" {
          *   const headers = {
          *     'content-length': stat.size,
          *     'last-modified': stat.mtime.toUTCString(),
-         *     'content-type': 'text/plain; charset=utf-8'
+         *     'content-type': 'text/plain; charset=utf-8',
          *   };
          *   stream.respondWithFD(fd, headers);
          *   stream.on('close', () => fs.closeSync(fd));
@@ -460,8 +459,8 @@ declare module "http2" {
          *
          * The optional `options.statCheck` function may be specified to give user code
          * an opportunity to set additional content headers based on the `fs.Stat` details
-         * of the given fd. If the `statCheck` function is provided, the`http2stream.respondWithFD()` method will perform an `fs.fstat()` call to
-         * collect details on the provided file descriptor.
+         * of the given fd. If the `statCheck` function is provided, the `http2stream.respondWithFD()` method will
+         * perform an `fs.fstat()` call to collect details on the provided file descriptor.
          *
          * The `offset` and `length` options may be used to limit the response to a
          * specific range subset. This can be used, for instance, to support HTTP Range
@@ -479,7 +478,8 @@ declare module "http2" {
          * header fields to the peer.
          *
          * When `options.waitForTrailers` is set, the `Http2Stream` will not automatically
-         * close when the final `DATA` frame is transmitted. User code _must_ call either`http2stream.sendTrailers()` or `http2stream.close()` to close the`Http2Stream`.
+         * close when the final `DATA` frame is transmitted. User code _must_ call either `http2stream.sendTrailers()`
+         * or `http2stream.close()` to close the `Http2Stream`.
          *
          * ```js
          * const http2 = require('http2');
@@ -493,7 +493,7 @@ declare module "http2" {
          *   const headers = {
          *     'content-length': stat.size,
          *     'last-modified': stat.mtime.toUTCString(),
-         *     'content-type': 'text/plain; charset=utf-8'
+         *     'content-type': 'text/plain; charset=utf-8',
          *   };
          *   stream.respondWithFD(fd, headers, { waitForTrailers: true });
          *   stream.on('wantTrailers', () => {
@@ -522,9 +522,9 @@ declare module "http2" {
          * an opportunity to set additional content headers based on the `fs.Stat` details
          * of the given file:
          *
-         * If an error occurs while attempting to read the file data, the `Http2Stream`will be closed using an `RST_STREAM` frame using the standard `INTERNAL_ERROR`code. If the `onError` callback is
-         * defined, then it will be called. Otherwise
-         * the stream will be destroyed.
+         * If an error occurs while attempting to read the file data, the `Http2Stream` will be closed using an
+         * `RST_STREAM` frame using the standard `INTERNAL_ERROR` code.
+         * If the `onError` callback is defined, then it will be called. Otherwise, the stream will be destroyed.
          *
          * Example using a file path:
          *
@@ -547,7 +547,7 @@ declare module "http2" {
          *       }
          *     } catch (err) {
          *       // Perform actual error handling.
-         *       console.log(err);
+         *       console.error(err);
          *     }
          *     stream.end();
          *   }
@@ -560,7 +560,7 @@ declare module "http2" {
          *
          * The `options.statCheck` function may also be used to cancel the send operation
          * by returning `false`. For instance, a conditional request may check the stat
-         * results to determine if the file has been modified to return an appropriate`304` response:
+         * results to determine if the file has been modified to return an appropriate `304` response:
          *
          * ```js
          * const http2 = require('http2');
@@ -648,18 +648,18 @@ declare module "http2" {
         /**
          * Value will be `undefined` if the `Http2Session` is not yet connected to a
          * socket, `h2c` if the `Http2Session` is not connected to a `TLSSocket`, or
-         * will return the value of the connected `TLSSocket`'s own `alpnProtocol`property.
+         * will return the value of the connected `TLSSocket`'s own `alpnProtocol` property.
          * @since v9.4.0
          */
         readonly alpnProtocol?: string | undefined;
         /**
-         * Will be `true` if this `Http2Session` instance has been closed, otherwise`false`.
+         * Will be `true` if this `Http2Session` instance has been closed, otherwise `false`.
          * @since v9.4.0
          */
         readonly closed: boolean;
         /**
          * Will be `true` if this `Http2Session` instance is still connecting, will be set
-         * to `false` before emitting `connect` event and/or calling the `http2.connect`callback.
+         * to `false` before emitting `connect` event and/or calling the `http2.connect` callback.
          * @since v10.0.0
          */
         readonly connecting: boolean;
@@ -678,7 +678,8 @@ declare module "http2" {
          */
         readonly encrypted?: boolean | undefined;
         /**
-         * A prototype-less object describing the current local settings of this`Http2Session`. The local settings are local to _this_`Http2Session` instance.
+         * A prototype-less object describing the current local settings of this `Http2Session`.
+         * The local settings are local to _this_`Http2Session` instance.
          * @since v8.4.0
          */
         readonly localSettings: Settings;
@@ -693,12 +694,14 @@ declare module "http2" {
         readonly originSet?: string[] | undefined;
         /**
          * Indicates whether the `Http2Session` is currently waiting for acknowledgment of
-         * a sent `SETTINGS` frame. Will be `true` after calling the`http2session.settings()` method. Will be `false` once all sent `SETTINGS`frames have been acknowledged.
+         * a sent `SETTINGS` frame. Will be `true` after calling the `http2session.settings()` method.
+         * Will be `false` once all sent `SETTINGS` frames have been acknowledged.
          * @since v8.4.0
          */
         readonly pendingSettingsAck: boolean;
         /**
-         * A prototype-less object describing the current remote settings of this`Http2Session`. The remote settings are set by the _connected_ HTTP/2 peer.
+         * A prototype-less object describing the current remote settings of this`Http2Session`.
+         * The remote settings are set by the _connected_ HTTP/2 peer.
          * @since v8.4.0
          */
         readonly remoteSettings: Settings;
@@ -723,7 +726,7 @@ declare module "http2" {
          */
         readonly state: SessionState;
         /**
-         * The `http2session.type` will be equal to`http2.constants.NGHTTP2_SESSION_SERVER` if this `Http2Session` instance is a
+         * The `http2session.type` will be equal to `http2.constants.NGHTTP2_SESSION_SERVER` if this `Http2Session` instance is a
          * server, and `http2.constants.NGHTTP2_SESSION_CLIENT` if the instance is a
          * client.
          * @since v8.4.0
@@ -740,11 +743,11 @@ declare module "http2" {
          */
         close(callback?: () => void): void;
         /**
-         * Immediately terminates the `Http2Session` and the associated `net.Socket` or`tls.TLSSocket`.
+         * Immediately terminates the `Http2Session` and the associated `net.Socket` or `tls.TLSSocket`.
          *
-         * Once destroyed, the `Http2Session` will emit the `'close'` event. If `error`is not undefined, an `'error'` event will be emitted immediately before the`'close'` event.
+         * Once destroyed, the `Http2Session` will emit the `'close'` event. If `error` is not undefined, an `'error'` event will be emitted immediately before the `'close'` event.
          *
-         * If there are any remaining open `Http2Streams` associated with the`Http2Session`, those will also be destroyed.
+         * If there are any remaining open `Http2Streams` associated with the `Http2Session`, those will also be destroyed.
          * @since v8.4.0
          * @param error An `Error` object if the `Http2Session` is being destroyed due to an error.
          * @param code The HTTP/2 error code to send in the final `GOAWAY` frame. If unspecified, and `error` is not undefined, the default is `INTERNAL_ERROR`, otherwise defaults to `NO_ERROR`.
@@ -760,9 +763,9 @@ declare module "http2" {
         goaway(code?: number, lastStreamID?: number, opaqueData?: NodeJS.ArrayBufferView): void;
         /**
          * Sends a `PING` frame to the connected HTTP/2 peer. A `callback` function must
-         * be provided. The method will return `true` if the `PING` was sent, `false`otherwise.
+         * be provided. The method will return `true` if the `PING` was sent, `false` otherwise.
          *
-         * The maximum number of outstanding (unacknowledged) pings is determined by the`maxOutstandingPings` configuration option. The default maximum is 10.
+         * The maximum number of outstanding (unacknowledged) pings is determined by the `maxOutstandingPings` configuration option. The default maximum is 10.
          *
          * If provided, the `payload` must be a `Buffer`, `TypedArray`, or `DataView` containing 8 bytes of data that will be transmitted with the `PING` and
          * returned with the ping acknowledgment.
@@ -770,7 +773,7 @@ declare module "http2" {
          * The callback will be invoked with three arguments: an error argument that will
          * be `null` if the `PING` was successfully acknowledged, a `duration` argument
          * that reports the number of milliseconds elapsed since the ping was sent and the
-         * acknowledgment was received, and a `Buffer` containing the 8-byte `PING`payload.
+         * acknowledgment was received, and a `Buffer` containing the 8-byte `PING` payload.
          *
          * ```js
          * session.ping(Buffer.from('abcdefgh'), (err, duration, payload) => {
@@ -792,7 +795,7 @@ declare module "http2" {
             callback: (err: Error | null, duration: number, payload: Buffer) => void,
         ): boolean;
         /**
-         * Calls `ref()` on this `Http2Session`instance's underlying `net.Socket`.
+         * Calls `ref()` on this `Http2Session` instance's underlying `net.Socket`.
          * @since v9.4.0
          */
         ref(): void;
@@ -812,7 +815,7 @@ declare module "http2" {
          *   session.setLocalWindowSize(expectedWindowSize);
          * });
          * ```
-         * @since v15.3.0
+         * @since v15.3.0, v14.18.0
          */
         setLocalWindowSize(windowSize: number): void;
         /**
@@ -823,9 +826,9 @@ declare module "http2" {
          */
         setTimeout(msecs: number, callback?: () => void): void;
         /**
-         * Updates the current local settings for this `Http2Session` and sends a new`SETTINGS` frame to the connected HTTP/2 peer.
+         * Updates the current local settings for this `Http2Session` and sends a new `SETTINGS` frame to the connected HTTP/2 peer.
          *
-         * Once called, the `http2session.pendingSettingsAck` property will be `true`while the session is waiting for the remote peer to acknowledge the new
+         * Once called, the `http2session.pendingSettingsAck` property will be `true` while the session is waiting for the remote peer to acknowledge the new
          * settings.
          *
          * The new settings will not become effective until the `SETTINGS` acknowledgment
@@ -918,7 +921,7 @@ declare module "http2" {
     }
     export interface ClientHttp2Session extends Http2Session {
         /**
-         * For HTTP/2 Client `Http2Session` instances only, the `http2session.request()`creates and returns an `Http2Stream` instance that can be used to send an
+         * For HTTP/2 Client `Http2Session` instances only, the `http2session.request()` creates and returns an `Http2Stream` instance that can be used to send an
          * HTTP/2 request to the connected server.
          *
          * This method is only available if `http2session.type` is equal to`http2.constants.NGHTTP2_SESSION_CLIENT`.
@@ -928,7 +931,7 @@ declare module "http2" {
          * const clientSession = http2.connect('https://localhost:1234');
          * const {
          *   HTTP2_HEADER_PATH,
-         *   HTTP2_HEADER_STATUS
+         *   HTTP2_HEADER_STATUS,
          * } = http2.constants;
          *
          * const req = clientSession.request({ [HTTP2_HEADER_PATH]: '/' });
@@ -1044,8 +1047,19 @@ declare module "http2" {
     export interface AlternativeServiceOptions {
         origin: number | string | url.URL;
     }
-    export interface ServerHttp2Session extends Http2Session {
-        readonly server: Http2Server | Http2SecureServer;
+    export interface ServerHttp2Session<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    > extends Http2Session {
+        readonly server:
+            | Http2Server<Http1Request, Http1Response, Http2Request, Http2Response>
+            | Http2SecureServer<Http1Request, Http1Response, Http2Request, Http2Response>;
         /**
          * Submits an `ALTSVC` frame (as defined by [RFC 7838](https://tools.ietf.org/html/rfc7838)) to the connected client.
          *
@@ -1104,7 +1118,7 @@ declare module "http2" {
          * ```
          *
          * When a string is passed as an `origin`, it will be parsed as a URL and the
-         * origin will be derived. For instance, the origin for the HTTP URL`'https://example.org/foo/bar'` is the ASCII string`'https://example.org'`. An error will be thrown if either the given
+         * origin will be derived. For instance, the origin for the HTTP URL `'https://example.org/foo/bar'` is the ASCII string` 'https://example.org'`. An error will be thrown if either the given
          * string
          * cannot be parsed as a URL or if a valid origin cannot be derived.
          *
@@ -1140,17 +1154,30 @@ declare module "http2" {
         ): void;
         addListener(
             event: "connect",
-            listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void,
+            listener: (
+                session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+                socket: net.Socket | tls.TLSSocket,
+            ) => void,
         ): this;
         addListener(
             event: "stream",
             listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void,
         ): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        emit(event: "connect", session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket): boolean;
+        emit(
+            event: "connect",
+            session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+            socket: net.Socket | tls.TLSSocket,
+        ): boolean;
         emit(event: "stream", stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
         emit(event: string | symbol, ...args: any[]): boolean;
-        on(event: "connect", listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void): this;
+        on(
+            event: "connect",
+            listener: (
+                session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+                socket: net.Socket | tls.TLSSocket,
+            ) => void,
+        ): this;
         on(
             event: "stream",
             listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void,
@@ -1158,7 +1185,10 @@ declare module "http2" {
         on(event: string | symbol, listener: (...args: any[]) => void): this;
         once(
             event: "connect",
-            listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void,
+            listener: (
+                session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+                socket: net.Socket | tls.TLSSocket,
+            ) => void,
         ): this;
         once(
             event: "stream",
@@ -1167,7 +1197,10 @@ declare module "http2" {
         once(event: string | symbol, listener: (...args: any[]) => void): this;
         prependListener(
             event: "connect",
-            listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void,
+            listener: (
+                session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+                socket: net.Socket | tls.TLSSocket,
+            ) => void,
         ): this;
         prependListener(
             event: "stream",
@@ -1176,7 +1209,10 @@ declare module "http2" {
         prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
         prependOnceListener(
             event: "connect",
-            listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void,
+            listener: (
+                session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+                socket: net.Socket | tls.TLSSocket,
+            ) => void,
         ): this;
         prependOnceListener(
             event: "stream",
@@ -1208,16 +1244,52 @@ declare module "http2" {
         createConnection?: ((authority: url.URL, option: SessionOptions) => stream.Duplex) | undefined;
         protocol?: "http:" | "https:" | undefined;
     }
-    export interface ServerSessionOptions extends SessionOptions {
-        Http1IncomingMessage?: typeof IncomingMessage | undefined;
-        Http1ServerResponse?: typeof ServerResponse | undefined;
-        Http2ServerRequest?: typeof Http2ServerRequest | undefined;
-        Http2ServerResponse?: typeof Http2ServerResponse | undefined;
+    export interface ServerSessionOptions<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    > extends SessionOptions {
+        Http1IncomingMessage?: Http1Request | undefined;
+        Http1ServerResponse?: Http1Response | undefined;
+        Http2ServerRequest?: Http2Request | undefined;
+        Http2ServerResponse?: Http2Response | undefined;
     }
     export interface SecureClientSessionOptions extends ClientSessionOptions, tls.ConnectionOptions {}
-    export interface SecureServerSessionOptions extends ServerSessionOptions, tls.TlsOptions {}
-    export interface ServerOptions extends ServerSessionOptions {}
-    export interface SecureServerOptions extends SecureServerSessionOptions {
+    export interface SecureServerSessionOptions<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    > extends ServerSessionOptions<Http1Request, Http1Response, Http2Request, Http2Response>, tls.TlsOptions {}
+    export interface ServerOptions<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    > extends ServerSessionOptions<Http1Request, Http1Response, Http2Request, Http2Response> {}
+    export interface SecureServerOptions<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    > extends SecureServerSessionOptions<Http1Request, Http1Response, Http2Request, Http2Response> {
         allowHTTP1?: boolean | undefined;
         origins?: string[] | undefined;
     }
@@ -1229,16 +1301,28 @@ declare module "http2" {
          */
         updateSettings(settings: Settings): void;
     }
-    export interface Http2Server extends net.Server, HTTP2ServerCommon {
+    export interface Http2Server<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    > extends net.Server, HTTP2ServerCommon {
         addListener(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
         addListener(
             event: "request",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        addListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        addListener(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         addListener(event: "sessionError", listener: (err: Error) => void): this;
         addListener(
             event: "stream",
@@ -1246,19 +1330,32 @@ declare module "http2" {
         ): this;
         addListener(event: "timeout", listener: () => void): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        emit(event: "checkContinue", request: Http2ServerRequest, response: Http2ServerResponse): boolean;
-        emit(event: "request", request: Http2ServerRequest, response: Http2ServerResponse): boolean;
-        emit(event: "session", session: ServerHttp2Session): boolean;
+        emit(
+            event: "checkContinue",
+            request: InstanceType<Http2Request>,
+            response: InstanceType<Http2Response>,
+        ): boolean;
+        emit(event: "request", request: InstanceType<Http2Request>, response: InstanceType<Http2Response>): boolean;
+        emit(
+            event: "session",
+            session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+        ): boolean;
         emit(event: "sessionError", err: Error): boolean;
         emit(event: "stream", stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
         emit(event: "timeout"): boolean;
         emit(event: string | symbol, ...args: any[]): boolean;
         on(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        on(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        on(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        on(
+            event: "request",
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
+        ): this;
+        on(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         on(event: "sessionError", listener: (err: Error) => void): this;
         on(
             event: "stream",
@@ -1268,10 +1365,16 @@ declare module "http2" {
         on(event: string | symbol, listener: (...args: any[]) => void): this;
         once(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        once(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        once(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        once(
+            event: "request",
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
+        ): this;
+        once(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         once(event: "sessionError", listener: (err: Error) => void): this;
         once(
             event: "stream",
@@ -1281,13 +1384,16 @@ declare module "http2" {
         once(event: string | symbol, listener: (...args: any[]) => void): this;
         prependListener(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
         prependListener(
             event: "request",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        prependListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        prependListener(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         prependListener(event: "sessionError", listener: (err: Error) => void): this;
         prependListener(
             event: "stream",
@@ -1297,13 +1403,16 @@ declare module "http2" {
         prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
         prependOnceListener(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
         prependOnceListener(
             event: "request",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        prependOnceListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        prependOnceListener(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         prependOnceListener(event: "sessionError", listener: (err: Error) => void): this;
         prependOnceListener(
             event: "stream",
@@ -1312,16 +1421,28 @@ declare module "http2" {
         prependOnceListener(event: "timeout", listener: () => void): this;
         prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
     }
-    export interface Http2SecureServer extends tls.Server, HTTP2ServerCommon {
+    export interface Http2SecureServer<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    > extends tls.Server, HTTP2ServerCommon {
         addListener(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
         addListener(
             event: "request",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        addListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        addListener(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         addListener(event: "sessionError", listener: (err: Error) => void): this;
         addListener(
             event: "stream",
@@ -1330,9 +1451,16 @@ declare module "http2" {
         addListener(event: "timeout", listener: () => void): this;
         addListener(event: "unknownProtocol", listener: (socket: tls.TLSSocket) => void): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        emit(event: "checkContinue", request: Http2ServerRequest, response: Http2ServerResponse): boolean;
-        emit(event: "request", request: Http2ServerRequest, response: Http2ServerResponse): boolean;
-        emit(event: "session", session: ServerHttp2Session): boolean;
+        emit(
+            event: "checkContinue",
+            request: InstanceType<Http2Request>,
+            response: InstanceType<Http2Response>,
+        ): boolean;
+        emit(event: "request", request: InstanceType<Http2Request>, response: InstanceType<Http2Response>): boolean;
+        emit(
+            event: "session",
+            session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+        ): boolean;
         emit(event: "sessionError", err: Error): boolean;
         emit(event: "stream", stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
         emit(event: "timeout"): boolean;
@@ -1340,10 +1468,16 @@ declare module "http2" {
         emit(event: string | symbol, ...args: any[]): boolean;
         on(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        on(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        on(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        on(
+            event: "request",
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
+        ): this;
+        on(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         on(event: "sessionError", listener: (err: Error) => void): this;
         on(
             event: "stream",
@@ -1354,10 +1488,16 @@ declare module "http2" {
         on(event: string | symbol, listener: (...args: any[]) => void): this;
         once(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        once(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        once(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        once(
+            event: "request",
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
+        ): this;
+        once(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         once(event: "sessionError", listener: (err: Error) => void): this;
         once(
             event: "stream",
@@ -1368,13 +1508,16 @@ declare module "http2" {
         once(event: string | symbol, listener: (...args: any[]) => void): this;
         prependListener(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
         prependListener(
             event: "request",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        prependListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        prependListener(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         prependListener(event: "sessionError", listener: (err: Error) => void): this;
         prependListener(
             event: "stream",
@@ -1385,13 +1528,16 @@ declare module "http2" {
         prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
         prependOnceListener(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
         prependOnceListener(
             event: "request",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        prependOnceListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        prependOnceListener(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         prependOnceListener(event: "sessionError", listener: (err: Error) => void): this;
         prependOnceListener(
             event: "stream",
@@ -1422,7 +1568,7 @@ declare module "http2" {
         readonly aborted: boolean;
         /**
          * The request authority pseudo header field. Because HTTP/2 allows requests
-         * to set either `:authority` or `host`, this value is derived from`req.headers[':authority']` if present. Otherwise, it is derived from`req.headers['host']`.
+         * to set either `:authority` or `host`, this value is derived from `req.headers[':authority']` if present. Otherwise, it is derived from `req.headers['host']`.
          * @since v8.4.0
          */
         readonly authority: string;
@@ -1469,9 +1615,9 @@ declare module "http2" {
         readonly headers: IncomingHttpHeaders;
         /**
          * In case of server request, the HTTP version sent by the client. In the case of
-         * client response, the HTTP version of the connected-to server. Returns`'2.0'`.
+         * client response, the HTTP version of the connected-to server. Returns `'2.0'`.
          *
-         * Also `message.httpVersionMajor` is the first integer and`message.httpVersionMinor` is the second.
+         * Also `message.httpVersionMajor` is the first integer and `message.httpVersionMinor` is the second.
          * @since v8.4.0
          */
         readonly httpVersion: string;
@@ -1526,11 +1672,11 @@ declare module "http2" {
          * `destroyed`, `readable`, and `writable` properties will be retrieved from and
          * set on `request.stream`.
          *
-         * `destroy`, `emit`, `end`, `on` and `once` methods will be called on`request.stream`.
+         * `destroy`, `emit`, `end`, `on` and `once` methods will be called on `request.stream`.
          *
          * `setTimeout` method will be called on `request.stream.session`.
          *
-         * `pause`, `read`, `resume`, and `write` will throw an error with code`ERR_HTTP2_NO_SOCKET_MANIPULATION`. See `Http2Session and Sockets` for
+         * `pause`, `read`, `resume`, and `write` will throw an error with code `ERR_HTTP2_NO_SOCKET_MANIPULATION`. See `Http2Session and Sockets` for
          * more information.
          *
          * All other interactions will be routed directly to the socket. With TLS support,
@@ -1593,7 +1739,7 @@ declare module "http2" {
          * the response object.
          *
          * If no `'timeout'` listener is added to the request, the response, or
-         * the server, then `Http2Stream` s are destroyed when they time out. If a
+         * the server, then `Http2Stream`s are destroyed when they time out. If a
          * handler is assigned to the request, the response, or the server's `'timeout'`events, timed out sockets must be handled explicitly.
          * @since v8.4.0
          */
@@ -1647,7 +1793,7 @@ declare module "http2" {
      * passed as the second parameter to the `'request'` event.
      * @since v8.4.0
      */
-    export class Http2ServerResponse extends stream.Writable {
+    export class Http2ServerResponse<Request extends Http2ServerRequest = Http2ServerRequest> extends stream.Writable {
         constructor(stream: ServerHttp2Stream);
         /**
          * See `response.socket`.
@@ -1668,10 +1814,10 @@ declare module "http2" {
          */
         readonly headersSent: boolean;
         /**
-         * A reference to the original HTTP2 request object.
+         * A reference to the original HTTP2 `request` object.
          * @since v15.7.0
          */
-        readonly req: Http2ServerRequest;
+        readonly req: Request;
         /**
          * Returns a `Proxy` object that acts as a `net.Socket` (or `tls.TLSSocket`) but
          * applies getters, setters, and methods based on HTTP/2 logic.
@@ -1679,11 +1825,11 @@ declare module "http2" {
          * `destroyed`, `readable`, and `writable` properties will be retrieved from and
          * set on `response.stream`.
          *
-         * `destroy`, `emit`, `end`, `on` and `once` methods will be called on`response.stream`.
+         * `destroy`, `emit`, `end`, `on` and `once` methods will be called on `response.stream`.
          *
          * `setTimeout` method will be called on `response.stream.session`.
          *
-         * `pause`, `read`, `resume`, and `write` will throw an error with code`ERR_HTTP2_NO_SOCKET_MANIPULATION`. See `Http2Session and Sockets` for
+         * `pause`, `read`, `resume`, and `write` will throw an error with code `ERR_HTTP2_NO_SOCKET_MANIPULATION`. See `Http2Session and Sockets` for
          * more information.
          *
          * All other interactions will be routed directly to the socket.
@@ -1787,7 +1933,7 @@ declare module "http2" {
          * header names and the values are the respective header values. All header names
          * are lowercase.
          *
-         * The object returned by the `response.getHeaders()` method _does not_prototypically inherit from the JavaScript `Object`. This means that typical`Object` methods such as `obj.toString()`,
+         * The object returned by the `response.getHeaders()` method _does not_ prototypically inherit from the JavaScript `Object`. This means that typical `Object` methods such as `obj.toString()`,
          * `obj.hasOwnProperty()`, and others
          * are not defined and _will not work_.
          *
@@ -1861,7 +2007,7 @@ declare module "http2" {
          *
          * If no `'timeout'` listener is added to the request, the response, or
          * the server, then `Http2Stream` s are destroyed when they time out. If a
-         * handler is assigned to the request, the response, or the server's `'timeout'`events, timed out sockets must be handled explicitly.
+         * handler is assigned to the request, the response, or the server's `'timeout'` events, timed out sockets must be handled explicitly.
          * @since v8.4.0
          */
         setTimeout(msecs: number, callback?: () => void): void;
@@ -1872,8 +2018,8 @@ declare module "http2" {
          * This sends a chunk of the response body. This method may
          * be called multiple times to provide successive parts of the body.
          *
-         * In the `http` module, the response body is omitted when the
-         * request is a HEAD request. Similarly, the `204` and `304` responses_must not_ include a message body.
+         * In the `node:http` module, the response body is omitted when the
+         * request is a HEAD request. Similarly, the `204` and `304` responses _must not_ include a message body.
          *
          * `chunk` can be a string or a buffer. If `chunk` is a string,
          * the second parameter specifies how to encode it into a byte stream.
@@ -1923,7 +2069,7 @@ declare module "http2" {
          * `Content-Length` is given in bytes not characters. The`Buffer.byteLength()` API may be used to determine the number of bytes in a
          * given encoding. On outbound messages, Node.js does not check if Content-Length
          * and the length of the body being transmitted are equal or not. However, when
-         * receiving messages, Node.js will automatically reject messages when the`Content-Length` does not match the actual payload size.
+         * receiving messages, Node.js will automatically reject messages when the `Content-Length` does not match the actual payload size.
          *
          * This method may be called at most one time on a message before `response.end()` is called.
          *
@@ -2229,7 +2375,7 @@ declare module "http2" {
      */
     export const sensitiveHeaders: symbol;
     /**
-     * Returns an object containing the default settings for an `Http2Session`instance. This method returns a new object instance every time it is called
+     * Returns an object containing the default settings for an `Http2Session` instance. This method returns a new object instance every time it is called
      * so instances returned may be safely modified for use.
      * @since v8.4.0
      */
@@ -2258,7 +2404,7 @@ declare module "http2" {
      */
     export function getUnpackedSettings(buf: Uint8Array): Settings;
     /**
-     * Returns a `net.Server` instance that creates and manages `Http2Session`instances.
+     * Returns a `net.Server` instance that creates and manages `Http2Session` instances.
      *
      * Since there are no browsers known that support [unencrypted HTTP/2](https://http2.github.io/faq/#does-http2-require-encryption), the use of {@link createSecureServer} is necessary when
      * communicating
@@ -2276,12 +2422,12 @@ declare module "http2" {
      * server.on('stream', (stream, headers) => {
      *   stream.respond({
      *     'content-type': 'text/html; charset=utf-8',
-     *     ':status': 200
+     *     ':status': 200,
      *   });
      *   stream.end('<h1>Hello World</h1>');
      * });
      *
-     * server.listen(80);
+     * server.listen(8000);
      * ```
      * @since v8.4.0
      * @param onRequestHandler See `Compatibility API`
@@ -2289,12 +2435,21 @@ declare module "http2" {
     export function createServer(
         onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
     ): Http2Server;
-    export function createServer(
-        options: ServerOptions,
-        onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
-    ): Http2Server;
+    export function createServer<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    >(
+        options: ServerOptions<Http1Request, Http1Response, Http2Request, Http2Response>,
+        onRequestHandler?: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
+    ): Http2Server<Http1Request, Http1Response, Http2Request, Http2Response>;
     /**
-     * Returns a `tls.Server` instance that creates and manages `Http2Session`instances.
+     * Returns a `tls.Server` instance that creates and manages `Http2Session` instances.
      *
      * ```js
      * const http2 = require('http2');
@@ -2302,7 +2457,7 @@ declare module "http2" {
      *
      * const options = {
      *   key: fs.readFileSync('server-key.pem'),
-     *   cert: fs.readFileSync('server-cert.pem')
+     *   cert: fs.readFileSync('server-cert.pem'),
      * };
      *
      * // Create a secure HTTP/2 server
@@ -2311,12 +2466,12 @@ declare module "http2" {
      * server.on('stream', (stream, headers) => {
      *   stream.respond({
      *     'content-type': 'text/html; charset=utf-8',
-     *     ':status': 200
+     *     ':status': 200,
      *   });
      *   stream.end('<h1>Hello World</h1>');
      * });
      *
-     * server.listen(80);
+     * server.listen(8443);
      * ```
      * @since v8.4.0
      * @param onRequestHandler See `Compatibility API`
@@ -2324,10 +2479,19 @@ declare module "http2" {
     export function createSecureServer(
         onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
     ): Http2SecureServer;
-    export function createSecureServer(
-        options: SecureServerOptions,
-        onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
-    ): Http2SecureServer;
+    export function createSecureServer<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    >(
+        options: SecureServerOptions<Http1Request, Http1Response, Http2Request, Http2Response>,
+        onRequestHandler?: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
+    ): Http2SecureServer<Http1Request, Http1Response, Http2Request, Http2Response>;
     /**
      * Returns a `ClientHttp2Session` instance.
      *

--- a/types/node/v16/https.d.ts
+++ b/types/node/v16/https.d.ts
@@ -10,7 +10,7 @@ declare module "https" {
     import { URL } from "node:url";
     type ServerOptions<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse = typeof http.ServerResponse,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
     > = tls.SecureContextOptions & tls.TlsOptions & http.ServerOptions<Request, Response>;
     type RequestOptions =
         & http.RequestOptions
@@ -34,7 +34,7 @@ declare module "https" {
     }
     interface Server<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse = typeof http.ServerResponse,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
     > extends http.Server<Request, Response> {}
     /**
      * See `http.Server` for more information.
@@ -42,7 +42,7 @@ declare module "https" {
      */
     class Server<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse = typeof http.ServerResponse,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
     > extends tls.Server {
         constructor(requestListener?: http.RequestListener<Request, Response>);
         constructor(
@@ -109,19 +109,19 @@ declare module "https" {
         emit(
             event: "checkContinue",
             req: InstanceType<Request>,
-            res: InstanceType<Response> & { req: InstanceType<Request> },
+            res: InstanceType<Response>,
         ): boolean;
         emit(
             event: "checkExpectation",
             req: InstanceType<Request>,
-            res: InstanceType<Response> & { req: InstanceType<Request> },
+            res: InstanceType<Response>,
         ): boolean;
         emit(event: "clientError", err: Error, socket: Duplex): boolean;
         emit(event: "connect", req: InstanceType<Request>, socket: Duplex, head: Buffer): boolean;
         emit(
             event: "request",
             req: InstanceType<Request>,
-            res: InstanceType<Response> & { req: InstanceType<Request> },
+            res: InstanceType<Response>,
         ): boolean;
         emit(event: "upgrade", req: InstanceType<Request>, socket: Duplex, head: Buffer): boolean;
         on(event: string, listener: (...args: any[]) => void): this;
@@ -296,11 +296,11 @@ declare module "https" {
      */
     function createServer<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse = typeof http.ServerResponse,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
     >(requestListener?: http.RequestListener<Request, Response>): Server<Request, Response>;
     function createServer<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse = typeof http.ServerResponse,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
     >(
         options: ServerOptions<Request, Response>,
         requestListener?: http.RequestListener<Request, Response>,

--- a/types/node/v16/https.d.ts
+++ b/types/node/v16/https.d.ts
@@ -10,7 +10,9 @@ declare module "https" {
     import { URL } from "node:url";
     type ServerOptions<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<
+            InstanceType<Request>
+        >,
     > = tls.SecureContextOptions & tls.TlsOptions & http.ServerOptions<Request, Response>;
     type RequestOptions =
         & http.RequestOptions
@@ -34,7 +36,9 @@ declare module "https" {
     }
     interface Server<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<
+            InstanceType<Request>
+        >,
     > extends http.Server<Request, Response> {}
     /**
      * See `http.Server` for more information.
@@ -42,7 +46,9 @@ declare module "https" {
      */
     class Server<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<
+            InstanceType<Request>
+        >,
     > extends tls.Server {
         constructor(requestListener?: http.RequestListener<Request, Response>);
         constructor(
@@ -296,11 +302,15 @@ declare module "https" {
      */
     function createServer<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<
+            InstanceType<Request>
+        >,
     >(requestListener?: http.RequestListener<Request, Response>): Server<Request, Response>;
     function createServer<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<
+            InstanceType<Request>
+        >,
     >(
         options: ServerOptions<Request, Response>,
         requestListener?: http.RequestListener<Request, Response>,

--- a/types/node/v16/test/http2.ts
+++ b/types/node/v16/test/http2.ts
@@ -404,7 +404,9 @@ import { URL } from "node:url";
         foo: number;
     }
 
-    class MyHttp2ServerResponse extends Http2ServerResponse {
+    class MyHttp2ServerResponse<Request extends Http2ServerRequest = Http2ServerRequest>
+        extends Http2ServerResponse<Request>
+    {
         bar: string;
     }
 

--- a/types/node/v18/http.d.ts
+++ b/types/node/v18/http.d.ts
@@ -231,7 +231,7 @@ declare module "http" {
     }
     interface ServerOptions<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Response extends typeof ServerResponse = typeof ServerResponse,
+        Response extends typeof ServerResponse<InstanceType<Request>> = typeof ServerResponse<InstanceType<Request>>,
     > {
         /**
          * Specifies the `IncomingMessage` class to be used. Useful for extending the original `IncomingMessage`.
@@ -316,14 +316,14 @@ declare module "http" {
     }
     type RequestListener<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Response extends typeof ServerResponse = typeof ServerResponse,
+        Response extends typeof ServerResponse<InstanceType<Request>> = typeof ServerResponse<InstanceType<Request>>,
     > = (req: InstanceType<Request>, res: InstanceType<Response> & { req: InstanceType<Request> }) => void;
     /**
      * @since v0.1.17
      */
     class Server<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Response extends typeof ServerResponse = typeof ServerResponse,
+        Response extends typeof ServerResponse<InstanceType<Request>> = typeof ServerResponse<InstanceType<Request>>,
     > extends NetServer {
         constructor(requestListener?: RequestListener<Request, Response>);
         constructor(options: ServerOptions<Request, Response>, requestListener?: RequestListener<Request, Response>);
@@ -1499,11 +1499,11 @@ declare module "http" {
      */
     function createServer<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Response extends typeof ServerResponse = typeof ServerResponse,
+        Response extends typeof ServerResponse<InstanceType<Request>> = typeof ServerResponse<InstanceType<Request>>,
     >(requestListener?: RequestListener<Request, Response>): Server<Request, Response>;
     function createServer<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Response extends typeof ServerResponse = typeof ServerResponse,
+        Response extends typeof ServerResponse<InstanceType<Request>> = typeof ServerResponse<InstanceType<Request>>,
     >(
         options: ServerOptions<Request, Response>,
         requestListener?: RequestListener<Request, Response>,

--- a/types/node/v18/http2.d.ts
+++ b/types/node/v18/http2.d.ts
@@ -1,6 +1,6 @@
 /**
- * The `http2` module provides an implementation of the [HTTP/2](https://tools.ietf.org/html/rfc7540) protocol. It
- * can be accessed using:
+ * The `http2` module provides an implementation of the [HTTP/2](https://tools.ietf.org/html/rfc7540) protocol.
+ * It can be accessed using:
  *
  * ```js
  * const http2 = require('http2');
@@ -96,7 +96,7 @@ declare module "http2" {
          */
         readonly endAfterHeaders: boolean;
         /**
-         * The numeric stream identifier of this `Http2Stream` instance. Set to `undefined`if the stream identifier has not yet been assigned.
+         * The numeric stream identifier of this `Http2Stream` instance. Set to `undefined` if the stream identifier has not yet been assigned.
          * @since v8.4.0
          */
         readonly id?: number | undefined;
@@ -109,7 +109,7 @@ declare module "http2" {
         /**
          * Set to the `RST_STREAM` `error code` reported when the `Http2Stream` is
          * destroyed after either receiving an `RST_STREAM` frame from the connected peer,
-         * calling `http2stream.close()`, or `http2stream.destroy()`. Will be`undefined` if the `Http2Stream` has not been closed.
+         * calling `http2stream.close()`, or `http2stream.destroy()`. Will be `undefined` if the `Http2Stream` has not been closed.
          * @since v8.4.0
          */
         readonly rstCode: number;
@@ -136,7 +136,7 @@ declare module "http2" {
          */
         readonly session: Http2Session | undefined;
         /**
-         * Provides miscellaneous information about the current state of the`Http2Stream`.
+         * Provides miscellaneous information about the current state of the `Http2Stream`.
          *
          * A current state of this `Http2Stream`.
          * @since v8.4.0
@@ -355,7 +355,7 @@ declare module "http2" {
         /**
          * Read-only property mapped to the `SETTINGS_ENABLE_PUSH` flag of the remote
          * client's most recent `SETTINGS` frame. Will be `true` if the remote peer
-         * accepts push streams, `false` otherwise. Settings are the same for every`Http2Stream` in the same `Http2Session`.
+         * accepts push streams, `false` otherwise. Settings are the same for every `Http2Stream` in the same `Http2Session`.
          * @since v8.4.0
          */
         readonly pushAllowed: boolean;
@@ -365,7 +365,7 @@ declare module "http2" {
          */
         additionalHeaders(headers: OutgoingHttpHeaders): void;
         /**
-         * Initiates a push stream. The callback is invoked with the new `Http2Stream`instance created for the push stream passed as the second argument, or an`Error` passed as the first argument.
+         * Initiates a push stream. The callback is invoked with the new `Http2Stream` instance created for the push stream passed as the second argument, or an `Error` passed as the first argument.
          *
          * ```js
          * const http2 = require('http2');
@@ -382,7 +382,7 @@ declare module "http2" {
          * ```
          *
          * Setting the weight of a push stream is not allowed in the `HEADERS` frame. Pass
-         * a `weight` value to `http2stream.priority` with the `silent` option set to`true` to enable server-side bandwidth balancing between concurrent streams.
+         * a `weight` value to `http2stream.priority` with the `silent` option set to `true` to enable server-side bandwidth balancing between concurrent streams.
          *
          * Calling `http2stream.pushStream()` from within a pushed stream is not permitted
          * and will throw an error.
@@ -408,13 +408,12 @@ declare module "http2" {
          * });
          * ```
          *
-         * When the `options.waitForTrailers` option is set, the `'wantTrailers'` event
-         * will be emitted immediately after queuing the last chunk of payload data to be
-         * sent. The `http2stream.sendTrailers()` method can then be used to sent trailing
-         * header fields to the peer.
+         * Initiates a response. When the `options.waitForTrailers` option is set, the `'wantTrailers'` event
+         * will be emitted immediately after queuing the last chunk of payload data to be sent.
+         * The `http2stream.sendTrailers()` method can then be used to send trailing header fields to the peer.
          *
          * When `options.waitForTrailers` is set, the `Http2Stream` will not automatically
-         * close when the final `DATA` frame is transmitted. User code must call either`http2stream.sendTrailers()` or `http2stream.close()` to close the`Http2Stream`.
+         * close when the final `DATA` frame is transmitted. User code must call either `http2stream.sendTrailers()` or `http2stream.close()` to close the `Http2Stream`.
          *
          * ```js
          * const http2 = require('http2');
@@ -451,7 +450,7 @@ declare module "http2" {
          *   const headers = {
          *     'content-length': stat.size,
          *     'last-modified': stat.mtime.toUTCString(),
-         *     'content-type': 'text/plain; charset=utf-8'
+         *     'content-type': 'text/plain; charset=utf-8',
          *   };
          *   stream.respondWithFD(fd, headers);
          *   stream.on('close', () => fs.closeSync(fd));
@@ -460,8 +459,8 @@ declare module "http2" {
          *
          * The optional `options.statCheck` function may be specified to give user code
          * an opportunity to set additional content headers based on the `fs.Stat` details
-         * of the given fd. If the `statCheck` function is provided, the`http2stream.respondWithFD()` method will perform an `fs.fstat()` call to
-         * collect details on the provided file descriptor.
+         * of the given fd. If the `statCheck` function is provided, the `http2stream.respondWithFD()` method will
+         * perform an `fs.fstat()` call to collect details on the provided file descriptor.
          *
          * The `offset` and `length` options may be used to limit the response to a
          * specific range subset. This can be used, for instance, to support HTTP Range
@@ -479,7 +478,8 @@ declare module "http2" {
          * header fields to the peer.
          *
          * When `options.waitForTrailers` is set, the `Http2Stream` will not automatically
-         * close when the final `DATA` frame is transmitted. User code _must_ call either`http2stream.sendTrailers()` or `http2stream.close()` to close the`Http2Stream`.
+         * close when the final `DATA` frame is transmitted. User code _must_ call either `http2stream.sendTrailers()`
+         * or `http2stream.close()` to close the `Http2Stream`.
          *
          * ```js
          * const http2 = require('http2');
@@ -493,7 +493,7 @@ declare module "http2" {
          *   const headers = {
          *     'content-length': stat.size,
          *     'last-modified': stat.mtime.toUTCString(),
-         *     'content-type': 'text/plain; charset=utf-8'
+         *     'content-type': 'text/plain; charset=utf-8',
          *   };
          *   stream.respondWithFD(fd, headers, { waitForTrailers: true });
          *   stream.on('wantTrailers', () => {
@@ -522,9 +522,9 @@ declare module "http2" {
          * an opportunity to set additional content headers based on the `fs.Stat` details
          * of the given file:
          *
-         * If an error occurs while attempting to read the file data, the `Http2Stream`will be closed using an `RST_STREAM` frame using the standard `INTERNAL_ERROR`code. If the `onError` callback is
-         * defined, then it will be called. Otherwise
-         * the stream will be destroyed.
+         * If an error occurs while attempting to read the file data, the `Http2Stream` will be closed using an
+         * `RST_STREAM` frame using the standard `INTERNAL_ERROR` code.
+         * If the `onError` callback is defined, then it will be called. Otherwise, the stream will be destroyed.
          *
          * Example using a file path:
          *
@@ -547,7 +547,7 @@ declare module "http2" {
          *       }
          *     } catch (err) {
          *       // Perform actual error handling.
-         *       console.log(err);
+         *       console.error(err);
          *     }
          *     stream.end();
          *   }
@@ -560,7 +560,7 @@ declare module "http2" {
          *
          * The `options.statCheck` function may also be used to cancel the send operation
          * by returning `false`. For instance, a conditional request may check the stat
-         * results to determine if the file has been modified to return an appropriate`304` response:
+         * results to determine if the file has been modified to return an appropriate `304` response:
          *
          * ```js
          * const http2 = require('http2');
@@ -648,18 +648,18 @@ declare module "http2" {
         /**
          * Value will be `undefined` if the `Http2Session` is not yet connected to a
          * socket, `h2c` if the `Http2Session` is not connected to a `TLSSocket`, or
-         * will return the value of the connected `TLSSocket`'s own `alpnProtocol`property.
+         * will return the value of the connected `TLSSocket`'s own `alpnProtocol` property.
          * @since v9.4.0
          */
         readonly alpnProtocol?: string | undefined;
         /**
-         * Will be `true` if this `Http2Session` instance has been closed, otherwise`false`.
+         * Will be `true` if this `Http2Session` instance has been closed, otherwise `false`.
          * @since v9.4.0
          */
         readonly closed: boolean;
         /**
          * Will be `true` if this `Http2Session` instance is still connecting, will be set
-         * to `false` before emitting `connect` event and/or calling the `http2.connect`callback.
+         * to `false` before emitting `connect` event and/or calling the `http2.connect` callback.
          * @since v10.0.0
          */
         readonly connecting: boolean;
@@ -678,7 +678,8 @@ declare module "http2" {
          */
         readonly encrypted?: boolean | undefined;
         /**
-         * A prototype-less object describing the current local settings of this`Http2Session`. The local settings are local to _this_`Http2Session` instance.
+         * A prototype-less object describing the current local settings of this `Http2Session`.
+         * The local settings are local to _this_`Http2Session` instance.
          * @since v8.4.0
          */
         readonly localSettings: Settings;
@@ -693,12 +694,14 @@ declare module "http2" {
         readonly originSet?: string[] | undefined;
         /**
          * Indicates whether the `Http2Session` is currently waiting for acknowledgment of
-         * a sent `SETTINGS` frame. Will be `true` after calling the`http2session.settings()` method. Will be `false` once all sent `SETTINGS`frames have been acknowledged.
+         * a sent `SETTINGS` frame. Will be `true` after calling the `http2session.settings()` method.
+         * Will be `false` once all sent `SETTINGS` frames have been acknowledged.
          * @since v8.4.0
          */
         readonly pendingSettingsAck: boolean;
         /**
-         * A prototype-less object describing the current remote settings of this`Http2Session`. The remote settings are set by the _connected_ HTTP/2 peer.
+         * A prototype-less object describing the current remote settings of this`Http2Session`.
+         * The remote settings are set by the _connected_ HTTP/2 peer.
          * @since v8.4.0
          */
         readonly remoteSettings: Settings;
@@ -723,7 +726,7 @@ declare module "http2" {
          */
         readonly state: SessionState;
         /**
-         * The `http2session.type` will be equal to`http2.constants.NGHTTP2_SESSION_SERVER` if this `Http2Session` instance is a
+         * The `http2session.type` will be equal to `http2.constants.NGHTTP2_SESSION_SERVER` if this `Http2Session` instance is a
          * server, and `http2.constants.NGHTTP2_SESSION_CLIENT` if the instance is a
          * client.
          * @since v8.4.0
@@ -740,11 +743,11 @@ declare module "http2" {
          */
         close(callback?: () => void): void;
         /**
-         * Immediately terminates the `Http2Session` and the associated `net.Socket` or`tls.TLSSocket`.
+         * Immediately terminates the `Http2Session` and the associated `net.Socket` or `tls.TLSSocket`.
          *
-         * Once destroyed, the `Http2Session` will emit the `'close'` event. If `error`is not undefined, an `'error'` event will be emitted immediately before the`'close'` event.
+         * Once destroyed, the `Http2Session` will emit the `'close'` event. If `error` is not undefined, an `'error'` event will be emitted immediately before the `'close'` event.
          *
-         * If there are any remaining open `Http2Streams` associated with the`Http2Session`, those will also be destroyed.
+         * If there are any remaining open `Http2Streams` associated with the `Http2Session`, those will also be destroyed.
          * @since v8.4.0
          * @param error An `Error` object if the `Http2Session` is being destroyed due to an error.
          * @param code The HTTP/2 error code to send in the final `GOAWAY` frame. If unspecified, and `error` is not undefined, the default is `INTERNAL_ERROR`, otherwise defaults to `NO_ERROR`.
@@ -760,9 +763,9 @@ declare module "http2" {
         goaway(code?: number, lastStreamID?: number, opaqueData?: NodeJS.ArrayBufferView): void;
         /**
          * Sends a `PING` frame to the connected HTTP/2 peer. A `callback` function must
-         * be provided. The method will return `true` if the `PING` was sent, `false`otherwise.
+         * be provided. The method will return `true` if the `PING` was sent, `false` otherwise.
          *
-         * The maximum number of outstanding (unacknowledged) pings is determined by the`maxOutstandingPings` configuration option. The default maximum is 10.
+         * The maximum number of outstanding (unacknowledged) pings is determined by the `maxOutstandingPings` configuration option. The default maximum is 10.
          *
          * If provided, the `payload` must be a `Buffer`, `TypedArray`, or `DataView` containing 8 bytes of data that will be transmitted with the `PING` and
          * returned with the ping acknowledgment.
@@ -770,7 +773,7 @@ declare module "http2" {
          * The callback will be invoked with three arguments: an error argument that will
          * be `null` if the `PING` was successfully acknowledged, a `duration` argument
          * that reports the number of milliseconds elapsed since the ping was sent and the
-         * acknowledgment was received, and a `Buffer` containing the 8-byte `PING`payload.
+         * acknowledgment was received, and a `Buffer` containing the 8-byte `PING` payload.
          *
          * ```js
          * session.ping(Buffer.from('abcdefgh'), (err, duration, payload) => {
@@ -792,7 +795,7 @@ declare module "http2" {
             callback: (err: Error | null, duration: number, payload: Buffer) => void,
         ): boolean;
         /**
-         * Calls `ref()` on this `Http2Session`instance's underlying `net.Socket`.
+         * Calls `ref()` on this `Http2Session` instance's underlying `net.Socket`.
          * @since v9.4.0
          */
         ref(): void;
@@ -823,9 +826,9 @@ declare module "http2" {
          */
         setTimeout(msecs: number, callback?: () => void): void;
         /**
-         * Updates the current local settings for this `Http2Session` and sends a new`SETTINGS` frame to the connected HTTP/2 peer.
+         * Updates the current local settings for this `Http2Session` and sends a new `SETTINGS` frame to the connected HTTP/2 peer.
          *
-         * Once called, the `http2session.pendingSettingsAck` property will be `true`while the session is waiting for the remote peer to acknowledge the new
+         * Once called, the `http2session.pendingSettingsAck` property will be `true` while the session is waiting for the remote peer to acknowledge the new
          * settings.
          *
          * The new settings will not become effective until the `SETTINGS` acknowledgment
@@ -918,22 +921,22 @@ declare module "http2" {
     }
     export interface ClientHttp2Session extends Http2Session {
         /**
-         * For HTTP/2 Client `Http2Session` instances only, the `http2session.request()`creates and returns an `Http2Stream` instance that can be used to send an
+         * For HTTP/2 Client `Http2Session` instances only, the `http2session.request()` creates and returns an `Http2Stream` instance that can be used to send an
          * HTTP/2 request to the connected server.
          *
          * When a `ClientHttp2Session` is first created, the socket may not yet be
          * connected. if `clienthttp2session.request()` is called during this time, the
          * actual request will be deferred until the socket is ready to go.
-         * If the `session` is closed before the actual request be executed, an`ERR_HTTP2_GOAWAY_SESSION` is thrown.
+         * If the `session` is closed before the actual request be executed, an `ERR_HTTP2_GOAWAY_SESSION` is thrown.
          *
-         * This method is only available if `http2session.type` is equal to`http2.constants.NGHTTP2_SESSION_CLIENT`.
+         * This method is only available if `http2session.type` is equal to `http2.constants.NGHTTP2_SESSION_CLIENT`.
          *
          * ```js
          * const http2 = require('http2');
          * const clientSession = http2.connect('https://localhost:1234');
          * const {
          *   HTTP2_HEADER_PATH,
-         *   HTTP2_HEADER_STATUS
+         *   HTTP2_HEADER_STATUS,
          * } = http2.constants;
          *
          * const req = clientSession.request({ [HTTP2_HEADER_PATH]: '/' });
@@ -1049,8 +1052,19 @@ declare module "http2" {
     export interface AlternativeServiceOptions {
         origin: number | string | url.URL;
     }
-    export interface ServerHttp2Session extends Http2Session {
-        readonly server: Http2Server | Http2SecureServer;
+    export interface ServerHttp2Session<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    > extends Http2Session {
+        readonly server:
+            | Http2Server<Http1Request, Http1Response, Http2Request, Http2Response>
+            | Http2SecureServer<Http1Request, Http1Response, Http2Request, Http2Response>;
         /**
          * Submits an `ALTSVC` frame (as defined by [RFC 7838](https://tools.ietf.org/html/rfc7838)) to the connected client.
          *
@@ -1109,7 +1123,7 @@ declare module "http2" {
          * ```
          *
          * When a string is passed as an `origin`, it will be parsed as a URL and the
-         * origin will be derived. For instance, the origin for the HTTP URL`'https://example.org/foo/bar'` is the ASCII string`'https://example.org'`. An error will be thrown if either the given
+         * origin will be derived. For instance, the origin for the HTTP URL `'https://example.org/foo/bar'` is the ASCII string` 'https://example.org'`. An error will be thrown if either the given
          * string
          * cannot be parsed as a URL or if a valid origin cannot be derived.
          *
@@ -1145,17 +1159,30 @@ declare module "http2" {
         ): void;
         addListener(
             event: "connect",
-            listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void,
+            listener: (
+                session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+                socket: net.Socket | tls.TLSSocket,
+            ) => void,
         ): this;
         addListener(
             event: "stream",
             listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void,
         ): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        emit(event: "connect", session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket): boolean;
+        emit(
+            event: "connect",
+            session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+            socket: net.Socket | tls.TLSSocket,
+        ): boolean;
         emit(event: "stream", stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
         emit(event: string | symbol, ...args: any[]): boolean;
-        on(event: "connect", listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void): this;
+        on(
+            event: "connect",
+            listener: (
+                session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+                socket: net.Socket | tls.TLSSocket,
+            ) => void,
+        ): this;
         on(
             event: "stream",
             listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void,
@@ -1163,7 +1190,10 @@ declare module "http2" {
         on(event: string | symbol, listener: (...args: any[]) => void): this;
         once(
             event: "connect",
-            listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void,
+            listener: (
+                session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+                socket: net.Socket | tls.TLSSocket,
+            ) => void,
         ): this;
         once(
             event: "stream",
@@ -1172,7 +1202,10 @@ declare module "http2" {
         once(event: string | symbol, listener: (...args: any[]) => void): this;
         prependListener(
             event: "connect",
-            listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void,
+            listener: (
+                session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+                socket: net.Socket | tls.TLSSocket,
+            ) => void,
         ): this;
         prependListener(
             event: "stream",
@@ -1181,7 +1214,10 @@ declare module "http2" {
         prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
         prependOnceListener(
             event: "connect",
-            listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void,
+            listener: (
+                session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+                socket: net.Socket | tls.TLSSocket,
+            ) => void,
         ): this;
         prependOnceListener(
             event: "stream",
@@ -1213,16 +1249,52 @@ declare module "http2" {
         createConnection?: ((authority: url.URL, option: SessionOptions) => stream.Duplex) | undefined;
         protocol?: "http:" | "https:" | undefined;
     }
-    export interface ServerSessionOptions extends SessionOptions {
-        Http1IncomingMessage?: typeof IncomingMessage | undefined;
-        Http1ServerResponse?: typeof ServerResponse | undefined;
-        Http2ServerRequest?: typeof Http2ServerRequest | undefined;
-        Http2ServerResponse?: typeof Http2ServerResponse | undefined;
+    export interface ServerSessionOptions<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    > extends SessionOptions {
+        Http1IncomingMessage?: Http1Request | undefined;
+        Http1ServerResponse?: Http1Response | undefined;
+        Http2ServerRequest?: Http2Request | undefined;
+        Http2ServerResponse?: Http2Response | undefined;
     }
     export interface SecureClientSessionOptions extends ClientSessionOptions, tls.ConnectionOptions {}
-    export interface SecureServerSessionOptions extends ServerSessionOptions, tls.TlsOptions {}
-    export interface ServerOptions extends ServerSessionOptions {}
-    export interface SecureServerOptions extends SecureServerSessionOptions {
+    export interface SecureServerSessionOptions<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    > extends ServerSessionOptions<Http1Request, Http1Response, Http2Request, Http2Response>, tls.TlsOptions {}
+    export interface ServerOptions<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    > extends ServerSessionOptions<Http1Request, Http1Response, Http2Request, Http2Response> {}
+    export interface SecureServerOptions<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    > extends SecureServerSessionOptions<Http1Request, Http1Response, Http2Request, Http2Response> {
         allowHTTP1?: boolean | undefined;
         origins?: string[] | undefined;
     }
@@ -1234,16 +1306,28 @@ declare module "http2" {
          */
         updateSettings(settings: Settings): void;
     }
-    export interface Http2Server extends net.Server, HTTP2ServerCommon {
+    export interface Http2Server<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    > extends net.Server, HTTP2ServerCommon {
         addListener(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
         addListener(
             event: "request",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        addListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        addListener(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         addListener(event: "sessionError", listener: (err: Error) => void): this;
         addListener(
             event: "stream",
@@ -1251,19 +1335,32 @@ declare module "http2" {
         ): this;
         addListener(event: "timeout", listener: () => void): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        emit(event: "checkContinue", request: Http2ServerRequest, response: Http2ServerResponse): boolean;
-        emit(event: "request", request: Http2ServerRequest, response: Http2ServerResponse): boolean;
-        emit(event: "session", session: ServerHttp2Session): boolean;
+        emit(
+            event: "checkContinue",
+            request: InstanceType<Http2Request>,
+            response: InstanceType<Http2Response>,
+        ): boolean;
+        emit(event: "request", request: InstanceType<Http2Request>, response: InstanceType<Http2Response>): boolean;
+        emit(
+            event: "session",
+            session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+        ): boolean;
         emit(event: "sessionError", err: Error): boolean;
         emit(event: "stream", stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
         emit(event: "timeout"): boolean;
         emit(event: string | symbol, ...args: any[]): boolean;
         on(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        on(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        on(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        on(
+            event: "request",
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
+        ): this;
+        on(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         on(event: "sessionError", listener: (err: Error) => void): this;
         on(
             event: "stream",
@@ -1273,10 +1370,16 @@ declare module "http2" {
         on(event: string | symbol, listener: (...args: any[]) => void): this;
         once(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        once(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        once(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        once(
+            event: "request",
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
+        ): this;
+        once(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         once(event: "sessionError", listener: (err: Error) => void): this;
         once(
             event: "stream",
@@ -1286,13 +1389,16 @@ declare module "http2" {
         once(event: string | symbol, listener: (...args: any[]) => void): this;
         prependListener(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
         prependListener(
             event: "request",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        prependListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        prependListener(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         prependListener(event: "sessionError", listener: (err: Error) => void): this;
         prependListener(
             event: "stream",
@@ -1302,13 +1408,16 @@ declare module "http2" {
         prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
         prependOnceListener(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
         prependOnceListener(
             event: "request",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        prependOnceListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        prependOnceListener(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         prependOnceListener(event: "sessionError", listener: (err: Error) => void): this;
         prependOnceListener(
             event: "stream",
@@ -1317,16 +1426,28 @@ declare module "http2" {
         prependOnceListener(event: "timeout", listener: () => void): this;
         prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
     }
-    export interface Http2SecureServer extends tls.Server, HTTP2ServerCommon {
+    export interface Http2SecureServer<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    > extends tls.Server, HTTP2ServerCommon {
         addListener(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
         addListener(
             event: "request",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        addListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        addListener(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         addListener(event: "sessionError", listener: (err: Error) => void): this;
         addListener(
             event: "stream",
@@ -1335,9 +1456,16 @@ declare module "http2" {
         addListener(event: "timeout", listener: () => void): this;
         addListener(event: "unknownProtocol", listener: (socket: tls.TLSSocket) => void): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        emit(event: "checkContinue", request: Http2ServerRequest, response: Http2ServerResponse): boolean;
-        emit(event: "request", request: Http2ServerRequest, response: Http2ServerResponse): boolean;
-        emit(event: "session", session: ServerHttp2Session): boolean;
+        emit(
+            event: "checkContinue",
+            request: InstanceType<Http2Request>,
+            response: InstanceType<Http2Response>,
+        ): boolean;
+        emit(event: "request", request: InstanceType<Http2Request>, response: InstanceType<Http2Response>): boolean;
+        emit(
+            event: "session",
+            session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+        ): boolean;
         emit(event: "sessionError", err: Error): boolean;
         emit(event: "stream", stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
         emit(event: "timeout"): boolean;
@@ -1345,10 +1473,16 @@ declare module "http2" {
         emit(event: string | symbol, ...args: any[]): boolean;
         on(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        on(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        on(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        on(
+            event: "request",
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
+        ): this;
+        on(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         on(event: "sessionError", listener: (err: Error) => void): this;
         on(
             event: "stream",
@@ -1359,10 +1493,16 @@ declare module "http2" {
         on(event: string | symbol, listener: (...args: any[]) => void): this;
         once(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        once(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        once(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        once(
+            event: "request",
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
+        ): this;
+        once(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         once(event: "sessionError", listener: (err: Error) => void): this;
         once(
             event: "stream",
@@ -1373,13 +1513,16 @@ declare module "http2" {
         once(event: string | symbol, listener: (...args: any[]) => void): this;
         prependListener(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
         prependListener(
             event: "request",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        prependListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        prependListener(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         prependListener(event: "sessionError", listener: (err: Error) => void): this;
         prependListener(
             event: "stream",
@@ -1390,13 +1533,16 @@ declare module "http2" {
         prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
         prependOnceListener(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
         prependOnceListener(
             event: "request",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        prependOnceListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        prependOnceListener(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         prependOnceListener(event: "sessionError", listener: (err: Error) => void): this;
         prependOnceListener(
             event: "stream",
@@ -1427,7 +1573,7 @@ declare module "http2" {
         readonly aborted: boolean;
         /**
          * The request authority pseudo header field. Because HTTP/2 allows requests
-         * to set either `:authority` or `host`, this value is derived from`req.headers[':authority']` if present. Otherwise, it is derived from`req.headers['host']`.
+         * to set either `:authority` or `host`, this value is derived from `req.headers[':authority']` if present. Otherwise, it is derived from `req.headers['host']`.
          * @since v8.4.0
          */
         readonly authority: string;
@@ -1474,9 +1620,9 @@ declare module "http2" {
         readonly headers: IncomingHttpHeaders;
         /**
          * In case of server request, the HTTP version sent by the client. In the case of
-         * client response, the HTTP version of the connected-to server. Returns`'2.0'`.
+         * client response, the HTTP version of the connected-to server. Returns `'2.0'`.
          *
-         * Also `message.httpVersionMajor` is the first integer and`message.httpVersionMinor` is the second.
+         * Also `message.httpVersionMajor` is the first integer and `message.httpVersionMinor` is the second.
          * @since v8.4.0
          */
         readonly httpVersion: string;
@@ -1531,11 +1677,11 @@ declare module "http2" {
          * `destroyed`, `readable`, and `writable` properties will be retrieved from and
          * set on `request.stream`.
          *
-         * `destroy`, `emit`, `end`, `on` and `once` methods will be called on`request.stream`.
+         * `destroy`, `emit`, `end`, `on` and `once` methods will be called on `request.stream`.
          *
          * `setTimeout` method will be called on `request.stream.session`.
          *
-         * `pause`, `read`, `resume`, and `write` will throw an error with code`ERR_HTTP2_NO_SOCKET_MANIPULATION`. See `Http2Session and Sockets` for
+         * `pause`, `read`, `resume`, and `write` will throw an error with code `ERR_HTTP2_NO_SOCKET_MANIPULATION`. See `Http2Session and Sockets` for
          * more information.
          *
          * All other interactions will be routed directly to the socket. With TLS support,
@@ -1598,7 +1744,7 @@ declare module "http2" {
          * the response object.
          *
          * If no `'timeout'` listener is added to the request, the response, or
-         * the server, then `Http2Stream` s are destroyed when they time out. If a
+         * the server, then `Http2Stream`s are destroyed when they time out. If a
          * handler is assigned to the request, the response, or the server's `'timeout'`events, timed out sockets must be handled explicitly.
          * @since v8.4.0
          */
@@ -1652,7 +1798,7 @@ declare module "http2" {
      * passed as the second parameter to the `'request'` event.
      * @since v8.4.0
      */
-    export class Http2ServerResponse extends stream.Writable {
+    export class Http2ServerResponse<Request extends Http2ServerRequest = Http2ServerRequest> extends stream.Writable {
         constructor(stream: ServerHttp2Stream);
         /**
          * See `response.socket`.
@@ -1673,10 +1819,10 @@ declare module "http2" {
          */
         readonly headersSent: boolean;
         /**
-         * A reference to the original HTTP2 request object.
+         * A reference to the original HTTP2 `request` object.
          * @since v15.7.0
          */
-        readonly req: Http2ServerRequest;
+        readonly req: Request;
         /**
          * Returns a `Proxy` object that acts as a `net.Socket` (or `tls.TLSSocket`) but
          * applies getters, setters, and methods based on HTTP/2 logic.
@@ -1684,11 +1830,11 @@ declare module "http2" {
          * `destroyed`, `readable`, and `writable` properties will be retrieved from and
          * set on `response.stream`.
          *
-         * `destroy`, `emit`, `end`, `on` and `once` methods will be called on`response.stream`.
+         * `destroy`, `emit`, `end`, `on` and `once` methods will be called on `response.stream`.
          *
          * `setTimeout` method will be called on `response.stream.session`.
          *
-         * `pause`, `read`, `resume`, and `write` will throw an error with code`ERR_HTTP2_NO_SOCKET_MANIPULATION`. See `Http2Session and Sockets` for
+         * `pause`, `read`, `resume`, and `write` will throw an error with code `ERR_HTTP2_NO_SOCKET_MANIPULATION`. See `Http2Session and Sockets` for
          * more information.
          *
          * All other interactions will be routed directly to the socket.
@@ -1792,7 +1938,7 @@ declare module "http2" {
          * header names and the values are the respective header values. All header names
          * are lowercase.
          *
-         * The object returned by the `response.getHeaders()` method _does not_prototypically inherit from the JavaScript `Object`. This means that typical`Object` methods such as `obj.toString()`,
+         * The object returned by the `response.getHeaders()` method _does not_ prototypically inherit from the JavaScript `Object`. This means that typical `Object` methods such as `obj.toString()`,
          * `obj.hasOwnProperty()`, and others
          * are not defined and _will not work_.
          *
@@ -1866,7 +2012,7 @@ declare module "http2" {
          *
          * If no `'timeout'` listener is added to the request, the response, or
          * the server, then `Http2Stream` s are destroyed when they time out. If a
-         * handler is assigned to the request, the response, or the server's `'timeout'`events, timed out sockets must be handled explicitly.
+         * handler is assigned to the request, the response, or the server's `'timeout'` events, timed out sockets must be handled explicitly.
          * @since v8.4.0
          */
         setTimeout(msecs: number, callback?: () => void): void;
@@ -1912,7 +2058,7 @@ declare module "http2" {
          * The `hints` is an object containing the values of headers to be sent with
          * early hints message.
          *
-         * Example:
+         * **Example**
          *
          * ```js
          * const earlyHintsLink = '</styles.css>; rel=preload; as=style';
@@ -1926,12 +2072,9 @@ declare module "http2" {
          * ];
          * response.writeEarlyHints({
          *   'link': earlyHintsLinks,
-         *   'x-trace-id': 'id for diagnostics'
          * });
          * ```
-         *
          * @since v18.11.0
-         * @param hints An object containing the values of headers
          */
         writeEarlyHints(hints: Record<string, string | string[]>): void;
         /**
@@ -1956,7 +2099,7 @@ declare module "http2" {
          * `Content-Length` is given in bytes not characters. The`Buffer.byteLength()` API may be used to determine the number of bytes in a
          * given encoding. On outbound messages, Node.js does not check if Content-Length
          * and the length of the body being transmitted are equal or not. However, when
-         * receiving messages, Node.js will automatically reject messages when the`Content-Length` does not match the actual payload size.
+         * receiving messages, Node.js will automatically reject messages when the `Content-Length` does not match the actual payload size.
          *
          * This method may be called at most one time on a message before `response.end()` is called.
          *
@@ -2262,7 +2405,7 @@ declare module "http2" {
      */
     export const sensitiveHeaders: symbol;
     /**
-     * Returns an object containing the default settings for an `Http2Session`instance. This method returns a new object instance every time it is called
+     * Returns an object containing the default settings for an `Http2Session` instance. This method returns a new object instance every time it is called
      * so instances returned may be safely modified for use.
      * @since v8.4.0
      */
@@ -2291,7 +2434,7 @@ declare module "http2" {
      */
     export function getUnpackedSettings(buf: Uint8Array): Settings;
     /**
-     * Returns a `net.Server` instance that creates and manages `Http2Session`instances.
+     * Returns a `net.Server` instance that creates and manages `Http2Session` instances.
      *
      * Since there are no browsers known that support [unencrypted HTTP/2](https://http2.github.io/faq/#does-http2-require-encryption), the use of {@link createSecureServer} is necessary when
      * communicating
@@ -2309,12 +2452,12 @@ declare module "http2" {
      * server.on('stream', (stream, headers) => {
      *   stream.respond({
      *     'content-type': 'text/html; charset=utf-8',
-     *     ':status': 200
+     *     ':status': 200,
      *   });
      *   stream.end('<h1>Hello World</h1>');
      * });
      *
-     * server.listen(80);
+     * server.listen(8000);
      * ```
      * @since v8.4.0
      * @param onRequestHandler See `Compatibility API`
@@ -2322,12 +2465,21 @@ declare module "http2" {
     export function createServer(
         onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
     ): Http2Server;
-    export function createServer(
-        options: ServerOptions,
-        onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
-    ): Http2Server;
+    export function createServer<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    >(
+        options: ServerOptions<Http1Request, Http1Response, Http2Request, Http2Response>,
+        onRequestHandler?: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
+    ): Http2Server<Http1Request, Http1Response, Http2Request, Http2Response>;
     /**
-     * Returns a `tls.Server` instance that creates and manages `Http2Session`instances.
+     * Returns a `tls.Server` instance that creates and manages `Http2Session` instances.
      *
      * ```js
      * const http2 = require('http2');
@@ -2335,7 +2487,7 @@ declare module "http2" {
      *
      * const options = {
      *   key: fs.readFileSync('server-key.pem'),
-     *   cert: fs.readFileSync('server-cert.pem')
+     *   cert: fs.readFileSync('server-cert.pem'),
      * };
      *
      * // Create a secure HTTP/2 server
@@ -2344,12 +2496,12 @@ declare module "http2" {
      * server.on('stream', (stream, headers) => {
      *   stream.respond({
      *     'content-type': 'text/html; charset=utf-8',
-     *     ':status': 200
+     *     ':status': 200,
      *   });
      *   stream.end('<h1>Hello World</h1>');
      * });
      *
-     * server.listen(80);
+     * server.listen(8443);
      * ```
      * @since v8.4.0
      * @param onRequestHandler See `Compatibility API`
@@ -2357,10 +2509,19 @@ declare module "http2" {
     export function createSecureServer(
         onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
     ): Http2SecureServer;
-    export function createSecureServer(
-        options: SecureServerOptions,
-        onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
-    ): Http2SecureServer;
+    export function createSecureServer<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    >(
+        options: SecureServerOptions<Http1Request, Http1Response, Http2Request, Http2Response>,
+        onRequestHandler?: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
+    ): Http2SecureServer<Http1Request, Http1Response, Http2Request, Http2Response>;
     /**
      * Returns a `ClientHttp2Session` instance.
      *

--- a/types/node/v18/https.d.ts
+++ b/types/node/v18/https.d.ts
@@ -10,7 +10,9 @@ declare module "https" {
     import { URL } from "node:url";
     type ServerOptions<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<
+            InstanceType<Request>
+        >,
     > = tls.SecureContextOptions & tls.TlsOptions & http.ServerOptions<Request, Response>;
     type RequestOptions =
         & http.RequestOptions
@@ -34,7 +36,9 @@ declare module "https" {
     }
     interface Server<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<
+            InstanceType<Request>
+        >,
     > extends http.Server<Request, Response> {}
     /**
      * See `http.Server` for more information.
@@ -42,7 +46,9 @@ declare module "https" {
      */
     class Server<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<
+            InstanceType<Request>
+        >,
     > extends tls.Server {
         constructor(requestListener?: http.RequestListener<Request, Response>);
         constructor(
@@ -306,11 +312,15 @@ declare module "https" {
      */
     function createServer<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<
+            InstanceType<Request>
+        >,
     >(requestListener?: http.RequestListener<Request, Response>): Server<Request, Response>;
     function createServer<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<
+            InstanceType<Request>
+        >,
     >(
         options: ServerOptions<Request, Response>,
         requestListener?: http.RequestListener<Request, Response>,

--- a/types/node/v18/https.d.ts
+++ b/types/node/v18/https.d.ts
@@ -10,7 +10,7 @@ declare module "https" {
     import { URL } from "node:url";
     type ServerOptions<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse = typeof http.ServerResponse,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
     > = tls.SecureContextOptions & tls.TlsOptions & http.ServerOptions<Request, Response>;
     type RequestOptions =
         & http.RequestOptions
@@ -34,7 +34,7 @@ declare module "https" {
     }
     interface Server<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse = typeof http.ServerResponse,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
     > extends http.Server<Request, Response> {}
     /**
      * See `http.Server` for more information.
@@ -42,7 +42,7 @@ declare module "https" {
      */
     class Server<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse = typeof http.ServerResponse,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
     > extends tls.Server {
         constructor(requestListener?: http.RequestListener<Request, Response>);
         constructor(
@@ -119,19 +119,19 @@ declare module "https" {
         emit(
             event: "checkContinue",
             req: InstanceType<Request>,
-            res: InstanceType<Response> & { req: InstanceType<Request> },
+            res: InstanceType<Response>,
         ): boolean;
         emit(
             event: "checkExpectation",
             req: InstanceType<Request>,
-            res: InstanceType<Response> & { req: InstanceType<Request> },
+            res: InstanceType<Response>,
         ): boolean;
         emit(event: "clientError", err: Error, socket: Duplex): boolean;
         emit(event: "connect", req: InstanceType<Request>, socket: Duplex, head: Buffer): boolean;
         emit(
             event: "request",
             req: InstanceType<Request>,
-            res: InstanceType<Response> & { req: InstanceType<Request> },
+            res: InstanceType<Response>,
         ): boolean;
         emit(event: "upgrade", req: InstanceType<Request>, socket: Duplex, head: Buffer): boolean;
         on(event: string, listener: (...args: any[]) => void): this;
@@ -306,11 +306,11 @@ declare module "https" {
      */
     function createServer<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse = typeof http.ServerResponse,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
     >(requestListener?: http.RequestListener<Request, Response>): Server<Request, Response>;
     function createServer<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse = typeof http.ServerResponse,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
     >(
         options: ServerOptions<Request, Response>,
         requestListener?: http.RequestListener<Request, Response>,

--- a/types/node/v18/test/http2.ts
+++ b/types/node/v18/test/http2.ts
@@ -420,7 +420,9 @@ import { URL } from "node:url";
         foo: number;
     }
 
-    class MyHttp2ServerResponse extends Http2ServerResponse {
+    class MyHttp2ServerResponse<Request extends Http2ServerRequest = Http2ServerRequest>
+        extends Http2ServerResponse<Request>
+    {
         bar: string;
     }
 

--- a/types/node/v20/http.d.ts
+++ b/types/node/v20/http.d.ts
@@ -231,7 +231,7 @@ declare module "http" {
     }
     interface ServerOptions<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Response extends typeof ServerResponse = typeof ServerResponse,
+        Response extends typeof ServerResponse<InstanceType<Request>> = typeof ServerResponse<InstanceType<Request>>,
     > {
         /**
          * Specifies the `IncomingMessage` class to be used. Useful for extending the original `IncomingMessage`.
@@ -315,14 +315,14 @@ declare module "http" {
     }
     type RequestListener<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Response extends typeof ServerResponse = typeof ServerResponse,
+        Response extends typeof ServerResponse<InstanceType<Request>> = typeof ServerResponse<InstanceType<Request>>,
     > = (req: InstanceType<Request>, res: InstanceType<Response> & { req: InstanceType<Request> }) => void;
     /**
      * @since v0.1.17
      */
     class Server<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Response extends typeof ServerResponse = typeof ServerResponse,
+        Response extends typeof ServerResponse<InstanceType<Request>> = typeof ServerResponse<InstanceType<Request>>,
     > extends NetServer {
         constructor(requestListener?: RequestListener<Request, Response>);
         constructor(options: ServerOptions<Request, Response>, requestListener?: RequestListener<Request, Response>);
@@ -1553,11 +1553,11 @@ declare module "http" {
      */
     function createServer<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Response extends typeof ServerResponse = typeof ServerResponse,
+        Response extends typeof ServerResponse<InstanceType<Request>> = typeof ServerResponse<InstanceType<Request>>,
     >(requestListener?: RequestListener<Request, Response>): Server<Request, Response>;
     function createServer<
         Request extends typeof IncomingMessage = typeof IncomingMessage,
-        Response extends typeof ServerResponse = typeof ServerResponse,
+        Response extends typeof ServerResponse<InstanceType<Request>> = typeof ServerResponse<InstanceType<Request>>,
     >(
         options: ServerOptions<Request, Response>,
         requestListener?: RequestListener<Request, Response>,

--- a/types/node/v20/http2.d.ts
+++ b/types/node/v20/http2.d.ts
@@ -408,9 +408,9 @@ declare module "http2" {
          * });
          * ```
          *
-         * Initiates a response. When the `options.waitForTrailers` option is set, the`'wantTrailers'` event will be emitted immediately after queuing the last chunk
-         * of payload data to be sent. The `http2stream.sendTrailers()` method can then be
-         * used to sent trailing header fields to the peer.
+         * Initiates a response. When the `options.waitForTrailers` option is set, the `'wantTrailers'` event
+         * will be emitted immediately after queuing the last chunk of payload data to be sent.
+         * The `http2stream.sendTrailers()` method can then be used to send trailing header fields to the peer.
          *
          * When `options.waitForTrailers` is set, the `Http2Stream` will not automatically
          * close when the final `DATA` frame is transmitted. User code must call either `http2stream.sendTrailers()` or `http2stream.close()` to close the `Http2Stream`.
@@ -459,8 +459,8 @@ declare module "http2" {
          *
          * The optional `options.statCheck` function may be specified to give user code
          * an opportunity to set additional content headers based on the `fs.Stat` details
-         * of the given fd. If the `statCheck` function is provided, the `http2stream.respondWithFD()` method will perform an `fs.fstat()` call to
-         * collect details on the provided file descriptor.
+         * of the given fd. If the `statCheck` function is provided, the `http2stream.respondWithFD()` method will
+         * perform an `fs.fstat()` call to collect details on the provided file descriptor.
          *
          * The `offset` and `length` options may be used to limit the response to a
          * specific range subset. This can be used, for instance, to support HTTP Range
@@ -478,7 +478,8 @@ declare module "http2" {
          * header fields to the peer.
          *
          * When `options.waitForTrailers` is set, the `Http2Stream` will not automatically
-         * close when the final `DATA` frame is transmitted. User code _must_ call either `http2stream.sendTrailers()` or `http2stream.close()` to close the `Http2Stream`.
+         * close when the final `DATA` frame is transmitted. User code _must_ call either `http2stream.sendTrailers()`
+         * or `http2stream.close()` to close the `Http2Stream`.
          *
          * ```js
          * const http2 = require('node:http2');
@@ -521,9 +522,9 @@ declare module "http2" {
          * an opportunity to set additional content headers based on the `fs.Stat` details
          * of the given file:
          *
-         * If an error occurs while attempting to read the file data, the `Http2Stream` will be closed using an `RST_STREAM` frame using the standard `INTERNAL_ERROR` code. If the `onError` callback is
-         * defined, then it will be called. Otherwise
-         * the stream will be destroyed.
+         * If an error occurs while attempting to read the file data, the `Http2Stream` will be closed using an
+         * `RST_STREAM` frame using the standard `INTERNAL_ERROR` code.
+         * If the `onError` callback is defined, then it will be called. Otherwise, the stream will be destroyed.
          *
          * Example using a file path:
          *
@@ -677,7 +678,8 @@ declare module "http2" {
          */
         readonly encrypted?: boolean | undefined;
         /**
-         * A prototype-less object describing the current local settings of this `Http2Session`. The local settings are local to _this_`Http2Session` instance.
+         * A prototype-less object describing the current local settings of this `Http2Session`.
+         * The local settings are local to _this_`Http2Session` instance.
          * @since v8.4.0
          */
         readonly localSettings: Settings;
@@ -692,12 +694,14 @@ declare module "http2" {
         readonly originSet?: string[] | undefined;
         /**
          * Indicates whether the `Http2Session` is currently waiting for acknowledgment of
-         * a sent `SETTINGS` frame. Will be `true` after calling the `http2session.settings()` method. Will be `false` once all sent `SETTINGS` frames have been acknowledged.
+         * a sent `SETTINGS` frame. Will be `true` after calling the `http2session.settings()` method.
+         * Will be `false` once all sent `SETTINGS` frames have been acknowledged.
          * @since v8.4.0
          */
         readonly pendingSettingsAck: boolean;
         /**
-         * A prototype-less object describing the current remote settings of this`Http2Session`. The remote settings are set by the _connected_ HTTP/2 peer.
+         * A prototype-less object describing the current remote settings of this`Http2Session`.
+         * The remote settings are set by the _connected_ HTTP/2 peer.
          * @since v8.4.0
          */
         readonly remoteSettings: Settings;
@@ -1048,8 +1052,19 @@ declare module "http2" {
     export interface AlternativeServiceOptions {
         origin: number | string | url.URL;
     }
-    export interface ServerHttp2Session extends Http2Session {
-        readonly server: Http2Server | Http2SecureServer;
+    export interface ServerHttp2Session<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    > extends Http2Session {
+        readonly server:
+            | Http2Server<Http1Request, Http1Response, Http2Request, Http2Response>
+            | Http2SecureServer<Http1Request, Http1Response, Http2Request, Http2Response>;
         /**
          * Submits an `ALTSVC` frame (as defined by [RFC 7838](https://tools.ietf.org/html/rfc7838)) to the connected client.
          *
@@ -1144,17 +1159,30 @@ declare module "http2" {
         ): void;
         addListener(
             event: "connect",
-            listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void,
+            listener: (
+                session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+                socket: net.Socket | tls.TLSSocket,
+            ) => void,
         ): this;
         addListener(
             event: "stream",
             listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void,
         ): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        emit(event: "connect", session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket): boolean;
+        emit(
+            event: "connect",
+            session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+            socket: net.Socket | tls.TLSSocket,
+        ): boolean;
         emit(event: "stream", stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
         emit(event: string | symbol, ...args: any[]): boolean;
-        on(event: "connect", listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void): this;
+        on(
+            event: "connect",
+            listener: (
+                session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+                socket: net.Socket | tls.TLSSocket,
+            ) => void,
+        ): this;
         on(
             event: "stream",
             listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void,
@@ -1162,7 +1190,10 @@ declare module "http2" {
         on(event: string | symbol, listener: (...args: any[]) => void): this;
         once(
             event: "connect",
-            listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void,
+            listener: (
+                session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+                socket: net.Socket | tls.TLSSocket,
+            ) => void,
         ): this;
         once(
             event: "stream",
@@ -1171,7 +1202,10 @@ declare module "http2" {
         once(event: string | symbol, listener: (...args: any[]) => void): this;
         prependListener(
             event: "connect",
-            listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void,
+            listener: (
+                session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+                socket: net.Socket | tls.TLSSocket,
+            ) => void,
         ): this;
         prependListener(
             event: "stream",
@@ -1180,7 +1214,10 @@ declare module "http2" {
         prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
         prependOnceListener(
             event: "connect",
-            listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void,
+            listener: (
+                session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+                socket: net.Socket | tls.TLSSocket,
+            ) => void,
         ): this;
         prependOnceListener(
             event: "stream",
@@ -1213,16 +1250,52 @@ declare module "http2" {
         createConnection?: ((authority: url.URL, option: SessionOptions) => stream.Duplex) | undefined;
         protocol?: "http:" | "https:" | undefined;
     }
-    export interface ServerSessionOptions extends SessionOptions {
-        Http1IncomingMessage?: typeof IncomingMessage | undefined;
-        Http1ServerResponse?: typeof ServerResponse | undefined;
-        Http2ServerRequest?: typeof Http2ServerRequest | undefined;
-        Http2ServerResponse?: typeof Http2ServerResponse | undefined;
+    export interface ServerSessionOptions<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    > extends SessionOptions {
+        Http1IncomingMessage?: Http1Request | undefined;
+        Http1ServerResponse?: Http1Response | undefined;
+        Http2ServerRequest?: Http2Request | undefined;
+        Http2ServerResponse?: Http2Response | undefined;
     }
     export interface SecureClientSessionOptions extends ClientSessionOptions, tls.ConnectionOptions {}
-    export interface SecureServerSessionOptions extends ServerSessionOptions, tls.TlsOptions {}
-    export interface ServerOptions extends ServerSessionOptions {}
-    export interface SecureServerOptions extends SecureServerSessionOptions {
+    export interface SecureServerSessionOptions<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    > extends ServerSessionOptions<Http1Request, Http1Response, Http2Request, Http2Response>, tls.TlsOptions {}
+    export interface ServerOptions<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    > extends ServerSessionOptions<Http1Request, Http1Response, Http2Request, Http2Response> {}
+    export interface SecureServerOptions<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    > extends SecureServerSessionOptions<Http1Request, Http1Response, Http2Request, Http2Response> {
         allowHTTP1?: boolean | undefined;
         origins?: string[] | undefined;
     }
@@ -1234,16 +1307,28 @@ declare module "http2" {
          */
         updateSettings(settings: Settings): void;
     }
-    export interface Http2Server extends net.Server, HTTP2ServerCommon {
+    export interface Http2Server<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    > extends net.Server, HTTP2ServerCommon {
         addListener(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
         addListener(
             event: "request",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        addListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        addListener(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         addListener(event: "sessionError", listener: (err: Error) => void): this;
         addListener(
             event: "stream",
@@ -1251,19 +1336,32 @@ declare module "http2" {
         ): this;
         addListener(event: "timeout", listener: () => void): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        emit(event: "checkContinue", request: Http2ServerRequest, response: Http2ServerResponse): boolean;
-        emit(event: "request", request: Http2ServerRequest, response: Http2ServerResponse): boolean;
-        emit(event: "session", session: ServerHttp2Session): boolean;
+        emit(
+            event: "checkContinue",
+            request: InstanceType<Http2Request>,
+            response: InstanceType<Http2Response>,
+        ): boolean;
+        emit(event: "request", request: InstanceType<Http2Request>, response: InstanceType<Http2Response>): boolean;
+        emit(
+            event: "session",
+            session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+        ): boolean;
         emit(event: "sessionError", err: Error): boolean;
         emit(event: "stream", stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
         emit(event: "timeout"): boolean;
         emit(event: string | symbol, ...args: any[]): boolean;
         on(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        on(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        on(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        on(
+            event: "request",
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
+        ): this;
+        on(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         on(event: "sessionError", listener: (err: Error) => void): this;
         on(
             event: "stream",
@@ -1273,10 +1371,16 @@ declare module "http2" {
         on(event: string | symbol, listener: (...args: any[]) => void): this;
         once(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        once(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        once(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        once(
+            event: "request",
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
+        ): this;
+        once(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         once(event: "sessionError", listener: (err: Error) => void): this;
         once(
             event: "stream",
@@ -1286,13 +1390,16 @@ declare module "http2" {
         once(event: string | symbol, listener: (...args: any[]) => void): this;
         prependListener(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
         prependListener(
             event: "request",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        prependListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        prependListener(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         prependListener(event: "sessionError", listener: (err: Error) => void): this;
         prependListener(
             event: "stream",
@@ -1302,13 +1409,16 @@ declare module "http2" {
         prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
         prependOnceListener(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
         prependOnceListener(
             event: "request",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        prependOnceListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        prependOnceListener(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         prependOnceListener(event: "sessionError", listener: (err: Error) => void): this;
         prependOnceListener(
             event: "stream",
@@ -1317,16 +1427,28 @@ declare module "http2" {
         prependOnceListener(event: "timeout", listener: () => void): this;
         prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
     }
-    export interface Http2SecureServer extends tls.Server, HTTP2ServerCommon {
+    export interface Http2SecureServer<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    > extends tls.Server, HTTP2ServerCommon {
         addListener(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
         addListener(
             event: "request",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        addListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        addListener(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         addListener(event: "sessionError", listener: (err: Error) => void): this;
         addListener(
             event: "stream",
@@ -1335,9 +1457,16 @@ declare module "http2" {
         addListener(event: "timeout", listener: () => void): this;
         addListener(event: "unknownProtocol", listener: (socket: tls.TLSSocket) => void): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        emit(event: "checkContinue", request: Http2ServerRequest, response: Http2ServerResponse): boolean;
-        emit(event: "request", request: Http2ServerRequest, response: Http2ServerResponse): boolean;
-        emit(event: "session", session: ServerHttp2Session): boolean;
+        emit(
+            event: "checkContinue",
+            request: InstanceType<Http2Request>,
+            response: InstanceType<Http2Response>,
+        ): boolean;
+        emit(event: "request", request: InstanceType<Http2Request>, response: InstanceType<Http2Response>): boolean;
+        emit(
+            event: "session",
+            session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
+        ): boolean;
         emit(event: "sessionError", err: Error): boolean;
         emit(event: "stream", stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
         emit(event: "timeout"): boolean;
@@ -1345,10 +1474,16 @@ declare module "http2" {
         emit(event: string | symbol, ...args: any[]): boolean;
         on(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        on(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        on(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        on(
+            event: "request",
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
+        ): this;
+        on(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         on(event: "sessionError", listener: (err: Error) => void): this;
         on(
             event: "stream",
@@ -1359,10 +1494,16 @@ declare module "http2" {
         on(event: string | symbol, listener: (...args: any[]) => void): this;
         once(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        once(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
-        once(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        once(
+            event: "request",
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
+        ): this;
+        once(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         once(event: "sessionError", listener: (err: Error) => void): this;
         once(
             event: "stream",
@@ -1373,13 +1514,16 @@ declare module "http2" {
         once(event: string | symbol, listener: (...args: any[]) => void): this;
         prependListener(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
         prependListener(
             event: "request",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        prependListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        prependListener(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         prependListener(event: "sessionError", listener: (err: Error) => void): this;
         prependListener(
             event: "stream",
@@ -1390,13 +1534,16 @@ declare module "http2" {
         prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
         prependOnceListener(
             event: "checkContinue",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
         prependOnceListener(
             event: "request",
-            listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
+            listener: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
         ): this;
-        prependOnceListener(event: "session", listener: (session: ServerHttp2Session) => void): this;
+        prependOnceListener(
+            event: "session",
+            listener: (session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>) => void,
+        ): this;
         prependOnceListener(event: "sessionError", listener: (err: Error) => void): this;
         prependOnceListener(
             event: "stream",
@@ -1652,7 +1799,7 @@ declare module "http2" {
      * passed as the second parameter to the `'request'` event.
      * @since v8.4.0
      */
-    export class Http2ServerResponse extends stream.Writable {
+    export class Http2ServerResponse<Request extends Http2ServerRequest = Http2ServerRequest> extends stream.Writable {
         constructor(stream: ServerHttp2Stream);
         /**
          * See `response.socket`.
@@ -1698,7 +1845,7 @@ declare module "http2" {
          * A reference to the original HTTP2 `request` object.
          * @since v15.7.0
          */
-        readonly req: Http2ServerRequest;
+        readonly req: Request;
         /**
          * Returns a `Proxy` object that acts as a `net.Socket` (or `tls.TLSSocket`) but
          * applies getters, setters, and methods based on HTTP/2 logic.
@@ -2341,10 +2488,19 @@ declare module "http2" {
     export function createServer(
         onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
     ): Http2Server;
-    export function createServer(
-        options: ServerOptions,
-        onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
-    ): Http2Server;
+    export function createServer<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    >(
+        options: ServerOptions<Http1Request, Http1Response, Http2Request, Http2Response>,
+        onRequestHandler?: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
+    ): Http2Server<Http1Request, Http1Response, Http2Request, Http2Response>;
     /**
      * Returns a `tls.Server` instance that creates and manages `Http2Session` instances.
      *
@@ -2376,10 +2532,19 @@ declare module "http2" {
     export function createSecureServer(
         onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
     ): Http2SecureServer;
-    export function createSecureServer(
-        options: SecureServerOptions,
-        onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void,
-    ): Http2SecureServer;
+    export function createSecureServer<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    >(
+        options: SecureServerOptions<Http1Request, Http1Response, Http2Request, Http2Response>,
+        onRequestHandler?: (request: InstanceType<Http2Request>, response: InstanceType<Http2Response>) => void,
+    ): Http2SecureServer<Http1Request, Http1Response, Http2Request, Http2Response>;
     /**
      * Returns a `ClientHttp2Session` instance.
      *
@@ -2411,7 +2576,19 @@ declare module "http2" {
      * @param options Any `{@link createServer}` options can be provided.
      * @since v20.12.0
      */
-    export function performServerHandshake(socket: stream.Duplex, options?: ServerOptions): ServerHttp2Session;
+    export function performServerHandshake<
+        Http1Request extends typeof IncomingMessage = typeof IncomingMessage,
+        Http1Response extends typeof ServerResponse<InstanceType<Http1Request>> = typeof ServerResponse<
+            InstanceType<Http1Request>
+        >,
+        Http2Request extends typeof Http2ServerRequest = typeof Http2ServerRequest,
+        Http2Response extends typeof Http2ServerResponse<InstanceType<Http2Request>> = typeof Http2ServerResponse<
+            InstanceType<Http2Request>
+        >,
+    >(
+        socket: stream.Duplex,
+        options?: ServerOptions<Http1Request, Http1Response, Http2Request, Http2Response>,
+    ): ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>;
 }
 declare module "node:http2" {
     export * from "http2";

--- a/types/node/v20/https.d.ts
+++ b/types/node/v20/https.d.ts
@@ -10,7 +10,9 @@ declare module "https" {
     import { URL } from "node:url";
     type ServerOptions<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<
+            InstanceType<Request>
+        >,
     > = tls.SecureContextOptions & tls.TlsOptions & http.ServerOptions<Request, Response>;
     type RequestOptions =
         & http.RequestOptions
@@ -34,7 +36,9 @@ declare module "https" {
     }
     interface Server<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<
+            InstanceType<Request>
+        >,
     > extends http.Server<Request, Response> {}
     /**
      * See `http.Server` for more information.
@@ -42,7 +46,9 @@ declare module "https" {
      */
     class Server<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<
+            InstanceType<Request>
+        >,
     > extends tls.Server {
         constructor(requestListener?: http.RequestListener<Request, Response>);
         constructor(
@@ -306,11 +312,15 @@ declare module "https" {
      */
     function createServer<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<
+            InstanceType<Request>
+        >,
     >(requestListener?: http.RequestListener<Request, Response>): Server<Request, Response>;
     function createServer<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<
+            InstanceType<Request>
+        >,
     >(
         options: ServerOptions<Request, Response>,
         requestListener?: http.RequestListener<Request, Response>,

--- a/types/node/v20/https.d.ts
+++ b/types/node/v20/https.d.ts
@@ -10,7 +10,7 @@ declare module "https" {
     import { URL } from "node:url";
     type ServerOptions<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse = typeof http.ServerResponse,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
     > = tls.SecureContextOptions & tls.TlsOptions & http.ServerOptions<Request, Response>;
     type RequestOptions =
         & http.RequestOptions
@@ -34,7 +34,7 @@ declare module "https" {
     }
     interface Server<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse = typeof http.ServerResponse,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
     > extends http.Server<Request, Response> {}
     /**
      * See `http.Server` for more information.
@@ -42,7 +42,7 @@ declare module "https" {
      */
     class Server<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse = typeof http.ServerResponse,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
     > extends tls.Server {
         constructor(requestListener?: http.RequestListener<Request, Response>);
         constructor(
@@ -119,25 +119,19 @@ declare module "https" {
         emit(
             event: "checkContinue",
             req: InstanceType<Request>,
-            res: InstanceType<Response> & {
-                req: InstanceType<Request>;
-            },
+            res: InstanceType<Response>,
         ): boolean;
         emit(
             event: "checkExpectation",
             req: InstanceType<Request>,
-            res: InstanceType<Response> & {
-                req: InstanceType<Request>;
-            },
+            res: InstanceType<Response>,
         ): boolean;
         emit(event: "clientError", err: Error, socket: Duplex): boolean;
         emit(event: "connect", req: InstanceType<Request>, socket: Duplex, head: Buffer): boolean;
         emit(
             event: "request",
             req: InstanceType<Request>,
-            res: InstanceType<Response> & {
-                req: InstanceType<Request>;
-            },
+            res: InstanceType<Response>,
         ): boolean;
         emit(event: "upgrade", req: InstanceType<Request>, socket: Duplex, head: Buffer): boolean;
         on(event: string, listener: (...args: any[]) => void): this;
@@ -312,11 +306,11 @@ declare module "https" {
      */
     function createServer<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse = typeof http.ServerResponse,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
     >(requestListener?: http.RequestListener<Request, Response>): Server<Request, Response>;
     function createServer<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,
-        Response extends typeof http.ServerResponse = typeof http.ServerResponse,
+        Response extends typeof http.ServerResponse<InstanceType<Request>> = typeof http.ServerResponse<InstanceType<Request>>,
     >(
         options: ServerOptions<Request, Response>,
         requestListener?: http.RequestListener<Request, Response>,

--- a/types/node/v20/test/http2.ts
+++ b/types/node/v20/test/http2.ts
@@ -421,7 +421,9 @@ import { URL } from "node:url";
         foo: number;
     }
 
-    class MyHttp2ServerResponse extends Http2ServerResponse {
+    class MyHttp2ServerResponse<Request extends Http2ServerRequest = Http2ServerRequest>
+        extends Http2ServerResponse<Request>
+    {
         bar: string;
     }
 
@@ -485,7 +487,7 @@ import { URL } from "node:url";
     const http2Stream: Http2Stream = {} as any;
     const duplex: Duplex = http2Stream;
 
-    performServerHandshake(duplex, serverOptions); // $ExpectType ServerHttp2Session
+    const session: ServerHttp2Session = performServerHandshake(duplex, serverOptions);
 }
 
 // constants

--- a/types/stoppable/stoppable-tests.ts
+++ b/types/stoppable/stoppable-tests.ts
@@ -6,10 +6,10 @@ import stoppable = require("stoppable");
 type Stoppable = stoppable.StoppableServer;
 type WithStop = stoppable.WithStop;
 
-const httpServer = stoppable(http.createServer()); // $ExpectType Server<typeof IncomingMessage, typeof ServerResponse> & WithStop
-const httpsServer = stoppable(https.createServer()); // $ExpectType Server<typeof IncomingMessage, typeof ServerResponse> & WithStop
-stoppable(http.createServer(), 10000); // $ExpectType Server<typeof IncomingMessage, typeof ServerResponse> & WithStop
-stoppable(https.createServer(), 10000); // $ExpectType Server<typeof IncomingMessage, typeof ServerResponse> & WithStop
+const httpServer: http.Server & WithStop = stoppable(http.createServer());
+const httpsServer: https.Server & WithStop = stoppable(https.createServer());
+const httpServerWithGrace: http.Server & WithStop = stoppable(http.createServer(), 10000);
+const httpsServerWithGrace: https.Server & WithStop = stoppable(https.createServer(), 10000);
 
 // check return type is actually a http.Server/https.Server
 httpServer.addListener("connection", socket => {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

I am changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: [none applicable]

Basically, `createServer`'s current definition doesn't work when using custom prototypes like the following for `IncomingMessage`, `ServerResponse`:

```ts
class MyRequest extends http.IncomingMessage {
    foo: string 
}

class MyResponse<Request extends MyRequest = MyRequest> extends http.ServerResponse<Request> {
    foo: string
}

createServer({ IncomingMessage: MyRequest, ServerResponse: MyResponse }) // this fails
```

because the construct signature of `MyResponse` doesn't match 
```ts
new <Request extends IncomingMessage = IncomingMessage>(request: Request): ServerResponse<Request>
```
Which is the wrong signature to match against, it should be matching against `ServerResponse<InstanceType<Request>>` instead of `ServerResponse`, which is equivalent to `ServerResponse<IncomingMessage>`

`https.d.ts` and `http2.d.ts` have the same/similar issues, ~~I haven't addressed those in this PR~~ I have now addressed those in this PR.