### PR TITLE
Fix react-native-confetti test's JSX fragment usage

### DIFF
--- a/types/react-native-confetti/react-native-confetti-tests.tsx
+++ b/types/react-native-confetti/react-native-confetti-tests.tsx
@@ -1,4 +1,4 @@
-import { FC, useRef } from "react";
+import React, { FC, useRef } from "react";
 import { Button } from "react-native";
 import Confetti from "react-native-confetti";
 


### PR DESCRIPTION
It now requires an explicit import of React in order to use JSX fragments.

Here is the Typescript 5.7 PR that introduced this error:

https://github.com/microsoft/TypeScript/pull/59933
