### PR TITLE
Replace "with this of" with "with this as" in d3-selection and d3-transition types

### DIFF
--- a/types/d3-selection/index.d.ts
+++ b/types/d3-selection/index.d.ts
@@ -897,11 +897,11 @@ export interface Selection<GElement extends BaseType, Datum, PElement extends Ba
 
     /**
      * Invoke the specified function for each selected element, passing in the current datum (d),
-     * the current index (i), and the current group (nodes), with this of the current DOM element (nodes[i]).
+     * the current index (i), and the current group (nodes), with this as the current DOM element (nodes[i]).
      * This method can be used to invoke arbitrary code for each selected element, and is useful for creating a context to access parent and child data simultaneously.
      *
      * @param func A function which is invoked for each selected element,
-     *             being passed the current datum (d), the current index (i), and the current group (nodes), with this of the current DOM element (nodes[i]).
+     *             being passed the current datum (d), the current index (i), and the current group (nodes), with this as the current DOM element (nodes[i]).
      */
     each(func: ValueFn<GElement, Datum, void>): this;
 

--- a/types/d3-selection/v1/index.d.ts
+++ b/types/d3-selection/v1/index.d.ts
@@ -940,11 +940,11 @@ export interface Selection<GElement extends BaseType, Datum, PElement extends Ba
 
     /**
      * Invoke the specified function for each selected element, passing in the current datum (d),
-     * the current index (i), and the current group (nodes), with this of the current DOM element (nodes[i]).
+     * the current index (i), and the current group (nodes), with this as the current DOM element (nodes[i]).
      * This method can be used to invoke arbitrary code for each selected element, and is useful for creating a context to access parent and child data simultaneously.
      *
      * @param func A function which is invoked for each selected element,
-     *             being passed the current datum (d), the current index (i), and the current group (nodes), with this of the current DOM element (nodes[i]).
+     *             being passed the current datum (d), the current index (i), and the current group (nodes), with this as the current DOM element (nodes[i]).
      */
     each(func: ValueFn<GElement, Datum, void>): this;
 

--- a/types/d3-selection/v2/index.d.ts
+++ b/types/d3-selection/v2/index.d.ts
@@ -993,11 +993,11 @@ export interface Selection<GElement extends BaseType, Datum, PElement extends Ba
 
     /**
      * Invoke the specified function for each selected element, passing in the current datum (d),
-     * the current index (i), and the current group (nodes), with this of the current DOM element (nodes[i]).
+     * the current index (i), and the current group (nodes), with this as the current DOM element (nodes[i]).
      * This method can be used to invoke arbitrary code for each selected element, and is useful for creating a context to access parent and child data simultaneously.
      *
      * @param func A function which is invoked for each selected element,
-     *             being passed the current datum (d), the current index (i), and the current group (nodes), with this of the current DOM element (nodes[i]).
+     *             being passed the current datum (d), the current index (i), and the current group (nodes), with this as the current DOM element (nodes[i]).
      */
     each(func: ValueFn<GElement, Datum, void>): this;
 

--- a/types/d3-transition/index.d.ts
+++ b/types/d3-transition/index.d.ts
@@ -516,11 +516,11 @@ export interface Transition<GElement extends BaseType, Datum, PElement extends B
 
     /**
      * Invoke the specified function for each selected element, passing the current datum (d),
-     * the current index (i), and the current group (nodes), with this of the current DOM element (nodes[i]).
+     * the current index (i), and the current group (nodes), with this as the current DOM element (nodes[i]).
      * This method can be used to invoke arbitrary code for each selected element, and is useful for creating a context to access parent and child data simultaneously.
      *
      * @param func A function which is invoked for each selected element,
-     *             being passed the current datum (d), the current index (i), and the current group (nodes), with this of the current DOM element (nodes[i]).
+     *             being passed the current datum (d), the current index (i), and the current group (nodes), with this as the current DOM element (nodes[i]).
      */
     each(func: ValueFn<GElement, Datum, void>): this;
 
@@ -575,7 +575,7 @@ export interface Transition<GElement extends BaseType, Datum, PElement extends B
      * value function.
      *
      * @param milliseconds A value function which is evaluated for each selected element, being passed the current datum (d),
-     * the current index (i), and the current group (nodes), with this of the current DOM element (nodes[i]). The return value is a number
+     * the current index (i), and the current group (nodes), with this as the current DOM element (nodes[i]). The return value is a number
      * specifying the delay in milliseconds.
      */
     delay(milliseconds: ValueFn<GElement, Datum, number>): this;
@@ -597,7 +597,7 @@ export interface Transition<GElement extends BaseType, Datum, PElement extends B
      * value function.
      *
      * @param milliseconds A value function which is evaluated for each selected element, being passed the current datum (d),
-     * the current index (i), and the current group (nodes), with this of the current DOM element (nodes[i]). The return value is a number
+     * the current index (i), and the current group (nodes), with this as the current DOM element (nodes[i]). The return value is a number
      * specifying the duration in milliseconds.
      */
     duration(milliseconds: ValueFn<GElement, Datum, number>): this;

--- a/types/d3-transition/v1/index.d.ts
+++ b/types/d3-transition/v1/index.d.ts
@@ -507,11 +507,11 @@ export interface Transition<GElement extends BaseType, Datum, PElement extends B
 
     /**
      * Invoke the specified function for each selected element, passing the current datum (d),
-     * the current index (i), and the current group (nodes), with this of the current DOM element (nodes[i]).
+     * the current index (i), and the current group (nodes), with this as the current DOM element (nodes[i]).
      * This method can be used to invoke arbitrary code for each selected element, and is useful for creating a context to access parent and child data simultaneously.
      *
      * @param func A function which is invoked for each selected element,
-     *             being passed the current datum (d), the current index (i), and the current group (nodes), with this of the current DOM element (nodes[i]).
+     *             being passed the current datum (d), the current index (i), and the current group (nodes), with this as the current DOM element (nodes[i]).
      */
     each(func: ValueFn<GElement, Datum, void>): this;
 
@@ -566,7 +566,7 @@ export interface Transition<GElement extends BaseType, Datum, PElement extends B
      * value function.
      *
      * @param milliseconds A value function which is evaluated for each selected element, being passed the current datum (d),
-     * the current index (i), and the current group (nodes), with this of the current DOM element (nodes[i]). The return value is a number
+     * the current index (i), and the current group (nodes), with this as the current DOM element (nodes[i]). The return value is a number
      * specifying the delay in milliseconds.
      */
     delay(milliseconds: ValueFn<GElement, Datum, number>): this;
@@ -588,7 +588,7 @@ export interface Transition<GElement extends BaseType, Datum, PElement extends B
      * value function.
      *
      * @param milliseconds A value function which is evaluated for each selected element, being passed the current datum (d),
-     * the current index (i), and the current group (nodes), with this of the current DOM element (nodes[i]). The return value is a number
+     * the current index (i), and the current group (nodes), with this as the current DOM element (nodes[i]). The return value is a number
      * specifying the duration in milliseconds.
      */
     duration(milliseconds: ValueFn<GElement, Datum, number>): this;

--- a/types/d3-transition/v2/index.d.ts
+++ b/types/d3-transition/v2/index.d.ts
@@ -507,11 +507,11 @@ export interface Transition<GElement extends BaseType, Datum, PElement extends B
 
     /**
      * Invoke the specified function for each selected element, passing the current datum (d),
-     * the current index (i), and the current group (nodes), with this of the current DOM element (nodes[i]).
+     * the current index (i), and the current group (nodes), with this as the current DOM element (nodes[i]).
      * This method can be used to invoke arbitrary code for each selected element, and is useful for creating a context to access parent and child data simultaneously.
      *
      * @param func A function which is invoked for each selected element,
-     *             being passed the current datum (d), the current index (i), and the current group (nodes), with this of the current DOM element (nodes[i]).
+     *             being passed the current datum (d), the current index (i), and the current group (nodes), with this as the current DOM element (nodes[i]).
      */
     each(func: ValueFn<GElement, Datum, void>): this;
 
@@ -566,7 +566,7 @@ export interface Transition<GElement extends BaseType, Datum, PElement extends B
      * value function.
      *
      * @param milliseconds A value function which is evaluated for each selected element, being passed the current datum (d),
-     * the current index (i), and the current group (nodes), with this of the current DOM element (nodes[i]). The return value is a number
+     * the current index (i), and the current group (nodes), with this as the current DOM element (nodes[i]). The return value is a number
      * specifying the delay in milliseconds.
      */
     delay(milliseconds: ValueFn<GElement, Datum, number>): this;
@@ -588,7 +588,7 @@ export interface Transition<GElement extends BaseType, Datum, PElement extends B
      * value function.
      *
      * @param milliseconds A value function which is evaluated for each selected element, being passed the current datum (d),
-     * the current index (i), and the current group (nodes), with this of the current DOM element (nodes[i]). The return value is a number
+     * the current index (i), and the current group (nodes), with this as the current DOM element (nodes[i]). The return value is a number
      * specifying the duration in milliseconds.
      */
     duration(milliseconds: ValueFn<GElement, Datum, number>): this;


### PR DESCRIPTION
This PR replaces the string "with this of" with "with this as", which seems to be more widely used across the board:

```bash
> grep -rw 'with this of' | wc -l
18
 
> grep -rw 'with this as' | wc -l
139
```
