### PR TITLE
fix[@types+identicon.js]: Complete missing IdenticonOptions values

### DIFF
--- a/types/identicon.js/identicon.js-tests.ts
+++ b/types/identicon.js/identicon.js-tests.ts
@@ -1,4 +1,4 @@
-import Identicon, { Svg } from "identicon.js";
+import Identicon, {Svg} from "identicon.js";
 
 // create an identicon with only a hash and a size
 new Identicon("d3b07384d113edec49eaa6238ad5ff00", 420).toString();
@@ -10,6 +10,9 @@ const svg = new Identicon("d3b07384d113edec49eaa6238ad5ff00", {
     margin: 0.05,
     size: 64,
     format: "svg",
+    // I don't know why, but previous versions have forgotten these two parameters
+    brightness: 0.48,
+    saturation: 0.65,
 }).image() as Svg;
 svg.getDump();
 // or get the base64 encoded svg

--- a/types/identicon.js/identicon.js-tests.ts
+++ b/types/identicon.js/identicon.js-tests.ts
@@ -1,4 +1,4 @@
-import Identicon, {Svg} from "identicon.js";
+import Identicon, { Svg } from "identicon.js";
 
 // create an identicon with only a hash and a size
 new Identicon("d3b07384d113edec49eaa6238ad5ff00", 420).toString();

--- a/types/identicon.js/index.d.ts
+++ b/types/identicon.js/index.d.ts
@@ -6,6 +6,8 @@ export interface IdenticonOptions {
     margin?: number | undefined;
     size?: number | undefined;
     format?: "svg" | "png" | undefined;
+    saturation?: number | undefined;
+    brightness?: number | undefined;
 }
 
 export interface PNGlib {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

I run the test but it reports an error, I don't know how to fix it, please help me (but this error was not introduced by me)
```
❗️ The resolved types use export default where the JavaScript file appears to use module.exports =. This will cause TypeScript under the node16 module mode to think an extra .default property access is required, but that will likely fail at runtime. These types should  use export = instead of export default. https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseExportDefault.md

┌───────────────────┬──────────────────────────────┐
│                   │ "identicon.js"               │
├───────────────────┼──────────────────────────────┤
│ node10            │ ❗️ Incorrect default export │
├───────────────────┼──────────────────────────────┤
│ node16 (from CJS) │ ❗️ Incorrect default export │
├───────────────────┼──────────────────────────────┤
│ node16 (from ESM) │ ❗️ Incorrect default export │
├───────────────────┼──────────────────────────────┤
│ bundler           │ ❗️ Incorrect default export │
└───────────────────┴──────────────────────────────┘
```
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/stewartlord/identicon.js/blob/7063ae16142fd39d3563699b9af2dc321326ff52/identicon.js#L49-L50