### PR TITLE
http-headers: narrower return type if onlyHeaders parameter is true

### DIFF
--- a/types/http-headers/http-headers-tests.ts
+++ b/types/http-headers/http-headers-tests.ts
@@ -17,6 +17,11 @@ const h1: ResponseData | Headers = httpHeaders(res);
 const h2: RequestData | ResponseData = httpHeaders(res);
 // @ts-expect-error
 const h3: RequestData | Headers = httpHeaders(res);
+
+const h4: Headers = httpHeaders(res, true);
+// @ts-expect-error
+const h5: RequestData | ResponseData = httpHeaders(res, true);
+
 httpHeaders(Buffer.alloc(1));
 httpHeaders("foo");
 

--- a/types/http-headers/index.d.ts
+++ b/types/http-headers/index.d.ts
@@ -43,10 +43,10 @@ export = httpHeaders;
  *   console.log(httpHeaders(res))
  * }).listen(8080)
  */
-declare function httpHeaders(
+declare function httpHeaders<T extends boolean>(
     data: string | Buffer | ServerResponse,
-    onlyHeaders?: boolean,
-): httpHeaders.RequestData | httpHeaders.ResponseData | httpHeaders.Headers;
+    onlyHeaders?: T,
+): T extends true ? httpHeaders.Headers : (httpHeaders.RequestData | httpHeaders.ResponseData | httpHeaders.Headers);
 
 declare namespace httpHeaders {
     interface RequestData {


### PR DESCRIPTION
In line with the documentation at https://github.com/watson/http-headers#onlyheaders-example, when the optional parameter `onlyHeaders` is set to `true` the return type will always be `Headers`.

I wasn't able to run dprint because the prettier plugin uses a dynamically linked executable (NixOS).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

