### PR TITLE
[dom-serial] Add setSignals and getSignals methods from draft spec and implemented in Chrome 89

### DIFF
--- a/types/dom-serial/dom-serial-tests.ts
+++ b/types/dom-serial/dom-serial-tests.ts
@@ -28,6 +28,15 @@ async function connect() {
     port.writable.getWriter();
     port.readable.getReader();
 
+    const signals = await port.getSignals();
+    const cts = signals.clearToSend;
+
+    await port.setSignals({
+        dataTerminalReady: true,
+        requestToSend: false,
+        break: false,
+    });
+
     await port.close();
 
     await port.forget();

--- a/types/dom-serial/index.d.ts
+++ b/types/dom-serial/index.d.ts
@@ -21,6 +21,19 @@ type ParityType = "none" | "even" | "odd" | "mark" | "space";
 
 type FlowControlType = "none" | "hardware";
 
+interface SerialOutputSignals {
+    dataTerminalReady?: boolean;
+    requestToSend?: boolean;
+    break?: boolean;
+}
+
+interface SerialInputSignals {
+    dataCarrierDetect: boolean;
+    clearToSend: boolean;
+    ringIndicator: boolean;
+    dataSetReady: boolean;
+}
+
 interface SerialOptions {
     baudRate: number;
     dataBits?: number | undefined;
@@ -39,6 +52,8 @@ interface SerialPort extends EventTarget {
     close(): Promise<void>;
     getInfo(): Partial<SerialPortInfo>;
     forget(): Promise<void>;
+    setSignals(signals: SerialOutputSignals): Promise<void>;
+    getSignals(): Promise<SerialInputSignals>;
 }
 
 interface SerialPortRequestOptions {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://wicg.github.io/serial/#setsignals-method and https://wicg.github.io/serial/#getsignals-method

Browser compatibility: https://developer.mozilla.org/en-US/docs/Web/API/SerialPort/getSignals#browser_compatibility


I recently had to achieve some low-level serial operations, and while JS was working fine, the type definition did not recognize them. I hope this helps others with type safety!