### PR TITLE
Add missing WidgetSize of "flexible" to cloudflare-turnstile

### DIFF
--- a/types/cloudflare-turnstile/cloudflare-turnstile-tests.ts
+++ b/types/cloudflare-turnstile/cloudflare-turnstile-tests.ts
@@ -19,6 +19,7 @@ const themeDark: Turnstile.Theme = "dark";
 
 const widgetSizeNormal: Turnstile.WidgetSize = "normal";
 const widgetSizeCompact: Turnstile.WidgetSize = "compact";
+const widgetSizeFlexible: Turnstile.WidgetSize = "flexible";
 
 const failureRetryModeNever: Turnstile.FailureRetryMode = "never";
 const failureRetryModeAuto: Turnstile.FailureRetryMode = "auto";

--- a/types/cloudflare-turnstile/index.d.ts
+++ b/types/cloudflare-turnstile/index.d.ts
@@ -61,7 +61,7 @@ declare namespace Turnstile {
      * The widget size.
      * Can take the following values: normal, compact.
      */
-    type WidgetSize = "normal" | "compact";
+    type WidgetSize = "normal" | "compact" | "flexible";
 
     /**
      * How to retry on widget failure.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Widget size](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#widget-size)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
