### PR TITLE
Allow overriding Backbone model with a function

### DIFF
--- a/types/backbone/backbone-tests.ts
+++ b/types/backbone/backbone-tests.ts
@@ -232,6 +232,12 @@ class Library extends Backbone.Collection<Book> {
     }
 }
 
+class AnotherLibrary extends Backbone.Collection<Book> {
+    model = (...args: any[]): Book => {
+        return new Book();
+    };
+}
+
 class Books extends Backbone.Collection<Book> {}
 
 class ArbitraryCollection extends Backbone.Collection {}

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -311,7 +311,7 @@ declare namespace Backbone {
          */
         static extend(properties: any, classProperties?: any): any;
 
-        model: new(...args: any[]) => TModel;
+        model: (new(...args: any[]) => TModel) | ((...args: any[]) => TModel);
         models: TModel[];
         length: number;
 


### PR DESCRIPTION
The `model:` property on Backbone Collections defaults to a constructor.
However, they also allow for it to be a function that [dynamically
returns an instance][dy]. Unfortunately, due to limitations in
TypeScript this [cannot be defined as a method][me]. However, we can
assign it as an arrow function instead.

[dy]: http://backbonejs.org/#Collection-model
[me]: https://github.com/Microsoft/TypeScript/issues/27965
