### PR TITLE
fix(latlon-geohash): add "type: module", change Direction to str union

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -1220,7 +1220,6 @@
         "kos-core",
         "kss",
         "kythe",
-        "latlon-geohash",
         "leadfoot",
         "leaflet-areaselect",
         "leaflet-curve",

--- a/types/latlon-geohash/index.d.ts
+++ b/types/latlon-geohash/index.d.ts
@@ -1,10 +1,13 @@
 declare namespace Geohash {
-    enum Direction {
-        North = "N",
-        South = "S",
-        East = "E",
-        West = "W",
-    }
+    type Direction =
+        | "n"
+        | "N"
+        | "s"
+        | "S"
+        | "e"
+        | "E"
+        | "w"
+        | "W";
 
     interface Neighbours {
         n: string;
@@ -76,7 +79,7 @@ declare namespace Geohash {
      * @returns Geocode of adjacent cell.
      * @throws  Invalid geohash.
      */
-    function adjacent(geohash: string, direction: Direction | string): string;
+    function adjacent(geohash: string, direction: Direction): string;
 
     /**
      * Returns all 8 adjacent cells to specified geohash.

--- a/types/latlon-geohash/latlon-geohash-tests.ts
+++ b/types/latlon-geohash/latlon-geohash-tests.ts
@@ -11,7 +11,7 @@ const atx_latlong: Geohash.Point = Geohash.decode(atx_geohash);
 const atx_bounds: Geohash.Bounds = Geohash.bounds(atx_geohash);
 
 // Adjacent
-const atx_adj_cell1: string = Geohash.adjacent(atx_geohash, Geohash.Direction.North);
+const atx_adj_cell1: string = Geohash.adjacent(atx_geohash, "n");
 const atx_adj_cell2: string = Geohash.adjacent(atx_geohash, "N");
 
 // Neighbors

--- a/types/latlon-geohash/package.json
+++ b/types/latlon-geohash/package.json
@@ -2,6 +2,7 @@
     "private": true,
     "name": "@types/latlon-geohash",
     "version": "2.0.9999",
+    "type": "module",
     "projects": [
         "https://github.com/chrisveness/latlon-geohash",
         "http://www.movable-type.co.uk/scripts/geohash.html"


### PR DESCRIPTION
`enum Direction` in current typedef will mislead consumer into thinking that the original package has an actual `Direction` object that can be imported and (re)use, which is simply not true at all.

This PR prevents that by removing such enum and turn it into a pure string union.

Signature of `.adjacent()` (and test) is modified accordingly. See the [source code implementation](https://github.com/chrisveness/latlon-geohash/blob/master/latlon-geohash.js#L180-L184).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
