### PR TITLE
fix(body-parser): Add `depth` option to customize the depth level in the parser

### DIFF
--- a/types/body-parser/body-parser-tests.ts
+++ b/types/body-parser/body-parser-tests.ts
@@ -32,7 +32,7 @@ const jsonParser = app.use(
 app.post("/api/users", jsonParser, (req, res) => {});
 app.use(jsonParser);
 
-const urlencodedParser = urlencoded({ extended: false });
+const urlencodedParser = urlencoded({ extended: false, depth: 32 });
 app.post("/login", urlencodedParser, (req, res) => {
     res.send("welcome, " + req.body.username);
 });

--- a/types/body-parser/index.d.ts
+++ b/types/body-parser/index.d.ts
@@ -87,6 +87,12 @@ declare namespace bodyParser {
          * a 413 will be returned to the client. Defaults to 1000.
          */
         parameterLimit?: number | undefined;
+        /**
+         * The `depth` option is used to configure the maximum depth of the `qs` library when `extended` is `true`.
+         * This allows you to limit the amount of keys that are parsed and can be useful to prevent certain types of abuse.
+         * Defaults to `32`. It is recommended to keep this value as low as possible.
+         */
+        depth?: number | undefined;
     }
 }
 

--- a/types/body-parser/package.json
+++ b/types/body-parser/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/body-parser",
-    "version": "1.19.9999",
+    "version": "1.20.9999",
     "projects": [
         "https://github.com/expressjs/body-parser"
     ],


### PR DESCRIPTION
I updated typings to `depth` option introduced in body-parser@1.20.3.
- https://github.com/expressjs/body-parser/releases/tag/1.20.3
- https://github.com/expressjs/body-parser/blob/17529513673e39ba79886a7ce3363320cf1c0c50/README.md#depth
- https://github.com/expressjs/body-parser/commit/b2695c4450f06ba3b0ccf48d872a229bb41c9bce

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/expressjs/body-parser/commit/b2695c4450f06ba3b0ccf48d872a229bb41c9bce>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

