### PR TITLE
fix(rollup-plugin-progress): Fix for "export =", add jsdoc

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -1599,7 +1599,6 @@
         "rocksdb",
         "roll-a-die",
         "rollup-plugin-node-globals",
-        "rollup-plugin-progress",
         "rollup-plugin-svelte-svg",
         "rollup-plugin-url",
         "rosie",

--- a/types/rollup-plugin-progress/index.d.ts
+++ b/types/rollup-plugin-progress/index.d.ts
@@ -1,9 +1,12 @@
 import { Plugin } from "rollup";
 
-export interface PluginProgressOptions {
-    clearLine?: boolean | undefined;
+declare namespace PluginProgress {
+    interface PluginProgressOptions {
+        /** @default true */
+        clearLine?: boolean | undefined;
+    }
 }
 
-declare function progress(options?: PluginProgressOptions): Plugin;
+declare function PluginProgress(options?: PluginProgress.PluginProgressOptions): Plugin;
 
-export default progress;
+export = PluginProgress;

--- a/types/rollup-plugin-progress/rollup-plugin-progress-tests.ts
+++ b/types/rollup-plugin-progress/rollup-plugin-progress-tests.ts
@@ -1,4 +1,4 @@
-import progress from "rollup-plugin-progress";
+import progress, { PluginProgressOptions } from "rollup-plugin-progress";
 
 progress(); // $ExpectType Plugin
 


### PR DESCRIPTION
The newly-added default value jsdoc can be seen in [npm page example](https://www.npmjs.com/package/rollup-plugin-progress#usage).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
