### PR TITLE
fix: make n3 DataFactory extend RDF.DataFactory

### DIFF
--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -95,31 +95,33 @@ export class Quad extends BaseQuad implements RDF.Quad {
 
 export class Triple extends Quad implements RDF.Quad {}
 
-export namespace DataFactory {
-    function namedNode<Iri extends string = string>(value: Iri): NamedNode<Iri>;
-    function blankNode(value?: string): BlankNode;
-    function literal(value: string | number, languageOrDatatype?: string | RDF.NamedNode): Literal;
-    function variable(value: string): Variable;
-    function defaultGraph(): DefaultGraph;
-    function quad(
+export interface DataFactoryInterface<Q_In extends RDF.BaseQuad = RDF.Quad, Q_Out extends BaseQuad = Quad> extends RDF.DataFactory<Q_In, Q_Out> {
+    namedNode<Iri extends string = string>(value: Iri): NamedNode<Iri>;
+    blankNode(value?: string): BlankNode;
+    literal(value: string | number, languageOrDatatype?: string | RDF.NamedNode): Literal;
+    variable(value: string): Variable;
+    defaultGraph(): DefaultGraph;
+    quad(
         subject: RDF.Quad_Subject,
         predicate: RDF.Quad_Predicate,
         object: RDF.Quad_Object,
         graph?: RDF.Quad_Graph,
     ): Quad;
-    function quad<Q_In extends RDF.BaseQuad = RDF.Quad, Q_Out extends BaseQuad = Quad>(
+    quad<Q_In extends RDF.BaseQuad = RDF.Quad, Q_Out extends BaseQuad = Quad>(
         subject: Q_In["subject"],
         predicate: Q_In["predicate"],
         object: Q_In["object"],
         graph?: Q_In["graph"],
     ): Q_Out;
-    function triple(subject: RDF.Quad_Subject, predicate: RDF.Quad_Predicate, object: RDF.Quad_Object): Quad;
-    function triple<Q_In extends RDF.BaseQuad = RDF.Quad, Q_Out extends BaseQuad = Quad>(
+    triple(subject: RDF.Quad_Subject, predicate: RDF.Quad_Predicate, object: RDF.Quad_Object): Quad;
+    triple<Q_In extends RDF.BaseQuad = RDF.Quad, Q_Out extends BaseQuad = Quad>(
         subject: Q_In["subject"],
         predicate: Q_In["predicate"],
         object: Q_In["object"],
     ): Q_Out;
 }
+
+export const DataFactory: DataFactoryInterface;
 
 export type ErrorCallback = (err: Error, result: any) => void;
 export type QuadCallback<Q extends BaseQuad = Quad> = (result: Q) => void;

--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -95,7 +95,9 @@ export class Quad extends BaseQuad implements RDF.Quad {
 
 export class Triple extends Quad implements RDF.Quad {}
 
-export interface DataFactoryInterface<Q_In extends RDF.BaseQuad = RDF.Quad, Q_Out extends BaseQuad = Quad> extends RDF.DataFactory<Q_In, Q_Out> {
+export interface DataFactoryInterface<Q_In extends RDF.BaseQuad = RDF.Quad, Q_Out extends BaseQuad = Quad>
+    extends RDF.DataFactory<Q_In, Q_Out>
+{
     namedNode<Iri extends string = string>(value: Iri): NamedNode<Iri>;
     blankNode(value?: string): BlankNode;
     literal(value: string | number, languageOrDatatype?: string | RDF.NamedNode): Literal;

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -567,3 +567,6 @@ function test_reasoner() {
     new N3.Reasoner(store).reason(new N3.Store());
     new N3.Reasoner(store).reason(new N3.Store<RDF.BaseQuad>());
 }
+
+export const namedNode: ReturnType<RDF.DataFactory['namedNode']> = N3.DataFactory.namedNode('hello world')
+export const df: RDF.DataFactory = N3.DataFactory;

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -568,5 +568,5 @@ function test_reasoner() {
     new N3.Reasoner(store).reason(new N3.Store<RDF.BaseQuad>());
 }
 
-export const namedNode: ReturnType<RDF.DataFactory['namedNode']> = N3.DataFactory.namedNode('hello world')
+export const namedNode: ReturnType<RDF.DataFactory["namedNode"]> = N3.DataFactory.namedNode("hello world");
 export const df: RDF.DataFactory = N3.DataFactory;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [NA] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [NA] Provide a URL to documentation or source code which provides context for the suggested changes: N3 implements RDF/JS spec, it is expected that it should extend this interface
- [NA] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
