### PR TITLE
[Chrome] add missing `webRequestAuthProvider` permission

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -7448,7 +7448,8 @@ declare namespace chrome.runtime {
         | "wallpaper"
         | "webNavigation"
         | "webRequest"
-        | "webRequestBlocking";
+        | "webRequestBlocking"
+        | "webRequestAuthProvider";
 
     export interface SearchProvider {
         name?: string | undefined;

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -11718,7 +11718,14 @@ declare namespace chrome.webRequest {
     export var onSendHeaders: WebRequestHeadersEvent;
     /** Fired when HTTP response headers of a request have been received. */
     export var onHeadersReceived: WebResponseHeadersEvent;
-    /** Fired when an authentication failure is received. The listener has three options: it can provide authentication credentials, it can cancel the request and display the error page, or it can take no action on the challenge. If bad user credentials are provided, this may be called multiple times for the same request. */
+    /**
+     * Fired when an authentication failure is received.
+     * The listener has three options: it can provide authentication credentials, it can cancel the request and display the error page, or it can take no action on the challenge.
+     * If bad user credentials are provided, this may be called multiple times for the same request.
+     * Note, only one of `blocking` or `asyncBlocking` modes must be specified in the extraInfoSpec parameter.
+     *
+     * Requires the `webRequestAuthProvider` permission.
+     */
     export var onAuthRequired: WebAuthenticationChallengeEvent;
     /** Fired when the first byte of the response body is received. For HTTP requests, this means that the status line and response headers are available. */
     export var onResponseStarted: WebResponseCacheEvent;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/webRequest?hl=en#permissions
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.


Use cases :
```json
{
  "permissions": [
    "webRequest",
    "webRequestAuthProvider"
  ]
}
```

A screenshot of runtime : 
![image](https://github.com/user-attachments/assets/e08ff75c-2119-4351-93f6-a233490cb524)

