### PR TITLE
[node] add types to `t.assert.strictEqual`

### DIFF
--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -650,6 +650,7 @@ declare module "node:test" {
          */
         readonly mock: MockTracker;
     }
+    import { strictEqual } from "node:assert";
     interface TestContextAssert {
         /**
          * Identical to the `deepEqual` function from the `node:assert` module, but bound to the test context.
@@ -714,7 +715,7 @@ declare module "node:test" {
         /**
          * Identical to the `strictEqual` function from the `node:assert` module, but bound to the test context.
          */
-        strictEqual: typeof import("node:assert").strictEqual;
+        strictEqual: <T>(...args: Parameters<typeof strictEqual<T>>) => ReturnType<typeof strictEqual<T>>;
         /**
          * Identical to the `throws` function from the `node:assert` module, but bound to the test context.
          */

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -975,7 +975,7 @@ const invalidTestContext = new TestContext();
 // @ts-expect-error Should not be able to instantiate a SuiteContext
 const invalidSuiteContext = new SuiteContext();
 
-test("planning with streams", (t: TestContext, done) => {
+test("planning with streams", (t, done) => {
     function* generate() {
         yield "a";
         yield "b";
@@ -993,6 +993,10 @@ test("planning with streams", (t: TestContext, done) => {
         done();
     });
 });
+
+test("assert.strictEqual in TestContextAssert", (t) => {
+    t.assert.strictEqual(1, 1)
+})
 
 // Test snapshot assertion.
 test(t => {


### PR DESCRIPTION
- add types to `assert.strictEqual` provided within TestContextAssert

An error occurred when attempting to use `t.assert.strictEqual` from TestContextAssert.

ref: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70193#discussion_r1701279488

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://nodejs.org/api/test.html#contextassert>>
