### PR TITLE
feat(react-text-truncate): fix MissingExportEquals, upgrade version

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -1588,7 +1588,6 @@
         "react-tag-input",
         "react-tap-event-plugin",
         "react-text-mask",
-        "react-text-truncate",
         "react-touch",
         "react-transition-group",
         "react-type-animation",

--- a/types/react-text-truncate/index.d.ts
+++ b/types/react-text-truncate/index.d.ts
@@ -1,19 +1,27 @@
 import * as React from "react";
 
-export interface TextTruncateProps {
-    containerClassName?: string | undefined;
-    element?: string | undefined;
-    line?: number | boolean | undefined;
-    onCalculated?: (() => void) | undefined;
-    onTruncated?: (() => void) | undefined;
-    onToggled?: ((truncated: boolean) => void) | undefined;
-    text?: string | undefined;
-    textElement?: React.ReactNode | undefined;
-    textTruncateChild?: React.ReactNode | undefined;
-    truncateText?: string | undefined;
-    maxCalculateTimes?: number | undefined;
+declare namespace TextTruncate {
+    interface TextTruncateProps {
+        containerClassName?: string | undefined;
+        /** @default "div" */
+        element?: string | undefined;
+        /** @default 1 */
+        line?: number | boolean | undefined;
+        onCalculated?: (() => void) | undefined;
+        onTruncated?: (() => void) | undefined;
+        onToggled?: ((truncated: boolean) => void) | undefined;
+        /** @default "" */
+        text?: string | undefined;
+        /** @default "span" */
+        textElement?: React.ReactNode | undefined;
+        textTruncateChild?: React.ReactNode | undefined;
+        /** @default "..." */
+        truncateText?: string | undefined;
+        /** @default 10 */
+        maxCalculateTimes?: number | undefined;
+    }
 }
 
-declare class TextTruncate extends React.Component<TextTruncateProps> {}
+declare class TextTruncate extends React.Component<TextTruncate.TextTruncateProps> {}
 
-export default TextTruncate;
+export = TextTruncate;

--- a/types/react-text-truncate/package.json
+++ b/types/react-text-truncate/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/react-text-truncate",
-    "version": "0.14.9999",
+    "version": "0.19.9999",
     "projects": [
         "https://github.com/ShinyChang/react-text-truncate"
     ],

--- a/types/react-text-truncate/react-text-truncate-tests.tsx
+++ b/types/react-text-truncate/react-text-truncate-tests.tsx
@@ -1,18 +1,53 @@
 import * as React from "react";
 import TextTruncate from "react-text-truncate";
 
-const TruncatedText = () => (
-    <TextTruncate
-        text="My Text"
-        line={2}
-        containerClassName="my-container"
-        element="span"
-        onCalculated={() => {}}
-        onTruncated={() => {}}
-        onToggled={(truncate: boolean) => {}}
-        textElement={<div />}
-        textTruncateChild={<div />}
-        truncateText="..."
-        maxCalculateTimes={5}
-    />
-);
+<TextTruncate />;
+
+// @ts-expect-error
+<TextTruncate containerClassName={1} />;
+<TextTruncate containerClassName="class-name" />;
+
+// @ts-expect-error
+<TextTruncate element={2} />;
+<TextTruncate element="textarea" />;
+
+// @ts-expect-error
+<TextTruncate line="textarea" />;
+<TextTruncate line={2} />;
+<TextTruncate line={true} />;
+
+// @ts-expect-error
+<TextTruncate onCalculated="textarea" />;
+<TextTruncate onCalculated={() => {}} />;
+
+// @ts-expect-error
+<TextTruncate onTruncated="textarea" />;
+<TextTruncate onTruncated={() => {}} />;
+
+// @ts-expect-error
+<TextTruncate onToggled="textarea" />;
+<TextTruncate
+    onToggled={(arg) => {
+        arg; // $ExpectType boolean
+    }}
+/>;
+
+// @ts-expect-error
+<TextTruncate text={2} />;
+<TextTruncate text="textarea" />;
+
+// @ts-expect-error
+<TextTruncate textElement={{}} />;
+<TextTruncate textElement={<div />} />;
+
+// @ts-expect-error
+<TextTruncate textTruncateChild={{}} />;
+<TextTruncate textTruncateChild={<div />} />;
+
+// @ts-expect-error
+<TextTruncate truncateText={2} />;
+<TextTruncate truncateText="textarea" />;
+
+// @ts-expect-error
+<TextTruncate maxCalculateTimes="textarea" />;
+<TextTruncate maxCalculateTimes={2} />;


### PR DESCRIPTION
- Change `export default` to `export =` for resolving error.
- Upgrade version to sync with the library's one.
- Add a few `@default` jsdoc comment according to [`defaultProps`](https://github.com/ShinyChang/React-Text-Truncate/blob/35f8ac6abfc9b02c4f46f081cec1488feedab224/src/TextTruncate.js#L22-L29) in library implementation.
- Refine test to show optional-ness of each props.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
