### PR TITLE
fix(react-world-flags): Fix "FalseExportDefault", remove src, upgrade

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -1597,7 +1597,6 @@
         "react-user-tour",
         "react-widgets-moment",
         "react-window-size",
-        "react-world-flags",
         "react-youtube-embed",
         "readline-transform",
         "readmore-js",

--- a/types/react-world-flags/index.d.ts
+++ b/types/react-world-flags/index.d.ts
@@ -1,20 +1,22 @@
 import * as React from "react";
 
-export interface FlagProps extends React.HTMLProps<HTMLImageElement> {
-    /**
-     * code is the two letter, three letter or three digit country code.
-     */
-    code?: string | undefined;
+declare namespace Flag {
+    interface FlagProps extends Omit<React.HTMLProps<HTMLImageElement>, "src"> {
+        /**
+         * code is the two letter, three letter or three digit country code.
+         */
+        code?: string | undefined;
 
-    /**
-     * You can also pass an optional fallback which renders if the given code doesn't correspond to a flag
-     */
-    fallback?: React.ReactNode | null | undefined;
+        /**
+         * You can also pass an optional fallback which renders if the given code doesn't correspond to a flag
+         */
+        fallback?: React.ReactNode | null | undefined;
+    }
 }
 
 /**
  * Easy to use SVG flags of the world for react
  */
-declare const Flag: React.FC<FlagProps>;
+declare const Flag: React.FC<Flag.FlagProps>;
 
-export default Flag;
+export = Flag;

--- a/types/react-world-flags/package.json
+++ b/types/react-world-flags/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/react-world-flags",
-    "version": "1.4.9999",
+    "version": "1.6.9999",
     "projects": [
         "https://github.com/smucode/react-world-flags#readme"
     ],

--- a/types/react-world-flags/react-world-flags-tests.tsx
+++ b/types/react-world-flags/react-world-flags-tests.tsx
@@ -1,11 +1,14 @@
 import * as React from "react";
 import Flag from "react-world-flags";
 
-const tests = () => {
-    return [
-        <Flag code="nor" height="16" />,
-        <Flag code="foo" fallback={<span>Unknown</span>} />,
-        <Flag code="" height="42" fallback={<span>Does not exist.</span>} />,
-        <Flag code="xxx" height="42" />,
-    ];
-};
+// $ExpectType Element
+<Flag code="nor" height="16" />;
+// $ExpectType Element
+<Flag code="foo" fallback={<span>Unknown</span>} />;
+// $ExpectType Element
+<Flag code="" height="42" fallback={<span>Does not exist.</span>} />;
+// $ExpectType Element
+<Flag code="xxx" height="42" />;
+
+// @ts-expect-error
+<Flag src="abc.com" />;


### PR DESCRIPTION
From the [implementation](https://github.com/smucode/react-world-flags/blob/9f8df135b408cc80f531e34563fbd0e8dd12f2f7/src/Flag.js#L14), `img.src` is actually an internal computed value, and is not affected by `props.src`, hence typescript users shall be warned about that.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
