### PR TITLE
feat(@types/react): trusted types for ScriptHTMLAttributes, ReactNode…

### DIFF
--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -157,4 +157,11 @@ interface TouchList {}
 interface WebGLRenderingContext {}
 interface WebGL2RenderingContext {}
 
+// Trusted Types
+//
+// See: https://www.w3.org/TR/trusted-types/
+// See: https://web.dev/articles/trusted-types
+// See: https://w3c.github.io/trusted-types/dist/spec/#trusted-types
 interface TrustedHTML {}
+interface TrustedScript {}
+interface TrustedScriptURL {}

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -477,6 +477,7 @@ declare namespace React {
     // non-thenables need to be kept in sync with AwaitedReactNode
     type ReactNode =
         | ReactElement
+        | TrustedScript
         | string
         | number
         | Iterable<ReactNode>
@@ -3064,7 +3065,7 @@ declare namespace React {
         sizes?: string | undefined;
         span?: number | undefined;
         src?: string | undefined;
-        srcDoc?: string | undefined;
+        srcDoc?: string | TrustedHTML | undefined;
         srcLang?: string | undefined;
         srcSet?: string | undefined;
         start?: number | undefined;
@@ -3236,7 +3237,7 @@ declare namespace React {
         scrolling?: string | undefined;
         seamless?: boolean | undefined;
         src?: string | undefined;
-        srcDoc?: string | undefined;
+        srcDoc?: string | TrustedHTML | undefined;
         width?: number | string | undefined;
     }
 
@@ -3524,7 +3525,7 @@ declare namespace React {
         integrity?: string | undefined;
         noModule?: boolean | undefined;
         referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
-        src?: string | undefined;
+        src?: string | TrustedScriptURL | undefined;
         type?: string | undefined;
     }
 
@@ -3762,7 +3763,7 @@ declare namespace React {
         hanging?: number | string | undefined;
         horizAdvX?: number | string | undefined;
         horizOriginX?: number | string | undefined;
-        href?: string | undefined;
+        href?: string | TrustedScriptURL | undefined;
         ideographic?: number | string | undefined;
         imageRendering?: number | string | undefined;
         in2?: number | string | undefined;
@@ -3904,7 +3905,7 @@ declare namespace React {
         xHeight?: number | string | undefined;
         xlinkActuate?: string | undefined;
         xlinkArcrole?: string | undefined;
-        xlinkHref?: string | undefined;
+        xlinkHref?: string | TrustedScriptURL | undefined;
         xlinkRole?: string | undefined;
         xlinkShow?: string | undefined;
         xlinkTitle?: string | undefined;

--- a/types/react/ts5.0/global.d.ts
+++ b/types/react/ts5.0/global.d.ts
@@ -157,4 +157,11 @@ interface TouchList {}
 interface WebGLRenderingContext {}
 interface WebGL2RenderingContext {}
 
+// Trusted Types
+//
+// See: https://www.w3.org/TR/trusted-types/
+// See: https://web.dev/articles/trusted-types
+// See: https://w3c.github.io/trusted-types/dist/spec/#trusted-types
 interface TrustedHTML {}
+interface TrustedScript {}
+interface TrustedScriptURL {}

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -478,6 +478,7 @@ declare namespace React {
     // non-thenables need to be kept in sync with AwaitedReactNode
     type ReactNode =
         | ReactElement
+        | TrustedScript
         | string
         | number
         | Iterable<ReactNode>
@@ -3065,7 +3066,7 @@ declare namespace React {
         sizes?: string | undefined;
         span?: number | undefined;
         src?: string | undefined;
-        srcDoc?: string | undefined;
+        srcDoc?: string | TrustedHTML | undefined;
         srcLang?: string | undefined;
         srcSet?: string | undefined;
         start?: number | undefined;
@@ -3237,7 +3238,7 @@ declare namespace React {
         scrolling?: string | undefined;
         seamless?: boolean | undefined;
         src?: string | undefined;
-        srcDoc?: string | undefined;
+        srcDoc?: string | TrustedHTML | undefined;
         width?: number | string | undefined;
     }
 
@@ -3525,7 +3526,7 @@ declare namespace React {
         integrity?: string | undefined;
         noModule?: boolean | undefined;
         referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
-        src?: string | undefined;
+        src?: string | TrustedScriptURL | undefined;
         type?: string | undefined;
     }
 
@@ -3763,7 +3764,7 @@ declare namespace React {
         hanging?: number | string | undefined;
         horizAdvX?: number | string | undefined;
         horizOriginX?: number | string | undefined;
-        href?: string | undefined;
+        href?: string | TrustedScriptURL | undefined;
         ideographic?: number | string | undefined;
         imageRendering?: number | string | undefined;
         in2?: number | string | undefined;
@@ -3905,7 +3906,7 @@ declare namespace React {
         xHeight?: number | string | undefined;
         xlinkActuate?: string | undefined;
         xlinkArcrole?: string | undefined;
-        xlinkHref?: string | undefined;
+        xlinkHref?: string | TrustedScriptURL | undefined;
         xlinkRole?: string | undefined;
         xlinkShow?: string | undefined;
         xlinkTitle?: string | undefined;

--- a/types/react/v16/global.d.ts
+++ b/types/react/v16/global.d.ts
@@ -150,4 +150,11 @@ interface TouchList {}
 interface WebGLRenderingContext {}
 interface WebGL2RenderingContext {}
 
+// Trusted Types
+//
+// See: https://www.w3.org/TR/trusted-types/
+// See: https://web.dev/articles/trusted-types
+// See: https://w3c.github.io/trusted-types/dist/spec/#trusted-types
 interface TrustedHTML {}
+interface TrustedScript {}
+interface TrustedScriptURL {}

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -208,7 +208,7 @@ declare namespace React {
     // React Nodes
     // ----------------------------------------------------------------------
 
-    type ReactText = string | number;
+    type ReactText = string | TrustedScript | number;
     type ReactChild = ReactElement | ReactText;
 
     interface ReactNodeArray extends Array<ReactNode> {}
@@ -2010,7 +2010,7 @@ declare namespace React {
         sizes?: string | undefined;
         span?: number | undefined;
         src?: string | undefined;
-        srcDoc?: string | undefined;
+        srcDoc?: string | TrustedHTML | undefined;
         srcLang?: string | undefined;
         srcSet?: string | undefined;
         start?: number | undefined;
@@ -2173,7 +2173,7 @@ declare namespace React {
         scrolling?: string | undefined;
         seamless?: boolean | undefined;
         src?: string | undefined;
-        srcDoc?: string | undefined;
+        srcDoc?: string | TrustedHTML | undefined;
         width?: number | string | undefined;
     }
 
@@ -2391,7 +2391,7 @@ declare namespace React {
         integrity?: string | undefined;
         noModule?: boolean | undefined;
         referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
-        src?: string | undefined;
+        src?: string | TrustedScriptURL | undefined;
         type?: string | undefined;
     }
 
@@ -2620,7 +2620,7 @@ declare namespace React {
         hanging?: number | string | undefined;
         horizAdvX?: number | string | undefined;
         horizOriginX?: number | string | undefined;
-        href?: string | undefined;
+        href?: string | TrustedScriptURL | undefined;
         ideographic?: number | string | undefined;
         imageRendering?: number | string | undefined;
         in2?: number | string | undefined;
@@ -2762,7 +2762,7 @@ declare namespace React {
         xHeight?: number | string | undefined;
         xlinkActuate?: string | undefined;
         xlinkArcrole?: string | undefined;
-        xlinkHref?: string | undefined;
+        xlinkHref?: string | TrustedScriptURL | undefined;
         xlinkRole?: string | undefined;
         xlinkShow?: string | undefined;
         xlinkTitle?: string | undefined;

--- a/types/react/v17/global.d.ts
+++ b/types/react/v17/global.d.ts
@@ -154,4 +154,11 @@ interface TouchList {}
 interface WebGLRenderingContext {}
 interface WebGL2RenderingContext {}
 
+// Trusted Types
+//
+// See: https://www.w3.org/TR/trusted-types/
+// See: https://web.dev/articles/trusted-types
+// See: https://w3c.github.io/trusted-types/dist/spec/#trusted-types
 interface TrustedHTML {}
+interface TrustedScript {}
+interface TrustedScriptURL {}

--- a/types/react/v17/index.d.ts
+++ b/types/react/v17/index.d.ts
@@ -203,7 +203,7 @@ declare namespace React {
     // React Nodes
     // ----------------------------------------------------------------------
 
-    type ReactText = string | number;
+    type ReactText = string | TrustedScript | number;
     type ReactChild = ReactElement | ReactText;
 
     /**
@@ -2010,7 +2010,7 @@ declare namespace React {
         sizes?: string | undefined;
         span?: number | undefined;
         src?: string | undefined;
-        srcDoc?: string | undefined;
+        srcDoc?: string | TrustedHTML | undefined;
         srcLang?: string | undefined;
         srcSet?: string | undefined;
         start?: number | undefined;
@@ -2172,7 +2172,7 @@ declare namespace React {
         scrolling?: string | undefined;
         seamless?: boolean | undefined;
         src?: string | undefined;
-        srcDoc?: string | undefined;
+        srcDoc?: string | TrustedHTML | undefined;
         width?: number | string | undefined;
     }
 
@@ -2391,7 +2391,7 @@ declare namespace React {
         integrity?: string | undefined;
         noModule?: boolean | undefined;
         referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
-        src?: string | undefined;
+        src?: string | TrustedScriptURL | undefined;
         type?: string | undefined;
     }
 
@@ -2621,7 +2621,7 @@ declare namespace React {
         hanging?: number | string | undefined;
         horizAdvX?: number | string | undefined;
         horizOriginX?: number | string | undefined;
-        href?: string | undefined;
+        href?: string | TrustedScriptURL | undefined;
         ideographic?: number | string | undefined;
         imageRendering?: number | string | undefined;
         in2?: number | string | undefined;
@@ -2763,7 +2763,7 @@ declare namespace React {
         xHeight?: number | string | undefined;
         xlinkActuate?: string | undefined;
         xlinkArcrole?: string | undefined;
-        xlinkHref?: string | undefined;
+        xlinkHref?: string | TrustedScriptURL | undefined;
         xlinkRole?: string | undefined;
         xlinkShow?: string | undefined;
         xlinkTitle?: string | undefined;


### PR DESCRIPTION
…, and other elements

Changelog:

- [x] ScriptHTMLAttributes: src attribute now accepts TrustedScriptURL.
- [x] ReactNode now accepts TrustedScript
- [x] SVGAttributes: href and xlinkHref attributes now accept TrustedScriptURL
- [x] IframeHTMLAttributes: srcDoc attribute now accepts TrustedHTML

Rationale:

In order to support trusted types for some of our Next.js applications, we've had to patch `@types/react` locally to use these types. We're hoping these will be useful to the broader community.

References:

The types are based on the table found in the Trusted Types W3C specification:

- [x] https://www.w3.org/TR/trusted-types/#enforcement-in-scripts
- [x] https://www.w3.org/TR/trusted-types/#get-trusted-type-data-for-attribute

Please fill this template:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run npm test <package to test>](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Trusted Types](https://www.w3.org/TR/trusted-types/#get-trusted-type-data-for-attribute)
