### PR TITLE
[node] Update typings to v22.7.0

### DIFF
--- a/types/node/diagnostics_channel.d.ts
+++ b/types/node/diagnostics_channel.d.ts
@@ -540,11 +540,11 @@ declare module "diagnostics_channel" {
          * @param args Optional arguments to pass to the function
          * @return The return value of the given function
          */
-        traceCallback<Fn extends (this: any, ...args: any) => any>(
+        traceCallback<Fn extends (this: any, ...args: any[]) => any>(
             fn: Fn,
-            position: number | undefined,
-            context: ContextType | undefined,
-            thisArg: any,
+            position?: number,
+            context?: ContextType,
+            thisArg?: any,
             ...args: Parameters<Fn>
         ): void;
     }

--- a/types/node/inspector.d.ts
+++ b/types/node/inspector.d.ts
@@ -1705,6 +1705,10 @@ declare module 'inspector' {
     }
     namespace Network {
         /**
+         * Resource type as it was perceived by the rendering engine.
+         */
+        type ResourceType = string;
+        /**
          * Unique request identifier.
          */
         type RequestId = string;
@@ -1722,6 +1726,21 @@ declare module 'inspector' {
         interface Request {
             url: string;
             method: string;
+            headers: Headers;
+        }
+        /**
+         * HTTP response data.
+         */
+        interface Response {
+            url: string;
+            status: number;
+            statusText: string;
+            headers: Headers;
+        }
+        /**
+         * Request / response headers as keys / values of JSON object.
+         */
+        interface Headers {
         }
         interface RequestWillBeSentEventDataType {
             /**
@@ -1750,6 +1769,32 @@ declare module 'inspector' {
              * Timestamp.
              */
             timestamp: MonotonicTime;
+            /**
+             * Resource type.
+             */
+            type: ResourceType;
+            /**
+             * Response data.
+             */
+            response: Response;
+        }
+        interface LoadingFailedEventDataType {
+            /**
+             * Request identifier.
+             */
+            requestId: RequestId;
+            /**
+             * Timestamp.
+             */
+            timestamp: MonotonicTime;
+            /**
+             * Resource type.
+             */
+            type: ResourceType;
+            /**
+             * Error message.
+             */
+            errorText: string;
         }
         interface LoadingFinishedEventDataType {
             /**
@@ -2260,6 +2305,7 @@ declare module 'inspector' {
          * Fired when HTTP response is available.
          */
         addListener(event: 'Network.responseReceived', listener: (message: InspectorNotification<Network.ResponseReceivedEventDataType>) => void): this;
+        addListener(event: 'Network.loadingFailed', listener: (message: InspectorNotification<Network.LoadingFailedEventDataType>) => void): this;
         addListener(event: 'Network.loadingFinished', listener: (message: InspectorNotification<Network.LoadingFinishedEventDataType>) => void): this;
         /**
          * This event is fired instead of `Runtime.executionContextDestroyed` when
@@ -2302,6 +2348,7 @@ declare module 'inspector' {
         emit(event: 'NodeWorker.receivedMessageFromWorker', message: InspectorNotification<NodeWorker.ReceivedMessageFromWorkerEventDataType>): boolean;
         emit(event: 'Network.requestWillBeSent', message: InspectorNotification<Network.RequestWillBeSentEventDataType>): boolean;
         emit(event: 'Network.responseReceived', message: InspectorNotification<Network.ResponseReceivedEventDataType>): boolean;
+        emit(event: 'Network.loadingFailed', message: InspectorNotification<Network.LoadingFailedEventDataType>): boolean;
         emit(event: 'Network.loadingFinished', message: InspectorNotification<Network.LoadingFinishedEventDataType>): boolean;
         emit(event: 'NodeRuntime.waitingForDisconnect'): boolean;
         emit(event: 'NodeRuntime.waitingForDebugger'): boolean;
@@ -2408,6 +2455,7 @@ declare module 'inspector' {
          * Fired when HTTP response is available.
          */
         on(event: 'Network.responseReceived', listener: (message: InspectorNotification<Network.ResponseReceivedEventDataType>) => void): this;
+        on(event: 'Network.loadingFailed', listener: (message: InspectorNotification<Network.LoadingFailedEventDataType>) => void): this;
         on(event: 'Network.loadingFinished', listener: (message: InspectorNotification<Network.LoadingFinishedEventDataType>) => void): this;
         /**
          * This event is fired instead of `Runtime.executionContextDestroyed` when
@@ -2524,6 +2572,7 @@ declare module 'inspector' {
          * Fired when HTTP response is available.
          */
         once(event: 'Network.responseReceived', listener: (message: InspectorNotification<Network.ResponseReceivedEventDataType>) => void): this;
+        once(event: 'Network.loadingFailed', listener: (message: InspectorNotification<Network.LoadingFailedEventDataType>) => void): this;
         once(event: 'Network.loadingFinished', listener: (message: InspectorNotification<Network.LoadingFinishedEventDataType>) => void): this;
         /**
          * This event is fired instead of `Runtime.executionContextDestroyed` when
@@ -2640,6 +2689,7 @@ declare module 'inspector' {
          * Fired when HTTP response is available.
          */
         prependListener(event: 'Network.responseReceived', listener: (message: InspectorNotification<Network.ResponseReceivedEventDataType>) => void): this;
+        prependListener(event: 'Network.loadingFailed', listener: (message: InspectorNotification<Network.LoadingFailedEventDataType>) => void): this;
         prependListener(event: 'Network.loadingFinished', listener: (message: InspectorNotification<Network.LoadingFinishedEventDataType>) => void): this;
         /**
          * This event is fired instead of `Runtime.executionContextDestroyed` when
@@ -2756,6 +2806,7 @@ declare module 'inspector' {
          * Fired when HTTP response is available.
          */
         prependOnceListener(event: 'Network.responseReceived', listener: (message: InspectorNotification<Network.ResponseReceivedEventDataType>) => void): this;
+        prependOnceListener(event: 'Network.loadingFailed', listener: (message: InspectorNotification<Network.LoadingFailedEventDataType>) => void): this;
         prependOnceListener(event: 'Network.loadingFinished', listener: (message: InspectorNotification<Network.LoadingFinishedEventDataType>) => void): this;
         /**
          * This event is fired instead of `Runtime.executionContextDestroyed` when
@@ -2853,6 +2904,7 @@ declare module 'inspector' {
      */
     const console: InspectorConsole;
 
+    // DevTools protocol event broadcast methods
     namespace Network {
         /**
          * This feature is only available with the `--experimental-network-inspection` flag enabled.
@@ -2881,6 +2933,15 @@ declare module 'inspector' {
          * @experimental
          */
         function loadingFinished(params: LoadingFinishedEventDataType): void;
+        /**
+         * This feature is only available with the `--experimental-network-inspection` flag enabled.
+         *
+         * Broadcasts the `Network.loadingFailed` event to connected frontends. This event indicates that
+         * HTTP request has failed to load.
+         * @since v22.7.0
+         * @experimental
+         */
+        function loadingFailed(params: LoadingFailedEventDataType): void;
     }
 }
 
@@ -3357,6 +3418,7 @@ declare module 'inspector/promises' {
          * Fired when HTTP response is available.
          */
         addListener(event: 'Network.responseReceived', listener: (message: InspectorNotification<Network.ResponseReceivedEventDataType>) => void): this;
+        addListener(event: 'Network.loadingFailed', listener: (message: InspectorNotification<Network.LoadingFailedEventDataType>) => void): this;
         addListener(event: 'Network.loadingFinished', listener: (message: InspectorNotification<Network.LoadingFinishedEventDataType>) => void): this;
         /**
          * This event is fired instead of `Runtime.executionContextDestroyed` when
@@ -3399,6 +3461,7 @@ declare module 'inspector/promises' {
         emit(event: 'NodeWorker.receivedMessageFromWorker', message: InspectorNotification<NodeWorker.ReceivedMessageFromWorkerEventDataType>): boolean;
         emit(event: 'Network.requestWillBeSent', message: InspectorNotification<Network.RequestWillBeSentEventDataType>): boolean;
         emit(event: 'Network.responseReceived', message: InspectorNotification<Network.ResponseReceivedEventDataType>): boolean;
+        emit(event: 'Network.loadingFailed', message: InspectorNotification<Network.LoadingFailedEventDataType>): boolean;
         emit(event: 'Network.loadingFinished', message: InspectorNotification<Network.LoadingFinishedEventDataType>): boolean;
         emit(event: 'NodeRuntime.waitingForDisconnect'): boolean;
         emit(event: 'NodeRuntime.waitingForDebugger'): boolean;
@@ -3505,6 +3568,7 @@ declare module 'inspector/promises' {
          * Fired when HTTP response is available.
          */
         on(event: 'Network.responseReceived', listener: (message: InspectorNotification<Network.ResponseReceivedEventDataType>) => void): this;
+        on(event: 'Network.loadingFailed', listener: (message: InspectorNotification<Network.LoadingFailedEventDataType>) => void): this;
         on(event: 'Network.loadingFinished', listener: (message: InspectorNotification<Network.LoadingFinishedEventDataType>) => void): this;
         /**
          * This event is fired instead of `Runtime.executionContextDestroyed` when
@@ -3621,6 +3685,7 @@ declare module 'inspector/promises' {
          * Fired when HTTP response is available.
          */
         once(event: 'Network.responseReceived', listener: (message: InspectorNotification<Network.ResponseReceivedEventDataType>) => void): this;
+        once(event: 'Network.loadingFailed', listener: (message: InspectorNotification<Network.LoadingFailedEventDataType>) => void): this;
         once(event: 'Network.loadingFinished', listener: (message: InspectorNotification<Network.LoadingFinishedEventDataType>) => void): this;
         /**
          * This event is fired instead of `Runtime.executionContextDestroyed` when
@@ -3737,6 +3802,7 @@ declare module 'inspector/promises' {
          * Fired when HTTP response is available.
          */
         prependListener(event: 'Network.responseReceived', listener: (message: InspectorNotification<Network.ResponseReceivedEventDataType>) => void): this;
+        prependListener(event: 'Network.loadingFailed', listener: (message: InspectorNotification<Network.LoadingFailedEventDataType>) => void): this;
         prependListener(event: 'Network.loadingFinished', listener: (message: InspectorNotification<Network.LoadingFinishedEventDataType>) => void): this;
         /**
          * This event is fired instead of `Runtime.executionContextDestroyed` when
@@ -3853,6 +3919,7 @@ declare module 'inspector/promises' {
          * Fired when HTTP response is available.
          */
         prependOnceListener(event: 'Network.responseReceived', listener: (message: InspectorNotification<Network.ResponseReceivedEventDataType>) => void): this;
+        prependOnceListener(event: 'Network.loadingFailed', listener: (message: InspectorNotification<Network.LoadingFailedEventDataType>) => void): this;
         prependOnceListener(event: 'Network.loadingFinished', listener: (message: InspectorNotification<Network.LoadingFinishedEventDataType>) => void): this;
         /**
          * This event is fired instead of `Runtime.executionContextDestroyed` when

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -43,6 +43,9 @@ declare module "net" {
          */
         callback(bytesWritten: number, buffer: Uint8Array): boolean;
     }
+    // TODO: remove empty ConnectOpts placeholder at next major @types/node version.
+    /** @deprecated */
+    interface ConnectOpts {}
     interface TcpSocketConnectOpts {
         port: number;
         host?: string | undefined;

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -29,6 +29,7 @@ declare module "net" {
     interface SocketConstructorOpts {
         fd?: number | undefined;
         allowHalfOpen?: boolean | undefined;
+        onread?: OnReadOpts | undefined;
         readable?: boolean | undefined;
         writable?: boolean | undefined;
         signal?: AbortSignal;
@@ -37,20 +38,12 @@ declare module "net" {
         buffer: Uint8Array | (() => Uint8Array);
         /**
          * This function is called for every chunk of incoming data.
-         * Two arguments are passed to it: the number of bytes written to buffer and a reference to buffer.
-         * Return false from this function to implicitly pause() the socket.
+         * Two arguments are passed to it: the number of bytes written to `buffer` and a reference to `buffer`.
+         * Return `false` from this function to implicitly `pause()` the socket.
          */
-        callback(bytesWritten: number, buf: Uint8Array): boolean;
+        callback(bytesWritten: number, buffer: Uint8Array): boolean;
     }
-    interface ConnectOpts {
-        /**
-         * If specified, incoming data is stored in a single buffer and passed to the supplied callback when data arrives on the socket.
-         * Note: this will cause the streaming functionality to not provide any data, however events like 'error', 'end', and 'close' will
-         * still be emitted as normal and methods like pause() and resume() will also behave as expected.
-         */
-        onread?: OnReadOpts | undefined;
-    }
-    interface TcpSocketConnectOpts extends ConnectOpts {
+    interface TcpSocketConnectOpts {
         port: number;
         host?: string | undefined;
         localAddress?: string | undefined;
@@ -70,7 +63,7 @@ declare module "net" {
          */
         autoSelectFamilyAttemptTimeout?: number | undefined;
     }
-    interface IpcSocketConnectOpts extends ConnectOpts {
+    interface IpcSocketConnectOpts {
         path: string;
     }
     type SocketConnectOpts = TcpSocketConnectOpts | IpcSocketConnectOpts;

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "22.6.9999",
+    "version": "22.7.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [

--- a/types/node/scripts/generate-inspector/inspector.d.ts.template
+++ b/types/node/scripts/generate-inspector/inspector.d.ts.template
@@ -156,6 +156,7 @@ declare module 'inspector' {
      */
     const console: InspectorConsole;
 
+    // DevTools protocol event broadcast methods
     namespace Network {
         /**
          * This feature is only available with the `--experimental-network-inspection` flag enabled.
@@ -184,6 +185,15 @@ declare module 'inspector' {
          * @experimental
          */
         function loadingFinished(params: LoadingFinishedEventDataType): void;
+        /**
+         * This feature is only available with the `--experimental-network-inspection` flag enabled.
+         *
+         * Broadcasts the `Network.loadingFailed` event to connected frontends. This event indicates that
+         * HTTP request has failed to load.
+         * @since v22.7.0
+         * @experimental
+         */
+        function loadingFailed(params: LoadingFailedEventDataType): void;
     }
 }
 

--- a/types/node/test/net.ts
+++ b/types/node/test/net.ts
@@ -47,6 +47,13 @@ import * as net from "node:net";
     let _socket: net.Socket = new net.Socket({
         fd: 1,
         allowHalfOpen: false,
+        onread: {
+            buffer: Buffer.alloc(4 * 1024),
+            callback: (bytesWritten, buffer) => {
+                console.log(Buffer.from(buffer).toString("utf-8", 0, bytesWritten));
+                return true;
+            },
+        },
         readable: false,
         writable: false,
     });


### PR DESCRIPTION
https://github.com/nodejs/node/releases/tag/v22.7.0

- inspector: support `Network.loadingFailed` event

...and that's really about it. Includes a couple of small documentation-only changes from the 22.7 changelog.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V22.md#22.7.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
