### PR TITLE
[lodash] Add overload signature to return tuple type for _.map when given a tuple

### DIFF
--- a/types/lodash/common/collection.d.ts
+++ b/types/lodash/common/collection.d.ts
@@ -1153,6 +1153,10 @@ declare module "../index" {
          * @param iteratee The function invoked per iteration.
          * @return Returns the new mapped array.
          */
+        map<T extends readonly unknown[], TResult>(collection: T, iteratee: TupleIterator<T, TResult>): { [K in keyof T]: TResult };
+        /**
+         * @see _.map
+         */
         map<T, TResult>(collection: T[] | null | undefined, iteratee: ArrayIterator<T, TResult>): TResult[];
         /**
          * @see _.map

--- a/types/lodash/common/common.d.ts
+++ b/types/lodash/common/common.d.ts
@@ -213,6 +213,7 @@ declare module "../index" {
     type NotVoid = unknown;
     type IterateeShorthand<T> = PropertyName | [PropertyName, any] | PartialShallow<T>;
     type ArrayIterator<T, TResult> = (value: T, index: number, collection: T[]) => TResult;
+    type TupleIterator<T extends readonly unknown[], TResult> = (value: T[number], index: { [K in keyof T]: StringToNumber<K> }[never], collection: T) => TResult;
     type ListIterator<T, TResult> = (value: T, index: number, collection: List<T>) => TResult;
     type ListIteratee<T> = ListIterator<T, NotVoid> | IterateeShorthand<T>;
     type ListIterateeCustom<T, TResult> = ListIterator<T, TResult> | IterateeShorthand<T>;
@@ -258,6 +259,7 @@ declare module "../index" {
     type PartialShallow<T> = {
         [P in keyof T]?: T[P] extends object ? object : T[P]
     };
+    type StringToNumber<T> = T extends `${infer N extends number}` ? N : never;
     // For backwards compatibility
     type LoDashImplicitArrayWrapper<T> = LoDashImplicitWrapper<T[]>;
     type LoDashImplicitNillableArrayWrapper<T> = LoDashImplicitWrapper<T[] | null | undefined>;

--- a/types/lodash/common/common.d.ts
+++ b/types/lodash/common/common.d.ts
@@ -213,7 +213,7 @@ declare module "../index" {
     type NotVoid = unknown;
     type IterateeShorthand<T> = PropertyName | [PropertyName, any] | PartialShallow<T>;
     type ArrayIterator<T, TResult> = (value: T, index: number, collection: T[]) => TResult;
-    type TupleIterator<T extends readonly unknown[], TResult> = (value: T[number], index: { [K in keyof T]: StringToNumber<K> }[never], collection: T) => TResult;
+    type TupleIterator<T extends readonly unknown[], TResult> = (value: T[number], index: StringToNumber<keyof T>, collection: T) => TResult;
     type ListIterator<T, TResult> = (value: T, index: number, collection: List<T>) => TResult;
     type ListIteratee<T> = ListIterator<T, NotVoid> | IterateeShorthand<T>;
     type ListIterateeCustom<T, TResult> = ListIterator<T, TResult> | IterateeShorthand<T>;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -2782,6 +2782,21 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType CollectionChain<number>
     _.map(list, { a: 42 });  // $ExpectType boolean[]
     _.map(dictionary, { a: 42 });  // $ExpectType boolean[]
     _.map(numericDictionary, { a: 42 });  // $ExpectType boolean[]
+    _.map([-1, -2, -3] as [number, number, number], (value) => value.toString());  // $ExpectType [string, string, string]
+    _.map([-1, -2, -3] as [number, number, number], (value) => value || "a");  // $ExpectType [number | "a", number | "a", number | "a"]
+    _.map([-1, -2, -3] as [number, number, number], (value, index, collection) => {
+        value; // $ExpectType number
+        index; // $ExpectType 0 | 1 | 2
+        collection; // $ExpectType [number, number, number]
+        return 0;
+    });
+    _.map([-1, -2, -3] as const, (value) => value.toString()) // $ExpectType readonly [string, string, string];
+    _.map([-1, -2, -3] as const, (value, index, collection) => {
+        value; // $ExpectType -1 | -2 | -3
+        index; // $ExpectType 0 | 1 | 2
+        collection; // $ExpectType readonly [-1, -2, -3]
+        return 0;
+    });
 
     _(list).map(); // $ExpectType Collection<AbcObject>
     // $ExpectType Collection<number>


### PR DESCRIPTION
Currently, `Array.prototype.map()` doesn't return tuple type when given a tuple (checked on TS v5.6.2). It would be useful if lodash's map function could handle tuples as well.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://lodash.com/docs/4.17.15#map>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
