### PR TITLE
[react] Add new Link/Style props to Canary release channel

### DIFF
--- a/types/react/canary.d.ts
+++ b/types/react/canary.d.ts
@@ -136,6 +136,15 @@ declare module "." {
         newState: "closed" | "open";
     }
 
+    interface LinkHTMLAttributes<T> {
+        precedence?: string | undefined;
+    }
+
+    interface StyleHTMLAttributes<T> {
+        href?: string | undefined;
+        precedence?: string | undefined;
+    }
+
     /**
      * @internal Use `Awaited<ReactNode>` instead
      */

--- a/types/react/test/canary.tsx
+++ b/types/react/test/canary.tsx
@@ -441,3 +441,7 @@ function PopoverAPI() {
         </>
     );
 }
+
+// New <link> and <style> props
+<link href="https://foo.bar" precedence="medium" rel="canonical" />;
+<style href="unique-style-hash" precedence="anything">{` p { color: red; } `}</style>;

--- a/types/react/ts5.0/canary.d.ts
+++ b/types/react/ts5.0/canary.d.ts
@@ -136,6 +136,15 @@ declare module "." {
         newState: "closed" | "open";
     }
 
+    interface LinkHTMLAttributes<T> {
+        precedence?: string | undefined;
+    }
+
+    interface StyleHTMLAttributes<T> {
+        href?: string | undefined;
+        precedence?: string | undefined;
+    }
+
     /**
      * @internal Use `Awaited<ReactNode>` instead
      */

--- a/types/react/ts5.0/test/canary.tsx
+++ b/types/react/ts5.0/test/canary.tsx
@@ -441,3 +441,7 @@ function PopoverAPI() {
         </>
     );
 }
+
+// New <link> and <style> props
+<link href="https://foo.bar" precedence="medium" rel="canonical" />;
+<style href="unique-style-hash" precedence="anything">{` p { color: red; } `}</style>;


### PR DESCRIPTION
Types for new React v19 props for [`<link>` element](https://react.dev/reference/react-dom/components/link#props) and [`<style>` element](https://react.dev/reference/react-dom/components/style#props)