### PR TITLE
[node] events: refactor module structure

### DIFF
--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -54,375 +54,11 @@ declare module "events" {
     type Listener2<K, T> = Listener<K, T, Function>;
     // #endregion Event map helper types
     global {
+        // TODO: Remove the legacy NodeJS.EventEmitter interface in next major @types/node version,
+        // in favour of this module's exported EventEmitter class.
         namespace NodeJS {
-            interface EventEmitter<T extends EventMap<T> = DefaultEventMap> {
-                /**
-                 * Alias for `emitter.on(eventName, listener)`.
-                 * @since v0.1.26
-                 */
-                addListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
-                /**
-                 * Synchronously calls each of the listeners registered for the event named
-                 * `eventName`, in the order they were registered, passing the supplied arguments
-                 * to each.
-                 *
-                 * Returns `true` if the event had listeners, `false` otherwise.
-                 *
-                 * ```js
-                 * import { EventEmitter } from 'node:events';
-                 * const myEmitter = new EventEmitter();
-                 *
-                 * // First listener
-                 * myEmitter.on('event', function firstListener() {
-                 *   console.log('Helloooo! first listener');
-                 * });
-                 * // Second listener
-                 * myEmitter.on('event', function secondListener(arg1, arg2) {
-                 *   console.log(`event with parameters ${arg1}, ${arg2} in second listener`);
-                 * });
-                 * // Third listener
-                 * myEmitter.on('event', function thirdListener(...args) {
-                 *   const parameters = args.join(', ');
-                 *   console.log(`event with parameters ${parameters} in third listener`);
-                 * });
-                 *
-                 * console.log(myEmitter.listeners('event'));
-                 *
-                 * myEmitter.emit('event', 1, 2, 3, 4, 5);
-                 *
-                 * // Prints:
-                 * // [
-                 * //   [Function: firstListener],
-                 * //   [Function: secondListener],
-                 * //   [Function: thirdListener]
-                 * // ]
-                 * // Helloooo! first listener
-                 * // event with parameters 1, 2 in second listener
-                 * // event with parameters 1, 2, 3, 4, 5 in third listener
-                 * ```
-                 * @since v0.1.26
-                 */
-                emit<K>(eventName: Key<K, T>, ...args: Args<K, T>): boolean;
-                /**
-                 * Returns an array listing the events for which the emitter has registered
-                 * listeners. The values in the array are strings or `Symbol`s.
-                 *
-                 * ```js
-                 * import { EventEmitter } from 'node:events';
-                 *
-                 * const myEE = new EventEmitter();
-                 * myEE.on('foo', () => {});
-                 * myEE.on('bar', () => {});
-                 *
-                 * const sym = Symbol('symbol');
-                 * myEE.on(sym, () => {});
-                 *
-                 * console.log(myEE.eventNames());
-                 * // Prints: [ 'foo', 'bar', Symbol(symbol) ]
-                 * ```
-                 * @since v6.0.0
-                 */
-                eventNames(): Array<(string | symbol) & Key2<unknown, T>>;
-                /**
-                 * Returns the current max listener value for the `EventEmitter` which is either
-                 * set by `emitter.setMaxListeners(n)` or defaults to `defaultMaxListeners`.
-                 * @since v1.0.0
-                 */
-                getMaxListeners(): number;
-                /**
-                 * Returns the number of listeners listening for the event named `eventName`.
-                 * If `listener` is provided, it will return how many times the listener is found
-                 * in the list of the listeners of the event.
-                 * @since v3.2.0
-                 * @param eventName The name of the event being listened for
-                 * @param listener The event handler function
-                 */
-                listenerCount<K>(eventName: Key<K, T>, listener?: Listener2<K, T>): number;
-                /**
-                 * Returns a copy of the array of listeners for the event named `eventName`.
-                 *
-                 * ```js
-                 * server.on('connection', (stream) => {
-                 *   console.log('someone connected!');
-                 * });
-                 * console.log(util.inspect(server.listeners('connection')));
-                 * // Prints: [ [Function] ]
-                 * ```
-                 * @since v0.1.26
-                 */
-                listeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
-                /**
-                 * Alias for `emitter.removeListener()`.
-                 * @since v10.0.0
-                 */
-                off<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
-                /**
-                 * Adds the `listener` function to the end of the listeners array for the event
-                 * named `eventName`. No checks are made to see if the `listener` has already
-                 * been added. Multiple calls passing the same combination of `eventName` and
-                 * `listener` will result in the `listener` being added, and called, multiple times.
-                 *
-                 * ```js
-                 * server.on('connection', (stream) => {
-                 *   console.log('someone connected!');
-                 * });
-                 * ```
-                 *
-                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
-                 *
-                 * By default, event listeners are invoked in the order they are added. The
-                 * `emitter.prependListener()` method can be used as an alternative to add the
-                 * event listener to the beginning of the listeners array.
-                 *
-                 * ```js
-                 * import { EventEmitter } from 'node:events';
-                 * const myEE = new EventEmitter();
-                 * myEE.on('foo', () => console.log('a'));
-                 * myEE.prependListener('foo', () => console.log('b'));
-                 * myEE.emit('foo');
-                 * // Prints:
-                 * //   b
-                 * //   a
-                 * ```
-                 * @since v0.1.101
-                 * @param eventName The name of the event.
-                 * @param listener The callback function
-                 */
-                on<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
-                /**
-                 * Adds a **one-time** `listener` function for the event named `eventName`. The
-                 * next time `eventName` is triggered, this listener is removed and then invoked.
-                 *
-                 * ```js
-                 * server.once('connection', (stream) => {
-                 *   console.log('Ah, we have our first user!');
-                 * });
-                 * ```
-                 *
-                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
-                 *
-                 * By default, event listeners are invoked in the order they are added. The
-                 * `emitter.prependOnceListener()` method can be used as an alternative to add the
-                 * event listener to the beginning of the listeners array.
-                 *
-                 * ```js
-                 * import { EventEmitter } from 'node:events';
-                 * const myEE = new EventEmitter();
-                 * myEE.once('foo', () => console.log('a'));
-                 * myEE.prependOnceListener('foo', () => console.log('b'));
-                 * myEE.emit('foo');
-                 * // Prints:
-                 * //   b
-                 * //   a
-                 * ```
-                 * @since v0.3.0
-                 * @param eventName The name of the event.
-                 * @param listener The callback function
-                 */
-                once<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
-                /**
-                 * Adds the `listener` function to the _beginning_ of the listeners array for the
-                 * event named `eventName`. No checks are made to see if the `listener` has
-                 * already been added. Multiple calls passing the same combination of `eventName`
-                 * and `listener` will result in the `listener` being added, and called, multiple times.
-                 *
-                 * ```js
-                 * server.prependListener('connection', (stream) => {
-                 *   console.log('someone connected!');
-                 * });
-                 * ```
-                 *
-                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
-                 * @since v6.0.0
-                 * @param eventName The name of the event.
-                 * @param listener The callback function
-                 */
-                prependListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
-                /**
-                 * Adds a **one-time**`listener` function for the event named `eventName` to the
-                 * _beginning_ of the listeners array. The next time `eventName` is triggered, this
-                 * listener is removed, and then invoked.
-                 *
-                 * ```js
-                 * server.prependOnceListener('connection', (stream) => {
-                 *   console.log('Ah, we have our first user!');
-                 * });
-                 * ```
-                 *
-                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
-                 * @since v6.0.0
-                 * @param eventName The name of the event.
-                 * @param listener The callback function
-                 */
-                prependOnceListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
-                /**
-                 * Removes all listeners, or those of the specified `eventName`.
-                 *
-                 * It is bad practice to remove listeners added elsewhere in the code,
-                 * particularly when the `EventEmitter` instance was created by some other
-                 * component or module (e.g. sockets or file streams).
-                 *
-                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
-                 * @since v0.1.26
-                 */
-                removeAllListeners(eventName?: Key<unknown, T>): this;
-                /**
-                 * Removes the specified `listener` from the listener array for the event named
-                 * `eventName`.
-                 *
-                 * ```js
-                 * const callback = (stream) => {
-                 *   console.log('someone connected!');
-                 * };
-                 * server.on('connection', callback);
-                 * // ...
-                 * server.removeListener('connection', callback);
-                 * ```
-                 *
-                 * `removeListener()` will remove, at most, one instance of a listener from the
-                 * listener array. If any single listener has been added multiple times to the
-                 * listener array for the specified `eventName`, then `removeListener()` must be
-                 * called multiple times to remove each instance.
-                 *
-                 * Once an event is emitted, all listeners attached to it at the
-                 * time of emitting are called in order. This implies that any
-                 * `removeListener()` or `removeAllListeners()` calls _after_ emitting and
-                 * _before_ the last listener finishes execution will not remove them from
-                 * `emit()` in progress. Subsequent events behave as expected.
-                 *
-                 * ```js
-                 * import { EventEmitter } from 'node:events';
-                 * class MyEmitter extends EventEmitter {}
-                 * const myEmitter = new MyEmitter();
-                 *
-                 * const callbackA = () => {
-                 *   console.log('A');
-                 *   myEmitter.removeListener('event', callbackB);
-                 * };
-                 *
-                 * const callbackB = () => {
-                 *   console.log('B');
-                 * };
-                 *
-                 * myEmitter.on('event', callbackA);
-                 *
-                 * myEmitter.on('event', callbackB);
-                 *
-                 * // callbackA removes listener callbackB but it will still be called.
-                 * // Internal listener array at time of emit [callbackA, callbackB]
-                 * myEmitter.emit('event');
-                 * // Prints:
-                 * //   A
-                 * //   B
-                 *
-                 * // callbackB is now removed.
-                 * // Internal listener array [callbackA]
-                 * myEmitter.emit('event');
-                 * // Prints:
-                 * //   A
-                 * ```
-                 *
-                 * Because listeners are managed using an internal array, calling this will
-                 * change the position indices of any listener registered _after_ the listener
-                 * being removed. This will not impact the order in which listeners are called,
-                 * but it means that any copies of the listener array as returned by
-                 * the `emitter.listeners()` method will need to be recreated.
-                 *
-                 * When a single function has been added as a handler multiple times for a single
-                 * event (as in the example below), `removeListener()` will remove the most
-                 * recently added instance. In the example the `once('ping')` listener is removed:
-                 *
-                 * ```js
-                 * import { EventEmitter } from 'node:events';
-                 * const ee = new EventEmitter();
-                 *
-                 * function pong() {
-                 *   console.log('pong');
-                 * }
-                 *
-                 * ee.on('ping', pong);
-                 * ee.once('ping', pong);
-                 * ee.removeListener('ping', pong);
-                 *
-                 * ee.emit('ping');
-                 * ee.emit('ping');
-                 * ```
-                 *
-                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
-                 * @since v0.1.26
-                 */
-                removeListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
-                /**
-                 * By default `EventEmitter`s will print a warning if more than `10` listeners are
-                 * added for a particular event. This is a useful default that helps finding
-                 * memory leaks. The `emitter.setMaxListeners()` method allows the limit to be
-                 * modified for this specific `EventEmitter` instance. The value can be set to
-                 * `Infinity` (or `0`) to indicate an unlimited number of listeners.
-                 *
-                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
-                 * @since v0.3.5
-                 */
-                setMaxListeners(n: number): this;
-                /**
-                 * Returns a copy of the array of listeners for the event named `eventName`,
-                 * including any wrappers (such as those created by `.once()`).
-                 *
-                 * ```js
-                 * import { EventEmitter } from 'node:events';
-                 * const emitter = new EventEmitter();
-                 * emitter.once('log', () => console.log('log once'));
-                 *
-                 * // Returns a new Array with a function `onceWrapper` which has a property
-                 * // `listener` which contains the original listener bound above
-                 * const listeners = emitter.rawListeners('log');
-                 * const logFnWrapper = listeners[0];
-                 *
-                 * // Logs "log once" to the console and does not unbind the `once` event
-                 * logFnWrapper.listener();
-                 *
-                 * // Logs "log once" to the console and removes the listener
-                 * logFnWrapper();
-                 *
-                 * emitter.on('log', () => console.log('log persistently'));
-                 * // Will return a new Array with a single function bound by `.on()` above
-                 * const newListeners = emitter.rawListeners('log');
-                 *
-                 * // Logs "log persistently" twice
-                 * newListeners[0]();
-                 * emitter.emit('log');
-                 * ```
-                 * @since v9.4.0
-                 */
-                rawListeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
-                /**
-                 * The `Symbol.for('nodejs.rejection')` method is called in case a
-                 * promise rejection happens when emitting an event and
-                 * `captureRejections` is enabled on the emitter.
-                 * It is possible to use `events.captureRejectionSymbol` in
-                 * place of `Symbol.for('nodejs.rejection')`.
-                 *
-                 * ```js
-                 * import { EventEmitter, captureRejectionSymbol } from 'node:events';
-                 *
-                 * class MyClass extends EventEmitter {
-                 *   constructor() {
-                 *     super({ captureRejections: true });
-                 *   }
-                 *
-                 *   [captureRejectionSymbol](err, event, ...args) {
-                 *     console.log('rejection happened for', event, 'with', err, ...args);
-                 *     this.destroy(err);
-                 *   }
-                 *
-                 *   destroy(err) {
-                 *     // Tear the resource down here.
-                 *   }
-                 * }
-                 * ```
-                 * @since v13.4.0, v12.16.0
-                 */
-                [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
-            }
+            import _EventEmitter = EventEmitter;
+            interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends _EventEmitter<T> {}
         }
     }
     interface EventEmitterOptions {
@@ -448,8 +84,373 @@ declare module "events" {
      */
     class EventEmitter<T extends EventMap<T> = DefaultEventMap> {
         constructor(options?: EventEmitterOptions);
+        /**
+         * Alias for `emitter.on(eventName, listener)`.
+         * @since v0.1.26
+         */
+        addListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+        /**
+         * Synchronously calls each of the listeners registered for the event named
+         * `eventName`, in the order they were registered, passing the supplied arguments
+         * to each.
+         *
+         * Returns `true` if the event had listeners, `false` otherwise.
+         *
+         * ```js
+         * import { EventEmitter } from 'node:events';
+         * const myEmitter = new EventEmitter();
+         *
+         * // First listener
+         * myEmitter.on('event', function firstListener() {
+         *   console.log('Helloooo! first listener');
+         * });
+         * // Second listener
+         * myEmitter.on('event', function secondListener(arg1, arg2) {
+         *   console.log(`event with parameters ${arg1}, ${arg2} in second listener`);
+         * });
+         * // Third listener
+         * myEmitter.on('event', function thirdListener(...args) {
+         *   const parameters = args.join(', ');
+         *   console.log(`event with parameters ${parameters} in third listener`);
+         * });
+         *
+         * console.log(myEmitter.listeners('event'));
+         *
+         * myEmitter.emit('event', 1, 2, 3, 4, 5);
+         *
+         * // Prints:
+         * // [
+         * //   [Function: firstListener],
+         * //   [Function: secondListener],
+         * //   [Function: thirdListener]
+         * // ]
+         * // Helloooo! first listener
+         * // event with parameters 1, 2 in second listener
+         * // event with parameters 1, 2, 3, 4, 5 in third listener
+         * ```
+         * @since v0.1.26
+         */
+        emit<K>(eventName: Key<K, T>, ...args: Args<K, T>): boolean;
+        /**
+         * Returns an array listing the events for which the emitter has registered
+         * listeners. The values in the array are strings or `Symbol`s.
+         *
+         * ```js
+         * import { EventEmitter } from 'node:events';
+         *
+         * const myEE = new EventEmitter();
+         * myEE.on('foo', () => {});
+         * myEE.on('bar', () => {});
+         *
+         * const sym = Symbol('symbol');
+         * myEE.on(sym, () => {});
+         *
+         * console.log(myEE.eventNames());
+         * // Prints: [ 'foo', 'bar', Symbol(symbol) ]
+         * ```
+         * @since v6.0.0
+         */
+        eventNames(): Array<(string | symbol) & Key2<unknown, T>>;
+        /**
+         * Returns the current max listener value for the `EventEmitter` which is either
+         * set by `emitter.setMaxListeners(n)` or defaults to `defaultMaxListeners`.
+         * @since v1.0.0
+         */
+        getMaxListeners(): number;
+        /**
+         * Returns the number of listeners listening for the event named `eventName`.
+         * If `listener` is provided, it will return how many times the listener is found
+         * in the list of the listeners of the event.
+         * @since v3.2.0
+         * @param eventName The name of the event being listened for
+         * @param listener The event handler function
+         */
+        listenerCount<K>(eventName: Key<K, T>, listener?: Listener2<K, T>): number;
+        /**
+         * Returns a copy of the array of listeners for the event named `eventName`.
+         *
+         * ```js
+         * server.on('connection', (stream) => {
+         *   console.log('someone connected!');
+         * });
+         * console.log(util.inspect(server.listeners('connection')));
+         * // Prints: [ [Function] ]
+         * ```
+         * @since v0.1.26
+         */
+        listeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
+        /**
+         * Alias for `emitter.removeListener()`.
+         * @since v10.0.0
+         */
+        off<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+        /**
+         * Adds the `listener` function to the end of the listeners array for the event
+         * named `eventName`. No checks are made to see if the `listener` has already
+         * been added. Multiple calls passing the same combination of `eventName` and
+         * `listener` will result in the `listener` being added, and called, multiple times.
+         *
+         * ```js
+         * server.on('connection', (stream) => {
+         *   console.log('someone connected!');
+         * });
+         * ```
+         *
+         * Returns a reference to the `EventEmitter`, so that calls can be chained.
+         *
+         * By default, event listeners are invoked in the order they are added. The
+         * `emitter.prependListener()` method can be used as an alternative to add the
+         * event listener to the beginning of the listeners array.
+         *
+         * ```js
+         * import { EventEmitter } from 'node:events';
+         * const myEE = new EventEmitter();
+         * myEE.on('foo', () => console.log('a'));
+         * myEE.prependListener('foo', () => console.log('b'));
+         * myEE.emit('foo');
+         * // Prints:
+         * //   b
+         * //   a
+         * ```
+         * @since v0.1.101
+         * @param eventName The name of the event.
+         * @param listener The callback function
+         */
+        on<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+        /**
+         * Adds a **one-time** `listener` function for the event named `eventName`. The
+         * next time `eventName` is triggered, this listener is removed and then invoked.
+         *
+         * ```js
+         * server.once('connection', (stream) => {
+         *   console.log('Ah, we have our first user!');
+         * });
+         * ```
+         *
+         * Returns a reference to the `EventEmitter`, so that calls can be chained.
+         *
+         * By default, event listeners are invoked in the order they are added. The
+         * `emitter.prependOnceListener()` method can be used as an alternative to add the
+         * event listener to the beginning of the listeners array.
+         *
+         * ```js
+         * import { EventEmitter } from 'node:events';
+         * const myEE = new EventEmitter();
+         * myEE.once('foo', () => console.log('a'));
+         * myEE.prependOnceListener('foo', () => console.log('b'));
+         * myEE.emit('foo');
+         * // Prints:
+         * //   b
+         * //   a
+         * ```
+         * @since v0.3.0
+         * @param eventName The name of the event.
+         * @param listener The callback function
+         */
+        once<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+        /**
+         * Adds the `listener` function to the _beginning_ of the listeners array for the
+         * event named `eventName`. No checks are made to see if the `listener` has
+         * already been added. Multiple calls passing the same combination of `eventName`
+         * and `listener` will result in the `listener` being added, and called, multiple times.
+         *
+         * ```js
+         * server.prependListener('connection', (stream) => {
+         *   console.log('someone connected!');
+         * });
+         * ```
+         *
+         * Returns a reference to the `EventEmitter`, so that calls can be chained.
+         * @since v6.0.0
+         * @param eventName The name of the event.
+         * @param listener The callback function
+         */
+        prependListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+        /**
+         * Adds a **one-time**`listener` function for the event named `eventName` to the
+         * _beginning_ of the listeners array. The next time `eventName` is triggered, this
+         * listener is removed, and then invoked.
+         *
+         * ```js
+         * server.prependOnceListener('connection', (stream) => {
+         *   console.log('Ah, we have our first user!');
+         * });
+         * ```
+         *
+         * Returns a reference to the `EventEmitter`, so that calls can be chained.
+         * @since v6.0.0
+         * @param eventName The name of the event.
+         * @param listener The callback function
+         */
+        prependOnceListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+        /**
+         * Removes all listeners, or those of the specified `eventName`.
+         *
+         * It is bad practice to remove listeners added elsewhere in the code,
+         * particularly when the `EventEmitter` instance was created by some other
+         * component or module (e.g. sockets or file streams).
+         *
+         * Returns a reference to the `EventEmitter`, so that calls can be chained.
+         * @since v0.1.26
+         */
+        removeAllListeners(eventName?: Key<unknown, T>): this;
+        /**
+         * Removes the specified `listener` from the listener array for the event named
+         * `eventName`.
+         *
+         * ```js
+         * const callback = (stream) => {
+         *   console.log('someone connected!');
+         * };
+         * server.on('connection', callback);
+         * // ...
+         * server.removeListener('connection', callback);
+         * ```
+         *
+         * `removeListener()` will remove, at most, one instance of a listener from the
+         * listener array. If any single listener has been added multiple times to the
+         * listener array for the specified `eventName`, then `removeListener()` must be
+         * called multiple times to remove each instance.
+         *
+         * Once an event is emitted, all listeners attached to it at the
+         * time of emitting are called in order. This implies that any
+         * `removeListener()` or `removeAllListeners()` calls _after_ emitting and
+         * _before_ the last listener finishes execution will not remove them from
+         * `emit()` in progress. Subsequent events behave as expected.
+         *
+         * ```js
+         * import { EventEmitter } from 'node:events';
+         * class MyEmitter extends EventEmitter {}
+         * const myEmitter = new MyEmitter();
+         *
+         * const callbackA = () => {
+         *   console.log('A');
+         *   myEmitter.removeListener('event', callbackB);
+         * };
+         *
+         * const callbackB = () => {
+         *   console.log('B');
+         * };
+         *
+         * myEmitter.on('event', callbackA);
+         *
+         * myEmitter.on('event', callbackB);
+         *
+         * // callbackA removes listener callbackB but it will still be called.
+         * // Internal listener array at time of emit [callbackA, callbackB]
+         * myEmitter.emit('event');
+         * // Prints:
+         * //   A
+         * //   B
+         *
+         * // callbackB is now removed.
+         * // Internal listener array [callbackA]
+         * myEmitter.emit('event');
+         * // Prints:
+         * //   A
+         * ```
+         *
+         * Because listeners are managed using an internal array, calling this will
+         * change the position indices of any listener registered _after_ the listener
+         * being removed. This will not impact the order in which listeners are called,
+         * but it means that any copies of the listener array as returned by
+         * the `emitter.listeners()` method will need to be recreated.
+         *
+         * When a single function has been added as a handler multiple times for a single
+         * event (as in the example below), `removeListener()` will remove the most
+         * recently added instance. In the example the `once('ping')` listener is removed:
+         *
+         * ```js
+         * import { EventEmitter } from 'node:events';
+         * const ee = new EventEmitter();
+         *
+         * function pong() {
+         *   console.log('pong');
+         * }
+         *
+         * ee.on('ping', pong);
+         * ee.once('ping', pong);
+         * ee.removeListener('ping', pong);
+         *
+         * ee.emit('ping');
+         * ee.emit('ping');
+         * ```
+         *
+         * Returns a reference to the `EventEmitter`, so that calls can be chained.
+         * @since v0.1.26
+         */
+        removeListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+        /**
+         * By default `EventEmitter`s will print a warning if more than `10` listeners are
+         * added for a particular event. This is a useful default that helps finding
+         * memory leaks. The `emitter.setMaxListeners()` method allows the limit to be
+         * modified for this specific `EventEmitter` instance. The value can be set to
+         * `Infinity` (or `0`) to indicate an unlimited number of listeners.
+         *
+         * Returns a reference to the `EventEmitter`, so that calls can be chained.
+         * @since v0.3.5
+         */
+        setMaxListeners(n: number): this;
+        /**
+         * Returns a copy of the array of listeners for the event named `eventName`,
+         * including any wrappers (such as those created by `.once()`).
+         *
+         * ```js
+         * import { EventEmitter } from 'node:events';
+         * const emitter = new EventEmitter();
+         * emitter.once('log', () => console.log('log once'));
+         *
+         * // Returns a new Array with a function `onceWrapper` which has a property
+         * // `listener` which contains the original listener bound above
+         * const listeners = emitter.rawListeners('log');
+         * const logFnWrapper = listeners[0];
+         *
+         * // Logs "log once" to the console and does not unbind the `once` event
+         * logFnWrapper.listener();
+         *
+         * // Logs "log once" to the console and removes the listener
+         * logFnWrapper();
+         *
+         * emitter.on('log', () => console.log('log persistently'));
+         * // Will return a new Array with a single function bound by `.on()` above
+         * const newListeners = emitter.rawListeners('log');
+         *
+         * // Logs "log persistently" twice
+         * newListeners[0]();
+         * emitter.emit('log');
+         * ```
+         * @since v9.4.0
+         */
+        rawListeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
+        /**
+         * The `Symbol.for('nodejs.rejection')` method is called in case a
+         * promise rejection happens when emitting an event and
+         * `captureRejections` is enabled on the emitter.
+         * It is possible to use `events.captureRejectionSymbol` in
+         * place of `Symbol.for('nodejs.rejection')`.
+         *
+         * ```js
+         * import { EventEmitter, captureRejectionSymbol } from 'node:events';
+         *
+         * class MyClass extends EventEmitter {
+         *   constructor() {
+         *     super({ captureRejections: true });
+         *   }
+         *
+         *   [captureRejectionSymbol](err, event, ...args) {
+         *     console.log('rejection happened for', event, 'with', err, ...args);
+         *     this.destroy(err);
+         *   }
+         *
+         *   destroy(err) {
+         *     // Tear the resource down here.
+         *   }
+         * }
+         * ```
+         * @since v13.4.0, v12.16.0
+         */
+        [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
     }
-    interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
     namespace EventEmitter {
         export { EventEmitter, EventEmitterOptions, EventMap };
     }
@@ -538,7 +539,7 @@ declare module "events" {
          * ```
          * @since v15.2.0, v14.17.0
          */
-        function getEventListeners(emitter: EventTarget | NodeJS.EventEmitter, name: string | symbol): Function[];
+        function getEventListeners(emitter: EventTarget | EventEmitter, name: string | symbol): Function[];
         /**
          * Returns the currently set max amount of listeners.
          *
@@ -567,7 +568,7 @@ declare module "events" {
          * ```
          * @since v19.9.0
          */
-        function getMaxListeners(emitter: EventTarget | NodeJS.EventEmitter): number;
+        function getMaxListeners(emitter: EventTarget | EventEmitter): number;
         interface OnceOptions extends Abortable {}
         /**
          * Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
@@ -652,7 +653,7 @@ declare module "events" {
          * @since v11.13.0, v10.16.0
          */
         function once(
-            emitter: NodeJS.EventEmitter,
+            emitter: EventEmitter,
             eventName: string | symbol,
             options?: OnceOptions,
         ): Promise<any[]>;
@@ -685,7 +686,7 @@ declare module "events" {
          * @param emitter The emitter to query
          * @param eventName The event name
          */
-        function listenerCount(emitter: NodeJS.EventEmitter, eventName: string | symbol): number;
+        function listenerCount(emitter: EventEmitter, eventName: string | symbol): number;
         interface OnOptions extends Abortable {
             /**
              * Names of events that will end the iteration.
@@ -768,7 +769,7 @@ declare module "events" {
          * @return An `AsyncIterator` that iterates `eventName` events emitted by the `emitter`
          */
         function on(
-            emitter: NodeJS.EventEmitter,
+            emitter: EventEmitter,
             eventName: string | symbol,
             options?: OnOptions,
         ): AsyncIterableIterator<any[]>;
@@ -793,7 +794,7 @@ declare module "events" {
          * If none are specified, `n` is set as the default max for all newly created
          * `EventTarget` and `EventEmitter` objects.
          */
-        function setMaxListeners(n?: number, ...eventTargets: Array<EventTarget | NodeJS.EventEmitter>): void;
+        function setMaxListeners(n?: number, ...eventTargets: Array<EventTarget | EventEmitter>): void;
         /**
          * Listens once to the `abort` event on the provided `signal`.
          *

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -36,71 +36,7 @@
  */
 declare module "events" {
     import { AsyncResource, AsyncResourceOptions } from "node:async_hooks";
-    // NOTE: This class is in the docs but is **not actually exported** by Node.
-    // If https://github.com/nodejs/node/issues/39903 gets resolved and Node
-    // actually starts exporting the class, uncomment below.
-    // import { EventListener, EventListenerObject } from '__dom-events';
-    // /** The NodeEventTarget is a Node.js-specific extension to EventTarget that emulates a subset of the EventEmitter API. */
-    // interface NodeEventTarget extends EventTarget {
-    //     /**
-    //      * Node.js-specific extension to the `EventTarget` class that emulates the equivalent `EventEmitter` API.
-    //      * The only difference between `addListener()` and `addEventListener()` is that addListener() will return a reference to the EventTarget.
-    //      */
-    //     addListener(type: string, listener: EventListener | EventListenerObject, options?: { once: boolean }): this;
-    //     /** Node.js-specific extension to the `EventTarget` class that returns an array of event `type` names for which event listeners are registered. */
-    //     eventNames(): string[];
-    //     /** Node.js-specific extension to the `EventTarget` class that returns the number of event listeners registered for the `type`. */
-    //     listenerCount(type: string): number;
-    //     /** Node.js-specific alias for `eventTarget.removeListener()`. */
-    //     off(type: string, listener: EventListener | EventListenerObject): this;
-    //     /** Node.js-specific alias for `eventTarget.addListener()`. */
-    //     on(type: string, listener: EventListener | EventListenerObject, options?: { once: boolean }): this;
-    //     /** Node.js-specific extension to the `EventTarget` class that adds a `once` listener for the given event `type`. This is equivalent to calling `on` with the `once` option set to `true`. */
-    //     once(type: string, listener: EventListener | EventListenerObject): this;
-    //     /**
-    //      * Node.js-specific extension to the `EventTarget` class.
-    //      * If `type` is specified, removes all registered listeners for `type`,
-    //      * otherwise removes all registered listeners.
-    //      */
-    //     removeAllListeners(type: string): this;
-    //     /**
-    //      * Node.js-specific extension to the `EventTarget` class that removes the listener for the given `type`.
-    //      * The only difference between `removeListener()` and `removeEventListener()` is that `removeListener()` will return a reference to the `EventTarget`.
-    //      */
-    //     removeListener(type: string, listener: EventListener | EventListenerObject): this;
-    // }
-    interface EventEmitterOptions {
-        /**
-         * Enables automatic capturing of promise rejection.
-         */
-        captureRejections?: boolean | undefined;
-    }
-    interface StaticEventEmitterOptions {
-        /**
-         * Can be used to cancel awaiting events.
-         */
-        signal?: AbortSignal | undefined;
-    }
-    interface StaticEventEmitterIteratorOptions extends StaticEventEmitterOptions {
-        /**
-         * Names of events that will end the iteration.
-         */
-        close?: string[] | undefined;
-        /**
-         * The high watermark. The emitter is paused every time the size of events being buffered is higher than it.
-         * Supported only on emitters implementing `pause()` and `resume()` methods.
-         * @default Number.MAX_SAFE_INTEGER
-         */
-        highWaterMark?: number | undefined;
-        /**
-         * The low watermark. The emitter is resumed every time the size of events being buffered is lower than it.
-         * Supported only on emitters implementing `pause()` and `resume()` methods.
-         * @default 1
-         */
-        lowWaterMark?: number | undefined;
-    }
-    interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
-    type EventMap<T> = Record<keyof T, any[]> | DefaultEventMap;
+    // #region Event map helper types
     type DefaultEventMap = [never];
     type AnyRest = [...args: any[]];
     type Args<K, T> = T extends DefaultEventMap ? AnyRest : (
@@ -116,485 +52,110 @@ declare module "events" {
     );
     type Listener1<K, T> = Listener<K, T, (...args: any[]) => void>;
     type Listener2<K, T> = Listener<K, T, Function>;
-
-    /**
-     * The `EventEmitter` class is defined and exposed by the `node:events` module:
-     *
-     * ```js
-     * import { EventEmitter } from 'node:events';
-     * ```
-     *
-     * All `EventEmitter`s emit the event `'newListener'` when new listeners are
-     * added and `'removeListener'` when existing listeners are removed.
-     *
-     * It supports the following option:
-     * @since v0.1.26
-     */
-    class EventEmitter<T extends EventMap<T> = DefaultEventMap> {
-        constructor(options?: EventEmitterOptions);
-
-        [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
-
-        /**
-         * Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
-         * event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
-         * The `Promise` will resolve with an array of all the arguments emitted to the
-         * given event.
-         *
-         * This method is intentionally generic and works with the web platform [EventTarget](https://dom.spec.whatwg.org/#interface-eventtarget) interface, which has no special`'error'` event
-         * semantics and does not listen to the `'error'` event.
-         *
-         * ```js
-         * import { once, EventEmitter } from 'node:events';
-         * import process from 'node:process';
-         *
-         * const ee = new EventEmitter();
-         *
-         * process.nextTick(() => {
-         *   ee.emit('myevent', 42);
-         * });
-         *
-         * const [value] = await once(ee, 'myevent');
-         * console.log(value);
-         *
-         * const err = new Error('kaboom');
-         * process.nextTick(() => {
-         *   ee.emit('error', err);
-         * });
-         *
-         * try {
-         *   await once(ee, 'myevent');
-         * } catch (err) {
-         *   console.error('error happened', err);
-         * }
-         * ```
-         *
-         * The special handling of the `'error'` event is only used when `events.once()` is used to wait for another event. If `events.once()` is used to wait for the
-         * '`error'` event itself, then it is treated as any other kind of event without
-         * special handling:
-         *
-         * ```js
-         * import { EventEmitter, once } from 'node:events';
-         *
-         * const ee = new EventEmitter();
-         *
-         * once(ee, 'error')
-         *   .then(([err]) => console.log('ok', err.message))
-         *   .catch((err) => console.error('error', err.message));
-         *
-         * ee.emit('error', new Error('boom'));
-         *
-         * // Prints: ok boom
-         * ```
-         *
-         * An `AbortSignal` can be used to cancel waiting for the event:
-         *
-         * ```js
-         * import { EventEmitter, once } from 'node:events';
-         *
-         * const ee = new EventEmitter();
-         * const ac = new AbortController();
-         *
-         * async function foo(emitter, event, signal) {
-         *   try {
-         *     await once(emitter, event, { signal });
-         *     console.log('event emitted!');
-         *   } catch (error) {
-         *     if (error.name === 'AbortError') {
-         *       console.error('Waiting for the event was canceled!');
-         *     } else {
-         *       console.error('There was an error', error.message);
-         *     }
-         *   }
-         * }
-         *
-         * foo(ee, 'foo', ac.signal);
-         * ac.abort(); // Abort waiting for the event
-         * ee.emit('foo'); // Prints: Waiting for the event was canceled!
-         * ```
-         * @since v11.13.0, v10.16.0
-         */
-        static once(
-            emitter: NodeJS.EventEmitter,
-            eventName: string | symbol,
-            options?: StaticEventEmitterOptions,
-        ): Promise<any[]>;
-        static once(emitter: EventTarget, eventName: string, options?: StaticEventEmitterOptions): Promise<any[]>;
-        /**
-         * ```js
-         * import { on, EventEmitter } from 'node:events';
-         * import process from 'node:process';
-         *
-         * const ee = new EventEmitter();
-         *
-         * // Emit later on
-         * process.nextTick(() => {
-         *   ee.emit('foo', 'bar');
-         *   ee.emit('foo', 42);
-         * });
-         *
-         * for await (const event of on(ee, 'foo')) {
-         *   // The execution of this inner block is synchronous and it
-         *   // processes one event at a time (even with await). Do not use
-         *   // if concurrent execution is required.
-         *   console.log(event); // prints ['bar'] [42]
-         * }
-         * // Unreachable here
-         * ```
-         *
-         * Returns an `AsyncIterator` that iterates `eventName` events. It will throw
-         * if the `EventEmitter` emits `'error'`. It removes all listeners when
-         * exiting the loop. The `value` returned by each iteration is an array
-         * composed of the emitted event arguments.
-         *
-         * An `AbortSignal` can be used to cancel waiting on events:
-         *
-         * ```js
-         * import { on, EventEmitter } from 'node:events';
-         * import process from 'node:process';
-         *
-         * const ac = new AbortController();
-         *
-         * (async () => {
-         *   const ee = new EventEmitter();
-         *
-         *   // Emit later on
-         *   process.nextTick(() => {
-         *     ee.emit('foo', 'bar');
-         *     ee.emit('foo', 42);
-         *   });
-         *
-         *   for await (const event of on(ee, 'foo', { signal: ac.signal })) {
-         *     // The execution of this inner block is synchronous and it
-         *     // processes one event at a time (even with await). Do not use
-         *     // if concurrent execution is required.
-         *     console.log(event); // prints ['bar'] [42]
-         *   }
-         *   // Unreachable here
-         * })();
-         *
-         * process.nextTick(() => ac.abort());
-         * ```
-         *
-         * Use the `close` option to specify an array of event names that will end the iteration:
-         *
-         * ```js
-         * import { on, EventEmitter } from 'node:events';
-         * import process from 'node:process';
-         *
-         * const ee = new EventEmitter();
-         *
-         * // Emit later on
-         * process.nextTick(() => {
-         *   ee.emit('foo', 'bar');
-         *   ee.emit('foo', 42);
-         *   ee.emit('close');
-         * });
-         *
-         * for await (const event of on(ee, 'foo', { close: ['close'] })) {
-         *   console.log(event); // prints ['bar'] [42]
-         * }
-         * // the loop will exit after 'close' is emitted
-         * console.log('done'); // prints 'done'
-         * ```
-         * @since v13.6.0, v12.16.0
-         * @return An `AsyncIterator` that iterates `eventName` events emitted by the `emitter`
-         */
-        static on(
-            emitter: NodeJS.EventEmitter,
-            eventName: string | symbol,
-            options?: StaticEventEmitterIteratorOptions,
-        ): AsyncIterableIterator<any[]>;
-        static on(
-            emitter: EventTarget,
-            eventName: string,
-            options?: StaticEventEmitterIteratorOptions,
-        ): AsyncIterableIterator<any[]>;
-        /**
-         * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
-         *
-         * ```js
-         * import { EventEmitter, listenerCount } from 'node:events';
-         *
-         * const myEmitter = new EventEmitter();
-         * myEmitter.on('event', () => {});
-         * myEmitter.on('event', () => {});
-         * console.log(listenerCount(myEmitter, 'event'));
-         * // Prints: 2
-         * ```
-         * @since v0.9.12
-         * @deprecated Since v3.2.0 - Use `listenerCount` instead.
-         * @param emitter The emitter to query
-         * @param eventName The event name
-         */
-        static listenerCount(emitter: NodeJS.EventEmitter, eventName: string | symbol): number;
-        /**
-         * Returns a copy of the array of listeners for the event named `eventName`.
-         *
-         * For `EventEmitter`s this behaves exactly the same as calling `.listeners` on
-         * the emitter.
-         *
-         * For `EventTarget`s this is the only way to get the event listeners for the
-         * event target. This is useful for debugging and diagnostic purposes.
-         *
-         * ```js
-         * import { getEventListeners, EventEmitter } from 'node:events';
-         *
-         * {
-         *   const ee = new EventEmitter();
-         *   const listener = () => console.log('Events are fun');
-         *   ee.on('foo', listener);
-         *   console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
-         * }
-         * {
-         *   const et = new EventTarget();
-         *   const listener = () => console.log('Events are fun');
-         *   et.addEventListener('foo', listener);
-         *   console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
-         * }
-         * ```
-         * @since v15.2.0, v14.17.0
-         */
-        static getEventListeners(emitter: EventTarget | NodeJS.EventEmitter, name: string | symbol): Function[];
-        /**
-         * Returns the currently set max amount of listeners.
-         *
-         * For `EventEmitter`s this behaves exactly the same as calling `.getMaxListeners` on
-         * the emitter.
-         *
-         * For `EventTarget`s this is the only way to get the max event listeners for the
-         * event target. If the number of event handlers on a single EventTarget exceeds
-         * the max set, the EventTarget will print a warning.
-         *
-         * ```js
-         * import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
-         *
-         * {
-         *   const ee = new EventEmitter();
-         *   console.log(getMaxListeners(ee)); // 10
-         *   setMaxListeners(11, ee);
-         *   console.log(getMaxListeners(ee)); // 11
-         * }
-         * {
-         *   const et = new EventTarget();
-         *   console.log(getMaxListeners(et)); // 10
-         *   setMaxListeners(11, et);
-         *   console.log(getMaxListeners(et)); // 11
-         * }
-         * ```
-         * @since v19.9.0
-         */
-        static getMaxListeners(emitter: EventTarget | NodeJS.EventEmitter): number;
-        /**
-         * ```js
-         * import { setMaxListeners, EventEmitter } from 'node:events';
-         *
-         * const target = new EventTarget();
-         * const emitter = new EventEmitter();
-         *
-         * setMaxListeners(5, target, emitter);
-         * ```
-         * @since v15.4.0
-         * @param n A non-negative number. The maximum number of listeners per `EventTarget` event.
-         * @param eventsTargets Zero or more {EventTarget} or {EventEmitter} instances. If none are specified, `n` is set as the default max for all newly created {EventTarget} and {EventEmitter}
-         * objects.
-         */
-        static setMaxListeners(n?: number, ...eventTargets: Array<EventTarget | NodeJS.EventEmitter>): void;
-        /**
-         * Listens once to the `abort` event on the provided `signal`.
-         *
-         * Listening to the `abort` event on abort signals is unsafe and may
-         * lead to resource leaks since another third party with the signal can
-         * call `e.stopImmediatePropagation()`. Unfortunately Node.js cannot change
-         * this since it would violate the web standard. Additionally, the original
-         * API makes it easy to forget to remove listeners.
-         *
-         * This API allows safely using `AbortSignal`s in Node.js APIs by solving these
-         * two issues by listening to the event such that `stopImmediatePropagation` does
-         * not prevent the listener from running.
-         *
-         * Returns a disposable so that it may be unsubscribed from more easily.
-         *
-         * ```js
-         * import { addAbortListener } from 'node:events';
-         *
-         * function example(signal) {
-         *   let disposable;
-         *   try {
-         *     signal.addEventListener('abort', (e) => e.stopImmediatePropagation());
-         *     disposable = addAbortListener(signal, (e) => {
-         *       // Do something when signal is aborted.
-         *     });
-         *   } finally {
-         *     disposable?.[Symbol.dispose]();
-         *   }
-         * }
-         * ```
-         * @since v20.5.0
-         * @experimental
-         * @return Disposable that removes the `abort` listener.
-         */
-        static addAbortListener(signal: AbortSignal, resource: (event: Event) => void): Disposable;
-        /**
-         * This symbol shall be used to install a listener for only monitoring `'error'` events. Listeners installed using this symbol are called before the regular `'error'` listeners are called.
-         *
-         * Installing a listener using this symbol does not change the behavior once an `'error'` event is emitted. Therefore, the process will still crash if no
-         * regular `'error'` listener is installed.
-         * @since v13.6.0, v12.17.0
-         */
-        static readonly errorMonitor: unique symbol;
-        /**
-         * Value: `Symbol.for('nodejs.rejection')`
-         *
-         * See how to write a custom `rejection handler`.
-         * @since v13.4.0, v12.16.0
-         */
-        static readonly captureRejectionSymbol: unique symbol;
-        /**
-         * Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
-         *
-         * Change the default `captureRejections` option on all new `EventEmitter` objects.
-         * @since v13.4.0, v12.16.0
-         */
-        static captureRejections: boolean;
-        /**
-         * By default, a maximum of `10` listeners can be registered for any single
-         * event. This limit can be changed for individual `EventEmitter` instances
-         * using the `emitter.setMaxListeners(n)` method. To change the default
-         * for _all_`EventEmitter` instances, the `events.defaultMaxListeners` property
-         * can be used. If this value is not a positive number, a `RangeError` is thrown.
-         *
-         * Take caution when setting the `events.defaultMaxListeners` because the
-         * change affects _all_ `EventEmitter` instances, including those created before
-         * the change is made. However, calling `emitter.setMaxListeners(n)` still has
-         * precedence over `events.defaultMaxListeners`.
-         *
-         * This is not a hard limit. The `EventEmitter` instance will allow
-         * more listeners to be added but will output a trace warning to stderr indicating
-         * that a "possible EventEmitter memory leak" has been detected. For any single
-         * `EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()` methods can be used to
-         * temporarily avoid this warning:
-         *
-         * ```js
-         * import { EventEmitter } from 'node:events';
-         * const emitter = new EventEmitter();
-         * emitter.setMaxListeners(emitter.getMaxListeners() + 1);
-         * emitter.once('event', () => {
-         *   // do stuff
-         *   emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
-         * });
-         * ```
-         *
-         * The `--trace-warnings` command-line flag can be used to display the
-         * stack trace for such warnings.
-         *
-         * The emitted warning can be inspected with `process.on('warning')` and will
-         * have the additional `emitter`, `type`, and `count` properties, referring to
-         * the event emitter instance, the event's name and the number of attached
-         * listeners, respectively.
-         * Its `name` property is set to `'MaxListenersExceededWarning'`.
-         * @since v0.11.2
-         */
-        static defaultMaxListeners: number;
-    }
-    import internal = require("node:events");
-    namespace EventEmitter {
-        // Should just be `export { EventEmitter }`, but that doesn't work in TypeScript 3.4
-        export { internal as EventEmitter };
-        export interface Abortable {
-            /**
-             * When provided the corresponding `AbortController` can be used to cancel an asynchronous action.
-             */
-            signal?: AbortSignal | undefined;
-        }
-
-        export interface EventEmitterReferencingAsyncResource extends AsyncResource {
-            readonly eventEmitter: EventEmitterAsyncResource;
-        }
-
-        export interface EventEmitterAsyncResourceOptions extends AsyncResourceOptions, EventEmitterOptions {
-            /**
-             * The type of async event, this is required when instantiating `EventEmitterAsyncResource`
-             * directly rather than as a child class.
-             * @default new.target.name if instantiated as a child class.
-             */
-            name?: string;
-        }
-
-        /**
-         * Integrates `EventEmitter` with `AsyncResource` for `EventEmitter`s that
-         * require manual async tracking. Specifically, all events emitted by instances
-         * of `events.EventEmitterAsyncResource` will run within its `async context`.
-         *
-         * ```js
-         * import { EventEmitterAsyncResource, EventEmitter } from 'node:events';
-         * import { notStrictEqual, strictEqual } from 'node:assert';
-         * import { executionAsyncId, triggerAsyncId } from 'node:async_hooks';
-         *
-         * // Async tracking tooling will identify this as 'Q'.
-         * const ee1 = new EventEmitterAsyncResource({ name: 'Q' });
-         *
-         * // 'foo' listeners will run in the EventEmitters async context.
-         * ee1.on('foo', () => {
-         *   strictEqual(executionAsyncId(), ee1.asyncId);
-         *   strictEqual(triggerAsyncId(), ee1.triggerAsyncId);
-         * });
-         *
-         * const ee2 = new EventEmitter();
-         *
-         * // 'foo' listeners on ordinary EventEmitters that do not track async
-         * // context, however, run in the same async context as the emit().
-         * ee2.on('foo', () => {
-         *   notStrictEqual(executionAsyncId(), ee2.asyncId);
-         *   notStrictEqual(triggerAsyncId(), ee2.triggerAsyncId);
-         * });
-         *
-         * Promise.resolve().then(() => {
-         *   ee1.emit('foo');
-         *   ee2.emit('foo');
-         * });
-         * ```
-         *
-         * The `EventEmitterAsyncResource` class has the same methods and takes the
-         * same options as `EventEmitter` and `AsyncResource` themselves.
-         * @since v17.4.0, v16.14.0
-         */
-        export class EventEmitterAsyncResource extends EventEmitter {
-            /**
-             * @param options Only optional in child class.
-             */
-            constructor(options?: EventEmitterAsyncResourceOptions);
-            /**
-             * Call all `destroy` hooks. This should only ever be called once. An error will
-             * be thrown if it is called more than once. This **must** be manually called. If
-             * the resource is left to be collected by the GC then the `destroy` hooks will
-             * never be called.
-             */
-            emitDestroy(): void;
-            /**
-             * The unique `asyncId` assigned to the resource.
-             */
-            readonly asyncId: number;
-            /**
-             * The same triggerAsyncId that is passed to the AsyncResource constructor.
-             */
-            readonly triggerAsyncId: number;
-            /**
-             * The returned `AsyncResource` object has an additional `eventEmitter` property
-             * that provides a reference to this `EventEmitterAsyncResource`.
-             */
-            readonly asyncResource: EventEmitterReferencingAsyncResource;
-        }
-    }
+    // #endregion Event map helper types
     global {
         namespace NodeJS {
             interface EventEmitter<T extends EventMap<T> = DefaultEventMap> {
-                [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
                 /**
                  * Alias for `emitter.on(eventName, listener)`.
                  * @since v0.1.26
                  */
                 addListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                /**
+                 * Synchronously calls each of the listeners registered for the event named
+                 * `eventName`, in the order they were registered, passing the supplied arguments
+                 * to each.
+                 *
+                 * Returns `true` if the event had listeners, `false` otherwise.
+                 *
+                 * ```js
+                 * import { EventEmitter } from 'node:events';
+                 * const myEmitter = new EventEmitter();
+                 *
+                 * // First listener
+                 * myEmitter.on('event', function firstListener() {
+                 *   console.log('Helloooo! first listener');
+                 * });
+                 * // Second listener
+                 * myEmitter.on('event', function secondListener(arg1, arg2) {
+                 *   console.log(`event with parameters ${arg1}, ${arg2} in second listener`);
+                 * });
+                 * // Third listener
+                 * myEmitter.on('event', function thirdListener(...args) {
+                 *   const parameters = args.join(', ');
+                 *   console.log(`event with parameters ${parameters} in third listener`);
+                 * });
+                 *
+                 * console.log(myEmitter.listeners('event'));
+                 *
+                 * myEmitter.emit('event', 1, 2, 3, 4, 5);
+                 *
+                 * // Prints:
+                 * // [
+                 * //   [Function: firstListener],
+                 * //   [Function: secondListener],
+                 * //   [Function: thirdListener]
+                 * // ]
+                 * // Helloooo! first listener
+                 * // event with parameters 1, 2 in second listener
+                 * // event with parameters 1, 2, 3, 4, 5 in third listener
+                 * ```
+                 * @since v0.1.26
+                 */
+                emit<K>(eventName: Key<K, T>, ...args: Args<K, T>): boolean;
+                /**
+                 * Returns an array listing the events for which the emitter has registered
+                 * listeners. The values in the array are strings or `Symbol`s.
+                 *
+                 * ```js
+                 * import { EventEmitter } from 'node:events';
+                 *
+                 * const myEE = new EventEmitter();
+                 * myEE.on('foo', () => {});
+                 * myEE.on('bar', () => {});
+                 *
+                 * const sym = Symbol('symbol');
+                 * myEE.on(sym, () => {});
+                 *
+                 * console.log(myEE.eventNames());
+                 * // Prints: [ 'foo', 'bar', Symbol(symbol) ]
+                 * ```
+                 * @since v6.0.0
+                 */
+                eventNames(): Array<(string | symbol) & Key2<unknown, T>>;
+                /**
+                 * Returns the current max listener value for the `EventEmitter` which is either
+                 * set by `emitter.setMaxListeners(n)` or defaults to `defaultMaxListeners`.
+                 * @since v1.0.0
+                 */
+                getMaxListeners(): number;
+                /**
+                 * Returns the number of listeners listening for the event named `eventName`.
+                 * If `listener` is provided, it will return how many times the listener is found
+                 * in the list of the listeners of the event.
+                 * @since v3.2.0
+                 * @param eventName The name of the event being listened for
+                 * @param listener The event handler function
+                 */
+                listenerCount<K>(eventName: Key<K, T>, listener?: Listener2<K, T>): number;
+                /**
+                 * Returns a copy of the array of listeners for the event named `eventName`.
+                 *
+                 * ```js
+                 * server.on('connection', (stream) => {
+                 *   console.log('someone connected!');
+                 * });
+                 * console.log(util.inspect(server.listeners('connection')));
+                 * // Prints: [ [Function] ]
+                 * ```
+                 * @since v0.1.26
+                 */
+                listeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
+                /**
+                 * Alias for `emitter.removeListener()`.
+                 * @since v10.0.0
+                 */
+                off<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
                 /**
                  * Adds the `listener` function to the end of the listeners array for the event
                  * named `eventName`. No checks are made to see if the `listener` has already
@@ -609,7 +170,8 @@ declare module "events" {
                  *
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  *
-                 * By default, event listeners are invoked in the order they are added. The `emitter.prependListener()` method can be used as an alternative to add the
+                 * By default, event listeners are invoked in the order they are added. The
+                 * `emitter.prependListener()` method can be used as an alternative to add the
                  * event listener to the beginning of the listeners array.
                  *
                  * ```js
@@ -639,7 +201,8 @@ declare module "events" {
                  *
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  *
-                 * By default, event listeners are invoked in the order they are added. The `emitter.prependOnceListener()` method can be used as an alternative to add the
+                 * By default, event listeners are invoked in the order they are added. The
+                 * `emitter.prependOnceListener()` method can be used as an alternative to add the
                  * event listener to the beginning of the listeners array.
                  *
                  * ```js
@@ -658,7 +221,54 @@ declare module "events" {
                  */
                 once<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
                 /**
-                 * Removes the specified `listener` from the listener array for the event named `eventName`.
+                 * Adds the `listener` function to the _beginning_ of the listeners array for the
+                 * event named `eventName`. No checks are made to see if the `listener` has
+                 * already been added. Multiple calls passing the same combination of `eventName`
+                 * and `listener` will result in the `listener` being added, and called, multiple times.
+                 *
+                 * ```js
+                 * server.prependListener('connection', (stream) => {
+                 *   console.log('someone connected!');
+                 * });
+                 * ```
+                 *
+                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
+                 * @since v6.0.0
+                 * @param eventName The name of the event.
+                 * @param listener The callback function
+                 */
+                prependListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                /**
+                 * Adds a **one-time**`listener` function for the event named `eventName` to the
+                 * _beginning_ of the listeners array. The next time `eventName` is triggered, this
+                 * listener is removed, and then invoked.
+                 *
+                 * ```js
+                 * server.prependOnceListener('connection', (stream) => {
+                 *   console.log('Ah, we have our first user!');
+                 * });
+                 * ```
+                 *
+                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
+                 * @since v6.0.0
+                 * @param eventName The name of the event.
+                 * @param listener The callback function
+                 */
+                prependOnceListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                /**
+                 * Removes all listeners, or those of the specified `eventName`.
+                 *
+                 * It is bad practice to remove listeners added elsewhere in the code,
+                 * particularly when the `EventEmitter` instance was created by some other
+                 * component or module (e.g. sockets or file streams).
+                 *
+                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
+                 * @since v0.1.26
+                 */
+                removeAllListeners(eventName?: Key<unknown, T>): this;
+                /**
+                 * Removes the specified `listener` from the listener array for the event named
+                 * `eventName`.
                  *
                  * ```js
                  * const callback = (stream) => {
@@ -675,8 +285,10 @@ declare module "events" {
                  * called multiple times to remove each instance.
                  *
                  * Once an event is emitted, all listeners attached to it at the
-                 * time of emitting are called in order. This implies that any `removeListener()` or `removeAllListeners()` calls _after_ emitting and _before_ the last listener finishes execution
-                 * will not remove them from`emit()` in progress. Subsequent events behave as expected.
+                 * time of emitting are called in order. This implies that any
+                 * `removeListener()` or `removeAllListeners()` calls _after_ emitting and
+                 * _before_ the last listener finishes execution will not remove them from
+                 * `emit()` in progress. Subsequent events behave as expected.
                  *
                  * ```js
                  * import { EventEmitter } from 'node:events';
@@ -741,50 +353,16 @@ declare module "events" {
                  */
                 removeListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
                 /**
-                 * Alias for `emitter.removeListener()`.
-                 * @since v10.0.0
-                 */
-                off<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
-                /**
-                 * Removes all listeners, or those of the specified `eventName`.
-                 *
-                 * It is bad practice to remove listeners added elsewhere in the code,
-                 * particularly when the `EventEmitter` instance was created by some other
-                 * component or module (e.g. sockets or file streams).
-                 *
-                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
-                 * @since v0.1.26
-                 */
-                removeAllListeners(eventName?: Key<unknown, T>): this;
-                /**
                  * By default `EventEmitter`s will print a warning if more than `10` listeners are
                  * added for a particular event. This is a useful default that helps finding
                  * memory leaks. The `emitter.setMaxListeners()` method allows the limit to be
-                 * modified for this specific `EventEmitter` instance. The value can be set to `Infinity` (or `0`) to indicate an unlimited number of listeners.
+                 * modified for this specific `EventEmitter` instance. The value can be set to
+                 * `Infinity` (or `0`) to indicate an unlimited number of listeners.
                  *
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.3.5
                  */
                 setMaxListeners(n: number): this;
-                /**
-                 * Returns the current max listener value for the `EventEmitter` which is either
-                 * set by `emitter.setMaxListeners(n)` or defaults to {@link defaultMaxListeners}.
-                 * @since v1.0.0
-                 */
-                getMaxListeners(): number;
-                /**
-                 * Returns a copy of the array of listeners for the event named `eventName`.
-                 *
-                 * ```js
-                 * server.on('connection', (stream) => {
-                 *   console.log('someone connected!');
-                 * });
-                 * console.log(util.inspect(server.listeners('connection')));
-                 * // Prints: [ [Function] ]
-                 * ```
-                 * @since v0.1.26
-                 */
-                listeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
                  * including any wrappers (such as those created by `.once()`).
@@ -817,110 +395,514 @@ declare module "events" {
                  */
                 rawListeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
                 /**
-                 * Synchronously calls each of the listeners registered for the event named `eventName`, in the order they were registered, passing the supplied arguments
-                 * to each.
-                 *
-                 * Returns `true` if the event had listeners, `false` otherwise.
-                 *
-                 * ```js
-                 * import { EventEmitter } from 'node:events';
-                 * const myEmitter = new EventEmitter();
-                 *
-                 * // First listener
-                 * myEmitter.on('event', function firstListener() {
-                 *   console.log('Helloooo! first listener');
-                 * });
-                 * // Second listener
-                 * myEmitter.on('event', function secondListener(arg1, arg2) {
-                 *   console.log(`event with parameters ${arg1}, ${arg2} in second listener`);
-                 * });
-                 * // Third listener
-                 * myEmitter.on('event', function thirdListener(...args) {
-                 *   const parameters = args.join(', ');
-                 *   console.log(`event with parameters ${parameters} in third listener`);
-                 * });
-                 *
-                 * console.log(myEmitter.listeners('event'));
-                 *
-                 * myEmitter.emit('event', 1, 2, 3, 4, 5);
-                 *
-                 * // Prints:
-                 * // [
-                 * //   [Function: firstListener],
-                 * //   [Function: secondListener],
-                 * //   [Function: thirdListener]
-                 * // ]
-                 * // Helloooo! first listener
-                 * // event with parameters 1, 2 in second listener
-                 * // event with parameters 1, 2, 3, 4, 5 in third listener
-                 * ```
-                 * @since v0.1.26
-                 */
-                emit<K>(eventName: Key<K, T>, ...args: Args<K, T>): boolean;
-                /**
-                 * Returns the number of listeners listening for the event named `eventName`.
-                 * If `listener` is provided, it will return how many times the listener is found
-                 * in the list of the listeners of the event.
-                 * @since v3.2.0
-                 * @param eventName The name of the event being listened for
-                 * @param listener The event handler function
-                 */
-                listenerCount<K>(eventName: Key<K, T>, listener?: Listener2<K, T>): number;
-                /**
-                 * Adds the `listener` function to the _beginning_ of the listeners array for the
-                 * event named `eventName`. No checks are made to see if the `listener` has
-                 * already been added. Multiple calls passing the same combination of `eventName`
-                 * and `listener` will result in the `listener` being added, and called, multiple times.
+                 * The `Symbol.for('nodejs.rejection')` method is called in case a
+                 * promise rejection happens when emitting an event and
+                 * `captureRejections` is enabled on the emitter.
+                 * It is possible to use `events.captureRejectionSymbol` in
+                 * place of `Symbol.for('nodejs.rejection')`.
                  *
                  * ```js
-                 * server.prependListener('connection', (stream) => {
-                 *   console.log('someone connected!');
-                 * });
+                 * import { EventEmitter, captureRejectionSymbol } from 'node:events';
+                 *
+                 * class MyClass extends EventEmitter {
+                 *   constructor() {
+                 *     super({ captureRejections: true });
+                 *   }
+                 *
+                 *   [captureRejectionSymbol](err, event, ...args) {
+                 *     console.log('rejection happened for', event, 'with', err, ...args);
+                 *     this.destroy(err);
+                 *   }
+                 *
+                 *   destroy(err) {
+                 *     // Tear the resource down here.
+                 *   }
+                 * }
                  * ```
-                 *
-                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
-                 * @since v6.0.0
-                 * @param eventName The name of the event.
-                 * @param listener The callback function
+                 * @since v13.4.0, v12.16.0
                  */
-                prependListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
-                /**
-                 * Adds a **one-time**`listener` function for the event named `eventName` to the _beginning_ of the listeners array. The next time `eventName` is triggered, this
-                 * listener is removed, and then invoked.
-                 *
-                 * ```js
-                 * server.prependOnceListener('connection', (stream) => {
-                 *   console.log('Ah, we have our first user!');
-                 * });
-                 * ```
-                 *
-                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
-                 * @since v6.0.0
-                 * @param eventName The name of the event.
-                 * @param listener The callback function
-                 */
-                prependOnceListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
-                /**
-                 * Returns an array listing the events for which the emitter has registered
-                 * listeners. The values in the array are strings or `Symbol`s.
-                 *
-                 * ```js
-                 * import { EventEmitter } from 'node:events';
-                 *
-                 * const myEE = new EventEmitter();
-                 * myEE.on('foo', () => {});
-                 * myEE.on('bar', () => {});
-                 *
-                 * const sym = Symbol('symbol');
-                 * myEE.on(sym, () => {});
-                 *
-                 * console.log(myEE.eventNames());
-                 * // Prints: [ 'foo', 'bar', Symbol(symbol) ]
-                 * ```
-                 * @since v6.0.0
-                 */
-                eventNames(): Array<(string | symbol) & Key2<unknown, T>>;
+                [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
             }
+        }
+    }
+    interface EventEmitterOptions {
+        /**
+         * Enables automatic capturing of promise rejection.
+         */
+        captureRejections?: boolean | undefined;
+    }
+    /**
+     * An interface mapping event names to event parameter tuples.
+     */
+    type EventMap<T> = Record<keyof T, any[]> | DefaultEventMap;
+    /**
+     * The `EventEmitter` class is defined and exposed by the `node:events` module:
+     *
+     * ```js
+     * import { EventEmitter } from 'node:events';
+     * ```
+     *
+     * All `EventEmitter`s emit the event `'newListener'` when new listeners are
+     * added and `'removeListener'` when existing listeners are removed.
+     * @since v0.1.26
+     */
+    class EventEmitter<T extends EventMap<T> = DefaultEventMap> {
+        constructor(options?: EventEmitterOptions);
+    }
+    interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
+    namespace EventEmitter {
+        export { EventEmitter, EventEmitterOptions, EventMap };
+    }
+    namespace EventEmitter {
+        interface Abortable {
+            /**
+             * When provided, the corresponding `AbortController` can be used to cancel an asynchronous action.
+             */
+            signal?: AbortSignal | undefined;
+        }
+        /**
+         * By default, a maximum of `10` listeners can be registered for any single
+         * event. This limit can be changed for individual `EventEmitter` instances
+         * using the `emitter.setMaxListeners(n)` method. To change the default
+         * for _all_ `EventEmitter` instances, the `events.defaultMaxListeners`
+         * property can be used. If this value is not a positive number, a `RangeError`
+         * is thrown.
+         *
+         * Take caution when setting the `events.defaultMaxListeners` because the
+         * change affects _all_ `EventEmitter` instances, including those created before
+         * the change is made. However, calling `emitter.setMaxListeners(n)` still has
+         * precedence over `events.defaultMaxListeners`.
+         *
+         * This is not a hard limit. The `EventEmitter` instance will allow
+         * more listeners to be added but will output a trace warning to stderr indicating
+         * that a "possible EventEmitter memory leak" has been detected. For any single
+         * `EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`
+         * methods can be used to temporarily avoid this warning:
+         *
+         * ```js
+         * import { EventEmitter } from 'node:events';
+         * const emitter = new EventEmitter();
+         * emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+         * emitter.once('event', () => {
+         *   // do stuff
+         *   emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+         * });
+         * ```
+         *
+         * The `--trace-warnings` command-line flag can be used to display the
+         * stack trace for such warnings.
+         *
+         * The emitted warning can be inspected with `process.on('warning')` and will
+         * have the additional `emitter`, `type`, and `count` properties, referring to
+         * the event emitter instance, the event's name and the number of attached
+         * listeners, respectively.
+         * Its `name` property is set to `'MaxListenersExceededWarning'`.
+         * @since v0.11.2
+         */
+        var defaultMaxListeners: number;
+        /**
+         * This symbol shall be used to install a listener for only monitoring `'error'`
+         * events. Listeners installed using this symbol are called before the regular
+         * `'error'` listeners are called.
+
+        * Installing a listener using this symbol does not change the behavior once an
+        * `'error'` event is emitted. Therefore, the process will still crash if no
+        * regular `'error'` listener is installed.
+        * @since v13.6.0, v12.17.0
+        */
+        const errorMonitor: unique symbol;
+        /**
+         * Returns a copy of the array of listeners for the event named `eventName`.
+         *
+         * For `EventEmitter`s this behaves exactly the same as calling `.listeners` on
+         * the emitter.
+         *
+         * For `EventTarget`s this is the only way to get the event listeners for the
+         * event target. This is useful for debugging and diagnostic purposes.
+         *
+         * ```js
+         * import { getEventListeners, EventEmitter } from 'node:events';
+         *
+         * {
+         *   const ee = new EventEmitter();
+         *   const listener = () => console.log('Events are fun');
+         *   ee.on('foo', listener);
+         *   console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
+         * }
+         * {
+         *   const et = new EventTarget();
+         *   const listener = () => console.log('Events are fun');
+         *   et.addEventListener('foo', listener);
+         *   console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
+         * }
+         * ```
+         * @since v15.2.0, v14.17.0
+         */
+        function getEventListeners(emitter: EventTarget | NodeJS.EventEmitter, name: string | symbol): Function[];
+        /**
+         * Returns the currently set max amount of listeners.
+         *
+         * For `EventEmitter`s this behaves exactly the same as calling `.getMaxListeners` on
+         * the emitter.
+         *
+         * For `EventTarget`s this is the only way to get the max event listeners for the
+         * event target. If the number of event handlers on a single EventTarget exceeds
+         * the max set, the EventTarget will print a warning.
+         *
+         * ```js
+         * import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
+         *
+         * {
+         *   const ee = new EventEmitter();
+         *   console.log(getMaxListeners(ee)); // 10
+         *   setMaxListeners(11, ee);
+         *   console.log(getMaxListeners(ee)); // 11
+         * }
+         * {
+         *   const et = new EventTarget();
+         *   console.log(getMaxListeners(et)); // 10
+         *   setMaxListeners(11, et);
+         *   console.log(getMaxListeners(et)); // 11
+         * }
+         * ```
+         * @since v19.9.0
+         */
+        function getMaxListeners(emitter: EventTarget | NodeJS.EventEmitter): number;
+        interface OnceOptions extends Abortable {}
+        /**
+         * Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
+         * event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
+         * The `Promise` will resolve with an array of all the arguments emitted to the
+         * given event.
+         *
+         * This method is intentionally generic and works with the web platform
+         * [EventTarget](https://dom.spec.whatwg.org/#interface-eventtarget)
+         * interface, which has no special`'error'` event
+         * semantics and does not listen to the `'error'` event.
+         *
+         * ```js
+         * import { once, EventEmitter } from 'node:events';
+         * import process from 'node:process';
+         *
+         * const ee = new EventEmitter();
+         *
+         * process.nextTick(() => {
+         *   ee.emit('myevent', 42);
+         * });
+         *
+         * const [value] = await once(ee, 'myevent');
+         * console.log(value);
+         *
+         * const err = new Error('kaboom');
+         * process.nextTick(() => {
+         *   ee.emit('error', err);
+         * });
+         *
+         * try {
+         *   await once(ee, 'myevent');
+         * } catch (err) {
+         *   console.error('error happened', err);
+         * }
+         * ```
+         *
+         * The special handling of the `'error'` event is only used when `events.once()`
+         * is used to wait for another event. If `events.once()` is used to wait for the
+         * '`error'` event itself, then it is treated as any other kind of event without
+         * special handling:
+         *
+         * ```js
+         * import { EventEmitter, once } from 'node:events';
+         *
+         * const ee = new EventEmitter();
+         *
+         * once(ee, 'error')
+         *   .then(([err]) => console.log('ok', err.message))
+         *   .catch((err) => console.error('error', err.message));
+         *
+         * ee.emit('error', new Error('boom'));
+         *
+         * // Prints: ok boom
+         * ```
+         *
+         * An `AbortSignal` can be used to cancel waiting for the event:
+         *
+         * ```js
+         * import { EventEmitter, once } from 'node:events';
+         *
+         * const ee = new EventEmitter();
+         * const ac = new AbortController();
+         *
+         * async function foo(emitter, event, signal) {
+         *   try {
+         *     await once(emitter, event, { signal });
+         *     console.log('event emitted!');
+         *   } catch (error) {
+         *     if (error.name === 'AbortError') {
+         *       console.error('Waiting for the event was canceled!');
+         *     } else {
+         *       console.error('There was an error', error.message);
+         *     }
+         *   }
+         * }
+         *
+         * foo(ee, 'foo', ac.signal);
+         * ac.abort(); // Abort waiting for the event
+         * ee.emit('foo'); // Prints: Waiting for the event was canceled!
+         * ```
+         * @since v11.13.0, v10.16.0
+         */
+        function once(
+            emitter: NodeJS.EventEmitter,
+            eventName: string | symbol,
+            options?: OnceOptions,
+        ): Promise<any[]>;
+        function once(emitter: EventTarget, eventName: string, options?: OnceOptions): Promise<any[]>;
+        /**
+         * Change the default `captureRejections` option on all new `EventEmitter` objects.
+         * @since v13.4.0, v12.16.0
+         */
+        var captureRejections: boolean;
+        /**
+         * Value: `Symbol.for('nodejs.rejection')`
+         * @since v13.4.0, v12.16.0
+         */
+        const captureRejectionSymbol: unique symbol;
+        /**
+         * A class method that returns the number of listeners for the given `eventName`
+         * registered on the given `emitter`.
+         *
+         * ```js
+         * import { EventEmitter, listenerCount } from 'node:events';
+         *
+         * const myEmitter = new EventEmitter();
+         * myEmitter.on('event', () => {});
+         * myEmitter.on('event', () => {});
+         * console.log(listenerCount(myEmitter, 'event'));
+         * // Prints: 2
+         * ```
+         * @since v0.9.12
+         * @deprecated Since v3.2.0 - Use `emitter.listenerCount` instead.
+         * @param emitter The emitter to query
+         * @param eventName The event name
+         */
+        function listenerCount(emitter: NodeJS.EventEmitter, eventName: string | symbol): number;
+        interface OnOptions extends Abortable {
+            /**
+             * Names of events that will end the iteration.
+             * @since v20.0.0
+             */
+            close?: string[] | undefined;
+            /**
+             * The high watermark. The emitter is paused every time the size of events
+             * being buffered is higher than it. Supported only on emitters implementing
+             * `pause()` and `resume()` methods.
+             * @default Number.MAX_SAFE_INTEGER
+             * @since v22.0.0
+             */
+            highWaterMark?: number | undefined;
+            /**
+             * The low watermark. The emitter is resumed every time the size of events
+             * being buffered is lower than it. Supported only on emitters implementing
+             * `pause()` and `resume()` methods.
+             * @default 1
+             * @since v22.0.0
+             */
+            lowWaterMark?: number | undefined;
+        }
+        /**
+         * ```js
+         * import { on, EventEmitter } from 'node:events';
+         * import process from 'node:process';
+         *
+         * const ee = new EventEmitter();
+         *
+         * // Emit later on
+         * process.nextTick(() => {
+         *   ee.emit('foo', 'bar');
+         *   ee.emit('foo', 42);
+         * });
+         *
+         * for await (const event of on(ee, 'foo')) {
+         *   // The execution of this inner block is synchronous and it
+         *   // processes one event at a time (even with await). Do not use
+         *   // if concurrent execution is required.
+         *   console.log(event); // prints ['bar'] [42]
+         * }
+         * // Unreachable here
+         * ```
+         *
+         * Returns an `AsyncIterator` that iterates `eventName` events. It will throw
+         * if the `EventEmitter` emits `'error'`. It removes all listeners when
+         * exiting the loop. The `value` returned by each iteration is an array
+         * composed of the emitted event arguments.
+         *
+         * An `AbortSignal` can be used to cancel waiting on events:
+         *
+         * ```js
+         * import { on, EventEmitter } from 'node:events';
+         * import process from 'node:process';
+         *
+         * const ac = new AbortController();
+         *
+         * (async () => {
+         *   const ee = new EventEmitter();
+         *
+         *   // Emit later on
+         *   process.nextTick(() => {
+         *     ee.emit('foo', 'bar');
+         *     ee.emit('foo', 42);
+         *   });
+         *
+         *   for await (const event of on(ee, 'foo', { signal: ac.signal })) {
+         *     // The execution of this inner block is synchronous and it
+         *     // processes one event at a time (even with await). Do not use
+         *     // if concurrent execution is required.
+         *     console.log(event); // prints ['bar'] [42]
+         *   }
+         *   // Unreachable here
+         * })();
+         *
+         * process.nextTick(() => ac.abort());
+         * ```
+         * @since v13.6.0, v12.16.0
+         * @return An `AsyncIterator` that iterates `eventName` events emitted by the `emitter`
+         */
+        function on(
+            emitter: NodeJS.EventEmitter,
+            eventName: string | symbol,
+            options?: OnOptions,
+        ): AsyncIterableIterator<any[]>;
+        function on(
+            emitter: EventTarget,
+            eventName: string,
+            options?: OnOptions,
+        ): AsyncIterableIterator<any[]>;
+        /**
+         * ```js
+         * import { setMaxListeners, EventEmitter } from 'node:events';
+         *
+         * const target = new EventTarget();
+         * const emitter = new EventEmitter();
+         *
+         * setMaxListeners(5, target, emitter);
+         * ```
+         * @since v15.4.0
+         * @param n A non-negative number. The maximum number of listeners per
+         * `EventTarget` event.
+         * @param eventsTargets Zero or more `EventTarget` or {EventEmitter} instances.
+         * If none are specified, `n` is set as the default max for all newly created
+         * `EventTarget` and `EventEmitter` objects.
+         */
+        function setMaxListeners(n?: number, ...eventTargets: Array<EventTarget | NodeJS.EventEmitter>): void;
+        /**
+         * Listens once to the `abort` event on the provided `signal`.
+         *
+         * Listening to the `abort` event on abort signals is unsafe and may
+         * lead to resource leaks since another third party with the signal can
+         * call `e.stopImmediatePropagation()`. Unfortunately Node.js cannot change
+         * this since it would violate the web standard. Additionally, the original
+         * API makes it easy to forget to remove listeners.
+         *
+         * This API allows safely using `AbortSignal`s in Node.js APIs by solving these
+         * two issues by listening to the event such that `stopImmediatePropagation` does
+         * not prevent the listener from running.
+         *
+         * Returns a disposable so that it may be unsubscribed from more easily.
+         *
+         * ```js
+         * import { addAbortListener } from 'node:events';
+         *
+         * function example(signal) {
+         *   let disposable;
+         *   try {
+         *     signal.addEventListener('abort', (e) => e.stopImmediatePropagation());
+         *     disposable = addAbortListener(signal, (e) => {
+         *       // Do something when signal is aborted.
+         *     });
+         *   } finally {
+         *     disposable?.[Symbol.dispose]();
+         *   }
+         * }
+         * ```
+         * @since v20.5.0, v18.18.0
+         * @experimental
+         * @return Disposable that removes the `abort` listener.
+         */
+        function addAbortListener(signal: AbortSignal, resource: (event: Event) => void): Disposable;
+        class EventEmitterReferencingAsyncResource extends AsyncResource {
+            private constructor();
+            readonly eventEmitter: EventEmitterAsyncResource;
+        }
+        interface EventEmitterAsyncResourceOptions extends AsyncResourceOptions, EventEmitterOptions {
+            /**
+             * The type of async event.
+             * @default new.target.name
+             */
+            name?: string | undefined;
+        }
+        /**
+         * Integrates `EventEmitter` with `AsyncResource` for `EventEmitter`s that
+         * require manual async tracking. Specifically, all events emitted by instances
+         * of `events.EventEmitterAsyncResource` will run within its `async context`.
+         *
+         * ```js
+         * import { EventEmitterAsyncResource, EventEmitter } from 'node:events';
+         * import { notStrictEqual, strictEqual } from 'node:assert';
+         * import { executionAsyncId, triggerAsyncId } from 'node:async_hooks';
+         *
+         * // Async tracking tooling will identify this as 'Q'.
+         * const ee1 = new EventEmitterAsyncResource({ name: 'Q' });
+         *
+         * // 'foo' listeners will run in the EventEmitters async context.
+         * ee1.on('foo', () => {
+         *   strictEqual(executionAsyncId(), ee1.asyncId);
+         *   strictEqual(triggerAsyncId(), ee1.triggerAsyncId);
+         * });
+         *
+         * const ee2 = new EventEmitter();
+         *
+         * // 'foo' listeners on ordinary EventEmitters that do not track async
+         * // context, however, run in the same async context as the emit().
+         * ee2.on('foo', () => {
+         *   notStrictEqual(executionAsyncId(), ee2.asyncId);
+         *   notStrictEqual(triggerAsyncId(), ee2.triggerAsyncId);
+         * });
+         *
+         * Promise.resolve().then(() => {
+         *   ee1.emit('foo');
+         *   ee2.emit('foo');
+         * });
+         * ```
+         *
+         * The `EventEmitterAsyncResource` class has the same methods and takes the
+         * same options as `EventEmitter` and `AsyncResource` themselves.
+         * @since v17.4.0, v16.14.0
+         */
+        class EventEmitterAsyncResource extends EventEmitter {
+            /**
+             * @param options Only optional in child class.
+             */
+            constructor(options?: EventEmitterAsyncResourceOptions);
+            /**
+             * Call all `destroy` hooks. This should only ever be called once. An error will
+             * be thrown if it is called more than once. This **must** be manually called. If
+             * the resource is left to be collected by the GC then the `destroy` hooks will
+             * never be called.
+             */
+            emitDestroy(): void;
+            /**
+             * The unique `asyncId` assigned to the resource.
+             */
+            readonly asyncId: number;
+            /**
+             * The same triggerAsyncId that is passed to the AsyncResource constructor.
+             */
+            readonly triggerAsyncId: number;
+            /**
+             * The returned `AsyncResource` object has an additional `eventEmitter` property
+             * that provides a reference to this `EventEmitterAsyncResource`.
+             */
+            readonly asyncResource: EventEmitterReferencingAsyncResource;
         }
     }
     export = EventEmitter;

--- a/types/node/test/events.ts
+++ b/types/node/test/events.ts
@@ -1,81 +1,128 @@
-import * as events from "node:events";
+// These should be equivalent
+import events = require("node:events");
+import { EventEmitter } from "node:events";
+{
+    let module: typeof events;
+    module = EventEmitter;
+    module = events.EventEmitter;
+}
 
-const emitter: events = new events.EventEmitter();
+const emitter = new EventEmitter();
 declare const listener: (...args: any[]) => void;
 declare const event: string | symbol;
-declare const any: any;
 
 {
-    let result: events.EventEmitter;
+    // dtslint won't alias the EventEmitter type, so we use this instead
+    function $ExpectEventEmitterType(...expr: EventEmitter[]) {}
 
-    result = emitter.addListener(event, listener);
-    result = emitter.on(event, listener);
-    result = emitter.once(event, listener);
-    result = emitter.prependListener(event, listener);
-    result = emitter.prependOnceListener(event, listener);
-    result = emitter.removeListener(event, listener);
-    result = emitter.off(event, listener);
-    result = emitter.removeAllListeners();
-    result = emitter.removeAllListeners(event);
-    result = emitter.setMaxListeners(42);
-}
+    $ExpectEventEmitterType(
+        emitter.addListener(event, listener),
+    );
 
-{
-    let result: number;
+    // $ExpectType boolean
+    emitter.emit(event);
+    // $ExpectType boolean
+    emitter.emit(event, ...[]);
 
-    result = events.EventEmitter.defaultMaxListeners;
-    result = events.EventEmitter.listenerCount(emitter, event); // deprecated
+    // $ExpectType (string | symbol)[]
+    emitter.eventNames();
 
-    const promise: Promise<any[]> = events.once(new events.EventEmitter(), "error");
+    // $ExpectType number
+    emitter.getMaxListeners();
 
-    result = emitter.getMaxListeners();
-    result = emitter.listenerCount(event);
+    // $ExpectType number
+    emitter.listenerCount(event);
+    // $ExpectType number
+    emitter.listenerCount(event, listener);
 
-    const handler: Function = () => {};
-    result = emitter.listenerCount(event, handler);
-}
+    $ExpectEventEmitterType(
+        emitter.off(event, listener),
+    );
 
-{
-    let result: Promise<number[]>;
+    $ExpectEventEmitterType(
+        emitter.on(event, listener),
+    );
 
-    result = events.once(emitter, event);
+    $ExpectEventEmitterType(
+        emitter.once(event, listener),
+    );
 
-    emitter.emit(event, 42);
-}
+    $ExpectEventEmitterType(
+        emitter.prependListener(event, listener),
+    );
 
-{
-    let result: Function[];
+    $ExpectEventEmitterType(
+        emitter.prependOnceListener(event, listener),
+    );
 
-    result = emitter.listeners(event);
-}
+    $ExpectEventEmitterType(
+        emitter.removeAllListeners(),
+        emitter.removeAllListeners(event),
+    );
 
-{
-    let result: boolean;
+    $ExpectEventEmitterType(
+        emitter.removeListener(event, listener),
+    );
 
-    result = emitter.emit(event);
-    result = emitter.emit(event, any);
-    result = emitter.emit(event, any, any);
-    result = emitter.emit(event, any, any, any);
-}
+    $ExpectEventEmitterType(
+        emitter.setMaxListeners(42),
+    );
 
-{
-    let result: Array<string | symbol>;
+    // $ExpectType Function[]
+    emitter.rawListeners(event);
 
-    result = emitter.eventNames();
-}
-
-{
-    class Networker extends events.EventEmitter {
-        constructor() {
-            super();
-
-            this.emit("mingling");
-        }
+    if (emitter[EventEmitter.captureRejectionSymbol]) {
+        // $ExpectType void
+        emitter[EventEmitter.captureRejectionSymbol](new Error(), event);
+        // $ExpectType void
+        emitter[EventEmitter.captureRejectionSymbol](new Error(), event, ...[]);
+    } else {
+        // $ExpectType undefined
+        emitter[EventEmitter.captureRejectionSymbol];
     }
 }
 
 {
-    const emitter2: events.EventEmitter = new events();
+    // $ExpectType number
+    EventEmitter.defaultMaxListeners;
+    EventEmitter.defaultMaxListeners = 50;
+
+    // $ExpectType Function[]
+    EventEmitter.getEventListeners(emitter, event);
+
+    // $ExpectType number
+    EventEmitter.getMaxListeners(emitter);
+
+    // $ExpectType Promise<any[]>
+    EventEmitter.once(emitter, event);
+
+    // $ExpectType boolean
+    EventEmitter.captureRejections;
+    EventEmitter.captureRejections = true;
+
+    // $ExpectType number
+    EventEmitter.listenerCount(emitter, event);
+
+    // $ExpectType AsyncIterableIterator<any[]>
+    EventEmitter.on(emitter, event);
+
+    // $ExpectType void
+    EventEmitter.setMaxListeners(50, emitter);
+}
+
+{
+    class Networker extends EventEmitter {
+        static {
+            // Check that namespace variables are accessible as constructor properties
+            this.captureRejections = true;
+            this.defaultMaxListeners = 25;
+        }
+
+        constructor() {
+            super();
+            this.emit("mingling");
+        }
+    }
 }
 
 {
@@ -96,65 +143,53 @@ declare const any: any;
 }
 
 async function test() {
-    for await (const e of events.on(new events.EventEmitter(), "test")) {
-        console.log(e.length);
+    for await (const e of events.on(new EventEmitter(), "test")) {
+        // $ExpectType any[]
+        e;
     }
-    events.on(new events.EventEmitter(), "test", { signal: new AbortController().signal });
-    events.on(new events.EventEmitter(), "test", { close: ["close"] });
-    events.on(new events.EventEmitter(), "test", { highWaterMark: 42 });
-    events.on(new events.EventEmitter(), "test", { lowWaterMark: 42 });
+    events.on(new EventEmitter(), "test", { signal: new AbortController().signal });
+    events.on(new EventEmitter(), "test", { close: ["close"] });
+    events.on(new EventEmitter(), "test", { highWaterMark: 42 });
+    events.on(new EventEmitter(), "test", { lowWaterMark: 42 });
 }
 
 async function testWithSymbol() {
-    for await (const e of events.on(new events.EventEmitter(), Symbol("test"))) {
-        console.log(e.length);
+    for await (const e of events.on(new EventEmitter(), Symbol("test"))) {
+        // $ExpectType any[]
+        e;
     }
-    events.on(new events.EventEmitter(), Symbol("test"), { signal: new AbortController().signal });
+    events.on(new EventEmitter(), Symbol("test"), { signal: new AbortController().signal });
 }
 
 async function testEventTarget() {
     for await (const e of events.on(new EventTarget(), "test")) {
-        console.log(e);
+        // $ExpectType any[]
+        e;
     }
     events.on(new EventTarget(), "test", { signal: new AbortController().signal });
 }
 
 {
-    emitter.on(events.errorMonitor, listener);
-    emitter.on(events.EventEmitter.errorMonitor, listener);
+    const errorMonitor: typeof events.errorMonitor = EventEmitter.errorMonitor;
+    emitter.on(errorMonitor, listener);
 }
 
 {
-    let errorMonitor1: typeof events.errorMonitor = events.errorMonitor;
-    errorMonitor1 = events.EventEmitter.errorMonitor;
-
-    let errorMonitor2: typeof events.EventEmitter.errorMonitor = events.EventEmitter.errorMonitor;
-    errorMonitor2 = events.errorMonitor;
+    const captureRejectionSymbol: typeof events.captureRejectionSymbol = EventEmitter.captureRejectionSymbol;
+    emitter[captureRejectionSymbol] = (err: Error, name: string, ...args: any[]) => {};
 }
 
 {
-    let captureRejectionSymbol1: typeof events.captureRejectionSymbol = events.captureRejectionSymbol;
-    captureRejectionSymbol1 = events.EventEmitter.captureRejectionSymbol;
-
-    let captureRejectionSymbol2: typeof events.EventEmitter.captureRejectionSymbol =
-        events.EventEmitter.captureRejectionSymbol;
-    captureRejectionSymbol2 = events.captureRejectionSymbol;
-
-    const emitter = new events.EventEmitter();
-    emitter[events.captureRejectionSymbol] = (err: Error, name: string, ...args: any[]) => {};
-}
-
-{
-    events.EventEmitter.setMaxListeners();
-    events.EventEmitter.setMaxListeners(42);
+    events.setMaxListeners();
+    events.setMaxListeners(42);
 
     const eventTarget = new EventTarget();
-    events.EventEmitter.setMaxListeners(42, eventTarget);
+    events.setMaxListeners(42, eventTarget);
     // @ts-expect-error - ensure constructor does not return a constructor
     new eventTarget();
 
-    const eventEmitter = new events.EventEmitter();
-    events.EventEmitter.setMaxListeners(42, eventTarget, eventEmitter);
+    const eventEmitter = new EventEmitter();
+    events.setMaxListeners(42, eventTarget, eventEmitter);
 }
 
 {
@@ -163,7 +198,8 @@ async function testEventTarget() {
         const signal = new AbortSignal();
         signal.addEventListener("abort", (e) => e.stopImmediatePropagation());
         disposable = events.addAbortListener(signal, (e) => {
-            console.log(e);
+            // $ExpectType Event
+            e;
         });
     } finally {
         disposable?.[Symbol.dispose]();
@@ -181,25 +217,27 @@ async function testEventTarget() {
         name: "test",
     });
 
-    emitter.asyncId; // $ExpectType number
-    emitter.asyncResource; // $ExpectType EventEmitterReferencingAsyncResource
-    emitter.triggerAsyncId; // $ExpectType number
+    // $ExpectType number
+    emitter.asyncId;
+    // $ExpectType EventEmitterReferencingAsyncResource
+    emitter.asyncResource;
+    // $ExpectType number
+    emitter.triggerAsyncId;
+    // $ExpectType void
     emitter.emitDestroy();
 }
 
-{
-    class MyEmitter extends events.EventEmitter {
-        addListener(event: string, listener: () => void): this {
-            return this;
-        }
-        listeners(event: string): Array<() => void> {
-            return [];
-        }
-        emit(event: string, ...args: any[]): boolean {
-            return true;
-        }
-        listenerCount(type: string): number {
-            return 0;
-        }
+class MyEmitter extends EventEmitter {
+    addListener(event: string, listener: () => void): this {
+        return this;
+    }
+    listeners(event: string): Array<() => void> {
+        return [];
+    }
+    emit(event: string, ...args: any[]): boolean {
+        return true;
+    }
+    listenerCount(type: string): number {
+        return 0;
     }
 }

--- a/types/node/v18/events.d.ts
+++ b/types/node/v18/events.d.ts
@@ -37,66 +37,7 @@
 declare module "events" {
     import { AsyncResource, AsyncResourceOptions } from "node:async_hooks";
 
-    // NOTE: This class is in the docs but is **not actually exported** by Node.
-    // If https://github.com/nodejs/node/issues/39903 gets resolved and Node
-    // actually starts exporting the class, uncomment below.
-
-    // import { EventListener, EventListenerObject } from '__dom-events';
-    // /** The NodeEventTarget is a Node.js-specific extension to EventTarget that emulates a subset of the EventEmitter API. */
-    // interface NodeEventTarget extends EventTarget {
-    //     /**
-    //      * Node.js-specific extension to the `EventTarget` class that emulates the equivalent `EventEmitter` API.
-    //      * The only difference between `addListener()` and `addEventListener()` is that addListener() will return a reference to the EventTarget.
-    //      */
-    //     addListener(type: string, listener: EventListener | EventListenerObject, options?: { once: boolean }): this;
-    //     /** Node.js-specific extension to the `EventTarget` class that returns an array of event `type` names for which event listeners are registered. */
-    //     eventNames(): string[];
-    //     /** Node.js-specific extension to the `EventTarget` class that returns the number of event listeners registered for the `type`. */
-    //     listenerCount(type: string): number;
-    //     /** Node.js-specific alias for `eventTarget.removeListener()`. */
-    //     off(type: string, listener: EventListener | EventListenerObject): this;
-    //     /** Node.js-specific alias for `eventTarget.addListener()`. */
-    //     on(type: string, listener: EventListener | EventListenerObject, options?: { once: boolean }): this;
-    //     /** Node.js-specific extension to the `EventTarget` class that adds a `once` listener for the given event `type`. This is equivalent to calling `on` with the `once` option set to `true`. */
-    //     once(type: string, listener: EventListener | EventListenerObject): this;
-    //     /**
-    //      * Node.js-specific extension to the `EventTarget` class.
-    //      * If `type` is specified, removes all registered listeners for `type`,
-    //      * otherwise removes all registered listeners.
-    //      */
-    //     removeAllListeners(type: string): this;
-    //     /**
-    //      * Node.js-specific extension to the `EventTarget` class that removes the listener for the given `type`.
-    //      * The only difference between `removeListener()` and `removeEventListener()` is that `removeListener()` will return a reference to the `EventTarget`.
-    //      */
-    //     removeListener(type: string, listener: EventListener | EventListenerObject): this;
-    // }
-
-    interface EventEmitterOptions {
-        /**
-         * Enables automatic capturing of promise rejection.
-         */
-        captureRejections?: boolean | undefined;
-    }
-    // Any EventTarget with a Node-style `once` function
-    interface _NodeEventTarget {
-        once(eventName: string | symbol, listener: (...args: any[]) => void): this;
-    }
-    // Any EventTarget with a DOM-style `addEventListener`
-    interface _DOMEventTarget {
-        addEventListener(
-            eventName: string,
-            listener: (...args: any[]) => void,
-            opts?: {
-                once: boolean;
-            },
-        ): any;
-    }
-    interface StaticEventEmitterOptions {
-        signal?: AbortSignal | undefined;
-    }
-    interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
-    type EventMap<T> = Record<keyof T, any[]> | DefaultEventMap;
+    // #region Event map helper types
     type DefaultEventMap = [never];
     type AnyRest = [...args: any[]];
     type Args<K, T> = T extends DefaultEventMap ? AnyRest : (
@@ -112,383 +53,111 @@ declare module "events" {
     );
     type Listener1<K, T> = Listener<K, T, (...args: any[]) => void>;
     type Listener2<K, T> = Listener<K, T, Function>;
-    /**
-     * The `EventEmitter` class is defined and exposed by the `events` module:
-     *
-     * ```js
-     * import EventEmitter from 'node:events';
-     * ```
-     *
-     * All `EventEmitter`s emit the event `'newListener'` when new listeners are
-     * added and `'removeListener'` when existing listeners are removed.
-     *
-     * It supports the following option:
-     * @since v0.1.26
-     */
-    class EventEmitter<T extends EventMap<T> = DefaultEventMap> {
-        constructor(options?: EventEmitterOptions);
+    // #endregion Event map helper types
 
-        [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
-
-        /**
-         * Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
-         * event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
-         * The `Promise` will resolve with an array of all the arguments emitted to the
-         * given event.
-         *
-         * This method is intentionally generic and works with the web platform [EventTarget](https://dom.spec.whatwg.org/#interface-eventtarget) interface, which has no special`'error'` event
-         * semantics and does not listen to the `'error'` event.
-         *
-         * ```js
-         * import { once, EventEmitter } from 'node:events';
-         *
-         * async function run() {
-         *   const ee = new EventEmitter();
-         *
-         *   process.nextTick(() => {
-         *     ee.emit('myevent', 42);
-         *   });
-         *
-         *   const [value] = await once(ee, 'myevent');
-         *   console.log(value);
-         *
-         *   const err = new Error('kaboom');
-         *   process.nextTick(() => {
-         *     ee.emit('error', err);
-         *   });
-         *
-         *   try {
-         *     await once(ee, 'myevent');
-         *   } catch (err) {
-         *     console.log('error happened', err);
-         *   }
-         * }
-         *
-         * run();
-         * ```
-         *
-         * The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
-         * '`error'` event itself, then it is treated as any other kind of event without
-         * special handling:
-         *
-         * ```js
-         * import { EventEmitter, once } from 'node:events';
-         *
-         * const ee = new EventEmitter();
-         *
-         * once(ee, 'error')
-         *   .then(([err]) => console.log('ok', err.message))
-         *   .catch((err) => console.log('error', err.message));
-         *
-         * ee.emit('error', new Error('boom'));
-         *
-         * // Prints: ok boom
-         * ```
-         *
-         * An `AbortSignal` can be used to cancel waiting for the event:
-         *
-         * ```js
-         * import { EventEmitter, once } from 'node:events';
-         *
-         * const ee = new EventEmitter();
-         * const ac = new AbortController();
-         *
-         * async function foo(emitter, event, signal) {
-         *   try {
-         *     await once(emitter, event, { signal });
-         *     console.log('event emitted!');
-         *   } catch (error) {
-         *     if (error.name === 'AbortError') {
-         *       console.error('Waiting for the event was canceled!');
-         *     } else {
-         *       console.error('There was an error', error.message);
-         *     }
-         *   }
-         * }
-         *
-         * foo(ee, 'foo', ac.signal);
-         * ac.abort(); // Abort waiting for the event
-         * ee.emit('foo'); // Prints: Waiting for the event was canceled!
-         * ```
-         * @since v11.13.0, v10.16.0
-         */
-        static once(
-            emitter: _NodeEventTarget,
-            eventName: string | symbol,
-            options?: StaticEventEmitterOptions,
-        ): Promise<any[]>;
-        static once(emitter: _DOMEventTarget, eventName: string, options?: StaticEventEmitterOptions): Promise<any[]>;
-        /**
-         * ```js
-         * import { on, EventEmitter } from 'node:events';
-         *
-         * (async () => {
-         *   const ee = new EventEmitter();
-         *
-         *   // Emit later on
-         *   process.nextTick(() => {
-         *     ee.emit('foo', 'bar');
-         *     ee.emit('foo', 42);
-         *   });
-         *
-         *   for await (const event of on(ee, 'foo')) {
-         *     // The execution of this inner block is synchronous and it
-         *     // processes one event at a time (even with await). Do not use
-         *     // if concurrent execution is required.
-         *     console.log(event); // prints ['bar'] [42]
-         *   }
-         *   // Unreachable here
-         * })();
-         * ```
-         *
-         * Returns an `AsyncIterator` that iterates `eventName` events. It will throw
-         * if the `EventEmitter` emits `'error'`. It removes all listeners when
-         * exiting the loop. The `value` returned by each iteration is an array
-         * composed of the emitted event arguments.
-         *
-         * An `AbortSignal` can be used to cancel waiting on events:
-         *
-         * ```js
-         * import { on, EventEmitter } from 'node:events';
-         * const ac = new AbortController();
-         *
-         * (async () => {
-         *   const ee = new EventEmitter();
-         *
-         *   // Emit later on
-         *   process.nextTick(() => {
-         *     ee.emit('foo', 'bar');
-         *     ee.emit('foo', 42);
-         *   });
-         *
-         *   for await (const event of on(ee, 'foo', { signal: ac.signal })) {
-         *     // The execution of this inner block is synchronous and it
-         *     // processes one event at a time (even with await). Do not use
-         *     // if concurrent execution is required.
-         *     console.log(event); // prints ['bar'] [42]
-         *   }
-         *   // Unreachable here
-         * })();
-         *
-         * process.nextTick(() => ac.abort());
-         * ```
-         * @since v13.6.0, v12.16.0
-         * @param eventName The name of the event being listened for
-         * @return that iterates `eventName` events emitted by the `emitter`
-         */
-        static on(
-            emitter: NodeJS.EventEmitter,
-            eventName: string,
-            options?: StaticEventEmitterOptions,
-        ): AsyncIterableIterator<any>;
-        /**
-         * A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
-         *
-         * ```js
-         * import { EventEmitter, listenerCount } from 'node:events';
-         * const myEmitter = new EventEmitter();
-         * myEmitter.on('event', () => {});
-         * myEmitter.on('event', () => {});
-         * console.log(listenerCount(myEmitter, 'event'));
-         * // Prints: 2
-         * ```
-         * @since v0.9.12
-         * @deprecated Since v3.2.0 - Use `listenerCount` instead.
-         * @param emitter The emitter to query
-         * @param eventName The event name
-         */
-        static listenerCount(emitter: NodeJS.EventEmitter, eventName: string | symbol): number;
-        /**
-         * Returns a copy of the array of listeners for the event named `eventName`.
-         *
-         * For `EventEmitter`s this behaves exactly the same as calling `.listeners` on
-         * the emitter.
-         *
-         * For `EventTarget`s this is the only way to get the event listeners for the
-         * event target. This is useful for debugging and diagnostic purposes.
-         *
-         * ```js
-         * import { getEventListeners, EventEmitter } from 'node:events';
-         *
-         * {
-         *   const ee = new EventEmitter();
-         *   const listener = () => console.log('Events are fun');
-         *   ee.on('foo', listener);
-         *   getEventListeners(ee, 'foo'); // [listener]
-         * }
-         * {
-         *   const et = new EventTarget();
-         *   const listener = () => console.log('Events are fun');
-         *   et.addEventListener('foo', listener);
-         *   getEventListeners(et, 'foo'); // [listener]
-         * }
-         * ```
-         * @since v15.2.0, v14.17.0
-         */
-        static getEventListeners(emitter: _DOMEventTarget | NodeJS.EventEmitter, name: string | symbol): Function[];
-        /**
-         * Returns the currently set max amount of listeners.
-         *
-         * For `EventEmitter`s this behaves exactly the same as calling `.getMaxListeners` on
-         * the emitter.
-         *
-         * For `EventTarget`s this is the only way to get the max event listeners for the
-         * event target. If the number of event handlers on a single EventTarget exceeds
-         * the max set, the EventTarget will print a warning.
-         *
-         * ```js
-         * import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
-         *
-         * {
-         *   const ee = new EventEmitter();
-         *   console.log(getMaxListeners(ee)); // 10
-         *   setMaxListeners(11, ee);
-         *   console.log(getMaxListeners(ee)); // 11
-         * }
-         * {
-         *   const et = new EventTarget();
-         *   console.log(getMaxListeners(et)); // 10
-         *   setMaxListeners(11, et);
-         *   console.log(getMaxListeners(et)); // 11
-         * }
-         * ```
-         * @since v18.17.0
-         */
-        static getMaxListeners(emitter: _DOMEventTarget | NodeJS.EventEmitter): number;
-        /**
-         * ```js
-         * import {
-         *   setMaxListeners,
-         *   EventEmitter
-         * } from 'node:events';
-         *
-         * const target = new EventTarget();
-         * const emitter = new EventEmitter();
-         *
-         * setMaxListeners(5, target, emitter);
-         * ```
-         * @since v15.4.0
-         * @param n A non-negative number. The maximum number of listeners per `EventTarget` event.
-         * @param eventsTargets Zero or more {EventTarget} or {EventEmitter} instances. If none are specified, `n` is set as the default max for all newly created {EventTarget} and {EventEmitter}
-         * objects.
-         */
-        static setMaxListeners(n?: number, ...eventTargets: Array<_DOMEventTarget | NodeJS.EventEmitter>): void;
-        /**
-         * Listens once to the `abort` event on the provided `signal`.
-         *
-         * Listening to the `abort` event on abort signals is unsafe and may
-         * lead to resource leaks since another third party with the signal can
-         * call `e.stopImmediatePropagation()`. Unfortunately Node.js cannot change
-         * this since it would violate the web standard. Additionally, the original
-         * API makes it easy to forget to remove listeners.
-         *
-         * This API allows safely using `AbortSignal`s in Node.js APIs by solving these
-         * two issues by listening to the event such that `stopImmediatePropagation` does
-         * not prevent the listener from running.
-         *
-         * Returns a disposable so that it may be unsubscribed from more easily.
-         *
-         * ```js
-         * import { addAbortListener } from 'node:events';
-         *
-         * function example(signal) {
-         *   let disposable;
-         *   try {
-         *     signal.addEventListener('abort', (e) => e.stopImmediatePropagation());
-         *     disposable = addAbortListener(signal, (e) => {
-         *       // Do something when signal is aborted.
-         *     });
-         *   } finally {
-         *     disposable?.[Symbol.dispose]();
-         *   }
-         * }
-         * ```
-         * @since v18.18.0
-         * @experimental
-         * @return Disposable that removes the `abort` listener.
-         */
-        static addAbortListener(signal: AbortSignal, resource: (event: Event) => void): Disposable;
-        /**
-         * This symbol shall be used to install a listener for only monitoring `'error'`
-         * events. Listeners installed using this symbol are called before the regular
-         * `'error'` listeners are called.
-         *
-         * Installing a listener using this symbol does not change the behavior once an
-         * `'error'` event is emitted, therefore the process will still crash if no
-         * regular `'error'` listener is installed.
-         */
-        static readonly errorMonitor: unique symbol;
-        static readonly captureRejectionSymbol: unique symbol;
-        /**
-         * Sets or gets the default captureRejection value for all emitters.
-         */
-        // TODO: These should be described using static getter/setter pairs:
-        static captureRejections: boolean;
-        static defaultMaxListeners: number;
-    }
-    import internal = require("node:events");
-    namespace EventEmitter {
-        // Should just be `export { EventEmitter }`, but that doesn't work in TypeScript 3.4
-        export { internal as EventEmitter };
-        export interface Abortable {
-            /**
-             * When provided the corresponding `AbortController` can be used to cancel an asynchronous action.
-             */
-            signal?: AbortSignal | undefined;
-        }
-
-        export interface EventEmitterReferencingAsyncResource extends AsyncResource {
-            readonly eventEmitter: EventEmitterAsyncResource;
-        }
-
-        export interface EventEmitterAsyncResourceOptions extends AsyncResourceOptions, EventEmitterOptions {
-            /**
-             * The type of async event, this is required when instantiating `EventEmitterAsyncResource`
-             * directly rather than as a child class.
-             * @default new.target.name if instantiated as a child class.
-             */
-            name?: string;
-        }
-
-        /**
-         * Integrates `EventEmitter` with `AsyncResource` for `EventEmitter`s that require
-         * manual async tracking. Specifically, all events emitted by instances of
-         * `EventEmitterAsyncResource` will run within its async context.
-         *
-         * The EventEmitterAsyncResource class has the same methods and takes the
-         * same options as EventEmitter and AsyncResource themselves.
-         * @throws if `options.name` is not provided when instantiated directly.
-         * @since v17.4.0, v16.14.0
-         */
-        export class EventEmitterAsyncResource extends EventEmitter {
-            /**
-             * @param options Only optional in child class.
-             */
-            constructor(options?: EventEmitterAsyncResourceOptions);
-            /**
-             * Call all destroy hooks. This should only ever be called once. An
-             * error will be thrown if it is called more than once. This must be
-             * manually called. If the resource is left to be collected by the GC then
-             * the destroy hooks will never be called.
-             */
-            emitDestroy(): void;
-            /** The unique asyncId assigned to the resource. */
-            readonly asyncId: number;
-            /** The same triggerAsyncId that is passed to the AsyncResource constructor. */
-            readonly triggerAsyncId: number;
-            /** The underlying AsyncResource */
-            readonly asyncResource: EventEmitterReferencingAsyncResource;
-        }
-    }
     global {
         namespace NodeJS {
             interface EventEmitter<T extends EventMap<T> = DefaultEventMap> {
-                [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
                 /**
                  * Alias for `emitter.on(eventName, listener)`.
                  * @since v0.1.26
                  */
                 addListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                /**
+                 * Synchronously calls each of the listeners registered for the event named
+                 * `eventName`, in the order they were registered, passing the supplied arguments
+                 * to each.
+                 *
+                 * Returns `true` if the event had listeners, `false` otherwise.
+                 *
+                 * ```js
+                 * import EventEmitter from 'node:events';
+                 * const myEmitter = new EventEmitter();
+                 *
+                 * // First listener
+                 * myEmitter.on('event', function firstListener() {
+                 *   console.log('Helloooo! first listener');
+                 * });
+                 * // Second listener
+                 * myEmitter.on('event', function secondListener(arg1, arg2) {
+                 *   console.log(`event with parameters ${arg1}, ${arg2} in second listener`);
+                 * });
+                 * // Third listener
+                 * myEmitter.on('event', function thirdListener(...args) {
+                 *   const parameters = args.join(', ');
+                 *   console.log(`event with parameters ${parameters} in third listener`);
+                 * });
+                 *
+                 * console.log(myEmitter.listeners('event'));
+                 *
+                 * myEmitter.emit('event', 1, 2, 3, 4, 5);
+                 *
+                 * // Prints:
+                 * // [
+                 * //   [Function: firstListener],
+                 * //   [Function: secondListener],
+                 * //   [Function: thirdListener]
+                 * // ]
+                 * // Helloooo! first listener
+                 * // event with parameters 1, 2 in second listener
+                 * // event with parameters 1, 2, 3, 4, 5 in third listener
+                 * ```
+                 * @since v0.1.26
+                 */
+                emit<K>(eventName: Key<K, T>, ...args: Args<K, T>): boolean;
+                /**
+                 * Returns an array listing the events for which the emitter has registered
+                 * listeners. The values in the array are strings or `Symbol`s.
+                 *
+                 * ```js
+                 * import EventEmitter from 'node:events';
+                 * const myEE = new EventEmitter();
+                 * myEE.on('foo', () => {});
+                 * myEE.on('bar', () => {});
+                 *
+                 * const sym = Symbol('symbol');
+                 * myEE.on(sym, () => {});
+                 *
+                 * console.log(myEE.eventNames());
+                 * // Prints: [ 'foo', 'bar', Symbol(symbol) ]
+                 * ```
+                 * @since v6.0.0
+                 */
+                eventNames(): Array<(string | symbol) & Key2<unknown, T>>;
+                /**
+                 * Returns the current max listener value for the `EventEmitter` which is either
+                 * set by `emitter.setMaxListeners(n)` or defaults to {@link defaultMaxListeners}.
+                 * @since v1.0.0
+                 */
+                getMaxListeners(): number;
+                /**
+                 * Returns the number of listeners listening to the event named `eventName`.
+                 *
+                 * If `listener` is provided, it will return how many times the listener
+                 * is found in the list of the listeners of the event.
+                 * @since v3.2.0
+                 * @param eventName The name of the event being listened for
+                 * @param listener The event handler function
+                 */
+                listenerCount<K>(eventName: Key<K, T>, listener?: Listener2<K, T>): number;
+                /**
+                 * Returns a copy of the array of listeners for the event named `eventName`.
+                 *
+                 * ```js
+                 * server.on('connection', (stream) => {
+                 *   console.log('someone connected!');
+                 * });
+                 * console.log(util.inspect(server.listeners('connection')));
+                 * // Prints: [ [Function] ]
+                 * ```
+                 * @since v0.1.26
+                 */
+                listeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
+                /**
+                 * Alias for `emitter.removeListener()`.
+                 * @since v10.0.0
+                 */
+                off<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
                 /**
                  * Adds the `listener` function to the end of the listeners array for the
                  * event named `eventName`. No checks are made to see if the `listener` has
@@ -503,7 +172,8 @@ declare module "events" {
                  *
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  *
-                 * By default, event listeners are invoked in the order they are added. The`emitter.prependListener()` method can be used as an alternative to add the
+                 * By default, event listeners are invoked in the order they are added. The
+                 * `emitter.prependListener()` method can be used as an alternative to add the
                  * event listener to the beginning of the listeners array.
                  *
                  * ```js
@@ -532,7 +202,8 @@ declare module "events" {
                  *
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  *
-                 * By default, event listeners are invoked in the order they are added. The`emitter.prependOnceListener()` method can be used as an alternative to add the
+                 * By default, event listeners are invoked in the order they are added. The
+                 * `emitter.prependOnceListener()` method can be used as an alternative to add the
                  * event listener to the beginning of the listeners array.
                  *
                  * ```js
@@ -550,7 +221,55 @@ declare module "events" {
                  */
                 once<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
                 /**
-                 * Removes the specified `listener` from the listener array for the event named`eventName`.
+                 * Adds the `listener` function to the _beginning_ of the listeners array for the
+                 * event named `eventName`. No checks are made to see if the `listener` has
+                 * already been added. Multiple calls passing the same combination of `eventName` and
+                 * `listener` will result in the `listener` being added, and called, multiple
+                 * times.
+                 *
+                 * ```js
+                 * server.prependListener('connection', (stream) => {
+                 *   console.log('someone connected!');
+                 * });
+                 * ```
+                 *
+                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
+                 * @since v6.0.0
+                 * @param eventName The name of the event.
+                 * @param listener The callback function
+                 */
+                prependListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                /**
+                 * Adds a **one-time**`listener` function for the event named `eventName` to the
+                 * _beginning_ of the listeners array. The next time `eventName` is triggered, this
+                 * listener is removed, and then invoked.
+                 *
+                 * ```js
+                 * server.prependOnceListener('connection', (stream) => {
+                 *   console.log('Ah, we have our first user!');
+                 * });
+                 * ```
+                 *
+                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
+                 * @since v6.0.0
+                 * @param eventName The name of the event.
+                 * @param listener The callback function
+                 */
+                prependOnceListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                /**
+                 * Removes all listeners, or those of the specified `eventName`.
+                 *
+                 * It is bad practice to remove listeners added elsewhere in the code,
+                 * particularly when the `EventEmitter` instance was created by some other
+                 * component or module (e.g. sockets or file streams).
+                 *
+                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
+                 * @since v0.1.26
+                 */
+                removeAllListeners(event?: Key<unknown, T>): this;
+                /**
+                 * Removes the specified `listener` from the listener array for the event named
+                 * `eventName`.
                  *
                  * ```js
                  * const callback = (stream) => {
@@ -567,7 +286,8 @@ declare module "events" {
                  * called multiple times to remove each instance.
                  *
                  * Once an event is emitted, all listeners attached to it at the
-                 * time of emitting are called in order. This implies that any`removeListener()` or `removeAllListeners()` calls _after_ emitting and _before_ the last listener finishes execution
+                 * time of emitting are called in order. This implies that any`removeListener()` or
+                 * `removeAllListeners()` calls _after_ emitting and _before_ the last listener finishes execution
                  * will not remove them from`emit()` in progress. Subsequent events behave as expected.
                  *
                  * ```js
@@ -630,50 +350,16 @@ declare module "events" {
                  */
                 removeListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
                 /**
-                 * Alias for `emitter.removeListener()`.
-                 * @since v10.0.0
-                 */
-                off<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
-                /**
-                 * Removes all listeners, or those of the specified `eventName`.
-                 *
-                 * It is bad practice to remove listeners added elsewhere in the code,
-                 * particularly when the `EventEmitter` instance was created by some other
-                 * component or module (e.g. sockets or file streams).
-                 *
-                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
-                 * @since v0.1.26
-                 */
-                removeAllListeners(event?: Key<unknown, T>): this;
-                /**
                  * By default `EventEmitter`s will print a warning if more than `10` listeners are
                  * added for a particular event. This is a useful default that helps finding
                  * memory leaks. The `emitter.setMaxListeners()` method allows the limit to be
-                 * modified for this specific `EventEmitter` instance. The value can be set to`Infinity` (or `0`) to indicate an unlimited number of listeners.
+                 * modified for this specific `EventEmitter` instance. The value can be set to
+                 * `Infinity` (or `0`) to indicate an unlimited number of listeners.
                  *
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.3.5
                  */
                 setMaxListeners(n: number): this;
-                /**
-                 * Returns the current max listener value for the `EventEmitter` which is either
-                 * set by `emitter.setMaxListeners(n)` or defaults to {@link defaultMaxListeners}.
-                 * @since v1.0.0
-                 */
-                getMaxListeners(): number;
-                /**
-                 * Returns a copy of the array of listeners for the event named `eventName`.
-                 *
-                 * ```js
-                 * server.on('connection', (stream) => {
-                 *   console.log('someone connected!');
-                 * });
-                 * console.log(util.inspect(server.listeners('connection')));
-                 * // Prints: [ [Function] ]
-                 * ```
-                 * @since v0.1.26
-                 */
-                listeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
                  * including any wrappers (such as those created by `.once()`).
@@ -705,114 +391,489 @@ declare module "events" {
                  */
                 rawListeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
                 /**
-                 * Synchronously calls each of the listeners registered for the event named`eventName`, in the order they were registered, passing the supplied arguments
-                 * to each.
-                 *
-                 * Returns `true` if the event had listeners, `false` otherwise.
-                 *
-                 * ```js
-                 * import EventEmitter from 'node:events';
-                 * const myEmitter = new EventEmitter();
-                 *
-                 * // First listener
-                 * myEmitter.on('event', function firstListener() {
-                 *   console.log('Helloooo! first listener');
-                 * });
-                 * // Second listener
-                 * myEmitter.on('event', function secondListener(arg1, arg2) {
-                 *   console.log(`event with parameters ${arg1}, ${arg2} in second listener`);
-                 * });
-                 * // Third listener
-                 * myEmitter.on('event', function thirdListener(...args) {
-                 *   const parameters = args.join(', ');
-                 *   console.log(`event with parameters ${parameters} in third listener`);
-                 * });
-                 *
-                 * console.log(myEmitter.listeners('event'));
-                 *
-                 * myEmitter.emit('event', 1, 2, 3, 4, 5);
-                 *
-                 * // Prints:
-                 * // [
-                 * //   [Function: firstListener],
-                 * //   [Function: secondListener],
-                 * //   [Function: thirdListener]
-                 * // ]
-                 * // Helloooo! first listener
-                 * // event with parameters 1, 2 in second listener
-                 * // event with parameters 1, 2, 3, 4, 5 in third listener
-                 * ```
-                 * @since v0.1.26
-                 */
-                emit<K>(eventName: Key<K, T>, ...args: Args<K, T>): boolean;
-                /**
-                 * Returns the number of listeners listening to the event named `eventName`.
-                 *
-                 * If `listener` is provided, it will return how many times the listener
-                 * is found in the list of the listeners of the event.
-                 * @since v3.2.0
-                 * @param eventName The name of the event being listened for
-                 * @param listener The event handler function
-                 */
-                listenerCount<K>(eventName: Key<K, T>, listener?: Listener2<K, T>): number;
-                /**
-                 * Adds the `listener` function to the _beginning_ of the listeners array for the
-                 * event named `eventName`. No checks are made to see if the `listener` has
-                 * already been added. Multiple calls passing the same combination of `eventName` and `listener` will result in the `listener` being added, and called, multiple
-                 * times.
+                 * The `Symbol.for('nodejs.rejection')` method is called in case a
+                 * promise rejection happens when emitting an event and
+                 * `captureRejections` is enabled on the emitter.
+                 * It is possible to use `events.captureRejectionSymbol` in
+                 * place of `Symbol.for('nodejs.rejection')`.
                  *
                  * ```js
-                 * server.prependListener('connection', (stream) => {
-                 *   console.log('someone connected!');
-                 * });
+                 * import { EventEmitter, captureRejectionSymbol } from 'node:events';
+                 *
+                 * class MyClass extends EventEmitter {
+                 *   constructor() {
+                 *     super({ captureRejections: true });
+                 *   }
+                 *
+                 *   [captureRejectionSymbol](err, event, ...args) {
+                 *     console.log('rejection happened for', event, 'with', err, ...args);
+                 *     this.destroy(err);
+                 *   }
+                 *
+                 *   destroy(err) {
+                 *     // Tear the resource down here.
+                 *   }
+                 * }
                  * ```
-                 *
-                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
-                 * @since v6.0.0
-                 * @param eventName The name of the event.
-                 * @param listener The callback function
+                 * @since v13.4.0, v12.16.0
                  */
-                prependListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
-                /**
-                 * Adds a **one-time**`listener` function for the event named `eventName` to the _beginning_ of the listeners array. The next time `eventName` is triggered, this
-                 * listener is removed, and then invoked.
-                 *
-                 * ```js
-                 * server.prependOnceListener('connection', (stream) => {
-                 *   console.log('Ah, we have our first user!');
-                 * });
-                 * ```
-                 *
-                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
-                 * @since v6.0.0
-                 * @param eventName The name of the event.
-                 * @param listener The callback function
-                 */
-                prependOnceListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
-                /**
-                 * Returns an array listing the events for which the emitter has registered
-                 * listeners. The values in the array are strings or `Symbol`s.
-                 *
-                 * ```js
-                 * import EventEmitter from 'node:events';
-                 * const myEE = new EventEmitter();
-                 * myEE.on('foo', () => {});
-                 * myEE.on('bar', () => {});
-                 *
-                 * const sym = Symbol('symbol');
-                 * myEE.on(sym, () => {});
-                 *
-                 * console.log(myEE.eventNames());
-                 * // Prints: [ 'foo', 'bar', Symbol(symbol) ]
-                 * ```
-                 * @since v6.0.0
-                 */
-                eventNames(): Array<(string | symbol) & Key2<unknown, T>>;
+                [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
             }
         }
     }
+
+    // Any EventTarget with a Node-style `once` function
+    interface _NodeEventTarget {
+        once(eventName: string | symbol, listener: (...args: any[]) => void): this;
+    }
+    // Any EventTarget with a DOM-style `addEventListener`
+    interface _DOMEventTarget {
+        addEventListener(
+            eventName: string,
+            listener: (...args: any[]) => void,
+            opts?: {
+                once: boolean;
+            },
+        ): any;
+    }
+
+    interface EventEmitterOptions {
+        /**
+         * Enables automatic capturing of promise rejection.
+         */
+        captureRejections?: boolean | undefined;
+    }
+    type EventMap<T> = Record<keyof T, any[]> | DefaultEventMap;
+    /**
+     * The `EventEmitter` class is defined and exposed by the `events` module:
+     *
+     * ```js
+     * import EventEmitter from 'node:events';
+     * ```
+     *
+     * All `EventEmitter`s emit the event `'newListener'` when new listeners are
+     * added and `'removeListener'` when existing listeners are removed.
+     *
+     * It supports the following option:
+     * @since v0.1.26
+     */
+    class EventEmitter<T extends EventMap<T> = DefaultEventMap> {
+        constructor(options?: EventEmitterOptions);
+    }
+    interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
+    namespace EventEmitter {
+        export { EventEmitter, EventEmitterOptions, EventMap };
+    }
+
+    namespace EventEmitter {
+        interface Abortable {
+            /**
+             * When provided, the corresponding `AbortController` can be used to cancel an asynchronous action.
+             */
+            signal?: AbortSignal | undefined;
+        }
+
+        /**
+         * By default, a maximum of `10` listeners can be registered for any single
+         * event. This limit can be changed for individual `EventEmitter` instances
+         * using the `emitter.setMaxListeners(n)` method. To change the default
+         * for _all_ `EventEmitter` instances, the `events.defaultMaxListeners`
+         * property can be used. If this value is not a positive number, a `RangeError`
+         * is thrown.
+         *
+         * Take caution when setting the `events.defaultMaxListeners` because the
+         * change affects _all_ `EventEmitter` instances, including those created before
+         * the change is made. However, calling `emitter.setMaxListeners(n)` still has
+         * precedence over `events.defaultMaxListeners`.
+         *
+         * This is not a hard limit. The `EventEmitter` instance will allow
+         * more listeners to be added but will output a trace warning to stderr indicating
+         * that a "possible EventEmitter memory leak" has been detected. For any single
+         * `EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`
+         * methods can be used to temporarily avoid this warning:
+         *
+         * ```js
+         * import { EventEmitter } from 'node:events';
+         * const emitter = new EventEmitter();
+         * emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+         * emitter.once('event', () => {
+         *   // do stuff
+         *   emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+         * });
+         * ```
+         *
+         * The `--trace-warnings` command-line flag can be used to display the
+         * stack trace for such warnings.
+         *
+         * The emitted warning can be inspected with `process.on('warning')` and will
+         * have the additional `emitter`, `type`, and `count` properties, referring to
+         * the event emitter instance, the event's name and the number of attached
+         * listeners, respectively.
+         * Its `name` property is set to `'MaxListenersExceededWarning'`.
+         * @since v0.11.2
+         */
+        var defaultMaxListeners: number;
+
+        /**
+         * This symbol shall be used to install a listener for only monitoring `'error'`
+         * events. Listeners installed using this symbol are called before the regular
+         * `'error'` listeners are called.
+
+        * Installing a listener using this symbol does not change the behavior once an
+        * `'error'` event is emitted. Therefore, the process will still crash if no
+        * regular `'error'` listener is installed.
+        * @since v13.6.0, v12.17.0
+        */
+        const errorMonitor: unique symbol;
+
+        /**
+         * Returns a copy of the array of listeners for the event named `eventName`.
+         *
+         * For `EventEmitter`s this behaves exactly the same as calling `.listeners` on
+         * the emitter.
+         *
+         * For `EventTarget`s this is the only way to get the event listeners for the
+         * event target. This is useful for debugging and diagnostic purposes.
+         *
+         * ```js
+         * import { getEventListeners, EventEmitter } from 'node:events';
+         *
+         * {
+         *   const ee = new EventEmitter();
+         *   const listener = () => console.log('Events are fun');
+         *   ee.on('foo', listener);
+         *   getEventListeners(ee, 'foo'); // [listener]
+         * }
+         * {
+         *   const et = new EventTarget();
+         *   const listener = () => console.log('Events are fun');
+         *   et.addEventListener('foo', listener);
+         *   getEventListeners(et, 'foo'); // [listener]
+         * }
+         * ```
+         * @since v15.2.0, v14.17.0
+         */
+        function getEventListeners(emitter: _DOMEventTarget | NodeJS.EventEmitter, name: string | symbol): Function[];
+
+        /**
+         * Returns the currently set max amount of listeners.
+         *
+         * For `EventEmitter`s this behaves exactly the same as calling `.getMaxListeners` on
+         * the emitter.
+         *
+         * For `EventTarget`s this is the only way to get the max event listeners for the
+         * event target. If the number of event handlers on a single EventTarget exceeds
+         * the max set, the EventTarget will print a warning.
+         *
+         * ```js
+         * import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
+         *
+         * {
+         *   const ee = new EventEmitter();
+         *   console.log(getMaxListeners(ee)); // 10
+         *   setMaxListeners(11, ee);
+         *   console.log(getMaxListeners(ee)); // 11
+         * }
+         * {
+         *   const et = new EventTarget();
+         *   console.log(getMaxListeners(et)); // 10
+         *   setMaxListeners(11, et);
+         *   console.log(getMaxListeners(et)); // 11
+         * }
+         * ```
+         * @since v18.17.0
+         */
+        function getMaxListeners(emitter: _DOMEventTarget | NodeJS.EventEmitter): number;
+
+        interface OnceOptions extends Abortable {}
+        /**
+         * Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
+         * event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
+         * The `Promise` will resolve with an array of all the arguments emitted to the
+         * given event.
+         *
+         * This method is intentionally generic and works with the web platform
+         * [EventTarget](https://dom.spec.whatwg.org/#interface-eventtarget)
+         * interface, which has no special`'error'` event
+         * semantics and does not listen to the `'error'` event.
+         *
+         * ```js
+         * import { once, EventEmitter } from 'node:events';
+         *
+         * async function run() {
+         *   const ee = new EventEmitter();
+         *
+         *   process.nextTick(() => {
+         *     ee.emit('myevent', 42);
+         *   });
+         *
+         *   const [value] = await once(ee, 'myevent');
+         *   console.log(value);
+         *
+         *   const err = new Error('kaboom');
+         *   process.nextTick(() => {
+         *     ee.emit('error', err);
+         *   });
+         *
+         *   try {
+         *     await once(ee, 'myevent');
+         *   } catch (err) {
+         *     console.log('error happened', err);
+         *   }
+         * }
+         *
+         * run();
+         * ```
+         *
+         * The special handling of the `'error'` event is only used when `events.once()`
+         * is used to wait for another event. If `events.once()` is used to wait for the
+         * '`error'` event itself, then it is treated as any other kind of event without
+         * special handling:
+         *
+         * ```js
+         * import { EventEmitter, once } from 'node:events';
+         *
+         * const ee = new EventEmitter();
+         *
+         * once(ee, 'error')
+         *   .then(([err]) => console.log('ok', err.message))
+         *   .catch((err) => console.log('error', err.message));
+         *
+         * ee.emit('error', new Error('boom'));
+         *
+         * // Prints: ok boom
+         * ```
+         *
+         * An `AbortSignal` can be used to cancel waiting for the event:
+         *
+         * ```js
+         * import { EventEmitter, once } from 'node:events';
+         *
+         * const ee = new EventEmitter();
+         * const ac = new AbortController();
+         *
+         * async function foo(emitter, event, signal) {
+         *   try {
+         *     await once(emitter, event, { signal });
+         *     console.log('event emitted!');
+         *   } catch (error) {
+         *     if (error.name === 'AbortError') {
+         *       console.error('Waiting for the event was canceled!');
+         *     } else {
+         *       console.error('There was an error', error.message);
+         *     }
+         *   }
+         * }
+         *
+         * foo(ee, 'foo', ac.signal);
+         * ac.abort(); // Abort waiting for the event
+         * ee.emit('foo'); // Prints: Waiting for the event was canceled!
+         * ```
+         * @since v11.13.0, v10.16.0
+         */
+        function once(
+            emitter: _NodeEventTarget,
+            eventName: string | symbol,
+            options?: OnceOptions,
+        ): Promise<any[]>;
+        function once(emitter: _DOMEventTarget, eventName: string, options?: OnceOptions): Promise<any[]>;
+
+        /**
+         * Change the default `captureRejections` option on all new `EventEmitter` objects.
+         * @since v13.4.0, v12.16.0
+         */
+        var captureRejections: boolean;
+        /**
+         * Value: `Symbol.for('nodejs.rejection')`
+         * @since v13.4.0, v12.16.0
+         */
+        const captureRejectionSymbol: unique symbol;
+
+        /**
+         * A class method that returns the number of listeners for the given `eventName`
+         * registered on the given `emitter`.
+         *
+         * ```js
+         * import { EventEmitter, listenerCount } from 'node:events';
+         * const myEmitter = new EventEmitter();
+         * myEmitter.on('event', () => {});
+         * myEmitter.on('event', () => {});
+         * console.log(listenerCount(myEmitter, 'event'));
+         * // Prints: 2
+         * ```
+         * @since v0.9.12
+         * @deprecated Since v3.2.0 - Use `emitter.listenerCount` instead.
+         * @param emitter The emitter to query
+         * @param eventName The event name
+         */
+        function listenerCount(emitter: NodeJS.EventEmitter, eventName: string | symbol): number;
+
+        interface OnOptions extends Abortable {}
+        /**
+         * ```js
+         * import { on, EventEmitter } from 'node:events';
+         *
+         * (async () => {
+         *   const ee = new EventEmitter();
+         *
+         *   // Emit later on
+         *   process.nextTick(() => {
+         *     ee.emit('foo', 'bar');
+         *     ee.emit('foo', 42);
+         *   });
+         *
+         *   for await (const event of on(ee, 'foo')) {
+         *     // The execution of this inner block is synchronous and it
+         *     // processes one event at a time (even with await). Do not use
+         *     // if concurrent execution is required.
+         *     console.log(event); // prints ['bar'] [42]
+         *   }
+         *   // Unreachable here
+         * })();
+         * ```
+         *
+         * Returns an `AsyncIterator` that iterates `eventName` events. It will throw
+         * if the `EventEmitter` emits `'error'`. It removes all listeners when
+         * exiting the loop. The `value` returned by each iteration is an array
+         * composed of the emitted event arguments.
+         *
+         * An `AbortSignal` can be used to cancel waiting on events:
+         *
+         * ```js
+         * import { on, EventEmitter } from 'node:events';
+         * const ac = new AbortController();
+         *
+         * (async () => {
+         *   const ee = new EventEmitter();
+         *
+         *   // Emit later on
+         *   process.nextTick(() => {
+         *     ee.emit('foo', 'bar');
+         *     ee.emit('foo', 42);
+         *   });
+         *
+         *   for await (const event of on(ee, 'foo', { signal: ac.signal })) {
+         *     // The execution of this inner block is synchronous and it
+         *     // processes one event at a time (even with await). Do not use
+         *     // if concurrent execution is required.
+         *     console.log(event); // prints ['bar'] [42]
+         *   }
+         *   // Unreachable here
+         * })();
+         *
+         * process.nextTick(() => ac.abort());
+         * ```
+         * @since v13.6.0, v12.16.0
+         * @param eventName The name of the event being listened for
+         * @return that iterates `eventName` events emitted by the `emitter`
+         */
+        function on(
+            emitter: NodeJS.EventEmitter,
+            eventName: string | symbol,
+            options?: OnOptions,
+        ): AsyncIterableIterator<any[]>;
+
+        /**
+         * ```js
+         * import {
+         *   setMaxListeners,
+         *   EventEmitter
+         * } from 'node:events';
+         *
+         * const target = new EventTarget();
+         * const emitter = new EventEmitter();
+         *
+         * setMaxListeners(5, target, emitter);
+         * ```
+         * @since v15.4.0
+         * @param n A non-negative number. The maximum number of listeners per `EventTarget` event.
+         * @param eventsTargets Zero or more `EventTarget` or `EventEmitter` instances.
+         * If none are specified, `n` is set as the default max for all newly created
+         * `EventTarget` and `EventEmitter` objects.
+         */
+        function setMaxListeners(n?: number, ...eventTargets: Array<_DOMEventTarget | NodeJS.EventEmitter>): void;
+
+        /**
+         * Listens once to the `abort` event on the provided `signal`.
+         *
+         * Listening to the `abort` event on abort signals is unsafe and may
+         * lead to resource leaks since another third party with the signal can
+         * call `e.stopImmediatePropagation()`. Unfortunately Node.js cannot change
+         * this since it would violate the web standard. Additionally, the original
+         * API makes it easy to forget to remove listeners.
+         *
+         * This API allows safely using `AbortSignal`s in Node.js APIs by solving these
+         * two issues by listening to the event such that `stopImmediatePropagation` does
+         * not prevent the listener from running.
+         *
+         * Returns a disposable so that it may be unsubscribed from more easily.
+         *
+         * ```js
+         * import { addAbortListener } from 'node:events';
+         *
+         * function example(signal) {
+         *   let disposable;
+         *   try {
+         *     signal.addEventListener('abort', (e) => e.stopImmediatePropagation());
+         *     disposable = addAbortListener(signal, (e) => {
+         *       // Do something when signal is aborted.
+         *     });
+         *   } finally {
+         *     disposable?.[Symbol.dispose]();
+         *   }
+         * }
+         * ```
+         * @since v18.18.0
+         * @experimental
+         * @return Disposable that removes the `abort` listener.
+         */
+        function addAbortListener(signal: AbortSignal, resource: (event: Event) => void): Disposable;
+
+        class EventEmitterReferencingAsyncResource extends AsyncResource {
+            private constructor();
+            readonly eventEmitter: EventEmitterAsyncResource;
+        }
+        interface EventEmitterAsyncResourceOptions extends AsyncResourceOptions, EventEmitterOptions {
+            /**
+             * The type of async event.
+             * @default new.target.name
+             */
+            name?: string | undefined;
+        }
+        /**
+         * Integrates `EventEmitter` with `AsyncResource` for `EventEmitter`s that require
+         * manual async tracking. Specifically, all events emitted by instances of
+         * `EventEmitterAsyncResource` will run within its async context.
+         *
+         * The EventEmitterAsyncResource class has the same methods and takes the
+         * same options as EventEmitter and AsyncResource themselves.
+         * @throws if `options.name` is not provided when instantiated directly.
+         * @since v17.4.0, v16.14.0
+         */
+        class EventEmitterAsyncResource extends EventEmitter {
+            /**
+             * @param options Only optional in child class.
+             */
+            constructor(options?: EventEmitterAsyncResourceOptions);
+            /**
+             * Call all destroy hooks. This should only ever be called once. An
+             * error will be thrown if it is called more than once. This must be
+             * manually called. If the resource is left to be collected by the GC then
+             * the destroy hooks will never be called.
+             */
+            emitDestroy(): void;
+            /** The unique asyncId assigned to the resource. */
+            readonly asyncId: number;
+            /** The same triggerAsyncId that is passed to the AsyncResource constructor. */
+            readonly triggerAsyncId: number;
+            /** The underlying AsyncResource */
+            readonly asyncResource: EventEmitterReferencingAsyncResource;
+        }
+    }
+
     export = EventEmitter;
 }
+
 declare module "node:events" {
     import events = require("events");
     export = events;

--- a/types/node/v20/events.d.ts
+++ b/types/node/v20/events.d.ts
@@ -32,75 +32,11 @@
  * });
  * myEmitter.emit('event');
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/events.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.x/lib/events.js)
  */
 declare module "events" {
     import { AsyncResource, AsyncResourceOptions } from "node:async_hooks";
-    // NOTE: This class is in the docs but is **not actually exported** by Node.
-    // If https://github.com/nodejs/node/issues/39903 gets resolved and Node
-    // actually starts exporting the class, uncomment below.
-    // import { EventListener, EventListenerObject } from '__dom-events';
-    // /** The NodeEventTarget is a Node.js-specific extension to EventTarget that emulates a subset of the EventEmitter API. */
-    // interface NodeEventTarget extends EventTarget {
-    //     /**
-    //      * Node.js-specific extension to the `EventTarget` class that emulates the equivalent `EventEmitter` API.
-    //      * The only difference between `addListener()` and `addEventListener()` is that addListener() will return a reference to the EventTarget.
-    //      */
-    //     addListener(type: string, listener: EventListener | EventListenerObject, options?: { once: boolean }): this;
-    //     /** Node.js-specific extension to the `EventTarget` class that returns an array of event `type` names for which event listeners are registered. */
-    //     eventNames(): string[];
-    //     /** Node.js-specific extension to the `EventTarget` class that returns the number of event listeners registered for the `type`. */
-    //     listenerCount(type: string): number;
-    //     /** Node.js-specific alias for `eventTarget.removeListener()`. */
-    //     off(type: string, listener: EventListener | EventListenerObject): this;
-    //     /** Node.js-specific alias for `eventTarget.addListener()`. */
-    //     on(type: string, listener: EventListener | EventListenerObject, options?: { once: boolean }): this;
-    //     /** Node.js-specific extension to the `EventTarget` class that adds a `once` listener for the given event `type`. This is equivalent to calling `on` with the `once` option set to `true`. */
-    //     once(type: string, listener: EventListener | EventListenerObject): this;
-    //     /**
-    //      * Node.js-specific extension to the `EventTarget` class.
-    //      * If `type` is specified, removes all registered listeners for `type`,
-    //      * otherwise removes all registered listeners.
-    //      */
-    //     removeAllListeners(type: string): this;
-    //     /**
-    //      * Node.js-specific extension to the `EventTarget` class that removes the listener for the given `type`.
-    //      * The only difference between `removeListener()` and `removeEventListener()` is that `removeListener()` will return a reference to the `EventTarget`.
-    //      */
-    //     removeListener(type: string, listener: EventListener | EventListenerObject): this;
-    // }
-    interface EventEmitterOptions {
-        /**
-         * Enables automatic capturing of promise rejection.
-         */
-        captureRejections?: boolean | undefined;
-    }
-    interface StaticEventEmitterOptions {
-        /**
-         * Can be used to cancel awaiting events.
-         */
-        signal?: AbortSignal | undefined;
-    }
-    interface StaticEventEmitterIteratorOptions extends StaticEventEmitterOptions {
-        /**
-         * Names of events that will end the iteration.
-         */
-        close?: string[] | undefined;
-        /**
-         * The high watermark. The emitter is paused every time the size of events being buffered is higher than it.
-         * Supported only on emitters implementing `pause()` and `resume()` methods.
-         * @default Number.MAX_SAFE_INTEGER
-         */
-        highWaterMark?: number | undefined;
-        /**
-         * The low watermark. The emitter is resumed every time the size of events being buffered is lower than it.
-         * Supported only on emitters implementing `pause()` and `resume()` methods.
-         * @default 1
-         */
-        lowWaterMark?: number | undefined;
-    }
-    interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
-    type EventMap<T> = Record<keyof T, any[]> | DefaultEventMap;
+    // #region Event map helper types
     type DefaultEventMap = [never];
     type AnyRest = [...args: any[]];
     type Args<K, T> = T extends DefaultEventMap ? AnyRest : (
@@ -116,485 +52,110 @@ declare module "events" {
     );
     type Listener1<K, T> = Listener<K, T, (...args: any[]) => void>;
     type Listener2<K, T> = Listener<K, T, Function>;
-
-    /**
-     * The `EventEmitter` class is defined and exposed by the `node:events` module:
-     *
-     * ```js
-     * import { EventEmitter } from 'node:events';
-     * ```
-     *
-     * All `EventEmitter`s emit the event `'newListener'` when new listeners are
-     * added and `'removeListener'` when existing listeners are removed.
-     *
-     * It supports the following option:
-     * @since v0.1.26
-     */
-    class EventEmitter<T extends EventMap<T> = DefaultEventMap> {
-        constructor(options?: EventEmitterOptions);
-
-        [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
-
-        /**
-         * Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
-         * event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
-         * The `Promise` will resolve with an array of all the arguments emitted to the
-         * given event.
-         *
-         * This method is intentionally generic and works with the web platform [EventTarget](https://dom.spec.whatwg.org/#interface-eventtarget) interface, which has no special`'error'` event
-         * semantics and does not listen to the `'error'` event.
-         *
-         * ```js
-         * import { once, EventEmitter } from 'node:events';
-         * import process from 'node:process';
-         *
-         * const ee = new EventEmitter();
-         *
-         * process.nextTick(() => {
-         *   ee.emit('myevent', 42);
-         * });
-         *
-         * const [value] = await once(ee, 'myevent');
-         * console.log(value);
-         *
-         * const err = new Error('kaboom');
-         * process.nextTick(() => {
-         *   ee.emit('error', err);
-         * });
-         *
-         * try {
-         *   await once(ee, 'myevent');
-         * } catch (err) {
-         *   console.error('error happened', err);
-         * }
-         * ```
-         *
-         * The special handling of the `'error'` event is only used when `events.once()` is used to wait for another event. If `events.once()` is used to wait for the
-         * '`error'` event itself, then it is treated as any other kind of event without
-         * special handling:
-         *
-         * ```js
-         * import { EventEmitter, once } from 'node:events';
-         *
-         * const ee = new EventEmitter();
-         *
-         * once(ee, 'error')
-         *   .then(([err]) => console.log('ok', err.message))
-         *   .catch((err) => console.error('error', err.message));
-         *
-         * ee.emit('error', new Error('boom'));
-         *
-         * // Prints: ok boom
-         * ```
-         *
-         * An `AbortSignal` can be used to cancel waiting for the event:
-         *
-         * ```js
-         * import { EventEmitter, once } from 'node:events';
-         *
-         * const ee = new EventEmitter();
-         * const ac = new AbortController();
-         *
-         * async function foo(emitter, event, signal) {
-         *   try {
-         *     await once(emitter, event, { signal });
-         *     console.log('event emitted!');
-         *   } catch (error) {
-         *     if (error.name === 'AbortError') {
-         *       console.error('Waiting for the event was canceled!');
-         *     } else {
-         *       console.error('There was an error', error.message);
-         *     }
-         *   }
-         * }
-         *
-         * foo(ee, 'foo', ac.signal);
-         * ac.abort(); // Abort waiting for the event
-         * ee.emit('foo'); // Prints: Waiting for the event was canceled!
-         * ```
-         * @since v11.13.0, v10.16.0
-         */
-        static once(
-            emitter: NodeJS.EventEmitter,
-            eventName: string | symbol,
-            options?: StaticEventEmitterOptions,
-        ): Promise<any[]>;
-        static once(emitter: EventTarget, eventName: string, options?: StaticEventEmitterOptions): Promise<any[]>;
-        /**
-         * ```js
-         * import { on, EventEmitter } from 'node:events';
-         * import process from 'node:process';
-         *
-         * const ee = new EventEmitter();
-         *
-         * // Emit later on
-         * process.nextTick(() => {
-         *   ee.emit('foo', 'bar');
-         *   ee.emit('foo', 42);
-         * });
-         *
-         * for await (const event of on(ee, 'foo')) {
-         *   // The execution of this inner block is synchronous and it
-         *   // processes one event at a time (even with await). Do not use
-         *   // if concurrent execution is required.
-         *   console.log(event); // prints ['bar'] [42]
-         * }
-         * // Unreachable here
-         * ```
-         *
-         * Returns an `AsyncIterator` that iterates `eventName` events. It will throw
-         * if the `EventEmitter` emits `'error'`. It removes all listeners when
-         * exiting the loop. The `value` returned by each iteration is an array
-         * composed of the emitted event arguments.
-         *
-         * An `AbortSignal` can be used to cancel waiting on events:
-         *
-         * ```js
-         * import { on, EventEmitter } from 'node:events';
-         * import process from 'node:process';
-         *
-         * const ac = new AbortController();
-         *
-         * (async () => {
-         *   const ee = new EventEmitter();
-         *
-         *   // Emit later on
-         *   process.nextTick(() => {
-         *     ee.emit('foo', 'bar');
-         *     ee.emit('foo', 42);
-         *   });
-         *
-         *   for await (const event of on(ee, 'foo', { signal: ac.signal })) {
-         *     // The execution of this inner block is synchronous and it
-         *     // processes one event at a time (even with await). Do not use
-         *     // if concurrent execution is required.
-         *     console.log(event); // prints ['bar'] [42]
-         *   }
-         *   // Unreachable here
-         * })();
-         *
-         * process.nextTick(() => ac.abort());
-         * ```
-         *
-         * Use the `close` option to specify an array of event names that will end the iteration:
-         *
-         * ```js
-         * import { on, EventEmitter } from 'node:events';
-         * import process from 'node:process';
-         *
-         * const ee = new EventEmitter();
-         *
-         * // Emit later on
-         * process.nextTick(() => {
-         *   ee.emit('foo', 'bar');
-         *   ee.emit('foo', 42);
-         *   ee.emit('close');
-         * });
-         *
-         * for await (const event of on(ee, 'foo', { close: ['close'] })) {
-         *   console.log(event); // prints ['bar'] [42]
-         * }
-         * // the loop will exit after 'close' is emitted
-         * console.log('done'); // prints 'done'
-         * ```
-         * @since v13.6.0, v12.16.0
-         * @return An `AsyncIterator` that iterates `eventName` events emitted by the `emitter`
-         */
-        static on(
-            emitter: NodeJS.EventEmitter,
-            eventName: string | symbol,
-            options?: StaticEventEmitterIteratorOptions,
-        ): AsyncIterableIterator<any[]>;
-        static on(
-            emitter: EventTarget,
-            eventName: string,
-            options?: StaticEventEmitterIteratorOptions,
-        ): AsyncIterableIterator<any[]>;
-        /**
-         * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
-         *
-         * ```js
-         * import { EventEmitter, listenerCount } from 'node:events';
-         *
-         * const myEmitter = new EventEmitter();
-         * myEmitter.on('event', () => {});
-         * myEmitter.on('event', () => {});
-         * console.log(listenerCount(myEmitter, 'event'));
-         * // Prints: 2
-         * ```
-         * @since v0.9.12
-         * @deprecated Since v3.2.0 - Use `listenerCount` instead.
-         * @param emitter The emitter to query
-         * @param eventName The event name
-         */
-        static listenerCount(emitter: NodeJS.EventEmitter, eventName: string | symbol): number;
-        /**
-         * Returns a copy of the array of listeners for the event named `eventName`.
-         *
-         * For `EventEmitter`s this behaves exactly the same as calling `.listeners` on
-         * the emitter.
-         *
-         * For `EventTarget`s this is the only way to get the event listeners for the
-         * event target. This is useful for debugging and diagnostic purposes.
-         *
-         * ```js
-         * import { getEventListeners, EventEmitter } from 'node:events';
-         *
-         * {
-         *   const ee = new EventEmitter();
-         *   const listener = () => console.log('Events are fun');
-         *   ee.on('foo', listener);
-         *   console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
-         * }
-         * {
-         *   const et = new EventTarget();
-         *   const listener = () => console.log('Events are fun');
-         *   et.addEventListener('foo', listener);
-         *   console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
-         * }
-         * ```
-         * @since v15.2.0, v14.17.0
-         */
-        static getEventListeners(emitter: EventTarget | NodeJS.EventEmitter, name: string | symbol): Function[];
-        /**
-         * Returns the currently set max amount of listeners.
-         *
-         * For `EventEmitter`s this behaves exactly the same as calling `.getMaxListeners` on
-         * the emitter.
-         *
-         * For `EventTarget`s this is the only way to get the max event listeners for the
-         * event target. If the number of event handlers on a single EventTarget exceeds
-         * the max set, the EventTarget will print a warning.
-         *
-         * ```js
-         * import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
-         *
-         * {
-         *   const ee = new EventEmitter();
-         *   console.log(getMaxListeners(ee)); // 10
-         *   setMaxListeners(11, ee);
-         *   console.log(getMaxListeners(ee)); // 11
-         * }
-         * {
-         *   const et = new EventTarget();
-         *   console.log(getMaxListeners(et)); // 10
-         *   setMaxListeners(11, et);
-         *   console.log(getMaxListeners(et)); // 11
-         * }
-         * ```
-         * @since v19.9.0
-         */
-        static getMaxListeners(emitter: EventTarget | NodeJS.EventEmitter): number;
-        /**
-         * ```js
-         * import { setMaxListeners, EventEmitter } from 'node:events';
-         *
-         * const target = new EventTarget();
-         * const emitter = new EventEmitter();
-         *
-         * setMaxListeners(5, target, emitter);
-         * ```
-         * @since v15.4.0
-         * @param n A non-negative number. The maximum number of listeners per `EventTarget` event.
-         * @param eventsTargets Zero or more {EventTarget} or {EventEmitter} instances. If none are specified, `n` is set as the default max for all newly created {EventTarget} and {EventEmitter}
-         * objects.
-         */
-        static setMaxListeners(n?: number, ...eventTargets: Array<EventTarget | NodeJS.EventEmitter>): void;
-        /**
-         * Listens once to the `abort` event on the provided `signal`.
-         *
-         * Listening to the `abort` event on abort signals is unsafe and may
-         * lead to resource leaks since another third party with the signal can
-         * call `e.stopImmediatePropagation()`. Unfortunately Node.js cannot change
-         * this since it would violate the web standard. Additionally, the original
-         * API makes it easy to forget to remove listeners.
-         *
-         * This API allows safely using `AbortSignal`s in Node.js APIs by solving these
-         * two issues by listening to the event such that `stopImmediatePropagation` does
-         * not prevent the listener from running.
-         *
-         * Returns a disposable so that it may be unsubscribed from more easily.
-         *
-         * ```js
-         * import { addAbortListener } from 'node:events';
-         *
-         * function example(signal) {
-         *   let disposable;
-         *   try {
-         *     signal.addEventListener('abort', (e) => e.stopImmediatePropagation());
-         *     disposable = addAbortListener(signal, (e) => {
-         *       // Do something when signal is aborted.
-         *     });
-         *   } finally {
-         *     disposable?.[Symbol.dispose]();
-         *   }
-         * }
-         * ```
-         * @since v20.5.0
-         * @experimental
-         * @return Disposable that removes the `abort` listener.
-         */
-        static addAbortListener(signal: AbortSignal, resource: (event: Event) => void): Disposable;
-        /**
-         * This symbol shall be used to install a listener for only monitoring `'error'` events. Listeners installed using this symbol are called before the regular `'error'` listeners are called.
-         *
-         * Installing a listener using this symbol does not change the behavior once an `'error'` event is emitted. Therefore, the process will still crash if no
-         * regular `'error'` listener is installed.
-         * @since v13.6.0, v12.17.0
-         */
-        static readonly errorMonitor: unique symbol;
-        /**
-         * Value: `Symbol.for('nodejs.rejection')`
-         *
-         * See how to write a custom `rejection handler`.
-         * @since v13.4.0, v12.16.0
-         */
-        static readonly captureRejectionSymbol: unique symbol;
-        /**
-         * Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
-         *
-         * Change the default `captureRejections` option on all new `EventEmitter` objects.
-         * @since v13.4.0, v12.16.0
-         */
-        static captureRejections: boolean;
-        /**
-         * By default, a maximum of `10` listeners can be registered for any single
-         * event. This limit can be changed for individual `EventEmitter` instances
-         * using the `emitter.setMaxListeners(n)` method. To change the default
-         * for _all_`EventEmitter` instances, the `events.defaultMaxListeners` property
-         * can be used. If this value is not a positive number, a `RangeError` is thrown.
-         *
-         * Take caution when setting the `events.defaultMaxListeners` because the
-         * change affects _all_ `EventEmitter` instances, including those created before
-         * the change is made. However, calling `emitter.setMaxListeners(n)` still has
-         * precedence over `events.defaultMaxListeners`.
-         *
-         * This is not a hard limit. The `EventEmitter` instance will allow
-         * more listeners to be added but will output a trace warning to stderr indicating
-         * that a "possible EventEmitter memory leak" has been detected. For any single
-         * `EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()` methods can be used to
-         * temporarily avoid this warning:
-         *
-         * ```js
-         * import { EventEmitter } from 'node:events';
-         * const emitter = new EventEmitter();
-         * emitter.setMaxListeners(emitter.getMaxListeners() + 1);
-         * emitter.once('event', () => {
-         *   // do stuff
-         *   emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
-         * });
-         * ```
-         *
-         * The `--trace-warnings` command-line flag can be used to display the
-         * stack trace for such warnings.
-         *
-         * The emitted warning can be inspected with `process.on('warning')` and will
-         * have the additional `emitter`, `type`, and `count` properties, referring to
-         * the event emitter instance, the event's name and the number of attached
-         * listeners, respectively.
-         * Its `name` property is set to `'MaxListenersExceededWarning'`.
-         * @since v0.11.2
-         */
-        static defaultMaxListeners: number;
-    }
-    import internal = require("node:events");
-    namespace EventEmitter {
-        // Should just be `export { EventEmitter }`, but that doesn't work in TypeScript 3.4
-        export { internal as EventEmitter };
-        export interface Abortable {
-            /**
-             * When provided the corresponding `AbortController` can be used to cancel an asynchronous action.
-             */
-            signal?: AbortSignal | undefined;
-        }
-
-        export interface EventEmitterReferencingAsyncResource extends AsyncResource {
-            readonly eventEmitter: EventEmitterAsyncResource;
-        }
-
-        export interface EventEmitterAsyncResourceOptions extends AsyncResourceOptions, EventEmitterOptions {
-            /**
-             * The type of async event, this is required when instantiating `EventEmitterAsyncResource`
-             * directly rather than as a child class.
-             * @default new.target.name if instantiated as a child class.
-             */
-            name?: string;
-        }
-
-        /**
-         * Integrates `EventEmitter` with `AsyncResource` for `EventEmitter`s that
-         * require manual async tracking. Specifically, all events emitted by instances
-         * of `events.EventEmitterAsyncResource` will run within its `async context`.
-         *
-         * ```js
-         * import { EventEmitterAsyncResource, EventEmitter } from 'node:events';
-         * import { notStrictEqual, strictEqual } from 'node:assert';
-         * import { executionAsyncId, triggerAsyncId } from 'node:async_hooks';
-         *
-         * // Async tracking tooling will identify this as 'Q'.
-         * const ee1 = new EventEmitterAsyncResource({ name: 'Q' });
-         *
-         * // 'foo' listeners will run in the EventEmitters async context.
-         * ee1.on('foo', () => {
-         *   strictEqual(executionAsyncId(), ee1.asyncId);
-         *   strictEqual(triggerAsyncId(), ee1.triggerAsyncId);
-         * });
-         *
-         * const ee2 = new EventEmitter();
-         *
-         * // 'foo' listeners on ordinary EventEmitters that do not track async
-         * // context, however, run in the same async context as the emit().
-         * ee2.on('foo', () => {
-         *   notStrictEqual(executionAsyncId(), ee2.asyncId);
-         *   notStrictEqual(triggerAsyncId(), ee2.triggerAsyncId);
-         * });
-         *
-         * Promise.resolve().then(() => {
-         *   ee1.emit('foo');
-         *   ee2.emit('foo');
-         * });
-         * ```
-         *
-         * The `EventEmitterAsyncResource` class has the same methods and takes the
-         * same options as `EventEmitter` and `AsyncResource` themselves.
-         * @since v17.4.0, v16.14.0
-         */
-        export class EventEmitterAsyncResource extends EventEmitter {
-            /**
-             * @param options Only optional in child class.
-             */
-            constructor(options?: EventEmitterAsyncResourceOptions);
-            /**
-             * Call all `destroy` hooks. This should only ever be called once. An error will
-             * be thrown if it is called more than once. This **must** be manually called. If
-             * the resource is left to be collected by the GC then the `destroy` hooks will
-             * never be called.
-             */
-            emitDestroy(): void;
-            /**
-             * The unique `asyncId` assigned to the resource.
-             */
-            readonly asyncId: number;
-            /**
-             * The same triggerAsyncId that is passed to the AsyncResource constructor.
-             */
-            readonly triggerAsyncId: number;
-            /**
-             * The returned `AsyncResource` object has an additional `eventEmitter` property
-             * that provides a reference to this `EventEmitterAsyncResource`.
-             */
-            readonly asyncResource: EventEmitterReferencingAsyncResource;
-        }
-    }
+    // #endregion Event map helper types
     global {
         namespace NodeJS {
             interface EventEmitter<T extends EventMap<T> = DefaultEventMap> {
-                [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
                 /**
                  * Alias for `emitter.on(eventName, listener)`.
                  * @since v0.1.26
                  */
                 addListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                /**
+                 * Synchronously calls each of the listeners registered for the event named
+                 * `eventName`, in the order they were registered, passing the supplied arguments
+                 * to each.
+                 *
+                 * Returns `true` if the event had listeners, `false` otherwise.
+                 *
+                 * ```js
+                 * import { EventEmitter } from 'node:events';
+                 * const myEmitter = new EventEmitter();
+                 *
+                 * // First listener
+                 * myEmitter.on('event', function firstListener() {
+                 *   console.log('Helloooo! first listener');
+                 * });
+                 * // Second listener
+                 * myEmitter.on('event', function secondListener(arg1, arg2) {
+                 *   console.log(`event with parameters ${arg1}, ${arg2} in second listener`);
+                 * });
+                 * // Third listener
+                 * myEmitter.on('event', function thirdListener(...args) {
+                 *   const parameters = args.join(', ');
+                 *   console.log(`event with parameters ${parameters} in third listener`);
+                 * });
+                 *
+                 * console.log(myEmitter.listeners('event'));
+                 *
+                 * myEmitter.emit('event', 1, 2, 3, 4, 5);
+                 *
+                 * // Prints:
+                 * // [
+                 * //   [Function: firstListener],
+                 * //   [Function: secondListener],
+                 * //   [Function: thirdListener]
+                 * // ]
+                 * // Helloooo! first listener
+                 * // event with parameters 1, 2 in second listener
+                 * // event with parameters 1, 2, 3, 4, 5 in third listener
+                 * ```
+                 * @since v0.1.26
+                 */
+                emit<K>(eventName: Key<K, T>, ...args: Args<K, T>): boolean;
+                /**
+                 * Returns an array listing the events for which the emitter has registered
+                 * listeners. The values in the array are strings or `Symbol`s.
+                 *
+                 * ```js
+                 * import { EventEmitter } from 'node:events';
+                 *
+                 * const myEE = new EventEmitter();
+                 * myEE.on('foo', () => {});
+                 * myEE.on('bar', () => {});
+                 *
+                 * const sym = Symbol('symbol');
+                 * myEE.on(sym, () => {});
+                 *
+                 * console.log(myEE.eventNames());
+                 * // Prints: [ 'foo', 'bar', Symbol(symbol) ]
+                 * ```
+                 * @since v6.0.0
+                 */
+                eventNames(): Array<(string | symbol) & Key2<unknown, T>>;
+                /**
+                 * Returns the current max listener value for the `EventEmitter` which is either
+                 * set by `emitter.setMaxListeners(n)` or defaults to `defaultMaxListeners`.
+                 * @since v1.0.0
+                 */
+                getMaxListeners(): number;
+                /**
+                 * Returns the number of listeners listening for the event named `eventName`.
+                 * If `listener` is provided, it will return how many times the listener is found
+                 * in the list of the listeners of the event.
+                 * @since v3.2.0
+                 * @param eventName The name of the event being listened for
+                 * @param listener The event handler function
+                 */
+                listenerCount<K>(eventName: Key<K, T>, listener?: Listener2<K, T>): number;
+                /**
+                 * Returns a copy of the array of listeners for the event named `eventName`.
+                 *
+                 * ```js
+                 * server.on('connection', (stream) => {
+                 *   console.log('someone connected!');
+                 * });
+                 * console.log(util.inspect(server.listeners('connection')));
+                 * // Prints: [ [Function] ]
+                 * ```
+                 * @since v0.1.26
+                 */
+                listeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
+                /**
+                 * Alias for `emitter.removeListener()`.
+                 * @since v10.0.0
+                 */
+                off<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
                 /**
                  * Adds the `listener` function to the end of the listeners array for the event
                  * named `eventName`. No checks are made to see if the `listener` has already
@@ -609,7 +170,8 @@ declare module "events" {
                  *
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  *
-                 * By default, event listeners are invoked in the order they are added. The `emitter.prependListener()` method can be used as an alternative to add the
+                 * By default, event listeners are invoked in the order they are added. The
+                 * `emitter.prependListener()` method can be used as an alternative to add the
                  * event listener to the beginning of the listeners array.
                  *
                  * ```js
@@ -639,7 +201,8 @@ declare module "events" {
                  *
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  *
-                 * By default, event listeners are invoked in the order they are added. The `emitter.prependOnceListener()` method can be used as an alternative to add the
+                 * By default, event listeners are invoked in the order they are added. The
+                 * `emitter.prependOnceListener()` method can be used as an alternative to add the
                  * event listener to the beginning of the listeners array.
                  *
                  * ```js
@@ -658,7 +221,54 @@ declare module "events" {
                  */
                 once<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
                 /**
-                 * Removes the specified `listener` from the listener array for the event named `eventName`.
+                 * Adds the `listener` function to the _beginning_ of the listeners array for the
+                 * event named `eventName`. No checks are made to see if the `listener` has
+                 * already been added. Multiple calls passing the same combination of `eventName`
+                 * and `listener` will result in the `listener` being added, and called, multiple times.
+                 *
+                 * ```js
+                 * server.prependListener('connection', (stream) => {
+                 *   console.log('someone connected!');
+                 * });
+                 * ```
+                 *
+                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
+                 * @since v6.0.0
+                 * @param eventName The name of the event.
+                 * @param listener The callback function
+                 */
+                prependListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                /**
+                 * Adds a **one-time**`listener` function for the event named `eventName` to the
+                 * _beginning_ of the listeners array. The next time `eventName` is triggered, this
+                 * listener is removed, and then invoked.
+                 *
+                 * ```js
+                 * server.prependOnceListener('connection', (stream) => {
+                 *   console.log('Ah, we have our first user!');
+                 * });
+                 * ```
+                 *
+                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
+                 * @since v6.0.0
+                 * @param eventName The name of the event.
+                 * @param listener The callback function
+                 */
+                prependOnceListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                /**
+                 * Removes all listeners, or those of the specified `eventName`.
+                 *
+                 * It is bad practice to remove listeners added elsewhere in the code,
+                 * particularly when the `EventEmitter` instance was created by some other
+                 * component or module (e.g. sockets or file streams).
+                 *
+                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
+                 * @since v0.1.26
+                 */
+                removeAllListeners(eventName?: Key<unknown, T>): this;
+                /**
+                 * Removes the specified `listener` from the listener array for the event named
+                 * `eventName`.
                  *
                  * ```js
                  * const callback = (stream) => {
@@ -675,8 +285,10 @@ declare module "events" {
                  * called multiple times to remove each instance.
                  *
                  * Once an event is emitted, all listeners attached to it at the
-                 * time of emitting are called in order. This implies that any `removeListener()` or `removeAllListeners()` calls _after_ emitting and _before_ the last listener finishes execution
-                 * will not remove them from`emit()` in progress. Subsequent events behave as expected.
+                 * time of emitting are called in order. This implies that any
+                 * `removeListener()` or `removeAllListeners()` calls _after_ emitting and
+                 * _before_ the last listener finishes execution will not remove them from
+                 * `emit()` in progress. Subsequent events behave as expected.
                  *
                  * ```js
                  * import { EventEmitter } from 'node:events';
@@ -741,50 +353,16 @@ declare module "events" {
                  */
                 removeListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
                 /**
-                 * Alias for `emitter.removeListener()`.
-                 * @since v10.0.0
-                 */
-                off<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
-                /**
-                 * Removes all listeners, or those of the specified `eventName`.
-                 *
-                 * It is bad practice to remove listeners added elsewhere in the code,
-                 * particularly when the `EventEmitter` instance was created by some other
-                 * component or module (e.g. sockets or file streams).
-                 *
-                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
-                 * @since v0.1.26
-                 */
-                removeAllListeners(eventName?: Key<unknown, T>): this;
-                /**
                  * By default `EventEmitter`s will print a warning if more than `10` listeners are
                  * added for a particular event. This is a useful default that helps finding
                  * memory leaks. The `emitter.setMaxListeners()` method allows the limit to be
-                 * modified for this specific `EventEmitter` instance. The value can be set to `Infinity` (or `0`) to indicate an unlimited number of listeners.
+                 * modified for this specific `EventEmitter` instance. The value can be set to
+                 * `Infinity` (or `0`) to indicate an unlimited number of listeners.
                  *
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.3.5
                  */
                 setMaxListeners(n: number): this;
-                /**
-                 * Returns the current max listener value for the `EventEmitter` which is either
-                 * set by `emitter.setMaxListeners(n)` or defaults to {@link defaultMaxListeners}.
-                 * @since v1.0.0
-                 */
-                getMaxListeners(): number;
-                /**
-                 * Returns a copy of the array of listeners for the event named `eventName`.
-                 *
-                 * ```js
-                 * server.on('connection', (stream) => {
-                 *   console.log('someone connected!');
-                 * });
-                 * console.log(util.inspect(server.listeners('connection')));
-                 * // Prints: [ [Function] ]
-                 * ```
-                 * @since v0.1.26
-                 */
-                listeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
                  * including any wrappers (such as those created by `.once()`).
@@ -817,110 +395,514 @@ declare module "events" {
                  */
                 rawListeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
                 /**
-                 * Synchronously calls each of the listeners registered for the event named `eventName`, in the order they were registered, passing the supplied arguments
-                 * to each.
-                 *
-                 * Returns `true` if the event had listeners, `false` otherwise.
-                 *
-                 * ```js
-                 * import { EventEmitter } from 'node:events';
-                 * const myEmitter = new EventEmitter();
-                 *
-                 * // First listener
-                 * myEmitter.on('event', function firstListener() {
-                 *   console.log('Helloooo! first listener');
-                 * });
-                 * // Second listener
-                 * myEmitter.on('event', function secondListener(arg1, arg2) {
-                 *   console.log(`event with parameters ${arg1}, ${arg2} in second listener`);
-                 * });
-                 * // Third listener
-                 * myEmitter.on('event', function thirdListener(...args) {
-                 *   const parameters = args.join(', ');
-                 *   console.log(`event with parameters ${parameters} in third listener`);
-                 * });
-                 *
-                 * console.log(myEmitter.listeners('event'));
-                 *
-                 * myEmitter.emit('event', 1, 2, 3, 4, 5);
-                 *
-                 * // Prints:
-                 * // [
-                 * //   [Function: firstListener],
-                 * //   [Function: secondListener],
-                 * //   [Function: thirdListener]
-                 * // ]
-                 * // Helloooo! first listener
-                 * // event with parameters 1, 2 in second listener
-                 * // event with parameters 1, 2, 3, 4, 5 in third listener
-                 * ```
-                 * @since v0.1.26
-                 */
-                emit<K>(eventName: Key<K, T>, ...args: Args<K, T>): boolean;
-                /**
-                 * Returns the number of listeners listening for the event named `eventName`.
-                 * If `listener` is provided, it will return how many times the listener is found
-                 * in the list of the listeners of the event.
-                 * @since v3.2.0
-                 * @param eventName The name of the event being listened for
-                 * @param listener The event handler function
-                 */
-                listenerCount<K>(eventName: Key<K, T>, listener?: Listener2<K, T>): number;
-                /**
-                 * Adds the `listener` function to the _beginning_ of the listeners array for the
-                 * event named `eventName`. No checks are made to see if the `listener` has
-                 * already been added. Multiple calls passing the same combination of `eventName`
-                 * and `listener` will result in the `listener` being added, and called, multiple times.
+                 * The `Symbol.for('nodejs.rejection')` method is called in case a
+                 * promise rejection happens when emitting an event and
+                 * `captureRejections` is enabled on the emitter.
+                 * It is possible to use `events.captureRejectionSymbol` in
+                 * place of `Symbol.for('nodejs.rejection')`.
                  *
                  * ```js
-                 * server.prependListener('connection', (stream) => {
-                 *   console.log('someone connected!');
-                 * });
+                 * import { EventEmitter, captureRejectionSymbol } from 'node:events';
+                 *
+                 * class MyClass extends EventEmitter {
+                 *   constructor() {
+                 *     super({ captureRejections: true });
+                 *   }
+                 *
+                 *   [captureRejectionSymbol](err, event, ...args) {
+                 *     console.log('rejection happened for', event, 'with', err, ...args);
+                 *     this.destroy(err);
+                 *   }
+                 *
+                 *   destroy(err) {
+                 *     // Tear the resource down here.
+                 *   }
+                 * }
                  * ```
-                 *
-                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
-                 * @since v6.0.0
-                 * @param eventName The name of the event.
-                 * @param listener The callback function
+                 * @since v13.4.0, v12.16.0
                  */
-                prependListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
-                /**
-                 * Adds a **one-time**`listener` function for the event named `eventName` to the _beginning_ of the listeners array. The next time `eventName` is triggered, this
-                 * listener is removed, and then invoked.
-                 *
-                 * ```js
-                 * server.prependOnceListener('connection', (stream) => {
-                 *   console.log('Ah, we have our first user!');
-                 * });
-                 * ```
-                 *
-                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
-                 * @since v6.0.0
-                 * @param eventName The name of the event.
-                 * @param listener The callback function
-                 */
-                prependOnceListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
-                /**
-                 * Returns an array listing the events for which the emitter has registered
-                 * listeners. The values in the array are strings or `Symbol`s.
-                 *
-                 * ```js
-                 * import { EventEmitter } from 'node:events';
-                 *
-                 * const myEE = new EventEmitter();
-                 * myEE.on('foo', () => {});
-                 * myEE.on('bar', () => {});
-                 *
-                 * const sym = Symbol('symbol');
-                 * myEE.on(sym, () => {});
-                 *
-                 * console.log(myEE.eventNames());
-                 * // Prints: [ 'foo', 'bar', Symbol(symbol) ]
-                 * ```
-                 * @since v6.0.0
-                 */
-                eventNames(): Array<(string | symbol) & Key2<unknown, T>>;
+                [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
             }
+        }
+    }
+    interface EventEmitterOptions {
+        /**
+         * Enables automatic capturing of promise rejection.
+         */
+        captureRejections?: boolean | undefined;
+    }
+    /**
+     * An interface mapping event names to event parameter tuples.
+     */
+    type EventMap<T> = Record<keyof T, any[]> | DefaultEventMap;
+    /**
+     * The `EventEmitter` class is defined and exposed by the `node:events` module:
+     *
+     * ```js
+     * import { EventEmitter } from 'node:events';
+     * ```
+     *
+     * All `EventEmitter`s emit the event `'newListener'` when new listeners are
+     * added and `'removeListener'` when existing listeners are removed.
+     * @since v0.1.26
+     */
+    class EventEmitter<T extends EventMap<T> = DefaultEventMap> {
+        constructor(options?: EventEmitterOptions);
+    }
+    interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
+    namespace EventEmitter {
+        export { EventEmitter, EventEmitterOptions, EventMap };
+    }
+    namespace EventEmitter {
+        interface Abortable {
+            /**
+             * When provided, the corresponding `AbortController` can be used to cancel an asynchronous action.
+             */
+            signal?: AbortSignal | undefined;
+        }
+        /**
+         * By default, a maximum of `10` listeners can be registered for any single
+         * event. This limit can be changed for individual `EventEmitter` instances
+         * using the `emitter.setMaxListeners(n)` method. To change the default
+         * for _all_ `EventEmitter` instances, the `events.defaultMaxListeners`
+         * property can be used. If this value is not a positive number, a `RangeError`
+         * is thrown.
+         *
+         * Take caution when setting the `events.defaultMaxListeners` because the
+         * change affects _all_ `EventEmitter` instances, including those created before
+         * the change is made. However, calling `emitter.setMaxListeners(n)` still has
+         * precedence over `events.defaultMaxListeners`.
+         *
+         * This is not a hard limit. The `EventEmitter` instance will allow
+         * more listeners to be added but will output a trace warning to stderr indicating
+         * that a "possible EventEmitter memory leak" has been detected. For any single
+         * `EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`
+         * methods can be used to temporarily avoid this warning:
+         *
+         * ```js
+         * import { EventEmitter } from 'node:events';
+         * const emitter = new EventEmitter();
+         * emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+         * emitter.once('event', () => {
+         *   // do stuff
+         *   emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+         * });
+         * ```
+         *
+         * The `--trace-warnings` command-line flag can be used to display the
+         * stack trace for such warnings.
+         *
+         * The emitted warning can be inspected with `process.on('warning')` and will
+         * have the additional `emitter`, `type`, and `count` properties, referring to
+         * the event emitter instance, the event's name and the number of attached
+         * listeners, respectively.
+         * Its `name` property is set to `'MaxListenersExceededWarning'`.
+         * @since v0.11.2
+         */
+        var defaultMaxListeners: number;
+        /**
+         * This symbol shall be used to install a listener for only monitoring `'error'`
+         * events. Listeners installed using this symbol are called before the regular
+         * `'error'` listeners are called.
+
+        * Installing a listener using this symbol does not change the behavior once an
+        * `'error'` event is emitted. Therefore, the process will still crash if no
+        * regular `'error'` listener is installed.
+        * @since v13.6.0, v12.17.0
+        */
+        const errorMonitor: unique symbol;
+        /**
+         * Returns a copy of the array of listeners for the event named `eventName`.
+         *
+         * For `EventEmitter`s this behaves exactly the same as calling `.listeners` on
+         * the emitter.
+         *
+         * For `EventTarget`s this is the only way to get the event listeners for the
+         * event target. This is useful for debugging and diagnostic purposes.
+         *
+         * ```js
+         * import { getEventListeners, EventEmitter } from 'node:events';
+         *
+         * {
+         *   const ee = new EventEmitter();
+         *   const listener = () => console.log('Events are fun');
+         *   ee.on('foo', listener);
+         *   console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
+         * }
+         * {
+         *   const et = new EventTarget();
+         *   const listener = () => console.log('Events are fun');
+         *   et.addEventListener('foo', listener);
+         *   console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
+         * }
+         * ```
+         * @since v15.2.0, v14.17.0
+         */
+        function getEventListeners(emitter: EventTarget | NodeJS.EventEmitter, name: string | symbol): Function[];
+        /**
+         * Returns the currently set max amount of listeners.
+         *
+         * For `EventEmitter`s this behaves exactly the same as calling `.getMaxListeners` on
+         * the emitter.
+         *
+         * For `EventTarget`s this is the only way to get the max event listeners for the
+         * event target. If the number of event handlers on a single EventTarget exceeds
+         * the max set, the EventTarget will print a warning.
+         *
+         * ```js
+         * import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
+         *
+         * {
+         *   const ee = new EventEmitter();
+         *   console.log(getMaxListeners(ee)); // 10
+         *   setMaxListeners(11, ee);
+         *   console.log(getMaxListeners(ee)); // 11
+         * }
+         * {
+         *   const et = new EventTarget();
+         *   console.log(getMaxListeners(et)); // 10
+         *   setMaxListeners(11, et);
+         *   console.log(getMaxListeners(et)); // 11
+         * }
+         * ```
+         * @since v19.9.0
+         */
+        function getMaxListeners(emitter: EventTarget | NodeJS.EventEmitter): number;
+        interface OnceOptions extends Abortable {}
+        /**
+         * Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
+         * event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
+         * The `Promise` will resolve with an array of all the arguments emitted to the
+         * given event.
+         *
+         * This method is intentionally generic and works with the web platform
+         * [EventTarget](https://dom.spec.whatwg.org/#interface-eventtarget)
+         * interface, which has no special`'error'` event
+         * semantics and does not listen to the `'error'` event.
+         *
+         * ```js
+         * import { once, EventEmitter } from 'node:events';
+         * import process from 'node:process';
+         *
+         * const ee = new EventEmitter();
+         *
+         * process.nextTick(() => {
+         *   ee.emit('myevent', 42);
+         * });
+         *
+         * const [value] = await once(ee, 'myevent');
+         * console.log(value);
+         *
+         * const err = new Error('kaboom');
+         * process.nextTick(() => {
+         *   ee.emit('error', err);
+         * });
+         *
+         * try {
+         *   await once(ee, 'myevent');
+         * } catch (err) {
+         *   console.error('error happened', err);
+         * }
+         * ```
+         *
+         * The special handling of the `'error'` event is only used when `events.once()`
+         * is used to wait for another event. If `events.once()` is used to wait for the
+         * '`error'` event itself, then it is treated as any other kind of event without
+         * special handling:
+         *
+         * ```js
+         * import { EventEmitter, once } from 'node:events';
+         *
+         * const ee = new EventEmitter();
+         *
+         * once(ee, 'error')
+         *   .then(([err]) => console.log('ok', err.message))
+         *   .catch((err) => console.error('error', err.message));
+         *
+         * ee.emit('error', new Error('boom'));
+         *
+         * // Prints: ok boom
+         * ```
+         *
+         * An `AbortSignal` can be used to cancel waiting for the event:
+         *
+         * ```js
+         * import { EventEmitter, once } from 'node:events';
+         *
+         * const ee = new EventEmitter();
+         * const ac = new AbortController();
+         *
+         * async function foo(emitter, event, signal) {
+         *   try {
+         *     await once(emitter, event, { signal });
+         *     console.log('event emitted!');
+         *   } catch (error) {
+         *     if (error.name === 'AbortError') {
+         *       console.error('Waiting for the event was canceled!');
+         *     } else {
+         *       console.error('There was an error', error.message);
+         *     }
+         *   }
+         * }
+         *
+         * foo(ee, 'foo', ac.signal);
+         * ac.abort(); // Abort waiting for the event
+         * ee.emit('foo'); // Prints: Waiting for the event was canceled!
+         * ```
+         * @since v11.13.0, v10.16.0
+         */
+        function once(
+            emitter: NodeJS.EventEmitter,
+            eventName: string | symbol,
+            options?: OnceOptions,
+        ): Promise<any[]>;
+        function once(emitter: EventTarget, eventName: string, options?: OnceOptions): Promise<any[]>;
+        /**
+         * Change the default `captureRejections` option on all new `EventEmitter` objects.
+         * @since v13.4.0, v12.16.0
+         */
+        var captureRejections: boolean;
+        /**
+         * Value: `Symbol.for('nodejs.rejection')`
+         * @since v13.4.0, v12.16.0
+         */
+        const captureRejectionSymbol: unique symbol;
+        /**
+         * A class method that returns the number of listeners for the given `eventName`
+         * registered on the given `emitter`.
+         *
+         * ```js
+         * import { EventEmitter, listenerCount } from 'node:events';
+         *
+         * const myEmitter = new EventEmitter();
+         * myEmitter.on('event', () => {});
+         * myEmitter.on('event', () => {});
+         * console.log(listenerCount(myEmitter, 'event'));
+         * // Prints: 2
+         * ```
+         * @since v0.9.12
+         * @deprecated Since v3.2.0 - Use `emitter.listenerCount` instead.
+         * @param emitter The emitter to query
+         * @param eventName The event name
+         */
+        function listenerCount(emitter: NodeJS.EventEmitter, eventName: string | symbol): number;
+        interface OnOptions extends Abortable {
+            /**
+             * Names of events that will end the iteration.
+             * @since v20.0.0
+             */
+            close?: string[] | undefined;
+            /**
+             * The high watermark. The emitter is paused every time the size of events
+             * being buffered is higher than it. Supported only on emitters implementing
+             * `pause()` and `resume()` methods.
+             * @default Number.MAX_SAFE_INTEGER
+             * @since v20.13.0
+             */
+            highWaterMark?: number | undefined;
+            /**
+             * The low watermark. The emitter is resumed every time the size of events
+             * being buffered is lower than it. Supported only on emitters implementing
+             * `pause()` and `resume()` methods.
+             * @default 1
+             * @since v20.13.0
+             */
+            lowWaterMark?: number | undefined;
+        }
+        /**
+         * ```js
+         * import { on, EventEmitter } from 'node:events';
+         * import process from 'node:process';
+         *
+         * const ee = new EventEmitter();
+         *
+         * // Emit later on
+         * process.nextTick(() => {
+         *   ee.emit('foo', 'bar');
+         *   ee.emit('foo', 42);
+         * });
+         *
+         * for await (const event of on(ee, 'foo')) {
+         *   // The execution of this inner block is synchronous and it
+         *   // processes one event at a time (even with await). Do not use
+         *   // if concurrent execution is required.
+         *   console.log(event); // prints ['bar'] [42]
+         * }
+         * // Unreachable here
+         * ```
+         *
+         * Returns an `AsyncIterator` that iterates `eventName` events. It will throw
+         * if the `EventEmitter` emits `'error'`. It removes all listeners when
+         * exiting the loop. The `value` returned by each iteration is an array
+         * composed of the emitted event arguments.
+         *
+         * An `AbortSignal` can be used to cancel waiting on events:
+         *
+         * ```js
+         * import { on, EventEmitter } from 'node:events';
+         * import process from 'node:process';
+         *
+         * const ac = new AbortController();
+         *
+         * (async () => {
+         *   const ee = new EventEmitter();
+         *
+         *   // Emit later on
+         *   process.nextTick(() => {
+         *     ee.emit('foo', 'bar');
+         *     ee.emit('foo', 42);
+         *   });
+         *
+         *   for await (const event of on(ee, 'foo', { signal: ac.signal })) {
+         *     // The execution of this inner block is synchronous and it
+         *     // processes one event at a time (even with await). Do not use
+         *     // if concurrent execution is required.
+         *     console.log(event); // prints ['bar'] [42]
+         *   }
+         *   // Unreachable here
+         * })();
+         *
+         * process.nextTick(() => ac.abort());
+         * ```
+         * @since v13.6.0, v12.16.0
+         * @return An `AsyncIterator` that iterates `eventName` events emitted by the `emitter`
+         */
+        function on(
+            emitter: NodeJS.EventEmitter,
+            eventName: string | symbol,
+            options?: OnOptions,
+        ): AsyncIterableIterator<any[]>;
+        function on(
+            emitter: EventTarget,
+            eventName: string,
+            options?: OnOptions,
+        ): AsyncIterableIterator<any[]>;
+        /**
+         * ```js
+         * import { setMaxListeners, EventEmitter } from 'node:events';
+         *
+         * const target = new EventTarget();
+         * const emitter = new EventEmitter();
+         *
+         * setMaxListeners(5, target, emitter);
+         * ```
+         * @since v15.4.0
+         * @param n A non-negative number. The maximum number of listeners per
+         * `EventTarget` event.
+         * @param eventsTargets Zero or more `EventTarget` or {EventEmitter} instances.
+         * If none are specified, `n` is set as the default max for all newly created
+         * `EventTarget` and `EventEmitter` objects.
+         */
+        function setMaxListeners(n?: number, ...eventTargets: Array<EventTarget | NodeJS.EventEmitter>): void;
+        /**
+         * Listens once to the `abort` event on the provided `signal`.
+         *
+         * Listening to the `abort` event on abort signals is unsafe and may
+         * lead to resource leaks since another third party with the signal can
+         * call `e.stopImmediatePropagation()`. Unfortunately Node.js cannot change
+         * this since it would violate the web standard. Additionally, the original
+         * API makes it easy to forget to remove listeners.
+         *
+         * This API allows safely using `AbortSignal`s in Node.js APIs by solving these
+         * two issues by listening to the event such that `stopImmediatePropagation` does
+         * not prevent the listener from running.
+         *
+         * Returns a disposable so that it may be unsubscribed from more easily.
+         *
+         * ```js
+         * import { addAbortListener } from 'node:events';
+         *
+         * function example(signal) {
+         *   let disposable;
+         *   try {
+         *     signal.addEventListener('abort', (e) => e.stopImmediatePropagation());
+         *     disposable = addAbortListener(signal, (e) => {
+         *       // Do something when signal is aborted.
+         *     });
+         *   } finally {
+         *     disposable?.[Symbol.dispose]();
+         *   }
+         * }
+         * ```
+         * @since v20.5.0, v18.18.0
+         * @experimental
+         * @return Disposable that removes the `abort` listener.
+         */
+        function addAbortListener(signal: AbortSignal, resource: (event: Event) => void): Disposable;
+        class EventEmitterReferencingAsyncResource extends AsyncResource {
+            private constructor();
+            readonly eventEmitter: EventEmitterAsyncResource;
+        }
+        interface EventEmitterAsyncResourceOptions extends AsyncResourceOptions, EventEmitterOptions {
+            /**
+             * The type of async event.
+             * @default new.target.name
+             */
+            name?: string | undefined;
+        }
+        /**
+         * Integrates `EventEmitter` with `AsyncResource` for `EventEmitter`s that
+         * require manual async tracking. Specifically, all events emitted by instances
+         * of `events.EventEmitterAsyncResource` will run within its `async context`.
+         *
+         * ```js
+         * import { EventEmitterAsyncResource, EventEmitter } from 'node:events';
+         * import { notStrictEqual, strictEqual } from 'node:assert';
+         * import { executionAsyncId, triggerAsyncId } from 'node:async_hooks';
+         *
+         * // Async tracking tooling will identify this as 'Q'.
+         * const ee1 = new EventEmitterAsyncResource({ name: 'Q' });
+         *
+         * // 'foo' listeners will run in the EventEmitters async context.
+         * ee1.on('foo', () => {
+         *   strictEqual(executionAsyncId(), ee1.asyncId);
+         *   strictEqual(triggerAsyncId(), ee1.triggerAsyncId);
+         * });
+         *
+         * const ee2 = new EventEmitter();
+         *
+         * // 'foo' listeners on ordinary EventEmitters that do not track async
+         * // context, however, run in the same async context as the emit().
+         * ee2.on('foo', () => {
+         *   notStrictEqual(executionAsyncId(), ee2.asyncId);
+         *   notStrictEqual(triggerAsyncId(), ee2.triggerAsyncId);
+         * });
+         *
+         * Promise.resolve().then(() => {
+         *   ee1.emit('foo');
+         *   ee2.emit('foo');
+         * });
+         * ```
+         *
+         * The `EventEmitterAsyncResource` class has the same methods and takes the
+         * same options as `EventEmitter` and `AsyncResource` themselves.
+         * @since v17.4.0, v16.14.0
+         */
+        class EventEmitterAsyncResource extends EventEmitter {
+            /**
+             * @param options Only optional in child class.
+             */
+            constructor(options?: EventEmitterAsyncResourceOptions);
+            /**
+             * Call all `destroy` hooks. This should only ever be called once. An error will
+             * be thrown if it is called more than once. This **must** be manually called. If
+             * the resource is left to be collected by the GC then the `destroy` hooks will
+             * never be called.
+             */
+            emitDestroy(): void;
+            /**
+             * The unique `asyncId` assigned to the resource.
+             */
+            readonly asyncId: number;
+            /**
+             * The same triggerAsyncId that is passed to the AsyncResource constructor.
+             */
+            readonly triggerAsyncId: number;
+            /**
+             * The returned `AsyncResource` object has an additional `eventEmitter` property
+             * that provides a reference to this `EventEmitterAsyncResource`.
+             */
+            readonly asyncResource: EventEmitterReferencingAsyncResource;
         }
     }
     export = EventEmitter;

--- a/types/node/v20/test/events.ts
+++ b/types/node/v20/test/events.ts
@@ -1,81 +1,127 @@
-import * as events from "node:events";
+// These should be equivalent
+import events = require("node:events");
+import { EventEmitter } from "node:events";
+{
+    let module: typeof events;
+    module = EventEmitter;
+    module = events.EventEmitter;
+}
 
-const emitter: events = new events.EventEmitter();
+const emitter = new EventEmitter();
 declare const listener: (...args: any[]) => void;
 declare const event: string | symbol;
-declare const any: any;
 
 {
-    let result: events.EventEmitter;
+    // dtslint won't alias the EventEmitter type, so we use this instead
+    function $ExpectEventEmitterType(...expr: EventEmitter[]) {}
 
-    result = emitter.addListener(event, listener);
-    result = emitter.on(event, listener);
-    result = emitter.once(event, listener);
-    result = emitter.prependListener(event, listener);
-    result = emitter.prependOnceListener(event, listener);
-    result = emitter.removeListener(event, listener);
-    result = emitter.off(event, listener);
-    result = emitter.removeAllListeners();
-    result = emitter.removeAllListeners(event);
-    result = emitter.setMaxListeners(42);
-}
+    $ExpectEventEmitterType(
+        emitter.addListener(event, listener),
+    );
 
-{
-    let result: number;
+    // $ExpectType boolean
+    emitter.emit(event);
+    // $ExpectType boolean
+    emitter.emit(event, ...[]);
 
-    result = events.EventEmitter.defaultMaxListeners;
-    result = events.EventEmitter.listenerCount(emitter, event); // deprecated
+    // $ExpectType (string | symbol)[]
+    emitter.eventNames();
 
-    const promise: Promise<any[]> = events.once(new events.EventEmitter(), "error");
+    // $ExpectType number
+    emitter.getMaxListeners();
 
-    result = emitter.getMaxListeners();
-    result = emitter.listenerCount(event);
+    // $ExpectType number
+    emitter.listenerCount(event);
+    // $ExpectType number
+    emitter.listenerCount(event, listener);
 
-    const handler: Function = () => {};
-    result = emitter.listenerCount(event, handler);
-}
+    $ExpectEventEmitterType(
+        emitter.off(event, listener),
+    );
 
-{
-    let result: Promise<number[]>;
+    $ExpectEventEmitterType(
+        emitter.on(event, listener),
+    );
 
-    result = events.once(emitter, event);
+    $ExpectEventEmitterType(
+        emitter.once(event, listener),
+    );
 
-    emitter.emit(event, 42);
-}
+    $ExpectEventEmitterType(
+        emitter.prependListener(event, listener),
+    );
 
-{
-    let result: Function[];
+    $ExpectEventEmitterType(
+        emitter.prependOnceListener(event, listener),
+    );
 
-    result = emitter.listeners(event);
-}
+    $ExpectEventEmitterType(
+        emitter.removeAllListeners(),
+        emitter.removeAllListeners(event),
+    );
 
-{
-    let result: boolean;
+    $ExpectEventEmitterType(
+        emitter.removeListener(event, listener),
+    );
 
-    result = emitter.emit(event);
-    result = emitter.emit(event, any);
-    result = emitter.emit(event, any, any);
-    result = emitter.emit(event, any, any, any);
-}
+    $ExpectEventEmitterType(
+        emitter.setMaxListeners(42),
+    );
 
-{
-    let result: Array<string | symbol>;
+    // $ExpectType Function[]
+    emitter.rawListeners(event);
 
-    result = emitter.eventNames();
-}
-
-{
-    class Networker extends events.EventEmitter {
-        constructor() {
-            super();
-
-            this.emit("mingling");
-        }
+    if (emitter[EventEmitter.captureRejectionSymbol]) {
+        // $ExpectType void
+        emitter[EventEmitter.captureRejectionSymbol](new Error(), event);
+        // $ExpectType void
+        emitter[EventEmitter.captureRejectionSymbol](new Error(), event, ...[]);
+    } else {
+        // $ExpectType undefined
+        emitter[EventEmitter.captureRejectionSymbol];
     }
 }
 
 {
-    const emitter2: events.EventEmitter = new events();
+    // $ExpectType number
+    EventEmitter.defaultMaxListeners;
+    EventEmitter.defaultMaxListeners = 50;
+
+    // $ExpectType Function[]
+    EventEmitter.getEventListeners(emitter, event);
+
+    // $ExpectType number
+    EventEmitter.getMaxListeners(emitter);
+
+    // $ExpectType Promise<any[]>
+    EventEmitter.once(emitter, event);
+
+    // $ExpectType boolean
+    EventEmitter.captureRejections;
+    EventEmitter.captureRejections = true;
+
+    // $ExpectType number
+    EventEmitter.listenerCount(emitter, event);
+
+    // $ExpectType AsyncIterableIterator<any[]>
+    EventEmitter.on(emitter, event);
+
+    // $ExpectType void
+    EventEmitter.setMaxListeners(50, emitter);
+}
+
+{
+    class Networker extends EventEmitter {
+        static {
+            // Check that namespace variables are accessible as constructor properties
+            this.captureRejections = true;
+            this.defaultMaxListeners = 25;
+        }
+        constructor() {
+            super();
+            this.emit("mingling");
+        }
+    }
 }
 
 {
@@ -96,65 +142,53 @@ declare const any: any;
 }
 
 async function test() {
-    for await (const e of events.on(new events.EventEmitter(), "test")) {
-        console.log(e.length);
+    for await (const e of events.on(new EventEmitter(), "test")) {
+        // $ExpectType any[]
+        e;
     }
-    events.on(new events.EventEmitter(), "test", { signal: new AbortController().signal });
-    events.on(new events.EventEmitter(), "test", { close: ["close"] });
-    events.on(new events.EventEmitter(), "test", { highWaterMark: 42 });
-    events.on(new events.EventEmitter(), "test", { lowWaterMark: 42 });
+    events.on(new EventEmitter(), "test", { signal: new AbortController().signal });
+    events.on(new EventEmitter(), "test", { close: ["close"] });
+    events.on(new EventEmitter(), "test", { highWaterMark: 42 });
+    events.on(new EventEmitter(), "test", { lowWaterMark: 42 });
 }
 
 async function testWithSymbol() {
-    for await (const e of events.on(new events.EventEmitter(), Symbol("test"))) {
-        console.log(e.length);
+    for await (const e of events.on(new EventEmitter(), Symbol("test"))) {
+        // $ExpectType any[]
+        e;
     }
-    events.on(new events.EventEmitter(), Symbol("test"), { signal: new AbortController().signal });
+    events.on(new EventEmitter(), Symbol("test"), { signal: new AbortController().signal });
 }
 
 async function testEventTarget() {
     for await (const e of events.on(new EventTarget(), "test")) {
-        console.log(e);
+        // $ExpectType any[]
+        e;
     }
     events.on(new EventTarget(), "test", { signal: new AbortController().signal });
 }
 
 {
-    emitter.on(events.errorMonitor, listener);
-    emitter.on(events.EventEmitter.errorMonitor, listener);
+    const errorMonitor: typeof events.errorMonitor = EventEmitter.errorMonitor;
+    emitter.on(errorMonitor, listener);
 }
 
 {
-    let errorMonitor1: typeof events.errorMonitor = events.errorMonitor;
-    errorMonitor1 = events.EventEmitter.errorMonitor;
-
-    let errorMonitor2: typeof events.EventEmitter.errorMonitor = events.EventEmitter.errorMonitor;
-    errorMonitor2 = events.errorMonitor;
+    const captureRejectionSymbol: typeof events.captureRejectionSymbol = EventEmitter.captureRejectionSymbol;
+    emitter[captureRejectionSymbol] = (err: Error, name: string, ...args: any[]) => {};
 }
 
 {
-    let captureRejectionSymbol1: typeof events.captureRejectionSymbol = events.captureRejectionSymbol;
-    captureRejectionSymbol1 = events.EventEmitter.captureRejectionSymbol;
-
-    let captureRejectionSymbol2: typeof events.EventEmitter.captureRejectionSymbol =
-        events.EventEmitter.captureRejectionSymbol;
-    captureRejectionSymbol2 = events.captureRejectionSymbol;
-
-    const emitter = new events.EventEmitter();
-    emitter[events.captureRejectionSymbol] = (err: Error, name: string, ...args: any[]) => {};
-}
-
-{
-    events.EventEmitter.setMaxListeners();
-    events.EventEmitter.setMaxListeners(42);
+    events.setMaxListeners();
+    events.setMaxListeners(42);
 
     const eventTarget = new EventTarget();
-    events.EventEmitter.setMaxListeners(42, eventTarget);
+    events.setMaxListeners(42, eventTarget);
     // @ts-expect-error - ensure constructor does not return a constructor
     new eventTarget();
 
-    const eventEmitter = new events.EventEmitter();
-    events.EventEmitter.setMaxListeners(42, eventTarget, eventEmitter);
+    const eventEmitter = new EventEmitter();
+    events.setMaxListeners(42, eventTarget, eventEmitter);
 }
 
 {
@@ -181,14 +215,18 @@ async function testEventTarget() {
         name: "test",
     });
 
-    emitter.asyncId; // $ExpectType number
-    emitter.asyncResource; // $ExpectType EventEmitterReferencingAsyncResource
-    emitter.triggerAsyncId; // $ExpectType number
+    // $ExpectType number
+    emitter.asyncId;
+    // $ExpectType EventEmitterReferencingAsyncResource
+    emitter.asyncResource;
+    // $ExpectType number
+    emitter.triggerAsyncId;
+    // $ExpectType void
     emitter.emitDestroy();
 }
 
 {
-    class MyEmitter extends events.EventEmitter {
+    class MyEmitter extends EventEmitter {
         addListener(event: string, listener: () => void): this {
             return this;
         }


### PR DESCRIPTION
The structure of the events module in @types/node hasn't really changed since TS3, and is an unholy assortment of definition paradigms and circuitous import-export behaviour (the module imports _itself_, via a different module, in order to re-declare itself as its own namespace property...) Additionally, the top-level functions/variables in the events module are currently defined as static properties on the EventEmitter "class", which doesn't mirror how they're implemented or documented in Node, and which subjects them to unnecessary accessibility checks etc. by the compiler.

This changeset looks large, but it's only a small number of restructuring tasks:
- Removes the circuitous self-imports, and defines a clean EventEmitter namespace containing all of the functions, variables and types that need exporting. This yields around a 10% reduction in instantiations for events.d.ts.
- Exports some previously unexported types (options interfaces etc.)
- Redefines the top-level variables/functions as namespace exports, rather than static elements on the EventEmitter pseudoclass. This doesn't change how those symbols are imported or referenced by the consumer, but does more accurately reflect the actual structure of the module. It also allows those functions to be overloaded by module augmentation definitions, which is not possible with class static methods.
- Reorders everything to mirror the ordering of the Node API documentation, to make maintenance easier.

There should be no change in import behaviour: both CJS- and ESM-style imports will continue to work the same as before.

This also includes an additional change in v22, which is to move the EventEmitter class definitions from the `NodeJS.EventEmitter` interface to the EventEmitter class itself. `NodeJS.EventEmitter` was the global event emitter interface added to @types/node in v0, prior to the existence of the events module and the EventEmitter class, which hangs around now as a vestigial entity that simply doesn't need to exist any more. While this change is transparent to consumers of the EventEmitter class, and keeps the global interface unaltered, it lays the groundwork for removing `NodeJS.EventEmitter` entirely in the next major @types/node version.