### PR TITLE
declare `age` as `number` on `PetDocument`

### DIFF
--- a/types/mongoose-delete/mongoose-delete-tests.ts
+++ b/types/mongoose-delete/mongoose-delete-tests.ts
@@ -3,6 +3,7 @@ import MongooseDelete = require("mongoose-delete");
 
 interface PetDocument extends MongooseDelete.SoftDeleteDocument {
     name: string;
+    age: number;
 }
 
 // Custom methods


### PR DESCRIPTION
Fixes ecosystem break revealed by #70455 