### PR TITLE
Fix various ecosystem breaks

### DIFF
--- a/types/fontagon/package.json
+++ b/types/fontagon/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/svg2ttf": "*",
-        "@types/svgicons2svgfont": "*",
+        "@types/svgicons2svgfont": "<14",
         "@types/ttf2woff": "*"
     },
     "devDependencies": {

--- a/types/libnpmpublish/package.json
+++ b/types/libnpmpublish/package.json
@@ -6,7 +6,7 @@
         "https://npmjs.com/package/libnpmpublish"
     ],
     "dependencies": {
-        "@npm/types": "*",
+        "@npm/types": "^1",
         "@types/node-fetch": "*",
         "@types/npm-registry-fetch": "*"
     },

--- a/types/npmcli__arborist/package.json
+++ b/types/npmcli__arborist/package.json
@@ -6,7 +6,7 @@
         "https://github.com/npm/cli/tree/latest/workspaces/arborist#readme"
     ],
     "dependencies": {
-        "@npm/types": "*",
+        "@npm/types": "^1",
         "@types/cacache": "*",
         "@types/node": "*",
         "@types/npmcli__package-json": "*",

--- a/types/unist/package.json
+++ b/types/unist/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "@types/unist",
     "version": "3.0.9999",
-    "nonNpm": true,
+    "nonNpm": "conflict",
     "nonNpmDescription": "unist",
     "projects": [
         "https://github.com/syntax-tree/unist"

--- a/types/unist/v2/package.json
+++ b/types/unist/v2/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "@types/unist",
     "version": "2.0.9999",
-    "nonNpm": true,
+    "nonNpm": "conflict",
     "nonNpmDescription": "Unist",
     "projects": [
         "https://github.com/syntax-tree/unist"


### PR DESCRIPTION
- `@npm/types` broke and changed `PackageJson` to `PackageJSON`.
- `fontagon` was not updated to request an older version of `svgicons2svgfont`.
- `unist` is now a placeholder package on npm.