### PR TITLE
[node] Correct context type in test hook functions

### DIFF
--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -484,32 +484,36 @@ declare module "node:test" {
         readonly assert: TestContextAssert;
         /**
          * This function is used to create a hook running before subtest of the current test.
-         * @param fn The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
+         * @param fn The hook function. The first argument to this function is a `TestContext` object.
+         * If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
-         * @since v20.1.0
+         * @since v20.1.0, v18.17.0
          */
-        before: typeof before;
+        before(fn?: TestContextHookFn, options?: HookOptions): void;
         /**
          * This function is used to create a hook running before each subtest of the current test.
-         * @param fn The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
+         * @param fn The hook function. The first argument to this function is a `TestContext` object.
+         * If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
          * @since v18.8.0
          */
-        beforeEach: typeof beforeEach;
+        beforeEach(fn?: TestContextHookFn, options?: HookOptions): void;
         /**
          * This function is used to create a hook that runs after the current test finishes.
-         * @param fn The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
+         * @param fn The hook function. The first argument to this function is a `TestContext` object.
+         * If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
          * @since v18.13.0
          */
-        after: typeof after;
+        after(fn?: TestContextHookFn, options?: HookOptions): void;
         /**
          * This function is used to create a hook running after each subtest of the current test.
-         * @param fn The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
+         * @param fn The hook function. The first argument to this function is a `TestContext` object.
+         * If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
          * @since v18.8.0
          */
-        afterEach: typeof afterEach;
+        afterEach(fn?: TestContextHookFn, options?: HookOptions): void;
         /**
          * This function is used to write diagnostics to the output. Any diagnostic
          * information is included at the end of the test's results. This function does
@@ -880,10 +884,15 @@ declare module "node:test" {
      */
     function afterEach(fn?: HookFn, options?: HookOptions): void;
     /**
-     * The hook function. If the hook uses callbacks, the callback function is passed as the
-     * second argument.
+     * The hook function. The first argument is the context in which the hook is called.
+     * If the hook uses callbacks, the callback function is passed as the second argument.
      */
-    type HookFn = (s: SuiteContext, done: (result?: any) => void) => any;
+    type HookFn = (c: TestContext | SuiteContext, done: (result?: any) => void) => any;
+    /**
+     * The hook function. The first argument is a `TestContext` object.
+     * If the hook uses callbacks, the callback function is passed as the second argument.
+     */
+    type TestContextHookFn = (t: TestContext, done: (result?: any) => void) => any;
     /**
      * Configuration options for hooks.
      * @since v18.8.0

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -117,13 +117,25 @@ test(undefined, undefined, t => {
     // $ExpectType void
     t.todo();
     // $ExpectType void
-    t.after(() => {});
+    t.after(t => {
+        // $ExpectType TestContext
+        t;
+    });
     // $ExpectType void
-    t.afterEach(() => {});
+    t.afterEach(t => {
+        // $ExpectType TestContext
+        t;
+    });
     // $ExpectType void
-    t.beforeEach(() => {});
+    t.beforeEach(t => {
+        // $ExpectType TestContext
+        t;
+    });
     // $ExpectType void
-    t.before(() => {});
+    t.before(t => {
+        // $ExpectType TestContext
+        t;
+    });
 
     // $ExpectType string
     t.name;
@@ -456,33 +468,33 @@ beforeEach(() => {});
 after(() => {});
 beforeEach(() => {});
 // - with callback
-before((s, cb) => {
-    // $ExpectType SuiteContext
-    s;
+before((c, cb) => {
+    // $ExpectType TestContext | SuiteContext
+    c;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void
     cb({ x: "anything" });
 });
-beforeEach((s, cb) => {
-    // $ExpectType SuiteContext
-    s;
+beforeEach((c, cb) => {
+    // $ExpectType TestContext | SuiteContext
+    c;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void
     cb({ x: "anything" });
 });
-after((s, cb) => {
-    // $ExpectType SuiteContext
-    s;
+after((c, cb) => {
+    // $ExpectType TestContext | SuiteContext
+    c;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void
     cb({ x: "anything" });
 });
-afterEach((s, cb) => {
-    // $ExpectType SuiteContext
-    s;
+afterEach((c, cb) => {
+    // $ExpectType TestContext | SuiteContext
+    c;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void

--- a/types/node/v18/test.d.ts
+++ b/types/node/v18/test.d.ts
@@ -315,39 +315,39 @@ declare module "node:test" {
     export interface TestContext {
         /**
          * This function is used to create a hook running before subtest of the current test.
-         * @param fn The hook function. If the hook uses callbacks, the callback function is passed as
-         *    the second argument. Default: A no-op function.
+         * @param fn The hook function. The first argument to this function is a `TestContext` object.
+         *    If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
          * @since v18.17.0
          */
-        before: typeof before;
+        before(fn?: TestContextHookFn, options?: HookOptions): void;
 
         /**
          * This function is used to create a hook running before each subtest of the current test.
-         * @param fn The hook function. If the hook uses callbacks, the callback function is passed as
-         *    the second argument. Default: A no-op function.
+         * @param fn The hook function. The first argument to this function is a `TestContext` object.
+         *    If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
          * @since v18.8.0
          */
-        beforeEach: typeof beforeEach;
+        beforeEach(fn?: TestContextHookFn, options?: HookOptions): void;
 
         /**
          * This function is used to create a hook that runs after the current test finishes.
-         * @param fn The hook function. If the hook uses callbacks, the callback function is passed as
-         *    the second argument. Default: A no-op function.
+         * @param fn The hook function. The first argument to this function is a `TestContext` object.
+         *    If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
          * @since v18.13.0
          */
-        after: typeof after;
+        after(fn?: TestContextHookFn, options?: HookOptions): void;
 
         /**
          * This function is used to create a hook running after each subtest of the current test.
-         * @param fn The hook function. If the hook uses callbacks, the callback function is passed as
-         *    the second argument. Default: A no-op function.
+         * @param fn The hook function. The first argument to this function is a `TestContext` object.
+         *    If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
          * @since v18.8.0
          */
-        afterEach: typeof afterEach;
+        afterEach(fn?: TestContextHookFn, options?: HookOptions): void;
 
         /**
          * This function is used to write diagnostics to the output. Any diagnostic information is
@@ -517,10 +517,16 @@ declare module "node:test" {
     function afterEach(fn?: HookFn, options?: HookOptions): void;
 
     /**
-     * The hook function. If the hook uses callbacks, the callback function is passed as the
-     * second argument.
+     * The hook function. The first argument is the context in which the hook is called.
+     * If the hook uses callbacks, the callback function is passed as the second argument.
      */
-    type HookFn = (s: SuiteContext, done: (result?: any) => void) => any;
+    type HookFn = (c: TestContext | SuiteContext, done: (result?: any) => void) => any;
+
+    /**
+     * The hook function. The first argument is a `TestContext` object.
+     * If the hook uses callbacks, the callback function is passed as the second argument.
+     */
+    type TestContextHookFn = (t: TestContext, done: (result?: any) => void) => any;
 
     /**
      * Configuration options for hooks.

--- a/types/node/v18/test/test.ts
+++ b/types/node/v18/test/test.ts
@@ -97,11 +97,25 @@ test(undefined, undefined, t => {
     // $ExpectType void
     t.todo();
     // $ExpectType void
-    t.after(() => {});
+    t.after(t => {
+        // $ExpectType TestContext
+        t;
+    });
     // $ExpectType void
-    t.afterEach(() => {});
+    t.afterEach(t => {
+        // $ExpectType TestContext
+        t;
+    });
     // $ExpectType void
-    t.beforeEach(() => {});
+    t.beforeEach(t => {
+        // $ExpectType TestContext
+        t;
+    });
+    // $ExpectType void
+    t.before(t => {
+        // $ExpectType TestContext
+        t;
+    });
 });
 
 // Test the subtest approach.
@@ -238,33 +252,33 @@ beforeEach(() => {});
 after(() => {});
 beforeEach(() => {});
 // - with callback
-before((s, cb) => {
-    // $ExpectType SuiteContext
-    s;
+before((c, cb) => {
+    // $ExpectType TestContext | SuiteContext
+    c;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void
     cb({ x: "anything" });
 });
-beforeEach((s, cb) => {
-    // $ExpectType SuiteContext
-    s;
+beforeEach((c, cb) => {
+    // $ExpectType TestContext | SuiteContext
+    c;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void
     cb({ x: "anything" });
 });
-after((s, cb) => {
-    // $ExpectType SuiteContext
-    s;
+after((c, cb) => {
+    // $ExpectType TestContext | SuiteContext
+    c;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void
     cb({ x: "anything" });
 });
-afterEach((s, cb) => {
-    // $ExpectType SuiteContext
-    s;
+afterEach((c, cb) => {
+    // $ExpectType TestContext | SuiteContext
+    c;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void

--- a/types/node/v20/test.d.ts
+++ b/types/node/v20/test.d.ts
@@ -460,32 +460,36 @@ declare module "node:test" {
         readonly assert: TestContextAssert;
         /**
          * This function is used to create a hook running before subtest of the current test.
-         * @param fn The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
+         * @param fn The hook function. The first argument to this function is a `TestContext` object.
+         * If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
-         * @since v20.1.0
+         * @since v20.1.0, v18.17.0
          */
-        before: typeof before;
+        before(fn?: TestContextHookFn, options?: HookOptions): void;
         /**
          * This function is used to create a hook running before each subtest of the current test.
-         * @param fn The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
+         * @param fn The hook function. The first argument to this function is a `TestContext` object.
+         * If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
          * @since v18.8.0
          */
-        beforeEach: typeof beforeEach;
+        beforeEach(fn?: TestContextHookFn, options?: HookOptions): void;
         /**
          * This function is used to create a hook that runs after the current test finishes.
-         * @param fn The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
+         * @param fn The hook function. The first argument to this function is a `TestContext` object.
+         * If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
          * @since v18.13.0
          */
-        after: typeof after;
+        after(fn?: TestContextHookFn, options?: HookOptions): void;
         /**
          * This function is used to create a hook running after each subtest of the current test.
-         * @param fn The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
+         * @param fn The hook function. The first argument to this function is a `TestContext` object.
+         * If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
          * @since v18.8.0
          */
-        afterEach: typeof afterEach;
+        afterEach(fn?: TestContextHookFn, options?: HookOptions): void;
         /**
          * This function is used to write diagnostics to the output. Any diagnostic
          * information is included at the end of the test's results. This function does
@@ -826,10 +830,15 @@ declare module "node:test" {
      */
     function afterEach(fn?: HookFn, options?: HookOptions): void;
     /**
-     * The hook function. If the hook uses callbacks, the callback function is passed as the
-     * second argument.
+     * The hook function. The first argument is the context in which the hook is called.
+     * If the hook uses callbacks, the callback function is passed as the second argument.
      */
-    type HookFn = (s: SuiteContext, done: (result?: any) => void) => any;
+    type HookFn = (c: TestContext | SuiteContext, done: (result?: any) => void) => any;
+    /**
+     * The hook function. The first argument is a `TestContext` object.
+     * If the hook uses callbacks, the callback function is passed as the second argument.
+     */
+    type TestContextHookFn = (t: TestContext, done: (result?: any) => void) => any;
     /**
      * Configuration options for hooks.
      * @since v18.8.0

--- a/types/node/v20/test/test.ts
+++ b/types/node/v20/test/test.ts
@@ -115,13 +115,25 @@ test(undefined, undefined, t => {
     // $ExpectType void
     t.todo();
     // $ExpectType void
-    t.after(() => {});
+    t.after(t => {
+        // $ExpectType TestContext
+        t;
+    });
     // $ExpectType void
-    t.afterEach(() => {});
+    t.afterEach(t => {
+        // $ExpectType TestContext
+        t;
+    });
     // $ExpectType void
-    t.beforeEach(() => {});
+    t.beforeEach(t => {
+        // $ExpectType TestContext
+        t;
+    });
     // $ExpectType void
-    t.before(() => {});
+    t.before(t => {
+        // $ExpectType TestContext
+        t;
+    });
 
     // $ExpectType string
     t.name;
@@ -454,33 +466,33 @@ beforeEach(() => {});
 after(() => {});
 beforeEach(() => {});
 // - with callback
-before((s, cb) => {
-    // $ExpectType SuiteContext
-    s;
+before((c, cb) => {
+    // $ExpectType TestContext | SuiteContext
+    c;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void
     cb({ x: "anything" });
 });
-beforeEach((s, cb) => {
-    // $ExpectType SuiteContext
-    s;
+beforeEach((c, cb) => {
+    // $ExpectType TestContext | SuiteContext
+    c;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void
     cb({ x: "anything" });
 });
-after((s, cb) => {
-    // $ExpectType SuiteContext
-    s;
+after((c, cb) => {
+    // $ExpectType TestContext | SuiteContext
+    c;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void
     cb({ x: "anything" });
 });
-afterEach((s, cb) => {
-    // $ExpectType SuiteContext
-    s;
+afterEach((c, cb) => {
+    // $ExpectType TestContext | SuiteContext
+    c;
     // $ExpectType (result?: any) => void
     cb;
     // $ExpectType void


### PR DESCRIPTION
The various hook functions in node:test (`before()` etc.) are currently typed on the assumption that the context object passed to the hook callback will always be a `SuiteContext`.

In fact:
- The top-level hook functions will register the hook on whatever the active context is in the test runner, so the object passed to the callback could be either a `TestContext` or a `SuiteContext`.
- The hook methods in `TestContext` will always pass a `TestContext` to the callback.

The properties on `TestContext` are a superset of those on `SuiteContext`, so this shouldn't break any current usage.

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [top-level hooks](https://github.com/nodejs/node/blob/v22.7.0/lib/internal/test_runner/harness.js#L292-L303), [TestContext hooks](https://github.com/nodejs/node/blob/v22.7.0/lib/internal/test_runner/test.js#L304-L343)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
