### PR TITLE
[react] Fix contextually inferred types of forwardRef arguments

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1597,7 +1597,7 @@ declare namespace React {
      * ```
      */
     function forwardRef<T, P = {}>(
-        render: ForwardRefRenderFunction<T, P>,
+        render: ForwardRefRenderFunction<T, PropsWithoutRef<P>>,
     ): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
 
     /**

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -425,6 +425,41 @@ const ForwardRefRenderFunction = (props: ForwardingRefComponentProps, ref: React
 };
 React.forwardRef(ForwardRefRenderFunction);
 
+const ForwardRefRenderFunctionWithInferrence: React.ForwardRefExoticComponent<
+    ForwardingRefComponentProps & React.RefAttributes<HTMLDivElement>
+> = React.forwardRef(
+    (
+        // $ExpectType Omit<ForwardingRefComponentProps & RefAttributes<HTMLDivElement>, "ref">
+        props,
+        // $ExpectType ForwardedRef<HTMLDivElement>
+        ref,
+    ) => null,
+);
+
+const ForwardRefRenderFunctionWithInferrence2: React.ComponentType<
+    ForwardingRefComponentProps & React.RefAttributes<HTMLDivElement>
+> = React.forwardRef(
+    (
+        // $ExpectType Omit<ForwardingRefComponentProps & RefAttributes<HTMLDivElement>, "ref">
+        props,
+        // $ExpectType ForwardedRef<HTMLDivElement>
+        ref,
+    ) => null,
+);
+
+const ForwardRefRenderFunctionWithInferrence3: React.ComponentType<
+    ForwardingRefComponentProps & { ref: React.Ref<HTMLDivElement> }
+> = React.memo(
+    React.forwardRef(
+        (
+            // $ExpectType Omit<ForwardingRefComponentProps & { ref: Ref<HTMLDivElement>; }, "ref">
+            props,
+            // $ExpectType ForwardedRef<HTMLDivElement>
+            ref,
+        ) => null,
+    ),
+);
+
 const ForwardingRefComponentPropTypes: React.WeakValidationMap<ForwardingRefComponentProps> = {};
 ForwardingRefComponent.propTypes = ForwardingRefComponentPropTypes;
 

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -1598,7 +1598,7 @@ declare namespace React {
      * ```
      */
     function forwardRef<T, P = {}>(
-        render: ForwardRefRenderFunction<T, P>,
+        render: ForwardRefRenderFunction<T, PropsWithoutRef<P>>,
     ): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
 
     /**

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -428,6 +428,41 @@ const ForwardRefRenderFunction = (props: ForwardingRefComponentProps, ref: React
 };
 React.forwardRef(ForwardRefRenderFunction);
 
+const ForwardRefRenderFunctionWithInferrence: React.ForwardRefExoticComponent<
+    ForwardingRefComponentProps & React.RefAttributes<HTMLDivElement>
+> = React.forwardRef(
+    (
+        // $ExpectType Omit<ForwardingRefComponentProps & RefAttributes<HTMLDivElement>, "ref">
+        props,
+        // $ExpectType ForwardedRef<HTMLDivElement>
+        ref,
+    ) => null,
+);
+
+const ForwardRefRenderFunctionWithInferrence2: React.ComponentType<
+    ForwardingRefComponentProps & React.RefAttributes<HTMLDivElement>
+> = React.forwardRef(
+    (
+        // $ExpectType Omit<ForwardingRefComponentProps & RefAttributes<HTMLDivElement>, "ref">
+        props,
+        // $ExpectType ForwardedRef<HTMLDivElement>
+        ref,
+    ) => null,
+);
+
+const ForwardRefRenderFunctionWithInferrence3: React.ComponentType<
+    ForwardingRefComponentProps & { ref: React.Ref<HTMLDivElement> }
+> = React.memo(
+    React.forwardRef(
+        (
+            // $ExpectType Omit<ForwardingRefComponentProps & { ref: Ref<HTMLDivElement>; }, "ref">
+            props,
+            // $ExpectType ForwardedRef<HTMLDivElement>
+            ref,
+        ) => null,
+    ),
+);
+
 const ForwardingRefComponentPropTypes: React.WeakValidationMap<ForwardingRefComponentProps> = {};
 ForwardingRefComponent.propTypes = ForwardingRefComponentPropTypes;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

TypeScript 5.5 introduced support for [isolated declarations](https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#isolated-declarations). Code that benefits from isolated declarations must explicitly annotate exported variables when the types can't be trivially inferred from syntax. This means that there will be an increased need for React components to be given explicit type annotations and greater usage of the utility types that `@types/react` provides.

One of the shortcomings I've come across is when using `forwardRef`, the inferred type of `props` incorrectly includes `ref`. This PR contains a fix for that.

Unfortunately, the representation of the type is suboptimal because the typing of `ForwardRefExoticComponent` doesn't separately take the prop type and ref type and requires you to pre-combine them as something like `ForwardRefExoticComponent<Props & React.RefAttributes<RefType>>`. In TypeScript, it's not generally possible to extract a type in an intersection back out of the intersection, which means that we can't pull `Props` out of `Props & React.RefAttributes<RefType>` with something like `extends infer TProps & React.RefAttributes<infer TRefType>`. Going forward, I would recommend providing a new utility type, `ForwardRefComponent<Props, RefType>` which preserves `Props`. That would also be an opportunity to deprecate `ForwardRefExoticComponent` whose name I've always found to be needlessly verbose and intimidating.

