### PR TITLE
Rgb and cmyk allowed in the form of array for stop method of gradient

### DIFF
--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -3,7 +3,7 @@
 declare namespace PDFKit {
     interface PDFGradient {
         new(document: any): PDFGradient;
-        stop(pos: number, color?: string | Array<number> | PDFKit.PDFGradient, opacity?: number): PDFGradient;
+        stop(pos: number, color?: string | number[] | PDFKit.PDFGradient, opacity?: number): PDFGradient;
         embed(): void;
         apply(): void;
     }

--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -3,7 +3,7 @@
 declare namespace PDFKit {
     interface PDFGradient {
         new(document: any): PDFGradient;
-        stop(pos: number, color?: string | PDFKit.PDFGradient, opacity?: number): PDFGradient;
+        stop(pos: number, color?: string | Array<number> | PDFKit.PDFGradient, opacity?: number): PDFGradient;
         embed(): void;
         apply(): void;
     }


### PR DESCRIPTION
In js version .stop method checks at its bottom whether color is array of numbers. Adding this extra type for ts allows to use both rgb and cmyk in form of array. 
