### PR TITLE
fix(esbuild-copy-static-files): Fix "export =", modify types, add jsdoc

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -412,7 +412,6 @@
         "error-cause",
         "es-get-iterator",
         "es6-weak-map",
-        "esbuild-copy-static-files",
         "esbuild-plugin-import-map",
         "eslint__eslintrc",
         "eslint-utils",

--- a/types/esbuild-copy-static-files/esbuild-copy-static-files-tests.ts
+++ b/types/esbuild-copy-static-files/esbuild-copy-static-files-tests.ts
@@ -1,4 +1,40 @@
 import copyStaticFiles from "esbuild-copy-static-files";
 
 // $ExpectType CopyStaticFilesPluginInstance
-copyStaticFiles({ src: "src", dest: "dest", filter: (src, dest) => true, recursive: true });
+copyStaticFiles({ src: "src" });
+
+// $ExpectType CopyStaticFilesPluginInstance
+copyStaticFiles({ dest: "dest" });
+
+// $ExpectType CopyStaticFilesPluginInstance
+copyStaticFiles({ dereference: true });
+
+// $ExpectType CopyStaticFilesPluginInstance
+copyStaticFiles({ errorOnExist: true });
+
+// $ExpectType CopyStaticFilesPluginInstance
+copyStaticFiles({
+    filter: (src, dest) => {
+        src; // $ExpectType string
+        dest; // $ExpectType string
+        return true;
+    },
+});
+
+// $ExpectType CopyStaticFilesPluginInstance
+copyStaticFiles({
+    filter: async (src, dest) => {
+        src; // $ExpectType string
+        dest; // $ExpectType string
+        return true;
+    },
+});
+
+// $ExpectType CopyStaticFilesPluginInstance
+copyStaticFiles({ force: true });
+
+// $ExpectType CopyStaticFilesPluginInstance
+copyStaticFiles({ preserveTimestamps: true });
+
+// $ExpectType CopyStaticFilesPluginInstance
+copyStaticFiles({ recursive: true });

--- a/types/esbuild-copy-static-files/index.d.ts
+++ b/types/esbuild-copy-static-files/index.d.ts
@@ -1,18 +1,78 @@
-export interface CopyStaticFilesOptions {
-    src: string;
-    dest: string;
-    filter: (src: string, dest: string) => boolean;
+/// <reference types="node" />
 
-    dereference: boolean;
-    errorOnExist: boolean;
-    force: boolean;
-    preserveTimestamps: boolean;
-    recursive: boolean;
+import fs from "node:fs";
+
+import { Plugin } from "esbuild";
+
+declare namespace EsbuildCopyStaticFiles {
+    interface CopyStaticFilesOptions {
+        /**
+         * source path to copy.
+         *
+         * @default './static'
+         */
+        src?: string | undefined;
+
+        /**
+         * destination path to copy to.
+         *
+         * @default '../public'
+         */
+        dest?: string | undefined;
+
+        /**
+         * dereference symlinks.
+         *
+         * @default true
+         */
+        dereference?: fs.CopyOptions["dereference"] | undefined;
+
+        /**
+         * when {@link CopyStaticFilesOptions.force|force} is false and the
+         * {@link CopyStaticFilesOptions.dest|destination} exists, throw an error.
+         *
+         * @default false
+         */
+        errorOnExist?: fs.CopyOptions["errorOnExist"] | undefined;
+
+        /**
+         * function to filter copied files / directories. Return true to copy the item, false to
+         * ignore it.
+         */
+        filter?: fs.CopyOptions["filter"] | undefined;
+
+        /**
+         * overwrite existing file or directory. The copy operation will ignore errors if you set
+         * this to false and the {@link CopyStaticFilesOptions.dest|destination} exists. Use the
+         * {@link CopyStaticFilesOptions.errorOnExist|errorOnExist} option to change this behavior.
+         *
+         * @default true
+         */
+        force?: fs.CopyOptions["force"] | undefined;
+
+        /**
+         * when true timestamps from {@link CopyStaticFilesOptions.src|src} will be preserved.
+         *
+         * @default true
+         */
+        preserveTimestamps?: fs.CopyOptions["preserveTimestamps"] | undefined;
+
+        /**
+         * copy directories recursively.
+         *
+         * @default true
+         */
+        recursive?: fs.CopyOptions["recursive"] | undefined;
+    }
+
+    interface CopyStaticFilesPluginInstance {
+        name: "copy-static-files";
+        setup: Plugin["setup"];
+    }
 }
 
-export interface CopyStaticFilesPluginInstance {
-    name: "copy-static-files";
-    setup(build: any): void;
-}
+declare function EsbuildCopyStaticFiles(
+    options?: Partial<EsbuildCopyStaticFiles.CopyStaticFilesOptions>,
+): EsbuildCopyStaticFiles.CopyStaticFilesPluginInstance;
 
-export default function(options?: Partial<CopyStaticFilesOptions>): CopyStaticFilesPluginInstance;
+export = EsbuildCopyStaticFiles;

--- a/types/esbuild-copy-static-files/package.json
+++ b/types/esbuild-copy-static-files/package.json
@@ -5,6 +5,10 @@
     "projects": [
         "https://github.com/nickjj/esbuild-copy-static-files"
     ],
+    "dependencies": {
+        "esbuild": "*",
+        "@types/node": "*"
+    },
     "devDependencies": {
         "@types/esbuild-copy-static-files": "workspace:."
     },


### PR DESCRIPTION
The added jsdoc is based on [readme](https://github.com/nickjj/esbuild-copy-static-files) and the default value is from [source code](https://github.com/nickjj/esbuild-copy-static-files/blob/f3ed5961fdce6cb43bcaef6f13f9bb9bab765e2f/index.js#L37-L49).

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
