### PR TITLE
`@types/mapbox__mapbox-sdk`: Update static image API types to match docs and SDK JSDoc

### DIFF
--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -1841,7 +1841,7 @@ declare module "@mapbox/mapbox-sdk/services/static" {
          * Get a static map image..
          * @param request
          */
-        getStaticImage(request: StaticMapRequest): MapiRequest;
+        getStaticImage(request: StaticMapRequest): MapiRequest<string>;
     }
 
     interface StaticMapRequest {
@@ -1856,6 +1856,7 @@ declare module "@mapbox/mapbox-sdk/services/static" {
                 bearing?: number | undefined;
                 pitch?: number | undefined;
             }
+            | { bbox: [number, number, number, number]; bearing?: number | undefined; pitch?: number | undefined }
             | "auto";
         padding?: string | undefined;
         overlays?: Array<CustomMarkerOverlay | SimpleMarkerOverlay | PathOverlay | GeoJsonOverlay> | undefined;

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -1856,7 +1856,11 @@ declare module "@mapbox/mapbox-sdk/services/static" {
                 bearing?: number | undefined;
                 pitch?: number | undefined;
             }
-            | { bbox: [number, number, number, number]; bearing?: number | undefined; pitch?: number | undefined }
+            | {
+                bbox: [number, number, number, number];
+                bearing?: number | undefined;
+                pitch?: number | undefined;
+            }
             | "auto";
         padding?: string | undefined;
         overlays?: Array<CustomMarkerOverlay | SimpleMarkerOverlay | PathOverlay | GeoJsonOverlay> | undefined;

--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -1856,11 +1856,7 @@ declare module "@mapbox/mapbox-sdk/services/static" {
                 bearing?: number | undefined;
                 pitch?: number | undefined;
             }
-            | {
-                bbox: [number, number, number, number];
-                bearing?: number | undefined;
-                pitch?: number | undefined;
-            }
+            | { bbox: [number, number, number, number] }
             | "auto";
         padding?: string | undefined;
         overlays?: Array<CustomMarkerOverlay | SimpleMarkerOverlay | PathOverlay | GeoJsonOverlay> | undefined;

--- a/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
+++ b/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
@@ -244,6 +244,14 @@ staticMapService.getStaticImage({
     layer_id: "building",
 });
 
+staticMapService.getStaticImage({
+    ownerId: "owner-id",
+    styleId: "some-style",
+    width: 16,
+    height: 16,
+    position: { bbox: [-7.66571044921875, 49.882247460433376, 1.7633056640625, 58.67051177185283] },
+});
+
 const geocodeService: GeocodeService = Geocoding(config);
 geocodeService
     .forwardGeocode({

--- a/types/mapbox__mapbox-sdk/package.json
+++ b/types/mapbox__mapbox-sdk/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/mapbox__mapbox-sdk",
-    "version": "0.15.9999",
+    "version": "0.16.9999",
     "projects": [
         "https://github.com/mapbox/mapbox-sdk-js"
     ],


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Mapbox-SDK](https://github.com/mapbox/mapbox-sdk-js/blob/12f5a42de575c6ea9dde011f2d0188e79303290b/services/static.js#L30) [Mapbox Docs](https://docs.mapbox.com/api/maps/static-images/#retrieve-a-static-map-from-a-style)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
