### PR TITLE
fix(async-retry): unknown error, opts as number[], randomize default

### DIFF
--- a/types/async-retry/async-retry-tests.ts
+++ b/types/async-retry/async-retry-tests.ts
@@ -9,11 +9,24 @@ retry(() => "hello"); // $ExpectType Promise<string>
 retry(() => 1); // $ExpectType Promise<number>
 retry(() => Promise.resolve("hello")); // $ExpectType Promise<string>
 retry(() => Promise.resolve(1)); // $ExpectType Promise<number>
+
 // $ExpectType Promise<void>
 retry((bail, attempt) => {
+    bail; // $ExpectType (e: unknown) => void
+    attempt; // $ExpectType number
+});
+
+// $ExpectType Promise<void>
+retry<void, Error>((bail, attempt) => { // eslint-disable-line @typescript-eslint/no-invalid-void-type
     bail; // $ExpectType (e: Error) => void
     attempt; // $ExpectType number
 });
+
+// $ExpectType Promise<void>
+retry((_: (e: Error) => void, attempt) => { // eslint-disable-line @typescript-eslint/no-invalid-void-type
+    attempt; // $ExpectType number
+});
+
 retry(() => "hello", { retries: 3 }); // $ExpectType Promise<string>
 retry(() => "hello", { factor: 2 }); // $ExpectType Promise<string>
 retry(() => "hello", { minTimeout: 3 }); // $ExpectType Promise<string>
@@ -22,9 +35,28 @@ retry(() => "hello", { randomize: true }); // $ExpectType Promise<string>
 retry(() => "hello", { forever: false }); // $ExpectType Promise<string>
 retry(() => "hello", { unref: true }); // $ExpectType Promise<string>
 retry(() => "hello", { maxRetryTime: 1 }); // $ExpectType Promise<string>
+
 // $ExpectType Promise<string>
 retry(() => "hello", {
     onRetry: (e, attempt) => {
+        e; // $ExpectType unknown
+        attempt; // $ExpectType number
+        return 42;
+    },
+});
+
+// $ExpectType Promise<string>
+retry<string, Error>(() => "hello", {
+    onRetry: (e, attempt) => {
+        e; // $ExpectType Error
+        attempt; // $ExpectType number
+        return 42;
+    },
+});
+
+// $ExpectType Promise<string>
+retry(() => "hello", {
+    onRetry: (e: Error, attempt) => {
         e; // $ExpectType Error
         attempt; // $ExpectType number
         return 42;

--- a/types/async-retry/index.d.ts
+++ b/types/async-retry/index.d.ts
@@ -26,22 +26,30 @@ import { WrapOptions } from "retry";
  *   }
  * );
  */
-declare function AsyncRetry<TRet>(fn: AsyncRetry.RetryFunction<TRet>, opts?: AsyncRetry.Options): Promise<TRet>;
+declare function AsyncRetry<TRet, TErr = unknown>(
+    fn: AsyncRetry.RetryFunction<TRet, TErr>,
+    opts?: AsyncRetry.Options<TErr> | number[],
+): Promise<TRet>;
 
 declare namespace AsyncRetry {
-    interface Options extends WrapOptions {
+    interface Options<TErr = unknown> extends Omit<WrapOptions, "randomize"> {
         /**
          * An optional function that is invoked after a new retry is performed. It's passed the
          * `Error` that triggered it as a parameter.
          */
-        onRetry?: ((e: Error, attempt: number) => any) | undefined;
+        onRetry?: ((e: TErr, attempt: number) => any) | undefined;
+        /**
+         * Randomizes the timeouts by multiplying a factor between 1-2.
+         * @default true
+         */
+        randomize?: boolean | undefined;
     }
 
     /**
      * @param bail A function you can invoke to abort the retrying (bail).
      * @param attempt The attempt number. The absolute first attempt (before any retries) is `1`.
      */
-    type RetryFunction<TRet> = (bail: (e: Error) => void, attempt: number) => TRet | Promise<TRet>;
+    type RetryFunction<TRet, TErr = unknown> = (bail: (e: TErr) => void, attempt: number) => TRet | Promise<TRet>;
 }
 
 export = AsyncRetry;


### PR DESCRIPTION
- Cast `error` to `unknown`, hence resolving [discussion #69565](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69565).
    - `error` parameter on `RetryFunction` bascially can be any type that the `fn` in `AsyncRetry` throws, hence its type should not be limited to only `Error`.
    - Follow typescript practice on treating try-catch-style error, it should be casted to `unknown` instead.
    - Following this new type impl, `error` type can be specified either by generic parameter or by `onRetry()`'s signature.
    ```ts
    // $ExpectType Promise<string>
    retry<string, Error>(() => "hello", {
        onRetry: (e, attempt) => {
            e; // $ExpectType Error
            attempt; // $ExpectType number
            return 42;
        },
    });

    // $ExpectType Promise<string>
    retry(() => "hello", {
        onRetry: (e: Error, attempt) => {
            e; // $ExpectType Error
            attempt; // $ExpectType number
            return 42;
        },
    });
    ```
- Allow `opts` to be `number[]`, hence resolving [PR #69513](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69513).
    - `OperationOptions` in `types/retry` is just `WrapOptions | number[];`.
    - Since `retry` either consumes a number array or a config object (as indicated by [this early return](https://github.com/tim-kos/node-retry/blob/11efd6e4e896e06b7873df4f6e187c1e6dd2cf1b/lib/retry.js#L13-15)), it should be reasonable to keep extending `WrapOptions` with `onRetry()?`, and let the `Options` type to be union with `number[]` to form the complete typing for `opts`.
- Modify default value for `randomize` in jsdoc, resolving [discussion #64987](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64987).
- Downgrade package version since the current one basically does not exist.
    - `async-retry` is hence removed from `attw.json`.

--- 


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
