### PR TITLE
CI: Add node types directive to mongodb dependents

### DIFF
--- a/types/migrate-mongo/index.d.ts
+++ b/types/migrate-mongo/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 import * as mongo from "mongodb";
 
 export function init(): Promise<void>;

--- a/types/mongodb-queue/index.d.ts
+++ b/types/mongodb-queue/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 import { Db, MongoError } from "mongodb";
 
 declare function mongodbQueue(db: Db, name: string, opts?: mongodbQueue.QueueOptions): mongodbQueue.Queue;


### PR DESCRIPTION
mongodb's .d.ts no longer includes triple-slash references to @types/node since upgrading its toolchain to TS 5.5, which breaks the tests which relied on these definitions (especially exported types from mongodb which are derived from node types).

Adding a types directive to the definitions is probably the easiest solution, although it does somewhat go against the philosophy of https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#simplified-reference-directive-declaration-emit.