### PR TITLE
[node] util.parseArgs(): correctly type non-defaulted values with `?:`

### DIFF
--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -270,7 +270,7 @@ access("file/that/does/not/exist", (err) => {
 
     util.parseArgs();
 
-    // $ExpectType { values: { foo: string | undefined; bar: boolean[] | undefined; }; positionals: string[]; }
+    // $ExpectType { values: { foo?: string | undefined; bar?: boolean[] | undefined; }; positionals: string[]; }
     util.parseArgs(config);
 }
 
@@ -322,6 +322,7 @@ access("file/that/does/not/exist", (err) => {
             x: { type: "string", multiple: true },
         },
     });
+
     // $ExpectType (string | boolean)[] | undefined
     result.values.x;
     // $ExpectType string | boolean | undefined
@@ -345,6 +346,10 @@ access("file/that/does/not/exist", (err) => {
         },
         allowNegative: true,
     });
+
+    // $ExpectType { alpha?: boolean | undefined; }
+    result.values;
+
     // $ExpectType boolean | undefined
     result.values.alpha; // false
 }
@@ -360,6 +365,10 @@ access("file/that/does/not/exist", (err) => {
         },
         allowNegative: true,
     });
+
+    // $ExpectType { alpha: boolean; beta?: boolean | undefined; gamma?: boolean | undefined; }
+    result.values;
+
     // $ExpectType boolean
     result.values.alpha; // false
     // $ExpectType boolean | undefined
@@ -377,6 +386,10 @@ access("file/that/does/not/exist", (err) => {
         },
         allowNegative: true,
     });
+
+    // $ExpectType { alpha?: boolean[] | undefined; }
+    result.values;
+
     // $ExpectType boolean[] | undefined
     result.values.alpha; // [false, true, false]
 }
@@ -390,6 +403,10 @@ access("file/that/does/not/exist", (err) => {
         },
         allowNegative: true,
     });
+
+    // $ExpectType { alpha?: boolean | undefined; }
+    result.values;
+
     // $ExpectType boolean | undefined
     result.values.alpha; // true
 }

--- a/types/node/v18/test/util.ts
+++ b/types/node/v18/test/util.ts
@@ -260,7 +260,7 @@ access("file/that/does/not/exist", (err) => {
 
     util.parseArgs();
 
-    // $ExpectType { values: { foo: string | undefined; bar: boolean[] | undefined; }; positionals: string[]; }
+    // $ExpectType { values: { foo?: string | undefined; bar?: boolean[] | undefined; }; positionals: string[]; }
     util.parseArgs(config);
 }
 
@@ -312,6 +312,7 @@ access("file/that/does/not/exist", (err) => {
             x: { type: "string", multiple: true },
         },
     });
+
     // $ExpectType (string | boolean)[] | undefined
     result.values.x;
     // $ExpectType string | boolean | undefined
@@ -324,6 +325,28 @@ access("file/that/does/not/exist", (err) => {
 
     // $ExpectType { values: { [longOption: string]: string | boolean | (string | boolean)[] | undefined; }; positionals: string[]; tokens?: Token[] | undefined; }
     const result = util.parseArgs(config);
+}
+
+{
+    // args are passed with a default
+    const result = util.parseArgs({
+        args: ["--alpha", "--beta"],
+        options: {
+            alpha: { type: "boolean", default: false },
+            beta: { type: "boolean", default: undefined },
+            gamma: { type: "boolean" },
+        },
+    });
+
+    // $ExpectType { alpha: boolean; beta?: boolean | undefined; gamma?: boolean | undefined; }
+    result.values;
+
+    // $ExpectType boolean
+    result.values.alpha; // true
+    // $ExpectType boolean | undefined
+    result.values.beta; // undefined
+    // $ExpectType boolean | undefined
+    result.values.gamma; // undefined
 }
 
 {

--- a/types/node/v18/util.d.ts
+++ b/types/node/v18/util.d.ts
@@ -1393,15 +1393,23 @@ declare module "util" {
         string | boolean
     >;
 
+    type ApplyOptionalModifiers<O extends ParseArgsOptionsConfig, V extends Record<keyof O, unknown>> = (
+        & { -readonly [LongOption in keyof O]?: V[LongOption] }
+        & { [LongOption in keyof O as O[LongOption]["default"] extends {} ? LongOption : never]: V[LongOption] }
+    ) extends infer P ? { [K in keyof P]: P[K] } : never; // resolve intersection to object
+
     type ParsedValues<T extends ParseArgsConfig> =
         & IfDefaultsTrue<T["strict"], unknown, { [longOption: string]: undefined | string | boolean }>
-        & (T["options"] extends ParseArgsOptionsConfig ? {
-                -readonly [LongOption in keyof T["options"]]: IfDefaultsFalse<
-                    T["options"][LongOption]["multiple"],
-                    undefined | Array<ExtractOptionValue<T, T["options"][LongOption]>>,
-                    undefined | ExtractOptionValue<T, T["options"][LongOption]>
-                >;
-            }
+        & (T["options"] extends ParseArgsOptionsConfig ? ApplyOptionalModifiers<
+                T["options"],
+                {
+                    [LongOption in keyof T["options"]]: IfDefaultsFalse<
+                        T["options"][LongOption]["multiple"],
+                        Array<ExtractOptionValue<T, T["options"][LongOption]>>,
+                        ExtractOptionValue<T, T["options"][LongOption]>
+                    >;
+                }
+            >
             : {});
 
     type ParsedPositionals<T extends ParseArgsConfig> = IfDefaultsTrue<

--- a/types/node/v20/test/util.ts
+++ b/types/node/v20/test/util.ts
@@ -270,7 +270,7 @@ access("file/that/does/not/exist", (err) => {
 
     util.parseArgs();
 
-    // $ExpectType { values: { foo: string | undefined; bar: boolean[] | undefined; }; positionals: string[]; }
+    // $ExpectType { values: { foo?: string | undefined; bar?: boolean[] | undefined; }; positionals: string[]; }
     util.parseArgs(config);
 }
 
@@ -322,6 +322,7 @@ access("file/that/does/not/exist", (err) => {
             x: { type: "string", multiple: true },
         },
     });
+
     // $ExpectType (string | boolean)[] | undefined
     result.values.x;
     // $ExpectType string | boolean | undefined
@@ -345,6 +346,10 @@ access("file/that/does/not/exist", (err) => {
         },
         allowNegative: true,
     });
+
+    // $ExpectType { alpha?: boolean | undefined; }
+    result.values;
+
     // $ExpectType boolean | undefined
     result.values.alpha; // false
 }
@@ -355,11 +360,21 @@ access("file/that/does/not/exist", (err) => {
         args: ["--no-alpha"],
         options: {
             alpha: { type: "boolean", default: true },
+            beta: { type: "boolean", default: undefined },
+            gamma: { type: "boolean" },
         },
         allowNegative: true,
     });
-    // $ExpectType boolean | undefined
+
+    // $ExpectType { alpha: boolean; beta?: boolean | undefined; gamma?: boolean | undefined; }
+    result.values;
+
+    // $ExpectType boolean
     result.values.alpha; // false
+    // $ExpectType boolean | undefined
+    result.values.beta; // undefined
+    // $ExpectType boolean | undefined
+    result.values.gamma; // undefined
 }
 
 {
@@ -371,6 +386,10 @@ access("file/that/does/not/exist", (err) => {
         },
         allowNegative: true,
     });
+
+    // $ExpectType { alpha?: boolean[] | undefined; }
+    result.values;
+
     // $ExpectType boolean[] | undefined
     result.values.alpha; // [false, true, false]
 }
@@ -384,6 +403,10 @@ access("file/that/does/not/exist", (err) => {
         },
         allowNegative: true,
     });
+
+    // $ExpectType { alpha?: boolean | undefined; }
+    result.values;
+
     // $ExpectType boolean | undefined
     result.values.alpha; // true
 }

--- a/types/node/v20/util.d.ts
+++ b/types/node/v20/util.d.ts
@@ -1517,15 +1517,23 @@ declare module "util" {
         string | boolean
     >;
 
+    type ApplyOptionalModifiers<O extends ParseArgsOptionsConfig, V extends Record<keyof O, unknown>> = (
+        & { -readonly [LongOption in keyof O]?: V[LongOption] }
+        & { [LongOption in keyof O as O[LongOption]["default"] extends {} ? LongOption : never]: V[LongOption] }
+    ) extends infer P ? { [K in keyof P]: P[K] } : never; // resolve intersection to object
+
     type ParsedValues<T extends ParseArgsConfig> =
         & IfDefaultsTrue<T["strict"], unknown, { [longOption: string]: undefined | string | boolean }>
-        & (T["options"] extends ParseArgsOptionsConfig ? {
-                -readonly [LongOption in keyof T["options"]]: IfDefaultsFalse<
-                    T["options"][LongOption]["multiple"],
-                    undefined | Array<ExtractOptionValue<T, T["options"][LongOption]>>,
-                    undefined | ExtractOptionValue<T, T["options"][LongOption]>
-                >;
-            }
+        & (T["options"] extends ParseArgsOptionsConfig ? ApplyOptionalModifiers<
+                T["options"],
+                {
+                    [LongOption in keyof T["options"]]: IfDefaultsFalse<
+                        T["options"][LongOption]["multiple"],
+                        Array<ExtractOptionValue<T, T["options"][LongOption]>>,
+                        ExtractOptionValue<T, T["options"][LongOption]>
+                    >;
+                }
+            >
             : {});
 
     type ParsedPositionals<T extends ParseArgsConfig> = IfDefaultsTrue<


### PR DESCRIPTION
See: #70766

Follows on from the changes in #70420.

The behaviour of `util.parseArgs()` has always been that the returned `values` object only defines properties for args that are either present, or declared with a valid default.

Originally, the definitions in @types/node added `values` properties for _all_ declared args, whether they were defaulted or not, with a property type of `T | undefined`. The above PR improved on that, only adding `| undefined` to args that didn't have a default value.

However, since Node doesn't actually declare properties for args that don't end up with a value, the correct format for a non-defaulted arg here is `name?: T`, not `name: T | undefined`. This discrepancy becomes apparent if `exactOptionalPropertyTypes` is enabled, as per the linked discussion.

This changeset updates the logic to correct this, and backports the changes to v18/v20. (Note that the types in the tests are resolved as `name?: T | undefined`, since the tests run with `exactOptionalPropertyTypes: false`, but testing with it enabled causes the `| undefined` to vanish as expected.)

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/blob/main/lib/internal/util/parse_args/parse_args.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
