### PR TITLE
[node] TS-specific documentation for `TestContext#assert` methods

### DIFF
--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -479,7 +479,7 @@ declare module "node:test" {
         /**
          * An object containing assertion methods bound to the test context.
          * The top-level functions from the `node:assert` module are exposed here for the purpose of creating test plans.
-         * @since v22.2.0
+         * @since v22.2.0, v20.15.0
          */
         readonly assert: TestContextAssert;
         /**
@@ -657,6 +657,21 @@ declare module "node:test" {
         deepEqual: typeof import("node:assert").deepEqual;
         /**
          * Identical to the `deepStrictEqual` function from the `node:assert` module, but bound to the test context.
+         *
+         * **Note:** as this method returns a type assertion, the context parameter in the callback signature must have a
+         * type annotation, otherwise an error will be raised by the TypeScript compiler:
+         * ```ts
+         * import { test, type TestContext } from 'node:test';
+         *
+         * // The test function's context parameter must have a type annotation.
+         * test('example', (t: TestContext) => {
+         *   t.assert.deepStrictEqual(actual, expected);
+         * });
+         *
+         * // Omitting the type annotation will result in a compilation error.
+         * test('example', t => {
+         *   t.assert.deepStrictEqual(actual, expected); // Error: 't' needs an explicit type annotation.
+         * });
          */
         deepStrictEqual: typeof import("node:assert").deepStrictEqual;
         /**
@@ -681,6 +696,21 @@ declare module "node:test" {
         fail: typeof import("node:assert").fail;
         /**
          * Identical to the `ifError` function from the `node:assert` module, but bound to the test context.
+         *
+         * **Note:** as this method returns a type assertion, the context parameter in the callback signature must have a
+         * type annotation, otherwise an error will be raised by the TypeScript compiler:
+         * ```ts
+         * import { test, type TestContext } from 'node:test';
+         *
+         * // The test function's context parameter must have a type annotation.
+         * test('example', (t: TestContext) => {
+         *   t.assert.ifError(err);
+         * });
+         *
+         * // Omitting the type annotation will result in a compilation error.
+         * test('example', t => {
+         *   t.assert.ifError(err); // Error: 't' needs an explicit type annotation.
+         * });
          */
         ifError: typeof import("node:assert").ifError;
         /**
@@ -705,6 +735,21 @@ declare module "node:test" {
         notStrictEqual: typeof import("node:assert").notStrictEqual;
         /**
          * Identical to the `ok` function from the `node:assert` module, but bound to the test context.
+         *
+         * **Note:** as this method returns a type assertion, the context parameter in the callback signature must have a
+         * type annotation, otherwise an error will be raised by the TypeScript compiler:
+         * ```ts
+         * import { test, type TestContext } from 'node:test';
+         *
+         * // The test function's context parameter must have a type annotation.
+         * test('example', (t: TestContext) => {
+         *   t.assert.ok(condition);
+         * });
+         *
+         * // Omitting the type annotation will result in a compilation error.
+         * test('example', t => {
+         *   t.assert.ok(condition)); // Error: 't' needs an explicit type annotation.
+         * });
          */
         ok: typeof import("node:assert").ok;
         /**
@@ -713,6 +758,21 @@ declare module "node:test" {
         rejects: typeof import("node:assert").rejects;
         /**
          * Identical to the `strictEqual` function from the `node:assert` module, but bound to the test context.
+         *
+         * **Note:** as this method returns a type assertion, the context parameter in the callback signature must have a
+         * type annotation, otherwise an error will be raised by the TypeScript compiler:
+         * ```ts
+         * import { test, type TestContext } from 'node:test';
+         *
+         * // The test function's context parameter must have a type annotation.
+         * test('example', (t: TestContext) => {
+         *   t.assert.strictEqual(actual, expected);
+         * });
+         *
+         * // Omitting the type annotation will result in a compilation error.
+         * test('example', t => {
+         *   t.assert.strictEqual(actual, expected); // Error: 't' needs an explicit type annotation.
+         * });
          */
         strictEqual: typeof import("node:assert").strictEqual;
         /**

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -672,6 +672,7 @@ declare module "node:test" {
          * test('example', t => {
          *   t.assert.deepStrictEqual(actual, expected); // Error: 't' needs an explicit type annotation.
          * });
+         * ```
          */
         deepStrictEqual: typeof import("node:assert").deepStrictEqual;
         /**
@@ -711,6 +712,7 @@ declare module "node:test" {
          * test('example', t => {
          *   t.assert.ifError(err); // Error: 't' needs an explicit type annotation.
          * });
+         * ```
          */
         ifError: typeof import("node:assert").ifError;
         /**
@@ -750,6 +752,7 @@ declare module "node:test" {
          * test('example', t => {
          *   t.assert.ok(condition)); // Error: 't' needs an explicit type annotation.
          * });
+         * ```
          */
         ok: typeof import("node:assert").ok;
         /**
@@ -773,6 +776,7 @@ declare module "node:test" {
          * test('example', t => {
          *   t.assert.strictEqual(actual, expected); // Error: 't' needs an explicit type annotation.
          * });
+         * ```
          */
         strictEqual: typeof import("node:assert").strictEqual;
         /**

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -986,7 +986,10 @@ test("planning with streams", (t: TestContext, done) => {
 
     const stream = Readable.from(generate());
     stream.on("data", (chunk) => {
-        t.assert.strictEqual(chunk, expected.shift());
+        t.assert.strictEqual(chunk, expected.shift()!);
+
+        // $ExpectType string
+        chunk;
     });
 
     stream.on("end", () => {

--- a/types/node/v20/test.d.ts
+++ b/types/node/v20/test.d.ts
@@ -633,6 +633,21 @@ declare module "node:test" {
         deepEqual: typeof import("node:assert").deepEqual;
         /**
          * Identical to the `deepStrictEqual` function from the `node:assert` module, but bound to the test context.
+         *
+         * **Note:** as this method returns a type assertion, the context parameter in the callback signature must have a
+         * type annotation, otherwise an error will be raised by the TypeScript compiler:
+         * ```ts
+         * import { test, type TestContext } from 'node:test';
+         *
+         * // The test function's context parameter must have a type annotation.
+         * test('example', (t: TestContext) => {
+         *   t.assert.deepStrictEqual(actual, expected);
+         * });
+         *
+         * // Omitting the type annotation will result in a compilation error.
+         * test('example', t => {
+         *   t.assert.deepStrictEqual(actual, expected); // Error: 't' needs an explicit type annotation.
+         * });
          */
         deepStrictEqual: typeof import("node:assert").deepStrictEqual;
         /**
@@ -657,6 +672,21 @@ declare module "node:test" {
         fail: typeof import("node:assert").fail;
         /**
          * Identical to the `ifError` function from the `node:assert` module, but bound to the test context.
+         *
+         * **Note:** as this method returns a type assertion, the context parameter in the callback signature must have a
+         * type annotation, otherwise an error will be raised by the TypeScript compiler:
+         * ```ts
+         * import { test, type TestContext } from 'node:test';
+         *
+         * // The test function's context parameter must have a type annotation.
+         * test('example', (t: TestContext) => {
+         *   t.assert.ifError(err);
+         * });
+         *
+         * // Omitting the type annotation will result in a compilation error.
+         * test('example', t => {
+         *   t.assert.ifError(err); // Error: 't' needs an explicit type annotation.
+         * });
          */
         ifError: typeof import("node:assert").ifError;
         /**
@@ -681,6 +711,21 @@ declare module "node:test" {
         notStrictEqual: typeof import("node:assert").notStrictEqual;
         /**
          * Identical to the `ok` function from the `node:assert` module, but bound to the test context.
+         *
+         * **Note:** as this method returns a type assertion, the context parameter in the callback signature must have a
+         * type annotation, otherwise an error will be raised by the TypeScript compiler:
+         * ```ts
+         * import { test, type TestContext } from 'node:test';
+         *
+         * // The test function's context parameter must have a type annotation.
+         * test('example', (t: TestContext) => {
+         *   t.assert.ok(condition);
+         * });
+         *
+         * // Omitting the type annotation will result in a compilation error.
+         * test('example', t => {
+         *   t.assert.ok(condition)); // Error: 't' needs an explicit type annotation.
+         * });
          */
         ok: typeof import("node:assert").ok;
         /**
@@ -689,6 +734,21 @@ declare module "node:test" {
         rejects: typeof import("node:assert").rejects;
         /**
          * Identical to the `strictEqual` function from the `node:assert` module, but bound to the test context.
+         *
+         * **Note:** as this method returns a type assertion, the context parameter in the callback signature must have a
+         * type annotation, otherwise an error will be raised by the TypeScript compiler:
+         * ```ts
+         * import { test, type TestContext } from 'node:test';
+         *
+         * // The test function's context parameter must have a type annotation.
+         * test('example', (t: TestContext) => {
+         *   t.assert.strictEqual(actual, expected);
+         * });
+         *
+         * // Omitting the type annotation will result in a compilation error.
+         * test('example', t => {
+         *   t.assert.strictEqual(actual, expected); // Error: 't' needs an explicit type annotation.
+         * });
          */
         strictEqual: typeof import("node:assert").strictEqual;
         /**

--- a/types/node/v20/test.d.ts
+++ b/types/node/v20/test.d.ts
@@ -648,6 +648,7 @@ declare module "node:test" {
          * test('example', t => {
          *   t.assert.deepStrictEqual(actual, expected); // Error: 't' needs an explicit type annotation.
          * });
+         * ```
          */
         deepStrictEqual: typeof import("node:assert").deepStrictEqual;
         /**
@@ -687,6 +688,7 @@ declare module "node:test" {
          * test('example', t => {
          *   t.assert.ifError(err); // Error: 't' needs an explicit type annotation.
          * });
+         * ```
          */
         ifError: typeof import("node:assert").ifError;
         /**
@@ -726,6 +728,7 @@ declare module "node:test" {
          * test('example', t => {
          *   t.assert.ok(condition)); // Error: 't' needs an explicit type annotation.
          * });
+         * ```
          */
         ok: typeof import("node:assert").ok;
         /**
@@ -749,6 +752,7 @@ declare module "node:test" {
          * test('example', t => {
          *   t.assert.strictEqual(actual, expected); // Error: 't' needs an explicit type annotation.
          * });
+         * ```
          */
         strictEqual: typeof import("node:assert").strictEqual;
         /**

--- a/types/node/v20/test/test.ts
+++ b/types/node/v20/test/test.ts
@@ -963,7 +963,10 @@ test("planning with streams", (t: TestContext, done) => {
 
     const stream = Readable.from(generate());
     stream.on("data", (chunk) => {
-        t.assert.strictEqual(chunk, expected.shift());
+        t.assert.strictEqual(chunk, expected.shift()!);
+
+        // $ExpectType string
+        chunk;
     });
 
     stream.on("end", () => {


### PR DESCRIPTION
See: #70477, #70584

The v22.2 and v20.15 typings introduced the `TestContext#assert` methods, aliases for the top-level node:assert functions which are bound to the test context.

The types are correct, but because some of these functions return assertion predicates, they cannot be used in expression statements unless the test context object is explicitly typed – and due to the setting in which test context objects arise, this isn't ordinarily necessary. For example, taking the test planning example from the Node documentation:
```js
test('top level test', (t) => {
  t.plan(2);
  t.assert.ok('some relevant assertion here'); // <== 😕
  t.subtest('subtest', () => {});
});
```

Although the compiler happily infers the type of `t`, the call to `t.assert.ok()` raises a compilation error in TypeScript unless the parameter also has an explicit `TestContext` type annotation. This was identified at the time that the types were added to TestContext (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70193#pullrequestreview-2214645441), but there's no way around it other than to re-type the methods to remove the assertion behaviour altogether, which isn't a particularly satisfactory solution.

Unfortunately, the error reported by TypeScript isn't particularly clear to users who aren't expecting it. Hopefully, some more explicit documentation might help.

Also adds a type check to the existing use of one of the assertion methods in the test suite, to ensure that it actually manifests a type assertion. This is motivated by a couple of suggested workarounds to this issue, which inadvertently re-type the assertion methods to return `void` instead of an assertion predicate.
