### PR TITLE
[react-dom]: Update createPortal 'key' parameter to include number

### DIFF
--- a/types/react-dom/index.d.ts
+++ b/types/react-dom/index.d.ts
@@ -11,6 +11,7 @@ import {
     DOMAttributes,
     DOMElement,
     FunctionComponentElement,
+    Key,
     ReactElement,
     ReactInstance,
     ReactNode,
@@ -29,7 +30,7 @@ export function unmountComponentAtNode(container: Element | DocumentFragment): b
 export function createPortal(
     children: ReactNode,
     container: Element | DocumentFragment,
-    key?: null | string,
+    key?: Key | null,
 ): ReactPortal;
 
 export const version: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react.dev/reference/react-dom/createPortal#parameters
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.


I noticed that number values can't be passed to `createPortal`; however, the documentation says it accepts a number.

> optional key: A unique string or number to be used as the portal’s key.

