### PR TITLE
[activestorage] Make callback error argument nullable

### DIFF
--- a/types/activestorage/index.d.ts
+++ b/types/activestorage/index.d.ts
@@ -9,7 +9,7 @@ export class DirectUpload {
 
     constructor(file: File, url: string, delegate?: DirectUploadDelegate);
 
-    create(callback: (error: Error, blob: Blob) => void): void;
+    create(callback: (error: Error | null, blob: Blob) => void): void;
 }
 
 export interface DirectUploadDelegate {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [N/A] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes:  https://github.com/rails/rails/blob/592a52b9370df79787d74b1bac9b201891c45054/activestorage/app/javascript/activestorage/direct_upload.js#L36
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Updates the DirectUpload create callback type to more closely match how it's used in Rail's Javascript. On successful direct upload the error argument is `null`. Excerpt 

```javascript
          upload.create(error => {
            if (error) {
              callback(error)
            } else {
              callback(null, blob.toJSON())
            }
          })
```