### PR TITLE
[pg] pool.ending and pool.ended

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -183,6 +183,9 @@ export class Pool extends events.EventEmitter {
     readonly idleCount: number;
     readonly waitingCount: number;
 
+    readonly ending: boolean;
+    readonly ended: boolean;
+
     options: PoolOptions;
 
     connect(): Promise<PoolClient>;

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -248,6 +248,12 @@ pool.connect((err, client, done) => {
     // $ExpectType PoolOptions
     pool.options;
 
+    // $ExpectType boolean
+    pool.ending;
+
+    // $ExpectType boolean
+    pool.ended;
+
     // @ts-expect-error
     client.query("SELECT");
     client?.query("SELECT $1::int AS number", ["1"], (err, result) => {


### PR DESCRIPTION
These let consumers know if `.end` has been called on a Pool.

See https://github.com/brianc/node-postgres/blob/54eb0fa216aaccd727765641e7d1cf5da2bc483d/packages/pg-pool/index.js#L106-L107

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/brianc/node-postgres/blob/54eb0fa216aaccd727765641e7d1cf5da2bc483d/packages/pg-pool/index.js#L106-L107
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. N/A, `.ending` and `.ended` have been around since at least https://github.com/brianc/node-postgres/commit/35a285c9a7a5815b0bac9e6a2274e3a47976c11e, which dates to 2018.


