### PR TITLE
Swap function signatures in Backbone types

### DIFF
--- a/types/backbone/backbone-tests.ts
+++ b/types/backbone/backbone-tests.ts
@@ -257,6 +257,8 @@ function test_collection() {
     // This gives better type checking than declaring an `any` overload.
     books.add({ title: "Title 2", author: "Mikey" });
 
+    const booksArray: Book[] = books.add([{ title: "Title 3", author: "Mickey" }]);
+
     const model: Book = book1.collection.first();
     if (model !== book1) {
         throw new Error("Error");

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -336,8 +336,8 @@ declare namespace Backbone {
             | { bivarianceHack(element: TModel): number | string }["bivarianceHack"]
             | { bivarianceHack(compare: TModel, to?: TModel): number }["bivarianceHack"];
 
-        add(model: {} | TModel, options?: AddOptions): TModel;
         add(models: Array<{} | TModel>, options?: AddOptions): TModel[];
+        add(model: {} | TModel, options?: AddOptions): TModel;
         at(index: number): TModel;
         /**
          * Get a model from a collection, specified by an id, a cid, or by passing in a model.


### PR DESCRIPTION
**Why**

TypeScript uses the first type signature that matches. In this case,
Array is a sub-class of `{}`, so it thinks `add` will always return a
single model. Swapping the order makes it so that TypeScript correctly
expects the function to return an array of models when it is given an
array.
