### PR TITLE
Add missing `extendedError` field for `LAUNCH_ERROR` messages in `castv2`

### DIFF
--- a/types/castv2/castv2-tests.ts
+++ b/types/castv2/castv2-tests.ts
@@ -151,8 +151,10 @@ function sendExplicitLaunchRequestWithParameters(channel: Channel) {
 function handleLaunchErrorMessages(channel: Channel) {
     channel.on("message", (message: ReceiverMessage, broadcast: boolean) => {
         if (message.type == "LAUNCH_ERROR") {
-            const reason = (message as ReceiverLaunchErrorMessage).reason;
-            console.log(`Launch failed, reason "${reason}"`);
+            const launchError = message as ReceiverLaunchErrorMessage;
+            const reason = launchError.reason;
+            const extendedError = launchError.extendedError;
+            console.log(`Launch failed, reason "${reason}" (${extendedError})`);
         }
     });
 }

--- a/types/castv2/index.d.ts
+++ b/types/castv2/index.d.ts
@@ -83,6 +83,7 @@ export interface ReceiverStatusMessage extends ReceiverMessage {
 export interface ReceiverLaunchErrorMessage extends ReceiverMessage {
     type: "LAUNCH_ERROR";
     reason: string;
+    extendedError: string;
 }
 
 export interface ReceiverLaunchStatusMessage extends ReceiverMessage {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: These messages are not part of a documented protocol, but this field was discovered while debugging a Cast device
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
