### PR TITLE
[react] improve act() return value

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2126,6 +2126,10 @@ declare namespace React {
      */
     export function startTransition(scope: TransitionFunction): void;
 
+    interface ActThenable<T> {
+        then(onFulfilled?: (value: T) => unknown, onRejected?: (reason: any) => unknown): void;
+    }
+
     /**
      * Wrap any code rendering and triggering updates to your components into `act()` calls.
      *
@@ -2139,7 +2143,7 @@ declare namespace React {
      */
     // While act does always return Thenable, if a void function is passed, we pretend the return value is also void to not trigger dangling Promise lint rules.
     export function act(callback: () => VoidOrUndefinedOnly): void;
-    export function act<T>(callback: () => T | Promise<T>): Promise<T>;
+    export function act<T>(callback: () => T | Promise<T>): ActThenable<T>;
 
     export function useId(): string;
 

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -980,4 +980,9 @@ function propsInferenceHelpersTests() {
 {
     // act() exposed from react
     React.act(() => null);
+
+    // @ts-expect-error
+    React.act(() => Promise.resolve()).then().catch();
+
+    Promise.resolve(React.act(() => Promise.resolve()).then()).catch();
 }

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -2127,6 +2127,10 @@ declare namespace React {
      */
     export function startTransition(scope: TransitionFunction): void;
 
+    interface ActThenable<T> {
+        then(onFulfilled?: (value: T) => unknown, onRejected?: (reason: any) => unknown): void;
+    }
+
     /**
      * Wrap any code rendering and triggering updates to your components into `act()` calls.
      *
@@ -2140,7 +2144,7 @@ declare namespace React {
      */
     // While act does always return Thenable, if a void function is passed, we pretend the return value is also void to not trigger dangling Promise lint rules.
     export function act(callback: () => VoidOrUndefinedOnly): void;
-    export function act<T>(callback: () => T | Promise<T>): Promise<T>;
+    export function act<T>(callback: () => T | Promise<T>): ActThenable<T>;
 
     export function useId(): string;
 

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -983,4 +983,9 @@ function propsInferenceHelpersTests() {
 {
     // act() exposed from react
     React.act(() => null);
+
+    // @ts-expect-error
+    React.act(() => Promise.resolve()).then().catch();
+
+    Promise.resolve(React.act(() => Promise.resolve()).then()).catch();
 }


### PR DESCRIPTION
This PR updates the React `act()` return type to be more accurate based on the [actual implementation](https://github.com/facebook/react/blob/92d26c8e93a88ca41338d3509b4324ad19a89c1e/packages/react/src/ReactAct.js). The function does not return a `Promise` and instead returns a `Thenable`-like object. This fix will prevent TypeScript from allowing code that will  break at runtime (e.g `act(...).then().catch()`). This should also prevent false positive floating promise lint warnings (e.g `act(...).then()`). 

I recognize that common `act()` usage tends not to run into these gotchas but we have a large codebase and have encountered them. This PR omits updating the deprecated `@types/react-dom` version of the `act()` types but that can be added if needed. 


One gotcha here is that since `act()` does not return a `PromiseLike<T>` it doesn't allow for code like this although it works at runtime

```
Promise.resolve().then(() => {
  return act(() => Promise.resolve()
});

```

I also wonder if this PR allows us to remove the ` function act(callback: () => VoidOrUndefinedOnly): void` overload because `ActThenable` _shouldn't_ trigger dangling promise lint rules. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react/blob/92d26c8e93a88ca41338d3509b4324ad19a89c1e/packages/react/src/ReactAct.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
