### PR TITLE
[sharedb] Add `doc.toSnapshot()`

### DIFF
--- a/types/sharedb/lib/sharedb.d.ts
+++ b/types/sharedb/lib/sharedb.d.ts
@@ -21,6 +21,7 @@ export interface Snapshot<T = any> {
     data?: T;
     m: SnapshotMeta | null;
 }
+export type IngestibleSnapshot<T = any> = Pick<Snapshot<T>, "v" | "type" | "data">;
 
 export interface SnapshotMeta {
     ctime: number;
@@ -174,7 +175,8 @@ export class Doc<T = any> extends TypedEmitter<DocEventMap<T>> {
     subscribe: (callback?: (err: Error) => void) => void;
     unsubscribe: (callback?: (err: Error) => void) => void;
 
-    ingestSnapshot(snapshot: Pick<Snapshot<T>, "v" | "type" | "data">, callback?: Callback): void;
+    toSnapshot(): IngestibleSnapshot<T>;
+    ingestSnapshot(snapshot: IngestibleSnapshot<T>, callback?: Callback): void;
     destroy(callback?: Callback): void;
     create(data: T, callback?: Callback): void;
     create(data: T, type?: string, callback?: Callback): void;

--- a/types/sharedb/sharedb-tests.ts
+++ b/types/sharedb/sharedb-tests.ts
@@ -290,6 +290,8 @@ doc.fetch((err) => {
 
 doc.create({ foo: true }, "http://sharejs.org/types/JSONv0");
 
+doc.ingestSnapshot(doc.toSnapshot());
+
 function startServer() {
     const server = http.createServer();
 


### PR DESCRIPTION
Adds support for the [`doc.toSnapshot()`][1] method, and commonises the type with `doc.ingestSnapshot()`.

[1]: https://github.com/share/sharedb/blob/945dc50ebc93d53e7306c522226bd804a802bc49/lib/client/doc.js#L930-L936

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
