### PR TITLE
Add missing field and fix return type in airbnb__node-memwatch

### DIFF
--- a/types/airbnb__node-memwatch/airbnb__node-memwatch-tests.ts
+++ b/types/airbnb__node-memwatch/airbnb__node-memwatch-tests.ts
@@ -4,10 +4,12 @@ import * as memwatch from "@airbnb/node-memwatch";
 memwatch.on("foobar");
 // @ts-expect-error
 memwatch.on("stats", "baz");
-// $ExpectType void
+// $ExpectType EventEmitter<DefaultEventMap>
 memwatch.on("stats", (
     result, // $ExpectType GcStats
-) => {});
+) => {
+    result.gc_ts; // $ExpectType number
+});
 
 new memwatch.HeapDiff(); // $ExpectType HeapDiff
 (new memwatch.HeapDiff()).end(); // $ExpectType HeapDiffResult

--- a/types/airbnb__node-memwatch/index.d.ts
+++ b/types/airbnb__node-memwatch/index.d.ts
@@ -1,4 +1,5 @@
 export interface GcStats {
+    gc_ts: number; // timestamp
     gcScavengeCount: number;
     gcScavengeTime: number; // nanoseconds
     gcMarkSweepCompactCount: number;

--- a/types/airbnb__node-memwatch/index.d.ts
+++ b/types/airbnb__node-memwatch/index.d.ts
@@ -1,3 +1,7 @@
+/// <reference types="node" />
+
+import { EventEmitter } from "events";
+
 export interface GcStats {
     gc_ts: number; // timestamp
     gcScavengeCount: number;
@@ -47,7 +51,7 @@ export interface HeapDiffResult {
     change: HeapChange;
 }
 
-export function on(event: "stats", callback: (stats: GcStats) => void): void;
+export function on(event: "stats", callback: (stats: GcStats) => void): EventEmitter;
 
 export class HeapDiff {
     end(): HeapDiffResult;

--- a/types/airbnb__node-memwatch/package.json
+++ b/types/airbnb__node-memwatch/package.json
@@ -5,6 +5,9 @@
     "projects": [
         "https://github.com/airbnb/node-memwatch#readme"
     ],
+    "dependencies": {
+        "@types/node": "*"
+    },
     "devDependencies": {
         "@types/airbnb__node-memwatch": "workspace:."
     },


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - Add gc_ts to GcStats: https://github.com/airbnb/node-memwatch/blob/master/src/memwatch.cc#L76
  - Change return type of memwatch.on from void to EventEmitter: https://nodejs.org/docs/latest/api/events.html#emitteroneventname-listener
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.