### PR TITLE
fix(maxmsp): LiveApi constructor arguments as optional

### DIFF
--- a/types/maxmsp/index.d.ts
+++ b/types/maxmsp/index.d.ts
@@ -608,7 +608,7 @@ declare class LiveAPI {
      * (the object sends a bang from its left outlet when the Device is fully initialized, including the Live API). Legacy note: previous versions of the LiveAPI object required the jsthis object's
      * this.patcher property as the first argument. For backward-compatibility, this first argument is still supported, but is no longer necessary.
      */
-    constructor(callback: any, name: string);
+    constructor(callback?: any, name?: string);
 
     /**
      * The id of the Live object referred to by the LiveAPI object. These ids are dynamic and awarded in realtime from the Live application, so should not be stored and used over multiple runs of Max

--- a/types/maxmsp/maxmsp-tests.ts
+++ b/types/maxmsp/maxmsp-tests.ts
@@ -127,6 +127,32 @@ liveApiInstance.call("reset_meter", []);
 liveApiInstance.property = "mute";
 liveApiInstance.mode = 0;
 
+// Create a new LiveAPI object without providing a callback function or a name
+const liveApiInstance_empty = new LiveAPI();
+
+// Accessing properties
+post(liveApiInstance_empty.id);
+post(liveApiInstance_empty.path);
+post(liveApiInstance_empty.unquotedpath);
+post(liveApiInstance_empty.children);
+post(liveApiInstance_empty.mode);
+post(liveApiInstance_empty.type);
+post(liveApiInstance_empty.info);
+post(liveApiInstance_empty.property);
+post(liveApiInstance_empty.proptype);
+
+// Using methods
+post(liveApiInstance_empty.getcount("callable_children"));
+liveApiInstance_empty.goto("live_set tracks 0 devices 1");
+post(liveApiInstance_empty.get("name"));
+post(liveApiInstance_empty.getstring("name"));
+liveApiInstance_empty.set("name", "New Device Name");
+liveApiInstance_empty.call("reset_meter", []);
+
+// Observing property changes
+liveApiInstance_empty.property = "mute";
+liveApiInstance_empty.mode = 0;
+
 // Get the max object from this
 const testmax = this.max;
 

--- a/types/maxmsp/maxmsp-tests.ts
+++ b/types/maxmsp/maxmsp-tests.ts
@@ -103,6 +103,7 @@ const liveApiCallback = (args: any) => {
 };
 
 const liveApiInstance = new LiveAPI(liveApiCallback, "live_set tracks 0 devices 0");
+const liveApiInstance_empty = new LiveAPI();
 
 // Accessing properties
 post(liveApiInstance.id);
@@ -126,32 +127,6 @@ liveApiInstance.call("reset_meter", []);
 // Observing property changes
 liveApiInstance.property = "mute";
 liveApiInstance.mode = 0;
-
-// Create a new LiveAPI object without providing a callback function or a name
-const liveApiInstance_empty = new LiveAPI();
-
-// Accessing properties
-post(liveApiInstance_empty.id);
-post(liveApiInstance_empty.path);
-post(liveApiInstance_empty.unquotedpath);
-post(liveApiInstance_empty.children);
-post(liveApiInstance_empty.mode);
-post(liveApiInstance_empty.type);
-post(liveApiInstance_empty.info);
-post(liveApiInstance_empty.property);
-post(liveApiInstance_empty.proptype);
-
-// Using methods
-post(liveApiInstance_empty.getcount("callable_children"));
-liveApiInstance_empty.goto("live_set tracks 0 devices 1");
-post(liveApiInstance_empty.get("name"));
-post(liveApiInstance_empty.getstring("name"));
-liveApiInstance_empty.set("name", "New Device Name");
-liveApiInstance_empty.call("reset_meter", []);
-
-// Observing property changes
-liveApiInstance_empty.property = "mute";
-liveApiInstance_empty.mode = 0;
 
 // Get the max object from this
 const testmax = this.max;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] (not changed) [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Live Api Object Docs](https://docs.cycling74.com/max8/vignettes/jsliveapi)
- [x] (n/a) If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
