### PR TITLE
[mongoose-delete] Fix tests after latest mongoose release

### DIFF
--- a/types/mongoose-delete/mongoose-delete-tests.ts
+++ b/types/mongoose-delete/mongoose-delete-tests.ts
@@ -99,22 +99,22 @@ type deletedType = PetDocument["deleted"];
 type deletedAtType = PetDocument["deletedAt"];
 
 // Additional Methods for overrides
-Pet.countDocumentsDeleted({ age: 10 });
-Pet.countDocumentsWithDeleted({ age: 10 });
-Pet.findDeleted({ age: 10 });
-Pet.findWithDeleted({ age: 10 });
-Pet.findOneDeleted({ age: 10 });
-Pet.findOneWithDeleted({ age: 10 });
-Pet.findOneAndUpdateDeleted({ age: 10 }, { name: "Fluffy" });
-Pet.findOneAndUpdateWithDeleted({ age: 10 }, { name: "Fluffy" });
-Pet.updateDeleted({ age: 10 }, { name: "Fluffy" });
-Pet.updateWithDeleted({ age: 10 }, { name: "Fluffy" });
-Pet.updateOneDeleted({ age: 10 }, { name: "Fluffy" });
-Pet.updateOneWithDeleted({ age: 10 }, { name: "Fluffy" });
-Pet.updateManyDeleted({ age: 10 }, { name: "Fluffy" });
-Pet.updateManyWithDeleted({ age: 10 }, { name: "Fluffy" });
-Pet.aggregateDeleted([{ $match: { age: 10 } }]);
-Pet.aggregateWithDeleted([{ $match: { age: 10 } }]);
+Pet.countDocumentsDeleted({ name: "Fuzzy" });
+Pet.countDocumentsWithDeleted({ name: "Fuzzy" });
+Pet.findDeleted({ name: "Fuzzy" });
+Pet.findWithDeleted({ name: "Fuzzy" });
+Pet.findOneDeleted({ name: "Fuzzy" });
+Pet.findOneWithDeleted({ name: "Fuzzy" });
+Pet.findOneAndUpdateDeleted({ name: "Fuzzy" }, { name: "Fluffy" });
+Pet.findOneAndUpdateWithDeleted({ name: "Fuzzy" }, { name: "Fluffy" });
+Pet.updateDeleted({ name: "Fuzzy" }, { name: "Fluffy" });
+Pet.updateWithDeleted({ name: "Fuzzy" }, { name: "Fluffy" });
+Pet.updateOneDeleted({ name: "Fuzzy" }, { name: "Fluffy" });
+Pet.updateOneWithDeleted({ name: "Fuzzy" }, { name: "Fluffy" });
+Pet.updateManyDeleted({ name: "Fuzzy" }, { name: "Fluffy" });
+Pet.updateManyWithDeleted({ name: "Fuzzy" }, { name: "Fluffy" });
+Pet.aggregateDeleted([{ $match: { name: "Fuzzy" } }]);
+Pet.aggregateWithDeleted([{ $match: { name: "Fuzzy" } }]);
 
 // $ExpectType string[]
 Pet3.getNames();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

This test code was never valid/meaningful, as far as I can tell, and mongoose very slightly tightened their types in 8.6.0.