### PR TITLE
@types/chrome: Add ability to type the data that is get or set with chrome.storage

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -8437,7 +8437,9 @@ declare namespace chrome.storage {
          * @return A Promise that resolves with an object containing items
          * @since MV3
          */
-        get<T = { [key: string]: any }>(keys?: keyof T | Array<keyof T> | Partial<T> | null): Promise<T>;
+        get<T = { [key: string]: any }>(
+            keys?: keyof T | Array<keyof T> | (T extends object ? Partial<T> : never) | null,
+        ): Promise<T>;
         /**
          * Gets one or more items from storage.
          * @param keys A single key to get, list of keys to get, or a dictionary specifying default values.
@@ -8446,7 +8448,7 @@ declare namespace chrome.storage {
          * Parameter items: Object with items in their key-value mappings.
          */
         get<T = { [key: string]: any }>(
-            keys: keyof T | Array<keyof T> | Partial<T> | null,
+            keys: keyof T | Array<keyof T> | (T extends object ? Partial<T> : never) | null,
             callback: (items: T) => void,
         ): void;
         /**

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -8363,7 +8363,7 @@ declare namespace chrome.storage {
      */
     type NoInferX<T> = T[][T extends any ? 0 : never];
     // The next line prevents things without the export keyword from being automatically exported (like NoInferX)
-    export {}
+    export {};
 
     export interface StorageArea {
         /**

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -8370,14 +8370,17 @@ declare namespace chrome.storage {
          * @return A Promise that resolves with a number
          * @since MV3
          */
-        getBytesInUse(keys?: string | string[] | null): Promise<number>;
+        getBytesInUse<T = { [key: string]: any }>(keys?: keyof T | Array<keyof T> | null): Promise<number>;
         /**
          * Gets the amount of space (in bytes) being used by one or more items.
          * @param keys Optional. A single key or list of keys to get the total usage for. An empty list will return 0. Pass in null to get the total usage of all of storage.
          * @param callback Callback with the amount of space being used by storage, or on failure (in which case runtime.lastError will be set).
          * Parameter bytesInUse: Amount of space being used in storage, in bytes.
          */
-        getBytesInUse(keys: string | string[] | null, callback: (bytesInUse: number) => void): void;
+        getBytesInUse<T = { [key: string]: any }>(
+            keys: keyof T | Array<keyof T> | null,
+            callback: (bytesInUse: number) => void,
+        ): void;
         /**
          * Removes all items from storage.
          * @return A void Promise
@@ -8397,7 +8400,7 @@ declare namespace chrome.storage {
          * @return A void Promise
          * @since MV3
          */
-        set(items: { [key: string]: any }): Promise<void>;
+        set<T = { [key: string]: any }>(items: Partial<T>): Promise<void>;
         /**
          * Sets multiple items.
          * @param items An object which gives each key/value pair to update storage with. Any other key/value pairs in storage will not be affected.
@@ -8405,7 +8408,7 @@ declare namespace chrome.storage {
          * @param callback Optional.
          * Callback on success, or on failure (in which case runtime.lastError will be set).
          */
-        set(items: { [key: string]: any }, callback: () => void): void;
+        set<T = { [key: string]: any }>(items: Partial<T>, callback: () => void): void;
         /**
          * Removes one or more items from storage.
          * @param keys A single key or a list of keys for items to remove.
@@ -8413,20 +8416,20 @@ declare namespace chrome.storage {
          * @return A void Promise
          * @since MV3
          */
-        remove(keys: string | string[]): Promise<void>;
+        remove<T = { [key: string]: any }>(keys: keyof T | Array<keyof T>): Promise<void>;
         /**
          * Removes one or more items from storage.
          * @param keys A single key or a list of keys for items to remove.
          * @param callback Optional.
          * Callback on success, or on failure (in which case runtime.lastError will be set).
          */
-        remove(keys: string | string[], callback: () => void): void;
+        remove<T = { [key: string]: any }>(keys: keyof T | Array<keyof T>, callback: () => void): void;
         /**
          * Gets the entire contents of storage.
          * @param callback Callback with storage items, or on failure (in which case runtime.lastError will be set).
          * Parameter items: Object with items in their key-value mappings.
          */
-        get(callback: (items: { [key: string]: any }) => void): void;
+        get<T = { [key: string]: any }>(callback: (items: T) => void): void;
         /**
          * Gets one or more items from storage.
          * @param keys A single key to get, list of keys to get, or a dictionary specifying default values.
@@ -8434,7 +8437,7 @@ declare namespace chrome.storage {
          * @return A Promise that resolves with an object containing items
          * @since MV3
          */
-        get(keys?: string | string[] | { [key: string]: any } | null): Promise<{ [key: string]: any }>;
+        get<T = { [key: string]: any }>(keys?: keyof T | Array<keyof T> | Partial<T> | null): Promise<T>;
         /**
          * Gets one or more items from storage.
          * @param keys A single key to get, list of keys to get, or a dictionary specifying default values.
@@ -8442,9 +8445,9 @@ declare namespace chrome.storage {
          * @param callback Callback with storage items, or on failure (in which case runtime.lastError will be set).
          * Parameter items: Object with items in their key-value mappings.
          */
-        get(
-            keys: string | string[] | { [key: string]: any } | null,
-            callback: (items: { [key: string]: any }) => void,
+        get<T = { [key: string]: any }>(
+            keys: keyof T | Array<keyof T> | Partial<T> | null,
+            callback: (items: T) => void,
         ): void;
         /**
          * Sets the desired access level for the storage area. The default will be only trusted contexts.

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2,6 +2,9 @@
 /// <reference path="./har-format/index.d.ts" />
 /// <reference path="./chrome-cast/index.d.ts" />
 
+// NoInfer for old TypeScript versions
+type NoInferX<T> = T[][T extends any ? 0 : never];
+
 ////////////////////
 // Global object
 ////////////////////
@@ -8438,7 +8441,7 @@ declare namespace chrome.storage {
          * @since MV3
          */
         get<T = { [key: string]: any }>(
-            keys?: keyof T | Array<keyof T> | (T extends object ? Partial<T> : never) | null,
+            keys?: NoInferX<keyof T> | Array<NoInferX<keyof T>> | Partial<NoInferX<T>> | null,
         ): Promise<T>;
         /**
          * Gets one or more items from storage.
@@ -8448,7 +8451,7 @@ declare namespace chrome.storage {
          * Parameter items: Object with items in their key-value mappings.
          */
         get<T = { [key: string]: any }>(
-            keys: keyof T | Array<keyof T> | (T extends object ? Partial<T> : never) | null,
+            keys: NoInferX<keyof T> | Array<NoInferX<keyof T>> | Partial<NoInferX<T>> | null,
             callback: (items: T) => void,
         ): void;
         /**

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2,9 +2,6 @@
 /// <reference path="./har-format/index.d.ts" />
 /// <reference path="./chrome-cast/index.d.ts" />
 
-// NoInfer for old TypeScript versions
-type NoInferX<T> = T[][T extends any ? 0 : never];
-
 ////////////////////
 // Global object
 ////////////////////
@@ -8360,6 +8357,14 @@ declare namespace chrome.sessions {
  * @since Chrome 20
  */
 declare namespace chrome.storage {
+    /**
+     * NoInfer for old TypeScript versions
+     * @internal
+     */
+    type NoInferX<T> = T[][T extends any ? 0 : never];
+    // The next line prevents things without the export keyword from being automatically exported (like NoInferX)
+    export {}
+
     export interface StorageArea {
         /**
          * Gets the amount of space (in bytes) being used by one or more items.
@@ -8521,12 +8526,12 @@ declare namespace chrome.storage {
         extends chrome.events.Event<(changes: { [key: string]: StorageChange }) => void>
     {}
 
-    type AreaName = keyof Pick<typeof chrome.storage, "sync" | "local" | "managed" | "session">;
+    export type AreaName = keyof Pick<typeof chrome.storage, "sync" | "local" | "managed" | "session">;
     export interface StorageChangedEvent
         extends chrome.events.Event<(changes: { [key: string]: StorageChange }, areaName: AreaName) => void>
     {}
 
-    type AccessLevel = keyof typeof AccessLevel;
+    export type AccessLevel = keyof typeof AccessLevel;
 
     /** The storage area's access level. */
     export var AccessLevel: {

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -8357,10 +8357,7 @@ declare namespace chrome.sessions {
  * @since Chrome 20
  */
 declare namespace chrome.storage {
-    /**
-     * NoInfer for old TypeScript versions
-     * @internal
-     */
+    /** NoInfer for old TypeScript versions */
     type NoInferX<T> = T[][T extends any ? 0 : never];
     // The next line prevents things without the export keyword from being automatically exported (like NoInferX)
     export {};

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -763,36 +763,68 @@ function testStorage() {
         myKey2: string;
     }
 
-    function getCallback(loadedData: StorageData) {
+    function getCallback(loadedData: { [key: string]: any }) {
         console.log(loadedData.myKey.x + loadedData.myKey.y);
     }
 
-    chrome.storage.sync.get<StorageData>(getCallback);
-    chrome.storage.sync.get<StorageData>("myKey", getCallback);
-    chrome.storage.sync.get<StorageData>(["myKey", "myKey2"], getCallback);
-    chrome.storage.sync.get<StorageData>({ myKey: { x: 1, y: 2 } }, getCallback);
-    chrome.storage.sync.get<StorageData>(null, getCallback);
+    function getCallbackTyped(loadedData: StorageData) {
+        console.log(loadedData.myKey.x + loadedData.myKey.y);
+    }
+
+    chrome.storage.sync.get("myKey", getCallback);
+    chrome.storage.sync.get("badKey", getCallback);
+    // @ts-expect-error
+    chrome.storage.sync.get("badKey", getCallbackTyped);
+    // @ts-expect-error
+    chrome.storage.sync.get({ myKey: { badKey: true } }, getCallbackTyped);
+    chrome.storage.sync.get(null, (data) => {
+        data.myKey;
+    });
+    chrome.storage.sync.get((data) => {
+        data.myKey;
+    });
+
+    chrome.storage.sync.get<StorageData>(getCallbackTyped);
+    chrome.storage.sync.get<StorageData>("myKey", getCallbackTyped);
+    chrome.storage.sync.get<StorageData>(["myKey", "myKey2"], getCallbackTyped);
+    chrome.storage.sync.get<StorageData>({ myKey: { x: 1, y: 2 } }, getCallbackTyped);
+    // @ts-expect-error
+    chrome.storage.sync.get<StorageData>({ myKey: { badKey: true } }, getCallback);
+    // @ts-expect-error
+    chrome.storage.sync.get<StorageData>({ myKey: { badKey: true } }, getCallbackTyped);
+    chrome.storage.sync.get<StorageData>(null, getCallbackTyped);
 
     function getBytesInUseCallback(bytesInUse: number) {
         console.log(bytesInUse);
     }
 
     chrome.storage.sync.getBytesInUse(getBytesInUseCallback);
+    chrome.storage.sync.getBytesInUse("myKey", getBytesInUseCallback);
+    chrome.storage.sync.getBytesInUse("badKey", getBytesInUseCallback);
+
     chrome.storage.sync.getBytesInUse<StorageData>("myKey", getBytesInUseCallback);
     chrome.storage.sync.getBytesInUse<StorageData>(["myKey", "myKey2"], getBytesInUseCallback);
     chrome.storage.sync.getBytesInUse<StorageData>(null, getBytesInUseCallback);
+    // @ts-expect-error
+    chrome.storage.sync.getBytesInUse<StorageData>(["badKey", "myKey2"], getBytesInUseCallback);
 
     function doneCallback() {
         console.log("done");
     }
 
+    chrome.storage.sync.set({ badKey: true });
     chrome.storage.sync.set<StorageData>({ myKey: { x: 1, y: 2 } });
     chrome.storage.sync.set<StorageData>({ myKey2: "hello world" }, doneCallback);
+    // @ts-expect-error
+    chrome.storage.sync.set<StorageData>({ badKey: "hello world" }, doneCallback);
 
+    chrome.storage.sync.remove("badKey");
     chrome.storage.sync.remove<StorageData>("myKey");
     chrome.storage.sync.remove<StorageData>("myKey", doneCallback);
     chrome.storage.sync.remove<StorageData>(["myKey", "myKey2"]);
     chrome.storage.sync.remove<StorageData>(["myKey", "myKey2"], doneCallback);
+    // @ts-expect-error
+    chrome.storage.sync.remove<StorageData>(["badKey", "myKey2"], doneCallback);
 
     chrome.storage.sync.clear();
     chrome.storage.sync.clear(doneCallback);

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -778,10 +778,10 @@ function testStorage() {
     // @ts-expect-error
     chrome.storage.sync.get({ myKey: { badKey: true } }, getCallbackTyped);
     chrome.storage.sync.get(null, (data) => {
-        data.myKey;
+        console.log(data.myKey);
     });
     chrome.storage.sync.get((data) => {
-        data.myKey;
+        console.log(data.badKey);
     });
 
     chrome.storage.sync.get<StorageData>(getCallbackTyped);

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -754,36 +754,45 @@ function testWindows() {
 
 // https://developer.chrome.com/extensions/storage#type-StorageArea
 function testStorage() {
-    function getCallback(loadedData: { [key: string]: any }) {
-        var myValue: { x: number } = loadedData["myKey"];
+    interface StorageData {
+        myKey: {
+            x: number;
+            y: number;
+            z?: number;
+        };
+        myKey2: string;
     }
 
-    chrome.storage.sync.get(getCallback);
-    chrome.storage.sync.get("myKey", getCallback);
-    chrome.storage.sync.get(["myKey", "myKey2"], getCallback);
-    chrome.storage.sync.get({ foo: 1, bar: 2 }, getCallback);
-    chrome.storage.sync.get(null, getCallback);
+    function getCallback(loadedData: StorageData) {
+        console.log(loadedData.myKey.x + loadedData.myKey.y);
+    }
+
+    chrome.storage.sync.get<StorageData>(getCallback);
+    chrome.storage.sync.get<StorageData>("myKey", getCallback);
+    chrome.storage.sync.get<StorageData>(["myKey", "myKey2"], getCallback);
+    chrome.storage.sync.get<StorageData>({ myKey: { x: 1, y: 2 } }, getCallback);
+    chrome.storage.sync.get<StorageData>(null, getCallback);
 
     function getBytesInUseCallback(bytesInUse: number) {
         console.log(bytesInUse);
     }
 
     chrome.storage.sync.getBytesInUse(getBytesInUseCallback);
-    chrome.storage.sync.getBytesInUse("myKey", getBytesInUseCallback);
-    chrome.storage.sync.getBytesInUse(["myKey", "myKey2"], getBytesInUseCallback);
-    chrome.storage.sync.getBytesInUse(null, getBytesInUseCallback);
+    chrome.storage.sync.getBytesInUse<StorageData>("myKey", getBytesInUseCallback);
+    chrome.storage.sync.getBytesInUse<StorageData>(["myKey", "myKey2"], getBytesInUseCallback);
+    chrome.storage.sync.getBytesInUse<StorageData>(null, getBytesInUseCallback);
 
     function doneCallback() {
         console.log("done");
     }
 
-    chrome.storage.sync.set({ foo: 1, bar: 2 });
-    chrome.storage.sync.set({ foo: 1, bar: 2 }, doneCallback);
+    chrome.storage.sync.set<StorageData>({ myKey: { x: 1, y: 2 } });
+    chrome.storage.sync.set<StorageData>({ myKey2: "hello world" }, doneCallback);
 
-    chrome.storage.sync.remove("myKey");
-    chrome.storage.sync.remove("myKey", doneCallback);
-    chrome.storage.sync.remove(["myKey", "myKey2"]);
-    chrome.storage.sync.remove(["myKey", "myKey2"], doneCallback);
+    chrome.storage.sync.remove<StorageData>("myKey");
+    chrome.storage.sync.remove<StorageData>("myKey", doneCallback);
+    chrome.storage.sync.remove<StorageData>(["myKey", "myKey2"]);
+    chrome.storage.sync.remove<StorageData>(["myKey", "myKey2"], doneCallback);
 
     chrome.storage.sync.clear();
     chrome.storage.sync.clear(doneCallback);

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -772,7 +772,7 @@ function testStorage() {
     }
 
     // @ts-expect-error
-    const testNoInferX: chrome.storage.NoInferX<string> = 'This test checks if NoInferX is accidentally exported';
+    const testNoInferX: chrome.storage.NoInferX<string> = "This test checks if NoInferX is accidentally exported";
 
     chrome.storage.sync.get("myKey", getCallback);
     chrome.storage.sync.get("badKey", getCallback);

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -771,6 +771,9 @@ function testStorage() {
         console.log(loadedData.myKey.x + loadedData.myKey.y);
     }
 
+    // @ts-expect-error
+    const testNoInferX: chrome.storage.NoInferX<string> = 'This test checks if NoInferX is accidentally exported';
+
     chrome.storage.sync.get("myKey", getCallback);
     chrome.storage.sync.get("badKey", getCallback);
     // @ts-expect-error


### PR DESCRIPTION

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

This makes it easy to type what's returned from the `chrome.storage` methods.

There is additional improvement that can be made, but I am not proficient enough with advanced typescript typings to make it work:

```typescript
get<T = { [key: string]: any }>(
    keys?: keyof T | Array<keyof T> | (T extends object ? Partial<T> : never) | null,
): Promise<T>;
```

If it would be possible to make the return `Promise<T>` restrict itself to the items provided in the input when the input is one of `keyof T | Array<keyof T> | (T extends object ? Partial<T> : never)`, then that would be really neat. Would love it if an expert could help with this.

I think this is a solid improvement even without that.
