### PR TITLE
[topojson-client] Functions `merge` and `mergeArcs` support `GeometryCollection`

### DIFF
--- a/types/topojson-client/index.d.ts
+++ b/types/topojson-client/index.d.ts
@@ -49,9 +49,15 @@ export function feature<P extends Properties = GeoJSON.GeoJsonProperties>(
     object: GeometryObject<P> | string,
 ): GeoJSON.Feature<GeoJSON.GeometryObject, P> | GeoJSON.FeatureCollection<GeoJSON.GeometryObject, P>;
 
-export function merge(topology: Topology, objects: GeometryCollection | Array<Polygon | MultiPolygon>): GeoJSON.MultiPolygon;
+export function merge(
+    topology: Topology,
+    objects: GeometryCollection | Array<Polygon | MultiPolygon>,
+): GeoJSON.MultiPolygon;
 
-export function mergeArcs(topology: Topology, objects: GeometryCollection | Array<Polygon | MultiPolygon>): MultiPolygon;
+export function mergeArcs(
+    topology: Topology,
+    objects: GeometryCollection | Array<Polygon | MultiPolygon>,
+): MultiPolygon;
 
 export function mesh(
     topology: Topology,

--- a/types/topojson-client/index.d.ts
+++ b/types/topojson-client/index.d.ts
@@ -49,9 +49,9 @@ export function feature<P extends Properties = GeoJSON.GeoJsonProperties>(
     object: GeometryObject<P> | string,
 ): GeoJSON.Feature<GeoJSON.GeometryObject, P> | GeoJSON.FeatureCollection<GeoJSON.GeometryObject, P>;
 
-export function merge(topology: Topology, objects: Array<Polygon | MultiPolygon>): GeoJSON.MultiPolygon;
+export function merge(topology: Topology, objects: GeometryCollection | Array<Polygon | MultiPolygon>): GeoJSON.MultiPolygon;
 
-export function mergeArcs(topology: Topology, objects: Array<Polygon | MultiPolygon>): MultiPolygon;
+export function mergeArcs(topology: Topology, objects: GeometryCollection | Array<Polygon | MultiPolygon>): MultiPolygon;
 
 export function mesh(
     topology: Topology,

--- a/types/topojson-client/topojson-client-tests.ts
+++ b/types/topojson-client/topojson-client-tests.ts
@@ -99,8 +99,8 @@ const prop3: GeoJSON.GeoJsonProperties = topojson.feature(topoWithProp, topoWith
 
 geoMP = topojson.merge(us, selectedGeometries);
 geoMP = topojson.merge(us, {
-  type: "GeometryCollection",
-  geometries: selectedGeometries,
+    type: "GeometryCollection",
+    geometries: selectedGeometries,
 });
 
 topoMP = topojson.mergeArcs(us, selectedGeometries);

--- a/types/topojson-client/topojson-client-tests.ts
+++ b/types/topojson-client/topojson-client-tests.ts
@@ -98,6 +98,10 @@ size = propCollection.size;
 const prop3: GeoJSON.GeoJsonProperties = topojson.feature(topoWithProp, topoWithProp.objects.more).properties;
 
 geoMP = topojson.merge(us, selectedGeometries);
+geoMP = topojson.merge(us, {
+  type: "GeometryCollection",
+  geometries: selectedGeometries,
+});
 
 topoMP = topojson.mergeArcs(us, selectedGeometries);
 


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/topojson/topojson-client/blob/71e5bd6428fd8b7a40fa980d2ef7862140851f03/src/merge.js#L23
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.


I discovered this when trying to [follow an example of merging a TopoJSON objects](https://gist.github.com/mbostock/5416405), which raised a type exception:

```
ts: Argument of type 'GeometryObject<{}>[]' is not assignable to parameter of type '(Polygon<{}> | MultiPolygon<{}>)[]'.
  Type 'GeometryObject<{}>' is not assignable to type 'Polygon<{}> | MultiPolygon<{}>'.
    Type 'GeometryCollection<{}>' is not assignable to type 'Polygon<{}> | MultiPolygon<{}>'.
      Property 'arcs' is missing in type 'GeometryCollection<{}>' but required in type 'MultiPolygon<{}>'.
```