### PR TITLE
Adds missing "border-*" properties

### DIFF
--- a/types/cytoscape/cytoscape-tests.ts
+++ b/types/cytoscape/cytoscape-tests.ts
@@ -190,6 +190,20 @@ const showAllStyle: cytoscape.Stylesheet[] = [
             "pie-16-background-size": 5,
         },
     },
+    {
+        selector: "node.border",
+        style: {
+            "border-width": 5,
+            "border-style": "dashed",
+            "border-color": "red",
+            "border-opacity": 0.85,
+            "border-position": "inside",
+            "border-cap": "round",
+            "border-join": "bevel",
+            "border-dash-pattern": [6, 3],
+            "border-dash-offset": 5,
+        },
+    },
 ];
 
 const cy = cytoscape({
@@ -715,6 +729,9 @@ eles.classes(oneOf("test", undefined));
 eles.classes();
 eles.flashClass("test flash", oneOf(1000, undefined));
 assert(ele.hasClass("test"));
+
+nodes.addClass("border");
+nodes.removeClass("border");
 
 eles.style("background-color", "green");
 Object.keys(eles.style()).map(key => eles.style(key));

--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -3897,6 +3897,29 @@ declare namespace cytoscape {
              * A value between [0 1].
              */
             "border-opacity"?: PropertyValueNode<number> | undefined;
+            /**
+             * The position of the node’s border.
+             * One of: center, inside, outside.
+             */
+            "border-position"?: PropertyValueNode<"center" | "inside" | "outside"> | undefined;
+            /**
+             * The cap style of the node’s border.
+             * One of: butt, round, square.
+             */
+            "border-cap"?: PropertyValueNode<"butt" | "round" | "square"> | undefined;
+            /**
+             * The join style of the node’s border.
+             * One of: miter, bevel, round.
+             */
+            "border-join"?: PropertyValueNode<"miter" | "bevel" | "round"> | undefined;
+            /**
+             * The dashed line pattern which specifies alternating lengths of lines and gaps. (e.g. [6, 3]).
+             */
+            "border-dash-pattern"?: PropertyValueNode<number[]> | undefined;
+            /**
+             * The dashed line offset (e.g. 24). It is useful for creating edge animations.
+             */
+            "border-dash-offset"?: PropertyValueNode<number> | undefined;
         }
 
         /**


### PR DESCRIPTION
Properties added (see https://js.cytoscape.org/#style/node-body): border-position, border-cap, border-join, border-dash-pattern, border-dash-offset

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  https://js.cytoscape.org/#style/node-body
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
