### PR TITLE
Added definitions for phonegap-nfc scanNdef, scanTag, cancelScan, beg…

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -1399,7 +1399,6 @@
         "pexrtc",
         "phoenix",
         "phonegap-facebook-plugin",
-        "phonegap-nfc",
         "phonegap-plugin-barcodescanner",
         "phonegap",
         "photoshop",

--- a/types/phonegap-nfc/index.d.ts
+++ b/types/phonegap-nfc/index.d.ts
@@ -434,6 +434,95 @@ declare namespace PhoneGapNfc {
          * @param fail Error callback function, invoked when error occurs.
          */
         showSettings(win?: () => void, fail?: () => void): void;
+
+        /**
+         * Function scanNdef starts the NFCNDEFReaderSession allowing iOS to scan NFC tags.
+         * Calling scanNdef will begin an iOS NFC scanning session. The NFC tag will be returned in a Promise.
+         * @param options
+         */
+        scanNdef(options: any[]): Promise<NdefTag>;
+
+        /**
+         * Calling scanTag will begin an iOS NFC scanning session. The NFC tag will be returned in a Promise.
+         * Function scanTag starts the NFCTagReaderSession allowing iOS to scan NFC tags.
+         * The Tag reader will attempt to get the UID from the NFC Tag. If can also read the UID from some non-NDEF tags.
+         * Use scanNdef for reading NFC tags on iOS unless you need to get the tag UID.
+         * @param options
+         */
+        scanTag(options: any[]): Promise<Tag>;
+
+        /**
+         * Invalidate the NFC session started by scanNdef or scanTag.
+         * Function cancelScan stops the NFCReaderSession returning control to your app.
+         */
+        cancelScan(): Promise<void>;
+
+        /**
+         * @deprecated beginSession is deprecated. Use scanNdef or scanTag
+         *
+         * iOS requires you to begin a session before scanning a NFC tag.
+         * Function beginSession starts the NFCNDEFReaderSession allowing iOS to scan NFC tags. Use nfc.addNdefListener to receive the results of the scan.
+         * @param win Success callback function called when the session begins (optional)
+         * @param fail Error callback function, invoked when error occurs. (optional)
+         */
+        beginSession(win?: () => void, fail?: () => void): void;
+
+        /**
+         * @deprecated invalidateSession is deprecated. Use cancelScan
+         *
+         * Invalidate the NFC session.
+         * Function invalidateSession stops the NFCNDEFReaderSession returning control to your app.
+         * @param win Success callback function called when the session begins (optional)
+         * @param fail Error callback function, invoked when error occurs. (optional)
+         */
+        invalidateSession(win?: () => void, fail?: () => void): void;
+
+        /**
+         * Connect to the tag and enable I/O operations to the tag from this TagTechnology object.
+         * Function connect enables I/O operations to the tag from this TagTechnology object.
+         * nfc.connect should be called after receiving a nfcEvent from the addTagDiscoveredListener or the readerMode callback.
+         * Only one TagTechnology object can be connected to a Tag at a time.
+         * See Android's TagTechnology.connect() for more info.
+         * @param tech The tag technology e.g. "android.nfc.tech.IsoDep"
+         * @param timeout The transceive(byte[]) timeout in milliseconds (optional)
+         * @returns Promise when the connection is successful, optionally with a maxTransceiveLength attribute in case the tag technology supports it
+         */
+        connect(tech: string, timeout?: number): Promise<void>;
+
+        /**
+         * Close TagTechnology connection.
+         * Function close disabled I/O operations to the tag from this TagTechnology object, and releases resources.
+         * See Android's TagTechnology.close() for more info.
+         * @returns Promise when the connection is successfully closed
+         */
+        close(): Promise<void>;
+
+        /**
+         * Send raw command to the tag and receive the response.
+         * Function transceive sends raw commands to the tag and receives the response.
+         * nfc.connect must be called before calling transceive. Data passed to transceive can be a hex string representation of bytes or an ArrayBuffer.
+         * The response is returned as an ArrayBuffer in the promise.
+         * See Android's documentation IsoDep.transceive(), NfcV.transceive(), MifareUltralight.transceive() for more info.
+         * @param data a string of hex data or an ArrayBuffer
+         */
+        transceive(data: string | ArrayBuffer): Promise<ArrayBuffer>;
+
+        /**
+         * Read NFC tags sending the tag data to the success callback.
+         * In reader mode, when a NFC tags is read, the results are returned to read callback as a tag object.
+         * Note that the normal event listeners are not used in reader mode. The callback receives the tag object without the event wrapper.
+         * @param flags Flags indicating poll technologies and other optional parameters
+         * @param readCallback The callback that is called when a NFC tag is scanned.
+         * @param errorCallback The callback that is called when NFC is disabled or missing.
+         */
+        readerMode(flags: number, readCallback: () => void, errorCallback: () => void): void;
+
+        /**
+         * Disable NFC reader mode.
+         * @param successCallback The callback that is called when a NFC reader mode is disabled.
+         * @param errorCallback The callback that is called when NFC reader mode can not be disabled.
+         */
+        disableReaderMode(successCallback: () => void, errorCallback: () => void): void;
     }
 }
 

--- a/types/phonegap-nfc/package.json
+++ b/types/phonegap-nfc/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/phonegap-nfc",
-    "version": "0.0.9999",
+    "version": "1.2.9999",
     "projects": [
         "https://github.com/chariotsolutions/phonegap-nfc"
     ],

--- a/types/phonegap-nfc/phonegap-nfc-tests.ts
+++ b/types/phonegap-nfc/phonegap-nfc-tests.ts
@@ -3,6 +3,7 @@ import ndef = require("ndef");
 import NdefRecord = PhoneGapNfc.NdefRecord;
 import NdefTag = PhoneGapNfc.NdefTag;
 import NdefTagEvent = PhoneGapNfc.NdefTagEvent;
+import Tag = PhoneGapNfc.Tag;
 
 nfc.addTagDiscoveredListener(() => {});
 nfc.addTagDiscoveredListener(() => {}, () => {}, () => {});
@@ -52,6 +53,34 @@ nfc.removeNdefListener(() => {}, () => {}, () => {});
 
 nfc.showSettings();
 nfc.showSettings(() => {}, () => {});
+
+let scannedNdefTag: Promise<NdefTag> = nfc.scanNdef([]);
+
+let scannedTag: Promise<Tag> = nfc.scanTag([]);
+
+nfc.cancelScan();
+
+nfc.beginSession();
+nfc.beginSession(() => {});
+nfc.beginSession(() => {}, () => {});
+
+nfc.invalidateSession();
+nfc.invalidateSession(() => {});
+nfc.invalidateSession(() => {}, () => {});
+
+nfc.connect("android.nfc.tech.IsoDep");
+nfc.connect("android.nfc.tech.IsoDep", 100);
+
+nfc.close();
+
+nfc.transceive("90 5A 00 00 03 AA AA AA 00");
+nfc.transceive(new ArrayBuffer(1024));
+
+nfc.readerMode(0x1, () => {}, () => {});
+nfc.readerMode(0x2, () => {}, () => {});
+nfc.readerMode(0x100, () => {}, () => {});
+
+nfc.disableReaderMode(() => {}, () => {});
 
 let record: NdefRecord = ndef.record(0x01, [0x0F], [0x0C], [0xFF]);
 


### PR DESCRIPTION
…inSession, invalidateSession, connect, close, tranceive, readerMode, disableReaderMode

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[phonegap-nfc](https://github.com/chariotsolutions/phonegap-nfc/tree/master?tab=readme-ov-file#nfctransceive)>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

