### PR TITLE
Add expirationTime to the PushSubscription in the web-push package

### DIFF
--- a/types/web-push/index.d.ts
+++ b/types/web-push/index.d.ts
@@ -205,6 +205,7 @@ export function setVapidDetails(subject: string, publicKey: string, privateKey: 
  */
 export interface PushSubscription {
     endpoint: string;
+    expirationTime?: null | number;
     keys: {
         p256dh: string;
         auth: string;

--- a/types/web-push/web-push-tests.ts
+++ b/types/web-push/web-push-tests.ts
@@ -169,6 +169,7 @@ setVapidDetails("subject", "publicKey", buffer);
 
 const pushSubscription: PushSubscription = {
     endpoint: "endpointString",
+    expirationTime: null,
     keys: {
         p256dh: "p256dhString",
         auth: "authString",
@@ -282,7 +283,7 @@ generateRequestDetails({ endpoint: null, keys: { p256dh: "p256dh", auth: "auth" 
 // @ts-expect-error
 generateRequestDetails({ endpoint: "endpoint", keys: null });
 
-generateRequestDetails({ endpoint: "endpoint", keys: { p256dh: "p256dh", auth: "auth" } });
+generateRequestDetails({ endpoint: "endpoint", expirationTime: null, keys: { p256dh: "p256dh", auth: "auth" } });
 
 // RequestOptions is optional
 generateRequestDetails(pushSubscription, "payload");


### PR DESCRIPTION
The JSON strigified PushSubscription object may have a expirationTime property. This is documented in the toJSON method at https://developer.mozilla.org/en-US/docs/Web/API/PushSubscription/toJSON

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [PushSubscription.toJSON](https://developer.mozilla.org/en-US/docs/Web/API/PushSubscription/toJSON)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. --  I believe the library already is accounting for this, but was omitted in the type declarations here
