### PR TITLE
big-json: Specify Readable/Transform instead of Stream

### DIFF
--- a/types/big-json/big-json-tests.ts
+++ b/types/big-json/big-json-tests.ts
@@ -1,5 +1,5 @@
 import bigJson = require("big-json");
-import type { Stream } from "node:stream";
+import type { Stream, Transform } from "node:stream";
 
 // ----------------------------------------------------------------
 // stringify
@@ -58,5 +58,7 @@ bigJson.createStringifyStream({ body: "blabla" });
 // ----------------------------------------------------------------
 // createParseStream
 // ----------------------------------------------------------------
-// $ExpectType Stream
+// $ExpectType Transform
 const parseStream = bigJson.createParseStream();
+
+stringifyStream.pipe(parseStream);

--- a/types/big-json/index.d.ts
+++ b/types/big-json/index.d.ts
@@ -1,8 +1,8 @@
 /// <reference types="node" />
 
-import type { Stream } from "node:stream";
+import type { Stream, Transform } from "node:stream";
 
-export function createParseStream(): Stream;
+export function createParseStream(): Transform;
 export function createStringifyStream(opts: { body: object }): Stream;
 
 export function parse(opts: { body: string | Buffer }): Promise<object | readonly object[]>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://github.com/DonutEspresso/big-json/blob/main/lib/index.js#L35-L76 `createParseStream` returns the result of `through2.obj()`, which is specifically a `Transform`: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/through2/index.d.ts#L30

Note that the added test demonstrates the incorrect type; the parse stream returned by `createParseStream` doesn't do you much good if you can't write to it.

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.