### PR TITLE
Make sources optional for JWPlayer playlist

### DIFF
--- a/types/jwplayer/index.d.ts
+++ b/types/jwplayer/index.d.ts
@@ -548,7 +548,7 @@ declare namespace jwplayer {
         minDvrWindow?: number;
         preload?: Preload;
         recommendations?: string;
-        sources: Source[]; // This is a "shortened" version of allSources that only contains one item
+        sources?: Source[]; // This is a "shortened" version of allSources that only contains one item
         starttime?: number;
         tags?: string;
         title: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.jwplayer.com/players/reference/playlists#playlist-1
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

`sources` property is marked as optional in JWPlayer documentation. I am not sure if it was so always or if it was changed, but according to the comment, it had to be optional always (as `allSources` was added as optional from the beginning).

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66478/files#diff-102e1bf672611527350890d751a1f8b3de987ecb5de593dcd21cc9e7cfb7c2deR565