### PR TITLE
Fix return type for cyrb53

### DIFF
--- a/types/cyrb53/cyrb53-tests.ts
+++ b/types/cyrb53/cyrb53-tests.ts
@@ -1,4 +1,4 @@
 import cyrb53 = require("cyrb53");
 
-cyrb53("aaa", 5); // $ExpectType string
-cyrb53("aaa"); // $ExpectType string
+cyrb53("aaa", 5); // $ExpectType number
+cyrb53("aaa"); // $ExpectType number

--- a/types/cyrb53/index.d.ts
+++ b/types/cyrb53/index.d.ts
@@ -2,5 +2,5 @@
  * A fast and simple 53-bit string hash function with decent collision resistance.
  * @see https://github.com/bryc/code/blob/master/jshash/experimental/cyrb53.js
  */
-declare function cyrb53(str: string, seed?: number): string;
+declare function cyrb53(str: string, seed?: number): number;
 export = cyrb53;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
> I made a mistake in my initial PR. In particular, the function [returns `number`](https://github.com/bryc/code/blob/master/jshash/experimental/cyrb53.js) and not `string`. 
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
