### PR TITLE
fix(react-column-resizer): Fix for "export =", add jsdoc

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -1461,7 +1461,6 @@
         "react-canvas-draw",
         "react-coinhive",
         "react-color",
-        "react-column-resizer",
         "react-compass",
         "react-custom-scroll",
         "react-cytoscapejs",

--- a/types/react-column-resizer/index.d.ts
+++ b/types/react-column-resizer/index.d.ts
@@ -1,9 +1,31 @@
 import { Component } from "react";
 
-export interface ResizerProps {
-    className?: string | undefined;
-    disabled?: boolean | undefined;
-    minWidth?: number | undefined;
+declare namespace ColumnResizer {
+    interface ResizerProps {
+        /**
+         * Any custom classes.
+         * If set, default width and backgroundColor styles will not be applied.
+         *
+         * @default ""
+         */
+        className?: string | undefined;
+
+        /**
+         * Set to true if you want to disable resizing
+         *
+         * @default false
+         */
+        disabled?: boolean | undefined;
+
+        /**
+         * The minimum width for the columns (in pixels)
+         *
+         * @default 0
+         */
+        minWidth?: number | undefined;
+    }
 }
 
-export default class ColumnResizer extends Component<ResizerProps> {}
+declare class ColumnResizer extends Component<ColumnResizer.ResizerProps> {}
+
+export = ColumnResizer;

--- a/types/react-column-resizer/react-column-resizer-tests.tsx
+++ b/types/react-column-resizer/react-column-resizer-tests.tsx
@@ -1,28 +1,6 @@
 import * as React from "react";
 import ColumnResizer from "react-column-resizer";
 
-class TableComponent extends React.Component {
-    render() {
-        return (
-            <div>
-                <table>
-                    <tbody>
-                        <tr>
-                            <td>1</td>
-                            <ColumnResizer className="columnResizer" minWidth={0} />
-                            <td>2</td>
-                        </tr>
-
-                        <tr>
-                            <td>3</td>
-                            <td />
-                            <td>4</td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-        );
-    }
-}
-
-<TableComponent />;
+<ColumnResizer className="columnResizer" />;
+<ColumnResizer disabled />;
+<ColumnResizer minWidth={12} />;


### PR DESCRIPTION
The newly-added jsdoc is based on [readme file](https://github.com/nicole-mcg/react-column-resizer?tab=readme-ov-file#props) in source code.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>