### PR TITLE
[@types/dom-webcodecs] add missing "dequeue" event to (Video|Audio)(En/De)coder

### DIFF
--- a/types/dom-webcodecs/test/dom-webcodecs-tests.ts
+++ b/types/dom-webcodecs/test/dom-webcodecs-tests.ts
@@ -128,6 +128,11 @@ AudioDecoder.isConfigSupported(futureAudioDecoderConfig);
 // $ExpectType void
 audioDecoder.configure(futureAudioDecoderConfig);
 
+audioDecoder.ondequeue = () => '';
+
+// $ExpectType void
+audioDecoder.addEventListener('dequeue', (e) => e, { once: true });
+
 genericCodec(audioDecoder);
 
 //////////////////////////////////////////////////
@@ -222,6 +227,9 @@ audioEncoder.configure(futureAudioEncoderConfig);
 
 // $ExpectType void
 audioEncoder.encode(audioFrame);
+
+// $ExpectType void
+audioEncoder.addEventListener('dequeue', (e) => e, { once: true });
 
 // $ExpectType void
 audioFrame.close();
@@ -425,6 +433,9 @@ videoDecoder.configure(futureVideoDecoderConfig);
 genericCodec(videoDecoder);
 
 // $ExpectType void
+videoDecoder.addEventListener('dequeue', () => {}, { once: true });
+
+// $ExpectType void
 videoDecoder.decode(encodedVideoChunk);
 
 // $ExpectType Promise<void>
@@ -543,6 +554,9 @@ videoEncoder.configure(futureVideoEncoderConfig);
 
 // $ExpectType number
 videoEncoder.encodeQueueSize;
+
+// $ExpectType void
+videoEncoder.addEventListener('dequeue', () => {}, { once: true });
 
 // $ExpectType void
 videoEncoder.encode(videoFrame);

--- a/types/dom-webcodecs/test/dom-webcodecs-tests.ts
+++ b/types/dom-webcodecs/test/dom-webcodecs-tests.ts
@@ -128,10 +128,10 @@ AudioDecoder.isConfigSupported(futureAudioDecoderConfig);
 // $ExpectType void
 audioDecoder.configure(futureAudioDecoderConfig);
 
-audioDecoder.ondequeue = () => '';
+audioDecoder.ondequeue = () => "";
 
 // $ExpectType void
-audioDecoder.addEventListener('dequeue', (e) => e, { once: true });
+audioDecoder.addEventListener("dequeue", (e) => e, { once: true });
 
 genericCodec(audioDecoder);
 
@@ -229,7 +229,7 @@ audioEncoder.configure(futureAudioEncoderConfig);
 audioEncoder.encode(audioFrame);
 
 // $ExpectType void
-audioEncoder.addEventListener('dequeue', (e) => e, { once: true });
+audioEncoder.addEventListener("dequeue", (e) => e, { once: true });
 
 // $ExpectType void
 audioFrame.close();
@@ -433,7 +433,7 @@ videoDecoder.configure(futureVideoDecoderConfig);
 genericCodec(videoDecoder);
 
 // $ExpectType void
-videoDecoder.addEventListener('dequeue', () => {}, { once: true });
+videoDecoder.addEventListener("dequeue", () => {}, { once: true });
 
 // $ExpectType void
 videoDecoder.decode(encodedVideoChunk);
@@ -556,7 +556,7 @@ videoEncoder.configure(futureVideoEncoderConfig);
 videoEncoder.encodeQueueSize;
 
 // $ExpectType void
-videoEncoder.addEventListener('dequeue', () => {}, { once: true });
+videoEncoder.addEventListener("dequeue", () => {}, { once: true });
 
 // $ExpectType void
 videoEncoder.encode(videoFrame);

--- a/types/dom-webcodecs/webcodecs.generated.d.ts
+++ b/types/dom-webcodecs/webcodecs.generated.d.ts
@@ -222,10 +222,26 @@ interface AudioDecoder {
     decode(chunk: EncodedAudioChunk): void;
     flush(): Promise<void>;
     reset(): void;
-    addEventListener<K extends keyof AudioDecoderEventMap>(type: K, listener: (this: AudioDecoder, ev: AudioDecoderEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener<K extends keyof AudioDecoderEventMap>(type: K, listener: (this: AudioDecoder, ev: AudioDecoderEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    addEventListener<K extends keyof AudioDecoderEventMap>(
+        type: K,
+        listener: (this: AudioDecoder, ev: AudioDecoderEventMap[K]) => any,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    addEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    removeEventListener<K extends keyof AudioDecoderEventMap>(
+        type: K,
+        listener: (this: AudioDecoder, ev: AudioDecoderEventMap[K]) => any,
+        options?: boolean | EventListenerOptions,
+    ): void;
+    removeEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | EventListenerOptions,
+    ): void;
 }
 
 declare var AudioDecoder: {
@@ -248,10 +264,26 @@ interface AudioEncoder {
     encode(data: AudioData): void;
     flush(): Promise<void>;
     reset(): void;
-    addEventListener<K extends keyof AudioEncoderEventMap>(type: K, listener: (this: AudioEncoder, ev: AudioEncoderEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener<K extends keyof AudioEncoderEventMap>(type: K, listener: (this: AudioEncoder, ev: AudioEncoderEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    addEventListener<K extends keyof AudioEncoderEventMap>(
+        type: K,
+        listener: (this: AudioEncoder, ev: AudioEncoderEventMap[K]) => any,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    addEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    removeEventListener<K extends keyof AudioEncoderEventMap>(
+        type: K,
+        listener: (this: AudioEncoder, ev: AudioEncoderEventMap[K]) => any,
+        options?: boolean | EventListenerOptions,
+    ): void;
+    removeEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | EventListenerOptions,
+    ): void;
 }
 
 declare var AudioEncoder: {
@@ -355,10 +387,26 @@ interface VideoDecoder {
     decode(chunk: EncodedVideoChunk): void;
     flush(): Promise<void>;
     reset(): void;
-    addEventListener<K extends keyof VideoDecoderEventMap>(type: K, listener: (this: VideoDecoder, ev: VideoDecoderEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener<K extends keyof VideoDecoderEventMap>(type: K, listener: (this: VideoDecoder, ev: VideoDecoderEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    addEventListener<K extends keyof VideoDecoderEventMap>(
+        type: K,
+        listener: (this: VideoDecoder, ev: VideoDecoderEventMap[K]) => any,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    addEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    removeEventListener<K extends keyof VideoDecoderEventMap>(
+        type: K,
+        listener: (this: VideoDecoder, ev: VideoDecoderEventMap[K]) => any,
+        options?: boolean | EventListenerOptions,
+    ): void;
+    removeEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | EventListenerOptions,
+    ): void;
 }
 
 declare var VideoDecoder: {
@@ -381,10 +429,26 @@ interface VideoEncoder {
     encode(frame: VideoFrame, options?: VideoEncoderEncodeOptions): void;
     flush(): Promise<void>;
     reset(): void;
-    addEventListener<K extends keyof VideoEncoderEventMap>(type: K, listener: (this: VideoEncoder, ev: VideoEncoderEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener<K extends keyof VideoEncoderEventMap>(type: K, listener: (this: VideoEncoder, ev: VideoEncoderEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    addEventListener<K extends keyof VideoEncoderEventMap>(
+        type: K,
+        listener: (this: VideoEncoder, ev: VideoEncoderEventMap[K]) => any,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    addEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    removeEventListener<K extends keyof VideoEncoderEventMap>(
+        type: K,
+        listener: (this: VideoEncoder, ev: VideoEncoderEventMap[K]) => any,
+        options?: boolean | EventListenerOptions,
+    ): void;
+    removeEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | EventListenerOptions,
+    ): void;
 }
 
 declare var VideoEncoder: {

--- a/types/dom-webcodecs/webcodecs.generated.d.ts
+++ b/types/dom-webcodecs/webcodecs.generated.d.ts
@@ -208,15 +208,24 @@ declare var AudioData: {
     new(init: AudioDataInit): AudioData;
 };
 
+interface AudioDecoderEventMap {
+    "dequeue": Event;
+}
+
 /** Available only in secure contexts. */
 interface AudioDecoder {
     readonly decodeQueueSize: number;
     readonly state: CodecState;
+    ondequeue: ((this: AudioDecoder, ev: Event) => any) | null;
     close(): void;
     configure(config: AudioDecoderConfig): void;
     decode(chunk: EncodedAudioChunk): void;
     flush(): Promise<void>;
     reset(): void;
+    addEventListener<K extends keyof AudioDecoderEventMap>(type: K, listener: (this: AudioDecoder, ev: AudioDecoderEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof AudioDecoderEventMap>(type: K, listener: (this: AudioDecoder, ev: AudioDecoderEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }
 
 declare var AudioDecoder: {
@@ -225,15 +234,24 @@ declare var AudioDecoder: {
     isConfigSupported(config: AudioDecoderConfig): Promise<AudioDecoderSupport>;
 };
 
+interface AudioEncoderEventMap {
+    "dequeue": Event;
+}
+
 /** Available only in secure contexts. */
 interface AudioEncoder {
     readonly encodeQueueSize: number;
     readonly state: CodecState;
+    ondequeue: ((this: AudioEncoder, ev: Event) => any) | null;
     close(): void;
     configure(config: AudioEncoderConfig): void;
     encode(data: AudioData): void;
     flush(): Promise<void>;
     reset(): void;
+    addEventListener<K extends keyof AudioEncoderEventMap>(type: K, listener: (this: AudioEncoder, ev: AudioEncoderEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof AudioEncoderEventMap>(type: K, listener: (this: AudioEncoder, ev: AudioEncoderEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }
 
 declare var AudioEncoder: {
@@ -323,15 +341,24 @@ declare var VideoColorSpace: {
     new(init?: VideoColorSpaceInit): VideoColorSpace;
 };
 
+interface VideoDecoderEventMap {
+    "dequeue": Event;
+}
+
 /** Available only in secure contexts. */
 interface VideoDecoder {
     readonly decodeQueueSize: number;
     readonly state: CodecState;
+    ondequeue: ((this: VideoDecoder, ev: Event) => any) | null;
     close(): void;
     configure(config: VideoDecoderConfig): void;
     decode(chunk: EncodedVideoChunk): void;
     flush(): Promise<void>;
     reset(): void;
+    addEventListener<K extends keyof VideoDecoderEventMap>(type: K, listener: (this: VideoDecoder, ev: VideoDecoderEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof VideoDecoderEventMap>(type: K, listener: (this: VideoDecoder, ev: VideoDecoderEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }
 
 declare var VideoDecoder: {
@@ -340,15 +367,24 @@ declare var VideoDecoder: {
     isConfigSupported(config: VideoDecoderConfig): Promise<VideoDecoderSupport>;
 };
 
+interface VideoEncoderEventMap {
+    "dequeue": Event;
+}
+
 /** Available only in secure contexts. */
 interface VideoEncoder {
     readonly encodeQueueSize: number;
     readonly state: CodecState;
     close(): void;
+    ondequeue: ((this: VideoEncoder, ev: Event) => any) | null;
     configure(config: VideoEncoderConfig): void;
     encode(frame: VideoFrame, options?: VideoEncoderEncodeOptions): void;
     flush(): Promise<void>;
     reset(): void;
+    addEventListener<K extends keyof VideoEncoderEventMap>(type: K, listener: (this: VideoEncoder, ev: VideoEncoderEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof VideoEncoderEventMap>(type: K, listener: (this: VideoEncoder, ev: VideoEncoderEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }
 
 declare var VideoEncoder: {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/w3c/webcodecs/pull/439

MDN - Video: [Encoder](https://developer.mozilla.org/en-US/docs/Web/API/VideoEncoder/dequeue_event), [Decoder](https://developer.mozilla.org/en-US/docs/Web/API/VideoDecoder/dequeue_event)
MDN - Audio: [Encoder](https://developer.mozilla.org/en-US/docs/Web/API/AudioEncoder/dequeue_event), [Decoder](https://developer.mozilla.org/en-US/docs/Web/API/AudioDecoder/dequeue_event)




