### PR TITLE
[node-red__util] Upgrade `jsonata` to 2.x used by Node-RED v4

### DIFF
--- a/types/node-red__util/index.d.ts
+++ b/types/node-red__util/index.d.ts
@@ -286,14 +286,12 @@ declare namespace util {
          *
          * @param   expr     - the prepared JSONata expression
          * @param   msg      - the message object to evaluate against
-         * @param   callback - (optional) called when the expression is evaluated
-         * @returns If no callback was provided, the result of the expression
+         * @param   callback - a callback with the result of the expression
          */
-        evaluateJSONataExpression(expr: JsonataExpression, msg: registry.NodeMessage): any;
         evaluateJSONataExpression(
             expr: JsonataExpression,
             msg: registry.NodeMessage,
-            callback: (err: Error | null, resp: any) => void,
+            callback: (error: Error | null, result: any) => void,
         ): void;
         /**
          * Normalise a node type name to camel case.

--- a/types/node-red__util/node-red__util-tests.ts
+++ b/types/node-red__util/node-red__util-tests.ts
@@ -123,7 +123,7 @@ function utilTests(someNode: Node) {
     // $ExpectType Expression
     const jsonataExpr = util.prepareJSONataExpression("expr", someNode);
 
-    // $ExpectType any
+    // @ts-expect-error
     util.evaluateJSONataExpression(jsonataExpr, {});
     // $ExpectType void
     util.evaluateJSONataExpression(jsonataExpr, {}, (err: Error | null, res: any): void => {});

--- a/types/node-red__util/package.json
+++ b/types/node-red__util/package.json
@@ -9,7 +9,7 @@
     "dependencies": {
         "@types/node-red__registry": "*",
         "@types/node-red__runtime": "*",
-        "jsonata": "1.8.3"
+        "jsonata": "2.0.5"
     },
     "devDependencies": {
         "@types/node-red__util": "workspace:."


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


Changes:

- Bump `jsonata` from 1.8.3 to 2.0.5 used by Node-RED v4
- Update the type of the `callback` parameter which is now required for NR v4

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/node-red/node-red/commit/3aeb4bd8680f2ca1805d056523009a5bec4147fd>>  <<https://github.com/node-red/node-red/pull/4590>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
