### PR TITLE
Update @types/meteor-roles: Add addRolesToParent and removeRolesFromParent functions

### DIFF
--- a/types/meteor-roles/index.d.ts
+++ b/types/meteor-roles/index.d.ts
@@ -246,6 +246,38 @@ declare namespace Roles {
         group?: string,
     ): boolean;
 
+    /**
+     * Add role parent to roles.
+     *
+     * Previous parents are kept (role can have multiple parents). For users which have the
+     * parent role set, new subroles are added automatically.
+     *
+     * @example
+     *     Roles.addRolesToParent('editor', 'admin');
+     *     Roles.addRolesToParent(['moderator', 'contributor'], 'editor');
+     *
+     * @method addRolesToParent
+     * @param {Array|String} roleNames Name(s) of role(s).
+     * @param {String} parentName Name of parent role.
+     */
+    function addRolesToParent(roleNames: string | string[], parentName: string): void;
+
+    /**
+     * Remove role parent from roles.
+     *
+     * Other parents are kept (role can have multiple parents). For users which have the
+     * parent role set, removed subrole is removed automatically.
+     *
+     * @example
+     *     Roles.removeRolesFromParent('editor', 'admin');
+     *     Roles.removeRolesFromParent(['moderator', 'contributor'], 'editor');
+     *
+     * @method removeRolesFromParent
+     * @param {Array|String} roleNames Name(s) of role(s).
+     * @param {String} parentName Name of parent role.
+     */
+    function removeRolesFromParent(roleNames: string | string[], parentName: string): void;
+
     interface Role {
         name: string;
     }
@@ -497,6 +529,38 @@ declare module "meteor/alanning:roles" {
             roles: string | string[],
             group?: string,
         ): boolean;
+
+        /**
+         * Add role parent to roles.
+         *
+         * Previous parents are kept (role can have multiple parents). For users which have the
+         * parent role set, new subroles are added automatically.
+         *
+         * @example
+         *     Roles.addRolesToParent('editor', 'admin');
+         *     Roles.addRolesToParent(['moderator', 'contributor'], 'editor');
+         *
+         * @method addRolesToParent
+         * @param {Array|String} roleNames Name(s) of role(s).
+         * @param {String} parentName Name of parent role.
+         */
+        function addRolesToParent(roleNames: string | string[], parentName: string): void;
+
+        /**
+         * Remove role parent from roles.
+         *
+         * Other parents are kept (role can have multiple parents). For users which have the
+         * parent role set, removed subrole is removed automatically.
+         *
+         * @example
+         *     Roles.removeRolesFromParent('editor', 'admin');
+         *     Roles.removeRolesFromParent(['moderator', 'contributor'], 'editor');
+         *
+         * @method removeRolesFromParent
+         * @param {Array|String} roleNames Name(s) of role(s).
+         * @param {String} parentName Name of parent role.
+         */
+        function removeRolesFromParent(roleNames: string | string[], parentName: string): void;
 
         interface Role {
             name: string;

--- a/types/meteor-roles/meteor-roles-tests.ts
+++ b/types/meteor-roles/meteor-roles-tests.ts
@@ -129,3 +129,29 @@ Meteor.methods({
         Roles.setUserRoles(targetUserId, roles, group);
     },
 });
+
+// $ExpectType void
+Roles.addRolesToParent("editor", "admin");
+// $ExpectType void
+Roles.addRolesToParent(["moderator", "contributor"], "editor");
+
+// $ExpectType void
+Roles.removeRolesFromParent("editor", "admin");
+// $ExpectType void
+Roles.removeRolesFromParent(["moderator", "contributor"], "editor");
+
+// Test with invalid inputs to ensure type safety
+// @ts-expect-error
+Roles.addRolesToParent(42, "admin");
+
+// @ts-expect-error
+Roles.removeRolesFromParent("editor", ["admin"]);
+
+// Test with correct types but as variables
+const rolesToAdd: string[] = ["reviewer", "proofreader"];
+const parentRole = "senior-editor";
+
+// $ExpectType void
+Roles.addRolesToParent(rolesToAdd, parentRole);
+// $ExpectType void
+Roles.removeRolesFromParent(rolesToAdd, parentRole);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test meteor-roles`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://meteor-community-packages.github.io/meteor-roles/files/roles_roles_client.js.html#l185:~:text=addRolesToParent%3A%20function%20(rolesNames%2C%20parentName)%20%7B
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Description:
This PR adds type definitions for the `addRolesToParent` and `removeRolesFromParent` functions in the meteor-roles package. These functions were previously missing from the type definitions. I've also added corresponding tests to ensure the new type definitions work as expected.
