### PR TITLE
[node] Update typings to v20.17.0

### DIFF
--- a/types/node/v20/package.json
+++ b/types/node/v20/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "20.16.9999",
+    "version": "20.17.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [

--- a/types/node/v20/path.d.ts
+++ b/types/node/v20/path.d.ts
@@ -95,6 +95,15 @@ declare module "path" {
              */
             resolve(...paths: string[]): string;
             /**
+             * The `path.matchesGlob()` method determines if `path` matches the `pattern`.
+             * @param path The path to glob-match against.
+             * @param pattern The glob to check the path against.
+             * @returns Whether or not the `path` matched the `pattern`.
+             * @throws {TypeError} if `path` or `pattern` are not strings.
+             * @since v20.17.0
+             */
+            matchesGlob(path: string, pattern: string): boolean;
+            /**
              * Determines whether {path} is an absolute path. An absolute path will always resolve to the same location, regardless of the working directory.
              *
              * If the given {path} is a zero-length string, `false` will be returned.

--- a/types/node/v20/stream.d.ts
+++ b/types/node/v20/stream.d.ts
@@ -1250,6 +1250,25 @@ declare module "stream" {
             removeListener(event: "unpipe", listener: (src: Readable) => void): this;
             removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
         }
+        /**
+         * The utility function `duplexPair` returns an Array with two items,
+         * each being a `Duplex` stream connected to the other side:
+         *
+         * ```js
+         * const [ sideA, sideB ] = duplexPair();
+         * ```
+         *
+         * Whatever is written to one stream is made readable on the other. It provides
+         * behavior analogous to a network connection, where the data written by the client
+         * becomes readable by the server, and vice-versa.
+         *
+         * The Duplex streams are symmetrical; one or the other may be used without any
+         * difference in behavior.
+         * @param options A value to pass to both {@link Duplex} constructors,
+         * to set options such as buffering.
+         * @since v20.17.0
+         */
+        function duplexPair(options?: DuplexOptions): [Duplex, Duplex];
         type TransformCallback = (error?: Error | null, data?: any) => void;
         interface TransformOptions extends DuplexOptions {
             construct?(this: Transform, callback: (error?: Error | null) => void): void;

--- a/types/node/v20/test/path.ts
+++ b/types/node/v20/test/path.ts
@@ -33,6 +33,8 @@ path.resolve("wwwroot", "static_files/png/", "../gif/image.gif");
 // if currently in /home/myself/node, it returns
 //    '/home/myself/node/wwwroot/static_files/gif/image.gif'
 
+path.matchesGlob("/foo/bar", "/foo/*"); // ExpectType boolean
+
 path.isAbsolute("/foo/bar"); // true
 path.isAbsolute("/baz/.."); // true
 path.isAbsolute("qux/"); // false

--- a/types/node/v20/test/stream.ts
+++ b/types/node/v20/test/stream.ts
@@ -2,6 +2,7 @@ import { createReadStream, createWriteStream } from "node:fs";
 import {
     addAbortSignal,
     Duplex,
+    duplexPair,
     finished,
     isErrored,
     isReadable,
@@ -615,6 +616,14 @@ addAbortSignal(new AbortSignal(), new Readable());
     const duplex = new Duplex();
     // $ExpectType { readable: ReadableStream<any>; writable: WritableStream<any>; }
     Duplex.toWeb(duplex);
+}
+
+{
+    const [duplexLeft, duplexRight] = duplexPair();
+    // $ExpectType Duplex
+    duplexLeft;
+    // $ExpectType Duplex
+    duplexRight;
 }
 
 {


### PR DESCRIPTION
https://github.com/nodejs/node/releases/tag/v20.17.0

- path: add `matchesGlob` method
- stream: add `duplexPair` function

Note these changes are just copied from the v22 definitions now these features have been backported.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/releases/tag/v20.17.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.