### PR TITLE
[navermaps] bounds type update

### DIFF
--- a/types/navermaps/index.d.ts
+++ b/types/navermaps/index.d.ts
@@ -22,11 +22,11 @@ declare namespace naver.maps {
     type BoundsLiteral = PointBoundsLiteral | LatLngBoundsLiteral;
     type CoordLiteral = PointLiteral | LatLngLiteral;
     type Coord = Point | LatLng;
-    type Bounds = PointBounds | LatLngBounds;
+    type Bounds = PointBounds & LatLngBounds;
     type DOMEvent = Event;
     type StylingFunction = (feature: Feature) => StyleOptions;
     type ArrayOfCoords = Point[] | LatLng[];
-    type ArrayOfBounds = PointBounds[] | LatLngBounds[];
+    type ArrayOfBounds = PointBounds[] & LatLngBounds[];
     type ArrayOfBoundsLiteral = PointBoundsLiteral[] | LatLngBoundsLiteral[];
     type forEachOverlayCallback = (overlay: Marker | Polyline | Polygon, index: number) => void;
     type GeoJSON = GeoJSON.Feature<GeoJSON.Geometry> | GeoJSON.FeatureCollection<GeoJSON.Geometry>;

--- a/types/navermaps/navermaps-tests.ts
+++ b/types/navermaps/navermaps-tests.ts
@@ -530,17 +530,44 @@ expectType<naver.maps.Point>(new naver.maps.Point(1, 1));
 new naver.maps.LatLngBounds([-100, -90, 100, 90]);
 new naver.maps.LatLngBounds(new naver.maps.LatLng(37.5, 126.9), new naver.maps.LatLng(37.5, 126.9));
 expectType<naver.maps.LatLngBounds>(
-    naver.maps.LatLngBounds.bounds(new naver.maps.LatLng(-180, -90), new naver.maps.LatLng(0, 0)),
+    naver.maps.LatLngBounds.bounds(new naver.maps.LatLng(-180, -90), new naver.maps.LatLng(0, 0))
 );
+
+let latLngBounds = map.getBounds();
+hasTypes(latLngBounds, "hasLatLng");
+hasTypes(latLngBounds, "getNE");
+
+latLngBounds.getNE();
 
 /**
  * PointBounds
  */
+
 new naver.maps.PointBounds([0, 0, 10, 10]);
 new naver.maps.PointBounds(new naver.maps.Point(-10, -10), new naver.maps.Point(10, 10));
 expectType<naver.maps.PointBounds>(
-    naver.maps.PointBounds.bounds(new naver.maps.Point(-1, -1), new naver.maps.Point(0, 0)),
+    naver.maps.PointBounds.bounds(new naver.maps.Point(-1, -1), new naver.maps.Point(0, 0))
 );
+
+let pointBounds = map.getBounds();
+hasTypes(pointBounds, "hasPoint");
+hasTypes(pointBounds, "west");
+
+pointBounds.west();
+
+/**
+ *
+ * @param object 확인하려는 객체
+ * @param property 확인하려는 속성 이름
+ * @returns property 존재 여부
+ *
+ * @example
+ * let pointBounds = map.getBounds();
+ * hasTypes(pointBounds, "hasPoint"); // true
+ */
+function hasTypes<T extends object, P extends keyof T>(object: T, property: P): property is P {
+    return property in object;
+}
 
 function expectType<T>(value: T) {
     return value;

--- a/types/navermaps/navermaps-tests.ts
+++ b/types/navermaps/navermaps-tests.ts
@@ -530,7 +530,7 @@ expectType<naver.maps.Point>(new naver.maps.Point(1, 1));
 new naver.maps.LatLngBounds([-100, -90, 100, 90]);
 new naver.maps.LatLngBounds(new naver.maps.LatLng(37.5, 126.9), new naver.maps.LatLng(37.5, 126.9));
 expectType<naver.maps.LatLngBounds>(
-    naver.maps.LatLngBounds.bounds(new naver.maps.LatLng(-180, -90), new naver.maps.LatLng(0, 0))
+    naver.maps.LatLngBounds.bounds(new naver.maps.LatLng(-180, -90), new naver.maps.LatLng(0, 0)),
 );
 
 let latLngBounds = map.getBounds();
@@ -546,7 +546,7 @@ latLngBounds.getNE();
 new naver.maps.PointBounds([0, 0, 10, 10]);
 new naver.maps.PointBounds(new naver.maps.Point(-10, -10), new naver.maps.Point(10, 10));
 expectType<naver.maps.PointBounds>(
-    naver.maps.PointBounds.bounds(new naver.maps.Point(-1, -1), new naver.maps.Point(0, 0))
+    naver.maps.PointBounds.bounds(new naver.maps.Point(-1, -1), new naver.maps.Point(0, 0)),
 );
 
 let pointBounds = map.getBounds();
@@ -556,7 +556,6 @@ hasTypes(pointBounds, "west");
 pointBounds.west();
 
 /**
- *
  * @param object 확인하려는 객체
  * @param property 확인하려는 속성 이름
  * @returns property 존재 여부


### PR DESCRIPTION
ENG

While following the official document example, I found that the type inference in [**Marker Example**](https://navermaps.github.io/maps.js.ncp/docs/tutorial-2-Marker.html) only looking at the current screen) behaves differently than the type guided by the document.

The document says that the Bounds type can be inferred as LatLngBounds and getSW, getNE can be used
In fact, when you follow the example, it is inferred as PointBounds and guides you that there are no such properties. (Attached a screenshot)

![스크린샷 2024-09-27 오전 11 25 16](https://github.com/user-attachments/assets/ef0e2197-613f-4315-8473-7a219fbac2f8)

Because LatLngBounds is already an inheritance relationship with PointBounds, we tried to erase PointBounds from the Bounds type and designate it as LatLngBounds single type, but we combined the two types by modifying the Union type to intersection to create a type that satisfies both types according to the document's guidance.

```ts
// before
type Bounds = PointBounds | LatLngBounds;

// after
type Bounds = PointBounds & LatLngBounds;
```

---

KOR

공식문서 예제를 따라하던 중 [**현재 화면만 보는 마커 예제**](https://navermaps.github.io/maps.js.ncp/docs/tutorial-2-Marker.html)의 타입 추론이 문서에서 안내하는 타입과 다르게 동작하는 것을 발견했습니다.

문서 상에는 Bounds 타입이 LatLngBounds 로 추론되어 getSW, getNE 을 사용할 수 있다고 안내되어있는데
실제로 예제를 따라해봤을 때에는 PointBounds 으로 추론되어 해당 속성들이 없다고 안내하고 있습니다. (스크린샷 첨부)

![스크린샷 2024-09-27 오전 11 25 16](https://github.com/user-attachments/assets/ef0e2197-613f-4315-8473-7a219fbac2f8)

LatLngBounds 이 이미 PointBounds 와 상속관계이기 때문에 Bounds 타입에서 PointBounds 을 지우고 LatLngBounds 단일 타입으로 지정하려고 했으나 문서의 안내에 따라 두 타입을 모두 만족시키는 타입을 만들기 위해서 유니온 타입을 인터섹션으로 수정하여 두 타입을 결합시켰습니다.

```ts
// before
type Bounds = PointBounds | LatLngBounds;

// after
type Bounds = PointBounds & LatLngBounds;
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [네이버지도 API](https://navermaps.github.io/maps.js.ncp/docs/tutorial-2-Marker.html)

If removing a declaration:

