### PR TITLE
feat(react-dnd-scrollzone): Add missing exports, add tests

### DIFF
--- a/types/react-dnd-scrollzone/index.d.ts
+++ b/types/react-dnd-scrollzone/index.d.ts
@@ -1,1 +1,64 @@
-export default function withScrolling<T>(component: T): T;
+import { ComponentType } from "react";
+
+/**
+ * The strength functions are both called with two arguments.
+ * 1. An object representing the rectangle occupied by the Scrollzone.
+ * 2. An object representing the coordinates of mouse.
+ *
+ * They should return a value between -1 and 1.
+ * - Negative values scroll up or left.
+ * - Positive values scroll down or right.
+ * - 0 stops all scrolling.
+ */
+export type StrengthCallback = (
+    scrollZone: {
+        x: number;
+        y: number;
+        w: number;
+        h: number;
+    },
+    mouse: {
+        x: number;
+        y: number;
+    },
+) => number;
+
+export function createVerticalStrength(buffer: number): StrengthCallback;
+export function createHorizontalStrength(buffer: number): StrengthCallback;
+
+export const defaultVerticalStrength: StrengthCallback;
+export const defaultHorizontalStrength: StrengthCallback;
+
+export default function withScrolling<T>(component: ComponentType<T>): ComponentType<
+    T & {
+        /**
+         * A function that is called when scrollLeft or scrollTop of the component are changed.
+         * Called with those two arguments in that order.
+         *
+         * @default noop
+         */
+        onScrollChange?: (top: number, left: number) => void;
+
+        /**
+         * A function that returns the strength of the vertical scroll direction.
+         * It should return a value between -1 and 1.
+         *
+         * @default defaultVerticalStrength
+         */
+        verticalStrength?: StrengthCallback;
+
+        /**
+         * A function that returns the strength of the horizontal scroll direction.
+         *
+         * @default defaultHorizontalStrength
+         */
+        horizontalStrength?: StrengthCallback;
+
+        /**
+         * Strength multiplier
+         *
+         * @default 30
+         */
+        strengthMultiplier?: number;
+    }
+>;

--- a/types/react-dnd-scrollzone/package.json
+++ b/types/react-dnd-scrollzone/package.json
@@ -5,8 +5,10 @@
     "projects": [
         "https://github.com/azuqua/react-dnd-scrollzone#readme"
     ],
+    "dependencies": {
+        "@types/react": "*"
+    },
     "devDependencies": {
-        "@types/react": "*",
         "@types/react-dnd-scrollzone": "workspace:."
     },
     "owners": [

--- a/types/react-dnd-scrollzone/react-dnd-scrollzone-tests.ts
+++ b/types/react-dnd-scrollzone/react-dnd-scrollzone-tests.ts
@@ -1,7 +1,0 @@
-import * as React from "react";
-import withScrolling from "react-dnd-scrollzone";
-
-class SimpleTestComponent extends React.Component {
-}
-
-export default withScrolling(SimpleTestComponent);

--- a/types/react-dnd-scrollzone/react-dnd-scrollzone-tests.tsx
+++ b/types/react-dnd-scrollzone/react-dnd-scrollzone-tests.tsx
@@ -1,0 +1,92 @@
+import * as React from "react";
+import withScrolling, { createHorizontalStrength, createVerticalStrength } from "react-dnd-scrollzone";
+
+// Test class component
+{
+    const TestClassComponent = withScrolling(class extends React.Component {});
+
+    <TestClassComponent />;
+
+    <TestClassComponent
+        onScrollChange={(top, left) => {
+            top; // $ExpectType number
+            left; // $ExpectType number
+        }}
+    />;
+
+    <TestClassComponent
+        verticalStrength={(scrollzone, mouse) => {
+            scrollzone.x; // $ExpectType number
+            scrollzone.y; // $ExpectType number
+            scrollzone.w; // $ExpectType number
+            scrollzone.h; // $ExpectType number
+            mouse.x; // $ExpectType number
+            mouse.y; // $ExpectType number
+
+            return -1;
+        }}
+    />;
+
+    <TestClassComponent
+        horizontalStrength={(scrollzone, mouse) => {
+            scrollzone.x; // $ExpectType number
+            scrollzone.y; // $ExpectType number
+            scrollzone.w; // $ExpectType number
+            scrollzone.h; // $ExpectType number
+            mouse.x; // $ExpectType number
+            mouse.y; // $ExpectType number
+
+            return -1;
+        }}
+    />;
+
+    <TestClassComponent strengthMultiplier={20} />;
+}
+
+// Test functional component
+{
+    const TestFnComponent = withScrolling(() => <div />);
+
+    <TestFnComponent />;
+
+    <TestFnComponent
+        onScrollChange={(top, left) => {
+            top; // $ExpectType number
+            left; // $ExpectType number
+        }}
+    />;
+
+    <TestFnComponent
+        verticalStrength={(scrollzone, mouse) => {
+            scrollzone.x; // $ExpectType number
+            scrollzone.y; // $ExpectType number
+            scrollzone.w; // $ExpectType number
+            scrollzone.h; // $ExpectType number
+            mouse.x; // $ExpectType number
+            mouse.y; // $ExpectType number
+
+            return -1;
+        }}
+    />;
+
+    <TestFnComponent
+        horizontalStrength={(scrollzone, mouse) => {
+            scrollzone.x; // $ExpectType number
+            scrollzone.y; // $ExpectType number
+            scrollzone.w; // $ExpectType number
+            scrollzone.h; // $ExpectType number
+            mouse.x; // $ExpectType number
+            mouse.y; // $ExpectType number
+
+            return -1;
+        }}
+    />;
+
+    <TestFnComponent strengthMultiplier={20} />;
+}
+
+// $ExpectType StrengthCallback
+createVerticalStrength(25);
+
+// $ExpectType StrengthCallback
+createHorizontalStrength(20);

--- a/types/react-dnd-scrollzone/tsconfig.json
+++ b/types/react-dnd-scrollzone/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": [
             "es6"
         ],
+        "jsx": "preserve",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,
@@ -14,6 +15,6 @@
     },
     "files": [
         "index.d.ts",
-        "react-dnd-scrollzone-tests.ts"
+        "react-dnd-scrollzone-tests.tsx"
     ]
 }


### PR DESCRIPTION
From `readme` and `index.js` in the [original repo](https://github.com/azuqua/react-dnd-scrollzone), there are some exports that the old typedef does not include.
- `createVerticalStrength()`
- `defaultHorizontalStrength()`
- `defaultVerticalStrength`
- `defaultHorizontalStrength`

This PR helps exports them to typescript users.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
