### PR TITLE
Fix angular-route tests for TS 5.7

### DIFF
--- a/types/angular-route/angular-route-tests.ts
+++ b/types/angular-route/angular-route-tests.ts
@@ -55,7 +55,7 @@ $routeProvider
         resolveAs: "baz",
         resolveRedirectTo: [
             "$http",
-            ($http: ng.IHttpService) => $http.get("/is-admin").then(() => "/admin/lounge", () => undefined),
+            ($http: ng.IHttpService) => $http.get("/is-admin").then(() => "/admin/lounge", (): undefined => undefined),
         ],
     })
     .when("/projects/:projectId/dashboard7", {


### PR DESCRIPTION
TS 5.7 adds a missed implicit any errors in callbacks when the inferred type is `any`. This PR adds an explicit type to silence the implicit any error.

The new error was introduced in https://github.com/microsoft/TypeScript/pull/59661
