### PR TITLE
[react] Add `name` prop to `Suspense`

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -842,6 +842,12 @@ declare namespace React {
 
         /** A fallback react tree to show when a Suspense child (like React.lazy) suspends */
         fallback?: ReactNode;
+
+        /**
+         * A name for this Suspense boundary for instrumentation purposes.
+         * The name will help identify this boundary in React DevTools.
+         */
+        name?: string | undefined;
     }
 
     /**

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -405,6 +405,13 @@ const LazyRefForwarding = React.lazy(async () => ({ default: Memoized4 }));
 // @ts-expect-error
 <React.Suspense fallback={null} unstable_avoidThisFallback />;
 
+<React.Suspense
+    fallback={null}
+    // @ts-expect-error -- Should use `name`
+    id="test"
+/>;
+<React.Suspense fallback={null} name="test" />;
+
 class LegacyContext extends React.Component {
     static contextTypes = { foo: PropTypes.node.isRequired };
 

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -843,6 +843,12 @@ declare namespace React {
 
         /** A fallback react tree to show when a Suspense child (like React.lazy) suspends */
         fallback?: ReactNode;
+
+        /**
+         * A name for this Suspense boundary for instrumentation purposes.
+         * The name will help identify this boundary in React DevTools.
+         */
+        name?: string | undefined;
     }
 
     /**

--- a/types/react/ts5.0/test/tsx.tsx
+++ b/types/react/ts5.0/test/tsx.tsx
@@ -405,6 +405,13 @@ const LazyRefForwarding = React.lazy(async () => ({ default: Memoized4 }));
 // @ts-expect-error
 <React.Suspense fallback={null} unstable_avoidThisFallback />;
 
+<React.Suspense
+    fallback={null}
+    // @ts-expect-error -- Should use `name`
+    id="test"
+/>;
+<React.Suspense fallback={null} name="test" />;
+
 class LegacyContext extends React.Component {
     static contextTypes = { foo: PropTypes.node.isRequired };
 

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -393,6 +393,12 @@ declare namespace React {
 
         /** A fallback react tree to show when a Suspense child (like React.lazy) suspends */
         fallback: NonNullable<ReactNode> | null;
+
+        /**
+         * A name for this Suspense boundary for instrumentation purposes.
+         * The name will help identify this boundary in React DevTools.
+         */
+        name?: string | undefined;
     }
     /**
      * This feature is not yet available for server-side rendering.

--- a/types/react/v16/test/tsx.tsx
+++ b/types/react/v16/test/tsx.tsx
@@ -342,6 +342,13 @@ const LazyRefForwarding = React.lazy(async () => ({ default: Memoized4 }));
 // @ts-expect-error
 <React.Suspense fallback={null} unstable_avoidThisFallback />;
 
+<React.Suspense
+    fallback={null}
+    // @ts-expect-error -- Should use `name`
+    id="test"
+/>;
+<React.Suspense fallback={null} name="test" />;
+
 class LegacyContext extends React.Component {
     static contextTypes = { foo: PropTypes.node.isRequired };
 

--- a/types/react/v17/index.d.ts
+++ b/types/react/v17/index.d.ts
@@ -392,6 +392,12 @@ declare namespace React {
         // TODO(react18): `fallback?: ReactNode;`
         /** A fallback react tree to show when a Suspense child (like React.lazy) suspends */
         fallback: NonNullable<ReactNode> | null;
+
+        /**
+         * A name for this Suspense boundary for instrumentation purposes.
+         * The name will help identify this boundary in React DevTools.
+         */
+        name?: string | undefined;
     }
 
     // TODO(react18): Updated JSDoc to reflect that Suspense works on the server.

--- a/types/react/v17/test/tsx.tsx
+++ b/types/react/v17/test/tsx.tsx
@@ -330,6 +330,13 @@ const LazyRefForwarding = React.lazy(async () => ({ default: Memoized4 }));
 // @ts-expect-error
 <React.Suspense fallback={null} unstable_avoidThisFallback />;
 
+<React.Suspense
+    fallback={null}
+    // @ts-expect-error -- Should use `name`
+    id="test"
+/>;
+<React.Suspense fallback={null} name="test" />;
+
 class LegacyContext extends React.Component {
     static contextTypes = { foo: PropTypes.node.isRequired };
 


### PR DESCRIPTION
This is just a convention we settled on. It doesn't need to be globally unique hence `name` and not `id`. This is not consistent with `Profiler#id` which is only kept for backwards compatibility.