### PR TITLE
[leaflet] Control.options: fixed hardcoded type (allow custom)

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -2503,9 +2503,11 @@ export interface ControlOptions {
     position?: ControlPosition | undefined;
 }
 
-export class Control extends Class {
-    static extend<T extends object>(props: T): { new(...args: any[]): T } & typeof Control;
-    constructor(options?: ControlOptions);
+export class Control<Options extends ControlOptions = ControlOptions> extends Class {
+    static extend<T extends object, Options extends ControlOptions = ControlOptions>(
+        props: T,
+    ): { new(...args: any[]): T } & typeof Control<Options>;
+    constructor(options?: Options);
     getPosition(): ControlPosition;
     setPosition(position: ControlPosition): this;
     getContainer(): HTMLElement | undefined;
@@ -2516,7 +2518,7 @@ export class Control extends Class {
     onAdd?(map: Map): HTMLElement;
     onRemove?(map: Map): void;
 
-    options: ControlOptions;
+    options: Options;
 }
 
 export namespace Control {

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -1002,3 +1002,48 @@ let circleMarker = new L.CircleMarker(latLng, { radius: 10 }).setStyle({});
 circleMarker = new L.CircleMarker(latLng, { radius: 10 }).setStyle({ radius: 10 });
 // @ts-expect-error
 circleMarker = new L.CircleMarker(latLng, { radius: 10 }).setStyle();
+
+// region Control typed custom options
+
+type CustomControlOptions = L.ControlOptions & {
+    foo?: string;
+    bar?: string;
+};
+const CustomControl = L.Control.extend<
+    // required because it's first type (kept for backwards compatibility - if moved second would be optional/inferred)
+    Pick<L.Control<CustomControlOptions>, "options" | "onAdd">,
+    CustomControlOptions
+>({
+    options: {
+        position: "topleft",
+        foo: "ok",
+        // @ts-expect-error
+        bar: 1,
+    },
+    onAdd: function(map: L.Map) {
+        this.options.foo;
+        this.options.bar;
+        // @ts-expect-error
+        this.options.baz;
+
+        return L.DomUtil.create("div");
+    },
+});
+new CustomControl({
+    foo: "foo",
+    // @ts-expect-error
+    bar: 1,
+    // @ts-expect-error
+    position: "center",
+});
+
+L.Control.extend({ options: {}, onAdd: (map: L.Map) => L.DomUtil.create("div") });
+
+new L.Control();
+// @ts-expect-error
+new L.Control<number>();
+// @ts-expect-error
+new L.Control<{ foo: string }>();
+new L.Control<{ foo: string } & L.ControlOptions>();
+
+// endregion


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

    The `options` type is hardcoded, but I actually can provide custom options. To overcome the hardcode I had to override the types like this:
    ```ts
    import leaflet, { ControlOptions } from 'leaflet';

    export type FiltersControlOptions = ControlOptions & {
      foo?: string; // custom option
    };

    // cazy stuff to make the `options` typed
    type FiltersControlInstanceType = InstanceType<typeof leaflet.Control> & { options: FiltersControlOptions };
    type FiltersControlClassType = {
      new (options: FiltersControlOptions): FiltersControlInstanceType;
    };
    type FiltersControlExtendPros = Parameters<(typeof leaflet.Control)['extend']>[0] & {
      options: FiltersControlOptions;
      onAdd: (this: FiltersControlInstanceType, map: leaflet.Map) => HTMLElement;
    };

    const FiltersControl: FiltersControlClassType = leaflet.Control.extend<FiltersControlExtendPros>({
      options: {
        position: 'topleft'
      },
      onAdd: function (map: leaflet.Map) {
        this.options.foo;
      }
    });

    new FiltersControl({ foo: 'foo' );
    ```

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

    I don't know how - it's `1.9.9999` [in code](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/24a32d6bec7e18c6a426b4ae63b1f2b508874184/types/leaflet/package.json#L4), but [the published](https://www.npmjs.com/package/@types/leaflet) version is `1.9.12`

