### PR TITLE
fix(react-show-more): Fix for "export =", add jsdoc, modify tests

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -1555,7 +1555,6 @@
         "react-router-redux",
         "react-rte",
         "react-s-alert",
-        "react-show-more",
         "react-sidebar",
         "react-sortable-tree-theme-file-explorer",
         "react-sortable-tree",

--- a/types/react-show-more/index.d.ts
+++ b/types/react-show-more/index.d.ts
@@ -1,12 +1,42 @@
 import * as React from "react";
 
-export interface ReactShowMoreProps {
-    lines?: number | undefined;
-    more?: string | undefined;
-    less?: string | undefined;
-    children?: string | undefined;
-    anchorClass?: string | undefined;
+declare namespace ReactShowMore {
+    interface ReactShowMoreProps {
+        /**
+         * Specifies how many lines of text should be preserved until it gets truncated. false and
+         * any integer < 1 will result in the text not getting clipped at all.
+         *
+         * @default false
+         */
+        lines?: number | false | undefined;
+
+        /**
+         * The text to display in the anchor element to show more.
+         *
+         * @default "Show more"
+         */
+        more?: React.ReactNode | undefined;
+
+        /**
+         * The text to display in the anchor element to show less.
+         *
+         * @default "Show less"
+         */
+        less?: React.ReactNode | undefined;
+
+        /**
+         * The text to be truncated. Anything that can be evaluated as text.
+         */
+        children?: React.ReactNode | undefined;
+
+        /**
+         * Class name(s) to add to the anchor elements.
+         *
+         * @default ""
+         */
+        anchorClass?: string | undefined;
+    }
 }
 
-declare const ShowMore: React.ClassicComponentClass<ReactShowMoreProps>;
-export default ShowMore;
+declare class ReactShowMore extends React.Component<ReactShowMore.ReactShowMoreProps> {}
+export = ReactShowMore;

--- a/types/react-show-more/react-show-more-tests.tsx
+++ b/types/react-show-more/react-show-more-tests.tsx
@@ -1,14 +1,25 @@
 import * as React from "react";
-import ShowMore from "react-show-more";
+import ShowMore, { ReactShowMoreProps } from "react-show-more";
 
-const longText =
-    "scenester Banksy single-origin coffee squid flannel XOXO chillwave Helvetica plaid slow-carb drinking vinegar Wes Anderson gastropub";
+const longText = (
+    <p>
+        scenester Banksy single-origin coffee squid flannel XOXO chillwave Helvetica plaid slow-carb drinking vinegar
+        Wes Anderson gastropub
+    </p>
+);
 
-<ShowMore
-    lines={3}
-    more="Show more"
-    less="Show less"
-    anchorClass=""
->
-    {longText}
-</ShowMore>;
+<ShowMore>{longText}</ShowMore>;
+
+<ShowMore lines={false}>{longText}</ShowMore>;
+<ShowMore lines={-1}>{longText}</ShowMore>;
+<ShowMore lines={0}>{longText}</ShowMore>;
+<ShowMore lines={1}>{longText}</ShowMore>;
+
+<ShowMore more="Show more">{longText}</ShowMore>;
+<ShowMore more={<span>Show more</span>}>{longText}</ShowMore>;
+
+<ShowMore more="Show less">{longText}</ShowMore>;
+<ShowMore more={<span>Show less</span>}>{longText}</ShowMore>;
+
+<ShowMore anchorClass={"my-anchor-class"}>{longText}</ShowMore>;
+<ShowMore anchorClass={"class-1 class-2"}>{longText}</ShowMore>;


### PR DESCRIPTION
Please refer to [the npm page](https://www.npmjs.com/package/react-show-more) for the added jsdoc in this PR.

--- 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
