### PR TITLE
[types/diff] Add Diff.formatPatch(patch) method

### DIFF
--- a/types/diff/diff-tests.ts
+++ b/types/diff/diff-tests.ts
@@ -126,6 +126,8 @@ const uniDiffPatch = Diff.structuredPatch("oldFile.ts", "newFile.ts", one, other
 });
 verifyPatchMethods(one, other, uniDiffPatch);
 
+const formatted: string = Diff.formatPatch(uniDiffPatch);
+
 const uniDiffStr = Diff.createPatch("file.ts", one, other, "old", "new", { context: 1 });
 verifyApplyMethods(one, other, uniDiffStr);
 

--- a/types/diff/index.d.ts
+++ b/types/diff/index.d.ts
@@ -401,3 +401,10 @@ export function merge(mine: string, theirs: string, base: string): ParsedDiff;
 export function reversePatch(patch: ParsedDiff | ParsedDiff[]): ParsedDiff;
 
 export function canonicalize(obj: any, stack: any[], replacementStack: any[]): any;
+
+/**
+ * creates a unified diff patch.
+ * patch may be either a single structured patch object (as returned by structuredPatch)
+ * or an array of them (as returned by parsePatch).
+ */
+export function formatPatch(patch: ParsedDiff | ParsedDiff[]): string;


### PR DESCRIPTION
This adds the `formatPatch` method to `diff`. This method has been in the library since [5.2.0](https://github.com/kpdecker/jsdiff/blob/master/release-notes.md#v520) and the version of `@types/diff` is 5.2.9999, so I haven't updated the version in package.json, but I could if that's the right move.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kpdecker/jsdiff#:~:text=Diff.createPatch(fileName%2C%20oldStr%2C%20newStr%5B%2C%20oldHeader%5B%2C%20newHeader%5B%2C%20options%5D%5D%5D)%20%2D%20creates%20a%20unified%20diff%20patch.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
