### PR TITLE
[passport] Revert "add prompt options" as it is not a standard option

### DIFF
--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -174,7 +174,6 @@ declare namespace passport {
          */
         userProperty?: string | undefined;
         passReqToCallback?: boolean | undefined;
-        prompt?: string | undefined;
     }
 
     interface InitializeOptions {

--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -174,6 +174,11 @@ declare namespace passport {
          */
         userProperty?: string | undefined;
         passReqToCallback?: boolean | undefined;
+        /**
+         * **Note:** The availability of this property depends on the passport strategy you are using.
+         * If not explicitly supported by the strategy or implemented by yourself, this property will be ignored.
+         */
+        prompt?: string | undefined;
     }
 
     interface InitializeOptions {


### PR DESCRIPTION
This reverts PR #24983. I agree that this option is useful, but it is not supported by default. Including it in the typing seems misleading to me. I've noticed that other non-standard options have also been merged, but at least they seem to be supported by more passport strategies than this one. For example, I noticed https://github.com/DefinitelyTyped/DefinitelyTyped/pull/21241#issuecomment-343101918 where the conclusion was that this change should be fine "for now", even though the option is only supported by some strategies?

The source for the property `prompt` in the PR was an answer on StackOverflow. The used strategy "passport-google-oauth20" supports the non-standard option `prompt` and includes it in the authorization request params (see [relevant code within the package](https://github.com/jaredhanson/passport-google-oauth2/blob/79f9ed6878f1d11150243a1429acb7ba3211e239/lib/strategy.js#L142)) The package relies on "passport-oauth2" which is more abstract and has a broader use but also does not utilize the property `prompt`. I added the link to the package "passport" with a list of valid options where this property does not occur at the end of this PR description.

In case you stumble over this PR and wonder how you could use the authorization request parameter `prompt` yourself (e. g. using "passport-oauth2") you could use the following code snippet to overwrite the otherwise empty method `authorizationParams`.
```ts
import OAuth2Strategy from 'passport-oauth2';

OAuth2Strategy.prototype.authorizationParams = (options) => ({ prompt: options.prompt });
```

I think the reason for the change back then was that you can't extend the typing for the passport strategy you're actually using. I think that would be a great feature, but of course that would be a major change.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jaredhanson/passport/blob/217018dbc46dcd4118dd6f2c60c8d97010c587f8/lib/authenticator.js#L149
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.