### PR TITLE
[reveal.js] fix missing showNotes value

### DIFF
--- a/types/reveal.js/index.d.ts
+++ b/types/reveal.js/index.d.ts
@@ -1067,7 +1067,7 @@ declare namespace Reveal {
          *
          * @defaultValue `false`
          */
-        showNotes?: boolean;
+        showNotes?: boolean | "separate-page";
 
         /**
          * Flags if slides with data-visibility="hidden" should be kep visible

--- a/types/reveal.js/reveal.esm.js-tests.ts
+++ b/types/reveal.js/reveal.esm.js-tests.ts
@@ -421,6 +421,11 @@ deck.initialize({
     },
 });
 
+// $ExpectType Promise<void>
+deck.initialize({
+    showNotes: "separate-page",
+}).then(() => {});
+
 // Alternate representations
 
 // $ExpectType Promise<void>

--- a/types/reveal.js/reveal.js-tests.ts
+++ b/types/reveal.js/reveal.js-tests.ts
@@ -451,6 +451,11 @@ deck.initialize({
     },
 });
 
+// $ExpectType Promise<void>
+deck.initialize({
+    showNotes: "separate-page",
+}).then(() => {});
+
 // Alternate representations
 
 // $ExpectType Promise<void>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://revealjs.com/pdf-export/#speaker-notes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
