### PR TITLE
Added Definitions for react-native-svg-charts-updated-peers

### DIFF
--- a/types/react-native-svg-charts-updated-peers/LICENSE
+++ b/types/react-native-svg-charts-updated-peers/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/types/react-native-svg-charts-updated-peers/README.md
+++ b/types/react-native-svg-charts-updated-peers/README.md
@@ -2,7 +2,7 @@
 > `npm install --save @types/react-native-svg-charts-updated-peers`
 
 # Summary
-This package contains type definitions for react-native-svg-charts (https://github.com/JesperLekland/react-native-svg-charts).
+This package contains type definitions for react-native-svg-charts-updated-peers (https://github.com/JesperLekland/react-native-svg-charts-updated-peers).
 
 # Details
 Files were exported from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-native-svg-charts-updated-peers.

--- a/types/react-native-svg-charts-updated-peers/README.md
+++ b/types/react-native-svg-charts-updated-peers/README.md
@@ -1,0 +1,15 @@
+# Installation
+> `npm install --save @types/react-native-svg-charts-updated-peers`
+
+# Summary
+This package contains type definitions for react-native-svg-charts (https://github.com/JesperLekland/react-native-svg-charts).
+
+# Details
+Files were exported from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-native-svg-charts-updated-peers.
+
+### Additional Details
+ * Last updated: Thu, 22 Aug 2024 19:06:51 GMT
+ * Dependencies: [@types/d3-scale](https://npmjs.com/package/@types/d3-scale), [@types/d3-shape](https://npmjs.com/package/@types/d3-shape), [@types/react](https://npmjs.com/package/@types/react), [react-native](https://npmjs.com/package/react-native), [react-native-svg](https://npmjs.com/package/react-native-svg)
+
+# Credits
+These definitions were written by [Krzysztof Miemiec](https://github.com/krzysztof-miemiec) and updated by [Peter van de Vyver](https://github.com/pete-dvr).

--- a/types/react-native-svg-charts-updated-peers/index.d.ts
+++ b/types/react-native-svg-charts-updated-peers/index.d.ts
@@ -1,0 +1,289 @@
+import { ScaleBand, ScaleLinear, ScaleLogarithmic, ScalePower, ScaleTime } from "d3-scale";
+import { CurveFactory, Series } from "d3-shape";
+import * as React from "react";
+import { StyleProp, ViewStyle } from "react-native";
+import {
+    CommonPathProps,
+    LinearGradientProps,
+    LineProps,
+    PathProps,
+    RadialGradientProps,
+    TextProps,
+} from "react-native-svg";
+
+export type ScaleType<Range, Output> =
+    | ScaleLinear<Range, Output>
+    | ScaleLogarithmic<Range, Output>
+    | ScalePower<Range, Output>
+    | ScaleTime<Range, Output>;
+
+export interface AccessorFunctionProps<T> {
+    index: number;
+    item: T;
+}
+
+export type ScaleFunction = () => ScaleType<any, any> | ScaleBand<any>;
+export type AccessorFunction<T, U> = (props: AccessorFunctionProps<T>) => U;
+export type SortFunction<T> = (a: T, b: T) => number;
+export type OffsetFunction = (series: Series<any, any>, order: number[]) => void;
+export type OrderFunction = (series: Series<any, any>) => number[];
+
+// Chart
+
+export interface ChartProps<T> {
+    data: T[];
+    children?: React.ReactNode;
+    style?: StyleProp<ViewStyle> | undefined;
+    animate?: boolean | undefined;
+    animationDuration?: number | undefined;
+    svg?: Partial<PathProps> | undefined;
+    width?: number | undefined;
+    height?: number | undefined;
+    curve?: CurveFactory | undefined;
+    contentInset?: {
+        top?: number | undefined;
+        left?: number | undefined;
+        right?: number | undefined;
+        bottom?: number | undefined;
+    } | undefined;
+    gridMin?: number | undefined;
+    gridMax?: number | undefined;
+    gridProps?: GridProps<any> | undefined;
+    numberOfTicks?: number | undefined;
+    xScale?: ScaleFunction | undefined;
+    yScale?: ScaleFunction | undefined;
+    xAccessor?: AccessorFunction<T, number> | undefined;
+    yAccessor?: AccessorFunction<T, number> | undefined;
+    yMin?: number | undefined;
+    yMax?: number | undefined;
+    xMin?: number | undefined;
+    xMax?: number | undefined;
+}
+
+// Line Chart
+
+export class LineChart<T> extends React.PureComponent<ChartProps<T>> {
+}
+
+// Pie Chart
+
+export interface PieChartData {
+    svg?: Partial<PathProps> | undefined;
+    key: string | number;
+    value?: number | undefined;
+    arc?: {
+        outerRadius?: number | string | undefined;
+        cornerRadius?: number | string | undefined;
+    } | undefined;
+}
+
+export interface PieChartProps<T extends PieChartData> extends ChartProps<T> {
+    innerRadius?: number | string | undefined;
+    outerRadius?: number | string | undefined;
+    labelRadius?: number | string | undefined;
+    padAngle?: number | undefined;
+    startAngle?: number | undefined;
+    endAngle?: number | undefined;
+    sort?: SortFunction<T> | undefined;
+    valueAccessor?: AccessorFunction<T, number> | undefined;
+}
+
+export class PieChart<T extends PieChartData> extends React.PureComponent<PieChartProps<T>> {
+}
+
+// Area Chart
+
+export interface AreaChartProps<T> extends ChartProps<T> {
+    start?: number | undefined;
+}
+
+export class AreaChart<T> extends React.PureComponent<AreaChartProps<T>> {
+}
+
+// Stacked Area Chart
+
+export interface StackedAreaChartProps<T> extends ChartProps<T> {
+    keys: ReadonlyArray<keyof T>;
+    colors: string[];
+    offset?: OffsetFunction | undefined;
+    order?: OrderFunction | undefined;
+    renderGradient?:
+        | ((props: {
+            id: string;
+            width: number;
+            height: number;
+            x: number;
+            y: number;
+            index: number;
+            key: keyof T;
+            color: string;
+        }) => React.Component<LinearGradientProps | RadialGradientProps>)
+        | undefined;
+    showGrid?: boolean | undefined;
+    extras?: any[] | undefined;
+    renderDecorator?: (() => {}) | undefined;
+}
+
+export class StackedAreaChart<T> extends React.PureComponent<StackedAreaChartProps<T>> {
+    static extractDataPoints<T>(
+        data: T[],
+        keys: ReadonlyArray<keyof T>,
+        order?: OrderFunction,
+        offset?: OffsetFunction,
+    ): number[];
+}
+
+// Bar Chart
+
+export interface BarChartProps<T> extends ChartProps<T> {
+    spacingInner?: number | undefined;
+    spacingOuter?: number | undefined;
+    horizontal?: boolean | undefined;
+}
+
+export class BarChart<T> extends React.PureComponent<BarChartProps<T>> {
+}
+
+// Stacked Bar Chart
+
+export interface StackedBarChartProps<T> extends BarChartProps<T> {
+    keys: ReadonlyArray<keyof T>;
+    colors: string[];
+    offset?: OffsetFunction | undefined;
+    order?: OrderFunction | undefined;
+    strokeColor?: string | undefined;
+    renderGradient?:
+        | ((props: { id: string }) => React.Component<LinearGradientProps | RadialGradientProps>)
+        | undefined;
+    showGrid?: boolean | undefined;
+    extras?: any[] | undefined;
+    extra?: (() => {}) | undefined;
+}
+
+export class StackedBarChart<T> extends React.PureComponent<StackedBarChartProps<T>> {
+    static extractDataPoints<T>(
+        data: T,
+        keys: ReadonlyArray<keyof T>,
+        order?: OrderFunction,
+        offset?: OffsetFunction,
+    ): number[];
+}
+
+// Axis
+
+export interface AxisProps<T> {
+    style?: StyleProp<ViewStyle> | undefined;
+    data: T[];
+    spacingInner?: number | undefined;
+    spacingOuter?: number | undefined;
+    formatLabel?: ((value: any, index: number) => number | string) | undefined;
+    scale?: ScaleFunction | undefined;
+    numberOfTicks?: number | undefined;
+    svg?: Partial<TextProps> | undefined;
+}
+
+// XAxis
+
+export interface XAxisProps<T> extends AxisProps<T> {
+    contentInset?: {
+        left?: number | undefined;
+        right?: number | undefined;
+    } | undefined;
+    xAccessor?: AccessorFunction<T, any> | undefined;
+}
+
+export class XAxis<T> extends React.PureComponent<XAxisProps<T>> {
+}
+
+// YAxis
+
+export interface YAxisProps<T> extends AxisProps<T> {
+    style?: StyleProp<ViewStyle> | undefined;
+    contentInset?: {
+        top?: number | undefined;
+        bottom?: number | undefined;
+    } | undefined;
+    min?: number | undefined;
+    max?: number | undefined;
+    yAccessor?: AccessorFunction<T, any> | undefined;
+}
+
+export class YAxis<T> extends React.PureComponent<YAxisProps<T>> {
+}
+
+// Progress Circle
+
+export interface ProgressCircleProps {
+    progress: number;
+    style?: StyleProp<ViewStyle> | undefined;
+    progressColor?: string | undefined;
+    backgroundColor?: string | undefined;
+    strokeWidth?: number | undefined;
+    cornerRadius?: number | string | undefined;
+    startAngle?: number | undefined;
+    endAngle?: number | undefined;
+    animate?: boolean | undefined;
+    animateDuration?: number | undefined;
+}
+
+export class ProgressCircle extends React.PureComponent<ProgressCircleProps> {
+}
+
+// Horizontal Line
+
+export interface HorizontalLineProps {
+    stroke: string;
+}
+
+// Point
+export interface PointProps {
+    value?: number | undefined;
+    radius?: number | undefined;
+    index?: number | undefined;
+    color?: string | undefined;
+}
+
+// Tooltip
+export interface TooltipProps {
+    value?: number | undefined;
+    index?: number | undefined;
+    height?: number | undefined;
+    stroke?: string | undefined;
+    text: string;
+    pointStroke?: string | undefined;
+}
+
+export namespace Decorators {
+    export class HorizontalLine extends React.Component<HorizontalLineProps> {}
+    export class Point extends React.Component<PointProps> {}
+    export class Tooltip extends React.Component<TooltipProps> {}
+}
+
+export type GridDirection = "VERTICAL" | "HORIZONTAL" | "BOTH";
+
+export interface GridProps<T> {
+    direction?: GridDirection | undefined;
+    belowChart?: boolean | undefined;
+    svg?: Partial<LineProps> | undefined;
+    ticks?: T[] | undefined;
+    x?: ((t: T) => number) | undefined;
+    y?: ((t: T) => number) | undefined;
+}
+
+// Export as Component despite it's FC.
+export class Grid<T> extends React.Component<GridProps<T>> {
+    static Direction: {
+        VERTICAL: "VERTICAL";
+        HORIZONTAL: "HORIZONTAL";
+        BOTH: "BOTH";
+    };
+}
+
+export interface AnimatedPathProps extends CommonPathProps {
+    animated?: boolean | undefined;
+    animationDuration?: number | undefined;
+    renderPlaceholder?: (() => any) | undefined;
+}
+
+export class Path extends React.Component<AnimatedPathProps> {
+}

--- a/types/react-native-svg-charts-updated-peers/package.json
+++ b/types/react-native-svg-charts-updated-peers/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/react-native-svg-charts-updated-peers",
-    "version": "5.1.0",
+    "version": "5.1.9999",
     "projects": [
         "https://github.com/AndreiBru/react-native-svg-charts-updated-peers"
     ],

--- a/types/react-native-svg-charts-updated-peers/package.json
+++ b/types/react-native-svg-charts-updated-peers/package.json
@@ -1,0 +1,24 @@
+{
+    "private": true,
+    "name": "@types/react-native-svg-charts-updated-peers",
+    "version": "5.1.0",
+    "projects": [
+        "https://github.com/AndreiBru/react-native-svg-charts-updated-peers"
+    ],
+    "dependencies": {
+        "@types/d3-scale": "^1",
+        "@types/d3-shape": "^1",
+        "@types/react": "*",
+        "react-native": "*",
+        "react-native-svg": ">=5.3.1"
+    },
+    "devDependencies": {
+        "@types/react-native-svg-charts-updated-peers": "workspace:."
+    },
+    "owners": [
+        {
+            "name": "Peter van de Vyver",
+            "githubUsername": "pete-dvr"
+        }
+    ]
+}

--- a/types/react-native-svg-charts-updated-peers/react-native-svg-charts-updated-peers-tests.tsx
+++ b/types/react-native-svg-charts-updated-peers/react-native-svg-charts-updated-peers-tests.tsx
@@ -1,0 +1,110 @@
+import { scaleTime } from "d3-scale";
+import { curveNatural } from "d3-shape";
+import * as React from "react";
+import { View } from "react-native";
+import { LinearGradientProps, Stop } from "react-native-svg";
+import { BarChart, Decorators, Grid, StackedAreaChart, StackedBarChart, XAxis } from "react-native-svg-charts-updated-peers";
+
+declare const Defs: React.ComponentClass<{ children?: React.ReactNode }>;
+declare const LinearGradient: React.ComponentClass<React.PropsWithChildren<LinearGradientProps>>;
+
+interface Data {
+    time: number;
+    cpuUsage: number;
+    totalMemoryConsumption: number;
+    privateMemoryConsumption: number;
+}
+
+interface Props {
+    data: Data[];
+    width: number;
+}
+
+class Example extends React.Component<Props> {
+    renderStackedAreaChart = ({ data, width }: Props) => (
+        <StackedAreaChart
+            style={{ height: 200 }}
+            data={data}
+            keys={["totalMemoryConsumption", "privateMemoryConsumption"]}
+            colors={["url(#totalMemoryConsumption)", "url(#privateMemoryConsumption)"]}
+            contentInset={{ top: 20 }}
+            curve={curveNatural}
+            showGrid={true}
+            animate={true}
+            animationDuration={350}
+            numberOfTicks={10}
+        >
+            <Defs key="defs">
+                <LinearGradient id="totalMemoryConsumption" x1="0%" y1="0%" x2="0%" y2="100%">
+                    <Stop offset="0%" stopColor="#4ccfef" stopOpacity={0.9} />
+                    <Stop offset="100%" stopColor="#182b41" stopOpacity={0.9} />
+                </LinearGradient>
+                <LinearGradient id="privateMemoryConsumption" x1="0%" y1="0%" x2="0%" y2="100%">
+                    <Stop offset="0%" stopColor="#a1d343" stopOpacity={0.8} />
+                    <Stop offset="100%" stopColor="#a1d343" stopOpacity={0.3} />
+                </LinearGradient>
+            </Defs>
+            <XAxis
+                data={data}
+                formatLabel={(value) => new Date(value).toTimeString()}
+                numberOfTicks={8}
+                scale={scaleTime}
+                contentInset={{ left: 10, right: 10 }}
+                svg={{
+                    fillOpacity: .2,
+                    fill: "#fff",
+                    fontFamily: "Regular",
+                    fontSize: 10,
+                }}
+                xAccessor={({ item }) => item.time}
+            />
+            <Grid
+                direction="BOTH"
+                ticks={[20, 40, 60, 80]}
+                x={x => x * width}
+                y={y => y * width}
+                svg={{
+                    stroke: "#fff",
+                    strokeOpacity: .2,
+                }}
+                belowChart={true}
+            />
+            <Decorators.Tooltip text="Test" />
+            <Decorators.Point />
+        </StackedAreaChart>
+    );
+
+    renderStackedBarChart = ({ data, width }: Props) => (
+        <StackedBarChart
+            animate={true}
+            animationDuration={250}
+            style={{ height: 100 }}
+            keys={["totalMemoryConsumption", "privateMemoryConsumption"]}
+            colors={["green", "red"]}
+            data={data}
+            horizontal={true}
+            contentInset={{ top: 10, bottom: 20 }}
+        />
+    );
+
+    renderBarChart = ({ data, width }: Props) => (
+        <BarChart
+            animate={true}
+            animationDuration={250}
+            style={{ height: 100 }}
+            data={data}
+            horizontal={true}
+            contentInset={{ top: 10, bottom: 20 }}
+        />
+    );
+
+    render() {
+        const { data, width } = this.props;
+        return (
+            <View>
+                {this.renderStackedAreaChart(this.props)}
+                {this.renderStackedBarChart(this.props)}
+            </View>
+        );
+    }
+}

--- a/types/react-native-svg-charts-updated-peers/tsconfig.json
+++ b/types/react-native-svg-charts-updated-peers/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "node16",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react"
+    },
+    "files": [
+        "index.d.ts"
+    ]
+}


### PR DESCRIPTION
The original react-native-svg-charts has dependency issues with newer versions of react-native. A fork which fixes these was created and pushed to NPM called react-native-svg-charts-updated-peers to fix this.

The creators of the new package did not create Typescript definitions for it so i've forked and updated the original react-native-svg-charts types written by Krzysztof Miemiec to work with the new package.