### PR TITLE
[regenerator-runtime] Fix AsyncIterator definition

### DIFF
--- a/types/regenerator-runtime/index.d.ts
+++ b/types/regenerator-runtime/index.d.ts
@@ -170,7 +170,7 @@ export interface ResolvablePromiseConstructorLike extends PromiseConstructorLike
 }
 
 export class AsyncIterator<TYield = unknown, TReturn = unknown, TNext = unknown>
-    implements AsyncGenerator<TYield, TReturn, TNext>
+    implements globalThis.AsyncIterator<TYield, TReturn, TNext>
 {
     constructor(
         generator: Generator<


### PR DESCRIPTION
Per the actual implementation, `AsyncIterator` does not actually inherit from the intrinsic %AsyncGeneratorPrototype% object.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/regenerator/blob/cb755fd82c648cbc5307a5a2d61cdd598e698fc4/packages/runtime/runtime.js#L158
