### PR TITLE
[node/fsPromises]: Add missing overloads for `read` and `write`

### DIFF
--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -238,6 +238,10 @@ declare module "fs/promises" {
             length?: number | null,
             position?: number | null,
         ): Promise<FileReadResult<T>>;
+        read<T extends NodeJS.ArrayBufferView = Buffer>(
+            buffer: T,
+            options?: FileReadOptions<T>,
+        ): Promise<FileReadResult<T>>;
         read<T extends NodeJS.ArrayBufferView = Buffer>(options?: FileReadOptions<T>): Promise<FileReadResult<T>>;
         /**
          * Returns a `ReadableStream` that may be used to read the files data.
@@ -425,6 +429,13 @@ declare module "fs/promises" {
             offset?: number | null,
             length?: number | null,
             position?: number | null,
+        ): Promise<{
+            bytesWritten: number;
+            buffer: TBuffer;
+        }>;
+        write<TBuffer extends Uint8Array>(
+            buffer: TBuffer,
+            options?: { offset?: number; length?: number; position?: number },
         ): Promise<{
             bytesWritten: number;
             buffer: TBuffer;

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -542,12 +542,20 @@ async function testPromisify() {
         position: 2,
         length: 3,
     })).buffer; // $ExpectType Uint32Array || Uint32Array<ArrayBuffer>
+    (await handle.read(
+        new Uint32Array(),
+    )).buffer; // $ExpectType Uint32Array || Uint32Array<ArrayBuffer>
+    (await handle.read(
+        new Uint32Array(),
+        { position: 1 },
+    )).buffer; // $ExpectType Uint32Array || Uint32Array<ArrayBuffer>
 
     await handle.read(new Uint32Array(), 1, 2, 3);
     await handle.read(Buffer.from("hurr"));
 
     await handle.write("hurr", 0, "utf-8");
     await handle.write(Buffer.from("hurr"), 0, 42, 10);
+    await handle.write(Buffer.from("hurr"), { position: 1 });
 
     handle.readableWebStream();
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/fs.html#filehandlereadbuffer-options https://nodejs.org/api/fs.html#filehandlewritebuffer-options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
