### PR TITLE
feat(react): Add "enterKeyHint" to "HTMLAttributes"

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2905,6 +2905,7 @@ declare namespace React {
         contextMenu?: string | undefined;
         dir?: string | undefined;
         draggable?: Booleanish | undefined;
+        enterKeyHint?: "enter" | "done" | "go" | "next" | "previous" | "search" | "send" | undefined;
         hidden?: boolean | undefined;
         id?: string | undefined;
         lang?: string | undefined;
@@ -3360,7 +3361,6 @@ declare namespace React {
         capture?: boolean | "user" | "environment" | undefined; // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
         checked?: boolean | undefined;
         disabled?: boolean | undefined;
-        enterKeyHint?: "enter" | "done" | "go" | "next" | "previous" | "search" | "send" | undefined;
         form?: string | undefined;
         formAction?:
             | string

--- a/types/react/test/elementAttributes.tsx
+++ b/types/react/test/elementAttributes.tsx
@@ -15,6 +15,7 @@ const testCases = [
     <span contextMenu="menuId" />,
     <span dir="rtl" />,
     <span draggable />,
+    <span enterKeyHint="done" />,
     <span hidden />,
     <span id="s" />,
     <span lang="art-x-tokipona" />,

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -106,6 +106,7 @@ const ComponentWithChildren3: React.FunctionComponent<React.PropsWithChildren<Co
     defaultChecked
     defaultValue="some value"
     contentEditable
+    enterKeyHint="done"
     suppressContentEditableWarning
     suppressHydrationWarning
 >

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -2906,6 +2906,7 @@ declare namespace React {
         contextMenu?: string | undefined;
         dir?: string | undefined;
         draggable?: Booleanish | undefined;
+        enterKeyHint?: "enter" | "done" | "go" | "next" | "previous" | "search" | "send" | undefined;
         hidden?: boolean | undefined;
         id?: string | undefined;
         lang?: string | undefined;
@@ -3361,7 +3362,6 @@ declare namespace React {
         capture?: boolean | "user" | "environment" | undefined; // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
         checked?: boolean | undefined;
         disabled?: boolean | undefined;
-        enterKeyHint?: "enter" | "done" | "go" | "next" | "previous" | "search" | "send" | undefined;
         form?: string | undefined;
         formAction?:
             | string

--- a/types/react/ts5.0/test/elementAttributes.tsx
+++ b/types/react/ts5.0/test/elementAttributes.tsx
@@ -15,6 +15,7 @@ const testCases = [
     <span contextMenu="menuId" />,
     <span dir="rtl" />,
     <span draggable />,
+    <span enterKeyHint="done" />,
     <span hidden />,
     <span id="s" />,
     <span lang="art-x-tokipona" />,

--- a/types/react/ts5.0/test/tsx.tsx
+++ b/types/react/ts5.0/test/tsx.tsx
@@ -106,6 +106,7 @@ const ComponentWithChildren3: React.FunctionComponent<React.PropsWithChildren<Co
     defaultChecked
     defaultValue="some value"
     contentEditable
+    enterKeyHint="done"
     suppressContentEditableWarning
     suppressHydrationWarning
 >

--- a/types/react/v17/index.d.ts
+++ b/types/react/v17/index.d.ts
@@ -1867,6 +1867,7 @@ declare namespace React {
         contextMenu?: string | undefined;
         dir?: string | undefined;
         draggable?: Booleanish | undefined;
+        enterKeyHint?: "enter" | "done" | "go" | "next" | "previous" | "search" | "send" | undefined;
         hidden?: boolean | undefined;
         id?: string | undefined;
         lang?: string | undefined;
@@ -2233,7 +2234,6 @@ declare namespace React {
         capture?: boolean | "user" | "environment" | undefined; // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
         checked?: boolean | undefined;
         disabled?: boolean | undefined;
-        enterKeyHint?: "enter" | "done" | "go" | "next" | "previous" | "search" | "send" | undefined;
         form?: string | undefined;
         formAction?: string | undefined;
         formEncType?: string | undefined;

--- a/types/react/v17/test/elementAttributes.tsx
+++ b/types/react/v17/test/elementAttributes.tsx
@@ -9,6 +9,7 @@ const testCases = [
     <span contextMenu="menuId" />,
     <span dir="rtl" />,
     <span draggable />,
+    <span enterKeyHint="done" />,
     <span hidden />,
     <span id="s" />,
     <span lang="art-x-tokipona" />,

--- a/types/react/v17/test/tsx.tsx
+++ b/types/react/v17/test/tsx.tsx
@@ -63,6 +63,7 @@ VoidFunctionComponent2.defaultProps = {
     defaultChecked
     defaultValue="some value"
     contentEditable
+    enterKeyHint="done"
     suppressContentEditableWarning
     suppressHydrationWarning
 >


### PR DESCRIPTION
As discussed in [discussion #70409](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/70409), the `enterKeyHint` prop (`enterkeyhint` attribute in plain HTML) is now global and available on all elements. See the [HTML Spec](https://html.spec.whatwg.org/multipage/interaction.html#attr-enterkeyhint) and [React DOM docs](https://react.dev/reference/react-dom/components/common#common-props).

This PR aims to address that by adding `enterKeyHint` to `interface HTMLAttributes`.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
