### PR TITLE
fix(gulp-help-doc): Move types/node to dev dep, bump version

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -983,7 +983,6 @@
         "gulp-coffeeify",
         "gulp-dtsm",
         "gulp-espower",
-        "gulp-help-doc",
         "gulp-imagemin",
         "gulp-load-plugins",
         "gulp-mocha",

--- a/types/gulp-help-doc/gulp-help-doc-tests.ts
+++ b/types/gulp-help-doc/gulp-help-doc-tests.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 import gulp = require("gulp");
 import usage = require("gulp-help-doc");
 

--- a/types/gulp-help-doc/index.d.ts
+++ b/types/gulp-help-doc/index.d.ts
@@ -1,48 +1,89 @@
-/// <reference types="node" />
-/// <reference types="gulp" />
+import gulp = require("gulp");
 
-declare module "gulp-help-doc" {
-    import gulp = require("gulp");
+declare namespace usage {
+    interface UsageOptions {
+        /**
+         * Defines max line width for the printed output lines.
+         *
+         * @default 80
+         */
+        lineWidth?: number | undefined;
 
-    namespace usage {
-        interface UsageOptions {
-            /**
-             * Defines  max line width for the printed output lines
-             * (by default is 80 characters long)
-             */
-            lineWidth?: number | undefined;
+        /**
+         * Defines max width of the column width tasks or args names.
+         *
+         * @default 20
+         */
+        keysColumnWidth?: number | undefined;
 
-            /**
-             * Defines max width of the column width tasks or args names
-             * (by default is 20 characters long)
-             */
-            keysColumnWidth?: number | undefined;
+        /**
+         * Defines number of empty characters for left-padding of the output.
+         * @default 4
+         */
+        padding?: number | undefined;
 
-            /**
-             * Defines number of empty characters for left-padding of the output
-             */
-            padding?: number | undefined;
+        /**
+         * Defines number of empty characters before group name output.
+         *
+         * @default 1
+         */
+        groupPadding?: number | undefined;
 
-            /**
-             * Printing engine (by default is console). Accepted any device
-             * which has log() function defined to do output.
-             */
-            logger?: { log: Function } | undefined;
+        /**
+         * Undocumented option.
+         *
+         * @default "magenta"
+         */
+        groupColor?: string | undefined;
 
-            /**
-             * Path to a gulpfile (default is gulpfile.js)
-             * Normally, there is no need to change this option. It may be used
-             * for some special cases, like mocking gulpfile for testing.
-             */
-            gulpfile?: string | undefined;
-        }
+        /**
+         * Printing engine. Accepted any device which has log() function defined to do output.
+         *
+         * @default console
+         */
+        logger?: { log: (message: string) => void } | undefined;
 
-        interface Usage {
-            (gulp: gulp.Gulp, options?: UsageOptions): Promise<any>;
-        }
+        /**
+         * Undocumented option.
+         *
+         * @default fs.existsSync('gulpfile.ts')
+         */
+        isTypescript?: boolean | undefined;
+
+        /**
+         * Path to a gulpfile.
+         * Normally, there is no need to change this option. It may be used
+         * for some special cases, like mocking gulpfile for testing.
+         */
+        gulpfile?: string | undefined;
+
+        /**
+         * if set to true, prints the task dependencies below its help description.
+         *
+         * @default true
+         */
+        displayDependencies?: boolean | undefined;
+
+        /**
+         * if set to true, prints an empty line between tasks help descriptions.
+         *
+         * @default true
+         */
+        emptyLineBetweenTasks?: boolean | undefined;
+
+        /**
+         * if group tag is not specified it will use specified group name.
+         *
+         * @default "Common tasks"
+         */
+        defaultGroupName?: string | undefined;
     }
 
-    var usage: usage.Usage;
-
-    export = usage;
+    interface Usage {
+        (gulp: gulp.Gulp, options?: UsageOptions): Promise<any>;
+    }
 }
+
+declare const usage: usage.Usage;
+
+export = usage;

--- a/types/gulp-help-doc/package.json
+++ b/types/gulp-help-doc/package.json
@@ -1,16 +1,16 @@
 {
     "private": true,
     "name": "@types/gulp-help-doc",
-    "version": "0.0.9999",
+    "version": "1.1.9999",
     "projects": [
         "https://github.com/Mikhus/gulp-help-doc"
     ],
     "dependencies": {
-        "@types/gulp": "*",
-        "@types/node": "*"
+        "@types/gulp": "*"
     },
     "devDependencies": {
-        "@types/gulp-help-doc": "workspace:."
+        "@types/gulp-help-doc": "workspace:.",
+        "@types/node": "*"
     },
     "owners": [
         {


### PR DESCRIPTION
See the [source code](https://github.com/Mikhus/gulp-help-doc/blob/e00fb0dbd347a72b35b5395827900f9e8c460240/index.js#L53-L65) for the newly-added / modified default value in jsdoc.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
