### PR TITLE
[node] Add compatibility for iterator helpers, re-home compatibility types

### DIFF
--- a/types/node/compatibility/disposable.d.ts
+++ b/types/node/compatibility/disposable.d.ts
@@ -1,0 +1,16 @@
+// Polyfills for the explicit resource management types added in TypeScript 5.2.
+// TODO: remove once this package no longer supports TS 5.1, and replace with a
+// <reference> to TypeScript's disposable library in index.d.ts.
+
+interface SymbolConstructor {
+    readonly dispose: unique symbol;
+    readonly asyncDispose: unique symbol;
+}
+
+interface Disposable {
+    [Symbol.dispose](): void;
+}
+
+interface AsyncDisposable {
+    [Symbol.asyncDispose](): PromiseLike<void>;
+}

--- a/types/node/compatibility/index.d.ts
+++ b/types/node/compatibility/index.d.ts
@@ -1,0 +1,8 @@
+// Declaration files in this directory contain types relating to TypeScript library features
+// that are not included in all TypeScript versions supported by DefinitelyTyped, but
+// which can be made backwards-compatible without needing `typesVersions`.
+// If adding declarations to this directory, please specify which versions of TypeScript require them,
+// so that they can be removed when no longer needed.
+
+/// <reference path="disposable.d.ts" />
+/// <reference path="indexable.d.ts" />

--- a/types/node/compatibility/index.d.ts
+++ b/types/node/compatibility/index.d.ts
@@ -6,3 +6,4 @@
 
 /// <reference path="disposable.d.ts" />
 /// <reference path="indexable.d.ts" />
+/// <reference path="iterators.d.ts" />

--- a/types/node/compatibility/indexable.d.ts
+++ b/types/node/compatibility/indexable.d.ts
@@ -1,0 +1,23 @@
+// Polyfill for ES2022's .at() method on string/array prototypes, added to TypeScript in 4.6.
+// TODO: these methods are not used within @types/node, and should be removed at the next
+// major @types/node version; users should include the es2022 TypeScript libraries
+// if they need these features.
+
+interface RelativeIndexable<T> {
+    at(index: number): T | undefined;
+}
+
+interface String extends RelativeIndexable<string> {}
+interface Array<T> extends RelativeIndexable<T> {}
+interface ReadonlyArray<T> extends RelativeIndexable<T> {}
+interface Int8Array extends RelativeIndexable<number> {}
+interface Uint8Array extends RelativeIndexable<number> {}
+interface Uint8ClampedArray extends RelativeIndexable<number> {}
+interface Int16Array extends RelativeIndexable<number> {}
+interface Uint16Array extends RelativeIndexable<number> {}
+interface Int32Array extends RelativeIndexable<number> {}
+interface Uint32Array extends RelativeIndexable<number> {}
+interface Float32Array extends RelativeIndexable<number> {}
+interface Float64Array extends RelativeIndexable<number> {}
+interface BigInt64Array extends RelativeIndexable<bigint> {}
+interface BigUint64Array extends RelativeIndexable<bigint> {}

--- a/types/node/compatibility/iterators.d.ts
+++ b/types/node/compatibility/iterators.d.ts
@@ -1,0 +1,21 @@
+// Backwards-compatible iterator interfaces, augmented with iterator helper methods by lib.esnext.iterator in TypeScript 5.6.
+// The IterableIterator interface does not contain these methods, which creates assignability issues in places where IteratorObjects
+// are expected (eg. DOM-compatible APIs) if lib.esnext.iterator is loaded.
+// Also ensures that iterators returned by the Node API, which inherit from Iterator.prototype, correctly expose the iterator helper methods
+// if lib.esnext.iterator is loaded.
+// TODO: remove once this package no longer supports TS 5.5, and replace NodeJS.BuiltinIteratorReturn with BuiltinIteratorReturn.
+
+// Placeholders for TS <5.6
+interface IteratorObject<T, TReturn, TNext> {}
+interface AsyncIteratorObject<T, TReturn, TNext> {}
+
+declare namespace NodeJS {
+    // Populate iterator methods for TS <5.6
+    interface Iterator<T, TReturn, TNext> extends globalThis.Iterator<T, TReturn, TNext> {}
+    interface AsyncIterator<T, TReturn, TNext> extends globalThis.AsyncIterator<T, TReturn, TNext> {}
+
+    // Polyfill for TS 5.6's instrinsic BuiltinIteratorReturn type, required for DOM-compatible iterators
+    type BuiltinIteratorReturn = ReturnType<any[][typeof Symbol.iterator]> extends
+        globalThis.Iterator<any, infer TReturn> ? TReturn
+        : any;
+}

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -304,12 +304,12 @@ declare module "events" {
             emitter: NodeJS.EventEmitter,
             eventName: string | symbol,
             options?: StaticEventEmitterIteratorOptions,
-        ): AsyncIterableIterator<any[]>;
+        ): NodeJS.AsyncIterator<any[]>;
         static on(
             emitter: EventTarget,
             eventName: string,
             options?: StaticEventEmitterIteratorOptions,
-        ): AsyncIterableIterator<any[]>;
+        ): NodeJS.AsyncIterator<any[]>;
         /**
          * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
          *

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -284,7 +284,7 @@ declare module "fs" {
         /**
          * Asynchronously iterates over the directory via `readdir(3)` until all entries have been read.
          */
-        [Symbol.asyncIterator](): AsyncIterableIterator<Dirent>;
+        [Symbol.asyncIterator](): NodeJS.AsyncIterator<Dirent>;
         /**
          * Asynchronously close the directory's underlying resource handle.
          * Subsequent reads will result in errors.

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -1245,19 +1245,19 @@ declare module "fs/promises" {
     /**
      * Retrieves the files matching the specified pattern.
      */
-    function glob(pattern: string | string[]): AsyncIterableIterator<string>;
+    function glob(pattern: string | string[]): NodeJS.AsyncIterator<string>;
     function glob(
         pattern: string | string[],
         opt: GlobOptionsWithFileTypes,
-    ): AsyncIterableIterator<Dirent>;
+    ): NodeJS.AsyncIterator<Dirent>;
     function glob(
         pattern: string | string[],
         opt: GlobOptionsWithoutFileTypes,
-    ): AsyncIterableIterator<string>;
+    ): NodeJS.AsyncIterator<string>;
     function glob(
         pattern: string | string[],
         opt: GlobOptions,
-    ): AsyncIterableIterator<Dirent> | AsyncIterableIterator<string>;
+    ): NodeJS.AsyncIterator<Dirent | string>;
 }
 declare module "node:fs/promises" {
     export * from "fs/promises";

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -419,7 +419,7 @@ declare global {
             unpipe(destination?: WritableStream): this;
             unshift(chunk: string | Uint8Array, encoding?: BufferEncoding): void;
             wrap(oldStream: ReadableStream): this;
-            [Symbol.asyncIterator](): AsyncIterableIterator<string | Buffer>;
+            [Symbol.asyncIterator](): NodeJS.AsyncIterator<string | Buffer>;
         }
 
         interface WritableStream extends EventEmitter {
@@ -487,6 +487,20 @@ declare global {
 
         interface ReadOnlyDict<T> {
             readonly [key: string]: T | undefined;
+        }
+
+        /** An iterable iterator returned by the Node.js API. */
+        // Default TReturn/TNext in v22 is `any`, for compatibility with the previously-used IterableIterator.
+        // TODO: In next major @types/node version, change default TReturn to undefined.
+        interface Iterator<T, TReturn = any, TNext = any> extends IteratorObject<T, TReturn, TNext> {
+            [Symbol.iterator](): NodeJS.Iterator<T, TReturn, TNext>;
+        }
+
+        /** An async iterable iterator returned by the Node.js API. */
+        // Default TReturn/TNext in v22 is `any`, for compatibility with the previously-used AsyncIterableIterator.
+        // TODO: In next major @types/node version, change default TReturn to undefined.
+        interface AsyncIterator<T, TReturn = any, TNext = any> extends AsyncIteratorObject<T, TReturn, TNext> {
+            [Symbol.asyncIterator](): NodeJS.AsyncIterator<T, TReturn, TNext>;
         }
     }
 

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -156,6 +156,8 @@ declare global {
     interface RequireResolve extends NodeJS.RequireResolve {}
     interface NodeModule extends NodeJS.Module {}
 
+    var global: typeof globalThis;
+
     var process: NodeJS.Process;
     var console: Console;
 
@@ -264,53 +266,6 @@ declare global {
      */
     var sessionStorage: Storage;
     // #endregion Storage
-
-    // #region Disposable
-    interface SymbolConstructor {
-        /**
-         * A method that is used to release resources held by an object. Called by the semantics of the `using` statement.
-         */
-        readonly dispose: unique symbol;
-
-        /**
-         * A method that is used to asynchronously release resources held by an object. Called by the semantics of the `await using` statement.
-         */
-        readonly asyncDispose: unique symbol;
-    }
-
-    interface Disposable {
-        [Symbol.dispose](): void;
-    }
-
-    interface AsyncDisposable {
-        [Symbol.asyncDispose](): PromiseLike<void>;
-    }
-    // #endregion Disposable
-
-    // #region ArrayLike.at()
-    interface RelativeIndexable<T> {
-        /**
-         * Takes an integer value and returns the item at that index,
-         * allowing for positive and negative integers.
-         * Negative integers count back from the last item in the array.
-         */
-        at(index: number): T | undefined;
-    }
-    interface String extends RelativeIndexable<string> {}
-    interface Array<T> extends RelativeIndexable<T> {}
-    interface ReadonlyArray<T> extends RelativeIndexable<T> {}
-    interface Int8Array extends RelativeIndexable<number> {}
-    interface Uint8Array extends RelativeIndexable<number> {}
-    interface Uint8ClampedArray extends RelativeIndexable<number> {}
-    interface Int16Array extends RelativeIndexable<number> {}
-    interface Uint16Array extends RelativeIndexable<number> {}
-    interface Int32Array extends RelativeIndexable<number> {}
-    interface Uint32Array extends RelativeIndexable<number> {}
-    interface Float32Array extends RelativeIndexable<number> {}
-    interface Float64Array extends RelativeIndexable<number> {}
-    interface BigInt64Array extends RelativeIndexable<bigint> {}
-    interface BigUint64Array extends RelativeIndexable<bigint> {}
-    // #endregion ArrayLike.at() end
 
     /**
      * @since v17.0.0

--- a/types/node/globals.global.d.ts
+++ b/types/node/globals.global.d.ts
@@ -1,1 +1,0 @@
-declare var global: typeof globalThis;

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -22,22 +22,22 @@
  * IN THE SOFTWARE.
  */
 
-// NOTE: These definitions support NodeJS and TypeScript 5.7+.
+// NOTE: These definitions support Node.js and TypeScript 5.7+.
 
-// Reference required types from the default lib:
+// Reference required TypeScript libs:
 /// <reference lib="es2020" />
-/// <reference lib="esnext.asynciterable" />
-/// <reference lib="esnext.intl" />
-/// <reference lib="esnext.bigint" />
 
-// Definitions specific to TypeScript 4.9 through 5.7+
+// TypeScript backwards-compatibility definitions:
+/// <reference path="compatibility/index.d.ts" />
+
+// Definitions specific to TypeScript 5.7+:
 /// <reference path="globals.typedarray.d.ts" />
 /// <reference path="buffer.buffer.d.ts" />
 
-// Base definitions for all NodeJS modules that are not specific to any version of TypeScript:
+// Definitions for Node.js modules that are not specific to any version of TypeScript:
+/// <reference path="globals.d.ts" />
 /// <reference path="assert.d.ts" />
 /// <reference path="assert/strict.d.ts" />
-/// <reference path="globals.d.ts" />
 /// <reference path="async_hooks.d.ts" />
 /// <reference path="buffer.d.ts" />
 /// <reference path="child_process.d.ts" />
@@ -90,5 +90,3 @@
 /// <reference path="wasi.d.ts" />
 /// <reference path="worker_threads.d.ts" />
 /// <reference path="zlib.d.ts" />
-
-/// <reference path="globals.global.d.ts" />

--- a/types/node/readline.d.ts
+++ b/types/node/readline.d.ts
@@ -304,7 +304,7 @@ declare module "readline" {
         prependOnceListener(event: "SIGINT", listener: () => void): this;
         prependOnceListener(event: "SIGTSTP", listener: () => void): this;
         prependOnceListener(event: "history", listener: (history: string[]) => void): this;
-        [Symbol.asyncIterator](): AsyncIterableIterator<string>;
+        [Symbol.asyncIterator](): NodeJS.AsyncIterator<string>;
     }
     export type ReadLine = Interface; // type forwarded for backwards compatibility
     export type Completer = (line: string) => CompleterResult;

--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -422,7 +422,7 @@ declare module "stream" {
          * or exiting a `for await...of` iteration using a `break`, `return`, or `throw` will not destroy the stream.
          * **Default: `true`**.
          */
-        iterator(options?: { destroyOnReturn?: boolean }): AsyncIterableIterator<any>;
+        iterator(options?: { destroyOnReturn?: boolean }): NodeJS.AsyncIterator<any>;
         /**
          * This method allows mapping over the stream. The *fn* function will be called for every chunk in the stream.
          * If the *fn* function returns a promise - that promise will be `await`ed before being passed to the result stream.
@@ -651,7 +651,7 @@ declare module "stream" {
         removeListener(event: "readable", listener: () => void): this;
         removeListener(event: "resume", listener: () => void): this;
         removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        [Symbol.asyncIterator](): AsyncIterableIterator<any>;
+        [Symbol.asyncIterator](): NodeJS.AsyncIterator<any>;
         /**
          * Calls `readable.destroy()` with an `AbortError` and returns a promise that fulfills when the stream is finished.
          * @since v20.4.0

--- a/types/node/stream/web.d.ts
+++ b/types/node/stream/web.d.ts
@@ -166,6 +166,9 @@ declare module "stream/web" {
     interface ReadableStreamErrorCallback {
         (reason: any): void | PromiseLike<void>;
     }
+    interface ReadableStreamAsyncIterator<T> extends NodeJS.AsyncIterator<T, NodeJS.BuiltinIteratorReturn, unknown> {
+        [Symbol.asyncIterator](): ReadableStreamAsyncIterator<T>;
+    }
     /** This Streams API interface represents a readable stream of byte data. */
     interface ReadableStream<R = any> {
         readonly locked: boolean;
@@ -176,8 +179,8 @@ declare module "stream/web" {
         pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
         pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
         tee(): [ReadableStream<R>, ReadableStream<R>];
-        values(options?: { preventCancel?: boolean }): AsyncIterableIterator<R>;
-        [Symbol.asyncIterator](): AsyncIterableIterator<R>;
+        values(options?: { preventCancel?: boolean }): ReadableStreamAsyncIterator<R>;
+        [Symbol.asyncIterator](): ReadableStreamAsyncIterator<R>;
     }
     const ReadableStream: {
         prototype: ReadableStream;

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -551,7 +551,7 @@ async function testPromisify() {
 
     handle.readableWebStream();
 
-    handle.readLines()[Symbol.asyncIterator](); // $ExpectType AsyncIterableIterator<string>
+    handle.readLines()[Symbol.asyncIterator](); // $ExpectType AsyncIterator<string, any, any>
 });
 
 {

--- a/types/node/ts5.6/index.d.ts
+++ b/types/node/ts5.6/index.d.ts
@@ -22,22 +22,22 @@
  * IN THE SOFTWARE.
  */
 
-// NOTE: These definitions support NodeJS and TypeScript 4.9 through 5.6.
+// NOTE: These definitions support Node.js and TypeScript 4.9 through 5.6.
 
-// Reference required types from the default lib:
+// Reference required TypeScript libs:
 /// <reference lib="es2020" />
-/// <reference lib="esnext.asynciterable" />
-/// <reference lib="esnext.intl" />
-/// <reference lib="esnext.bigint" />
 
-// Definitions specific to TypeScript 4.9 through 5.6
+// TypeScript backwards-compatibility definitions:
+/// <reference path="../compatibility/index.d.ts" />
+
+// Definitions specific to TypeScript 4.9 through 5.6:
 /// <reference path="./globals.typedarray.d.ts" />
 /// <reference path="./buffer.buffer.d.ts" />
 
-// Base definitions for all NodeJS modules that are not specific to any version of TypeScript:
+// Definitions for Node.js modules that are not specific to any version of TypeScript:
+/// <reference path="../globals.d.ts" />
 /// <reference path="../assert.d.ts" />
 /// <reference path="../assert/strict.d.ts" />
-/// <reference path="../globals.d.ts" />
 /// <reference path="../async_hooks.d.ts" />
 /// <reference path="../buffer.d.ts" />
 /// <reference path="../child_process.d.ts" />
@@ -90,5 +90,3 @@
 /// <reference path="../wasi.d.ts" />
 /// <reference path="../worker_threads.d.ts" />
 /// <reference path="../zlib.d.ts" />
-
-/// <reference path="../globals.global.d.ts" />

--- a/types/node/url.d.ts
+++ b/types/node/url.d.ts
@@ -757,6 +757,9 @@ declare module "url" {
          */
         toJSON(): string;
     }
+    interface URLSearchParamsIterator<T> extends NodeJS.Iterator<T, NodeJS.BuiltinIteratorReturn, unknown> {
+        [Symbol.iterator](): URLSearchParamsIterator<T>;
+    }
     /**
      * The `URLSearchParams` API provides read and write access to the query of a `URL`. The `URLSearchParams` class can also be used standalone with one of the
      * four following constructors.
@@ -827,7 +830,7 @@ declare module "url" {
          *
          * Alias for `urlSearchParams[@@iterator]()`.
          */
-        entries(): IterableIterator<[string, string]>;
+        entries(): URLSearchParamsIterator<[string, string]>;
         /**
          * Iterates over each name-value pair in the query and invokes the given function.
          *
@@ -881,7 +884,7 @@ declare module "url" {
          * //   foo
          * ```
          */
-        keys(): IterableIterator<string>;
+        keys(): URLSearchParamsIterator<string>;
         /**
          * Sets the value in the `URLSearchParams` object associated with `name` to `value`. If there are any pre-existing name-value pairs whose names are `name`,
          * set the first such pair's value to `value` and remove all others. If not,
@@ -931,8 +934,8 @@ declare module "url" {
         /**
          * Returns an ES6 `Iterator` over the values of each name-value pair.
          */
-        values(): IterableIterator<string>;
-        [Symbol.iterator](): IterableIterator<[string, string]>;
+        values(): URLSearchParamsIterator<string>;
+        [Symbol.iterator](): URLSearchParamsIterator<[string, string]>;
     }
     import { URL as _URL, URLSearchParams as _URLSearchParams } from "url";
     global {

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -1720,7 +1720,7 @@ declare module "util" {
          * Each item of the iterator is a JavaScript `Array`. The first item of the array
          * is the `name`, the second item of the array is the `value`.
          */
-        entries(): IterableIterator<[name: string, value: string]>;
+        entries(): NodeJS.Iterator<[name: string, value: string]>;
         /**
          * Returns the value of the first name-value pair whose name is `name`. If there
          * are no such pairs, `null` is returned.
@@ -1746,7 +1746,7 @@ declare module "util" {
          * //   bar
          * ```
          */
-        keys(): IterableIterator<string>;
+        keys(): NodeJS.Iterator<string>;
         /**
          * Sets the value in the `MIMEParams` object associated with `name` to `value`. If there are any pre-existing name-value pairs whose names are `name`,
          * set the first such pair's value to `value`.
@@ -1765,11 +1765,11 @@ declare module "util" {
         /**
          * Returns an iterator over the values of each name-value pair.
          */
-        values(): IterableIterator<string>;
+        values(): NodeJS.Iterator<string>;
         /**
          * Returns an iterator over each of the name-value pairs in the parameters.
          */
-        [Symbol.iterator]: typeof MIMEParams.prototype.entries;
+        [Symbol.iterator](): NodeJS.Iterator<[name: string, value: string]>;
     }
 }
 declare module "util/types" {

--- a/types/node/v16/compatibility/index.d.ts
+++ b/types/node/v16/compatibility/index.d.ts
@@ -1,0 +1,7 @@
+// Declaration files in this directory contain types relating to TypeScript library features
+// that are not included in all TypeScript versions supported by DefinitelyTyped, but
+// which can be made backwards-compatible without needing `typesVersions`.
+// If adding declarations to this directory, please specify which versions of TypeScript require them,
+// so that they can be removed when no longer needed.
+
+/// <reference path="indexable.d.ts" />

--- a/types/node/v16/compatibility/index.d.ts
+++ b/types/node/v16/compatibility/index.d.ts
@@ -5,3 +5,4 @@
 // so that they can be removed when no longer needed.
 
 /// <reference path="indexable.d.ts" />
+/// <reference path="iterators.d.ts" />

--- a/types/node/v16/compatibility/indexable.d.ts
+++ b/types/node/v16/compatibility/indexable.d.ts
@@ -1,0 +1,20 @@
+// Polyfill for ES2022's .at() method on string/array prototypes, added to TypeScript in 4.6.
+
+interface RelativeIndexable<T> {
+    at(index: number): T | undefined;
+}
+
+interface String extends RelativeIndexable<string> {}
+interface Array<T> extends RelativeIndexable<T> {}
+interface ReadonlyArray<T> extends RelativeIndexable<T> {}
+interface Int8Array extends RelativeIndexable<number> {}
+interface Uint8Array extends RelativeIndexable<number> {}
+interface Uint8ClampedArray extends RelativeIndexable<number> {}
+interface Int16Array extends RelativeIndexable<number> {}
+interface Uint16Array extends RelativeIndexable<number> {}
+interface Int32Array extends RelativeIndexable<number> {}
+interface Uint32Array extends RelativeIndexable<number> {}
+interface Float32Array extends RelativeIndexable<number> {}
+interface Float64Array extends RelativeIndexable<number> {}
+interface BigInt64Array extends RelativeIndexable<bigint> {}
+interface BigUint64Array extends RelativeIndexable<bigint> {}

--- a/types/node/v16/compatibility/iterators.d.ts
+++ b/types/node/v16/compatibility/iterators.d.ts
@@ -1,0 +1,20 @@
+// Backwards-compatible iterator interfaces, augmented with iterator helper methods by lib.esnext.iterator in TypeScript 5.6.
+// The IterableIterator interface does not contain these methods, which creates assignability issues in places where IteratorObjects
+// are expected (eg. DOM-compatible APIs) if lib.esnext.iterator is loaded.
+// Also ensures that iterators returned by the Node API, which inherit from Iterator.prototype, correctly expose the iterator helper methods
+// if lib.esnext.iterator is loaded.
+
+// Placeholders for TS <5.6
+interface IteratorObject<T, TReturn, TNext> {}
+interface AsyncIteratorObject<T, TReturn, TNext> {}
+
+declare namespace NodeJS {
+    // Populate iterator methods for TS <5.6
+    interface Iterator<T, TReturn, TNext> extends globalThis.Iterator<T, TReturn, TNext> {}
+    interface AsyncIterator<T, TReturn, TNext> extends globalThis.AsyncIterator<T, TReturn, TNext> {}
+
+    // Polyfill for TS 5.6's instrinsic BuiltinIteratorReturn type, required for DOM-compatible iterators
+    type BuiltinIteratorReturn = ReturnType<any[][typeof Symbol.iterator]> extends
+        globalThis.Iterator<any, infer TReturn> ? TReturn
+        : any;
+}

--- a/types/node/v16/events.d.ts
+++ b/types/node/v16/events.d.ts
@@ -243,7 +243,7 @@ declare module "events" {
             emitter: NodeJS.EventEmitter,
             eventName: string,
             options?: StaticEventEmitterOptions,
-        ): AsyncIterableIterator<any>;
+        ): NodeJS.AsyncIterator<any>;
         /**
          * A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
          *

--- a/types/node/v16/fs.d.ts
+++ b/types/node/v16/fs.d.ts
@@ -215,7 +215,7 @@ declare module "fs" {
         /**
          * Asynchronously iterates over the directory via `readdir(3)` until all entries have been read.
          */
-        [Symbol.asyncIterator](): AsyncIterableIterator<Dirent>;
+        [Symbol.asyncIterator](): NodeJS.AsyncIterator<Dirent>;
         /**
          * Asynchronously close the directory's underlying resource handle.
          * Subsequent reads will result in errors.

--- a/types/node/v16/globals.d.ts
+++ b/types/node/v16/globals.d.ts
@@ -182,7 +182,7 @@ declare namespace NodeJS {
         unpipe(destination?: WritableStream): this;
         unshift(chunk: string | Uint8Array, encoding?: BufferEncoding): void;
         wrap(oldStream: ReadableStream): this;
-        [Symbol.asyncIterator](): AsyncIterableIterator<string | Buffer>;
+        [Symbol.asyncIterator](): NodeJS.AsyncIterator<string | Buffer>;
     }
 
     interface WritableStream extends EventEmitter {
@@ -250,5 +250,17 @@ declare namespace NodeJS {
 
     interface ReadOnlyDict<T> {
         readonly [key: string]: T | undefined;
+    }
+
+    /** An iterable iterator returned by the Node.js API. */
+    // Default TReturn/TNext in v16 is `any`, for compatibility with the previously-used IterableIterator.
+    interface Iterator<T, TReturn = any, TNext = any> extends IteratorObject<T, TReturn, TNext> {
+        [Symbol.iterator](): NodeJS.Iterator<T, TReturn, TNext>;
+    }
+
+    /** An async iterable iterator returned by the Node.js API. */
+    // Default TReturn/TNext in v16 is `any`, for compatibility with the previously-used AsyncIterableIterator.
+    interface AsyncIterator<T, TReturn = any, TNext = any> extends AsyncIteratorObject<T, TReturn, TNext> {
+        [Symbol.asyncIterator](): NodeJS.AsyncIterator<T, TReturn, TNext>;
     }
 }

--- a/types/node/v16/globals.d.ts
+++ b/types/node/v16/globals.d.ts
@@ -27,6 +27,8 @@ interface NodeModule extends NodeJS.Module {}
 declare var process: NodeJS.Process;
 declare var console: Console;
 
+declare var global: typeof globalThis;
+
 declare var __filename: string;
 declare var __dirname: string;
 
@@ -81,31 +83,6 @@ declare var AbortSignal: typeof globalThis extends { onmessage: any; AbortSignal
         timeout(milliseconds: number): AbortSignal;
     };
 // #endregion borrowed
-
-// #region ArrayLike.at()
-interface RelativeIndexable<T> {
-    /**
-     * Takes an integer value and returns the item at that index,
-     * allowing for positive and negative integers.
-     * Negative integers count back from the last item in the array.
-     */
-    at(index: number): T | undefined;
-}
-interface String extends RelativeIndexable<string> {}
-interface Array<T> extends RelativeIndexable<T> {}
-interface ReadonlyArray<T> extends RelativeIndexable<T> {}
-interface Int8Array extends RelativeIndexable<number> {}
-interface Uint8Array extends RelativeIndexable<number> {}
-interface Uint8ClampedArray extends RelativeIndexable<number> {}
-interface Int16Array extends RelativeIndexable<number> {}
-interface Uint16Array extends RelativeIndexable<number> {}
-interface Int32Array extends RelativeIndexable<number> {}
-interface Uint32Array extends RelativeIndexable<number> {}
-interface Float32Array extends RelativeIndexable<number> {}
-interface Float64Array extends RelativeIndexable<number> {}
-interface BigInt64Array extends RelativeIndexable<bigint> {}
-interface BigUint64Array extends RelativeIndexable<bigint> {}
-// #endregion ArrayLike.at() end
 
 /*----------------------------------------------*
 *                                               *

--- a/types/node/v16/globals.global.d.ts
+++ b/types/node/v16/globals.global.d.ts
@@ -1,1 +1,0 @@
-declare var global: typeof globalThis;

--- a/types/node/v16/index.d.ts
+++ b/types/node/v16/index.d.ts
@@ -22,22 +22,22 @@
  * IN THE SOFTWARE.
  */
 
-// NOTE: These definitions support NodeJS and TypeScript 5.7+.
+// NOTE: These definitions support Node.js and TypeScript 5.7+.
 
-// Reference required types from the default lib:
+// Reference required TypeScript libs:
 /// <reference lib="es2020" />
-/// <reference lib="esnext.asynciterable" />
-/// <reference lib="esnext.intl" />
-/// <reference lib="esnext.bigint" />
 
-// Definitions specific to TypeScript 5.7+
+// TypeScript backwards-compatibility definitions:
+/// <reference path="compatibility/index.d.ts" />
+
+// Definitions specific to TypeScript 5.7+:
 /// <reference path="globals.typedarray.d.ts" />
 /// <reference path="buffer.buffer.d.ts" />
 
-// Base definitions for all NodeJS modules that are not specific to any version of TypeScript:
+// Definitions for Node.js modules that are not specific to any version of TypeScript:
+/// <reference path="globals.d.ts" />
 /// <reference path="assert.d.ts" />
 /// <reference path="assert/strict.d.ts" />
-/// <reference path="globals.d.ts" />
 /// <reference path="async_hooks.d.ts" />
 /// <reference path="buffer.d.ts" />
 /// <reference path="child_process.d.ts" />
@@ -86,5 +86,3 @@
 /// <reference path="wasi.d.ts" />
 /// <reference path="worker_threads.d.ts" />
 /// <reference path="zlib.d.ts" />
-
-/// <reference path="globals.global.d.ts" />

--- a/types/node/v16/readline.d.ts
+++ b/types/node/v16/readline.d.ts
@@ -314,7 +314,7 @@ declare module "readline" {
         prependOnceListener(event: "SIGINT", listener: () => void): this;
         prependOnceListener(event: "SIGTSTP", listener: () => void): this;
         prependOnceListener(event: "history", listener: (history: string[]) => void): this;
-        [Symbol.asyncIterator](): AsyncIterableIterator<string>;
+        [Symbol.asyncIterator](): NodeJS.AsyncIterator<string>;
     }
     type ReadLine = Interface; // type forwarded for backwards compatibility
     type Completer = (line: string) => CompleterResult;

--- a/types/node/v16/stream.d.ts
+++ b/types/node/v16/stream.d.ts
@@ -412,7 +412,7 @@ declare module "stream" {
              * or exiting a `for await...of` iteration using a `break`, `return`, or `throw` will not destroy the stream.
              * **Default: `true`**.
              */
-            iterator(options?: { destroyOnReturn?: boolean }): AsyncIterableIterator<any>;
+            iterator(options?: { destroyOnReturn?: boolean }): NodeJS.AsyncIterator<any>;
             /**
              * This method allows mapping over the stream. The *fn* function will be called for every chunk in the stream.
              * If the *fn* function returns a promise - that promise will be `await`ed before being passed to the result stream.
@@ -513,7 +513,7 @@ declare module "stream" {
             removeListener(event: "readable", listener: () => void): this;
             removeListener(event: "resume", listener: () => void): this;
             removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
-            [Symbol.asyncIterator](): AsyncIterableIterator<any>;
+            [Symbol.asyncIterator](): NodeJS.AsyncIterator<any>;
         }
         interface WritableOptions extends StreamOptions<Writable> {
             decodeStrings?: boolean | undefined;

--- a/types/node/v16/stream/web.d.ts
+++ b/types/node/v16/stream/web.d.ts
@@ -154,6 +154,10 @@ declare module "stream/web" {
         (reason: any): void | PromiseLike<void>;
     }
 
+    interface ReadableStreamAsyncIterator<T> extends NodeJS.AsyncIterator<T, NodeJS.BuiltinIteratorReturn, unknown> {
+        [Symbol.asyncIterator](): ReadableStreamAsyncIterator<T>;
+    }
+
     /** This Streams API interface represents a readable stream of byte data. */
     interface ReadableStream<R = any> {
         readonly locked: boolean;
@@ -162,8 +166,8 @@ declare module "stream/web" {
         pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
         pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
         tee(): [ReadableStream<R>, ReadableStream<R>];
-        values(options?: { preventCancel?: boolean }): AsyncIterableIterator<R>;
-        [Symbol.asyncIterator](): AsyncIterableIterator<R>;
+        values(options?: { preventCancel?: boolean }): ReadableStreamAsyncIterator<R>;
+        [Symbol.asyncIterator](): ReadableStreamAsyncIterator<R>;
     }
 
     const ReadableStream: {

--- a/types/node/v16/ts5.6/index.d.ts
+++ b/types/node/v16/ts5.6/index.d.ts
@@ -22,22 +22,22 @@
  * IN THE SOFTWARE.
  */
 
-// NOTE: These definitions support NodeJS and TypeScript 4.9 through 5.6.
+// NOTE: These definitions support Node.js and TypeScript 4.9 through 5.6.
 
-// Reference required types from the default lib:
+// Reference required TypeScript libs:
 /// <reference lib="es2020" />
-/// <reference lib="esnext.asynciterable" />
-/// <reference lib="esnext.intl" />
-/// <reference lib="esnext.bigint" />
 
-// Definitions specific to TypeScript 4.9 through 5.6
+// TypeScript backwards-compatibility definitions:
+/// <reference path="../compatibility/index.d.ts" />
+
+// Definitions specific to TypeScript 4.9 through 5.6:
 /// <reference path="./globals.typedarray.d.ts" />
 /// <reference path="./buffer.buffer.d.ts" />
 
-// Base definitions for all NodeJS modules that are not specific to any version of TypeScript:
+// Definitions for Node.js modules that are not specific to any version of TypeScript:
+/// <reference path="../globals.d.ts" />
 /// <reference path="../assert.d.ts" />
 /// <reference path="../assert/strict.d.ts" />
-/// <reference path="../globals.d.ts" />
 /// <reference path="../async_hooks.d.ts" />
 /// <reference path="../buffer.d.ts" />
 /// <reference path="../child_process.d.ts" />
@@ -86,5 +86,3 @@
 /// <reference path="../wasi.d.ts" />
 /// <reference path="../worker_threads.d.ts" />
 /// <reference path="../zlib.d.ts" />
-
-/// <reference path="../globals.global.d.ts" />

--- a/types/node/v16/url.d.ts
+++ b/types/node/v16/url.d.ts
@@ -687,6 +687,9 @@ declare module "url" {
          */
         toJSON(): string;
     }
+    interface URLSearchParamsIterator<T> extends NodeJS.Iterator<T, NodeJS.BuiltinIteratorReturn, unknown> {
+        [Symbol.iterator](): URLSearchParamsIterator<T>;
+    }
     /**
      * The `URLSearchParams` API provides read and write access to the query of a `URL`. The `URLSearchParams` class can also be used standalone with one of the
      * four following constructors.
@@ -755,7 +758,7 @@ declare module "url" {
          *
          * Alias for `urlSearchParams[@@iterator]()`.
          */
-        entries(): IterableIterator<[string, string]>;
+        entries(): URLSearchParamsIterator<[string, string]>;
         /**
          * Iterates over each name-value pair in the query and invokes the given function.
          *
@@ -803,7 +806,7 @@ declare module "url" {
          * //   foo
          * ```
          */
-        keys(): IterableIterator<string>;
+        keys(): URLSearchParamsIterator<string>;
         /**
          * Sets the value in the `URLSearchParams` object associated with `name` to`value`. If there are any pre-existing name-value pairs whose names are `name`,
          * set the first such pair's value to `value` and remove all others. If not,
@@ -848,8 +851,8 @@ declare module "url" {
         /**
          * Returns an ES6 `Iterator` over the values of each name-value pair.
          */
-        values(): IterableIterator<string>;
-        [Symbol.iterator](): IterableIterator<[string, string]>;
+        values(): URLSearchParamsIterator<string>;
+        [Symbol.iterator](): URLSearchParamsIterator<[string, string]>;
     }
 
     import { URL as _URL, URLSearchParams as _URLSearchParams } from "url";

--- a/types/node/v18/compatibility/disposable.d.ts
+++ b/types/node/v18/compatibility/disposable.d.ts
@@ -1,0 +1,14 @@
+// Polyfills for the explicit resource management types added in TypeScript 5.2.
+
+interface SymbolConstructor {
+    readonly dispose: unique symbol;
+    readonly asyncDispose: unique symbol;
+}
+
+interface Disposable {
+    [Symbol.dispose](): void;
+}
+
+interface AsyncDisposable {
+    [Symbol.asyncDispose](): PromiseLike<void>;
+}

--- a/types/node/v18/compatibility/index.d.ts
+++ b/types/node/v18/compatibility/index.d.ts
@@ -1,0 +1,8 @@
+// Declaration files in this directory contain types relating to TypeScript library features
+// that are not included in all TypeScript versions supported by DefinitelyTyped, but
+// which can be made backwards-compatible without needing `typesVersions`.
+// If adding declarations to this directory, please specify which versions of TypeScript require them,
+// so that they can be removed when no longer needed.
+
+/// <reference path="disposable.d.ts" />
+/// <reference path="indexable.d.ts" />

--- a/types/node/v18/compatibility/index.d.ts
+++ b/types/node/v18/compatibility/index.d.ts
@@ -6,3 +6,4 @@
 
 /// <reference path="disposable.d.ts" />
 /// <reference path="indexable.d.ts" />
+/// <reference path="iterators.d.ts" />

--- a/types/node/v18/compatibility/indexable.d.ts
+++ b/types/node/v18/compatibility/indexable.d.ts
@@ -1,0 +1,20 @@
+// Polyfill for ES2022's .at() method on string/array prototypes, added to TypeScript in 4.6.
+
+interface RelativeIndexable<T> {
+    at(index: number): T | undefined;
+}
+
+interface String extends RelativeIndexable<string> {}
+interface Array<T> extends RelativeIndexable<T> {}
+interface ReadonlyArray<T> extends RelativeIndexable<T> {}
+interface Int8Array extends RelativeIndexable<number> {}
+interface Uint8Array extends RelativeIndexable<number> {}
+interface Uint8ClampedArray extends RelativeIndexable<number> {}
+interface Int16Array extends RelativeIndexable<number> {}
+interface Uint16Array extends RelativeIndexable<number> {}
+interface Int32Array extends RelativeIndexable<number> {}
+interface Uint32Array extends RelativeIndexable<number> {}
+interface Float32Array extends RelativeIndexable<number> {}
+interface Float64Array extends RelativeIndexable<number> {}
+interface BigInt64Array extends RelativeIndexable<bigint> {}
+interface BigUint64Array extends RelativeIndexable<bigint> {}

--- a/types/node/v18/compatibility/iterators.d.ts
+++ b/types/node/v18/compatibility/iterators.d.ts
@@ -1,0 +1,20 @@
+// Backwards-compatible iterator interfaces, augmented with iterator helper methods by lib.esnext.iterator in TypeScript 5.6.
+// The IterableIterator interface does not contain these methods, which creates assignability issues in places where IteratorObjects
+// are expected (eg. DOM-compatible APIs) if lib.esnext.iterator is loaded.
+// Also ensures that iterators returned by the Node API, which inherit from Iterator.prototype, correctly expose the iterator helper methods
+// if lib.esnext.iterator is loaded.
+
+// Placeholders for TS <5.6
+interface IteratorObject<T, TReturn, TNext> {}
+interface AsyncIteratorObject<T, TReturn, TNext> {}
+
+declare namespace NodeJS {
+    // Populate iterator methods for TS <5.6
+    interface Iterator<T, TReturn, TNext> extends globalThis.Iterator<T, TReturn, TNext> {}
+    interface AsyncIterator<T, TReturn, TNext> extends globalThis.AsyncIterator<T, TReturn, TNext> {}
+
+    // Polyfill for TS 5.6's instrinsic BuiltinIteratorReturn type, required for DOM-compatible iterators
+    type BuiltinIteratorReturn = ReturnType<any[][typeof Symbol.iterator]> extends
+        globalThis.Iterator<any, infer TReturn> ? TReturn
+        : any;
+}

--- a/types/node/v18/events.d.ts
+++ b/types/node/v18/events.d.ts
@@ -280,7 +280,7 @@ declare module "events" {
             emitter: NodeJS.EventEmitter,
             eventName: string,
             options?: StaticEventEmitterOptions,
-        ): AsyncIterableIterator<any>;
+        ): NodeJS.AsyncIterator<any>;
         /**
          * A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
          *

--- a/types/node/v18/fs.d.ts
+++ b/types/node/v18/fs.d.ts
@@ -262,7 +262,7 @@ declare module "fs" {
         /**
          * Asynchronously iterates over the directory via `readdir(3)` until all entries have been read.
          */
-        [Symbol.asyncIterator](): AsyncIterableIterator<Dirent>;
+        [Symbol.asyncIterator](): NodeJS.AsyncIterator<Dirent>;
         /**
          * Asynchronously close the directory's underlying resource handle.
          * Subsequent reads will result in errors.

--- a/types/node/v18/globals.d.ts
+++ b/types/node/v18/globals.d.ts
@@ -111,6 +111,8 @@ declare global {
     interface RequireResolve extends NodeJS.RequireResolve {}
     interface NodeModule extends NodeJS.Module {}
 
+    var global: typeof globalThis;
+
     var process: NodeJS.Process;
     var console: Console;
 
@@ -181,53 +183,6 @@ declare global {
             any(signals: AbortSignal[]): AbortSignal;
         };
     // #endregion borrowed
-
-    // #region Disposable
-    interface SymbolConstructor {
-        /**
-         * A method that is used to release resources held by an object. Called by the semantics of the `using` statement.
-         */
-        readonly dispose: unique symbol;
-
-        /**
-         * A method that is used to asynchronously release resources held by an object. Called by the semantics of the `await using` statement.
-         */
-        readonly asyncDispose: unique symbol;
-    }
-
-    interface Disposable {
-        [Symbol.dispose](): void;
-    }
-
-    interface AsyncDisposable {
-        [Symbol.asyncDispose](): PromiseLike<void>;
-    }
-    // #endregion Disposable
-
-    // #region ArrayLike.at()
-    interface RelativeIndexable<T> {
-        /**
-         * Takes an integer value and returns the item at that index,
-         * allowing for positive and negative integers.
-         * Negative integers count back from the last item in the array.
-         */
-        at(index: number): T | undefined;
-    }
-    interface String extends RelativeIndexable<string> {}
-    interface Array<T> extends RelativeIndexable<T> {}
-    interface ReadonlyArray<T> extends RelativeIndexable<T> {}
-    interface Int8Array extends RelativeIndexable<number> {}
-    interface Uint8Array extends RelativeIndexable<number> {}
-    interface Uint8ClampedArray extends RelativeIndexable<number> {}
-    interface Int16Array extends RelativeIndexable<number> {}
-    interface Uint16Array extends RelativeIndexable<number> {}
-    interface Int32Array extends RelativeIndexable<number> {}
-    interface Uint32Array extends RelativeIndexable<number> {}
-    interface Float32Array extends RelativeIndexable<number> {}
-    interface Float64Array extends RelativeIndexable<number> {}
-    interface BigInt64Array extends RelativeIndexable<bigint> {}
-    interface BigUint64Array extends RelativeIndexable<bigint> {}
-    // #endregion ArrayLike.at() end
 
     /**
      * @since v17.0.0

--- a/types/node/v18/globals.d.ts
+++ b/types/node/v18/globals.d.ts
@@ -310,7 +310,7 @@ declare global {
             unpipe(destination?: WritableStream): this;
             unshift(chunk: string | Uint8Array, encoding?: BufferEncoding): void;
             wrap(oldStream: ReadableStream): this;
-            [Symbol.asyncIterator](): AsyncIterableIterator<string | Buffer>;
+            [Symbol.asyncIterator](): NodeJS.AsyncIterator<string | Buffer>;
         }
 
         interface WritableStream extends EventEmitter {
@@ -378,6 +378,18 @@ declare global {
 
         interface ReadOnlyDict<T> {
             readonly [key: string]: T | undefined;
+        }
+
+        /** An iterable iterator returned by the Node.js API. */
+        // Default TReturn/TNext in v18 is `any`, for compatibility with the previously-used IterableIterator.
+        interface Iterator<T, TReturn = any, TNext = any> extends IteratorObject<T, TReturn, TNext> {
+            [Symbol.iterator](): NodeJS.Iterator<T, TReturn, TNext>;
+        }
+
+        /** An async iterable iterator returned by the Node.js API. */
+        // Default TReturn/TNext in v18 is `any`, for compatibility with the previously-used AsyncIterableIterator.
+        interface AsyncIterator<T, TReturn = any, TNext = any> extends AsyncIteratorObject<T, TReturn, TNext> {
+            [Symbol.asyncIterator](): NodeJS.AsyncIterator<T, TReturn, TNext>;
         }
     }
 

--- a/types/node/v18/globals.global.d.ts
+++ b/types/node/v18/globals.global.d.ts
@@ -1,1 +1,0 @@
-declare var global: typeof globalThis;

--- a/types/node/v18/index.d.ts
+++ b/types/node/v18/index.d.ts
@@ -22,22 +22,22 @@
  * IN THE SOFTWARE.
  */
 
-// NOTE: These definitions support NodeJS and TypeScript 5.7+.
+// NOTE: These definitions support Node.js and TypeScript 5.7+.
 
-// Reference required types from the default lib:
+// Reference required TypeScript libs:
 /// <reference lib="es2020" />
-/// <reference lib="esnext.asynciterable" />
-/// <reference lib="esnext.intl" />
-/// <reference lib="esnext.bigint" />
 
-// Definitions specific to TypeScript 5.7+
+// TypeScript backwards-compatibility definitions:
+/// <reference path="compatibility/index.d.ts" />
+
+// Definitions specific to TypeScript 5.7+:
 /// <reference path="globals.typedarray.d.ts" />
 /// <reference path="buffer.buffer.d.ts" />
 
-// Base definitions for all NodeJS modules that are not specific to any version of TypeScript:
+// Definitions for Node.js modules that are not specific to any version of TypeScript:
+/// <reference path="globals.d.ts" />
 /// <reference path="assert.d.ts" />
 /// <reference path="assert/strict.d.ts" />
-/// <reference path="globals.d.ts" />
 /// <reference path="async_hooks.d.ts" />
 /// <reference path="buffer.d.ts" />
 /// <reference path="child_process.d.ts" />
@@ -88,5 +88,3 @@
 /// <reference path="wasi.d.ts" />
 /// <reference path="worker_threads.d.ts" />
 /// <reference path="zlib.d.ts" />
-
-/// <reference path="globals.global.d.ts" />

--- a/types/node/v18/readline.d.ts
+++ b/types/node/v18/readline.d.ts
@@ -321,7 +321,7 @@ declare module "readline" {
         prependOnceListener(event: "SIGINT", listener: () => void): this;
         prependOnceListener(event: "SIGTSTP", listener: () => void): this;
         prependOnceListener(event: "history", listener: (history: string[]) => void): this;
-        [Symbol.asyncIterator](): AsyncIterableIterator<string>;
+        [Symbol.asyncIterator](): NodeJS.AsyncIterator<string>;
     }
     export type ReadLine = Interface; // type forwarded for backwards compatibility
     export type Completer = (line: string) => CompleterResult;

--- a/types/node/v18/stream.d.ts
+++ b/types/node/v18/stream.d.ts
@@ -445,7 +445,7 @@ declare module "stream" {
              * or exiting a `for await...of` iteration using a `break`, `return`, or `throw` will not destroy the stream.
              * **Default: `true`**.
              */
-            iterator(options?: { destroyOnReturn?: boolean }): AsyncIterableIterator<any>;
+            iterator(options?: { destroyOnReturn?: boolean }): NodeJS.AsyncIterator<any>;
             /**
              * This method allows mapping over the stream. The *fn* function will be called for every chunk in the stream.
              * If the *fn* function returns a promise - that promise will be `await`ed before being passed to the result stream.
@@ -674,7 +674,7 @@ declare module "stream" {
             removeListener(event: "readable", listener: () => void): this;
             removeListener(event: "resume", listener: () => void): this;
             removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
-            [Symbol.asyncIterator](): AsyncIterableIterator<any>;
+            [Symbol.asyncIterator](): NodeJS.AsyncIterator<any>;
             /**
              * Calls `readable.destroy()` with an `AbortError` and returns a promise that fulfills when the stream is finished.
              * @since v18.18.0

--- a/types/node/v18/stream/web.d.ts
+++ b/types/node/v18/stream/web.d.ts
@@ -166,6 +166,9 @@ declare module "stream/web" {
     interface ReadableStreamErrorCallback {
         (reason: any): void | PromiseLike<void>;
     }
+    interface ReadableStreamAsyncIterator<T> extends NodeJS.AsyncIterator<T, NodeJS.BuiltinIteratorReturn, unknown> {
+        [Symbol.asyncIterator](): ReadableStreamAsyncIterator<T>;
+    }
     /** This Streams API interface represents a readable stream of byte data. */
     interface ReadableStream<R = any> {
         readonly locked: boolean;
@@ -176,8 +179,8 @@ declare module "stream/web" {
         pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
         pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
         tee(): [ReadableStream<R>, ReadableStream<R>];
-        values(options?: { preventCancel?: boolean }): AsyncIterableIterator<R>;
-        [Symbol.asyncIterator](): AsyncIterableIterator<R>;
+        values(options?: { preventCancel?: boolean }): ReadableStreamAsyncIterator<R>;
+        [Symbol.asyncIterator](): ReadableStreamAsyncIterator<R>;
     }
     const ReadableStream: {
         prototype: ReadableStream;

--- a/types/node/v18/test/fs.ts
+++ b/types/node/v18/test/fs.ts
@@ -528,7 +528,7 @@ async function testPromisify() {
 
     handle.readableWebStream();
 
-    handle.readLines()[Symbol.asyncIterator](); // $ExpectType AsyncIterableIterator<string>
+    handle.readLines()[Symbol.asyncIterator](); // $ExpectType AsyncIterator<string, any, any>
 });
 
 {

--- a/types/node/v18/ts5.6/index.d.ts
+++ b/types/node/v18/ts5.6/index.d.ts
@@ -22,22 +22,22 @@
  * IN THE SOFTWARE.
  */
 
-// NOTE: These definitions support NodeJS and TypeScript 4.9 through 5.6.
+// NOTE: These definitions support Node.js and TypeScript 4.9 through 5.6.
 
-// Reference required types from the default lib:
+// Reference required TypeScript libs:
 /// <reference lib="es2020" />
-/// <reference lib="esnext.asynciterable" />
-/// <reference lib="esnext.intl" />
-/// <reference lib="esnext.bigint" />
 
-// Definitions specific to TypeScript 4.9 through 5.6
+// TypeScript backwards-compatibility definitions:
+/// <reference path="../compatibility/index.d.ts" />
+
+// Definitions specific to TypeScript 4.9 through 5.6:
 /// <reference path="./globals.typedarray.d.ts" />
 /// <reference path="./buffer.buffer.d.ts" />
 
-// Base definitions for all NodeJS modules that are not specific to any version of TypeScript:
+// Definitions for Node.js modules that are not specific to any version of TypeScript:
+/// <reference path="../globals.d.ts" />
 /// <reference path="../assert.d.ts" />
 /// <reference path="../assert/strict.d.ts" />
-/// <reference path="../globals.d.ts" />
 /// <reference path="../async_hooks.d.ts" />
 /// <reference path="../buffer.d.ts" />
 /// <reference path="../child_process.d.ts" />
@@ -88,4 +88,3 @@
 /// <reference path="../wasi.d.ts" />
 /// <reference path="../worker_threads.d.ts" />
 /// <reference path="../zlib.d.ts" />
-/// <reference path="../globals.global.d.ts" />

--- a/types/node/v18/url.d.ts
+++ b/types/node/v18/url.d.ts
@@ -742,6 +742,9 @@ declare module "url" {
          */
         toJSON(): string;
     }
+    interface URLSearchParamsIterator<T> extends NodeJS.Iterator<T, NodeJS.BuiltinIteratorReturn, unknown> {
+        [Symbol.iterator](): URLSearchParamsIterator<T>;
+    }
     /**
      * The `URLSearchParams` API provides read and write access to the query of a `URL`. The `URLSearchParams` class can also be used standalone with one of the
      * four following constructors.
@@ -812,7 +815,7 @@ declare module "url" {
          *
          * Alias for `urlSearchParams[@@iterator]()`.
          */
-        entries(): IterableIterator<[string, string]>;
+        entries(): URLSearchParamsIterator<[string, string]>;
         /**
          * Iterates over each name-value pair in the query and invokes the given function.
          *
@@ -866,7 +869,7 @@ declare module "url" {
          * //   foo
          * ```
          */
-        keys(): IterableIterator<string>;
+        keys(): URLSearchParamsIterator<string>;
         /**
          * Sets the value in the `URLSearchParams` object associated with `name` to`value`. If there are any pre-existing name-value pairs whose names are `name`,
          * set the first such pair's value to `value` and remove all others. If not,
@@ -916,8 +919,8 @@ declare module "url" {
         /**
          * Returns an ES6 `Iterator` over the values of each name-value pair.
          */
-        values(): IterableIterator<string>;
-        [Symbol.iterator](): IterableIterator<[string, string]>;
+        values(): URLSearchParamsIterator<string>;
+        [Symbol.iterator](): URLSearchParamsIterator<[string, string]>;
     }
     import { URL as _URL, URLSearchParams as _URLSearchParams } from "url";
     global {

--- a/types/node/v18/util.d.ts
+++ b/types/node/v18/util.d.ts
@@ -1544,7 +1544,7 @@ declare module "util" {
         /**
          * Returns an iterator over each of the name-value pairs in the parameters.
          */
-        entries(): IterableIterator<[name: string, value: string]>;
+        entries(): NodeJS.Iterator<[name: string, value: string]>;
         /**
          * Returns the value of the first name-value pair whose name is `name`.
          * If there are no such pairs, `null` is returned.
@@ -1557,7 +1557,7 @@ declare module "util" {
         /**
          * Returns an iterator over the names of each name-value pair.
          */
-        keys(): IterableIterator<string>;
+        keys(): NodeJS.Iterator<string>;
         /**
          * Sets the value in the `MIMEParams` object associated with `name` to `value`.
          * If there are any pre-existing name-value pairs whose names are `name`,
@@ -1567,11 +1567,11 @@ declare module "util" {
         /**
          * Returns an iterator over the values of each name-value pair.
          */
-        values(): IterableIterator<string>;
+        values(): NodeJS.Iterator<string>;
         /**
          * Returns an iterator over each of the name-value pairs in the parameters.
          */
-        [Symbol.iterator]: typeof MIMEParams.prototype.entries;
+        [Symbol.iterator](): NodeJS.Iterator<[name: string, value: string]>;
     }
 }
 declare module "util/types" {

--- a/types/node/v20/compatibility/disposable.d.ts
+++ b/types/node/v20/compatibility/disposable.d.ts
@@ -1,0 +1,16 @@
+// Polyfills for the explicit resource management types added in TypeScript 5.2.
+// TODO: remove once this package no longer supports TS 5.1, and replace with a
+// <reference> to TypeScript's disposable library in index.d.ts.
+
+interface SymbolConstructor {
+    readonly dispose: unique symbol;
+    readonly asyncDispose: unique symbol;
+}
+
+interface Disposable {
+    [Symbol.dispose](): void;
+}
+
+interface AsyncDisposable {
+    [Symbol.asyncDispose](): PromiseLike<void>;
+}

--- a/types/node/v20/compatibility/index.d.ts
+++ b/types/node/v20/compatibility/index.d.ts
@@ -1,0 +1,8 @@
+// Declaration files in this directory contain types relating to TypeScript library features
+// that are not included in all TypeScript versions supported by DefinitelyTyped, but
+// which can be made backwards-compatible without needing `typesVersions`.
+// If adding declarations to this directory, please specify which versions of TypeScript require them,
+// so that they can be removed when no longer needed.
+
+/// <reference path="disposable.d.ts" />
+/// <reference path="indexable.d.ts" />

--- a/types/node/v20/compatibility/index.d.ts
+++ b/types/node/v20/compatibility/index.d.ts
@@ -6,3 +6,4 @@
 
 /// <reference path="disposable.d.ts" />
 /// <reference path="indexable.d.ts" />
+/// <reference path="iterators.d.ts" />

--- a/types/node/v20/compatibility/indexable.d.ts
+++ b/types/node/v20/compatibility/indexable.d.ts
@@ -1,0 +1,20 @@
+// Polyfill for ES2022's .at() method on string/array prototypes, added to TypeScript in 4.6.
+
+interface RelativeIndexable<T> {
+    at(index: number): T | undefined;
+}
+
+interface String extends RelativeIndexable<string> {}
+interface Array<T> extends RelativeIndexable<T> {}
+interface ReadonlyArray<T> extends RelativeIndexable<T> {}
+interface Int8Array extends RelativeIndexable<number> {}
+interface Uint8Array extends RelativeIndexable<number> {}
+interface Uint8ClampedArray extends RelativeIndexable<number> {}
+interface Int16Array extends RelativeIndexable<number> {}
+interface Uint16Array extends RelativeIndexable<number> {}
+interface Int32Array extends RelativeIndexable<number> {}
+interface Uint32Array extends RelativeIndexable<number> {}
+interface Float32Array extends RelativeIndexable<number> {}
+interface Float64Array extends RelativeIndexable<number> {}
+interface BigInt64Array extends RelativeIndexable<bigint> {}
+interface BigUint64Array extends RelativeIndexable<bigint> {}

--- a/types/node/v20/compatibility/iterators.d.ts
+++ b/types/node/v20/compatibility/iterators.d.ts
@@ -1,0 +1,21 @@
+// Backwards-compatible iterator interfaces, augmented with iterator helper methods by lib.esnext.iterator in TypeScript 5.6.
+// The IterableIterator interface does not contain these methods, which creates assignability issues in places where IteratorObjects
+// are expected (eg. DOM-compatible APIs) if lib.esnext.iterator is loaded.
+// Also ensures that iterators returned by the Node API, which inherit from Iterator.prototype, correctly expose the iterator helper methods
+// if lib.esnext.iterator is loaded.
+// TODO: remove once this package no longer supports TS 5.5, and replace NodeJS.BuiltinIteratorReturn with BuiltinIteratorReturn.
+
+// Placeholders for TS <5.6
+interface IteratorObject<T, TReturn, TNext> {}
+interface AsyncIteratorObject<T, TReturn, TNext> {}
+
+declare namespace NodeJS {
+    // Populate iterator methods for TS <5.6
+    interface Iterator<T, TReturn, TNext> extends globalThis.Iterator<T, TReturn, TNext> {}
+    interface AsyncIterator<T, TReturn, TNext> extends globalThis.AsyncIterator<T, TReturn, TNext> {}
+
+    // Polyfill for TS 5.6's instrinsic BuiltinIteratorReturn type, required for DOM-compatible iterators
+    type BuiltinIteratorReturn = ReturnType<any[][typeof Symbol.iterator]> extends
+        globalThis.Iterator<any, infer TReturn> ? TReturn
+        : any;
+}

--- a/types/node/v20/events.d.ts
+++ b/types/node/v20/events.d.ts
@@ -304,12 +304,12 @@ declare module "events" {
             emitter: NodeJS.EventEmitter,
             eventName: string | symbol,
             options?: StaticEventEmitterIteratorOptions,
-        ): AsyncIterableIterator<any[]>;
+        ): NodeJS.AsyncIterator<any[]>;
         static on(
             emitter: EventTarget,
             eventName: string,
             options?: StaticEventEmitterIteratorOptions,
-        ): AsyncIterableIterator<any[]>;
+        ): NodeJS.AsyncIterator<any[]>;
         /**
          * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
          *

--- a/types/node/v20/fs.d.ts
+++ b/types/node/v20/fs.d.ts
@@ -282,7 +282,7 @@ declare module "fs" {
         /**
          * Asynchronously iterates over the directory via `readdir(3)` until all entries have been read.
          */
-        [Symbol.asyncIterator](): AsyncIterableIterator<Dirent>;
+        [Symbol.asyncIterator](): NodeJS.AsyncIterator<Dirent>;
         /**
          * Asynchronously close the directory's underlying resource handle.
          * Subsequent reads will result in errors.

--- a/types/node/v20/globals.d.ts
+++ b/types/node/v20/globals.d.ts
@@ -336,7 +336,7 @@ declare global {
             unpipe(destination?: WritableStream): this;
             unshift(chunk: string | Uint8Array, encoding?: BufferEncoding): void;
             wrap(oldStream: ReadableStream): this;
-            [Symbol.asyncIterator](): AsyncIterableIterator<string | Buffer>;
+            [Symbol.asyncIterator](): NodeJS.AsyncIterator<string | Buffer>;
         }
 
         interface WritableStream extends EventEmitter {
@@ -404,6 +404,18 @@ declare global {
 
         interface ReadOnlyDict<T> {
             readonly [key: string]: T | undefined;
+        }
+
+        /** An iterable iterator returned by the Node.js API. */
+        // Default TReturn/TNext in v20 is `any`, for compatibility with the previously-used IterableIterator.
+        interface Iterator<T, TReturn = any, TNext = any> extends IteratorObject<T, TReturn, TNext> {
+            [Symbol.iterator](): NodeJS.Iterator<T, TReturn, TNext>;
+        }
+
+        /** An async iterable iterator returned by the Node.js API. */
+        // Default TReturn/TNext in v20 is `any`, for compatibility with the previously-used AsyncIterableIterator.
+        interface AsyncIterator<T, TReturn = any, TNext = any> extends AsyncIteratorObject<T, TReturn, TNext> {
+            [Symbol.asyncIterator](): NodeJS.AsyncIterator<T, TReturn, TNext>;
         }
     }
 

--- a/types/node/v20/globals.d.ts
+++ b/types/node/v20/globals.d.ts
@@ -111,6 +111,8 @@ declare global {
     interface RequireResolve extends NodeJS.RequireResolve {}
     interface NodeModule extends NodeJS.Module {}
 
+    var global: typeof globalThis;
+
     var process: NodeJS.Process;
     var console: Console;
 
@@ -181,53 +183,6 @@ declare global {
             any(signals: AbortSignal[]): AbortSignal;
         };
     // #endregion borrowed
-
-    // #region Disposable
-    interface SymbolConstructor {
-        /**
-         * A method that is used to release resources held by an object. Called by the semantics of the `using` statement.
-         */
-        readonly dispose: unique symbol;
-
-        /**
-         * A method that is used to asynchronously release resources held by an object. Called by the semantics of the `await using` statement.
-         */
-        readonly asyncDispose: unique symbol;
-    }
-
-    interface Disposable {
-        [Symbol.dispose](): void;
-    }
-
-    interface AsyncDisposable {
-        [Symbol.asyncDispose](): PromiseLike<void>;
-    }
-    // #endregion Disposable
-
-    // #region ArrayLike.at()
-    interface RelativeIndexable<T> {
-        /**
-         * Takes an integer value and returns the item at that index,
-         * allowing for positive and negative integers.
-         * Negative integers count back from the last item in the array.
-         */
-        at(index: number): T | undefined;
-    }
-    interface String extends RelativeIndexable<string> {}
-    interface Array<T> extends RelativeIndexable<T> {}
-    interface ReadonlyArray<T> extends RelativeIndexable<T> {}
-    interface Int8Array extends RelativeIndexable<number> {}
-    interface Uint8Array extends RelativeIndexable<number> {}
-    interface Uint8ClampedArray extends RelativeIndexable<number> {}
-    interface Int16Array extends RelativeIndexable<number> {}
-    interface Uint16Array extends RelativeIndexable<number> {}
-    interface Int32Array extends RelativeIndexable<number> {}
-    interface Uint32Array extends RelativeIndexable<number> {}
-    interface Float32Array extends RelativeIndexable<number> {}
-    interface Float64Array extends RelativeIndexable<number> {}
-    interface BigInt64Array extends RelativeIndexable<bigint> {}
-    interface BigUint64Array extends RelativeIndexable<bigint> {}
-    // #endregion ArrayLike.at() end
 
     /**
      * @since v17.0.0

--- a/types/node/v20/globals.global.d.ts
+++ b/types/node/v20/globals.global.d.ts
@@ -1,1 +1,0 @@
-declare var global: typeof globalThis;

--- a/types/node/v20/index.d.ts
+++ b/types/node/v20/index.d.ts
@@ -22,22 +22,22 @@
  * IN THE SOFTWARE.
  */
 
-// NOTE: These definitions support NodeJS and TypeScript 5.7+.
+// NOTE: These definitions support Node.js and TypeScript 5.7+.
 
-// Reference required types from the default lib:
+// Reference required TypeScript libs:
 /// <reference lib="es2020" />
-/// <reference lib="esnext.asynciterable" />
-/// <reference lib="esnext.intl" />
-/// <reference lib="esnext.bigint" />
 
-// Definitions specific to TypeScript 5.7+
+// TypeScript backwards-compatibility definitions:
+/// <reference path="compatibility/index.d.ts" />
+
+// Definitions specific to TypeScript 5.7+:
 /// <reference path="globals.typedarray.d.ts" />
 /// <reference path="buffer.buffer.d.ts" />
 
-// Base definitions for all NodeJS modules that are not specific to any version of TypeScript:
+// Definitions for Node.js modules that are not specific to any version of TypeScript:
+/// <reference path="globals.d.ts" />
 /// <reference path="assert.d.ts" />
 /// <reference path="assert/strict.d.ts" />
-/// <reference path="globals.d.ts" />
 /// <reference path="async_hooks.d.ts" />
 /// <reference path="buffer.d.ts" />
 /// <reference path="child_process.d.ts" />
@@ -89,5 +89,3 @@
 /// <reference path="wasi.d.ts" />
 /// <reference path="worker_threads.d.ts" />
 /// <reference path="zlib.d.ts" />
-
-/// <reference path="globals.global.d.ts" />

--- a/types/node/v20/readline.d.ts
+++ b/types/node/v20/readline.d.ts
@@ -304,7 +304,7 @@ declare module "readline" {
         prependOnceListener(event: "SIGINT", listener: () => void): this;
         prependOnceListener(event: "SIGTSTP", listener: () => void): this;
         prependOnceListener(event: "history", listener: (history: string[]) => void): this;
-        [Symbol.asyncIterator](): AsyncIterableIterator<string>;
+        [Symbol.asyncIterator](): NodeJS.AsyncIterator<string>;
     }
     export type ReadLine = Interface; // type forwarded for backwards compatibility
     export type Completer = (line: string) => CompleterResult;

--- a/types/node/v20/stream.d.ts
+++ b/types/node/v20/stream.d.ts
@@ -422,7 +422,7 @@ declare module "stream" {
          * or exiting a `for await...of` iteration using a `break`, `return`, or `throw` will not destroy the stream.
          * **Default: `true`**.
          */
-        iterator(options?: { destroyOnReturn?: boolean }): AsyncIterableIterator<any>;
+        iterator(options?: { destroyOnReturn?: boolean }): NodeJS.AsyncIterator<any>;
         /**
          * This method allows mapping over the stream. The *fn* function will be called for every chunk in the stream.
          * If the *fn* function returns a promise - that promise will be `await`ed before being passed to the result stream.
@@ -651,7 +651,7 @@ declare module "stream" {
         removeListener(event: "readable", listener: () => void): this;
         removeListener(event: "resume", listener: () => void): this;
         removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        [Symbol.asyncIterator](): AsyncIterableIterator<any>;
+        [Symbol.asyncIterator](): NodeJS.AsyncIterator<any>;
         /**
          * Calls `readable.destroy()` with an `AbortError` and returns a promise that fulfills when the stream is finished.
          * @since v20.4.0

--- a/types/node/v20/stream/web.d.ts
+++ b/types/node/v20/stream/web.d.ts
@@ -166,6 +166,9 @@ declare module "stream/web" {
     interface ReadableStreamErrorCallback {
         (reason: any): void | PromiseLike<void>;
     }
+    interface ReadableStreamAsyncIterator<T> extends NodeJS.AsyncIterator<T, NodeJS.BuiltinIteratorReturn, unknown> {
+        [Symbol.asyncIterator](): ReadableStreamAsyncIterator<T>;
+    }
     /** This Streams API interface represents a readable stream of byte data. */
     interface ReadableStream<R = any> {
         readonly locked: boolean;
@@ -176,8 +179,8 @@ declare module "stream/web" {
         pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
         pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
         tee(): [ReadableStream<R>, ReadableStream<R>];
-        values(options?: { preventCancel?: boolean }): AsyncIterableIterator<R>;
-        [Symbol.asyncIterator](): AsyncIterableIterator<R>;
+        values(options?: { preventCancel?: boolean }): ReadableStreamAsyncIterator<R>;
+        [Symbol.asyncIterator](): ReadableStreamAsyncIterator<R>;
     }
     const ReadableStream: {
         prototype: ReadableStream;

--- a/types/node/v20/test/fs.ts
+++ b/types/node/v20/test/fs.ts
@@ -550,7 +550,7 @@ async function testPromisify() {
 
     handle.readableWebStream();
 
-    handle.readLines()[Symbol.asyncIterator](); // $ExpectType AsyncIterableIterator<string>
+    handle.readLines()[Symbol.asyncIterator](); // $ExpectType AsyncIterator<string, any, any>
 });
 
 {

--- a/types/node/v20/ts5.6/index.d.ts
+++ b/types/node/v20/ts5.6/index.d.ts
@@ -22,22 +22,22 @@
  * IN THE SOFTWARE.
  */
 
-// NOTE: These definitions support NodeJS and TypeScript 4.9 through 5.6.
+// NOTE: These definitions support Node.js and TypeScript 4.9 through 5.6.
 
-// Reference required types from the default lib:
+// Reference required TypeScript libs:
 /// <reference lib="es2020" />
-/// <reference lib="esnext.asynciterable" />
-/// <reference lib="esnext.intl" />
-/// <reference lib="esnext.bigint" />
 
-// Definitions specific to TypeScript 4.9 through 5.6
+// TypeScript backwards-compatibility definitions:
+/// <reference path="../compatibility/index.d.ts" />
+
+// Definitions specific to TypeScript 4.9 through 5.6:
 /// <reference path="./globals.typedarray.d.ts" />
 /// <reference path="./buffer.buffer.d.ts" />
 
-// Base definitions for all NodeJS modules that are not specific to any version of TypeScript:
+// Definitions for Node.js modules that are not specific to any version of TypeScript:
+/// <reference path="../globals.d.ts" />
 /// <reference path="../assert.d.ts" />
 /// <reference path="../assert/strict.d.ts" />
-/// <reference path="../globals.d.ts" />
 /// <reference path="../async_hooks.d.ts" />
 /// <reference path="../buffer.d.ts" />
 /// <reference path="../child_process.d.ts" />
@@ -89,4 +89,3 @@
 /// <reference path="../wasi.d.ts" />
 /// <reference path="../worker_threads.d.ts" />
 /// <reference path="../zlib.d.ts" />
-/// <reference path="../globals.global.d.ts" />

--- a/types/node/v20/url.d.ts
+++ b/types/node/v20/url.d.ts
@@ -740,6 +740,9 @@ declare module "url" {
          */
         toJSON(): string;
     }
+    interface URLSearchParamsIterator<T> extends NodeJS.Iterator<T, NodeJS.BuiltinIteratorReturn, unknown> {
+        [Symbol.iterator](): URLSearchParamsIterator<T>;
+    }
     /**
      * The `URLSearchParams` API provides read and write access to the query of a `URL`. The `URLSearchParams` class can also be used standalone with one of the
      * four following constructors.
@@ -810,7 +813,7 @@ declare module "url" {
          *
          * Alias for `urlSearchParams[@@iterator]()`.
          */
-        entries(): IterableIterator<[string, string]>;
+        entries(): URLSearchParamsIterator<[string, string]>;
         /**
          * Iterates over each name-value pair in the query and invokes the given function.
          *
@@ -864,7 +867,7 @@ declare module "url" {
          * //   foo
          * ```
          */
-        keys(): IterableIterator<string>;
+        keys(): URLSearchParamsIterator<string>;
         /**
          * Sets the value in the `URLSearchParams` object associated with `name` to `value`. If there are any pre-existing name-value pairs whose names are `name`,
          * set the first such pair's value to `value` and remove all others. If not,
@@ -914,8 +917,8 @@ declare module "url" {
         /**
          * Returns an ES6 `Iterator` over the values of each name-value pair.
          */
-        values(): IterableIterator<string>;
-        [Symbol.iterator](): IterableIterator<[string, string]>;
+        values(): URLSearchParamsIterator<string>;
+        [Symbol.iterator](): URLSearchParamsIterator<[string, string]>;
     }
     import { URL as _URL, URLSearchParams as _URLSearchParams } from "url";
     global {

--- a/types/node/v20/util.d.ts
+++ b/types/node/v20/util.d.ts
@@ -1717,7 +1717,7 @@ declare module "util" {
          * Each item of the iterator is a JavaScript `Array`. The first item of the array
          * is the `name`, the second item of the array is the `value`.
          */
-        entries(): IterableIterator<[name: string, value: string]>;
+        entries(): NodeJS.Iterator<[name: string, value: string]>;
         /**
          * Returns the value of the first name-value pair whose name is `name`. If there
          * are no such pairs, `null` is returned.
@@ -1743,7 +1743,7 @@ declare module "util" {
          * //   bar
          * ```
          */
-        keys(): IterableIterator<string>;
+        keys(): NodeJS.Iterator<string>;
         /**
          * Sets the value in the `MIMEParams` object associated with `name` to `value`. If there are any pre-existing name-value pairs whose names are `name`,
          * set the first such pair's value to `value`.
@@ -1762,11 +1762,11 @@ declare module "util" {
         /**
          * Returns an iterator over the values of each name-value pair.
          */
-        values(): IterableIterator<string>;
+        values(): NodeJS.Iterator<string>;
         /**
          * Returns an iterator over each of the name-value pairs in the parameters.
          */
-        [Symbol.iterator]: typeof MIMEParams.prototype.entries;
+        [Symbol.iterator](): NodeJS.Iterator<[name: string, value: string]>;
     }
 }
 declare module "util/types" {


### PR DESCRIPTION
Resolves: microsoft/TypeScript#59996
Resolves: microsoft/TypeScript#60141

Within @types/node, methods that return builtin iterators (mostly implemented as generators within the library itself) are currently typed as IterableIterators.

This has a couple of issues in TS 5.6:
- Iterable web interfaces defined in @types/node are no longer type-compatible with their TypeScript companions (which use IteratorObject and BuiltinIteratorReturn) if the consumer is running TS 5.6 with lib.esnext, as per the linked issue.
- The TS iterator helpers library (lib.esnext.iterator) has no effect on IterableIterator, meaning that users can't access these methods on Node iterators that should expose them.

This proposed changeset does the following:
- Refactors existing "TypeScript compatibility definitions" out of globals.d.ts and into their own space, which makes it easier to keep track of them and remove them when no longer needed.
- Adds `NodeJS.Iterator` and `NodeJS.AsyncIterator` interfaces for iterators returned by the Node API.
  - In TS 5.6 and greater, Node iterators are IteratorObjects, meaning that they respect lib.esnext.iterator.
  - In TS 5.5 and earlier, these types are essentially just IterableIterator/AsyncIterableIterator.
- Adds DOM iterator types for compatibility between @types/node interfaces and lib.dom interfaces in TS 5.6.

IterableIterator's TReturn type is `any`, and although none of the Node iterators actually "return" a value, I've kept their TReturn types as `any` so as not to introduce any new errors with unchecked iterator access (à la the strictBuiltinIteratorReturn discussion). The default TReturn should ideally be changed to `undefined` in the next major @types/node release.