### PR TITLE
Add new options for @event-calendar/core v3.5 and v3.6

### DIFF
--- a/types/event-calendar__core/event-calendar__core-tests.ts
+++ b/types/event-calendar__core/event-calendar__core-tests.ts
@@ -181,6 +181,7 @@ cal = new Calendar({
             eventStartEditable: true,
             eventTimeFormat: dateFormat,
             eventTextColor: "yellow",
+            filterEventsWithResources: true,
             filterResourcesWithEvents: false,
             firstDay: 0,
             flexibleSlotTimeLimits: true,
@@ -203,7 +204,7 @@ cal = new Calendar({
             noEventsContent: "content",
             nowIndicator: true,
             pointer: true,
-            resources: [{ id: "foo" }, { id: "bar" }],
+            resources: [{ id: "foo" }, { id: "bar", extendedProps: { fred: "barney" } }],
             resourceLabelContent: "content",
             resourceLabelDidMount: (_info: Calendar.ResourceDidMountInfo) => {},
             select: (_info: Calendar.SelectInfo) => {},
@@ -267,7 +268,7 @@ cal.setOption("buttonText", () => {
     })
     .setOption("titleFormat", (_s: Date, _e: Date) => "content")
     .setOption("views", { resourceTimeGrid: { selectMinDistance: 300 } })
-    .setOption("buttonText", (text) => {
+    .setOption("buttonText", (text: Calendar.ButtonTextMapping) => {
         return { ...text, foo: "bar" };
     });
 
@@ -281,6 +282,7 @@ let validResource: Calendar.Resource = {
     title: "content",
     eventBackgroundColor: undefined,
     eventTextColor: undefined,
+    extendedProps: { a: 1, b: "two", c: [] },
 };
 const { title, ...rest } = validResource;
 // @ts-expect-error

--- a/types/event-calendar__core/index.d.ts
+++ b/types/event-calendar__core/index.d.ts
@@ -59,6 +59,7 @@ declare namespace Calendar {
         title?: Content;
         eventBackgroundColor?: string;
         eventTextColor?: string;
+        extendedProps?: Record<string, unknown>;
     }
 
     interface Resource {
@@ -66,6 +67,7 @@ declare namespace Calendar {
         title: Content;
         eventBackgroundColor: string | undefined;
         eventTextColor: string | undefined;
+        extendedProps: Record<string, unknown>;
     }
 
     type durationHMS = string;
@@ -312,6 +314,7 @@ declare namespace Calendar {
         eventStartEditable?: boolean;
         eventTimeFormat?: Intl.DateTimeFormatOptions | ((start: Date, end: Date) => Content);
         eventTextColor?: string;
+        filterEventsWithResources?: boolean;
         filterResourcesWithEvents?: boolean;
         firstDay?: dayOfWeek;
         flexibleSlotTimeLimits?: boolean | { eventFilter: (e: Event) => boolean };

--- a/types/event-calendar__core/package.json
+++ b/types/event-calendar__core/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "type": "module",
     "name": "@types/event-calendar__core",
-    "version": "3.4.9999",
+    "version": "3.6.9999",
     "projects": [
         "https://vkurko.github.io/calendar/"
     ],


### PR DESCRIPTION
# Description

Add the two new options of `@event-calendar` library versions 3.5 and 3.6.

- `extendedProps` added to the `Resource` object (and its plain-object mapping class)
- `filterEventsWithResources` flag added

Ref. also the [changelog](https://github.com/vkurko/calendar/blob/master/CHANGELOG.md) for the library, which shows the two new options landing in version 3.5.0.

Additional tweaks:
- Added a missing type in the test file (from an earlier contributor's PR, was missed by me)

# PR template

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
   - [FilterEventsWithResources](https://github.com/vkurko/calendar?tab=readme-ov-file#filtereventswithresources)
   - [extendedProps](https://github.com/vkurko/calendar?tab=readme-ov-file#resource-object)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.