### PR TITLE
[@types/react]: allow useState setter void calls when undefined

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1820,7 +1820,7 @@ declare namespace React {
      * }
      * ```
      */
-    type SetStateAction<S> = S | ((prevState: S) => S);
+    type SetStateAction<S> = undefined extends S ? void | S | ((prevState: S) => S) : S | ((prevState: S) => S);
 
     /**
      * A function that can be used to update the state of a {@link useState}

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -255,6 +255,9 @@ function useEveryHook(ref: React.Ref<{ id: number }> | undefined): () => boolean
     React.useState()[0];
     // $ExpectType number | undefined
     React.useState<number>()[0];
+    // allow void calls to update the state with this overload
+    React.useState()[1]();
+
     // default overload
     // $ExpectType number
     React.useState(0)[0];
@@ -263,12 +266,27 @@ function useEveryHook(ref: React.Ref<{ id: number }> | undefined): () => boolean
     // make sure the generic argument does reject actual potentially undefined inputs
     // @ts-expect-error
     React.useState<number>(undefined)[0];
+    // don't allow void calls to update the state with the default overload
+    // @ts-expect-error
+    React.useState(0)[1]();
+
     // make sure useState does not widen
-    const [toggle, setToggle] = React.useState(false);
-    // $ExpectType boolean
-    toggle;
-    // make sure setState accepts a function
-    setToggle(r => !r);
+    {
+        // default overload
+        const [toggle, setToggle] = React.useState(false);
+        // $ExpectType boolean
+        toggle;
+        // make sure setState accepts a function
+        setToggle(r => !r);
+    }
+    {
+        // undefined overload
+        const [toggle, setToggle] = React.useState<boolean>();
+        // $ExpectType boolean | undefined
+        toggle;
+        // make sure setState accepts a function
+        setToggle(r => !r);
+    }
 
     // Undesired
     // Should not type-check since `number` will be `number` at runtime but `() => number` in the type-checker

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -266,9 +266,9 @@ function useEveryHook(ref: React.Ref<{ id: number }> | undefined): () => boolean
     // make sure the generic argument does reject actual potentially undefined inputs
     // @ts-expect-error
     React.useState<number>(undefined)[0];
-    // don't allow void calls to update the state with the default overload
+    // don't allow void calls to update when the generic doesn't include undefined, e.g. when an initial value is set.
     // @ts-expect-error
-    React.useState(0)[1]();
+    React.useState('initialValue')[1]();
 
     // make sure useState does not widen
     {

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -1821,7 +1821,7 @@ declare namespace React {
      * }
      * ```
      */
-    type SetStateAction<S> = S | ((prevState: S) => S);
+    type SetStateAction<S> = undefined extends S ? void | S | ((prevState: S) => S) : S | ((prevState: S) => S);
 
     /**
      * A function that can be used to update the state of a {@link useState}

--- a/types/use-persisted-state/use-persisted-state-tests.ts
+++ b/types/use-persisted-state/use-persisted-state-tests.ts
@@ -62,4 +62,4 @@ const useCounterState = createPersistedState<number>("count");
 const initialCount = 1;
 const [count, setCount] = useCounterState(initialCount);
 count; // $ExpectType number
-setCount; // $ExpectType Dispatch<SetStateAction<number>>
+setCount; // $ExpectType Dispatch<number | ((prevState: number) => number)>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
This is tecnically something allowed by JS, but it's not a documented feature within React. Docs only shows examples with an initial state, and the Flow anotations don't allow undefined state either.
Since `@types/react` does support undefined, this will allow to call the setter without arguments.
