### PR TITLE
fix: mark fabricjs insertChars function parameters as optional

### DIFF
--- a/types/fabric/fabric-impl.d.ts
+++ b/types/fabric/fabric-impl.d.ts
@@ -4996,7 +4996,7 @@ export class IText extends Text {
      * @param {Number} start
      * @param {Number} end default to start + 1
      */
-    insertChars(text: string, style: any[], start: number, end: number): void;
+    insertChars(text: string, style?: any[], start?: number, end?: number): void;
     /**
      * Moves cursor down
      * @param {Event} e Event object

--- a/types/fabric/test/index.ts
+++ b/types/fabric/test/index.ts
@@ -1230,6 +1230,16 @@ function sample18() {
     canvas.freeDrawingBrush.decimate = 2;
 }
 
+function sample19() {
+    const canvas = new fabric.Canvas("c");
+    const textbox = new fabric.Textbox("original text");
+    canvas.add(textbox);
+    textbox.insertChars("c", [], 4, 7);
+    textbox.insertChars("chars at start", undefined, 2, 4);
+    textbox.insertChars("chars at start", undefined, 1);
+    textbox.insertChars("new chars");
+}
+
 function testIntersection() {
     const a1 = new fabric.Point(50, 400);
     const a2 = new fabric.Point(250, 40);

--- a/types/fabric/test/index.ts
+++ b/types/fabric/test/index.ts
@@ -1235,9 +1235,9 @@ function sample19() {
     const textbox = new fabric.Textbox("original text");
     canvas.add(textbox);
     textbox.insertChars("c", [], 4, 7);
-    textbox.insertChars("chars at start", undefined, 2, 4);
-    textbox.insertChars("chars at start", undefined, 1);
-    textbox.insertChars("new chars");
+    textbox.insertChars("new chars", undefined, 2, 4);
+    textbox.insertChars("more new chars", undefined, 1);
+    textbox.insertChars("even more new chars");
 }
 
 function testIntersection() {


### PR DESCRIPTION
Parameters 2-4 of the insertChars function should be optional

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [ITextBehavior insertChars](https://github.com/fabricjs/fabric.js/blob/master/src/shapes/IText/ITextBehavior.ts#L1020-L1037)