### PR TITLE
fix: add missing types in webtorrent

### DIFF
--- a/types/webtorrent/index.d.ts
+++ b/types/webtorrent/index.d.ts
@@ -13,14 +13,19 @@ declare namespace WebTorrent {
         (config?: Options): Instance;
         WEBRTC_SUPPORT: boolean;
     }
+
     interface Options {
         maxConns?: number | undefined;
         nodeId?: string | Buffer | undefined;
         peerId?: string | Buffer | undefined;
         tracker?: boolean | {} | undefined;
         dht?: boolean | {} | undefined;
+        lsd?: boolean | undefined;
         webSeeds?: boolean | undefined;
         utp?: boolean | undefined;
+        blocklist?: (string | Array<string | { start: string; end: string }>) | undefined;
+        downloadLimit?: number | undefined;
+        uploadLimit?: number | undefined;
     }
 
     interface ServerAddress {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

add missing types in webtorrent
![image](https://github.com/user-attachments/assets/3b848bf6-a52e-4e2e-8e3a-ee485dc8ed22)

the blocklist type is from here (https://github.com/webtorrent/webtorrent/blob/master/test/node/blocklist.js#L115)[https://github.com/webtorrent/webtorrent/blob/master/test/node/blocklist.js#L115]