### PR TITLE
[braintree-web] fix: add missing updatePayment function to PayPalCheckout

### DIFF
--- a/types/braintree-web/paypal-checkout.d.ts
+++ b/types/braintree-web/paypal-checkout.d.ts
@@ -162,7 +162,7 @@ export interface PayPalCheckoutUpdatePaymentOptions {
     /**
      * The currency code of the amount, such as 'USD'. Required when using the Checkout flow.
      */
-    currency: string
+    currency: string;
     /**
      * List of {@link paypal.ShippingOption|shipping options} offered by the payee or merchant to the payer to ship or pick up their items.
      * @see {@link https://braintree.github.io/braintree-web/current/PayPalCheckout.html#~shippingOption}
@@ -188,7 +188,7 @@ export interface PayPalCheckoutUpdatePaymentOptions {
         /**
          * Handling amount
          */
-        handling?: string
+        handling?: string;
         /**
          * Tax amount
          */
@@ -213,7 +213,7 @@ export interface PayPalCheckoutUpdatePaymentServerDataReturn {
         error: string | null;
         errorDescription: string | null;
         processorResponseCode: string | null;
-    }
+    };
     _httpStatus: number;
 }
 
@@ -421,9 +421,9 @@ export interface PayPalCheckout {
     teardown(): Promise<void>;
 
     /**
-     * Use this function to update {@link paypal.LineItem|line items} and/or {@link paypal.ShippingOption|shipping options} associated with a 
-     * PayPalCheckout flow (paymentId). When a {@link callback} is defined, this function returns undefined and invokes the callback. 
-     * The second callback argument, `data`, is the returned server data. If no callback is provided, `updatePayment` returns a 
+     * Use this function to update {@link paypal.LineItem|line items} and/or {@link paypal.ShippingOption|shipping options} associated with a
+     * PayPalCheckout flow (paymentId). When a {@link callback} is defined, this function returns undefined and invokes the callback.
+     * The second callback argument, `data`, is the returned server data. If no callback is provided, `updatePayment` returns a
      * promise that resolves with the server data.
      * @example
      * // this paypal object is created by the PayPal JS SDK

--- a/types/braintree-web/paypal-checkout.d.ts
+++ b/types/braintree-web/paypal-checkout.d.ts
@@ -149,6 +149,74 @@ export interface PayPalCheckoutLoadPayPalSDKOptions {
     "merchant-id"?: string;
 }
 
+export interface PayPalCheckoutUpdatePaymentOptions {
+    /**
+     * This should be PayPal paymentId.
+     */
+    paymentId: string;
+    /**
+     * The amount of the transaction, including the amount of the selected shipping option, and all line_items.
+     * Supports up to 2 decimal digits.
+     */
+    amount: string | number;
+    /**
+     * The currency code of the amount, such as 'USD'. Required when using the Checkout flow.
+     */
+    currency: string
+    /**
+     * List of {@link paypal.ShippingOption|shipping options} offered by the payee or merchant to the payer to ship or pick up their items.
+     * @see {@link https://braintree.github.io/braintree-web/current/PayPalCheckout.html#~shippingOption}
+     */
+    shippingOptions?: paypal.ShippingOption[];
+    /**
+     * The {@link paypal.LineItem|line items} for this transaction. It can include up to 249 line items.
+     * @see {@link https://braintree.github.io/braintree-web/current/PayPalCheckout.html#~lineItem}
+     */
+    lineItems?: paypal.LineItem[];
+    /**
+     * Optional collection of amounts that break down the total into individual pieces.
+     */
+    amountBreakdown?: {
+        /**
+         * Item amount
+         */
+        itemTotal?: string;
+        /**
+         * Shipping amount
+         */
+        shipping?: string;
+        /**
+         * Handling amount
+         */
+        handling?: string
+        /**
+         * Tax amount
+         */
+        taxTotal?: string;
+        /**
+         * Insurance amount
+         */
+        insurance?: string;
+        /**
+         * Shipping discount amount
+         */
+        shippingDiscount?: string;
+        /**
+         * Discount amount
+         */
+        discount?: string;
+    };
+}
+
+export interface PayPalCheckoutUpdatePaymentServerDataReturn {
+    authorization: {
+        error: string | null;
+        errorDescription: string | null;
+        processorResponseCode: string | null;
+    }
+    _httpStatus: number;
+}
+
 export interface PayPalCheckout {
     /**
      * Resolves when the PayPal SDK has been succesfully loaded onto the page.
@@ -351,6 +419,58 @@ export interface PayPalCheckout {
      */
     teardown(callback: () => void): void;
     teardown(): Promise<void>;
+
+    /**
+     * Use this function to update {@link paypal.LineItem|line items} and/or {@link paypal.ShippingOption|shipping options} associated with a 
+     * PayPalCheckout flow (paymentId). When a {@link callback} is defined, this function returns undefined and invokes the callback. 
+     * The second callback argument, `data`, is the returned server data. If no callback is provided, `updatePayment` returns a 
+     * promise that resolves with the server data.
+     * @example
+     * // this paypal object is created by the PayPal JS SDK
+     * // see https://github.com/paypal/paypal-checkout-components
+     * paypal.Buttons({
+     *   createOrder: function () {
+     *     // when createPayment resolves, it is automatically passed to the PayPal JS SDK
+     *     return paypalCheckoutInstance.createPayment({
+     *       //
+     *     });
+     *   },
+     *   onShippingChange: function (data) {
+     *     // Examine data and determine if the payment needs to be updated.
+     *     // when updatePayment resolves, it is automatically passed to the PayPal JS SDK
+     *     return paypalCheckoutInstance.updatePayment({
+     *         paymentId: data.paymentId,
+     *         amount: '15.00',
+     *         currency: 'USD',
+     *         shippingOptions: [
+     *           {
+     *             id: 'shipping-speed-fast',
+     *             type: 'SHIPPING',
+     *             label: 'Fast Shipping',
+     *             selected: true,
+     *             amount: {
+     *               value: '5.00',
+     *               currency: 'USD'
+     *             }
+     *           },
+     *           {
+     *             id: 'shipping-speed-slow',
+     *             type: 'SHIPPING',
+     *             label: 'Slow Shipping',
+     *             selected: false,
+     *             amount: {
+     *               value: '1.00',
+     *               currency: 'USD'
+     *             }
+     *           }
+     *         ]
+     *     });
+     *   }
+     *   // Add other options, e.g. onApproved, onCancel, onError
+     * }).render('#paypal-button');
+     */
+    updatePayment(options: PayPalCheckoutUpdatePaymentOptions): Promise<PayPalCheckoutUpdatePaymentServerDataReturn>;
+    updatePayment(options: PayPalCheckoutUpdatePaymentOptions, callback?: callback): void;
 }
 
 /**

--- a/types/braintree-web/test/web.ts
+++ b/types/braintree-web/test/web.ts
@@ -649,7 +649,7 @@ braintree.client.create(
                                     amount: "10.00",
                                     currency: "USD",
                                     paymentId: data.paymentId,
-                                });
+                                }).then(res => res);
                             },
                         });
                     });

--- a/types/braintree-web/test/web.ts
+++ b/types/braintree-web/test/web.ts
@@ -640,6 +640,18 @@ braintree.client.create(
                     })
                     .then(paypalCheckout => {
                         // window.paypal.Buttons is now available to use
+                        window.paypal.Buttons({
+                            onApprove(data) {
+                                return paypalCheckout.tokenizePayment(data);
+                            },
+                            onInit(data) {
+                                paypalCheckout.updatePayment({
+                                    amount: "10.00",
+                                    currency: "USD",
+                                    paymentId: data.paymentId,
+                                });
+                            },
+                        });
                     });
 
                 button.addEventListener("click", () => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
- https://braintree.github.io/braintree-web/current/PayPalCheckout.html#updatePayment
- https://github.com/braintree/braintree-web/blob/main/src/paypal-checkout/paypal-checkout.js#L727

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---
Additional information:
The `updatePayment` function was added in [3.90](https://github.com/braintree/braintree-web/commit/f33e15dff17eb98d999e72c32f76a51b9859d4e9#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) and this types package is at version 3.96. This function should already be included in the package so the version number of this package does not need to be changed.