### PR TITLE
fix(prompt): Add back missing "replace" attribute

### DIFF
--- a/types/prompt/index.d.ts
+++ b/types/prompt/index.d.ts
@@ -16,6 +16,7 @@ declare namespace prompt {
         name?: string | undefined;
         raw?: [string, string] | undefined;
         hidden?: boolean;
+        replace?: string;
     };
 
     interface Properties {

--- a/types/prompt/prompt-tests.ts
+++ b/types/prompt/prompt-tests.ts
@@ -64,6 +64,7 @@ prompt.get(
                 },
                 password: {
                     hidden: true,
+                    replace: "*",
                 },
             },
         },


### PR DESCRIPTION
- Resolving [discussion #64489](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64489)
- `replace` attribute is effective even back in v1.1.0 of the package. See [this npm page](https://www.npmjs.com/package/prompt/v/1.1.0#user-content-valid-property-settings). Hence this change does not require changing the version number in `package.json` file.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
