### PR TITLE
[any-db] fix: make config in createPool() and add null case in callback errors

### DIFF
--- a/types/any-db/any-db-tests.ts
+++ b/types/any-db/any-db-tests.ts
@@ -31,3 +31,5 @@ pool.query(sql).on("data", (row: Object[]): void => {
 
 pool.close((error: Error): void => {
 });
+
+anyDB.createPool("mysql://user:password@localhost/testdb");

--- a/types/any-db/any-db-tests.ts
+++ b/types/any-db/any-db-tests.ts
@@ -11,7 +11,7 @@ conn.query(sql).on("data", (row: Object[]): void => {
     // nothing
 });
 
-conn.query(sql, [1, "s"], (error: Error, result: anyDB.ResultSet): void => {
+conn.query(sql, [1, "s"], (error: Error | null, result: anyDB.ResultSet): void => {
     result.rows.length;
     result.fields.length;
 });
@@ -29,7 +29,7 @@ pool.query(sql).on("data", (row: Object[]): void => {
     // nothing
 });
 
-pool.close((error: Error): void => {
+pool.close((error: Error | null): void => {
 });
 
 anyDB.createPool("mysql://user:password@localhost/testdb");

--- a/types/any-db/index.d.ts
+++ b/types/any-db/index.d.ts
@@ -13,14 +13,14 @@ export interface Adapter {
      * Create a new connection object. In common usage, config will be created by parse-db-url and passed to the adapter by any-db.
      * If a continuation is given, it must be called, either with an error or the established connection.
      */
-    createConnection(opts: ConnectOpts, callback?: (error: Error, result: Connection) => void): Connection;
+    createConnection(opts: ConnectOpts, callback?: (error: Error | null, result: Connection) => void): Connection;
 
     /**
      * Create a Query that may eventually be executed later on by a Connection. While this function is rarely needed by user code,
      * it makes it possible for ConnectionPool.query and Transaction.query to fulfill the Queryable.query contract
      * by synchronously returning a Query stream
      */
-    createQuery(text: string, params?: any[], callback?: (error: Error, result: ResultSet) => void): Query;
+    createQuery(text: string, params?: any[], callback?: (error: Error | null, result: ResultSet) => void): Query;
     createQuery(query: Query): Query;
 }
 /**
@@ -125,7 +125,7 @@ export interface Query extends stream.Readable {
      * as other any-db libraries may rely on modifying the callback property
      * of a Query they did not create.
      */
-    callback: (error: Error, results: ResultSet) => void;
+    callback?: (error: Error | null, results: ResultSet) => void;
 }
 
 /**
@@ -147,7 +147,7 @@ export interface Queryable extends events.EventEmitter {
      * The second form is not needed for normal use, but must be implemented by adapters to work correctly
      * with ConnectionPool and Transaction. See Adapter.createQuery for more details.
      */
-    query(text: string, params?: any[], callback?: (error: Error, results: ResultSet) => void): Query;
+    query(text: string, params?: any[], callback?: (error: Error | null, results: ResultSet) => void): Query;
 
     /**
      * The second form is not needed for normal use, but must be implemented by adapters to work correctly
@@ -182,7 +182,7 @@ export interface Connection extends Queryable {
      * Close the database connection. If a continuation is provided it
      * will be called after the connection has closed.
      */
-    end(callback?: (error: Error) => void): void;
+    end(callback?: (error: Error | null) => void): void;
 }
 
 export interface ConnectionStatic {
@@ -207,13 +207,13 @@ export interface ConnectionPool extends Queryable {
      * Implements Queryable.query by automatically acquiring a connection
      * and releasing it when the query completes.
      */
-    query(text: string, params?: any[], callback?: (error: Error, results: ResultSet) => void): Query;
+    query(text: string, params?: any[], callback?: (error: Error | null, results: ResultSet) => void): Query;
 
     /**
      * Remove a connection from the pool. If you use this method you must
      * return the connection back to the pool using ConnectionPool.release
      */
-    acquire(callback: (error: Error, result: Connection) => void): void;
+    acquire(callback: (error: Error | null, result: Connection) => void): void;
 
     /**
      * Return a connection to the pool. This should only be called with connections
@@ -225,7 +225,7 @@ export interface ConnectionPool extends Queryable {
      * Stop giving out new connections, and close all existing database connections as they
      * are returned to the pool.
      */
-    close(callback?: (error: Error) => void): void;
+    close(callback?: (error: Error | null) => void): void;
 }
 
 /**
@@ -259,13 +259,15 @@ export interface PoolConfig {
      * Called immediately after a connection is first established. Use this to do one-time setup of new connections.
      * The supplied Connection will not be added to the pool until you pass it to the done continuation.
      */
-    onConnect?: ((connection: Connection, ready: (error: Error, result: Connection) => void) => void) | undefined;
+    onConnect?:
+        | ((connection: Connection, ready: (error: Error | null, result: Connection) => void) => void)
+        | undefined;
     /**
      * Called each time a connection is returned to the pool. Use this to restore a connection to
      * it's original state (e.g. rollback transactions, set the database session vars). If reset
      * fails to call the done continuation the connection will be lost in limbo.
      */
-    reset?: ((connection: Connection, done: (error: Error) => void) => void) | undefined;
+    reset?: ((connection: Connection, done: (error: Error | null) => void) => void) | undefined;
     /**
      * (default function (err) { return true }) - Called when an error is encountered
      * by pool.query or emitted by an idle connection. If shouldDestroyConnection(error)
@@ -282,7 +284,7 @@ export interface PoolConfig {
  */
 export declare function createConnection(
     url: string,
-    callback?: (error: Error, connection: Connection) => void,
+    callback?: (error: Error | null, connection: Connection) => void,
 ): Connection;
 
 /**
@@ -293,7 +295,7 @@ export declare function createConnection(
  */
 export declare function createConnection(
     opts: ConnectOpts,
-    callback?: (error: Error, connection: Connection) => void,
+    callback?: (error: Error | null, connection: Connection) => void,
 ): Connection;
 
 export declare function createPool(url: string, config?: PoolConfig): ConnectionPool;

--- a/types/any-db/index.d.ts
+++ b/types/any-db/index.d.ts
@@ -296,5 +296,5 @@ export declare function createConnection(
     callback?: (error: Error, connection: Connection) => void,
 ): Connection;
 
-export declare function createPool(url: string, config: PoolConfig): ConnectionPool;
-export declare function createPool(opts: ConnectOpts, config: PoolConfig): ConnectionPool;
+export declare function createPool(url: string, config?: PoolConfig): ConnectionPool;
+export declare function createPool(opts: ConnectOpts, config?: PoolConfig): ConnectionPool;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [createPool() test in original JS library](https://github.com/grncdr/node-any-db/blob/master/test.js#L19) takes one argument
  - Continuation grammar and uses in [API docs](https://github.com/grncdr/node-any-db#api), [any-db-db-adapter docs](https://github.com/grncdr/node-any-db/tree/master/packages/any-db-adapter-spec#callbacks), and [any-db-pool docs](https://github.com/grncdr/node-any-db/tree/master/packages/any-db-pool)
