### PR TITLE
jsforce: update parameters for SObject.upsertBulk method

### DIFF
--- a/types/jsforce/package.json
+++ b/types/jsforce/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/jsforce",
-    "version": "1.11.9999",
+    "version": "3.5.9999",
     "projects": [
         "https://github.com/jsforce/jsforce"
     ],

--- a/types/jsforce/salesforce-object.d.ts
+++ b/types/jsforce/salesforce-object.d.ts
@@ -26,7 +26,7 @@ export class SObject<T> {
         callback?: Callback<RecordResult[]>,
     ): Promise<RecordResult[]>;
     // should input really be optional? the documentation says so, but how can you actually update without it?
-    updateBulk(input?: Record[] | stream.Stream | string, callback?: Callback<RecordResult[]>): Batch;
+    updateBulk(input?: Record[] | stream.Stream | string, extIdField?: string): Batch;
     updated(
         start: string | Date,
         end: string | Date,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [>> Documentation Reference <<](https://jsforce.github.io/jsforce/classes/sobject.SObject.html#upsertBulk)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

### Note:
I've checked the previous box because my PR reflects a library change from a new version of the library (version 3.x). However my PR fixes only a single method and it's not a comprehensive change to accommodate the entire library update.
