### PR TITLE
Fix: make a MockOptions interface in types/jest/index.d.ts compatible with mock options coming from @jest/globals

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -429,7 +429,7 @@ declare namespace jest {
     function useRealTimers(): typeof jest;
 
     interface MockOptions {
-        virtual?: boolean;
+        virtual?: boolean; // Intentionally omitted "| undefined" to maintain compatibility with @jest/globals
     }
 
     type MockableFunction = (...args: any[]) => any;

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -429,7 +429,7 @@ declare namespace jest {
     function useRealTimers(): typeof jest;
 
     interface MockOptions {
-        virtual?: boolean | undefined;
+        virtual?: boolean;
     }
 
     type MockableFunction = (...args: any[]) => any;


### PR DESCRIPTION
In our project, we use both `@types/jest` and `@jest/globals`.

When the `exactOptionalPropertyTypes` TS compiler option is enabled, the project cannot be compiled due to a discrepancy between the mock options definitions in `@types/jest` and `@jest/globals`.

In `@types/jest`, the definition is as follows:

```
interface MockOptions {
    virtual?: boolean | undefined;
}
```
(See: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jest/index.d.ts#L431C15-L433)

However, in `@jest/globals`, the definition is:

```
options?: {virtual?: boolean}
```

(See: https://github.com/jestjs/jest/blob/main/packages/jest-environment/src/index.ts#L140)

The issue can be reproduced in this minimal repository: https://github.com/Tharos/types-jest-bug

The error message follows:

```
node_modules/@jest/environment/build/index.d.ts:401:26 - error TS2430: Interface 'JestImportMeta' incorrectly extends interface 'ImportMeta'.
  The types of 'jest.doMock' are incompatible between these types.
    Type '<T = unknown>(moduleName: string, moduleFactory?: (() => T) | undefined, options?: { virtual?: boolean; } | undefined) => Jest' is not assignable to type '<T = unknown>(moduleName: string, factory?: (() => T) | undefined, options?: MockOptions | undefined) => typeof jest'.
      Types of parameters 'options' and 'options' are incompatible.
        Type 'MockOptions | undefined' is not assignable to type '{ virtual?: boolean; } | undefined'.
          Type 'MockOptions' is not assignable to type '{ virtual?: boolean; }' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
            Types of property 'virtual' are incompatible.
              Type 'boolean | undefined' is not assignable to type 'boolean'.
                Type 'undefined' is not assignable to type 'boolean'.

401 export declare interface JestImportMeta extends ImportMeta {
```

------

This pull request resolves the compatibility issue between the two definitions.