### PR TITLE
fix(react-maskedinput): Fix "export =", add jsdoc, ban some props

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -1526,7 +1526,6 @@
         "react-linkify",
         "react-loadable-visibility",
         "react-mailchimp-subscribe",
-        "react-maskedinput",
         "react-native-bcrypt",
         "react-native-bluetooth-serial",
         "react-native-honeywell-scanner",

--- a/types/react-maskedinput/index.d.ts
+++ b/types/react-maskedinput/index.d.ts
@@ -1,19 +1,45 @@
 import * as React from "react";
 
-export interface FormatCharacter {
-    validate(char: string): string;
-    transform?(char: string): string;
+declare namespace MaskedInput {
+    interface FormatCharacter {
+        validate(char: string): string;
+        transform?(char: string): string;
+    }
+
+    interface CharsFormatters {
+        [char: string]: FormatCharacter;
+    }
+
+    interface MaskedInputProps extends
+        Omit<
+            React.InputHTMLAttributes<HTMLInputElement>,
+            | "maxLength"
+            | "onKeyDown"
+            | "onKeyPress"
+            | "onPaste"
+        >
+    {
+        /**
+         * The masking pattern to be applied to the `<input>`.
+         * See the {@link https://github.com/insin/inputmask-core#pattern|inputmask-core} docs for
+         * supported formatting characters.
+         */
+        mask: string;
+        /**
+         * Customised format character definitions for use in the pattern.
+         * See the {@link https://github.com/insin/inputmask-core#formatcharacters|inputmask-core}
+         * docs for details of the structure of this object.
+         */
+        formatCharacters?: CharsFormatters | undefined;
+        /**
+         * Customised placeholder character used to fill in editable parts of the pattern.
+         * See the {@link https://github.com/insin/inputmask-core#placeholderchar--string|inputmask-core}
+         * docs for details.
+         */
+        placeholderChar?: string | undefined;
+    }
 }
 
-export interface CharsFormatters {
-    [char: string]: FormatCharacter;
-}
+declare class MaskedInput extends React.Component<MaskedInput.MaskedInputProps> {}
 
-export interface MaskedInputProps extends React.InputHTMLAttributes<any> {
-    mask: string;
-    formatCharacters?: CharsFormatters | undefined;
-    placeholderChar?: string | undefined;
-}
-
-declare class MaskedInput extends React.Component<MaskedInputProps> {}
-export default MaskedInput;
+export = MaskedInput;

--- a/types/react-maskedinput/react-maskedinput-tests.tsx
+++ b/types/react-maskedinput/react-maskedinput-tests.tsx
@@ -1,22 +1,92 @@
 import * as React from "react";
-import MaskedInput from "react-maskedinput";
+import MaskedInput, { CharsFormatters, FormatCharacter, MaskedInputProps } from "react-maskedinput";
 
-class Test extends React.Component {
-    render() {
-        return (
-            <MaskedInput
-                mask="111"
-                placeholderChar="X"
-                formatCharacters={{
-                    a: {
-                        validate: (char: string) => char,
-                        transform: (char: string) => char,
-                    },
-                }}
-                name="react-maskedinput-test"
-                placeholder="XXX"
-                disabled={false}
-            />
-        );
-    }
+// props.mask is required.
+// @ts-expect-error
+<MaskedInput />;
+
+// $ExpectType Element
+<MaskedInput mask="111" />;
+
+// Can put usual React.InputHTMLAttributes into props
+// $ExpectType Element
+<MaskedInput
+    mask="111"
+    name="react-maskedinput-test"
+    placeholder="XXX"
+    disabled={false}
+/>;
+
+// $ExpectType Element
+<MaskedInput
+    mask="111"
+    placeholderChar="X"
+/>;
+
+// props.formatCharacters[char].validate() is required.
+<MaskedInput
+    mask="111"
+    // @ts-expect-error
+    formatCharacters={{ a: {} }}
+/>;
+
+// props.formatCharacters[char].transform() is optional.
+// $ExpectType Element
+<MaskedInput
+    mask="111"
+    formatCharacters={{
+        a: {
+            validate: (char) => {
+                // $ExpectType string
+                char;
+                return char;
+            },
+        },
+    }}
+/>;
+
+// $ExpectType Element
+<MaskedInput
+    mask="111"
+    formatCharacters={{
+        a: {
+            validate: (char) => {
+                // $ExpectType string
+                char;
+                return char;
+            },
+            transform: (char) => {
+                // $ExpectType string
+                char;
+                return char;
+            },
+        },
+    }}
+/>;
+
+// Testing for invalid props in React.InputHTMLAttributes
+{
+    <MaskedInput
+        mask="111"
+        // @ts-expect-error
+        maxLength={3}
+    />;
+
+    <MaskedInput
+        mask="111"
+        // @ts-expect-error
+        onKeyDown={() => {}}
+    />;
+
+    <MaskedInput
+        mask="111"
+        // @ts-expect-error
+        onKeyPress={() => {}}
+    />;
+
+    <MaskedInput
+        mask="111"
+        // @ts-expect-error
+        onPaste={() => {}}
+    />;
 }


### PR DESCRIPTION
- Fix `export =` issue.
- Add jsdoc according to [project readme](https://www.npmjs.com/package/react-maskedinput)
- Ban props that are not allowed for the component. See [this section](https://www.npmjs.com/package/react-maskedinput#other-props).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
