### PR TITLE
fix(promise-fn-retry): Change export style, add back jsdoc

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -1452,7 +1452,6 @@
         "pretty-proptypes",
         "prismic-dom",
         "progressjs",
-        "promise-fn-retry",
         "promise-pg",
         "promise-pool",
         "promise-sftp",

--- a/types/promise-fn-retry/index.d.ts
+++ b/types/promise-fn-retry/index.d.ts
@@ -1,18 +1,49 @@
-export interface RetryOptions {
-    times?: number;
-    initialDelayTime?: number;
-    onRetry?: (err: unknown, optionsParsed: RetryControlOptions) => void;
-    shouldRetry?: (err: unknown) => boolean;
-}
+declare namespace retry {
+    interface RetryOptions {
+        /**
+         * The number of times the lib will retry execute the promiseFn.
+         *
+         * @default 1
+         */
+        times?: number;
+        /**
+         * The first wait time to delay.
+         *
+         * @default 100
+         */
+        initialDelayTime?: number;
+        /**
+         * This callback is executed on each retry. It's useful to log your errors to a log
+         * service for example.
+         *
+         * @default null
+         */
+        onRetry?: ((err: unknown, optionsParsed: RetryControlOptions) => void) | null;
+        /**
+         * This callback is executed before each retry to determine if it's necessary retrying.
+         * If the function returns true, the next retry will be executed, else the retrying will
+         * be canceled.
+         *
+         * @default null
+         */
+        shouldRetry?: ((err: unknown) => boolean) | null;
+    }
 
-export interface RetryControlOptions extends RetryOptions {
-    retained: number;
-    currentDelay?: number;
+    interface RetryControlOptions extends RetryOptions {
+        /**
+         * The number of retries that are already made.
+         */
+        retained: number;
+        /**
+         * The current delay time that is used in current retry.
+         */
+        currentDelay: number | null;
+    }
 }
 
 declare function retry<T>(
     requestFn: () => Promise<T>,
-    options?: RetryOptions,
+    options?: retry.RetryOptions,
 ): Promise<T>;
 
-export default retry;
+export = retry;

--- a/types/promise-fn-retry/promise-fn-retry-tests.ts
+++ b/types/promise-fn-retry/promise-fn-retry-tests.ts
@@ -5,7 +5,20 @@ const requestFn = () => Promise.resolve(testString);
 const options: RetryOptions = {
     times: 1,
     initialDelayTime: 100,
-    onRetry: (err: unknown, controlOptions: RetryControlOptions) => {},
+    onRetry: (err: unknown, controlOptions: RetryControlOptions) => {
+        // $ExpectType number | undefined
+        controlOptions.times;
+        // $ExpectType number | undefined
+        controlOptions.initialDelayTime;
+        // $ExpectType ((err: unknown, optionsParsed: RetryControlOptions) => void) | null | undefined
+        controlOptions.onRetry;
+        // $ExpectType ((err: unknown) => boolean) | null | undefined
+        controlOptions.shouldRetry;
+        // $ExpectType number
+        controlOptions.retained;
+        // $ExpectType number | null
+        controlOptions.currentDelay;
+    },
     shouldRetry: (err: unknown) => true,
 };
 


### PR DESCRIPTION
- Change `export default` to `export =`
- Remove `undefined` from attributes in `RetryControlOptions`, 
    - These are always provided by the library. See the [library codes](https://github.com/felippemauricio/promise-fn-retry/blob/main/src/index.js#L11-L17).
- Add back jsdoc according to content in readme and comment in `index.js` from the original library.
- Add tests for `options` in `onRetry` callback.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
