### PR TITLE
[@types/backbone] Correct Backbone.View member types

### DIFF
--- a/types/backbone.marionette/index.d.ts
+++ b/types/backbone.marionette/index.d.ts
@@ -871,7 +871,7 @@ export interface ViewOptions<TModel extends Backbone.Model> extends Backbone.Vie
 export class View<TModel extends Backbone.Model> extends Backbone.View<TModel> implements ViewMixin, RegionsMixin {
     constructor(options?: ViewOptions<TModel>);
 
-    events(): EventsHash;
+    events: EventsHash | (() => EventsHash);
 
     /**
      * Returns a new HTML DOM node instance. The resulting node can be

--- a/types/backbone.marionette/index.d.ts
+++ b/types/backbone.marionette/index.d.ts
@@ -871,7 +871,7 @@ export interface ViewOptions<TModel extends Backbone.Model> extends Backbone.Vie
 export class View<TModel extends Backbone.Model> extends Backbone.View<TModel> implements ViewMixin, RegionsMixin {
     constructor(options?: ViewOptions<TModel>);
 
-    events: EventsHash | (() => EventsHash);
+    events: Backbone._Result<EventsHash>;
 
     /**
      * Returns a new HTML DOM node instance. The resulting node can be

--- a/types/backbone/backbone-tests.ts
+++ b/types/backbone/backbone-tests.ts
@@ -580,7 +580,7 @@ class EventsViewObject extends Backbone.View {
     }
 }
 
-function events(this: EventsViewMethod) {
+function eventsFn(this: EventsViewMethod) {
     const eventsHash: Backbone.EventsHash = {
         click: "onClick",
     };
@@ -604,7 +604,7 @@ class EventsViewMethod extends Backbone.View {
             this.events = options.events;
         }
 
-        this.events = events;
+        this.events = eventsFn;
     }
 }
 

--- a/types/backbone/backbone-tests.ts
+++ b/types/backbone/backbone-tests.ts
@@ -564,6 +564,38 @@ class ModellessView extends Backbone.View {
     }
 }
 
+class EventsViewObject extends Backbone.View {
+    events: Backbone.EventsHash;
+
+    constructor(options: Backbone.ViewOptions) {
+        super(options);
+
+        this.events = {
+            "click": "onClick",
+        };
+
+        if (typeof options.events === "object") {
+            this.events = options.events;
+        }
+    }
+}
+
+class EventsViewMethod extends Backbone.View {
+    events: () => Backbone.EventsHash;
+
+    constructor(options: Backbone.ViewOptions) {
+        super(options);
+
+        this.events = () => ({
+            "click": "onClick",
+        });
+
+        if (typeof options.events === "function") {
+            this.events = options.events;
+        }
+    }
+}
+
 interface SVGViewOptions extends Backbone.ViewOptions<Backbone.Model, SVGGraphicsElement> {
 }
 

--- a/types/backbone/backbone-tests.ts
+++ b/types/backbone/backbone-tests.ts
@@ -580,6 +580,16 @@ class EventsViewObject extends Backbone.View {
     }
 }
 
+function events(this: EventsViewMethod) {
+    const eventsHash: Backbone.EventsHash = {
+        click: "onClick",
+    };
+
+    if (this.model) eventsHash.reset = "onReset";
+
+    return eventsHash;
+}
+
 class EventsViewMethod extends Backbone.View {
     events: () => Backbone.EventsHash;
 
@@ -593,6 +603,8 @@ class EventsViewMethod extends Backbone.View {
         if (typeof options.events === "function") {
             this.events = options.events;
         }
+
+        this.events = events;
     }
 }
 

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -554,7 +554,7 @@ declare namespace Backbone {
          * For assigning events as object hash, do it like this: this.events = <any>{ "event:selector": callback, ... };
          * That works only if you set it in the constructor or the initialize method.
          */
-        events(): EventsHash;
+        events: EventsHash | (() => EventsHash);
 
         // A conditional type used here to prevent `TS2532: Object is possibly 'undefined'`
         model: TModel extends Model ? TModel : undefined;
@@ -569,8 +569,8 @@ declare namespace Backbone {
         $el: JQuery;
         attributes: Record<string, any>;
         $(selector: string): JQuery;
-        render(): this;
-        remove(): this;
+        render(): any;
+        remove(): any;
         delegateEvents(events?: _Result<EventsHash>): this;
         delegate(eventName: string, selector: string, listener: ViewEventListener): this;
         undelegateEvents(): this;

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -569,7 +569,7 @@ declare namespace Backbone {
         $el: JQuery;
         attributes: Record<string, any>;
         $(selector: string): JQuery;
-        render(): any;
+        render(...args: any[]): any;
         remove(): this;
         delegateEvents(events?: _Result<EventsHash>): this;
         delegate(eventName: string, selector: string, listener: ViewEventListener): this;

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -569,7 +569,7 @@ declare namespace Backbone {
         $el: JQuery;
         attributes: Record<string, any>;
         $(selector: string): JQuery;
-        render(...args: any[]): any;
+        render(): this;
         remove(): this;
         delegateEvents(events?: _Result<EventsHash>): this;
         delegate(eventName: string, selector: string, listener: ViewEventListener): this;

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -554,7 +554,7 @@ declare namespace Backbone {
          * For assigning events as object hash, do it like this: this.events = <any>{ "event:selector": callback, ... };
          * That works only if you set it in the constructor or the initialize method.
          */
-        events: EventsHash | (() => EventsHash);
+        events: _Result<EventsHash>;
 
         // A conditional type used here to prevent `TS2532: Object is possibly 'undefined'`
         model: TModel extends Model ? TModel : undefined;

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -570,7 +570,7 @@ declare namespace Backbone {
         attributes: Record<string, any>;
         $(selector: string): JQuery;
         render(): any;
-        remove(): any;
+        remove(): this;
         delegateEvents(events?: _Result<EventsHash>): this;
         delegate(eventName: string, selector: string, listener: ViewEventListener): this;
         undelegateEvents(): this;


### PR DESCRIPTION
`View.events` can be an `EventsHash` object or a method that returns an `EventsHash` object. `delegateEvents` uses `_Result` for this, so I've done the same here. Note that this change will cause errors if a subclass of `View` defines `events` as a method _declaration_ instead of an expression (this is by design in TypeScript).

`View.render` is a noop, the docs say convention is to return `this`, but in reality, it can return anything and have any arguments passed.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - https://backbonejs.org/#View-events
    - https://backbonejs.org/#View-render
    - https://backbonejs.org/#View-remove
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
