### PR TITLE
[react] `currentTarget` can be null

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2170,7 +2170,7 @@ declare namespace React {
     // TODO: change any to unknown when moving to TS v3
     interface BaseSyntheticEvent<E = object, C = any, T = any> {
         nativeEvent: E;
-        currentTarget: C;
+        currentTarget: C | null;
         target: T;
         bubbles: boolean;
         cancelable: boolean;

--- a/types/react/test/elementAttributes.tsx
+++ b/types/react/test/elementAttributes.tsx
@@ -121,12 +121,12 @@ declare global {
 }
 
 const eventCallbacksTestCases = [
-    <blockquote onClick={e => e.currentTarget.cite} />,
-    <del onClick={e => e.currentTarget.cite} />,
-    <details onClick={e => e.currentTarget.open} />,
-    <meter onClick={e => e.currentTarget.optimum} />,
-    <output onClick={e => e.currentTarget.value} />,
-    <time onClick={e => e.currentTarget.dateTime} />,
+    <blockquote onClick={e =>  e.currentTarget?.cite} />,
+    <del onClick={e => e.currentTarget?.cite} />,
+    <details onClick={e => e.currentTarget?.open} />,
+    <meter onClick={e => e.currentTarget?.optimum} />,
+    <output onClick={e => e.currentTarget?.value} />,
+    <time onClick={e => e.currentTarget?.dateTime} />,
 ];
 
 function formActionsTest() {

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -508,7 +508,7 @@ const htmlAttr: React.HTMLProps<HTMLElement> = {
         event.stopPropagation();
     },
     onAnimationStart: event => {
-        const currentTarget: EventTarget & HTMLElement = event.currentTarget;
+        const currentTarget: (EventTarget & HTMLElement) | null = event.currentTarget;
     },
     onBlur: (event: React.FocusEvent) => {
         const {


### PR DESCRIPTION
This PR prevents a footgun with the current types that can happen if you debouce a DOM event handler or otherwise access the event asynchronously. Here's a simple repro:

```jsx
function Repro() {
  return (
    <input
      onKeyUp={(e) => {
        queueMicrotask(() => {
          // Error: Cannot read properties of null (reading 'value')
          console.log(e.currentTarget.value);
        });
      }}
    />
  );
}
```

From [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Event/currentTarget):
> Note that the value of `currentTarget` is only available in a handler for the event. Outside an event handler it will be null. This means that, for example, if you take a reference to the `Event` object inside an event handler and then access its `currentTarget` property outside the event handler, its value will be `null`.





- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/docs/Web/API/Event/currentTarget
