### PR TITLE
[node] Update typings to v20.15.0

### DIFF
--- a/types/node/v20/package.json
+++ b/types/node/v20/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "20.14.9999",
+    "version": "20.15.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [
@@ -9,7 +9,7 @@
     ],
     "tsconfigs": ["tsconfig.dom.json", "tsconfig.non-dom.json"],
     "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.13.0"
     },
     "devDependencies": {
         "@types/node": "workspace:."

--- a/types/node/v20/test.d.ts
+++ b/types/node/v20/test.d.ts
@@ -453,6 +453,12 @@ declare module "node:test" {
      */
     class TestContext {
         /**
+         * An object containing assertion methods bound to the test context.
+         * The top-level functions from the `node:assert` module are exposed here for the purpose of creating test plans.
+         * @since v20.15.0
+         */
+        readonly assert: TestContextAssert;
+        /**
          * This function is used to create a hook running before subtest of the current test.
          * @param fn The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
@@ -499,6 +505,42 @@ declare module "node:test" {
          * @since v18.8.0, v16.18.0
          */
         readonly name: string;
+        /**
+         * Used to set the number of assertions and subtests that are expected to run within the test.
+         * If the number of assertions and subtests that run does not match the expected count, the test will fail.
+         *
+         * To make sure assertions are tracked, the assert functions on `context.assert` must be used,
+         * instead of importing from the `node:assert` module.
+         * ```js
+         * test('top level test', (t) => {
+         *   t.plan(2);
+         *   t.assert.ok('some relevant assertion here');
+         *   t.test('subtest', () => {});
+         * });
+         * ```
+         *
+         * When working with asynchronous code, the `plan` function can be used to ensure that the correct number of assertions are run:
+         * ```js
+         * test('planning with streams', (t, done) => {
+         *   function* generate() {
+         *     yield 'a';
+         *     yield 'b';
+         *     yield 'c';
+         *   }
+         *   const expected = ['a', 'b', 'c'];
+         *   t.plan(expected.length);
+         *   const stream = Readable.from(generate());
+         *   stream.on('data', (chunk) => {
+         *     t.assert.strictEqual(chunk, expected.shift());
+         *   });
+         *   stream.on('end', () => {
+         *     done();
+         *   });
+         * });
+         * ```
+         * @since v20.15.0
+         */
+        plan(count: number): void;
         /**
          * If `shouldRunOnlyTests` is truthy, the test context will only run tests that
          * have the `only` option set. Otherwise, all tests are run. If Node.js was not
@@ -575,6 +617,76 @@ declare module "node:test" {
          */
         readonly mock: MockTracker;
     }
+    interface TestContextAssert {
+        /**
+         * Identical to the `deepEqual` function from the `node:assert` module, but bound to the test context.
+         */
+        deepEqual: typeof import("node:assert").deepEqual;
+        /**
+         * Identical to the `deepStrictEqual` function from the `node:assert` module, but bound to the test context.
+         */
+        deepStrictEqual: typeof import("node:assert").deepStrictEqual;
+        /**
+         * Identical to the `doesNotMatch` function from the `node:assert` module, but bound to the test context.
+         */
+        doesNotMatch: typeof import("node:assert").doesNotMatch;
+        /**
+         * Identical to the `doesNotReject` function from the `node:assert` module, but bound to the test context.
+         */
+        doesNotReject: typeof import("node:assert").doesNotReject;
+        /**
+         * Identical to the `doesNotThrow` function from the `node:assert` module, but bound to the test context.
+         */
+        doesNotThrow: typeof import("node:assert").doesNotThrow;
+        /**
+         * Identical to the `equal` function from the `node:assert` module, but bound to the test context.
+         */
+        equal: typeof import("node:assert").equal;
+        /**
+         * Identical to the `fail` function from the `node:assert` module, but bound to the test context.
+         */
+        fail: typeof import("node:assert").fail;
+        /**
+         * Identical to the `ifError` function from the `node:assert` module, but bound to the test context.
+         */
+        ifError: typeof import("node:assert").ifError;
+        /**
+         * Identical to the `match` function from the `node:assert` module, but bound to the test context.
+         */
+        match: typeof import("node:assert").match;
+        /**
+         * Identical to the `notDeepEqual` function from the `node:assert` module, but bound to the test context.
+         */
+        notDeepEqual: typeof import("node:assert").notDeepEqual;
+        /**
+         * Identical to the `notDeepStrictEqual` function from the `node:assert` module, but bound to the test context.
+         */
+        notDeepStrictEqual: typeof import("node:assert").notDeepStrictEqual;
+        /**
+         * Identical to the `notEqual` function from the `node:assert` module, but bound to the test context.
+         */
+        notEqual: typeof import("node:assert").notEqual;
+        /**
+         * Identical to the `notStrictEqual` function from the `node:assert` module, but bound to the test context.
+         */
+        notStrictEqual: typeof import("node:assert").notStrictEqual;
+        /**
+         * Identical to the `ok` function from the `node:assert` module, but bound to the test context.
+         */
+        ok: typeof import("node:assert").ok;
+        /**
+         * Identical to the `rejects` function from the `node:assert` module, but bound to the test context.
+         */
+        rejects: typeof import("node:assert").rejects;
+        /**
+         * Identical to the `strictEqual` function from the `node:assert` module, but bound to the test context.
+         */
+        strictEqual: typeof import("node:assert").strictEqual;
+        /**
+         * Identical to the `throws` function from the `node:assert` module, but bound to the test context.
+         */
+        throws: typeof import("node:assert").throws;
+    }
 
     /**
      * An instance of `SuiteContext` is passed to each suite function in order to
@@ -634,6 +746,14 @@ declare module "node:test" {
          * @default false
          */
         todo?: boolean | string | undefined;
+        /**
+         * The number of assertions and subtests expected to be run in the test.
+         * If the number of assertions run in the test does not match the number
+         * specified in the plan, the test will fail.
+         * @default undefined
+         * @since v20.15.0
+         */
+        plan?: number | undefined;
     }
     /**
      * This function creates a hook that runs before executing a suite.

--- a/types/node/v20/test/test.ts
+++ b/types/node/v20/test/test.ts
@@ -1,4 +1,4 @@
-import { Transform, TransformCallback, TransformOptions } from "node:stream";
+import { Readable, Transform, TransformCallback, TransformOptions } from "node:stream";
 import {
     after,
     afterEach,
@@ -39,7 +39,10 @@ run({
     inspectPort: () => 8081,
     testNamePatterns: ["executed", /^core-/],
     only: true,
-    setup: (root) => {},
+    setup: (reporter) => {
+        // $ExpectType TestsStream
+        reporter;
+    },
     watch: true,
     shard: {
         index: 1,
@@ -97,7 +100,7 @@ test((t, cb) => {
     cb({ x: "anything" });
 });
 
-// Test the context's methods
+// Test the context's methods/properties
 test(undefined, undefined, t => {
     // $ExpectType void
     t.diagnostic("tap diagnostic");
@@ -119,6 +122,13 @@ test(undefined, undefined, t => {
     t.beforeEach(() => {});
     // $ExpectType void
     t.before(() => {});
+
+    // $ExpectType string
+    t.name;
+    // $ExpectType AbortSignal
+    t.signal;
+    // $ExpectType MockTracker
+    t.mock;
 });
 
 // Test the subtest approach.
@@ -144,7 +154,6 @@ test.describe("describe", () => {});
 test.it("it", () => {});
 // $ExpectType MockTracker
 test.mock;
-test.suite("suite", () => {});
 // $ExpectType typeof test
 test.test;
 test.test.test("chained self ref", (t) => {
@@ -152,6 +161,7 @@ test.test.test("chained self ref", (t) => {
     t.test;
 });
 test.skip("skip", () => {});
+test.suite("suite", () => {});
 test.todo("todo", () => {});
 test.only("only", () => {});
 
@@ -823,6 +833,11 @@ class TestReporter extends Transform {
                 );
                 break;
             }
+            case "test:coverage": {
+                const { summary, nesting } = event.data;
+                callback(null, `${nesting}/${summary.workingDirectory}/${summary.totals.totalLineCount}`);
+                break;
+            }
             case "test:dequeue": {
                 const { file, column, line, name, nesting } = event.data;
                 callback(null, `${name}/${nesting}/${file}/${column}/${line}`);
@@ -920,3 +935,22 @@ const invalidTestContext = new TestContext();
 
 // @ts-expect-error Should not be able to instantiate a SuiteContext
 const invalidSuiteContext = new SuiteContext();
+
+test("planning with streams", (t: TestContext, done) => {
+    function* generate() {
+        yield "a";
+        yield "b";
+        yield "c";
+    }
+    const expected = ["a", "b", "c"];
+    t.plan(expected.length);
+
+    const stream = Readable.from(generate());
+    stream.on("data", (chunk) => {
+        t.assert.strictEqual(chunk, expected.shift());
+    });
+
+    stream.on("end", () => {
+        done();
+    });
+});

--- a/types/node/v20/test/zlib.ts
+++ b/types/node/v20/test/zlib.ts
@@ -7,6 +7,7 @@ import {
     brotliDecompressSync,
     BrotliOptions,
     constants,
+    crc32,
     createBrotliCompress,
     createBrotliDecompress,
     deflate,
@@ -188,4 +189,12 @@ brotliDecompress(
         await pUnzip(Buffer.from("buf")); // $ExpectType Buffer
         await pUnzip(Buffer.from("buf"), { flush: constants.Z_NO_FLUSH }); // $ExpectType Buffer
     })();
+}
+
+{
+    let crc = crc32("hello");
+    crc = crc32("world", crc); // $ExpectType number
+
+    crc = crc32(Buffer.from("hello", "utf16le")); // $ExpectType number
+    crc = crc32(Buffer.from("world", "utf16le"), crc); // $ExpectType number
 }

--- a/types/node/v20/zlib.d.ts
+++ b/types/node/v20/zlib.d.ts
@@ -173,6 +173,15 @@ declare module "zlib" {
     interface InflateRaw extends stream.Transform, Zlib, ZlibReset {}
     interface Unzip extends stream.Transform, Zlib {}
     /**
+     * Computes a 32-bit [Cyclic Redundancy Check](https://en.wikipedia.org/wiki/Cyclic_redundancy_check) checksum of `data`.
+     * If `value` is specified, it is used as the starting value of the checksum, otherwise, 0 is used as the starting value.
+     * @param data When `data` is a string, it will be encoded as UTF-8 before being used for computation.
+     * @param value An optional starting value. It must be a 32-bit unsigned integer. @default 0
+     * @returns A 32-bit unsigned integer containing the checksum.
+     * @since v20.15.0
+     */
+    function crc32(data: string | Buffer | NodeJS.ArrayBufferView, value?: number): number;
+    /**
      * Creates and returns a new `BrotliCompress` object.
      * @since v11.7.0, v10.16.0
      */


### PR DESCRIPTION
https://github.com/nodejs/node/releases/tag/v20.15.0

- test_runner: support test plans
- zlib: expose zlib.crc32()
