### PR TITLE
[jquery-toast-plugin] Allow `string` and `string[]` as input

### DIFF
--- a/types/jquery-toast-plugin/index.d.ts
+++ b/types/jquery-toast-plugin/index.d.ts
@@ -1,11 +1,11 @@
 /// <reference types="jquery"/>
 
 interface JQueryStatic {
-    toast(options: toastOptions): void;
+    toast(options: string | readonly string[] | toastOptions): void;
 }
 
 interface toastOptions {
-    text: string;
+    text: string | readonly string[];
     heading?: string | undefined;
     showHideTransition?: "fade" | "slide" | "plain" | undefined;
     allowToastClose?: boolean | undefined;

--- a/types/jquery-toast-plugin/jquery-toast-plugin-tests.ts
+++ b/types/jquery-toast-plugin/jquery-toast-plugin-tests.ts
@@ -1,3 +1,7 @@
+$.toast("test");
+$.toast(["test1", "test2"]);
+$.toast({ text: ["test1", "test2"] });
+
 $.toast({ text: "test" });
 
 $.toast({ text: "test", heading: "Test Heading" });


### PR DESCRIPTION
Related discussion: #70880

Fixes the allowed types for the argument to `$.toast`

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
      <https://github.com/kamranahmedse/jquery-toast-plugin/blob/9ed0b7ac77bcd77eff79d07c7d340762aa38ffd1/src/jquery.toast.js#L24-L32>
      <https://github.com/kamranahmedse/jquery-toast-plugin#quick-usage-examples>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
