### PR TITLE
rax: fix JSX RaxFragment usage/export

### DIFF
--- a/types/rax/index.d.ts
+++ b/types/rax/index.d.ts
@@ -211,6 +211,7 @@ declare namespace Rax {
     interface RaxNodeArray extends Array<RaxNode> {}
     type RaxFragment = {} | RaxNodeArray;
     type RaxNode = RaxChild | RaxFragment | RaxPortal | boolean | null | undefined;
+    export const RaxFragment: FunctionComponent<{}>
 
     /**
      * ======================================================================

--- a/types/rax/test/hooks.tsx
+++ b/types/rax/test/hooks.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line jsdoc/check-tag-names
 /** @jsxFrag RaxFragment */
 import {
     ComponentRef,

--- a/types/rax/test/hooks.tsx
+++ b/types/rax/test/hooks.tsx
@@ -1,3 +1,4 @@
+/** @jsxFrag RaxFragment */
 import {
     ComponentRef,
     createContext,
@@ -5,6 +6,7 @@ import {
     forwardRef,
     MutableRefObject,
     RaxNode,
+    RaxFragment,
     Ref,
     RefObject,
     useCallback,


### PR DESCRIPTION
Typescript 5.7 will fail on uses of `<>` unless usage of RaxFragment is explicit, with an import of it and a `/** @jsxFrag RaxFragment */` pragma at the top of the file. This PR adds that.

RaxFragment also needs to have an exported value. I wasn't sure what to use here so I copied preact, since preact is used in the Typescript handbook as an example:

```ts
export const RaxFragment: FunctionComponent<{}>
```

Notably, though, the preact source has a comment indicating that *they're* not sure of the correct type either.

Here is the Typescript 5.7 PR that made this error appear:

https://github.com/microsoft/TypeScript/pull/59933
