### PR TITLE
Fix `Spy.calls` type to match ospec 4.2.0 behaviour, bump version

### DIFF
--- a/types/ospec/index.d.ts
+++ b/types/ospec/index.d.ts
@@ -7,7 +7,7 @@ declare namespace o {
         this: ((...args: unknown[]) => unknown) | undefined;
         args: Args;
     }
-    
+
     interface Spy<Args extends any[], Returns> {
         (...args: Args): Returns;
         /** The number of times the function has been called */

--- a/types/ospec/index.d.ts
+++ b/types/ospec/index.d.ts
@@ -3,14 +3,19 @@ type ObjectConstructor = new(...args: any[]) => any;
 declare namespace o {
     type AssertionDescriber = (description: string) => void;
 
+    interface Call<Args extends any[]> {
+        this: ((...args: unknown[]) => unknown) | undefined;
+        args: Args;
+    }
+    
     interface Spy<Args extends any[], Returns> {
         (...args: Args): Returns;
         /** The number of times the function has been called */
         readonly callCount: number;
-        /** The arguments that were passed to the function in the last time it was called */
+        /** The arguments that were passed to the function the last time it was called */
         readonly args: Args;
-        /** List of arguments that were passed to the function each tine it was called */
-        readonly calls: Args[];
+        /** The calls made to the spy.  Each array value is an object containing the `this` calling context and an `args` array. */
+        readonly calls: Array<Call<Args>>;
     }
 
     interface Assertion<T> {

--- a/types/ospec/ospec-tests.ts
+++ b/types/ospec/ospec-tests.ts
@@ -140,7 +140,7 @@ o.spec("ospec typings", () => {
     const {
         callCount, // $ExpectType number
         args, // $ExpectType any[]
-        calls, // $ExpectType any[][]
+        calls, // $ExpectType Call<any[]>[]
     } = dummySpy;
 
     const myFunc = (a: string, b?: boolean) => 42;
@@ -151,7 +151,7 @@ o.spec("ospec typings", () => {
     spiedFunc(..._args1); // $ExpectType number
     spiedFunc(..._args2); // $ExpectType number
     spiedFunc.args; // $ExpectType [string, (boolean | undefined)?] || [a: string, b?: boolean | undefined]
-    spiedFunc.calls; // $ExpectType [string, (boolean | undefined)?][] || [a: string, b?: boolean | undefined][]
+    spiedFunc.calls; // $ExpectType Call<[string, (boolean | undefined)?]>[] || Call<[a: string, b?: boolean | undefined]>[]
 
     // ======================================================================
 

--- a/types/ospec/package.json
+++ b/types/ospec/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/ospec",
-    "version": "4.0.9999",
+    "version": "4.2.9999",
     "projects": [
         "https://github.com/MithrilJS/mithril.js/tree/next/ospec"
     ],


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/MithrilJS/ospec/blob/dbce1afbb0ad0b18a3f07a9e06a3856bff2cc90c/ospec.js#L819>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
