### PR TITLE
feat(react): Apply csstype.SvgProperties to SVGAttributes<T>.style

### DIFF
--- a/types/react-pointable/index.d.ts
+++ b/types/react-pointable/index.d.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 
 export type TouchAction = "auto" | "none" | "pan-x" | "pan-y" | "manipulation";
 
-export interface PointableProps extends React.HTMLAttributes<Element>, React.SVGAttributes<Element> {
+export interface PointableProps extends React.HTMLAttributes<Element>, Omit<React.SVGAttributes<Element>, "style"> {
     tagName?: keyof ElementTagNameMap | undefined;
     touchAction?: TouchAction | undefined;
     elementRef?(el: HTMLElement | SVGElement): void;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2424,6 +2424,17 @@ declare namespace React {
          */
     }
 
+    export interface CSSSvgProperties extends CSS.SvgProperties<string | number> {
+        /**
+         * The index signature was removed to enable closed typing for style
+         * using CSSType. You're able to use type assertion or module augmentation
+         * to add properties or an index signature of your own.
+         *
+         * For examples and more information, visit:
+         * https://github.com/frenic/csstype#what-should-i-do-when-i-get-type-errors
+         */
+    }
+
     // All the WAI-ARIA 1.1 attributes from https://www.w3.org/TR/wai-aria-1.1/
     interface AriaAttributes {
         /** Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. */
@@ -3540,7 +3551,7 @@ declare namespace React {
         method?: string | undefined;
         min?: number | string | undefined;
         name?: string | undefined;
-        style?: CSSProperties | undefined;
+        style?: CSSSvgProperties | undefined;
         target?: string | undefined;
         type?: string | undefined;
         width?: number | string | undefined;

--- a/types/react/test/cssProperties.tsx
+++ b/types/react/test/cssProperties.tsx
@@ -38,11 +38,16 @@ const positionStyleTest = <div style={positionStyle} />;
 
 // SVG specific style attribute declarations
 
-const fillOpacityStyle: React.CSSProperties = { fillOpacity: 0.3 };
+const fillOpacityStyle: React.CSSSvgProperties = { fillOpacity: 0.3 };
 const fillOpacityStyleTest = <svg style={fillOpacityStyle} />;
 
-const strokeOpacityStyle: React.CSSProperties = { strokeOpacity: 0.3 };
+const strokeOpacityStyle: React.CSSSvgProperties = { strokeOpacity: 0.3 };
 const strokeOpacityStyleTest = <svg style={strokeOpacityStyle} />;
 
-const strokeWidthStyle: React.CSSProperties = { strokeWidth: "10px" };
+const strokeWidthStyle: React.CSSSvgProperties = { strokeWidth: "10px" };
 const strokeWidthStyleTest = <svg style={strokeWidthStyle} />;
+
+// @ts-expect-error -- position is not a valid attribute for svg style
+const invalidPositionStyle: React.CSSSvgProperties = { position: "relative" };
+// @ts-expect-error -- position is not a valid attribute for svg style
+const invalidPositionStyleTest = <svg style={{ position: "relative" }} />;

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -2423,6 +2423,17 @@ declare namespace React {
          */
     }
 
+    export interface CSSSvgProperties extends CSS.SvgProperties<string | number> {
+        /**
+         * The index signature was removed to enable closed typing for style
+         * using CSSType. You're able to use type assertion or module augmentation
+         * to add properties or an index signature of your own.
+         *
+         * For examples and more information, visit:
+         * https://github.com/frenic/csstype#what-should-i-do-when-i-get-type-errors
+         */
+    }
+
     // All the WAI-ARIA 1.1 attributes from https://www.w3.org/TR/wai-aria-1.1/
     interface AriaAttributes {
         /** Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. */
@@ -3539,7 +3550,7 @@ declare namespace React {
         method?: string | undefined;
         min?: number | string | undefined;
         name?: string | undefined;
-        style?: CSSProperties | undefined;
+        style?: CSSSvgProperties | undefined;
         target?: string | undefined;
         type?: string | undefined;
         width?: number | string | undefined;

--- a/types/react/ts5.0/test/cssProperties.tsx
+++ b/types/react/ts5.0/test/cssProperties.tsx
@@ -38,11 +38,16 @@ const positionStyleTest = <div style={positionStyle} />;
 
 // SVG specific style attribute declarations
 
-const fillOpacityStyle: React.CSSProperties = { fillOpacity: 0.3 };
+const fillOpacityStyle: React.CSSSvgProperties = { fillOpacity: 0.3 };
 const fillOpacityStyleTest = <svg style={fillOpacityStyle} />;
 
-const strokeOpacityStyle: React.CSSProperties = { strokeOpacity: 0.3 };
+const strokeOpacityStyle: React.CSSSvgProperties = { strokeOpacity: 0.3 };
 const strokeOpacityStyleTest = <svg style={strokeOpacityStyle} />;
 
-const strokeWidthStyle: React.CSSProperties = { strokeWidth: "10px" };
+const strokeWidthStyle: React.CSSSvgProperties = { strokeWidth: "10px" };
 const strokeWidthStyleTest = <svg style={strokeWidthStyle} />;
+
+// @ts-expect-error -- position is not a valid attribute for svg style
+const invalidPositionStyle: React.CSSSvgProperties = { position: "relative" };
+// @ts-expect-error -- position is not a valid attribute for svg style
+const invalidPositionStyleTest = <svg style={{ position: "relative" }} />;

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -1586,6 +1586,17 @@ declare namespace React {
          */
     }
 
+    export interface CSSSvgProperties extends CSS.SvgProperties<string | number> {
+        /**
+         * The index signature was removed to enable closed typing for style
+         * using CSSType. You're able to use type assertion or module augmentation
+         * to add properties or an index signature of your own.
+         *
+         * For examples and more information, visit:
+         * https://github.com/frenic/csstype#what-should-i-do-when-i-get-type-errors
+         */
+    }
+
     // All the WAI-ARIA 1.1 attributes from https://www.w3.org/TR/wai-aria-1.1/
     interface AriaAttributes {
         /** Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. */
@@ -2535,7 +2546,7 @@ declare namespace React {
         method?: string | undefined;
         min?: number | string | undefined;
         name?: string | undefined;
-        style?: CSSProperties | undefined;
+        style?: CSSSvgProperties | undefined;
         target?: string | undefined;
         type?: string | undefined;
         width?: number | string | undefined;

--- a/types/react/v16/test/cssProperties.tsx
+++ b/types/react/v16/test/cssProperties.tsx
@@ -38,11 +38,16 @@ const positionStyleTest = <div style={positionStyle} />;
 
 // SVG specific style attribute declarations
 
-const fillOpacityStyle: React.CSSProperties = { fillOpacity: 0.3 };
+const fillOpacityStyle: React.CSSSvgProperties = { fillOpacity: 0.3 };
 const fillOpacityStyleTest = <svg style={fillOpacityStyle} />;
 
-const strokeOpacityStyle: React.CSSProperties = { strokeOpacity: 0.3 };
+const strokeOpacityStyle: React.CSSSvgProperties = { strokeOpacity: 0.3 };
 const strokeOpacityStyleTest = <svg style={strokeOpacityStyle} />;
 
-const strokeWidthStyle: React.CSSProperties = { strokeWidth: "10px" };
+const strokeWidthStyle: React.CSSSvgProperties = { strokeWidth: "10px" };
 const strokeWidthStyleTest = <svg style={strokeWidthStyle} />;
+
+// @ts-expect-error -- position is not a valid attribute for svg style
+const invalidPositionStyle: React.CSSSvgProperties = { position: "relative" };
+// @ts-expect-error -- position is not a valid attribute for svg style
+const invalidPositionStyleTest = <svg style={{ position: "relative" }} />;

--- a/types/react/v17/index.d.ts
+++ b/types/react/v17/index.d.ts
@@ -1586,6 +1586,17 @@ declare namespace React {
          */
     }
 
+    export interface CSSSvgProperties extends CSS.SvgProperties<string | number> {
+        /**
+         * The index signature was removed to enable closed typing for style
+         * using CSSType. You're able to use type assertion or module augmentation
+         * to add properties or an index signature of your own.
+         *
+         * For examples and more information, visit:
+         * https://github.com/frenic/csstype#what-should-i-do-when-i-get-type-errors
+         */
+    }
+
     // All the WAI-ARIA 1.1 attributes from https://www.w3.org/TR/wai-aria-1.1/
     interface AriaAttributes {
         /** Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. */
@@ -2564,7 +2575,7 @@ declare namespace React {
         method?: string | undefined;
         min?: number | string | undefined;
         name?: string | undefined;
-        style?: CSSProperties | undefined;
+        style?: CSSSvgProperties | undefined;
         target?: string | undefined;
         type?: string | undefined;
         width?: number | string | undefined;

--- a/types/react/v17/test/cssProperties.tsx
+++ b/types/react/v17/test/cssProperties.tsx
@@ -38,11 +38,16 @@ const positionStyleTest = <div style={positionStyle} />;
 
 // SVG specific style attribute declarations
 
-const fillOpacityStyle: React.CSSProperties = { fillOpacity: 0.3 };
+const fillOpacityStyle: React.CSSSvgProperties = { fillOpacity: 0.3 };
 const fillOpacityStyleTest = <svg style={fillOpacityStyle} />;
 
-const strokeOpacityStyle: React.CSSProperties = { strokeOpacity: 0.3 };
+const strokeOpacityStyle: React.CSSSvgProperties = { strokeOpacity: 0.3 };
 const strokeOpacityStyleTest = <svg style={strokeOpacityStyle} />;
 
-const strokeWidthStyle: React.CSSProperties = { strokeWidth: "10px" };
+const strokeWidthStyle: React.CSSSvgProperties = { strokeWidth: "10px" };
 const strokeWidthStyleTest = <svg style={strokeWidthStyle} />;
+
+// @ts-expect-error -- position is not a valid attribute for svg style
+const invalidPositionStyle: React.CSSSvgProperties = { position: "relative" };
+// @ts-expect-error -- position is not a valid attribute for svg style
+const invalidPositionStyleTest = <svg style={{ position: "relative" }} />;


### PR DESCRIPTION
As the commit message suggests, `svg` can enjoy a much more refined style type from `csstype`, and this PR aims to make it happen.

I am not sure if it can happen in `v15`. Seems `csstype` is not (yet) used / not applicable there. Will need some comments to see if `v15` can / need to be changed with `csstype`.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
