### PR TITLE
[types/react] export CSS to use Property namespaces.

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2593,6 +2593,8 @@ declare namespace React {
          */
     }
 
+    export { CSS }
+
     // All the WAI-ARIA 1.1 attributes from https://www.w3.org/TR/wai-aria-1.1/
     interface AriaAttributes {
         /** Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. */

--- a/types/react/test/cssProperties.tsx
+++ b/types/react/test/cssProperties.tsx
@@ -46,3 +46,6 @@ const strokeOpacityStyleTest = <svg style={strokeOpacityStyle} />;
 
 const strokeWidthStyle: React.CSSProperties = { strokeWidth: "10px" };
 const strokeWidthStyleTest = <svg style={strokeWidthStyle} />;
+
+const propertyWidth: React.CSS.Property.Width = "10px";
+const propertyWidthTest = <div style={width:propertyWidth}/>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. **Numerous errors are detected in existing code.**
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/70612>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the package.json. ** It has nothing to do with libraries.**


### Description
#70612 
- This is the simplest way to solve the issue.
- In addition to this, there is a way to indirectly encourage developers to use the index signature of CSSProperty rather than Property by using JSDOC rather than type.
- Alternatively, there is a way to import the property name space of csstype into types/react.
I think there are many other ways besides this.
