### PR TITLE
fix(sparql-http-client): make it possible to init from another instance

### DIFF
--- a/types/sparql-http-client/ParsingClient.d.ts
+++ b/types/sparql-http-client/ParsingClient.d.ts
@@ -4,30 +4,16 @@ import { Client } from "./index.js";
 import ParsingQuery from "./ParsingQuery.js";
 import SimpleClient from "./SimpleClient.js";
 
-interface BaseOptions<Q extends Quad, D extends DatasetCore<Q>> {
+export interface Options<Q extends Quad = Quad, D extends DatasetCore<Q> = DatasetCore<Q>> {
     factory?: Environment<DatasetCoreFactory<Q, Q, D>>;
     fetch?: typeof fetch;
     headers?: HeadersInit;
     password?: string;
     user?: string;
+    endpointUrl?: string;
+    storeUrl?: string;
+    updateUrl?: string;
 }
-
-interface OptionWithQueryEndpoint<Q extends Quad, D extends DatasetCore<Q>> extends BaseOptions<Q, D> {
-    endpointUrl: string;
-}
-
-interface OptionWithStoreEndpoint<Q extends Quad, D extends DatasetCore<Q>> extends BaseOptions<Q, D> {
-    storeUrl: string;
-}
-
-interface OptionWithUpdateEndpoint<Q extends Quad, D extends DatasetCore<Q>> extends BaseOptions<Q, D> {
-    updateUrl: string;
-}
-
-export type Options<Q extends Quad = Quad, D extends DatasetCore<Q> = DatasetCore<Q>> =
-    | OptionWithQueryEndpoint<Q, D>
-    | OptionWithStoreEndpoint<Q, D>
-    | OptionWithUpdateEndpoint<Q, D>;
 
 export type ParsingClient<D extends DatasetCore = DatasetCore> = Client<ParsingQuery<D>>;
 

--- a/types/sparql-http-client/SimpleClient.d.ts
+++ b/types/sparql-http-client/SimpleClient.d.ts
@@ -11,7 +11,7 @@ interface StoreConstructor {
     new<Q extends BaseQuad = Quad>(options: { client: SimpleClientImpl }): Store<Q>;
 }
 
-interface BaseOptions {
+export interface Options {
     factory?: Environment<DataFactory | DatasetCoreFactory>;
     fetch?: typeof fetch;
     headers?: HeadersInit;
@@ -19,21 +19,10 @@ interface BaseOptions {
     user?: string;
     Query?: QueryConstructor;
     Store?: StoreConstructor;
+    endpointUrl?: string;
+    storeUrl?: string;
+    updateUrl?: string;
 }
-
-interface OptionWithQueryEndpoint extends BaseOptions {
-    endpointUrl: string;
-}
-
-interface OptionWithStoreEndpoint extends BaseOptions {
-    storeUrl: string;
-}
-
-interface OptionWithUpdateEndpoint extends BaseOptions {
-    updateUrl: string;
-}
-
-export type Options = OptionWithQueryEndpoint | OptionWithStoreEndpoint | OptionWithUpdateEndpoint;
 
 interface QueryOptions {
     headers?: HeadersInit;

--- a/types/sparql-http-client/StreamClient.d.ts
+++ b/types/sparql-http-client/StreamClient.d.ts
@@ -4,30 +4,16 @@ import { Client, SimpleClient } from "./index.js";
 import StreamQuery from "./StreamQuery.js";
 import StreamStore from "./StreamStore.js";
 
-interface BaseOptions<Q extends BaseQuad> {
+export interface Options<Q extends BaseQuad = BaseQuad> {
     factory?: Environment<DataFactory<Q> | DatasetCoreFactory>;
     fetch?: typeof fetch;
     headers?: HeadersInit;
     password?: string;
     user?: string;
+    endpointUrl?: string;
+    storeUrl?: string;
+    updateUrl?: string;
 }
-
-interface OptionWithQueryEndpoint<Q extends BaseQuad> extends BaseOptions<Q> {
-    endpointUrl: string;
-}
-
-interface OptionWithStoreEndpoint<Q extends BaseQuad> extends BaseOptions<Q> {
-    storeUrl: string;
-}
-
-interface OptionWithUpdateEndpoint<Q extends BaseQuad> extends BaseOptions<Q> {
-    updateUrl: string;
-}
-
-export type Options<Q extends BaseQuad = Quad> =
-    | OptionWithQueryEndpoint<Q>
-    | OptionWithStoreEndpoint<Q>
-    | OptionWithUpdateEndpoint<Q>;
 
 export type StreamClient<Q extends BaseQuad = Quad> = Client<StreamQuery<Q>, StreamStore<Q>>;
 

--- a/types/sparql-http-client/package.json
+++ b/types/sparql-http-client/package.json
@@ -17,6 +17,10 @@
         {
             "name": "Tomasz Pluskiewicz",
             "githubUsername": "tpluscode"
+        },
+        {
+            "name": "Ludovic Muller",
+            "githubUsername": "ludovicm67"
         }
     ]
 }

--- a/types/sparql-http-client/sparql-http-client-tests.ts
+++ b/types/sparql-http-client/sparql-http-client-tests.ts
@@ -241,3 +241,12 @@ async function simpleClient() {
         operation: "get",
     });
 }
+
+function initFromInstance() {
+    const client = new StreamClient({
+        endpointUrl,
+    });
+    const cloneClient = new StreamClient(client);
+    const parsingClient = new ParsingClient(client);
+    const simpleClient = new SimpleClient(client);
+}


### PR DESCRIPTION
I found that the current structure prevents initializing a new instance of a client from existing one because the union of `Option` types were too prohibiting. While the idea was to strong-type the runtime restriction from https://github.com/rdf-ext/sparql-http-client/blob/master/SimpleClient.js#L76-L78, it made a legitimate usage impossible, such as

```
let streamClient: StreamClient
let parsingClient = new ParsingClient(streamClient)
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
