### PR TITLE
Updated slotElicitationStyle to optional for LexV2ResultDialogAction

### DIFF
--- a/types/aws-lambda/trigger/lex-v2.d.ts
+++ b/types/aws-lambda/trigger/lex-v2.d.ts
@@ -95,7 +95,7 @@ export type LexV2DialogAction =
 
 export type LexV2ResultDialogAction =
     | (LevV2DialogActionWithoutSlot & { slotToElicit?: never })
-    | { type: "ElicitSlot"; slotToElicit: string; slotElicitationStyle: "Default" | "SpellByLetter" | "SpellByWord" };
+    | { type: "ElicitSlot"; slotToElicit: string; slotElicitationStyle?: "Default" | "SpellByLetter" | "SpellByWord" };
 
 export interface LexV2Result {
     sessionState: {


### PR DESCRIPTION
For Amazon Lex V2, `slotElicitationStyle` property for DialogAction is not required as described in [this document](https://docs.aws.amazon.com/lexv2/latest/APIReference/API_runtime_DialogAction.html). The [Capturing slot values with spelling styles](https://docs.aws.amazon.com/lexv2/latest/dg/how-languages.html#language-features) feature is supported in selected regions only. Unsupported regions don't accept API calls with `slotElicitationStyle` parameter and they will fail. Currently `slotElicitationStyle` is required parameter on LexV2ResultDialogAction, and it can cause the error in the unsupported regions. This PR updates `slotElicitationStyle` to an optional parameter.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/lexv2/latest/dg/how-languages.html, https://docs.aws.amazon.com/lexv2/latest/APIReference/API_runtime_DialogAction.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.