### PR TITLE
fix(opossum): Add typedef for missing methods and options

### DIFF
--- a/types/opossum/index.d.ts
+++ b/types/opossum/index.d.ts
@@ -2,25 +2,76 @@
 import { EventEmitter } from "events";
 
 declare class CircuitBreaker<TI extends unknown[] = unknown[], TR = unknown> extends EventEmitter {
-    static isOurError(error: any): boolean;
+    static isOurError(error: Error): boolean;
+    static newStatus(options: CircuitBreaker.StatusOptions): CircuitBreaker.Status;
 
     constructor(action: (...args: TI) => Promise<TR>, options?: CircuitBreaker.Options<TI>);
 
+    /**
+     * Gets the name of this circuit
+     */
     readonly name: string;
+
+    /**
+     * Gets the name of this circuit group
+     */
     readonly group: string;
+
+    /**
+     * Gets whether the circuit is enabled or not
+     */
     readonly enabled: boolean;
+    /**
+     * Gets whether this circuit is in the pendingClosed state
+     */
     readonly pendingClose: boolean;
+
+    /**
+     * True if the circuit is currently closed. False otherwise.
+     */
     readonly closed: boolean;
+
+    /**
+     * True if the circuit is currently opened. False otherwise.
+     */
     readonly opened: boolean;
+
+    /**
+     * True if the circuit is currently half opened. False otherwise.
+     */
     readonly halfOpen: boolean;
+
+    /**
+     * Determines if the circuit has been shutdown.
+     */
     readonly isShutdown: boolean;
+
+    /**
+     * The current {@link CircuitBreaker.Status} of this {@link CircuitBreaker}
+     */
     readonly status: CircuitBreaker.Status;
+
+    /**
+     * Get the current stats for the circuit.
+     */
     readonly stats: CircuitBreaker.Stats;
+
+    /**
+     * Gets whether the circuit is currently in warm up phase
+     */
     readonly warmUp: boolean;
+
+    /**
+     * Gets the volume threshold for this circuit
+     */
     readonly volumeThreshold: number;
 
     /**
-     * Execute the action for this circuit with a provided this argument
+     * Execute the action for this circuit using context as this.
+     * If the action fails or times out, the returned promise will be rejected.
+     * If the action succeeds, the promise will resolve with the resolved value from action.
+     * If a fallback function was provided, it will be invoked in the event of any failure or timeout.
+     * Any parameters in addition to `context` will be passed to the circuit function.
      */
     call(context: any, ...args: TI): Promise<TR>;
 
@@ -30,7 +81,7 @@ declare class CircuitBreaker<TI extends unknown[] = unknown[], TR = unknown> ext
     toJSON(): { state: CircuitBreaker.State; status: CircuitBreaker.Stats };
 
     /**
-     * Clears the cache of this CircuitBreaker
+     * Clears the cache of this {@link CircuitBreaker}
      */
     clearCache(): void;
 
@@ -65,7 +116,7 @@ declare class CircuitBreaker<TI extends unknown[] = unknown[], TR = unknown> ext
     enable(): void;
 
     /**
-     * Provide a fallback function for this CircuitBreaker.
+     * Provide a fallback function for this {@link CircuitBreaker}.
      * This function will be executed when the circuit is fired and fails.
      * It will always be preceded by a `failure` event, and `breaker.fire` returns a rejected Promise.
      */
@@ -76,6 +127,7 @@ declare class CircuitBreaker<TI extends unknown[] = unknown[], TR = unknown> ext
      * If the action fails or times out, the returned promise will be rejected.
      * If the action succeeds, the promise will resolve with the resolved value from action.
      * If a fallback function was provided, it will be invoked in the event of any failure or timeout.
+     * Any parameters passed to this function will be proxied to the circuit function.
      */
     fire(...args: TI): Promise<TR>;
 
@@ -94,26 +146,72 @@ declare class CircuitBreaker<TI extends unknown[] = unknown[], TR = unknown> ext
      */
     healthCheck(func: () => Promise<void>, interval?: number): void;
 
-    /* tslint:disable:unified-signatures */
+    /**
+     * Emitted after `options.resetTimeout` has elapsed, allowing for a single attempt to call the service again.
+     * If that attempt is successful, the circuit will be closed. Otherwise it remains open.
+     */
     on(event: "halfOpen", listener: (resetTimeout: number) => void): this;
+    /**
+     * Emitted when the breaker is reset allowing the action to execute again.
+     */
     on(event: "close", listener: () => void): this;
+    /**
+     * Emitted when the breaker opens because the action has failure percentage greater than `options.errorThresholdPercentage`.
+     */
     on(event: "open", listener: () => void): this;
+    /**
+     * Emitted when the circuit breaker has been shut down.
+     */
     on(event: "shutdown", listener: () => void): this;
+    /**
+     * Emitted when the circuit breaker action is executed.
+     */
     on(event: "fire", listener: (args: TI) => void): this;
+    /**
+     * Emitted when the circuit breaker is using the cache and finds a value.
+     */
     on(event: "cacheHit", listener: () => void): this;
+    /**
+     * Emitted when the circuit breaker does not find a value in the cache, but the cache option is enabled.
+     */
     on(event: "cacheMiss", listener: () => void): this;
+    /**
+     * Emitted when the circuit breaker is open and failing fast.
+     */
     on(event: "reject", listener: (err: Error) => void): this;
+    /**
+     * Emitted when the circuit breaker action takes longer than `options.timeout`.
+     */
     on(event: "timeout", listener: (err: Error) => void): this;
+    /**
+     * Emitted when the circuit breaker action succeeds.
+     */
     on(event: "success", listener: (result: TR, latencyMs: number) => void): this;
+    /**
+     * Emitted when the rate limit has been reached and there are no more locks to be obtained.
+     */
     on(event: "semaphoreLocked", listener: (err: Error) => void): this;
+    /**
+     * Emitted with the user-supplied health check function returns a rejected promise.
+     */
     on(event: "healthCheckFailed", listener: (err: Error) => void): this;
+    /**
+     * Emitted when the circuit breaker executes a fallback function.
+     */
     on(event: "fallback", listener: (result: unknown, err: Error) => void): this;
+    /**
+     * Emitted when the circuit breaker action fails.
+     */
     on(event: "failure", listener: (err: Error, latencyMs: number, args: TI) => void): this;
-    /* tslint:enable:unified-signatures */
 }
 
 declare namespace CircuitBreaker {
     interface Options<TI extends unknown[] = unknown[]> {
+        /**
+         * A {@link Status} object that might have pre-prime stats
+         */
+        status?: Status | undefined;
+
         /**
          * The time in milliseconds that action should be allowed to execute before timing out.
          * Timeout can be disabled by setting this to `false`.
@@ -124,7 +222,8 @@ declare namespace CircuitBreaker {
         /**
          * The number of times the circuit can fail before opening.
          * @default 10
-         * @deprecated see options.errorThresholdPercentage
+         * @deprecated
+         * @see {@link Options.errorThresholdPercentage}
          */
         maxFailures?: number | undefined;
 
@@ -143,8 +242,8 @@ declare namespace CircuitBreaker {
 
         /**
          * Sets the number of buckets the rolling statistical window is divided into.
-         * So, if options.rollingCountTimeout is 10,000, and options.rollingCountBuckets is 10, then the
-         * statistical window will be 1,000 1 second snapshots in the statistical window.
+         * So, if `options.rollingCountTimeout` is 10,000, and `options.rollingCountBuckets` is 10, then the
+         * statistical window will be 1,000 per 1 second snapshots in the statistical window.
          * @default 10
          */
         rollingCountBuckets?: number | undefined;
@@ -156,6 +255,7 @@ declare namespace CircuitBreaker {
         name?: string | undefined;
 
         /**
+         * (Undocumented)
          * A grouping key for reporting.
          * Defaults to the computed value of `name`
          */
@@ -170,9 +270,9 @@ declare namespace CircuitBreaker {
 
         /**
          * The number of concurrent requests allowed.
-         * If the number currently executing function calls is equal to options.capacity, further calls
+         * If the number currently executing function calls is equal to `options.capacity`, further calls
          * to `fire()` are rejected until at least one of the current requests completes.
-         * @default MAX_SAFE_INTEGER
+         * @default Number.MAX_SAFE_INTEGER
          */
         capacity?: number | undefined;
 
@@ -223,13 +323,13 @@ declare namespace CircuitBreaker {
         /**
          * The cache time to live (TTL) in milliseconds.
          * The default value is 0, which means the cache will never be cleared.
-         * @default 0
+         * @default 0 (no TTL)
          */
         cacheTTL?: number;
 
         /**
          * An optional function that will be called to generate a cache key for the circuit's function.
-         * The function is passed the original `fire` arguments. If no `cacheKey` function is supplied, a JSON.stringify of the arguments will be used as the key.
+         * The function is passed the original `fire` arguments. If no `cacheKey` function is supplied, a `JSON.stringify` of the arguments will be used as the key.
          * @default (...args) => JSON.stringify(args)
          */
         cacheGetKey?: ((...args: TI) => string) | undefined;
@@ -239,6 +339,11 @@ declare namespace CircuitBreaker {
          * If a cacheTransport is provided, the cache will be stored there instead.
          */
         cacheTransport?: CacheTransport | undefined;
+
+        /**
+         * If present, Opossum can signal upon timeout and properly abort your on going requests instead of leaving it in the background.
+         */
+        abortController?: AbortController | undefined;
 
         /**
          * Whether to enable the periodic snapshots that are emitted by the Status class.
@@ -258,6 +363,22 @@ declare namespace CircuitBreaker {
         window: Window;
 
         on(event: "snapshot", listener: (snapshot: Stats) => void): this;
+    }
+
+    interface StatusOptions extends
+        Pick<
+            CircuitBreaker.Options,
+            | "rollingCountBuckets"
+            | "rollingCountTimeout"
+            | "rollingPercentilesEnabled"
+            | "enableSnapshots"
+            | "rotateBucketController"
+        >
+    {
+        /**
+         * object of previous stats
+         */
+        stats?: Stats;
     }
 
     interface Bucket {
@@ -291,7 +412,10 @@ declare namespace CircuitBreaker {
         lastTimerAt: symbol;
     }
 
-    interface CacheTransport {
+    /**
+     * Simple in-memory cache implementation
+     */
+    interface MemoryCache {
         /**
          * Get cache value by key
          * @param {string} key Cache key
@@ -312,6 +436,8 @@ declare namespace CircuitBreaker {
          */
         flush(): void;
     }
+
+    type CacheTransport = MemoryCache;
 }
 
 export = CircuitBreaker;

--- a/types/opossum/opossum-tests.ts
+++ b/types/opossum/opossum-tests.ts
@@ -1,39 +1,58 @@
-import * as fs from "fs";
+/// <reference types="node"/>
+import { EventEmitter } from "node:events";
+import * as fs from "node:fs";
+import { promisify } from "node:util";
+
 import * as CircuitBreaker from "opossum";
-import { promisify } from "util";
 
 let breaker: CircuitBreaker;
 const callbackNoArgs = async () => console.log("foo");
 
 CircuitBreaker.isOurError(new Error()); // $ExpectType boolean
 
+CircuitBreaker.newStatus({}); // $ExpectType Status
+CircuitBreaker.newStatus({ rollingCountBuckets: 20 }); // $ExpectType Status
+CircuitBreaker.newStatus({ rollingCountTimeout: 500 }); // $ExpectType Status
+CircuitBreaker.newStatus({ rollingPercentilesEnabled: true }); // $ExpectType Status
+CircuitBreaker.newStatus({ enableSnapshots: true }); // $ExpectType Status
+CircuitBreaker.newStatus({ rotateBucketController: new EventEmitter() }); // $ExpectType Status
+
+breaker = new CircuitBreaker(async () => true, {});
+breaker = new CircuitBreaker(async () => true, { status: CircuitBreaker.newStatus({}) });
+breaker = new CircuitBreaker(async () => true, { timeout: 1000 });
+breaker = new CircuitBreaker(async () => true, { maxFailures: 50 });
+breaker = new CircuitBreaker(async () => true, { resetTimeout: 10 });
+breaker = new CircuitBreaker(async () => true, { rollingCountTimeout: 500 });
+breaker = new CircuitBreaker(async () => true, { rollingCountBuckets: 20 });
+breaker = new CircuitBreaker(async () => true, { name: "test" });
+breaker = new CircuitBreaker(async () => true, { group: "group" });
+breaker = new CircuitBreaker(async () => true, { rollingPercentilesEnabled: true });
+breaker = new CircuitBreaker(async () => true, { capacity: 1 });
+breaker = new CircuitBreaker(async () => true, { errorThresholdPercentage: 1 });
+breaker = new CircuitBreaker(async () => true, { enabled: true });
+breaker = new CircuitBreaker(async () => true, { allowWarmUp: true });
+breaker = new CircuitBreaker(async () => true, { volumeThreshold: 1 });
 breaker = new CircuitBreaker(async () => true, {
-    timeout: 1000,
-    maxFailures: 50,
-    resetTimeout: 10,
-    rollingCountTimeout: 500,
-    rollingCountBuckets: 20,
-    name: "test",
-    group: "group",
-    rollingPercentilesEnabled: true,
-    capacity: 1,
-    errorThresholdPercentage: 1,
-    enabled: true,
-    allowWarmUp: true,
-    volumeThreshold: 1,
-    cache: true,
-    cacheTTL: 100,
-    cacheGetKey: (...args) => JSON.stringify(args),
-    cacheTransport: {
-        get: (key) => key,
-        set: (key, value, ttl) => {},
-        flush: () => {},
-    },
     errorFilter: (err) => {
         err; // $ExpectType any
         return true;
     },
 });
+breaker = new CircuitBreaker(async () => true, { cache: true });
+breaker = new CircuitBreaker(async () => true, { cacheTTL: 100 });
+breaker = new CircuitBreaker(async () => true, {
+    cacheGetKey: (...args) => JSON.stringify(args),
+});
+breaker = new CircuitBreaker(async () => true, {
+    cacheTransport: {
+        get: (key) => key,
+        set: (key, value, ttl) => {},
+        flush: () => {},
+    },
+});
+breaker = new CircuitBreaker(async () => true, { abortController: new AbortController() });
+breaker = new CircuitBreaker(async () => true, { enableSnapshots: true });
+breaker = new CircuitBreaker(async () => true, { rotateBucketController: new EventEmitter() });
 
 breaker.name; // $ExpectType string
 breaker.group; // $ExpectType string
@@ -45,8 +64,42 @@ breaker.halfOpen; // $ExpectType boolean
 breaker.warmUp; // $ExpectType boolean
 breaker.isShutdown; // $ExpectType boolean
 breaker.volumeThreshold; // $ExpectType number
+breaker.status; // $ExpectType Status
+breaker.status.stats; // $ExpectType Stats
 breaker.status.stats.latencyMean; // $ExpectType number
+breaker.status.stats.failures; // $ExpectType number
+breaker.status.stats.fallbacks; // $ExpectType number
+breaker.status.stats.successes; // $ExpectType number
+breaker.status.stats.rejects; // $ExpectType number
+breaker.status.stats.fires; // $ExpectType number
+breaker.status.stats.timeouts; // $ExpectType number
+breaker.status.stats.cacheHits; // $ExpectType number
+breaker.status.stats.cacheMisses; // $ExpectType number
+breaker.status.stats.semaphoreRejections; // $ExpectType number
+breaker.status.stats.percentiles; // $ExpectType { [percentile: number]: number }
+breaker.status.stats.latencyTimes; // $ExpectType number[]
+breaker.status.stats.latencyMean; // $ExpectType number
+breaker.stats; // $ExpectType Stats
+breaker.stats.latencyMean; // $ExpectType number
+breaker.stats.failures; // $ExpectType number
+breaker.stats.fallbacks; // $ExpectType number
+breaker.stats.successes; // $ExpectType number
+breaker.stats.rejects; // $ExpectType number
+breaker.stats.fires; // $ExpectType number
+breaker.stats.timeouts; // $ExpectType number
+breaker.stats.cacheHits; // $ExpectType number
+breaker.stats.cacheMisses; // $ExpectType number
+breaker.stats.semaphoreRejections; // $ExpectType number
+breaker.stats.percentiles; // $ExpectType { [percentile: number]: number }
 breaker.stats.latencyTimes; // $ExpectType number[]
+breaker.stats.latencyMean; // $ExpectType number
+
+// @ts-expect-error
+breaker.healthCheck();
+breaker.healthCheck(async () => {}); // ExpectType void
+// @ts-expect-error
+breaker.healthCheck(async () => {}, "300");
+breaker.healthCheck(async () => {}, 300); // ExpectType void
 
 breaker.clearCache(); // $ExpectType void
 breaker.open(); // $ExpectType void


### PR DESCRIPTION
- Add missing things according to [documentation](https://nodeshift.dev/opossum/#memorycache).
    - Add `static CircuitBreaker.newStatus()`.
    - Add `status?`, `abortController?` to `CircuitBreaker.Options`. Resolve [discussion #55318](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/55318) and [discussion #69415](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69415).
    - Add `interface StatusOptions`.
- Modify (a lot of) jsdoc comments.
- Removed no-longer useful `tslint:disable`.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
