### PR TITLE
[@types/xrm] Added generics to WebAPI Types

### DIFF
--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -6105,7 +6105,7 @@ declare namespace Xrm {
          * @returns On success, returns a promise containing a JSON object with the retrieved attributes and their values.
          * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/xrm-webapi/retrieverecord External Link: retrieveRecord (Client API reference)}
          */
-        retrieveRecord(entityLogicalName: string, id: string, options?: string): Async.PromiseLike<any>;
+        retrieveRecord<T = any>(entityLogicalName: string, id: string, options?: string): Async.PromiseLike<T>;
 
         /**
          * Retrieves a collection of entity records.
@@ -6123,11 +6123,11 @@ declare namespace Xrm {
          * @returns On success, returns a promise object containing the attributes specified earlier in the description of the successCallback parameter.
          * @see {@link https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/xrm-webapi/retrievemultiplerecords External Link: retrieveMultipleRecords (Client API reference)}
          */
-        retrieveMultipleRecords(
+        retrieveMultipleRecords<T = any>(
             entityLogicalName: string,
             options?: string,
             maxPageSize?: number,
-        ): Async.PromiseLike<RetrieveMultipleResult>;
+        ): Async.PromiseLike<RetrieveMultipleResult<T>>;
 
         /**
          * Updates an entity record.

--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -1475,7 +1475,7 @@ declare namespace Xrm {
          * @see {@link https://learn.microsoft.com/en-us/dynamics365/customerengagement/on-premises/customize/actions External Link: Actions overview}
          * @see {@link https://learn.microsoft.com/en-us/dynamics365/customerengagement/on-premises/developer/create-own-actions External Link: Create your own actions}
          */
-        invokeProcessAction(name: string, parameters: Collection.Dictionary<any>): Async.PromiseLike<any>;
+        invokeProcessAction<T = any>(name: string, parameters: Collection.Dictionary<any>): Async.PromiseLike<T>;
 
         /**
          * Opens a lookup control to select one or more items.

--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -6159,11 +6159,11 @@ declare namespace Xrm {
     /**
      * Interface for the WebAPI RetrieveMultiple request response
      */
-    interface RetrieveMultipleResult {
+    interface RetrieveMultipleResult<T = any> {
         /**
          * An array of JSON objects, where each object represents the retrieved entity record containing attributes and their values as key: value pairs. The Id of the entity record is retrieved by default.
          */
-        entities: any[];
+        entities: T[];
         /**
          * If the number of records being retrieved is more than the value specified in the maxPageSize parameter, this attribute returns the URL to return next set of records.
          */

--- a/types/xrm/xrm-tests.ts
+++ b/types/xrm/xrm-tests.ts
@@ -253,11 +253,7 @@ Xrm.WebApi.retrieveMultipleRecords(
         <order attribute='fullname' descending='false' />
     </entity>
     </fetch>`,
-).then((response:Xrm.RetrieveMultipleResult<{
-    contactid: string,
-    fullname: string,
-    telephone1: string
-}>) => {
+).then((response: Xrm.RetrieveMultipleResult<{ contactid: string; fullname: string; telephone1: string }>) => {
     console.log("Query Returned : " + response.entities.length);
 });
 

--- a/types/xrm/xrm-tests.ts
+++ b/types/xrm/xrm-tests.ts
@@ -242,6 +242,25 @@ Xrm.WebApi.retrieveMultipleRecords(
     console.log("Query Returned : " + response.entities.length);
 });
 
+// Confirm generics on query
+Xrm.WebApi.retrieveMultipleRecords(
+    "contact",
+    `?fetchXml=<fetch version='1.0' mapping='logical' distinct='false'>
+    <entity name='contact'>
+        <attribute name='fullname' />
+        <attribute name='telephone1' />
+        <attribute name='contactid' />
+        <order attribute='fullname' descending='false' />
+    </entity>
+    </fetch>`,
+).then((response:Xrm.RetrieveMultipleResult<{
+    contactid: string,
+    fullname: string,
+    telephone1: string
+}>) => {
+    console.log("Query Returned : " + response.entities.length);
+});
+
 // Demonstrate add/removeTabStateChange
 const contextHandler = (context: Xrm.Page.EventContext) => {
     context.getEventSource();


### PR DESCRIPTION
While working on our TypeScript Web Resources, it has driven our team absolutely crazy that we can't easily specify Types for the Xrm.WebApi Calls. This PR hopes to resolve that. I have broken this change into 4 different commits which can be merged wholesale, or picked at will:

1) Adding a Generic Type to the `RetrieveMultipleResult` interface. This will allow a developer to specify the type they are expecting back from Dataverse within the interface contract. I have added in an example test utilizing this. To maintain backwards compatibility, I have added in a default parameter of type `any`

2) I have added in a Test detailing the previous commit. This also serves as an example of the new syntax developers will be able to use
```
Xrm.WebApi.retrieveMultipleRecords(
    "contact",
    `?fetchXml=<fetch version='1.0' mapping='logical' distinct='false'>
    <entity name='contact'>
        <attribute name='fullname' />
        <attribute name='telephone1' />
        <attribute name='contactid' />
        <order attribute='fullname' descending='false' />
    </entity>
    </fetch>`,
).then((response:Xrm.RetrieveMultipleResult<{
    contactid: string,
    fullname: string,
    telephone1: string
}>) => {
    console.log("Query Returned : " + response.entities.length);
});
```

3 & 4) These two technically go against one of the identified "common mistakes", however the definitions currently ignore the check for `@definitelytyped/no-unnecessary-generics` in the lint, so I think it should be okay. 

Essentially, these two commits add in a generic Type to the `retrieveMultiple`, `retrieve` and `invokeProcessAction` which will carry it through to the result. This way should a developer want to use the await pattern the value will automatically be typed in properly within their IDE. Should this not be acceptable, please feel free to drop these two commits. 

As with #1, I have enabled backwards compatibility by specifying a default type of `any`.  

-------

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <types\xrm\index.d.ts>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

------

My team and I are hoping that we can get these changes merged in so that we can more easily utilize typing when using Xrm.
Thank you