### PR TITLE
Make `@types/relay-runtime` compatible with Relay@18's `@catch` directive

### DIFF
--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -266,3 +266,16 @@ export type FragmentRefs<Refs extends string> = {
 
 // This is a utility type for converting from a data type to a fragment reference that will resolve to that data type.
 export type FragmentRef<Fragment> = Fragment extends _RefType<infer U> ? _FragmentRefs<U> : never;
+
+type ErrorResult<Error> = {
+    ok: false,
+    errors: ReadOnlyArray<Error>,
+};
+  
+type OkayResult<T> = {
+    ok: true,
+    value: T,
+};
+
+// The type returned by fields annotated with `@catch`
+export type Result<T, Error> = OkayResult<T> | ErrorResult<Error>;

--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -267,15 +267,15 @@ export type FragmentRefs<Refs extends string> = {
 // This is a utility type for converting from a data type to a fragment reference that will resolve to that data type.
 export type FragmentRef<Fragment> = Fragment extends _RefType<infer U> ? _FragmentRefs<U> : never;
 
-type ErrorResult<Error> = {
-    ok: false,
-    errors: ReadOnlyArray<Error>,
-};
-  
-type OkayResult<T> = {
-    ok: true,
-    value: T,
-};
+interface ErrorResult<Error> {
+    ok: false;
+    errors: readonly Error[];
+}
+
+interface OkayResult<T> {
+    ok: true;
+    value: T;
+}
 
 // The type returned by fields annotated with `@catch`
 export type Result<T, Error> = OkayResult<T> | ErrorResult<Error>;

--- a/types/relay-runtime/package.json
+++ b/types/relay-runtime/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/relay-runtime",
-    "version": "18.0.0",
+    "version": "18.0.9999",
     "projects": [
         "https://github.com/facebook/relay",
         "https://facebook.github.io/relay"

--- a/types/relay-runtime/package.json
+++ b/types/relay-runtime/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/relay-runtime",
-    "version": "17.0.9999",
+    "version": "18.0.0",
     "projects": [
         "https://github.com/facebook/relay",
         "https://facebook.github.io/relay"

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -848,10 +848,11 @@ export function myLiveState(): LiveState<string> {
 // ~~~~~~~~~~~~~~~~~~
 // @catch directive's Result
 // ~~~~~~~~~~~~~~~~~~
+// eslint-disable-next-line @definitelytyped/no-unnecessary-generics
 export function handleResult<T, E>(result: Result<T, E>) {
     if (result.ok) {
         const value: T = result.value;
     } else {
-        const errors: ReadonlyArray<E> = result.error;
+        const errors: readonly E[] = result.errors;
     }
 }

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -26,6 +26,7 @@ import {
     RecordSource,
     RecordSourceSelectorProxy,
     requestSubscription,
+    Result,
     ROOT_ID,
     ROOT_TYPE,
     Store,
@@ -842,4 +843,15 @@ export function myLiveState(): LiveState<string> {
             return unsubscribe;
         },
     };
+}
+
+// ~~~~~~~~~~~~~~~~~~
+// @catch directive's Result
+// ~~~~~~~~~~~~~~~~~~
+export function handleResult<T, E>(result: Result<T, E>) {
+    if (result.ok) {
+        const value: T = result.value;
+    } else {
+        const errors: ReadonlyArray<E> = result.error;
+    }
 }


### PR DESCRIPTION
This PR:

- Exports a `Result` type from `@types/relay-runtime`, which is consumed by TS files generated by the Relay compiler when the `@catch` directive is used. The TS types are based on Relay's own Flow types ([ref](https://github.com/facebook/relay/blob/main/packages/relay-runtime/experimental.js#L34-L44)).
- Bumps package version to 18 to match the Relay version it corresponds to

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/relay/blob/main/packages/relay-runtime/experimental.js#L34-L44
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
