### PR TITLE
Update `puppeteer-core` dependency in `@types/aws-synthetics-puppeteer`

### DIFF
--- a/types/aws-synthetics-puppeteer/package.json
+++ b/types/aws-synthetics-puppeteer/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/aws-synthetics-puppeteer",
-    "version": "3.1.9999",
+    "version": "9.0.9999",
     "nonNpm": true,
     "nonNpmDescription": "aws-synthetics-puppeteer",
     "projects": [

--- a/types/aws-synthetics-puppeteer/package.json
+++ b/types/aws-synthetics-puppeteer/package.json
@@ -9,7 +9,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "puppeteer-core": "21.11.0",
+        "puppeteer-core": "22.12.1",
         "aws-xray-sdk-core": "=3.3.1"
     },
     "devDependencies": {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Latest version of CloudWatch Synthetics runtime uses `puppeteer-core` version `22.12.1`
  - https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Library_nodejs_puppeteer.html#CloudWatch_Synthetics_runtimeversion-nodejs-puppeteer-9.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
  - Updates version to match AWS runtime version (i.e. `syn-nodejs-puppeteer-9.0`, see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Library_nodejs_puppeteer.html#CloudWatch_Synthetics_runtimeversion-nodejs-puppeteer-9.0).
