### PR TITLE
[@types/google-publisher-tag] Deprecate adYield & add threadYield

### DIFF
--- a/types/google-publisher-tag/google-publisher-tag-tests.ts
+++ b/types/google-publisher-tag/google-publisher-tag-tests.ts
@@ -658,6 +658,18 @@ function test_googletag_config_pageSettingsConfig_adYield() {
     googletag.setConfig({ adYield: null });
 }
 
+// Test for googletag.config.PageSettingsConfig.threadYield
+function test_googletag_config_pageSettingsConfig_threadYield() {
+    // Disable yielding.
+    googletag.setConfig({ threadYield: "DISABLED" });
+
+    // Enable yielding for all slots.
+    googletag.setConfig({ threadYield: "ENABLED_ALL_SLOTS" });
+
+    // Enable yielding only for slots outside of the viewport (default).
+    googletag.setConfig({ threadYield: null });
+}
+
 // Test for googletag.config.PrivacyTreatmentsConfig.treatments
 function test_googletag_config_privacyTreatmentsConfig_treatments() {
     // Disable personalization across the entire page.

--- a/types/google-publisher-tag/google-publisher-tag-tests.ts
+++ b/types/google-publisher-tag/google-publisher-tag-tests.ts
@@ -1,4 +1,4 @@
-// Tests for Google Publisher Tag 1.20240729
+// Tests for Google Publisher Tag 1.20240826
 // Synced from: https://github.com/googleads/google-publisher-tag-types/commit/1b9687184a46e7cf847a897b13539b78c3393305
 
 // Test for googletag.cmd

--- a/types/google-publisher-tag/index.d.ts
+++ b/types/google-publisher-tag/index.d.ts
@@ -1804,6 +1804,11 @@ declare namespace googletag {
             pps?: PublisherProvidedSignalsConfig | null;
 
             /**
+             * @deprecated Use threadYield instead. This will be removed in the near future. 
+             */
+            adYield?: "DISABLED" | "ENABLED_ALL_SLOTS" | null;
+
+            /**
              * Setting to control whether GPT should yield the JS thread when
              * rendering creatives.
              *
@@ -1829,7 +1834,7 @@ declare namespace googletag {
              *
              * @see [Scheduler: postTask() method](https://developer.mozilla.org/docs/Web/API/Scheduler/postTask)
              */
-            adYield?: "DISABLED" | "ENABLED_ALL_SLOTS" | null;
+            threadYield?: "DISABLED" | "ENABLED_ALL_SLOTS" | null;
         }
 
         /**

--- a/types/google-publisher-tag/package.json
+++ b/types/google-publisher-tag/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/google-publisher-tag",
-    "version": "1.20240729.9999",
+    "version": "1.20240826.9999",
     "nonNpm": true,
     "nonNpmDescription": "Google Publisher Tag",
     "projects": [


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
---
I've noticed that the adYield method will be deprecated and replaced by threadYield, here's the link to the doc: [Doc](https://developers.google.com/publisher-tag/reference#googletag.config.PageSettingsConfig.adYield)

![Screenshot from 2024-08-27 09-42-57](https://github.com/user-attachments/assets/cfed8431-7c3c-4813-a13b-23494a960900)