### PR TITLE
add `get_session_recording_properties` method

### DIFF
--- a/types/mixpanel-browser/index.d.ts
+++ b/types/mixpanel-browser/index.d.ts
@@ -197,6 +197,7 @@ export interface Mixpanel {
     people: People;
     start_session_recording(): void;
     stop_session_recording(): void;
+    get_session_recording_properties(): { $mp_replay_id?: string } | {};
 }
 
 export interface OverridedMixpanel extends Mixpanel {
@@ -250,6 +251,7 @@ export function track_links(query: Query, event_name: string, properties?: Dict 
 export function track_with_groups(event_name: string, properties: Dict, groups: Dict, callback?: Callback): void;
 export function unregister(property: string, options?: Partial<RegisterOptions>): void;
 export const people: People;
+export function get_session_recording_properties(): { $mp_replay_id?: string } | {};
 
 declare const mixpanel: OverridedMixpanel;
 export default mixpanel;

--- a/types/mixpanel-browser/mixpanel-browser-tests.ts
+++ b/types/mixpanel-browser/mixpanel-browser-tests.ts
@@ -112,6 +112,7 @@ mixpanel.init("token", {
 });
 mixpanel.start_session_recording();
 mixpanel.stop_session_recording();
+mixpanel.get_session_recording_properties();
 mixpanel.opt_in_tracking();
 mixpanel.opt_in_tracking({
     track_event_name: "User opted in",


### PR DESCRIPTION
Mixpanel SDK has a `get_session_recording_properties()` method in the browser SDK:
https://docs.mixpanel.com/docs/tracking-methods/sdks/javascript#get-replay-properties

This PR adds that method and the appropriate tests and types.

CHECKLIST
-------
- [ X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ X] Test the change in your own code. (Compile and run.)
- [ X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
https://docs.mixpanel.com/docs/tracking-methods/sdks/javascript#get-replay-properties
