### PR TITLE
[node] Fix Storage declaration in WebWorkers, run DT tests with lib.webworker

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -154,6 +154,7 @@ declare global {
          * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/setItem)
          */
         setItem(key: string, value: string): void;
+        [key: string]: any;
     }
 
     // Conditional on `onabort` rather than `onmessage`, in order to exclude lib.webworker

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -156,7 +156,8 @@ declare global {
         setItem(key: string, value: string): void;
     }
 
-    var Storage: typeof globalThis extends { onmessage: any; Storage: infer T } ? T
+    // Conditional on `onabort` rather than `onmessage`, in order to exclude lib.webworker
+    var Storage: typeof globalThis extends { onabort: any; Storage: infer T } ? T
         : {
             prototype: Storage;
             new(): Storage;

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -17,8 +17,54 @@ type _WebSocket = typeof globalThis extends { onmessage: any } ? {} : import("un
 type _EventSource = typeof globalThis extends { onmessage: any } ? {} : import("undici-types").EventSource;
 // #endregion Fetch and friends
 
-// Conditional type alias for webstorage interface, which conflicts with lib.dom otherwise.
-type _Storage = typeof globalThis extends { onabort: any } ? {} : NodeJS.Storage;
+// Conditional type definitions for webstorage interface, which conflicts with lib.dom otherwise.
+type _Storage = typeof globalThis extends { onabort: any } ? {} : {
+    /**
+     * Returns the number of key/value pairs.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/length)
+     */
+    readonly length: number;
+    /**
+     * Removes all key/value pairs, if there are any.
+     *
+     * Dispatches a storage event on Window objects holding an equivalent Storage object.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/clear)
+     */
+    clear(): void;
+    /**
+     * Returns the current value associated with the given key, or null if the given key does not exist.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/getItem)
+     */
+    getItem(key: string): string | null;
+    /**
+     * Returns the name of the nth key, or null if n is greater than or equal to the number of key/value pairs.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/key)
+     */
+    key(index: number): string | null;
+    /**
+     * Removes the key/value pair with the given key, if a key/value pair with the given key exists.
+     *
+     * Dispatches a storage event on Window objects holding an equivalent Storage object.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/removeItem)
+     */
+    removeItem(key: string): void;
+    /**
+     * Sets the value of the pair identified by key to value, creating a new key/value pair if none existed for key previously.
+     *
+     * Throws a "QuotaExceededError" DOMException exception if the new value couldn't be set. (Setting could fail if, e.g., the user has disabled storage for the site, or if the quota has been exceeded.)
+     *
+     * Dispatches a storage event on Window objects holding an equivalent Storage object.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/setItem)
+     */
+    setItem(key: string, value: string): void;
+    [key: string]: any;
+};
 
 declare global {
     // Declare "static" methods in Error
@@ -403,55 +449,6 @@ declare global {
 
         interface ReadOnlyDict<T> {
             readonly [key: string]: T | undefined;
-        }
-
-        // Conditionally merged into the global scope if lib.dom is absent.
-        interface Storage {
-            /**
-             * Returns the number of key/value pairs.
-             *
-             * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/length)
-             */
-            readonly length: number;
-            /**
-             * Removes all key/value pairs, if there are any.
-             *
-             * Dispatches a storage event on Window objects holding an equivalent Storage object.
-             *
-             * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/clear)
-             */
-            clear(): void;
-            /**
-             * Returns the current value associated with the given key, or null if the given key does not exist.
-             *
-             * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/getItem)
-             */
-            getItem(key: string): string | null;
-            /**
-             * Returns the name of the nth key, or null if n is greater than or equal to the number of key/value pairs.
-             *
-             * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/key)
-             */
-            key(index: number): string | null;
-            /**
-             * Removes the key/value pair with the given key, if a key/value pair with the given key exists.
-             *
-             * Dispatches a storage event on Window objects holding an equivalent Storage object.
-             *
-             * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/removeItem)
-             */
-            removeItem(key: string): void;
-            /**
-             * Sets the value of the pair identified by key to value, creating a new key/value pair if none existed for key previously.
-             *
-             * Throws a "QuotaExceededError" DOMException exception if the new value couldn't be set. (Setting could fail if, e.g., the user has disabled storage for the site, or if the quota has been exceeded.)
-             *
-             * Dispatches a storage event on Window objects holding an equivalent Storage object.
-             *
-             * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/setItem)
-             */
-            setItem(key: string, value: string): void;
-            [key: string]: any;
         }
     }
 

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -28,8 +28,6 @@ type _Storage = typeof globalThis extends { onabort: any } ? {} : {
     /**
      * Removes all key/value pairs, if there are any.
      *
-     * Dispatches a storage event on Window objects holding an equivalent Storage object.
-     *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/clear)
      */
     clear(): void;
@@ -48,17 +46,13 @@ type _Storage = typeof globalThis extends { onabort: any } ? {} : {
     /**
      * Removes the key/value pair with the given key, if a key/value pair with the given key exists.
      *
-     * Dispatches a storage event on Window objects holding an equivalent Storage object.
-     *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/removeItem)
      */
     removeItem(key: string): void;
     /**
      * Sets the value of the pair identified by key to value, creating a new key/value pair if none existed for key previously.
      *
-     * Throws a "QuotaExceededError" DOMException exception if the new value couldn't be set. (Setting could fail if, e.g., the user has disabled storage for the site, or if the quota has been exceeded.)
-     *
-     * Dispatches a storage event on Window objects holding an equivalent Storage object.
+     * Throws a "QuotaExceededError" DOMException exception if the new value couldn't be set.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/setItem)
      */

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -2,7 +2,7 @@ export {}; // Make this a module
 
 // #region Fetch and friends
 // Conditional type aliases, used at the end of this file.
-// Will either be empty if lib-dom is included, or the undici version otherwise.
+// Will either be empty if lib.dom (or lib.webworker) is included, or the undici version otherwise.
 type _Request = typeof globalThis extends { onmessage: any } ? {} : import("undici-types").Request;
 type _Response = typeof globalThis extends { onmessage: any } ? {} : import("undici-types").Response;
 type _FormData = typeof globalThis extends { onmessage: any } ? {} : import("undici-types").FormData;
@@ -16,6 +16,9 @@ type _File = typeof globalThis extends { onmessage: any } ? {} : import("node:bu
 type _WebSocket = typeof globalThis extends { onmessage: any } ? {} : import("undici-types").WebSocket;
 type _EventSource = typeof globalThis extends { onmessage: any } ? {} : import("undici-types").EventSource;
 // #endregion Fetch and friends
+
+// Conditional type alias for webstorage interface, which conflicts with lib.dom otherwise.
+type _Storage = typeof globalThis extends { onabort: any } ? {} : NodeJS.Storage;
 
 declare global {
     // Declare "static" methods in Error
@@ -109,53 +112,7 @@ declare global {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage)
      */
-    interface Storage {
-        /**
-         * Returns the number of key/value pairs.
-         *
-         * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/length)
-         */
-        readonly length: number;
-        /**
-         * Removes all key/value pairs, if there are any.
-         *
-         * Dispatches a storage event on Window objects holding an equivalent Storage object.
-         *
-         * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/clear)
-         */
-        clear(): void;
-        /**
-         * Returns the current value associated with the given key, or null if the given key does not exist.
-         *
-         * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/getItem)
-         */
-        getItem(key: string): string | null;
-        /**
-         * Returns the name of the nth key, or null if n is greater than or equal to the number of key/value pairs.
-         *
-         * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/key)
-         */
-        key(index: number): string | null;
-        /**
-         * Removes the key/value pair with the given key, if a key/value pair with the given key exists.
-         *
-         * Dispatches a storage event on Window objects holding an equivalent Storage object.
-         *
-         * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/removeItem)
-         */
-        removeItem(key: string): void;
-        /**
-         * Sets the value of the pair identified by key to value, creating a new key/value pair if none existed for key previously.
-         *
-         * Throws a "QuotaExceededError" DOMException exception if the new value couldn't be set. (Setting could fail if, e.g., the user has disabled storage for the site, or if the quota has been exceeded.)
-         *
-         * Dispatches a storage event on Window objects holding an equivalent Storage object.
-         *
-         * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/setItem)
-         */
-        setItem(key: string, value: string): void;
-        [key: string]: any;
-    }
+    interface Storage extends _Storage {}
 
     // Conditional on `onabort` rather than `onmessage`, in order to exclude lib.webworker
     var Storage: typeof globalThis extends { onabort: any; Storage: infer T } ? T
@@ -446,6 +403,55 @@ declare global {
 
         interface ReadOnlyDict<T> {
             readonly [key: string]: T | undefined;
+        }
+
+        // Conditionally merged into the global scope if lib.dom is absent.
+        interface Storage {
+            /**
+             * Returns the number of key/value pairs.
+             *
+             * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/length)
+             */
+            readonly length: number;
+            /**
+             * Removes all key/value pairs, if there are any.
+             *
+             * Dispatches a storage event on Window objects holding an equivalent Storage object.
+             *
+             * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/clear)
+             */
+            clear(): void;
+            /**
+             * Returns the current value associated with the given key, or null if the given key does not exist.
+             *
+             * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/getItem)
+             */
+            getItem(key: string): string | null;
+            /**
+             * Returns the name of the nth key, or null if n is greater than or equal to the number of key/value pairs.
+             *
+             * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/key)
+             */
+            key(index: number): string | null;
+            /**
+             * Removes the key/value pair with the given key, if a key/value pair with the given key exists.
+             *
+             * Dispatches a storage event on Window objects holding an equivalent Storage object.
+             *
+             * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/removeItem)
+             */
+            removeItem(key: string): void;
+            /**
+             * Sets the value of the pair identified by key to value, creating a new key/value pair if none existed for key previously.
+             *
+             * Throws a "QuotaExceededError" DOMException exception if the new value couldn't be set. (Setting could fail if, e.g., the user has disabled storage for the site, or if the quota has been exceeded.)
+             *
+             * Dispatches a storage event on Window objects holding an equivalent Storage object.
+             *
+             * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Storage/setItem)
+             */
+            setItem(key: string, value: string): void;
+            [key: string]: any;
         }
     }
 

--- a/types/node/node-tests-webworker.ts
+++ b/types/node/node-tests-webworker.ts
@@ -1,0 +1,5 @@
+// Currently, all of the DOM-specific tests target APIs that are also available in WebWorkers.
+// If this changes, and it's necessary to create a WebWorker-specific test script, then the import should be updated here.
+import "./test/events-dom";
+import "./test/globals-dom";
+import "./test/perf_hooks-dom";

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -7,7 +7,7 @@
     "projects": [
         "https://nodejs.org/"
     ],
-    "tsconfigs": ["tsconfig.dom.json", "tsconfig.non-dom.json"],
+    "tsconfigs": ["tsconfig.dom.json", "tsconfig.non-dom.json", "tsconfig.webworker.json"],
     "dependencies": {
         "undici-types": "~6.19.2"
     },

--- a/types/node/test/globals.ts
+++ b/types/node/test/globals.ts
@@ -54,9 +54,10 @@ declare var RANDOM_GLOBAL_VARIABLE: true;
 
 {
     const s = new Storage();
-    s.setItem('foo', 'bar');
-    s.getItem('foo'); // $ExpectType string | null
-    s.foo = 'baz';
-    s.foo; // $ExpectType any
+    s.setItem("foo", "bar");
+    s.getItem("foo"); // $ExpectType string | null
+    s["foo"] = "baz";
+    s["foo"]; // $ExpectType any
+    delete s["foo"];
     s.clear();
 }

--- a/types/node/test/globals.ts
+++ b/types/node/test/globals.ts
@@ -51,3 +51,12 @@ declare var RANDOM_GLOBAL_VARIABLE: true;
     x.reason; // $ExpectType any
     x.throwIfAborted(); // $ExpectType void
 }
+
+{
+    const s = new Storage();
+    s.setItem('foo', 'bar');
+    s.getItem('foo'); // $ExpectType string | null
+    s.foo = 'baz';
+    s.foo; // $ExpectType any
+    s.clear();
+}

--- a/types/node/tsconfig.webworker.json
+++ b/types/node/tsconfig.webworker.json
@@ -2,8 +2,6 @@
     "files": [
         "index.d.ts",
         "node-tests.ts",
-        "node-tests-dom.ts",
-        "node-tests-non-dom.ts",
         "node-tests-webworker.ts"
     ],
     "compilerOptions": {
@@ -11,7 +9,7 @@
         "target": "esnext",
         "lib": [
             "es6",
-            "dom"
+            "webworker"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
- Fixes the conditional in the `Storage` definition, to avoid a self-inference error in WebWorker builds.
  - The definition currently checks for the global `onmessage`, which is present both in lib.dom and lib.webworker. This works just fine for fetch and friends, since those APIs are present in both. However, lib.webworker doesn't contain a webstorage implementation, so screening based on `onmessage` leads to a self-inference error in WebWorker builds, unless lib checks are skipped.
  - The `onabort` global is only present in lib.dom and not lib.webworker, so this excludes the conditional inference from WebWorker builds.
- Adds a WebWorker tsconfig, so that tests are run with lib.webworker as well as lib.dom. As more and more web-compatible APIs are being added to Node, this seems like a sensible idea.

Also includes supplementary changes to the webstorage definitions:
- Adds the index signature to the `Storage` interface, matching the existing [lib.dom implementation](https://github.com/microsoft/TypeScript/blob/release-5.5/src/lib/dom.generated.d.ts#L21943).
  - Node's webstorage implementation, as in the web standard, intercepts undefined property access. This means that statements like `storage['key'] = 'value'` and `delete storage['key']` etc. are valid equivalents to `storage.setItem(...)` and `storage.removeItem(...)` etc.
  - The indexed property signature has to be of type `any` rather than `string`, as the string index also matches the interface method names.
  - This also necessitates adding conditional merging into the global interface, similar to the undici imports, otherwise TypeScript will complain about duplicate index signatures.
- Removes references to event dispatching in the docblocks, as Node's implementation doesn't dispatch DOM events.

Resolves #70320.

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/blob/v22.x/src/node_webstorage.cc
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
