### PR TITLE
[pg] pool.options

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -44,11 +44,12 @@ export interface PoolConfig extends ClientConfig {
     // properties from module 'node-pool'
     max?: number | undefined;
     min?: number | undefined;
-    idleTimeoutMillis?: number | undefined;
+    idleTimeoutMillis?: number | undefined | null;
     log?: ((...messages: any[]) => void) | undefined;
     Promise?: PromiseConstructorLike | undefined;
     allowExitOnIdle?: boolean | undefined;
     maxUses?: number | undefined;
+    maxLifetimeSeconds?: number | undefined;
     Client?: (new() => ClientBase) | undefined;
 }
 
@@ -159,6 +160,14 @@ export class Connection extends events.EventEmitter {
     end(): void;
 }
 
+export interface PoolOptions extends PoolConfig {
+    max: number;
+    maxUses: number;
+    allowExitOnIdle: boolean;
+    maxLifetimeSeconds: number;
+    idleTimeoutMillis: number | null;
+}
+
 /**
  * {@link https://node-postgres.com/apis/pool}
  */
@@ -173,6 +182,8 @@ export class Pool extends events.EventEmitter {
     readonly totalCount: number;
     readonly idleCount: number;
     readonly waitingCount: number;
+
+    options: PoolOptions;
 
     connect(): Promise<PoolClient>;
     connect(

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -244,6 +244,10 @@ pool.connect((err, client, done) => {
         console.error("error fetching client from pool", err);
         return;
     }
+
+    // $ExpectType PoolOptions
+    pool.options;
+
     // @ts-expect-error
     client.query("SELECT");
     client?.query("SELECT $1::int AS number", ["1"], (err, result) => {


### PR DESCRIPTION
node-pg's Pool saves the config passed to its constructor under `options`. This is the only way to get things like the connection info that a pool object is using.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/brianc/node-postgres/blob/54eb0fa216aaccd727765641e7d1cf5da2bc483d/packages/pg-pool/index.js#L69-L99
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

