### PR TITLE
feat(react-splitter-layout): fix "export =", refine props, upgrade

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -1543,7 +1543,6 @@
         "react-sidebar",
         "react-sortable-tree-theme-file-explorer",
         "react-sortable-tree",
-        "react-splitter-layout",
         "react-sticky-el",
         "react-svg-radar-chart",
         "react-swf",

--- a/types/react-splitter-layout/index.d.ts
+++ b/types/react-splitter-layout/index.d.ts
@@ -1,96 +1,101 @@
 import * as React from "react";
 
-export default class SplitterLayout extends React.PureComponent<SplitterLayoutProps> {
+declare class SplitterLayout extends React.PureComponent<SplitterLayout.SplitterLayoutProps> {}
+
+declare namespace SplitterLayout {
+    type TPrimaryIndex = 0 | 1;
+
+    interface SplitterLayoutProps {
+        /**
+         * Custom CSS class name applied to the layout div.
+         * You can use this to customize layout style.
+         * Refers to the original stylesheet to see what you can customize.
+         *
+         * @default ""
+         */
+        customClassName?: string | undefined;
+
+        /**
+         * Determine whether the layout should be a horizontal split or a vertical split.
+         *
+         * @default false
+         */
+        vertical?: boolean | undefined;
+
+        /**
+         * Determine whether the width of each pane should be calculated in percentage or by pixels.
+         * The default value is false, which means width is calculated in pixels.
+         *
+         * @default false
+         */
+        percentage?: boolean | undefined;
+
+        /**
+         * Index of the primary pane.
+         * Since SplitterLayout supports at most 2 children, only 0 or 1 is allowed.
+         *
+         * A primary pane is used to show users primary content, while a secondary pane is the other pane.
+         * When window size changes and percentage is set to false, primary pane's size is flexible
+         * and secondary pane's size is kept unchanged. However, when the window size is not enough
+         * for showing both minimal primary pane and minimal secondary pane,
+         * the primary pane's size is served first.
+         *
+         * @default 0
+         */
+        primaryIndex?: TPrimaryIndex | undefined;
+
+        /**
+         * Minimal size of primary pane.
+         * When percentage is set to false, this value is pixel size (25 means 25px).
+         * When percentage is set to true, this value is percentage (25 means 25%).
+         *
+         * @default 0
+         */
+        primaryMinSize?: number | undefined;
+
+        /**
+         * Minimal size of secondary pane.
+         *
+         * @default 0
+         */
+        secondaryMinSize?: number | undefined;
+
+        /**
+         * Initial size of secondary pane when page loads.
+         * If this prop is not defined, SplitterLayout tries to split the layout with equal sizes.
+         * (Note: equal size may not apply when there are nested layouts.)
+         */
+        secondaryInitialSize?: number | undefined;
+
+        /**
+         * Called when dragging is started.
+         *
+         * No parameter will be passed to event handlers.
+         */
+        onDragStart?: (() => void) | undefined;
+
+        /**
+         * Called when dragging finishes.
+         *
+         * No parameter will be passed to event handlers.
+         */
+        onDragEnd?: (() => void) | undefined;
+
+        /**
+         * Called when the size of secondary pane is changed.
+         *
+         * Event handlers will be passed with a single parameter of number type representing
+         * new size of secondary pane.
+         * When percentage is set to false, the value is in pixel size.
+         * When percentage is set to true, the value is in percentage.
+         */
+        onSecondaryPaneSizeChange?: ((value: number) => void) | undefined;
+
+        /**
+         * Placeholder of the panel(s) inside the splitter
+         */
+        children?: React.ReactNode | React.ReactNode[];
+    }
 }
 
-export type TPrimaryIndex = 0 | 1;
-
-export interface SplitterLayoutProps {
-    /**
-     * Custom CSS class name applied to the layout div.
-     * You can use this to customize layout style.
-     * Refers to the original stylesheet to see what you can customize.
-     */
-    customClassName?: string | undefined;
-
-    /**
-     * Determine whether the layout should be a horizontal split or a vertical split.
-     *
-     * @default false
-     */
-    vertical?: boolean | undefined;
-
-    /**
-     * Determine whether the width of each pane should be calculated in percentage or by pixels.
-     * The default value is false, which means width is calculated in pixels.
-     *
-     * @default false
-     */
-    percentage?: boolean | undefined;
-
-    /**
-     * Index of the primary pane.
-     * Since SplitterLayout supports at most 2 children, only 0 or 1 is allowed.
-     *
-     * A primary pane is used to show users primary content, while a secondary pane is the other pane.
-     * When window size changes and percentage is set to false, primary pane's size is flexible
-     * and secondary pane's size is kept unchanged. However, when the window size is not enough
-     * for showing both minimal primary pane and minimal secondary pane,
-     * the primary pane's size is served first.
-     *
-     * @default 0
-     */
-    primaryIndex?: TPrimaryIndex | undefined;
-
-    /**
-     * Minimal size of primary pane.
-     * When percentage is set to false, this value is pixel size (25 means 25px).
-     * When percentage is set to true, this value is percentage (25 means 25%).
-     *
-     * @default 0
-     */
-    primaryMinSize?: number | undefined;
-
-    /**
-     * Minimal size of secondary pane.
-     */
-    secondaryMinSize?: number | undefined;
-
-    /**
-     * Initial size of secondary pane when page loads.
-     * If this prop is not defined, SplitterLayout tries to split the layout with equal sizes.
-     * (Note: equal size may not apply when there are nested layouts.)
-     *
-     * @default undefined
-     */
-    secondaryInitialSize?: number | undefined;
-
-    /**
-     * Called when dragging is started.
-     *
-     * No parameter will be passed to event handlers.
-     */
-    onDragStart?: (() => void) | undefined;
-
-    /**
-     * Called when dragging finishes.
-     *
-     * No parameter will be passed to event handlers.
-     */
-    onDragEnd?: (() => void) | undefined;
-
-    /**
-     * Called when the size of secondary pane is changed.
-     *
-     * Event handlers will be passed with a single parameter of number type representing
-     * new size of secondary pane.
-     * When percentage is set to false, the value is in pixel size.
-     * When percentage is set to true, the value is in percentage.
-     */
-    onSecondaryPaneSizeChange?: ((value: number) => void) | undefined;
-
-    /**
-     * Placeholder of the panel(s) inside the splitter
-     */
-    children?: any;
-}
+export = SplitterLayout;

--- a/types/react-splitter-layout/package.json
+++ b/types/react-splitter-layout/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/react-splitter-layout",
-    "version": "3.0.9999",
+    "version": "4.0.9999",
     "projects": [
         "https://github.com/zesik/react-splitter-layout"
     ],

--- a/types/react-splitter-layout/react-splitter-layout-tests.tsx
+++ b/types/react-splitter-layout/react-splitter-layout-tests.tsx
@@ -1,17 +1,38 @@
 import * as React from "react";
 import SplitterLayout, { SplitterLayoutProps } from "react-splitter-layout";
 
-export class SplitterLayoutTest extends React.PureComponent {
-    render(): React.JSX.Element {
-        const props: SplitterLayoutProps = {
-            percentage: true,
-            secondaryInitialSize: 40,
-        };
-        return (
-            <SplitterLayout {...props}>
-                <div>1st</div>
-                <div>2nd</div>
-            </SplitterLayout>
-        );
-    }
-}
+<SplitterLayout />;
+
+<SplitterLayout customClassName="custom-class" />;
+
+<SplitterLayout vertical />;
+
+<SplitterLayout percentage />;
+
+<SplitterLayout primaryIndex={1} />;
+
+<SplitterLayout primaryMinSize={25} />;
+
+<SplitterLayout secondaryMinSize={25} />;
+
+<SplitterLayout secondaryInitialSize={25} />;
+
+<SplitterLayout onDragStart={() => {}} />;
+
+<SplitterLayout onDragEnd={() => {}} />;
+
+<SplitterLayout
+    onSecondaryPaneSizeChange={(value) => {
+        // $ExpectType number
+        value;
+    }}
+/>;
+
+<SplitterLayout>
+    <div>1st</div>
+</SplitterLayout>;
+
+<SplitterLayout>
+    <div>1st</div>
+    <div>2nd</div>
+</SplitterLayout>;


### PR DESCRIPTION
- The newly-added `@default` tags in jsdoc is from [`defaultProps` in source code](https://github.com/zesik/react-splitter-layout/blob/e0e54194071b778d83894179622b9ae1c58b8d34/src/components/SplitterLayout.jsx#L238-L250)
- The type of `props.children` is changed to `React.ReactNode | React.ReactNode[]`, since from [source code](https://github.com/zesik/react-splitter-layout/blob/e0e54194071b778d83894179622b9ae1c58b8d34/src/components/SplitterLayout.jsx#L184), it is supposed to be consumed by `React.Children.toArray()`.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
