### PR TITLE
[eslint] Strict `ParserOptions` type

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -735,6 +735,38 @@ const _processor: Linter.Processor = {
     },
 };
 
+const _parserOptions: Linter.ParserOptions = {
+    ecmaVersion: 2021,
+    sourceType: "module",
+    ecmaFeatures: {
+        globalReturn: true,
+        impliedStrict: true,
+        jsx: true,
+        // This type is loose, so you can pass arbitrary properties.
+        foo: "bar",
+        experimentalObjectRestSpread: new Date(),
+    },
+    // This type is loose, so you can pass arbitrary properties.
+    foo: "bar",
+};
+
+const _flatParserOptions: Linter.FlatParserOptions = {
+    allowReserved: true,
+    ecmaFeatures: {
+        globalReturn: true,
+        impliedStrict: true,
+        jsx: true,
+        // This type is loose, so you can pass arbitrary properties.
+        foo: "bar",
+        experimentalObjectRestSpread: new Date(),
+    },
+    // This type is loose, so you can pass arbitrary properties.
+    foo: "bar",
+    // This type differs from the one for legacy config in that any type can be passed for `sourceType` and `ecmaVersion`.
+    ecmaVersion: new Date(),
+    sourceType: new Date(),
+};
+
 // #region Linter with flat config
 
 const linterWithFlatConfig = new Linter({ configType: "flat" });

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -741,7 +741,7 @@ export namespace Rule {
         parserPath: string | undefined;
         languageOptions: Linter.LanguageOptions;
         /** @deprecated Use property `languageOptions.parserOptions` instead. */
-        parserOptions: Linter.LegacyParserOptions;
+        parserOptions: Linter.ParserOptions;
         cwd: string;
         filename: string;
         physicalFilename: string;
@@ -1015,7 +1015,7 @@ export namespace Linter {
          * @see [Working with Custom Parsers](https://eslint.org/docs/latest/extend/custom-parsers)
          * @see [Specifying Parser Options](https://eslint.org/docs/latest/use/configure/language-options-deprecated#specifying-parser-options)
          */
-        parserOptions?: LegacyParserOptions | undefined;
+        parserOptions?: ParserOptions | undefined;
 
         /**
          * Which third-party plugins define additional rules, environments, configs, etc. for ESLint to use.
@@ -1084,7 +1084,7 @@ export namespace Linter {
     }
 
     /**
-     * Parser options.
+     * Parser options for flat config.
      *
      * This properties are used to pass options directly to parsers. These options are always parser-specific,
      * so you’ll need to check the documentation of the parser you’re using for available options.
@@ -1092,7 +1092,7 @@ export namespace Linter {
      * @see [Specifying Parser Options](https://eslint.org/docs/latest/use/configure/language-options#specifying-parser-options)
      * @see [Configure Parser Options](https://eslint.org/docs/latest/use/configure/parser#configure-parser-options)
      */
-    interface ParserOptions {
+    interface FlatParserOptions {
         /**
          * Allow the use of reserved words as identifiers (if ecmaVersion is 3).
          * @default false
@@ -1113,14 +1113,14 @@ export namespace Linter {
     }
 
     /**
-     * Parser options for LegacyConfig.
+     * Parser options for legacy config.
      *
      * Parsers are all passed this properties and may or may not use them to determine which features to enable.
      *
      * @see [Specifying Parser Options](https://eslint.org/docs/latest/use/configure/language-options-deprecated#specifying-parser-options)
      * @see [Configure a Custom Parser](https://eslint.org/docs/latest/use/configure/parser-deprecated#configure-a-custom-parser)
      */
-    interface LegacyParserOptions {
+    interface ParserOptions {
         /**
          * Accepts any valid ECMAScript version number or `'latest'`:
          *
@@ -1350,7 +1350,7 @@ export namespace Linter {
          * An object specifying additional options that are passed directly to the
          * parser() method on the parser. The available options are parser-dependent
          */
-        parserOptions?: Linter.ParserOptions | undefined;
+        parserOptions?: Linter.FlatParserOptions | undefined;
     }
 
     interface LinterOptions {
@@ -1429,7 +1429,7 @@ export namespace ESLint {
 
     interface Environment {
         globals?: Linter.Globals | undefined;
-        parserOptions?: Linter.LegacyParserOptions | undefined;
+        parserOptions?: Linter.ParserOptions | undefined;
     }
 
     interface ObjectMetaProperties {

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -1103,7 +1103,6 @@ export namespace Linter {
             globalReturn?: boolean | undefined;
             impliedStrict?: boolean | undefined;
             jsx?: boolean | undefined;
-            experimentalObjectRestSpread?: boolean | undefined;
             [key: string]: any;
         } | undefined;
         [key: string]: any;
@@ -1150,7 +1149,6 @@ export namespace Linter {
             globalReturn?: boolean | undefined;
             impliedStrict?: boolean | undefined;
             jsx?: boolean | undefined;
-            experimentalObjectRestSpread?: boolean | undefined;
             [key: string]: any;
         } | undefined;
         [key: string]: any;

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -1442,6 +1442,7 @@ export namespace ESLint {
 
     interface Plugin extends ObjectMetaProperties {
         configs?: Record<string, Linter.LegacyConfig | Linter.Config | Linter.Config[]> | undefined;
+        /** @deprecated See https://eslint.org/docs/latest/extend/plugin-migration-flat-config#migrating-environments-for-flat-config */
         environments?: Record<string, Environment> | undefined;
         processors?: Record<string, Linter.Processor> | undefined;
         rules?: Record<string, Rule.RuleModule> | undefined;

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -1086,7 +1086,11 @@ export namespace Linter {
     /**
      * Parser options.
      *
+     * This properties are used to pass options directly to parsers. These options are always parser-specific,
+     * so you’ll need to check the documentation of the parser you’re using for available options.
+     *
      * @see [Specifying Parser Options](https://eslint.org/docs/latest/use/configure/language-options#specifying-parser-options)
+     * @see [Configure Parser Options](https://eslint.org/docs/latest/use/configure/parser#configure-parser-options)
      */
     interface ParserOptions {
         /**
@@ -1111,7 +1115,10 @@ export namespace Linter {
     /**
      * Parser options for LegacyConfig.
      *
+     * Parsers are all passed this properties and may or may not use them to determine which features to enable.
+     *
      * @see [Specifying Parser Options](https://eslint.org/docs/latest/use/configure/language-options-deprecated#specifying-parser-options)
+     * @see [Configure a Custom Parser](https://eslint.org/docs/latest/use/configure/parser-deprecated#configure-a-custom-parser)
      */
     interface LegacyParserOptions {
         /**

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -740,7 +740,8 @@ export namespace Rule {
         settings: { [name: string]: any };
         parserPath: string | undefined;
         languageOptions: Linter.LanguageOptions;
-        parserOptions: Linter.ParserOptions;
+        /** @deprecated Use property `languageOptions.parserOptions` instead. */
+        parserOptions: Linter.LegacyParserOptions;
         cwd: string;
         filename: string;
         physicalFilename: string;
@@ -1014,7 +1015,7 @@ export namespace Linter {
          * @see [Working with Custom Parsers](https://eslint.org/docs/latest/extend/custom-parsers)
          * @see [Specifying Parser Options](https://eslint.org/docs/latest/use/configure/language-options-deprecated#specifying-parser-options)
          */
-        parserOptions?: ParserOptions | undefined;
+        parserOptions?: LegacyParserOptions | undefined;
 
         /**
          * Which third-party plugins define additional rules, environments, configs, etc. for ESLint to use.
@@ -1085,9 +1086,35 @@ export namespace Linter {
     /**
      * Parser options.
      *
-     * @see [Specifying Parser Options](https://eslint.org/docs/latest/use/configure/language-options-deprecated#specifying-parser-options)
+     * @see [Specifying Parser Options](https://eslint.org/docs/latest/use/configure/language-options#specifying-parser-options)
      */
     interface ParserOptions {
+        /**
+         * Allow the use of reserved words as identifiers (if ecmaVersion is 3).
+         * @default false
+         */
+        allowReserved?: boolean;
+        /**
+         * An object indicating which additional language features you'd like to use.
+         *
+         * @see https://eslint.org/docs/latest/use/configure/language-options#specifying-parser-options
+         */
+        ecmaFeatures?: {
+            globalReturn?: boolean | undefined;
+            impliedStrict?: boolean | undefined;
+            jsx?: boolean | undefined;
+            experimentalObjectRestSpread?: boolean | undefined;
+            [key: string]: any;
+        } | undefined;
+        [key: string]: any;
+    }
+
+    /**
+     * Parser options for LegacyConfig.
+     *
+     * @see [Specifying Parser Options](https://eslint.org/docs/latest/use/configure/language-options-deprecated#specifying-parser-options)
+     */
+    interface LegacyParserOptions {
         /**
          * Accepts any valid ECMAScript version number or `'latest'`:
          *
@@ -1397,7 +1424,7 @@ export namespace ESLint {
 
     interface Environment {
         globals?: Linter.Globals | undefined;
-        parserOptions?: Linter.ParserOptions | undefined;
+        parserOptions?: Linter.LegacyParserOptions | undefined;
     }
 
     interface ObjectMetaProperties {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes
  - https://eslint.org/docs/latest/use/configure/language-options#specifying-parser-options
  - https://eslint.org/docs/latest/use/configure/language-options-deprecated#specifying-parser-options
- [ ] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.~
  - This is not a change for newer versions. It is just to make the type strictly for the current version.
