### PR TITLE
Fix react-native-razorpay test's JSX fragment usage

### DIFF
--- a/types/react-native-razorpay/package.json
+++ b/types/react-native-razorpay/package.json
@@ -6,13 +6,16 @@
         "https://www.npmjs.com/package/react-native-razorpay"
     ],
     "devDependencies": {
-        "react-native": "*",
-        "@types/react-native-razorpay": "workspace:."
+        "@types/react-native-razorpay": "workspace:.",
+        "react-native": "*"
     },
     "owners": [
         {
             "name": "Ankan Bhattacharya",
             "githubUsername": "Ankan002"
         }
-    ]
+    ],
+    "dependencies": {
+        "@types/react": "*"
+    }
 }

--- a/types/react-native-razorpay/react-native-razorpay-tests.tsx
+++ b/types/react-native-razorpay/react-native-razorpay-tests.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { Button } from "react-native";
 import RazorpayCheckout, { ErrorResponse } from "react-native-razorpay";
 


### PR DESCRIPTION
It now requires an explicit import of React in order to use JSX fragments.

Here is the Typescript 5.7 PR that introduced this error:

microsoft/TypeScript#59933