### PR TITLE
fix(svg-arc-to-cubic-bezier): fix "export =", add jsdoc

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -1705,7 +1705,6 @@
         "stylis",
         "succinct",
         "suitescript",
-        "svg-arc-to-cubic-bezier",
         "svg-injector",
         "svg-maps__common",
         "svgjs.draggable",

--- a/types/svg-arc-to-cubic-bezier/index.d.ts
+++ b/types/svg-arc-to-cubic-bezier/index.d.ts
@@ -1,22 +1,37 @@
-export interface Arc {
-    px: number;
-    py: number;
-    cx: number;
-    cy: number;
-    rx: number;
-    ry: number;
-    xAxisRotation: number;
-    largeArcFlag: 0 | 1;
-    sweepFlag: 0 | 1;
+declare namespace arcToBezier {
+    interface Arc {
+        px: number;
+
+        py: number;
+
+        cx: number;
+
+        cy: number;
+
+        rx: number;
+
+        ry: number;
+
+        /** @default 0 */
+        xAxisRotation: number;
+
+        /** @default 0 */
+        largeArcFlag: 0 | 1;
+
+        /** @default 0 */
+        sweepFlag: 0 | 1;
+    }
+
+    interface CubicBezierCurve {
+        x1: number;
+        y1: number;
+        x2: number;
+        y2: number;
+        x: number;
+        y: number;
+    }
 }
 
-export interface CubicBezierCurve {
-    x1: number;
-    y1: number;
-    x2: number;
-    y2: number;
-    x: number;
-    y: number;
-}
+declare function arcToBezier(x: arcToBezier.Arc): arcToBezier.CubicBezierCurve[];
 
-export default function arcToBezier(x: Arc): CubicBezierCurve[];
+export = arcToBezier;

--- a/types/svg-arc-to-cubic-bezier/svg-arc-to-cubic-bezier-tests.ts
+++ b/types/svg-arc-to-cubic-bezier/svg-arc-to-cubic-bezier-tests.ts
@@ -17,4 +17,8 @@ arc.largeArcFlag = 0;
 arc.sweepFlag = 0;
 
 // $ExpectType CubicBezierCurve[]
-const curves: CubicBezierCurve[] = arcToBezier(arc);
+arcToBezier(arc);
+
+// Should pass argument to the function
+// @ts-expect-error
+arcToBezier();


### PR DESCRIPTION
Newly added jsdoc default value can be found from the [source code](https://github.com/colinmeinke/svg-arc-to-cubic-bezier/blob/f02ab118609817ee562c69aea98579ecd3eb810e/src/index.js#L122-L124).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
