### PR TITLE
[@type/express-serve-static-core] Allow express RequestHandler to return Response

### DIFF
--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -326,3 +326,7 @@ app.get("/:readonly", req => {
 
 // Starting with Express 5 RequestHandler can be async
 app.get("/async", Promise.resolve);
+
+// RequestHandler can return a value
+app.get("/test", (_, res) => res.json("ok"));
+app.get("/test", async (_, res) => res.json(await "ok"));

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -61,7 +61,7 @@ export interface RequestHandler<
         req: Request<P, ResBody, ReqBody, ReqQuery, LocalsObj>,
         res: Response<ResBody, LocalsObj>,
         next: NextFunction,
-    ): void | Promise<void>;
+    ): unknown;
 }
 
 export type ErrorRequestHandler<
@@ -75,7 +75,7 @@ export type ErrorRequestHandler<
     req: Request<P, ResBody, ReqBody, ReqQuery, LocalsObj>,
     res: Response<ResBody, LocalsObj>,
     next: NextFunction,
-) => void | Promise<void>;
+) => unknown;
 
 export type PathParams = string | RegExp | Array<string | RegExp>;
 


### PR DESCRIPTION
In v4 we used to write handler with a compact syntax like this
```typescript
app.get("/response", (_, res) => res.json('ok'));
```

This was possible because;
* from javascript perspective, express don't care about the returned value of the handler, so returning something doesn't matter
* from typescript perspective, due to the specific handling of `void` returning function, it's possible to return anything in a void function.

However, as noted in  #70563 using `void | Promise<void>` cannot accept anything, including `Response` or `Promise<Response>`

The PR change the return type of `RequestHandler` to permit to return `Response` in addition to `void` (and the same for async/Promise)

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
