### PR TITLE
Add commaRoundTrip option to qs.stringify

### DIFF
--- a/types/qs/index.d.ts
+++ b/types/qs/index.d.ts
@@ -26,6 +26,7 @@ declare namespace QueryString {
         charset?: "utf-8" | "iso-8859-1" | undefined;
         charsetSentinel?: boolean | undefined;
         allowEmptyArrays?: boolean | undefined;
+        commaRoundTrip?: boolean | undefined;
     }
 
     type IStringifyDynamicOptions<AllowDots extends BooleanOptional> = AllowDots extends true

--- a/types/qs/qs-tests.ts
+++ b/types/qs/qs-tests.ts
@@ -381,6 +381,11 @@ qs.parse("a=b&c=d", { delimiter: "&" });
 });
 
 (() => {
+    var singleValueArray = qs.stringify({ foo: [null], bar: "baz" }, { arrayFormat: 'comma', commaRoundTrip: true, encode: false, strictNullHandling: true });
+    assert.deepEqual(singleValueArray, "foo[]&bar=baz");
+});
+
+(() => {
     assert.deepEqual(qs.parse("foo=bar&foo=baz"), { foo: ["bar", "baz"] });
     assert.deepEqual(qs.parse("foo=bar&foo=baz", { duplicates: "combine" }), { foo: ["bar", "baz"] });
     assert.deepEqual(qs.parse("foo=bar&foo=baz", { duplicates: "first" }), { foo: "bar" });

--- a/types/qs/qs-tests.ts
+++ b/types/qs/qs-tests.ts
@@ -381,7 +381,12 @@ qs.parse("a=b&c=d", { delimiter: "&" });
 });
 
 (() => {
-    var singleValueArray = qs.stringify({ foo: [null], bar: "baz" }, { arrayFormat: 'comma', commaRoundTrip: true, encode: false, strictNullHandling: true });
+    var singleValueArray = qs.stringify({ foo: [null], bar: "baz" }, { 
+        arrayFormat: 'comma',
+        commaRoundTrip: true,
+        encode: false,
+        strictNullHandling: true,
+    });
     assert.deepEqual(singleValueArray, "foo[]&bar=baz");
 });
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [stringify.js](https://github.com/ljharb/qs/blob/3c8a6f5a1e8d2c4772fd733c7ca1a28e92498fd7/lib/stringify.js#L37) - [commit](https://github.com/ljharb/qs/commit/c31347299f34afca90e8b5ff793eb4d0f77cfa56)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
