### PR TITLE
fix(apple-mapkit-js-browser): Modify "points" type in PolygonOverlay

### DIFF
--- a/types/apple-mapkit-js-browser/apple-mapkit-js-browser-tests.ts
+++ b/types/apple-mapkit-js-browser/apple-mapkit-js-browser-tests.ts
@@ -146,3 +146,44 @@ search.autocomplete("Apple", (error, data) => {}, {
 
 // Check that all StyleConstructorOptions are optional
 const style = new mapkit.Style({});
+
+let pointList = [
+    new mapkit.Coordinate(41, -109.05),
+    new mapkit.Coordinate(41, -102.05),
+    new mapkit.Coordinate(37, -102.05),
+    new mapkit.Coordinate(37, -109.05),
+];
+let pointListList = [pointList, pointList];
+
+// PolygonOverlay
+{
+    // ctor
+    {
+        let rectangle: mapkit.PolygonOverlay;
+
+        rectangle = new mapkit.PolygonOverlay(pointList);
+
+        rectangle = new mapkit.PolygonOverlay(pointListList);
+    }
+
+    // get points
+    {
+        let rectangle: mapkit.PolygonOverlay;
+        let points: mapkit.Coordinate[][];
+
+        rectangle = new mapkit.PolygonOverlay(pointList);
+        points = rectangle.points;
+
+        rectangle = new mapkit.PolygonOverlay(pointListList);
+        points = rectangle.points;
+    }
+
+    // set points
+    {
+        const rectangle = new mapkit.PolygonOverlay(pointList);
+
+        rectangle.points = pointList;
+
+        rectangle.points = [pointList, pointList];
+    }
+}

--- a/types/apple-mapkit-js-browser/index.d.ts
+++ b/types/apple-mapkit-js-browser/index.d.ts
@@ -1370,11 +1370,12 @@ declare namespace mapkit {
          * @param options An object literal of options with which to initialize the
          * polygon.
          */
-        constructor(points: Coordinate[], options?: StylesOverlayOptions);
+        constructor(points: Coordinate[] | Coordinate[][], options?: StylesOverlayOptions);
         /**
          * One or more arrays of coordinates that define the polygon overlay shape.
          */
-        points: Coordinate[];
+        get points(): Coordinate[][];
+        set points(points: Coordinate[] | Coordinate[][]);
     }
 
     interface OverlayOptions {


### PR DESCRIPTION
- Allow `points` in `PolygonOverlay` to be `Coordinate[] | Coordinate[][]`.
    - Resolve [discussion #70484](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/70484).
    - See the [documentation](https://developer.apple.com/documentation/mapkitjs/polygonoverlay/2974010-mapkit_polygonoverlay#parameters).
    - The added test codes works as expected with the [latest cdn release](https://cdn.apple-mapkit.com/mk/5.45.0/mapkit.js) from apple.
    
---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
