### PR TITLE
feat(node): add filePath prop to TestContext and SuiteContext

### DIFF
--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -529,6 +529,12 @@ declare module "node:test" {
          */
         diagnostic(message: string): void;
         /**
+         * The absolute path of the test file that created the current test. If a test file imports
+         * additional modules that generate tests, the imported tests will return the path of the root test file.
+         * @since v22.6.0
+         */
+        readonly filePath: string;
+        /**
          * The name of the test and each of its ancestors, separated by `>`.
          * @since v22.3.0
          */
@@ -758,6 +764,12 @@ declare module "node:test" {
      * @since v18.7.0, v16.17.0
      */
     class SuiteContext {
+        /**
+         * The absolute path of the test file that created the current suite. If a test file imports
+         * additional modules that generate suites, the imported suites will return the path of the root test file.
+         * @since v22.6.0
+         */
+        readonly filePath: string;
         /**
          * The name of the suite.
          * @since v18.8.0, v16.18.0

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -140,6 +140,8 @@ test(undefined, undefined, t => {
     // $ExpectType string
     t.name;
     // $ExpectType string
+    t.filePath;
+    // $ExpectType string
     t.fullName;
     // $ExpectType AbortSignal
     t.signal;
@@ -340,6 +342,8 @@ describe(s => {
     s;
     // $ExpectType string
     s.name;
+    // $ExpectType string
+    s.filePath;
 });
 
 // Test callback mode


### PR DESCRIPTION
This PR adds `filePath` prop to [TestContext](https://nodejs.org/api/test.html#contextfilepath) and [SuiteContext](https://nodejs.org/api/test.html#contextfilepath_1)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: adds `filePath` prop to [TestContext](https://nodejs.org/api/test.html#contextfilepath) and [SuiteContext](https://nodejs.org/api/test.html#contextfilepath_1)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
