### PR TITLE
streamsaver: Specify WritableStream

### DIFF
--- a/types/streamsaver/index.d.ts
+++ b/types/streamsaver/index.d.ts
@@ -8,7 +8,7 @@ export as namespace streamSaver;
 export function createWriteStream(
     filename: string,
     options?: CreateWriteStreamOptions,
-): WritableStream;
+): WritableStream<Uint8Array>;
 
 export interface CreateWriteStreamOptions<I = any, O = any> {
     /**


### PR DESCRIPTION
As being specified by the library author ([readme](https://github.com/jimmywarting/StreamSaver.js?tab=readme-ov-file#getting-started) > examle code > `// The WritableStream only accepts Uint8Array chunks`) the writer should only accept `Uint8Array`s but it instead accepts `any`. By specifing the generic `WritableStream` that `createWriteStream()` returns, we can limit the usage to the correct implementation.

This prevouisly incorrect type already provoked a bug in my code, so I hope I can spare any future coder the headache.