### PR TITLE
fix(multiparty): refine parse callback signature, bump version

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -1329,7 +1329,6 @@
         "msgpack",
         "mu2",
         "mudder",
-        "multiparty",
         "musickit-js",
         "musicmatch",
         "mysql-import",

--- a/types/multiparty/index.d.ts
+++ b/types/multiparty/index.d.ts
@@ -12,7 +12,14 @@ export declare class Form extends events.EventEmitter {
      * @param request
      * @param callback
      */
-    parse(request: http.IncomingMessage, callback?: (error: Error, fields: any, files: any) => any): void;
+    parse(
+        request: http.IncomingMessage,
+        callback?: (
+            error: Error | null,
+            fields: Record<string, string[] | undefined>,
+            files: Record<string, string[] | undefined>,
+        ) => void,
+    ): void;
 
     on(event: "part", listener: (part: Part) => void): this;
     on(event: "close", listener: () => void): this;

--- a/types/multiparty/multiparty-tests.ts
+++ b/types/multiparty/multiparty-tests.ts
@@ -4,8 +4,8 @@ import util = require("util");
 
 http.createServer(function(req: http.IncomingMessage, res: http.ServerResponse) {
     if (req.url === "/upload" && req.method === "POST") {
-        var count = 0;
-        var form = new multiparty.Form();
+        let count = 0;
+        const form = new multiparty.Form();
 
         // Errors may be emitted
         // Note that if you are listening to 'part' events, the same error may be
@@ -56,6 +56,16 @@ http.createServer(function(req: http.IncomingMessage, res: http.ServerResponse) 
 
         // Parse req
         form.parse(req);
+
+        form.parse(req, (error, fields, files) => {
+            if (error instanceof Error) {
+                error; // $ExpectType Error
+            } else {
+                error; // $ExpectType null
+                fields; // $ExpectType Record<string, string[] | undefined>
+                files; // $ExpectType Record<string, string[] | undefined>
+            }
+        });
     }
 
     // show a file upload form

--- a/types/multiparty/package.json
+++ b/types/multiparty/package.json
@@ -1,9 +1,9 @@
 {
     "private": true,
     "name": "@types/multiparty",
-    "version": "0.0.9999",
+    "version": "4.2.9999",
     "projects": [
-        "https://github.com/andrewrk/node-multiparty"
+        "https://github.com/pillarjs/multiparty"
     ],
     "dependencies": {
         "@types/node": "*"


### PR DESCRIPTION
- Refine parse callback signature
    - See the [source code](https://github.com/pillarjs/multiparty/blob/master/index.js#L122-L141).
    - `fields` and `files` are now "corrected" as `Record<string, string[]>`.
    - `error` becomes `Error | null`.
- Bump version

Note: Overloaded function signature is not suitable for error-result type callback.
Consumer would not be able to implicitly type the callback parameters and have proper type inference.
See [typescript issue #25352](https://github.com/microsoft/TypeScript/issues/25352)

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
