### PR TITLE
oauth2-server: fix AbstractGrantType class

### DIFF
--- a/types/oauth2-server/index.d.ts
+++ b/types/oauth2-server/index.d.ts
@@ -97,21 +97,30 @@ declare namespace OAuth2Server {
         redirect(url: string): void;
     }
 
+    interface AbstractGrantOptions extends TokenOptions {
+        model: BaseModel
+    }
+
     abstract class AbstractGrantType {
+        model: BaseModel;
+        accessTokenLifetime?: number | undefined;
+        refreshTokenLifetime?: number | undefined;
+        alwaysIssueNewRefreshToken?: boolean | undefined;
+        
         /**
          * Instantiates AbstractGrantType using the supplied options.
          */
-        constructor(options: TokenOptions);
+        constructor(options: AbstractGrantOptions);
 
         /**
          * Generate access token. Calls Model#generateAccessToken() if implemented.
          */
-        generateAccessToken(client: Client, user: User, scope: string | string[]): Promise<string>;
+        generateAccessToken(client: Client, user: User, scope: Scope): Promise<string>;
 
         /**
          * Generate refresh token. Calls Model#generateRefreshToken() if implemented.
          */
-        generateRefreshToken(client: Client, user: User, scope: string | string[]): Promise<string>;
+        generateRefreshToken(client: Client, user: User, scope: Scope): Promise<string>;
 
         /**
          * Get access token expiration date.
@@ -131,7 +140,7 @@ declare namespace OAuth2Server {
         /**
          * Validate requested scope. Calls Model#validateScope() if implemented.
          */
-        validateScope(user: User, client: Client, scope: string | string[]): Promise<string | string[] | Falsey>;
+        validateScope(user: User, client: Client, scope: Scope): Promise<Scope | Falsey>;
 
         /**
          * Retrieve info from the request and client and return token
@@ -150,7 +159,7 @@ declare namespace OAuth2Server {
         /**
          * The scope(s) to authenticate.
          */
-        scope?: string | string[] | undefined;
+        scope?: Scope | undefined;
 
         /**
          * Set the X-Accepted-OAuth-Scopes HTTP header on response objects.
@@ -227,6 +236,8 @@ declare namespace OAuth2Server {
      */
     type Falsey = "" | 0 | false | null | undefined;
 
+    type Scope = string | string[];
+
     interface BaseModel {
         /**
          * Invoked to generate a new access token.
@@ -234,7 +245,7 @@ declare namespace OAuth2Server {
         generateAccessToken?(
             client: Client,
             user: User,
-            scope: string | string[],
+            scope: Scope,
             callback?: Callback<string>,
         ): Promise<string>;
 
@@ -250,7 +261,7 @@ declare namespace OAuth2Server {
         /**
          * Invoked to save an access token and optionally a refresh token, depending on the grant type.
          */
-        saveToken(token: Token, client: Client, user: User, callback?: Callback<Token>): Promise<Token | Falsey>;
+        saveToken(token: PartialToken, client: Client, user: User, callback?: Callback<Token>): Promise<Token | Falsey>;
     }
 
     interface RequestAuthenticationModel {
@@ -262,7 +273,7 @@ declare namespace OAuth2Server {
         /**
          * Invoked during request authentication to check if the provided access token was authorized the requested scopes.
          */
-        verifyScope(token: Token, scope: string | string[], callback?: Callback<boolean>): Promise<boolean>;
+        verifyScope(token: Token, scope: Scope, callback?: Callback<boolean>): Promise<boolean>;
     }
 
     interface AuthorizationCodeModel extends BaseModel, RequestAuthenticationModel {
@@ -272,7 +283,7 @@ declare namespace OAuth2Server {
         generateRefreshToken?(
             client: Client,
             user: User,
-            scope: string | string[],
+            scope: Scope,
             callback?: Callback<string>,
         ): Promise<string>;
 
@@ -282,7 +293,7 @@ declare namespace OAuth2Server {
         generateAuthorizationCode?(
             client: Client,
             user: User,
-            scope: string | string[],
+            scope: Scope,
             callback?: Callback<string>,
         ): Promise<string>;
 
@@ -315,9 +326,9 @@ declare namespace OAuth2Server {
         validateScope?(
             user: User,
             client: Client,
-            scope: string | string[],
+            scope: Scope,
             callback?: Callback<string | Falsey>,
-        ): Promise<string | string[] | Falsey>;
+        ): Promise<Scope | Falsey>;
     }
 
     interface PasswordModel extends BaseModel, RequestAuthenticationModel {
@@ -327,7 +338,7 @@ declare namespace OAuth2Server {
         generateRefreshToken?(
             client: Client,
             user: User,
-            scope: string | string[],
+            scope: Scope,
             callback?: Callback<string>,
         ): Promise<string>;
 
@@ -342,9 +353,9 @@ declare namespace OAuth2Server {
         validateScope?(
             user: User,
             client: Client,
-            scope: string | string[],
+            scope: Scope,
             callback?: Callback<string | Falsey>,
-        ): Promise<string | string[] | Falsey>;
+        ): Promise<Scope | Falsey>;
     }
 
     interface RefreshTokenModel extends BaseModel, RequestAuthenticationModel {
@@ -354,7 +365,7 @@ declare namespace OAuth2Server {
         generateRefreshToken?(
             client: Client,
             user: User,
-            scope: string | string[],
+            scope: Scope,
             callback?: Callback<string>,
         ): Promise<string>;
 
@@ -381,9 +392,9 @@ declare namespace OAuth2Server {
         validateScope?(
             user: User,
             client: Client,
-            scope: string | string[],
+            scope: Scope,
             callback?: Callback<string | Falsey>,
-        ): Promise<string | string[] | Falsey>;
+        ): Promise<Scope | Falsey>;
     }
 
     interface ExtensionModel extends BaseModel, RequestAuthenticationModel {}
@@ -415,7 +426,7 @@ declare namespace OAuth2Server {
         authorizationCode: string;
         expiresAt: Date;
         redirectUri: string;
-        scope?: string | string[] | undefined;
+        scope?: Scope | undefined;
         client: Client;
         user: User;
         [key: string]: any;
@@ -429,9 +440,18 @@ declare namespace OAuth2Server {
         accessTokenExpiresAt?: Date | undefined;
         refreshToken?: string | undefined;
         refreshTokenExpiresAt?: Date | undefined;
-        scope?: string | string[] | undefined;
+        scope?: Scope | undefined;
         client: Client;
         user: User;
+        [key: string]: any;
+    }
+
+    interface PartialToken {
+        scope?: Scope;
+        accessToken: string;
+        accessTokenExpiresAt?: Date | undefined;
+        refreshToken?: string | undefined;
+        refreshTokenExpiresAt?: Date | undefined;
         [key: string]: any;
     }
 
@@ -441,7 +461,7 @@ declare namespace OAuth2Server {
     interface RefreshToken {
         refreshToken: string;
         refreshTokenExpiresAt?: Date | undefined;
-        scope?: string | string[] | undefined;
+        scope?: Scope | undefined;
         client: Client;
         user: User;
         [key: string]: any;

--- a/types/oauth2-server/index.d.ts
+++ b/types/oauth2-server/index.d.ts
@@ -98,7 +98,7 @@ declare namespace OAuth2Server {
     }
 
     interface AbstractGrantOptions extends TokenOptions {
-        model: BaseModel
+        model: BaseModel;
     }
 
     abstract class AbstractGrantType {
@@ -106,7 +106,7 @@ declare namespace OAuth2Server {
         accessTokenLifetime?: number | undefined;
         refreshTokenLifetime?: number | undefined;
         alwaysIssueNewRefreshToken?: boolean | undefined;
-        
+
         /**
          * Instantiates AbstractGrantType using the supplied options.
          */

--- a/types/oauth2-server/oauth2-server-tests.ts
+++ b/types/oauth2-server/oauth2-server-tests.ts
@@ -137,8 +137,8 @@ class CustomGrantType extends OAuth2Server.AbstractGrantType {
     }
 
     async handle(request: OAuth2Server.Request, client: OAuth2Server.Client) {
-        if (!request) throw new OAuth2Server.InvalidArgumentError('Missing `request`');
-        if (!client) throw new OAuth2Server.InvalidArgumentError('Missing `client`');
+        if (!request) throw new OAuth2Server.InvalidArgumentError("Missing `request`");
+        if (!client) throw new OAuth2Server.InvalidArgumentError("Missing `client`");
 
         const scope = this.getScope(request);
         const user = {};
@@ -146,7 +146,11 @@ class CustomGrantType extends OAuth2Server.AbstractGrantType {
         return this.saveToken(user, client, scope);
     }
 
-    async saveToken(user: OAuth2Server.User, client: OAuth2Server.Client, scope: string): Promise<OAuth2Server.Token | OAuth2Server.Falsey> {
+    async saveToken(
+        user: OAuth2Server.User,
+        client: OAuth2Server.Client,
+        scope: string,
+    ): Promise<OAuth2Server.Token | OAuth2Server.Falsey> {
         this.validateScope(user, client, scope);
 
         let token: OAuth2Server.PartialToken = {
@@ -159,6 +163,4 @@ class CustomGrantType extends OAuth2Server.AbstractGrantType {
 
         return this.model.saveToken(token, client, user);
     }
-
 }
-

--- a/types/oauth2-server/oauth2-server-tests.ts
+++ b/types/oauth2-server/oauth2-server-tests.ts
@@ -130,3 +130,35 @@ app.get(
 );
 
 app.listen(3000);
+
+class CustomGrantType extends OAuth2Server.AbstractGrantType {
+    constructor(opts: OAuth2Server.AbstractGrantOptions) {
+        super(opts);
+    }
+
+    async handle(request: OAuth2Server.Request, client: OAuth2Server.Client) {
+        if (!request) throw new OAuth2Server.InvalidArgumentError('Missing `request`');
+        if (!client) throw new OAuth2Server.InvalidArgumentError('Missing `client`');
+
+        const scope = this.getScope(request);
+        const user = {};
+
+        return this.saveToken(user, client, scope);
+    }
+
+    async saveToken(user: OAuth2Server.User, client: OAuth2Server.Client, scope: string): Promise<OAuth2Server.Token | OAuth2Server.Falsey> {
+        this.validateScope(user, client, scope);
+
+        let token: OAuth2Server.PartialToken = {
+            accessToken: await this.generateAccessToken(client, user, scope),
+            accessTokenExpiresAt: this.getAccessTokenExpiresAt(),
+            refreshToken: await this.generateRefreshToken(client, user, scope),
+            refreshTokenExpiresAt: this.getRefreshTokenExpiresAt(),
+            scope,
+        };
+
+        return this.model.saveToken(token, client, user);
+    }
+
+}
+


### PR DESCRIPTION
I was following the documentation to add an Extension Grant, and ran into type errors:

The abstract grant type was missing a model in its constructor options, but excluding one caused an error in the JavaScript.

Furthermore, BaseModel.saveToken does NOT use the client and user within the token, instead using separate parameters for these, so I switched the argument to a PartialToken type omitting them, to avoid confusion and so the upstream example code passes type checks.

The test is updated with example code from [the library's documentation on Extension Grants](https://node-oauthoauth2-server.readthedocs.io/en/master/misc/extension-grants.html)

I also added a Scope type to simplify things.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <https://node-oauthoauth2-server.readthedocs.io/en/master/misc/extension-grants.html>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
