### PR TITLE
[aws-lambda] Adds missing MD5OfMessageAttributes

### DIFF
--- a/types/aws-lambda/trigger/sqs.d.ts
+++ b/types/aws-lambda/trigger/sqs.d.ts
@@ -12,7 +12,7 @@ export interface SQSRecord {
     attributes: SQSRecordAttributes;
     messageAttributes: SQSMessageAttributes;
     md5OfBody: string;
-    MD5OfMessageAttributes?: string;
+    md5OfMessageAttributes?: string;
     eventSource: string;
     eventSourceARN: string;
     awsRegion: string;

--- a/types/aws-lambda/trigger/sqs.d.ts
+++ b/types/aws-lambda/trigger/sqs.d.ts
@@ -12,6 +12,7 @@ export interface SQSRecord {
     attributes: SQSRecordAttributes;
     messageAttributes: SQSMessageAttributes;
     md5OfBody: string;
+    MD5OfMessageAttributes?: string;
     eventSource: string;
     eventSourceARN: string;
     awsRegion: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

I noticed that this property was missing when I tried to apply the provided type to a event that I captured from a real lambda.

The attribute is documented in here: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html

I don't know for sure if the property is always added to the lambda event or not, so I assumed it isn't.