### PR TITLE
@event-calendar/core: Conform to a Svelte component

### DIFF
--- a/types/event-calendar__core/event-calendar__core-tests.ts
+++ b/types/event-calendar__core/event-calendar__core-tests.ts
@@ -1,8 +1,13 @@
 import Calendar from "@event-calendar/core";
 
-// ensure all options are optional
 const target = document.createElement("div");
+// ensure props is optional
 let cal = new Calendar({
+    target: target,
+});
+cal.destroy();
+// ensure all options are marked as optional
+cal = new Calendar({
     target: target,
     props: {
         plugins: [],

--- a/types/event-calendar__core/event-calendar__core-tests.ts
+++ b/types/event-calendar__core/event-calendar__core-tests.ts
@@ -14,6 +14,12 @@ cal = new Calendar({
         options: {},
     },
 });
+cal.destroy();
+// exercise at least one other SvelteComponent constructor option
+cal = new Calendar({
+    target: target,
+    hydrate: true,
+});
 
 // exercise each member function
 cal.getOption("date");

--- a/types/event-calendar__core/index.d.ts
+++ b/types/event-calendar__core/index.d.ts
@@ -1,9 +1,10 @@
 /// <reference lib="es5" />
 /// <reference lib="dom" />
+import { SvelteComponent } from "svelte";
 
 export default Calendar;
 
-declare class Calendar {
+declare class Calendar extends SvelteComponent {
     constructor(options: Calendar.ConstructorOptions);
     getOption<K extends keyof Calendar.Options>(option: K): Calendar.Options[K];
     setOption<K extends keyof Calendar.Options>(option: K, value: Calendar.Options[K]): Calendar;
@@ -28,7 +29,7 @@ declare namespace Calendar {
 
     interface ConstructorOptions {
         target: HTMLElement;
-        props: {
+        props?: {
             plugins: Plugin[];
             options: Options;
         };

--- a/types/event-calendar__core/index.d.ts
+++ b/types/event-calendar__core/index.d.ts
@@ -4,7 +4,7 @@ import { SvelteComponent } from "svelte";
 
 export default Calendar;
 
-declare class Calendar extends SvelteComponent {
+declare class Calendar extends SvelteComponent<Calendar.ComponentProps> {
     constructor(options: Calendar.ConstructorOptions);
     getOption<K extends keyof Calendar.Options>(option: K): Calendar.Options[K];
     setOption<K extends keyof Calendar.Options>(option: K, value: Calendar.Options[K]): Calendar;
@@ -27,12 +27,14 @@ declare namespace Calendar {
 
     type DomEvent = GlobalEventHandlersEventMap[keyof GlobalEventHandlersEventMap];
 
+    interface ComponentProps {
+        plugins: Plugin[];
+        options: Options;
+    }
+
     interface ConstructorOptions {
         target: HTMLElement;
-        props?: {
-            plugins: Plugin[];
-            options: Options;
-        };
+        props?: ComponentProps;
     }
 
     type Content = string | { html: string } | { domNodes: Node[] };

--- a/types/event-calendar__core/index.d.ts
+++ b/types/event-calendar__core/index.d.ts
@@ -1,11 +1,11 @@
 /// <reference lib="es5" />
 /// <reference lib="dom" />
-import { SvelteComponent } from "svelte";
+import { ComponentConstructorOptions, SvelteComponent } from "svelte";
 
 export default Calendar;
 
 declare class Calendar extends SvelteComponent<Calendar.ComponentProps> {
-    constructor(options: Calendar.ConstructorOptions);
+    constructor(options: ComponentConstructorOptions<Calendar.ComponentProps>);
     getOption<K extends keyof Calendar.Options>(option: K): Calendar.Options[K];
     setOption<K extends keyof Calendar.Options>(option: K, value: Calendar.Options[K]): Calendar;
     addEvent(event: Calendar.Event | Calendar.EventInput): Calendar.Event | null;
@@ -30,11 +30,6 @@ declare namespace Calendar {
     interface ComponentProps {
         plugins: Plugin[];
         options: Options;
-    }
-
-    interface ConstructorOptions {
-        target: HTMLElement;
-        props?: ComponentProps;
     }
 
     type Content = string | { html: string } | { domNodes: Node[] };

--- a/types/event-calendar__core/package.json
+++ b/types/event-calendar__core/package.json
@@ -14,5 +14,8 @@
             "name": "Michael Driscoll",
             "githubUsername": "syncsynchalt"
         }
-    ]
+    ],
+    "dependencies": {
+        "svelte": "^4"
+    }
 }


### PR DESCRIPTION
# Description

This library advertises itself as being optionally usable as a Svelte component.  Users [found that VSCode was reporting type errors](https://github.com/vkurko/calendar/issues/95#issuecomment-2407015535) when used with the combination of library + TS + Svelte.

cc @Flymeth

# PR Template

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [library's readme indicates its use as a Svelte component](https://github.com/vkurko/calendar/?tab=readme-ov-file#javascript-module--svelte-component)
- [x] (N/A) If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
