### PR TITLE
[gatsbyjs__reach-router]: Adds an import for `History` from `@reach/router` to make LocationProvider accept the right type

### DIFF
--- a/types/gatsbyjs__reach-router/gatsbyjs__reach-router-tests.tsx
+++ b/types/gatsbyjs__reach-router/gatsbyjs__reach-router-tests.tsx
@@ -1,4 +1,6 @@
 import {
+    createHistory,
+    createMemorySource,
     Link,
     Location,
     LocationProvider,
@@ -93,3 +95,7 @@ const refObject: React.RefObject<HTMLAnchorElement> = { current: null };
 <Link ref={refObject} to="./foo"></Link>;
 
 const elem: React.JSX.Element = <Link<number> state={5} to="./foo">Click me!</Link>;
+
+<LocationProvider history={createHistory(createMemorySource("/"))}>
+    This text has history
+</LocationProvider>;

--- a/types/gatsbyjs__reach-router/index.d.ts
+++ b/types/gatsbyjs__reach-router/index.d.ts
@@ -40,6 +40,8 @@ export {
     WindowLocation,
 } from "@reach/router";
 
+import { History } from "@reach/router"; // eslint-disable-line no-duplicate-imports
+
 // Override location to remove navigate function for React 18 server components compatibility
 // https://github.com/gatsbyjs/reach-router/pull/4
 


### PR DESCRIPTION
Without this import, TypeScript uses the `History` type definition for the global `window.history` object and therefore `LocationProvider` will not accept a `history` prop created by `createHistory`.

The problem was in this declaration: 

```
export interface LocationProviderProps {
    history?: History | undefined;
    children?: React.ReactNode | LocationProviderRenderFn | undefined;
}
```

This compiles, but `history` is not what it seems. Although we do `export { History } from "@reach/router"` earlier, this is not the `History` we're looking for. [MDN on re-exporting](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export#re-exporting_aggregating):

> This can be achieved with the "export from" syntax:
> ```
> export { default as function1, function2 } from "bar.js";
> ```
> Which is comparable to a combination of import and export, except that `function1` and `function2` do not become available inside the current module:
> ```
> import { default as function1, function2 } from "bar.js";
> export { function1, function2 };
> ```

So what happens is that we're using the TypeScript builtin [`History`](https://github.com/microsoft/TypeScript/blob/main/src/lib/dom.generated.d.ts#L13998) type. The solution was simply adding a separate import for `History` so that we're using the correct type.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export#re-exporting_aggregating
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
