### PR TITLE
[node] Update typings to v20.16.0

### DIFF
--- a/types/node/v20/buffer.d.ts
+++ b/types/node/v20/buffer.d.ts
@@ -171,6 +171,18 @@ declare module "buffer" {
          */
         arrayBuffer(): Promise<ArrayBuffer>;
         /**
+         * The `blob.bytes()` method returns the byte of the `Blob` object as a `Promise<Uint8Array>`.
+         *
+         * ```js
+         * const blob = new Blob(['hello']);
+         * blob.bytes().then((bytes) => {
+         *   console.log(bytes); // Outputs: Uint8Array(5) [ 104, 101, 108, 108, 111 ]
+         * });
+         * ```
+         * @since v20.16.0
+         */
+        bytes(): Promise<Uint8Array>;
+        /**
          * Creates and returns a new `Blob` containing a subset of this `Blob` objects
          * data. The original `Blob` is not altered.
          * @since v15.7.0, v14.18.0

--- a/types/node/v20/package.json
+++ b/types/node/v20/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "20.15.9999",
+    "version": "20.16.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [
@@ -9,7 +9,7 @@
     ],
     "tsconfigs": ["tsconfig.dom.json", "tsconfig.non-dom.json"],
     "dependencies": {
-        "undici-types": "~6.13.0"
+        "undici-types": "~6.19.2"
     },
     "devDependencies": {
         "@types/node": "workspace:."

--- a/types/node/v20/process.d.ts
+++ b/types/node/v20/process.d.ts
@@ -1,8 +1,122 @@
 declare module "process" {
-    import * as net from "node:net";
-    import * as os from "node:os";
     import * as tty from "node:tty";
     import { Worker } from "node:worker_threads";
+
+    interface BuiltInModule {
+        "assert": typeof import("assert");
+        "node:assert": typeof import("node:assert");
+        "assert/strict": typeof import("assert/strict");
+        "node:assert/strict": typeof import("node:assert/strict");
+        "async_hooks": typeof import("async_hooks");
+        "node:async_hooks": typeof import("node:async_hooks");
+        "buffer": typeof import("buffer");
+        "node:buffer": typeof import("node:buffer");
+        "child_process": typeof import("child_process");
+        "node:child_process": typeof import("node:child_process");
+        "cluster": typeof import("cluster");
+        "node:cluster": typeof import("node:cluster");
+        "console": typeof import("console");
+        "node:console": typeof import("node:console");
+        "constants": typeof import("constants");
+        "node:constants": typeof import("node:constants");
+        "crypto": typeof import("crypto");
+        "node:crypto": typeof import("node:crypto");
+        "dgram": typeof import("dgram");
+        "node:dgram": typeof import("node:dgram");
+        "diagnostics_channel": typeof import("diagnostics_channel");
+        "node:diagnostics_channel": typeof import("node:diagnostics_channel");
+        "dns": typeof import("dns");
+        "node:dns": typeof import("node:dns");
+        "dns/promises": typeof import("dns/promises");
+        "node:dns/promises": typeof import("node:dns/promises");
+        "domain": typeof import("domain");
+        "node:domain": typeof import("node:domain");
+        "events": typeof import("events");
+        "node:events": typeof import("node:events");
+        "fs": typeof import("fs");
+        "node:fs": typeof import("node:fs");
+        "fs/promises": typeof import("fs/promises");
+        "node:fs/promises": typeof import("node:fs/promises");
+        "http": typeof import("http");
+        "node:http": typeof import("node:http");
+        "http2": typeof import("http2");
+        "node:http2": typeof import("node:http2");
+        "https": typeof import("https");
+        "node:https": typeof import("node:https");
+        "inspector": typeof import("inspector");
+        "node:inspector": typeof import("node:inspector");
+        // FIXME: module is missed
+        // "inspector/promises": typeof import("inspector/promises");
+        // "node:inspector/promises": typeof import("node:inspector/promises");
+        "module": typeof import("module");
+        "node:module": typeof import("node:module");
+        "net": typeof import("net");
+        "node:net": typeof import("node:net");
+        "os": typeof import("os");
+        "node:os": typeof import("node:os");
+        "path": typeof import("path");
+        "node:path": typeof import("node:path");
+        "path/posix": typeof import("path/posix");
+        "node:path/posix": typeof import("node:path/posix");
+        "path/win32": typeof import("path/win32");
+        "node:path/win32": typeof import("node:path/win32");
+        "perf_hooks": typeof import("perf_hooks");
+        "node:perf_hooks": typeof import("node:perf_hooks");
+        "process": typeof import("process");
+        "node:process": typeof import("node:process");
+        "punycode": typeof import("punycode");
+        "node:punycode": typeof import("node:punycode");
+        "querystring": typeof import("querystring");
+        "node:querystring": typeof import("node:querystring");
+        "readline": typeof import("readline");
+        "node:readline": typeof import("node:readline");
+        "readline/promises": typeof import("readline/promises");
+        "node:readline/promises": typeof import("node:readline/promises");
+        "repl": typeof import("repl");
+        "node:repl": typeof import("node:repl");
+        "node:sea": typeof import("node:sea");
+        "stream": typeof import("stream");
+        "node:stream": typeof import("node:stream");
+        "stream/consumers": typeof import("stream/consumers");
+        "node:stream/consumers": typeof import("node:stream/consumers");
+        "stream/promises": typeof import("stream/promises");
+        "node:stream/promises": typeof import("node:stream/promises");
+        "stream/web": typeof import("stream/web");
+        "node:stream/web": typeof import("node:stream/web");
+        "string_decoder": typeof import("string_decoder");
+        "node:string_decoder": typeof import("node:string_decoder");
+        "node:test": typeof import("node:test");
+        "node:test/reporters": typeof import("node:test/reporters");
+        "timers": typeof import("timers");
+        "node:timers": typeof import("node:timers");
+        "timers/promises": typeof import("timers/promises");
+        "node:timers/promises": typeof import("node:timers/promises");
+        "tls": typeof import("tls");
+        "node:tls": typeof import("node:tls");
+        "trace_events": typeof import("trace_events");
+        "node:trace_events": typeof import("node:trace_events");
+        "tty": typeof import("tty");
+        "node:tty": typeof import("node:tty");
+        "url": typeof import("url");
+        "node:url": typeof import("node:url");
+        "util": typeof import("util");
+        "node:util": typeof import("node:util");
+        "sys": typeof import("util");
+        "node:sys": typeof import("node:util");
+        "util/types": typeof import("util/types");
+        "node:util/types": typeof import("node:util/types");
+        "v8": typeof import("v8");
+        "node:v8": typeof import("node:v8");
+        "vm": typeof import("vm");
+        "node:vm": typeof import("node:vm");
+        "wasi": typeof import("wasi");
+        "node:wasi": typeof import("node:wasi");
+        "worker_threads": typeof import("worker_threads");
+        "node:worker_threads": typeof import("node:worker_threads");
+        "zlib": typeof import("zlib");
+        "node:zlib": typeof import("node:zlib");
+    }
+
     global {
         var process: NodeJS.Process;
         namespace NodeJS {
@@ -793,6 +907,13 @@ declare module "process" {
                  * @since v17.3.0, v16.14.0
                  */
                 getActiveResourcesInfo(): string[];
+                /**
+                 * Provides a way to load built-in modules in a globally available function.
+                 * @param id ID of the built-in module being requested.
+                 * @since v20.16.0
+                 */
+                getBuiltinModule<ID extends keyof BuiltInModule>(id: ID): BuiltInModule[ID];
+                getBuiltinModule(id: string): object | undefined;
                 /**
                  * The `process.getgid()` method returns the numerical group identity of the
                  * process. (See [`getgid(2)`](http://man7.org/linux/man-pages/man2/getgid.2.html).)

--- a/types/node/v20/test.d.ts
+++ b/types/node/v20/test.d.ts
@@ -501,6 +501,11 @@ declare module "node:test" {
          */
         diagnostic(message: string): void;
         /**
+         * The name of the test and each of its ancestors, separated by `>`.
+         * @since v20.16.0
+         */
+        readonly fullName: string;
+        /**
          * The name of the test.
          * @since v18.8.0, v16.18.0
          */

--- a/types/node/v20/test/buffer.ts
+++ b/types/node/v20/test/buffer.ts
@@ -504,6 +504,7 @@ declare class NodeFile implements File {
     slice(start?: number, end?: number, type?: string): NodeBlob;
     stream(): ReadableStream;
     arrayBuffer(): Promise<ArrayBuffer>;
+    bytes(): Promise<Uint8Array>;
     text(): Promise<string>;
 }
 

--- a/types/node/v20/test/process.ts
+++ b/types/node/v20/test/process.ts
@@ -211,3 +211,8 @@ process.env.TZ = "test";
         process.setSourceMapsEnabled(true);
     }
 }
+
+{
+    const fs = globalThis.process.getBuiltinModule("fs");
+    fs.constants.F_OK;
+}

--- a/types/node/v20/test/test.ts
+++ b/types/node/v20/test/test.ts
@@ -125,6 +125,8 @@ test(undefined, undefined, t => {
 
     // $ExpectType string
     t.name;
+    // $ExpectType string
+    t.fullName;
     // $ExpectType AbortSignal
     t.signal;
     // $ExpectType MockTracker

--- a/types/node/v20/test/util.ts
+++ b/types/node/v20/test/util.ts
@@ -337,6 +337,58 @@ access("file/that/does/not/exist", (err) => {
 }
 
 {
+    // args are passed `type: "boolean"` and allow negative options
+    const result = util.parseArgs({
+        args: ["--no-alpha"],
+        options: {
+            alpha: { type: "boolean" },
+        },
+        allowNegative: true,
+    });
+    // $ExpectType boolean | undefined
+    result.values.alpha; // false
+}
+
+{
+    // args are passed `default: "true"` and allow negative options
+    const result = util.parseArgs({
+        args: ["--no-alpha"],
+        options: {
+            alpha: { type: "boolean", default: true },
+        },
+        allowNegative: true,
+    });
+    // $ExpectType boolean | undefined
+    result.values.alpha; // false
+}
+
+{
+    // allow negative options and multiple as true
+    const result = util.parseArgs({
+        args: ["--no-alpha", "--alpha", "--no-alpha"],
+        options: {
+            alpha: { type: "boolean", multiple: true },
+        },
+        allowNegative: true,
+    });
+    // $ExpectType boolean[] | undefined
+    result.values.alpha; // [false, true, false]
+}
+
+{
+    // allow negative options and passed multiple arguments
+    const result = util.parseArgs({
+        args: ["--no-alpha", "--alpha"],
+        options: {
+            alpha: { type: "boolean" },
+        },
+        allowNegative: true,
+    });
+    // $ExpectType boolean | undefined
+    result.values.alpha; // true
+}
+
+{
     const controller: AbortController = util.transferableAbortController();
     const signal: AbortSignal = util.transferableAbortSignal(controller.signal);
     util.aborted(signal, {}).then(() => {});

--- a/types/node/v20/util.d.ts
+++ b/types/node/v20/util.d.ts
@@ -1481,6 +1481,12 @@ declare module "util" {
          */
         allowPositionals?: boolean | undefined;
         /**
+         * If `true`, allows explicitly setting boolean options to `false` by prefixing the option name with `--no-`.
+         * @default false
+         * @since v20.16.0
+         */
+        allowNegative?: boolean | undefined;
+        /**
          * Return the parsed tokens. This is useful for extending the built-in behavior,
          * from adding additional checks through to reprocessing the tokens in different ways.
          * @default false


### PR DESCRIPTION
https://github.com/nodejs/node/releases/tag/v20.16.0

- buffer: add .bytes() method to Blob
- process: add process.getBuiltinModule(id)
- test_runner: add context.fullName
- util: support `--no-` for argument with boolean type for parseArgs