### PR TITLE
[lodash] Make _.head return a non-nullish type for tuples with length >= 1

### DIFF
--- a/types/lodash/common/array.d.ts
+++ b/types/lodash/common/array.d.ts
@@ -574,7 +574,7 @@ declare module "../index" {
          * @param array The array to query.
          * @return Returns the first element of array.
          */
-        head<T extends readonly unknown[]>(array: T): never[] extends T ? T[number] | undefined : T[0];
+        head<T>(array: readonly [T, ...unknown[]]): T;
         head<T>(array: List<T> | null | undefined): T | undefined;
     }
     interface String {

--- a/types/lodash/common/array.d.ts
+++ b/types/lodash/common/array.d.ts
@@ -574,6 +574,7 @@ declare module "../index" {
          * @param array The array to query.
          * @return Returns the first element of array.
          */
+        head<T extends readonly unknown[]>(array: T): number extends T['length'] ? T[number] | undefined : T[0];
         head<T>(array: List<T> | null | undefined): T | undefined;
     }
     interface String {

--- a/types/lodash/common/array.d.ts
+++ b/types/lodash/common/array.d.ts
@@ -574,7 +574,7 @@ declare module "../index" {
          * @param array The array to query.
          * @return Returns the first element of array.
          */
-        head<T extends readonly unknown[]>(array: T): number extends T['length'] ? T[number] | undefined : T[0];
+        head<T extends readonly unknown[]>(array: T): never[] extends T ? T[number] | undefined : T[0];
         head<T>(array: List<T> | null | undefined): T | undefined;
     }
     interface String {

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -560,6 +560,8 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType CollectionChain<number>
     _.head([] as []); // $ExpectType undefined
     _.head([1, 2, 3] as const); // $ExpectType 1
     _.head([1, 2, 3] as [number, number, number]); // $ExpectType number
+    _.head([1, 2, 3] as [...number[]]); // $ExpectType number | undefined
+    _.head([1, 2, 3] as [number, ...number[]]); // $ExpectType number
 
     _("abc").head(); // $ExpectType string | undefined
     _(list).head(); // $ExpectType AbcObject | undefined

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -555,7 +555,8 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType CollectionChain<number>
 {
     _.head("abc"); // $ExpectType string | undefined
     _.head(list); // $ExpectType AbcObject | undefined
-    _.head([1, 2, 3]); // $ExpectType number | undefined
+    _.head([1, 2, 3]); // $ExpectType number
+    _.head([1, 2, 3] as number[]); // $ExpectType number | undefined
     _.head([]); // $ExpectType undefined
     _.head([] as []); // $ExpectType undefined
     _.head([1, 2, 3] as const); // $ExpectType 1

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -555,6 +555,11 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType CollectionChain<number>
 {
     _.head("abc"); // $ExpectType string | undefined
     _.head(list); // $ExpectType AbcObject | undefined
+    _.head([1, 2, 3]); // $ExpectType number | undefined
+    _.head([]); // $ExpectType undefined
+    _.head([] as []); // $ExpectType undefined
+    _.head([1, 2, 3] as const); // $ExpectType 1
+    _.head([1, 2, 3] as [number, number, number]); // $ExpectType number
 
     _("abc").head(); // $ExpectType string | undefined
     _(list).head(); // $ExpectType AbcObject | undefined


### PR DESCRIPTION
If a tuple has at least one element, we can ensure that `_.head(tuple)` returns `T` not `T | undefined`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://lodash.com/docs/4.17.15#head>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
