### PR TITLE
feat(validator): isAbaRouting, isEmail, isLicensePlate, isLuhnNumber

### DIFF
--- a/types/validator/es/lib/isAbaRouting.d.ts
+++ b/types/validator/es/lib/isAbaRouting.d.ts
@@ -1,0 +1,2 @@
+import validator from "../../";
+export default validator.isAbaRouting;

--- a/types/validator/es/lib/isLicensePlate.d.ts
+++ b/types/validator/es/lib/isLicensePlate.d.ts
@@ -1,0 +1,3 @@
+import validator from "../../";
+export type LicensePlateLocale = validator.LicensePlateLocale;
+export default validator.isLicensePlate;

--- a/types/validator/es/lib/isLuhnNumber.d.ts
+++ b/types/validator/es/lib/isLuhnNumber.d.ts
@@ -1,0 +1,2 @@
+import validator from "../../";
+export default validator.isLuhnNumber;

--- a/types/validator/index.d.ts
+++ b/types/validator/index.d.ts
@@ -41,6 +41,11 @@ declare namespace validator {
     export function equals(str: string, comparison: string): boolean;
 
     /**
+     * Check if the string is an ABA routing number for US bank account / cheque.
+     */
+    export function isAbaRouting(str: string): boolean;
+
+    /**
      * Check if the string is a date that's after the specified date.
      *
      * @param [date] - Date string (defaults to now)
@@ -808,29 +813,25 @@ declare namespace validator {
      */
     export function isLength(str: string, options?: IsLengthOptions): boolean;
 
-    /**
-     * Check  if the string matches the format of a country's license plate.
-     */
-    export function isLicensePlate(
-        str: string,
-        locale:
-            | "cs-CZ"
-            | "de-DE"
-            | "de-LI"
-            | "en-IN"
-            | "es-AR"
-            | "hu-HU"
-            | "pt-BR"
-            | "pt-PT"
-            | "sq-AL"
-            | "sv-SE"
-            | "any",
-    ): boolean;
+    export type LicensePlateLocale =
+        | "cs-CZ"
+        | "de-DE"
+        | "de-LI"
+        | "en-IN"
+        | "es-AR"
+        | "hu-HU"
+        | "pt-BR"
+        | "pt-PT"
+        | "sq-AL"
+        | "sv-SE"
+        | "en-PK"
+        | "any";
 
     /**
-     * Check if the string passes the [Luhn algorithm check](https://en.m.wikipedia.org/wiki/Luhn_algorithm).
+     * Check if the string matches the format of a country's license plate.
      */
-    export function isLuhnNumber(str: string): boolean;
+    export function isLicensePlate(str: string, locale: LicensePlateLocale): boolean;
+    export function isLicensePlate(str: string, locale: string): unknown;
 
     /**
      * Check if the string is a locale.
@@ -867,6 +868,11 @@ declare namespace validator {
          */
         eui?: "48" | "64" | undefined;
     }
+
+    /**
+     * Check if the string passes the [Luhn algorithm check](https://en.m.wikipedia.org/wiki/Luhn_algorithm).
+     */
+    export function isLuhnNumber(str: string): boolean;
 
     /**
      * Check if the string is a MAC address.

--- a/types/validator/lib/isAbaRouting.d.ts
+++ b/types/validator/lib/isAbaRouting.d.ts
@@ -1,0 +1,2 @@
+import validator from "../";
+export default validator.isAbaRouting;

--- a/types/validator/lib/isEmail.d.ts
+++ b/types/validator/lib/isEmail.d.ts
@@ -43,6 +43,12 @@ export interface IsEmailOptions {
      */
     domain_specific_validation?: boolean | undefined;
     /**
+     * If `allow_underscores` is set to `true`, the validator will allow underscores in an email address.
+     *
+     * @default false
+     */
+    allow_underscores?: boolean | undefined;
+    /**
      *  If host_blacklist is set to an array of strings
      *  and the part of the email after the @ symbol matches one of the strings defined in it,
      *  the validation fails.

--- a/types/validator/lib/isLicensePlate.d.ts
+++ b/types/validator/lib/isLicensePlate.d.ts
@@ -1,0 +1,3 @@
+import validator from "../";
+export type LicensePlateLocale = validator.LicensePlateLocale;
+export default validator.isLicensePlate;

--- a/types/validator/lib/isLuhnNumber.d.ts
+++ b/types/validator/lib/isLuhnNumber.d.ts
@@ -1,0 +1,2 @@
+import validator from "../";
+export default validator.isLuhnNumber;

--- a/types/validator/validator-tests.ts
+++ b/types/validator/validator-tests.ts
@@ -9,6 +9,7 @@ import blacklistFunc from "validator/lib/blacklist";
 import containsFunc from "validator/lib/contains";
 import equalsFunc from "validator/lib/equals";
 import escapeFunc from "validator/lib/escape";
+import isAbaRoutingFunc from "validator/lib/isAbaRouting";
 import isAfterFunc from "validator/lib/isAfter";
 import isAlphaFunc from "validator/lib/isAlpha";
 import isAlphanumericFunc from "validator/lib/isAlphanumeric";
@@ -58,8 +59,10 @@ import isJSONFunc from "validator/lib/isJSON";
 import isJWTFunc from "validator/lib/isJWT";
 import isLatLongFunc from "validator/lib/isLatLong";
 import isLengthFunc from "validator/lib/isLength";
+import isLicensePlateFunc from "validator/lib/isLicensePlate";
 import isLocaleFunc from "validator/lib/isLocale";
 import isLowercaseFunc from "validator/lib/isLowercase";
+import isLuhnNumberFunc from "validator/lib/isLuhnNumber";
 import isMACAddressFunc from "validator/lib/isMACAddress";
 import isMailtoURIFunc from "validator/lib/isMailtoURI";
 import isMD5Func from "validator/lib/isMD5";
@@ -110,6 +113,10 @@ import whitelistFunc from "validator/lib/whitelist";
 
     let _escape = validator.escape;
     _escape = escapeFunc;
+
+    // $ExpectType (str: string) => boolean
+    let _isAbaRouting = validator.isAbaRouting;
+    _isAbaRouting = isAbaRoutingFunc;
 
     let _isAfter = validator.isAfter;
     _isAfter = isAfterFunc;
@@ -264,11 +271,19 @@ import whitelistFunc from "validator/lib/whitelist";
     let _isLength = validator.isLength;
     _isLength = isLengthFunc;
 
+    // $ExpectType { (str: string, locale: LicensePlateLocale): boolean; (str: string, locale: string): unknown; }
+    let _isLicensePlate = validator.isLicensePlate;
+    _isLicensePlate = isLicensePlateFunc;
+
     let _isLocale = validator.isLocale;
     _isLocale = isLocaleFunc;
 
     let _isLowercase = validator.isLowercase;
     _isLowercase = isLowercaseFunc;
+
+    // $ExpectType (str: string) => boolean
+    let _isLuhnNumber = validator.isLuhnNumber;
+    _isLuhnNumber = isLuhnNumberFunc;
 
     let _isMACAddress = validator.isMACAddress;
     _isMACAddress = isMACAddressFunc;
@@ -385,6 +400,7 @@ import blacklistFuncEs from "validator/es/lib/blacklist";
 import containsFuncEs from "validator/es/lib/contains";
 import equalsFuncEs from "validator/es/lib/equals";
 import escapeFuncEs from "validator/es/lib/escape";
+import isAbaRoutingFuncEs from "validator/es/lib/isAbaRouting";
 import isAfterFuncEs from "validator/es/lib/isAfter";
 import isAlphaFuncEs from "validator/es/lib/isAlpha";
 import isAlphanumericFuncEs from "validator/es/lib/isAlphanumeric";
@@ -433,8 +449,10 @@ import isJSONFuncEs from "validator/es/lib/isJSON";
 import isJWTFuncEs from "validator/es/lib/isJWT";
 import isLatLongFuncEs from "validator/es/lib/isLatLong";
 import isLengthFuncEs from "validator/es/lib/isLength";
+import isLicensePlateFuncEs from "validator/es/lib/isLicensePlate";
 import isLocaleFuncEs from "validator/es/lib/isLocale";
 import isLowercaseFuncEs from "validator/es/lib/isLowercase";
+import isLuhnNumberFuncEs from "validator/es/lib/isLuhnNumber";
 import isMACAddressFuncEs from "validator/es/lib/isMACAddress";
 import isMailtoURIFuncEs from "validator/es/lib/isMailtoURI";
 import isMD5FuncEs from "validator/es/lib/isMD5";
@@ -493,6 +511,8 @@ const any: any = null;
     result = validator.contains("Sampletestsample", "sample", { ignoreCase: true, minOccurrences: 2 });
 
     result = validator.equals("sample", "sample");
+
+    result = validator.isAbaRouting("sample");
 
     result = validator.isAfter("sample");
     result = validator.isAfter("sample", new Date().toString());
@@ -649,7 +669,39 @@ const any: any = null;
 
     result = validator.isDivisibleBy("sample", 2);
 
-    const isEmailOptions: validator.IsEmailOptions = {
+    const isEmailOptionsWithAllowDisplayName: validator.IsEmailOptions = {
+        allow_display_name: true,
+    };
+
+    const isEmailOptionsWithRequireDisplayName: validator.IsEmailOptions = {
+        require_display_name: true,
+    };
+
+    const isEmailOptionsWithAllowUtf8LocalPart: validator.IsEmailOptions = {
+        allow_utf8_local_part: true,
+    };
+
+    const isEmailOptionsWithRequiredTld: validator.IsEmailOptions = {
+        require_tld: true,
+    };
+
+    const isEmailOptionsWitIgnoreMaxLength: validator.IsEmailOptions = {
+        ignore_max_length: true,
+    };
+
+    const isEmailOptionsWithAllowIpDomain: validator.IsEmailOptions = {
+        allow_ip_domain: true,
+    };
+
+    const isEmailOptionsWithDomainSpecificValidation: validator.IsEmailOptions = {
+        domain_specific_validation: true,
+    };
+
+    const isEmailOptionsWithAllowUnderscores: validator.IsEmailOptions = {
+        allow_underscores: true,
+    };
+
+    const isEmailOptionsWithBlacklistedHosts: validator.IsEmailOptions = {
         host_blacklist: ["domain"],
     };
 
@@ -662,7 +714,15 @@ const any: any = null;
     };
 
     result = validator.isEmail("sample");
-    result = validator.isEmail("sample", isEmailOptions);
+    result = validator.isEmail("sample", isEmailOptionsWithAllowDisplayName);
+    result = validator.isEmail("sample", isEmailOptionsWithRequireDisplayName);
+    result = validator.isEmail("sample", isEmailOptionsWithAllowUtf8LocalPart);
+    result = validator.isEmail("sample", isEmailOptionsWithRequiredTld);
+    result = validator.isEmail("sample", isEmailOptionsWitIgnoreMaxLength);
+    result = validator.isEmail("sample", isEmailOptionsWithAllowIpDomain);
+    result = validator.isEmail("sample", isEmailOptionsWithDomainSpecificValidation);
+    result = validator.isEmail("sample", isEmailOptionsWithAllowUnderscores);
+    result = validator.isEmail("sample", isEmailOptionsWithBlacklistedHosts);
     result = validator.isEmail("sample", isEmailOptionsWithBlacklistedCharacters);
     result = validator.isEmail("sample", isEmailOptionsWithWhitelistedHosts);
 
@@ -774,9 +834,16 @@ const any: any = null;
     result = validator.isLength("sample", isLengthOptions);
     result = validator.isLength("sample");
 
+    const licensePlateLocale: validator.LicensePlateLocale = "any";
+    result = validator.isLicensePlate("sample", licensePlateLocale);
+    // $ExpectType unknown
+    validator.isLicensePlate("sample", "");
+
     result = validator.isLocale("sample");
 
     result = validator.isLowercase("sample");
+
+    result = validator.isLuhnNumber("sample");
 
     result = validator.isMACAddress("sample", { no_separators: true, eui: "48" });
     result = validator.isMACAddress("sample", { no_separators: true, eui: "64" });


### PR DESCRIPTION
- Add `isAbaRouting` to `index.d.ts`, `lib`, `es/lib`; add tests
    - This function is added since [v13.12.0](https://github.com/validatorjs/validator.js/releases/tag/13.12.0)
- Modify `isEmail` signature; add tests
    - `allow_underscores` options is added since [v13.11.0](https://github.com/validatorjs/validator.js/releases/tag/13.11.0)
- Modify `isLicensePlate` signature; add it to `lib`, `es/lib`; add tests
    - A new overloaded type is added, `export function isLicensePlate(str: string, locale: string): unknown;`. This is done since the function will throw error for any unspecified locale. See [the implementation](https://github.com/validatorjs/validator.js/blob/ff56dcf5ad16abc4127528eafae559ac716863fb/src/lib/isLicensePlate.js#L39)
    - A string union type `LicensePlateLocale` is exported for typescript user to better utilize the function.
- Add `isLuhnNumber` to `lib`, `es/lib`; add tests
    - This function is added since [v13.9.0](https://github.com/validatorjs/validator.js/releases/tag/13.9.0)

Resolves https://github.com/DefinitelyTyped/DefinitelyTyped/issues/69469.

Resolves https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66794.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
