### PR TITLE
@types/plotly.js: Fix customdata for 2D plots

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1492,7 +1492,7 @@ export interface PlotData {
     rotation: number;
     theta: Datum[];
     r: Datum[];
-    customdata: Datum[] | Datum[][];
+    customdata: Datum[] | Datum[][] | Datum[][][];
     selectedpoints: Datum[];
     domain: Partial<{
         row: number;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://community.plotly.com/t/adding-customdata-to-hovertemplate-containing-a-json-for-each-data-point/49619
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.


In 2D-Plots like `heatmap` or `contour` the first two indices are used for the x,y position and the last 3. index can be used for `customdata[0], customdata[1], customdata[2], …`.