### PR TITLE
[react-native-web] Fix UIManager fn typing

### DIFF
--- a/types/react-native-web/index.d.ts
+++ b/types/react-native-web/index.d.ts
@@ -1507,6 +1507,6 @@ declare module "react-native" {
         paddingBottom?: CSSProperties["paddingBottom"] | DimensionValue | undefined;
         paddingLeft?: CSSProperties["paddingLeft"] | DimensionValue | undefined;
     }
-
+    // tslint disable-next-line @typescript-eslint/no-empty-interface
     interface UIManagerStatic extends UIManager {}
 }

--- a/types/react-native-web/index.d.ts
+++ b/types/react-native-web/index.d.ts
@@ -1507,6 +1507,6 @@ declare module "react-native" {
         paddingBottom?: CSSProperties["paddingBottom"] | DimensionValue | undefined;
         paddingLeft?: CSSProperties["paddingLeft"] | DimensionValue | undefined;
     }
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
     interface UIManagerStatic extends UIManager {}
 }

--- a/types/react-native-web/index.d.ts
+++ b/types/react-native-web/index.d.ts
@@ -1507,6 +1507,6 @@ declare module "react-native" {
         paddingBottom?: CSSProperties["paddingBottom"] | DimensionValue | undefined;
         paddingLeft?: CSSProperties["paddingLeft"] | DimensionValue | undefined;
     }
-    // tslint:disable-next-line:no-empty-interface
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
     interface UIManagerStatic extends UIManager {}
 }

--- a/types/react-native-web/index.d.ts
+++ b/types/react-native-web/index.d.ts
@@ -793,7 +793,7 @@ export interface UIManager {
     ): void;
     updateView(node: number, props: any): void;
     configureNextLayoutAnimation(config: any, onAnimationDidEnd: GenericFunction): void;
-    setLayoutAnimationEnabledExperimental(): void;
+    setLayoutAnimationEnabledExperimental(value: boolean): void;
 }
 
 export interface Vibration {

--- a/types/react-native-web/index.d.ts
+++ b/types/react-native-web/index.d.ts
@@ -1507,6 +1507,6 @@ declare module "react-native" {
         paddingBottom?: CSSProperties["paddingBottom"] | DimensionValue | undefined;
         paddingLeft?: CSSProperties["paddingLeft"] | DimensionValue | undefined;
     }
-    // tslint:disable-next-line @typescript-eslint/no-empty-interface
+    // tslint:disable-next-line:no-empty-interface
     interface UIManagerStatic extends UIManager {}
 }

--- a/types/react-native-web/index.d.ts
+++ b/types/react-native-web/index.d.ts
@@ -1507,4 +1507,6 @@ declare module "react-native" {
         paddingBottom?: CSSProperties["paddingBottom"] | DimensionValue | undefined;
         paddingLeft?: CSSProperties["paddingLeft"] | DimensionValue | undefined;
     }
+
+    interface UIManagerStatic extends UIManager {}
 }

--- a/types/react-native-web/index.d.ts
+++ b/types/react-native-web/index.d.ts
@@ -1507,6 +1507,6 @@ declare module "react-native" {
         paddingBottom?: CSSProperties["paddingBottom"] | DimensionValue | undefined;
         paddingLeft?: CSSProperties["paddingLeft"] | DimensionValue | undefined;
     }
-    // tslint disable-next-line @typescript-eslint/no-empty-interface
+    // tslint:disable-next-line @typescript-eslint/no-empty-interface
     interface UIManagerStatic extends UIManager {}
 }

--- a/types/react-native-web/package.json
+++ b/types/react-native-web/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/react-native-web",
-    "version": "0.0.9999",
+    "version": "0.19.9999",
     "projects": [
         "https://github.com/necolas/react-native-web#readme"
     ],

--- a/types/react-native-web/react-native-web-tests.tsx
+++ b/types/react-native-web/react-native-web-tests.tsx
@@ -395,4 +395,3 @@ UIManager.measureLayout(
 );
 UIManager.updateView(node, {});
 UIManager.configureNextLayoutAnimation(null, () => {});
-UIManager.setLayoutAnimationEnabledExperimental(true);

--- a/types/react-native-web/react-native-web-tests.tsx
+++ b/types/react-native-web/react-native-web-tests.tsx
@@ -391,7 +391,7 @@ UIManager.measureLayout(
     node,
     node,
     () => {},
-    () => {}
+    () => {},
 );
 UIManager.updateView(node, {});
 UIManager.configureNextLayoutAnimation(null, () => {});

--- a/types/react-native-web/react-native-web-tests.tsx
+++ b/types/react-native-web/react-native-web-tests.tsx
@@ -7,6 +7,7 @@ import {
     TextInputProps,
     TextProps,
     TextStyle,
+    UIManager,
     ViewProps,
     ViewStyle,
 } from "react-native";
@@ -380,3 +381,18 @@ const yellowBox = <YellowBox />;
 const colorScheme = useColorScheme();
 const localeContext = useLocaleContext();
 const windowDimensions = useWindowDimensions();
+
+const node = 0;
+UIManager.blur(node);
+UIManager.focus(node);
+UIManager.measure(node, () => {});
+UIManager.measureInWindow(node, () => {});
+UIManager.measureLayout(
+    node,
+    node,
+    () => {},
+    () => {}
+);
+UIManager.updateView(node, {});
+UIManager.configureNextLayoutAnimation(null, () => {});
+UIManager.setLayoutAnimationEnabledExperimental();

--- a/types/react-native-web/react-native-web-tests.tsx
+++ b/types/react-native-web/react-native-web-tests.tsx
@@ -395,4 +395,4 @@ UIManager.measureLayout(
 );
 UIManager.updateView(node, {});
 UIManager.configureNextLayoutAnimation(null, () => {});
-UIManager.setLayoutAnimationEnabledExperimental();
+UIManager.setLayoutAnimationEnabledExperimental(true);


### PR DESCRIPTION
# Why

We need to extend `UIManagerStatic`, otherwise attempting to `import {UIManager} from 'react-native'` and call fns results in `TS2339: Property 'blur' does not exist on type 'UIManagerStatic'.`