### PR TITLE
[node] Update typings to v22.5.0

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -1902,6 +1902,19 @@ declare module "http" {
      * Defaults to 16KB. Configurable using the `--max-http-header-size` CLI option.
      */
     const maxHeaderSize: number;
+    /**
+     * A browser-compatible implementation of [WebSocket](https://nodejs.org/docs/latest/api/http.html#websocket).
+     * @since v22.5.0
+     */
+    const WebSocket: import("undici-types").WebSocket;
+    /**
+     * @since v22.5.0
+     */
+    const CloseEvent: import("undici-types").CloseEvent;
+    /**
+     * @since v22.5.0
+     */
+    const MessageEvent: import("undici-types").MessageEvent;
 }
 declare module "node:http" {
     export * from "http";

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -67,6 +67,7 @@
 /// <reference path="readline/promises.d.ts" />
 /// <reference path="repl.d.ts" />
 /// <reference path="sea.d.ts" />
+/// <reference path="sqlite.d.ts" />
 /// <reference path="stream.d.ts" />
 /// <reference path="stream/promises.d.ts" />
 /// <reference path="stream/consumers.d.ts" />

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -27,6 +27,7 @@ import "./test/querystring";
 import "./test/readline";
 import "./test/repl";
 import "./test/sea";
+import "./test/sqlite";
 import "./test/stream";
 import "./test/string_decoder";
 import "./test/test";

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "22.4.9999",
+    "version": "22.5.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [

--- a/types/node/path.d.ts
+++ b/types/node/path.d.ts
@@ -95,6 +95,15 @@ declare module "path" {
              */
             resolve(...paths: string[]): string;
             /**
+             * The `path.matchesGlob()` method determines if `path` matches the `pattern`.
+             * @param path The path to glob-match against.
+             * @param pattern The glob to check the path against.
+             * @returns Whether or not the `path` matched the `pattern`.
+             * @throws {TypeError} if `path` or `pattern` are not strings.
+             * @since v22.5.0
+             */
+            matchesGlob(path: string, pattern: string): boolean;
+            /**
              * Determines whether {path} is an absolute path. An absolute path will always resolve to the same location, regardless of the working directory.
              *
              * If the given {path} is a zero-length string, `false` will be returned.

--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -75,6 +75,7 @@ declare module "process" {
         "repl": typeof import("repl");
         "node:repl": typeof import("node:repl");
         "node:sea": typeof import("node:sea");
+        "node:sqlite": typeof import("node:sqlite");
         "stream": typeof import("stream");
         "node:stream": typeof import("node:stream");
         "stream/consumers": typeof import("stream/consumers");
@@ -893,6 +894,40 @@ declare module "process" {
                  * @since v0.11.8
                  */
                 exitCode?: number | string | number | undefined;
+                finalization: {
+                    /**
+                     * This function registers a callback to be called when the process emits the `exit` event if the `ref` object was not garbage collected.
+                     * If the object `ref` was garbage collected before the `exit` event is emitted, the callback will be removed from the finalization registry, and it will not be called on process exit.
+                     * 
+                     * Inside the callback you can release the resources allocated by the `ref` object.
+                     * Be aware that all limitations applied to the `beforeExit` event are also applied to the callback function,
+                     * this means that there is a possibility that the callback will not be called under special circumstances.
+                     * 
+                     * The idea of ​​this function is to help you free up resources when the starts process exiting, but also let the object be garbage collected if it is no longer being used.
+                     * @param ref The reference to the resource that is being tracked.
+                     * @param callback The callback function to be called when the resource is finalized.
+                     * @since v22.5.0
+                     * @experimental
+                     */
+                    register<T extends object>(ref: T, callback: (ref: T, event: "exit") => void): void;
+                    /**
+                     * This function behaves exactly like the `register`, except that the callback will be called when the process emits the `beforeExit` event if `ref` object was not garbage collected.
+                     * 
+                     * Be aware that all limitations applied to the `beforeExit` event are also applied to the callback function, this means that there is a possibility that the callback will not be called under special circumstances.
+                     * @param ref The reference to the resource that is being tracked.
+                     * @param callback The callback function to be called when the resource is finalized.
+                     * @since v22.5.0
+                     * @experimental
+                     */
+                    registerBeforeExit<T extends object>(ref: T, callback: (ref: T, event: "beforeExit") => void): void;
+                    /**
+                     * This function remove the register of the object from the finalization registry, so the callback will not be called anymore.
+                     * @param ref The reference to the resource that was registered previously.
+                     * @since v22.5.0
+                     * @experimental
+                     */
+                    unregister(ref: object): void;
+                };
                 /**
                  * The `process.getActiveResourcesInfo()` method returns an array of strings containing
                  * the types of the active resources that are currently keeping the event loop alive.

--- a/types/node/scripts/generate-docs/ast-processing.ts
+++ b/types/node/scripts/generate-docs/ast-processing.ts
@@ -524,7 +524,7 @@ export class NodeProcessingContext {
             processRes = this.processFunctionDeclaration(node);
         } else if (
             isNamedModuleDeclaration(node)
-            && !(node.name.text.startsWith("node:") && node.name.text !== "node:test") // apparently everything is a module
+            && !(node.name.text.startsWith("node:") && node.name.text !== "node:test" && node.name.text !== "node:sqlite") // apparently everything is a module
         ) {
             processRes = this.handleModuleDeclaration();
         } else if (isClassDeclaration(node)) {

--- a/types/node/scripts/generate-docs/docs.ts
+++ b/types/node/scripts/generate-docs/docs.ts
@@ -44,7 +44,7 @@ function transformer(printer: Printer, typeChecker: TypeChecker, rootDocs: DocRo
             const moduleName = node.name.text;
 
             // skip non prefixed modules
-            if (moduleName.startsWith("node:") && moduleName !== "node:sea" && moduleName !== "node:test") {
+            if (moduleName.startsWith("node:") && moduleName !== "node:sea" && moduleName !== "node:test" && moduleName !== "node:sqlite") {
                 return node;
             }
 

--- a/types/node/scripts/generate-docs/node-doc-processing.ts
+++ b/types/node/scripts/generate-docs/node-doc-processing.ts
@@ -226,6 +226,9 @@ function fixupModuleStructure(node: DocRoot): void {
         ["in_the_injected_main_script", "single-executable_application_api"],
     ]);
 
+    // sqlite
+    renameModule("sqlite", "node:sqlite");
+
     // some of the methods of Http2ServerResponse are incorrectly nested under the `req` property.
     const http2Module = getModule(node, "http2");
     const httpResponseClass = getClass(http2Module, "http2.Http2ServerResponse");

--- a/types/node/sqlite.d.ts
+++ b/types/node/sqlite.d.ts
@@ -1,0 +1,207 @@
+/**
+ * The `node:sqlite` module facilitates working with SQLite databases.
+ * To access it:
+ *
+ * ```js
+ * import sqlite from 'node:sqlite';
+ * ```
+ *
+ * This module is only available under the `node:` scheme. The following will not
+ * work:
+ *
+ * ```js
+ * import sqlite from 'sqlite';
+ * ```
+ *
+ * The following example shows the basic usage of the `node:sqlite` module to open
+ * an in-memory database, write data to the database, and then read the data back.
+ *
+ * ```js
+ * import { DatabaseSync } from 'node:sqlite';
+ * const database = new DatabaseSync(':memory:');
+ *
+ * // Execute SQL statements from strings.
+ * database.exec(`
+ *   CREATE TABLE data(
+ *     key INTEGER PRIMARY KEY,
+ *     value TEXT
+ *   ) STRICT
+ * `);
+ * // Create a prepared statement to insert data into the database.
+ * const insert = database.prepare('INSERT INTO data (key, value) VALUES (?, ?)');
+ * // Execute the prepared statement with bound values.
+ * insert.run(1, 'hello');
+ * insert.run(2, 'world');
+ * // Create a prepared statement to read data from the database.
+ * const query = database.prepare('SELECT * FROM data ORDER BY key');
+ * // Execute the prepared statement and log the result set.
+ * console.log(query.all());
+ * // Prints: [ { key: 1, value: 'hello' }, { key: 2, value: 'world' } ]
+ * ```
+ * @since v22.5.0
+ * @experimental
+ * @see [source](https://github.com/nodejs/node/blob/v22.x/lib/sqlite.js)
+ */
+declare module "node:sqlite" {
+    interface DatabaseSyncOptions {
+        /**
+         * If `true`, the database is opened by the constructor.
+         * When this value is `false`, the database must be opened via the `open()` method.
+         */
+        open?: boolean | undefined;
+    }
+    /**
+     * This class represents a single [connection](https://www.sqlite.org/c3ref/sqlite3.html) to a SQLite database. All APIs
+     * exposed by this class execute synchronously.
+     * @since v22.5.0
+     */
+    class DatabaseSync {
+        /**
+         * Constructs a new `DatabaseSync` instance.
+         * @param location The location of the database.
+         * A SQLite database can be stored in a file or completely [in memory](https://www.sqlite.org/inmemorydb.html).
+         * To use a file-backed database, the location should be a file path.
+         * To use an in-memory database, the location should be the special name `':memory:'`.
+         * @param options Configuration options for the database connection.
+         */
+        constructor(location: string, options?: DatabaseSyncOptions);
+        /**
+         * Closes the database connection. An exception is thrown if the database is not
+         * open. This method is a wrapper around [`sqlite3_close_v2()`](https://www.sqlite.org/c3ref/close.html).
+         * @since v22.5.0
+         */
+        close(): void;
+        /**
+         * This method allows one or more SQL statements to be executed without returning
+         * any results. This method is useful when executing SQL statements read from a
+         * file. This method is a wrapper around [`sqlite3_exec()`](https://www.sqlite.org/c3ref/exec.html).
+         * @since v22.5.0
+         * @param sql A SQL string to execute.
+         */
+        exec(sql: string): void;
+        /**
+         * Opens the database specified in the `location` argument of the `DatabaseSync`constructor. This method should only be used when the database is not opened via
+         * the constructor. An exception is thrown if the database is already open.
+         * @since v22.5.0
+         */
+        open(): void;
+        /**
+         * Compiles a SQL statement into a [prepared statement](https://www.sqlite.org/c3ref/stmt.html). This method is a wrapper
+         * around [`sqlite3_prepare_v2()`](https://www.sqlite.org/c3ref/prepare.html).
+         * @since v22.5.0
+         * @param sql A SQL string to compile to a prepared statement.
+         * @return The prepared statement.
+         */
+        prepare(sql: string): StatementSync;
+    }
+    type SupportedValueType = null | number | bigint | string | Uint8Array;
+    interface StatementResultingChanges {
+        /**
+         * The number of rows modified, inserted, or deleted by the most recently completed `INSERT`, `UPDATE`, or `DELETE` statement.
+         * This field is either a number or a `BigInt` depending on the prepared statement's configuration.
+         * This property is the result of [`sqlite3_changes64()`](https://www.sqlite.org/c3ref/changes.html).
+         */
+        changes: number | bigint;
+        /**
+         * The most recently inserted rowid.
+         * This field is either a number or a `BigInt` depending on the prepared statement's configuration.
+         * This property is the result of [`sqlite3_last_insert_rowid()`](https://www.sqlite.org/c3ref/last_insert_rowid.html).
+         */
+        lastInsertRowid: number | bigint;
+    }
+    /**
+     * This class represents a single [prepared statement](https://www.sqlite.org/c3ref/stmt.html). This class cannot be
+     * instantiated via its constructor. Instead, instances are created via the`database.prepare()` method. All APIs exposed by this class execute
+     * synchronously.
+     *
+     * A prepared statement is an efficient binary representation of the SQL used to
+     * create it. Prepared statements are parameterizable, and can be invoked multiple
+     * times with different bound values. Parameters also offer protection against [SQL injection](https://en.wikipedia.org/wiki/SQL_injection) attacks. For these reasons, prepared statements are
+     * preferred
+     * over hand-crafted SQL strings when handling user input.
+     * @since v22.5.0
+     */
+    class StatementSync {
+        private constructor();
+        /**
+         * This method executes a prepared statement and returns all results as an array of
+         * objects. If the prepared statement does not return any results, this method
+         * returns an empty array. The prepared statement [parameters are bound](https://www.sqlite.org/c3ref/bind_blob.html) using
+         * the values in `namedParameters` and `anonymousParameters`.
+         * @since v22.5.0
+         * @param namedParameters An optional object used to bind named parameters. The keys of this object are used to configure the mapping.
+         * @param anonymousParameters Zero or more values to bind to anonymous parameters.
+         * @return An array of objects. Each object corresponds to a row returned by executing the prepared statement. The keys and values of each object correspond to the column names and values of
+         * the row.
+         */
+        all(...anonymousParameters: SupportedValueType[]): unknown[];
+        all(namedParameters: Record<string, SupportedValueType>, ...anonymousParameters: SupportedValueType[]): unknown[];
+        /**
+         * This method returns the source SQL of the prepared statement with parameter
+         * placeholders replaced by values. This method is a wrapper around [`sqlite3_expanded_sql()`](https://www.sqlite.org/c3ref/expanded_sql.html).
+         * @since v22.5.0
+         * @return The source SQL expanded to include parameter values.
+         */
+        expandedSQL(): string;
+        /**
+         * This method executes a prepared statement and returns the first result as an
+         * object. If the prepared statement does not return any results, this method
+         * returns `undefined`. The prepared statement [parameters are bound](https://www.sqlite.org/c3ref/bind_blob.html) using the
+         * values in `namedParameters` and `anonymousParameters`.
+         * @since v22.5.0
+         * @param namedParameters An optional object used to bind named parameters. The keys of this object are used to configure the mapping.
+         * @param anonymousParameters Zero or more values to bind to anonymous parameters.
+         * @return An object corresponding to the first row returned by executing the prepared statement. The keys and values of the object correspond to the column names and values of the row. If no
+         * rows were returned from the database then this method returns `undefined`.
+         */
+        get(...anonymousParameters: SupportedValueType[]): unknown;
+        get(namedParameters: Record<string, SupportedValueType>, ...anonymousParameters: SupportedValueType[]): unknown;
+        /**
+         * This method executes a prepared statement and returns an object summarizing the
+         * resulting changes. The prepared statement [parameters are bound](https://www.sqlite.org/c3ref/bind_blob.html) using the
+         * values in `namedParameters` and `anonymousParameters`.
+         * @since v22.5.0
+         * @param namedParameters An optional object used to bind named parameters. The keys of this object are used to configure the mapping.
+         * @param anonymousParameters Zero or more values to bind to anonymous parameters.
+         */
+        run(...anonymousParameters: SupportedValueType[]): StatementResultingChanges;
+        run(namedParameters: Record<string, SupportedValueType>, ...anonymousParameters: SupportedValueType[]): StatementResultingChanges;
+        /**
+         * The names of SQLite parameters begin with a prefix character. By default,`node:sqlite` requires that this prefix character is present when binding
+         * parameters. However, with the exception of dollar sign character, these
+         * prefix characters also require extra quoting when used in object keys.
+         *
+         * To improve ergonomics, this method can be used to also allow bare named
+         * parameters, which do not require the prefix character in JavaScript code. There
+         * are several caveats to be aware of when enabling bare named parameters:
+         *
+         * * The prefix character is still required in SQL.
+         * * The prefix character is still allowed in JavaScript. In fact, prefixed names
+         * will have slightly better binding performance.
+         * * Using ambiguous named parameters, such as `$k` and `@k`, in the same prepared
+         * statement will result in an exception as it cannot be determined how to bind
+         * a bare name.
+         * @since v22.5.0
+         * @param enabled Enables or disables support for binding named parameters without the prefix character.
+         */
+        setAllowBareNamedParameters(enabled: boolean): void;
+        /**
+         * When reading from the database, SQLite `INTEGER`s are mapped to JavaScript
+         * numbers by default. However, SQLite `INTEGER`s can store values larger than
+         * JavaScript numbers are capable of representing. In such cases, this method can
+         * be used to read `INTEGER` data using JavaScript `BigInt`s. This method has no
+         * impact on database write operations where numbers and `BigInt`s are both
+         * supported at all times.
+         * @since v22.5.0
+         * @param enabled Enables or disables the use of `BigInt`s when reading `INTEGER` fields from the database.
+         */
+        setReadBigInts(enabled: boolean): void;
+        /**
+         * This method returns the source SQL of the prepared statement. This method is a
+         * wrapper around [`sqlite3_sql()`](https://www.sqlite.org/c3ref/expanded_sql.html).
+         * @since v22.5.0
+         * @return The source SQL used to create this prepared statement.
+         */
+        sourceSQL(): string;
+    }
+}

--- a/types/node/test/path.ts
+++ b/types/node/test/path.ts
@@ -33,6 +33,8 @@ path.resolve("wwwroot", "static_files/png/", "../gif/image.gif");
 // if currently in /home/myself/node, it returns
 //    '/home/myself/node/wwwroot/static_files/gif/image.gif'
 
+path.matchesGlob("/foo/bar", "/foo/*"); // ExpectType boolean
+
 path.isAbsolute("/foo/bar"); // true
 path.isAbsolute("/baz/.."); // true
 path.isAbsolute("qux/"); // false

--- a/types/node/test/process.ts
+++ b/types/node/test/process.ts
@@ -1,4 +1,5 @@
 import * as p from "node:process";
+import { finalization } from "node:process";
 import assert = require("node:assert");
 import EventEmitter = require("node:events");
 import { constants } from "node:os";
@@ -216,4 +217,25 @@ process.env.TZ = "test";
 {
     const fs = globalThis.process.getBuiltinModule("fs");
     fs.constants.F_OK;
+}
+
+{
+    const myDisposableObject = {
+        dispose() {
+            // Free your resources synchronously
+        },
+    };
+
+    function onFinalize(obj: typeof myDisposableObject, event: string) {
+        // You can do whatever you want with the object
+        obj.dispose();
+    }
+
+    finalization.register(myDisposableObject, onFinalize);
+    finalization.registerBeforeExit(myDisposableObject, onFinalize);
+
+    // Do something
+
+    myDisposableObject.dispose();
+    finalization.unregister(myDisposableObject);
 }

--- a/types/node/test/sqlite.ts
+++ b/types/node/test/sqlite.ts
@@ -1,0 +1,34 @@
+import { DatabaseSync } from "node:sqlite";
+import { TextEncoder } from "node:util";
+
+{
+    const database = new DatabaseSync(":memory:", { open: false });
+    database.open();
+
+    database.exec(`
+    CREATE TABLE data(
+        key INTEGER PRIMARY KEY,
+        value TEXT
+    ) STRICT
+    `);
+
+    const insert = database.prepare("INSERT INTO types (key, int, double, text, buf) VALUES (?, ?, ?, ?, ?)");
+    insert.setReadBigInts(true);
+    insert.setAllowBareNamedParameters(true);
+    insert.run(1, 42, 3.14159, "foo", new TextEncoder().encode("a☃b☃c"));
+    insert.run(2, null, null, null, null);
+    insert.run(3, Number(8), Number(2.718), String("bar"), Buffer.from("x☃y☃"));
+    insert.run(4, 99n, 0xf, "", new Uint8Array());
+    insert.get(); // $ExpectType unknown
+
+    const query = database.prepare("SELECT * FROM data ORDER BY key");
+    query.all(); // $ExpectType unknown[]
+
+    const sql = "INSERT INTO types (key, val) VALUES ($k, ?)";
+    const stmt = database.prepare(sql);
+    const result = stmt.run({ $k: "33" }, "42");
+    result.changes; // $ExpectType number | bigint
+    result.lastInsertRowid; // $ExpectType number | bigint
+
+    database.close();
+}

--- a/types/node/test/worker_threads.ts
+++ b/types/node/test/worker_threads.ts
@@ -176,6 +176,10 @@ import { createContext } from "node:vm";
         // emit message event
         worker.postMessage({ port: port2 }, [port2]);
         port1.postMessage("From main to parent");
+        worker.postMessageToThread(10, { port: port2 }, [port2], 1000);
+        worker.postMessageToThread(10, { port: port2 }, [port2]);
+        worker.postMessageToThread(10, { x: 100 }, 1000);
+        worker.postMessageToThread(10, { x: 100 });
 
         // close event
         setTimeout(() => {

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -410,6 +410,19 @@ declare module "worker_threads" {
          */
         postMessage(value: any, transferList?: readonly TransferListItem[]): void;
         /**
+         * Sends a value to another worker, identified by its thread ID.
+         * @param threadId The target thread ID. If the thread ID is invalid, a `ERR_WORKER_MESSAGING_FAILED` error will be thrown.
+         * If the target thread ID is the current thread ID, a `ERR_WORKER_MESSAGING_SAME_THREAD` error will be thrown.
+         * @param value The value to send.
+         * @param transferList If one or more `MessagePort`-like objects are passed in value, a `transferList` is required for those items
+         * or `ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST` is thrown. See `port.postMessage()` for more information.
+         * @param timeout Time to wait for the message to be delivered in milliseconds. By default it's `undefined`, which means wait forever.
+         * If the operation times out, a `ERR_WORKER_MESSAGING_TIMEOUT` error is thrown.
+         * @since v22.5.0
+         */
+        postMessageToThread(threadId: number, value: any, timeout?: number): Promise<void>;
+        postMessageToThread(threadId: number, value: any, transferList: readonly TransferListItem[], timeout?: number): Promise<void>;
+        /**
          * Opposite of `unref()`, calling `ref()` on a previously `unref()`ed worker does _not_ let the program exit if it's the only active handle left (the default
          * behavior). If the worker is `ref()`ed, calling `ref()` again has
          * no effect.


### PR DESCRIPTION
https://github.com/nodejs/node/releases/tag/v22.5.0

- http: expose websockets
- lib: add `node:sqlite` module
- path: add `matchesGlob` method
- worker: add `postMessageToThread`
- process: port on-exit-leak-free to core

------------------------------------

Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/70210