### PR TITLE
[svelte-leafletjs] fix test for TS 5.7

### DIFF
--- a/types/svelte-leafletjs/svelte-leafletjs-tests.ts
+++ b/types/svelte-leafletjs/svelte-leafletjs-tests.ts
@@ -66,7 +66,7 @@ import { Circle, LeafletContext, LeafletMap, TileLayer } from "svelte-leafletjs"
 
 {
     /* tslint:disable-next-line */
-    let getMap: () => Map;
+    let getMap!: () => Map;
 
     const f = () => {
         const mapEl = new LeafletMap({


### PR DESCRIPTION
Fixes test to avoid new errors introduced by [this TS PR](https://github.com/microsoft/TypeScript/pull/55887) merged for TS 5.7.