### PR TITLE
chrome-apps: Update HTMLElement requestPointerLock to return Promise

### DIFF
--- a/types/chrome-apps/index.d.ts
+++ b/types/chrome-apps/index.d.ts
@@ -13750,7 +13750,7 @@ interface HTMLElement {
     /**
      * @requires Permissions: 'pointerLock'
      */
-    requestPointerLock(): void;
+    requestPointerLock(): Promise<void>;
     /**
      * @requires Permissions: 'pointerLock'
      */

--- a/types/chrome-apps/test/index.ts
+++ b/types/chrome-apps/test/index.ts
@@ -2178,6 +2178,13 @@ appview.connect("id of app");
 document.appendChild(appview);
 // #endregion
 
-// #region HTMLElement correctly subtypes Element in TS3.1.
-const htmlElement = document.querySelector("zzzzzz") as HTMLElement | null;
+// #region HTMLElement.
+function testHTMLElementCorrectlySubtypesElement() {
+    const htmlElement = document.querySelector("zzzzzz") as HTMLElement | null;
+}
+
+function testHTMLElementRequestPointerLockReturnsPromise() {
+    const htmlElement = document.querySelector("x")! as HTMLElement;
+    htmlElement.requestPointerLock().then(() => {});
+}
 // #endregion


### PR DESCRIPTION
This is consistent with both the API:
https://developer.mozilla.org/en-US/docs/Web/API/Element/requestPointerLock#return_value

As well as its upcoming inclusion in TypeScript's built-in types for requestPointerLock: https://github.com/microsoft/TypeScript/blob/90da3ca5dd694f7029b535ea09727be899854d40/src/lib/dom.generated.d.ts#L7873

Which was added here:
https://github.com/microsoft/TypeScript/pull/59259