### PR TITLE
Update node tests for TS5.7

### DIFF
--- a/types/node/test/globals-dom.ts
+++ b/types/node/test/globals-dom.ts
@@ -61,8 +61,8 @@
     const stream = new ReadableStream<string>({ start: (controller) => controller.enqueue("hello") }); // $ExpectType ReadableStream<string>
     const compressionStream = new CompressionStream("gzip");
     const encodedStream = stream.pipeThrough(new TextEncoderStream()); // $ExpectType ReadableStream<Uint8Array> || ReadableStream<Uint8Array<ArrayBufferLike>>
-    const compressedStream = encodedStream.pipeThrough(compressionStream); // $ExpectType ReadableStream<any>
-    compressedStream.pipeThrough(new DecompressionStream("gzip")); // $ExpectType ReadableStream<any>
+    const compressedStream = encodedStream.pipeThrough(compressionStream); // $ExpectType ReadableStream<any> || ReadableStream<Uint8Array<ArrayBufferLike>>
+    compressedStream.pipeThrough(new DecompressionStream("gzip")); // $ExpectType ReadableStream<any> || ReadableStream<Uint8Array<ArrayBufferLike>>
     void (async () => {
         const reader = compressedStream.getReader();
         const readNext = async () => {


### PR DESCRIPTION
`CompressionStream.readable` is now generic: `ReadableStream<Uint8Array>`. 

Required by the TS 5.7 PR: https://github.com/microsoft/TypeScript/pull/60061
