### PR TITLE
[react-native-material-ripple] Fix CI

### DIFF
--- a/types/react-native-material-ripple/react-native-material-ripple-tests.tsx
+++ b/types/react-native-material-ripple/react-native-material-ripple-tests.tsx
@@ -101,6 +101,7 @@ const RippleTest: React.FC = () => {
             renderToHardwareTextureAndroid
             shouldRasterizeIOS
             tvParallaxMagnification={aNumber}
+            // @ts-expect-error -- No longer part of props with latest `react-native` types
             tvParallaxProperties={{
                 enabled: true,
                 shiftDistanceX: aNumber,


### PR DESCRIPTION
`tvParallaxProperties` is no longer part of the props with latest `react-native` types.

Ignoring this error for now to unblock CI. Up to `react-native-material-ripple` maintainers if this is expected, needs a fix or `react-native-material-ripple` is just not compatible with latest `react-native`.