### PR TITLE
[lodash] Fix signature of map() when iteratee is an arbitary function

### DIFF
--- a/types/lodash/common/collection.d.ts
+++ b/types/lodash/common/collection.d.ts
@@ -1173,7 +1173,7 @@ declare module "../index" {
         /**
          * @see _.map
          */
-        map<T>(collection: Dictionary<T> | NumericDictionary<T> | null | undefined, iteratee?: string): any[];
+        map<T>(collection: Dictionary<T> | NumericDictionary<T> | null | undefined, iteratee?: string | ((...args: any[]) => any)): any[];
         /**
          * @see _.map
          */
@@ -1202,7 +1202,7 @@ declare module "../index" {
         /**
          * @see _.map
          */
-        map(iteratee: PropertyName): Collection<any>;
+        map(iteratee: PropertyName | ((...args: any[]) => any)): Collection<any>;
         /**
          * @see _.map
          */
@@ -1224,7 +1224,7 @@ declare module "../index" {
         /**
          * @see _.map
          */
-        map(iteratee: PropertyName): Collection<any>;
+        map(iteratee: PropertyName | ((...args: any[]) => any)): Collection<any>;
         /**
          * @see _.map
          */
@@ -1266,7 +1266,7 @@ declare module "../index" {
         /**
          * @see _.map
          */
-        map(iteratee: PropertyName): CollectionChain<any>;
+        map(iteratee: PropertyName | ((...args: any[]) => any)): CollectionChain<any>;
         /**
          * @see _.map
          */
@@ -1288,7 +1288,7 @@ declare module "../index" {
         /**
          * @see _.map
          */
-        map(iteratee: PropertyName): CollectionChain<any>;
+        map(iteratee: PropertyName | ((...args: any[]) => any)): CollectionChain<any>;
         /**
          * @see _.map
          */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. (**Couldn't find any tests for lodash?**)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://lodash.com/docs/4.17.15#map
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. (**Not related to any changes in recent versions.**)

In order to reproduce the bug try following expressions for example and inspect the the type that is inferred for the result which is `boolean[]` instead of `any[]`:

```ts
const result = _.map([] as any[], _.toLower);
const resultChained = _([] as any[]).map(_.toLower).value();
```

That is because without explicitly targeting functions for the `iteratee` argument in the function signature, function arguments match the `object` type from a different signature of the map function.