### PR TITLE
fix(ember-changeset-validations): Make @types/ember__array optional peer

### DIFF
--- a/types/ember-changeset-validations/package.json
+++ b/types/ember-changeset-validations/package.json
@@ -5,10 +5,16 @@
     "projects": [
         "https://github.com/poteto/ember-changeset-validations"
     ],
-    "dependencies": {
+    "peerDependencies": {
         "@types/ember__array": "*"
     },
+    "peerDependenciesMeta": {
+      "@types/ember__array": {
+        "optional": true
+      }
+    },
     "devDependencies": {
+        "@types/ember__array": "^4.0.10",
         "@types/ember-changeset-validations": "workspace:."
     },
     "owners": [


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

This change allows to use Native Types https://blog.emberjs.com/stable-typescript-types-in-ember-5-1/ and avoid pulling definitely typed packages if not necessary.