### PR TITLE
Update types to match react-dual-listbox 6.0.x API 

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -1468,7 +1468,6 @@
         "react-date-range/v0",
         "react-document-meta",
         "react-dom",
-        "react-dual-listbox",
         "react-dynamic-number",
         "react-email-editor",
         "react-embed-gist",

--- a/types/react-dual-listbox/index.d.ts
+++ b/types/react-dual-listbox/index.d.ts
@@ -1,293 +1,297 @@
 import * as React from "react";
 
-/**
- * A value-based option.
- */
-export interface ValueOption<T> {
+declare namespace DualListBox {
     /**
-     * Whether the option is disabled or not.
-     *
-     * @default false
+     * A value-based option.
      */
-    disabled?: boolean;
+    interface ValueOption<T> {
+        /**
+         * Whether the option is disabled or not.
+         *
+         * @default false
+         */
+        disabled?: boolean;
+        /**
+         * Adds the HTML `title` attribute to the option.
+         */
+        title?: string;
+        /**
+         * The option label.
+         */
+        label: string;
+        /**
+         * The option value.
+         */
+        value: T;
+    }
+
     /**
-     * Adds the HTML `title` attribute to the option.
+     * A category with other categories and values.
      */
-    title?: string;
+    interface CategoryOption<T> {
+        /**
+         * Whether the category is disabled or not.
+         *
+         * @default false
+         */
+        disabled?: boolean;
+        /**
+         * Adds the HTML `title` attribute to the option.
+         */
+        title?: string;
+        /**
+         * The category label.
+         */
+        label: string;
+        /**
+         * The category child options.
+         */
+        options: ReadonlyArray<Option<T>> | Array<Option<T>>;
+    }
+
     /**
-     * The option label.
+     * Valid options include values and categories.
      */
-    label: string;
+    type Option<T> = ValueOption<T> | CategoryOption<T>;
+
     /**
-     * The option value.
+     * A filter.
      */
-    value: T;
+    interface Filter<T> {
+        /**
+         * Available options.
+         */
+        available: readonly T[] | T[];
+        /**
+         * Selected options.
+         */
+        selected: readonly T[] | T[];
+    }
+
+    /**
+     * Properties common to every `DualListBox`.
+     */
+    interface CommonProperties<T> {
+        /**
+         * Available options.
+         */
+        options: ReadonlyArray<Option<T>> | Array<Option<T>>;
+        /**
+         * Selected options.
+         */
+        selected?: readonly T[] | T[];
+        /**
+         * A React function `ref` to the "selected" list box.
+         */
+        selectedRef?: ((availableInput: HTMLSelectElement) => void) | null;
+        /**
+         * Override the default alignment of action buttons.
+         *
+         * @default "middle"
+         */
+        alignActions?: "top" | "middle";
+        /**
+         * If true, duplicate options will be allowed in the selected list box.
+         *
+         * @default false
+         */
+        allowDuplicates?: boolean;
+        /**
+         * A subset of the `options` array to optionally filter the available list
+         * box.
+         */
+        available?: readonly T[] | T[];
+        /**
+         * A React function `ref` to the "available" list box.
+         *
+         * @default null
+         */
+        availableRef?: ((availableInput: HTMLSelectElement) => void) | null;
+        /**
+         * An optional `className` to apply to the root node.
+         *
+         * @default null
+         */
+        className?: string | null;
+        /**
+         * If true, both "available" and "selected" list boxes will be disabled.
+         *
+         * @default false
+         */
+        disabled?: boolean;
+        /**
+         * Resolve the label from an option
+         *
+         * @default option => option.label
+         */
+        getOptionLabel?: (option: ValueOption<T>) => string;
+        /**
+         * Resolve the value from an option
+         *
+         * @default option => option.value
+         */
+        getOptionValue?: (option: ValueOption<T>) => string;
+        /**
+         * The {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir | directionality}
+         * of the component's elements. Set to 'rtl' if using a right-to-left language.
+         */
+        htmlDir?: string;
+        /**
+         * A key-value pairing of action icons and their React nodes.
+         */
+        icons?: {
+            [
+                k in
+                    | "moveToAvailable"
+                    | "moveAllToAvailable"
+                    | "moveToSelected"
+                    | "moveAllToSelected"
+                    | "moveDown"
+                    | "moveUp"
+                    | "moveTop"
+                    | "moveBottom"
+            ]?: React.ReactNode;
+        };
+        /**
+         * A value specifying which overarching icon class to use.
+         * Built-in support for fa5, fa6, and native icons.
+         *
+         * @default "fa6"
+         */
+        iconsClass?: string;
+        /**
+         * An HTML ID prefix for the various sub elements.
+         *
+         * @default null
+         */
+        id?: string | null;
+        /**
+         * A key-value pairing of localized text.
+         */
+        lang?: {
+            [
+                k in
+                    | "availableFilterHeader"
+                    | "availableFilterPlaceholer"
+                    | "availableHeader"
+                    | "hiddenInputLabel"
+                    | "moveAllToAvailable"
+                    | "moveAllToSelected"
+                    | "moveToAvailable"
+                    | "moveToSelected"
+                    | "moveBottom"
+                    | "moveDown"
+                    | "moveUp"
+                    | "moveTop"
+                    | "noAvailableOptions"
+                    | "noSelectedOptions"
+                    | "requiredError"
+                    | "selectedFilterHeader"
+                    | "selectedFilterPlaceholder"
+                    | "selectedHeader"
+            ]?: string;
+        };
+        /**
+         * A list of key codes that will trigger a toggle of the selected options.
+         *
+         * @default [' ', 'Enter']
+         */
+        moveKeys?: string[];
+        /**
+         * A value for the `name` attribute on the hidden `<input />` element. This is potentially
+         * useful for form submissions.
+         *
+         * @default null
+         */
+        name?: string | null;
+        /**
+         * This flag will preserve the selection order.  By default, `react-dual-listbox` orders
+         * selected items according to the order of the `options` property.
+         *
+         * @default false
+         */
+        preserveSelectOrder?: boolean;
+        /**
+         * f true, this component will require selected to be non-empty to pass a form validation
+         *
+         * @default false
+         */
+        required?: boolean;
+        /**
+         * If true, labels above both the available and selected list boxes will appear. These labels
+         * derive from `lang`.
+         *
+         * @default false
+         */
+        showHeaderLabels?: boolean;
+        /**
+         * If true, text will appear in place of the available/selected list boxes when no options are
+         * present.
+         *
+         * @default false;
+         */
+        showNoOptionsText?: boolean;
+        /**
+         * If true, a set of up/down buttons will appear near the selected list box to allow the user
+         * to re-arrange the items.
+         *
+         * @default false
+         */
+        showOrderButtons?: boolean;
+    }
+
+    /**
+     * Additional `DualListBox` properties with filter.
+     */
+    interface FilterProperties<T, F extends boolean, V extends boolean> {
+        /**
+         * Flag that determines whether filtering is enabled.
+         *
+         * @default false
+         */
+        canFilter?: F;
+        /**
+         * Override the default filtering function.
+         */
+        filterCallback?: F extends true
+            ? (option: Option<T>, filterInput: string, props: DualListBoxProperties<T, true, V>) => boolean
+            : undefined;
+        /**
+         * Control the filter search text.
+         */
+        filter?: Filter<T>;
+        /**
+         * Handle filter change.
+         */
+        onFilterChange?: F extends true ? (filter: string) => void : undefined;
+    }
+
+    /**
+     * Additional `DualListBox` properties with complex selected values.
+     */
+    interface ValueProperties<T, V extends boolean> {
+        /**
+         * The handler called when options are moved to either side.
+         */
+        // onChange?: (selected: (T | Option<T>)[]) => void;
+        onChange?: (selected: V extends true ? T[] : Array<Option<T>>) => void;
+        /**
+         * If true, the selected value passed in onChange is an array of string values.
+         * Otherwise, it is an array of options.
+         *
+         * @default true
+         */
+        simpleValue?: V;
+    }
+
+    /**
+     * `DualListBox` component properties.
+     */
+    // export type DualListBoxProperties<P> = CommonProperties<P> & FilterProperties<P> & ValueProperties<P>;
+    interface DualListBoxProperties<P, F extends boolean, V extends boolean>
+        extends CommonProperties<P>, FilterProperties<P, F, V>, ValueProperties<P, V>
+    {}
 }
-
-/**
- * A category with other categories and values.
- */
-export interface CategoryOption<T> {
-    /**
-     * Whether the category is disabled or not.
-     *
-     * @default false
-     */
-    disabled?: boolean;
-    /**
-     * Adds the HTML `title` attribute to the option.
-     */
-    title?: string;
-    /**
-     * The category label.
-     */
-    label: string;
-    /**
-     * The category child options.
-     */
-    options: ReadonlyArray<Option<T>> | Array<Option<T>>;
-}
-
-/**
- * Valid options include values and categories.
- */
-export type Option<T> = ValueOption<T> | CategoryOption<T>;
-
-/**
- * A filter.
- */
-export interface Filter<T> {
-    /**
-     * Available options.
-     */
-    available: readonly T[] | T[];
-    /**
-     * Selected options.
-     */
-    selected: readonly T[] | T[];
-}
-
-/**
- * Properties common to every `DualListBox`.
- */
-export interface CommonProperties<T> {
-    /**
-     * Available options.
-     */
-    options: ReadonlyArray<Option<T>> | Array<Option<T>>;
-    /**
-     * Selected options.
-     */
-    selected?: readonly T[] | T[];
-    /**
-     * A React function `ref` to the "selected" list box.
-     */
-    selectedRef?: ((availableInput: HTMLSelectElement) => void) | null;
-    /**
-     * Override the default alignment of action buttons.
-     *
-     * @default "middle"
-     */
-    alignActions?: "top" | "middle";
-    /**
-     * If true, duplicate options will be allowed in the selected list box.
-     *
-     * @default false
-     */
-    allowDuplicates?: boolean;
-    /**
-     * A subset of the `options` array to optionally filter the available list
-     * box.
-     */
-    available?: readonly T[] | T[];
-    /**
-     * A React function `ref` to the "available" list box.
-     *
-     * @default null
-     */
-    availableRef?: ((availableInput: HTMLSelectElement) => void) | null;
-    /**
-     * An optional `className` to apply to the root node.
-     *
-     * @default null
-     */
-    className?: string | null;
-    /**
-     * If true, both "available" and "selected" list boxes will be disabled.
-     *
-     * @default false
-     */
-    disabled?: boolean;
-    /**
-     * Resolve the label from an option
-     * 
-     * @default option => option.label
-     */
-    getOptionLabel?: (option: ValueOption<T>) => string;
-    /**
-     * Resolve the value from an option
-     * 
-     * @default option => option.value
-     */
-    getOptionValue?: (option: ValueOption<T>) => string;
-    /**
-     * The {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir | directionality}
-     * of the component's elements. Set to 'rtl' if using a right-to-left language.
-     */
-    htmlDir?: string;
-    /**
-     * A key-value pairing of action icons and their React nodes.
-     */
-    icons?: {
-        [
-            k in
-                | "moveToAvailable"
-                | "moveAllToAvailable"
-                | "moveToSelected"
-                | "moveAllToSelected"
-                | "moveDown"
-                | "moveUp"
-                | "moveTop"
-                | "moveBottom"
-        ]?: React.ReactNode;
-    };
-    /**
-     * A value specifying which overarching icon class to use.
-     * Built-in support for fa5, fa6, and native icons.
-     * 
-     * @default "fa6"
-     */
-    iconsClass?: string;
-    /**
-     * An HTML ID prefix for the various sub elements.
-     *
-     * @default null
-     */
-    id?: string | null;
-    /**
-     * A key-value pairing of localized text.
-     */
-    lang?: {
-        [
-            k in
-                | "availableFilterHeader"
-                | "availableFilterPlaceholer"
-                | "availableHeader"
-                | "hiddenInputLabel"
-                | "moveAllToAvailable"
-                | "moveAllToSelected"
-                | "moveToAvailable"
-                | "moveToSelected"
-                | "moveBottom"
-                | "moveDown"
-                | "moveUp"
-                | "moveTop"
-                | "noAvailableOptions"
-                | "noSelectedOptions"
-                | "requiredError"
-                | "selectedFilterHeader"
-                | "selectedFilterPlaceholder"
-                | "selectedHeader"
-        ]?: string;
-    };
-    /**
-     * A list of key codes that will trigger a toggle of the selected options.
-     *
-     * @default [' ', 'Enter']
-     */
-    moveKeys?: string[];
-    /**
-     * A value for the `name` attribute on the hidden `<input />` element. This is potentially
-     * useful for form submissions.
-     *
-     * @default null
-     */
-    name?: string | null;
-    /**
-     * This flag will preserve the selection order.  By default, `react-dual-listbox` orders
-     * selected items according to the order of the `options` property.
-     *
-     * @default false
-     */
-    preserveSelectOrder?: boolean;
-    /**
-     * f true, this component will require selected to be non-empty to pass a form validation
-     * 
-     * @default false
-     */
-    required?: boolean;
-    /**
-     * If true, labels above both the available and selected list boxes will appear. These labels
-     * derive from `lang`.
-     *
-     * @default false
-     */
-    showHeaderLabels?: boolean;
-    /**
-     * If true, text will appear in place of the available/selected list boxes when no options are
-     * present.
-     *
-     * @default false;
-     */
-    showNoOptionsText?: boolean;
-    /**
-     * If true, a set of up/down buttons will appear near the selected list box to allow the user
-     * to re-arrange the items.
-     *
-     * @default false
-     */
-    showOrderButtons?: boolean;
-}
-
-/**
- * Additional `DualListBox` properties with filter.
- */
-export interface FilterProperties<T, F extends boolean, V extends boolean> {
-    /**
-     * Flag that determines whether filtering is enabled.
-     *
-     * @default false
-     */
-    canFilter?: F;
-    /**
-     * Override the default filtering function.
-     */
-    filterCallback?: F extends true ? (option: Option<T>, filterInput: string, props: DualListBoxProperties<T, true, V>) => boolean : undefined;
-    /**
-     * Control the filter search text.
-     */
-    filter?: Filter<T>;
-    /**
-     * Handle filter change.
-     */
-    onFilterChange?: F extends true ? (filter: string) => void : undefined;
-}
-
-/**
- * Additional `DualListBox` properties with complex selected values.
- */
-export interface ValueProperties<T, V extends boolean> {
-    /**
-     * The handler called when options are moved to either side.
-     */
-    // onChange?: (selected: (T | Option<T>)[]) => void;
-    onChange?: (selected: V extends true ? T[] : Array<Option<T>>) => void;
-    /**
-     * If true, the selected value passed in onChange is an array of string values.
-     * Otherwise, it is an array of options.
-     *
-     * @default true
-     */
-    simpleValue?: V;
-}
-
-/**
- * `DualListBox` component properties.
- */
-// export type DualListBoxProperties<P> = CommonProperties<P> & FilterProperties<P> & ValueProperties<P>;
-export interface DualListBoxProperties<P, F extends boolean, V extends boolean>
-    extends CommonProperties<P>, FilterProperties<P, F, V>, ValueProperties<P, V>
-{}
 
 /**
  * A feature-rich dual list box for React.
@@ -295,6 +299,8 @@ export interface DualListBoxProperties<P, F extends boolean, V extends boolean>
  * The `DualListBox` is a controlled component, so you have to update the `selected` property in
  * conjunction with the `onChange` handler if you want the selected values to change.
  */
-export default class DualListBox<P, F extends boolean = false, V extends boolean = true> extends React.Component<
-    DualListBoxProperties<P, F, V>
+declare class DualListBox<P, F extends boolean = false, V extends boolean = true> extends React.Component<
+    DualListBox.DualListBoxProperties<P, F, V>
 > {}
+
+export = DualListBox;

--- a/types/react-dual-listbox/index.d.ts
+++ b/types/react-dual-listbox/index.d.ts
@@ -119,21 +119,45 @@ export interface CommonProperties<T> {
      */
     disabled?: boolean;
     /**
+     * Resolve the label from an option
+     * 
+     * @default option => option.label
+     */
+    getOptionLabel?: (option: ValueOption<T>) => string;
+    /**
+     * Resolve the value from an option
+     * 
+     * @default option => option.value
+     */
+    getOptionValue?: (option: ValueOption<T>) => string;
+    /**
+     * The {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir | directionality}
+     * of the component's elements. Set to 'rtl' if using a right-to-left language.
+     */
+    htmlDir?: string;
+    /**
      * A key-value pairing of action icons and their React nodes.
      */
     icons?: {
         [
             k in
-                | "moveLeft"
-                | "moveAllLeft"
-                | "moveRight"
-                | "moveAllRight"
+                | "moveToAvailable"
+                | "moveAllToAvailable"
+                | "moveToSelected"
+                | "moveAllToSelected"
                 | "moveDown"
                 | "moveUp"
                 | "moveTop"
                 | "moveBottom"
         ]?: React.ReactNode;
     };
+    /**
+     * A value specifying which overarching icon class to use.
+     * Built-in support for fa5, fa6, and native icons.
+     * 
+     * @default "fa6"
+     */
+    iconsClass?: string;
     /**
      * An HTML ID prefix for the various sub elements.
      *
@@ -147,27 +171,31 @@ export interface CommonProperties<T> {
         [
             k in
                 | "availableFilterHeader"
+                | "availableFilterPlaceholer"
                 | "availableHeader"
-                | "moveAllLeft"
-                | "moveAllRight"
-                | "moveLeft"
-                | "moveRight"
+                | "hiddenInputLabel"
+                | "moveAllToAvailable"
+                | "moveAllToSelected"
+                | "moveToAvailable"
+                | "moveToSelected"
                 | "moveBottom"
                 | "moveDown"
                 | "moveUp"
                 | "moveTop"
                 | "noAvailableOptions"
                 | "noSelectedOptions"
+                | "requiredError"
                 | "selectedFilterHeader"
+                | "selectedFilterPlaceholder"
                 | "selectedHeader"
         ]?: string;
     };
     /**
      * A list of key codes that will trigger a toggle of the selected options.
      *
-     * @default [13, 32]
+     * @default [' ', 'Enter']
      */
-    moveKeyCodes?: number[];
+    moveKeys?: string[];
     /**
      * A value for the `name` attribute on the hidden `<input />` element. This is potentially
      * useful for form submissions.
@@ -182,6 +210,12 @@ export interface CommonProperties<T> {
      * @default false
      */
     preserveSelectOrder?: boolean;
+    /**
+     * f true, this component will require selected to be non-empty to pass a form validation
+     * 
+     * @default false
+     */
+    required?: boolean;
     /**
      * If true, labels above both the available and selected list boxes will appear. These labels
      * derive from `lang`.
@@ -208,7 +242,7 @@ export interface CommonProperties<T> {
 /**
  * Additional `DualListBox` properties with filter.
  */
-export interface FilterProperties<T, F extends boolean> {
+export interface FilterProperties<T, F extends boolean, V extends boolean> {
     /**
      * Flag that determines whether filtering is enabled.
      *
@@ -218,11 +252,7 @@ export interface FilterProperties<T, F extends boolean> {
     /**
      * Override the default filtering function.
      */
-    filterCallback?: F extends true ? (option: Option<T>, filterInput: string) => boolean : undefined;
-    /**
-     * Override the default filter placeholder.
-     */
-    filterPlaceholder?: F extends true ? string : undefined;
+    filterCallback?: F extends true ? (option: Option<T>, filterInput: string, props: DualListBoxProperties<T, true, V>) => boolean : undefined;
     /**
      * Control the filter search text.
      */
@@ -256,7 +286,7 @@ export interface ValueProperties<T, V extends boolean> {
  */
 // export type DualListBoxProperties<P> = CommonProperties<P> & FilterProperties<P> & ValueProperties<P>;
 export interface DualListBoxProperties<P, F extends boolean, V extends boolean>
-    extends CommonProperties<P>, FilterProperties<P, F>, ValueProperties<P, V>
+    extends CommonProperties<P>, FilterProperties<P, F, V>, ValueProperties<P, V>
 {}
 
 /**

--- a/types/react-dual-listbox/package.json
+++ b/types/react-dual-listbox/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/react-dual-listbox",
-    "version": "2.2.9999",
+    "version": "4.0.9999",
     "projects": [
         "https://github.com/jakezatecky/react-dual-listbox"
     ],

--- a/types/react-dual-listbox/package.json
+++ b/types/react-dual-listbox/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/react-dual-listbox",
-    "version": "4.0.9999",
+    "version": "6.0.9999",
     "projects": [
         "https://github.com/jakezatecky/react-dual-listbox"
     ],

--- a/types/react-dual-listbox/react-dual-listbox-tests.tsx
+++ b/types/react-dual-listbox/react-dual-listbox-tests.tsx
@@ -77,7 +77,6 @@ const optionsChange = (selectedValues: Array<Option<string>>) => {};
         selected: [],
     }}
     onFilterChange={() => {}}
-    filterPlaceholder={""}
     filterCallback={(option: Option<string>) => true}
 />;
 <DualListBox
@@ -88,7 +87,6 @@ const optionsChange = (selectedValues: Array<Option<string>>) => {};
         selected: [],
     }}
     onFilterChange={() => {}}
-    filterPlaceholder={""}
     filterCallback={(option: Option<string>) => true}
 />;
 
@@ -133,17 +131,17 @@ const optionsChange = (selectedValues: Array<Option<string>>) => {};
 /** Preserving select order. */
 <DualListBox options={flatOptions} preserveSelectOrder />;
 
-/** `moveKeyCodes` example. */
-<DualListBox options={flatOptions} moveKeyCodes={[13, 32]} />;
+/** `moveKeys` example. */
+<DualListBox options={flatOptions} moveKeys={[' ', 'Enter']} />;
 
 /** `icons` example. */
 <DualListBox
     options={flatOptions}
     icons={{
-        moveLeft: <span className="fa fa-chevron-left" />,
-        moveAllLeft: [<span key={0} className="fa fa-chevron-left" />, <span key={1} className="fa fa-chevron-left" />],
-        moveRight: <span className="fa fa-chevron-right" />,
-        moveAllRight: [
+        moveToAvailable: <span className="fa fa-chevron-left" />,
+        moveAllToAvailable: [<span key={0} className="fa fa-chevron-left" />, <span key={1} className="fa fa-chevron-left" />],
+        moveToSelected: <span className="fa fa-chevron-right" />,
+        moveAllToSelected: [
             <span key={0} className="fa fa-chevron-right" />,
             <span key={1} className="fa fa-chevron-right" />,
         ],
@@ -165,10 +163,10 @@ const optionsChange = (selectedValues: Array<Option<string>>) => {};
     allowDuplicates
     available={flatOptions.map(o => o.value)}
     icons={{
-        moveLeft: <span className="fa fa-chevron-left" />,
-        moveAllLeft: [<span key={0} className="fa fa-chevron-left" />, <span key={1} className="fa fa-chevron-left" />],
-        moveRight: <span className="fa fa-chevron-right" />,
-        moveAllRight: [
+        moveToAvailable: <span className="fa fa-chevron-left" />,
+        moveAllToAvailable: [<span key={0} className="fa fa-chevron-left" />, <span key={1} className="fa fa-chevron-left" />],
+        moveToSelected: <span className="fa fa-chevron-right" />,
+        moveAllToSelected: [
             <span key={0} className="fa fa-chevron-right" />,
             <span key={1} className="fa fa-chevron-right" />,
         ],
@@ -178,7 +176,7 @@ const optionsChange = (selectedValues: Array<Option<string>>) => {};
         moveBottom: <span className="fa fa-double-angle-down" />,
     }}
     lang={{ availableHeader: "Available", selectedHeader: "Selected" }}
-    moveKeyCodes={[13, 32]}
+    moveKeys={[' ', 'Enter']}
     simpleValue={false}
     onChange={optionsChange}
     canFilter
@@ -187,11 +185,12 @@ const optionsChange = (selectedValues: Array<Option<string>>) => {};
         selected: [],
     }}
     onFilterChange={() => {}}
-    filterPlaceholder={""}
     filterCallback={(option: Option<string>) => true}
     disabled
     preserveSelectOrder
     showHeaderLabels
     showNoOptionsText
     showOrderButtons
+    getOptionLabel={(option) => option.label}
+    getOptionValue={(option) => option.value}
 />;

--- a/types/react-dual-listbox/react-dual-listbox-tests.tsx
+++ b/types/react-dual-listbox/react-dual-listbox-tests.tsx
@@ -132,14 +132,17 @@ const optionsChange = (selectedValues: Array<Option<string>>) => {};
 <DualListBox options={flatOptions} preserveSelectOrder />;
 
 /** `moveKeys` example. */
-<DualListBox options={flatOptions} moveKeys={[' ', 'Enter']} />;
+<DualListBox options={flatOptions} moveKeys={[" ", "Enter"]} />;
 
 /** `icons` example. */
 <DualListBox
     options={flatOptions}
     icons={{
         moveToAvailable: <span className="fa fa-chevron-left" />,
-        moveAllToAvailable: [<span key={0} className="fa fa-chevron-left" />, <span key={1} className="fa fa-chevron-left" />],
+        moveAllToAvailable: [
+            <span key={0} className="fa fa-chevron-left" />,
+            <span key={1} className="fa fa-chevron-left" />,
+        ],
         moveToSelected: <span className="fa fa-chevron-right" />,
         moveAllToSelected: [
             <span key={0} className="fa fa-chevron-right" />,
@@ -164,7 +167,10 @@ const optionsChange = (selectedValues: Array<Option<string>>) => {};
     available={flatOptions.map(o => o.value)}
     icons={{
         moveToAvailable: <span className="fa fa-chevron-left" />,
-        moveAllToAvailable: [<span key={0} className="fa fa-chevron-left" />, <span key={1} className="fa fa-chevron-left" />],
+        moveAllToAvailable: [
+            <span key={0} className="fa fa-chevron-left" />,
+            <span key={1} className="fa fa-chevron-left" />,
+        ],
         moveToSelected: <span className="fa fa-chevron-right" />,
         moveAllToSelected: [
             <span key={0} className="fa fa-chevron-right" />,
@@ -176,7 +182,7 @@ const optionsChange = (selectedValues: Array<Option<string>>) => {};
         moveBottom: <span className="fa fa-double-angle-down" />,
     }}
     lang={{ availableHeader: "Available", selectedHeader: "Selected" }}
-    moveKeys={[' ', 'Enter']}
+    moveKeys={[" ", "Enter"]}
     simpleValue={false}
     onChange={optionsChange}
     canFilter


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jakezatecky/react-dual-listbox/blob/714756ecd850ccf95ed1df6cfe1b25d07ed377a6/CHANGELOG.md
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

This PR updates the type definitions to match the current state of the react-dual-listbox library.

The types are updated to match the changes described in
https://github.com/jakezatecky/react-dual-listbox/blob/714756ecd850ccf95ed1df6cfe1b25d07ed377a6/CHANGELOG.md#600-2023-12-06 and https://github.com/jakezatecky/react-dual-listbox/blob/714756ecd850ccf95ed1df6cfe1b25d07ed377a6/CHANGELOG.md#breaking-changes-1
