### PR TITLE
@event-calendar/core: add missing text parameter for buttonText

### DIFF
--- a/types/event-calendar__core/event-calendar__core-tests.ts
+++ b/types/event-calendar__core/event-calendar__core-tests.ts
@@ -266,7 +266,10 @@ cal.setOption("buttonText", () => {
         return result;
     })
     .setOption("titleFormat", (_s: Date, _e: Date) => "content")
-    .setOption("views", { resourceTimeGrid: { selectMinDistance: 300 } });
+    .setOption("views", { resourceTimeGrid: { selectMinDistance: 300 } })
+    .setOption("buttonText", (text) => {
+        return { ...text, foo: "bar" };
+    });
 
 // check some invalid combinations for FooInput and Foo types
 // @ts-expect-error

--- a/types/event-calendar__core/index.d.ts
+++ b/types/event-calendar__core/index.d.ts
@@ -274,7 +274,7 @@ declare namespace Calendar {
     interface Options {
         allDayContent?: Content;
         allDaySlot?: boolean;
-        buttonText?: ButtonTextMapping | (() => ButtonTextMapping);
+        buttonText?: ButtonTextMapping | ((text: ButtonTextMapping) => ButtonTextMapping);
         customButtons?: Record<string, CustomButton>;
         date?: Date | string | undefined;
         dateClick?: (info: DateClickInfo) => void;


### PR DESCRIPTION
## Description
According to the [library documentation](https://github.com/vkurko/calendar#buttontext), `buttonText` can accept a function that receives a default button text object as a parameter and is expected to return a new one. Currently, the said  function does not accept any parameters.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [here](https://github.com/vkurko/calendar#buttontext)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. **N/A**
