### PR TITLE
feat(node): Add setHeaders() to class OutgoingMessage

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -589,6 +589,42 @@ declare module "http" {
          */
         setHeader(name: string, value: number | string | readonly string[]): this;
         /**
+         * Sets multiple header values for implicit headers. headers must be an instance of
+         * `Headers` or `Map`, if a header already exists in the to-be-sent headers, its
+         * value will be replaced.
+         *
+         * ```js
+         * const headers = new Headers({ foo: 'bar' });
+         * outgoingMessage.setHeaders(headers);
+         * ```
+         *
+         * or
+         *
+         * ```js
+         * const headers = new Map([['foo', 'bar']]);
+         * outgoingMessage.setHeaders(headers);
+         * ```
+         *
+         * When headers have been set with `outgoingMessage.setHeaders()`, they will be
+         * merged with any headers passed to `response.writeHead()`, with the headers passed
+         * to `response.writeHead()` given precedence.
+         *
+         * ```js
+         * // Returns content-type = text/plain
+         * const server = http.createServer((req, res) => {
+         *   const headers = new Headers({ 'Content-Type': 'text/html' });
+         *   res.setHeaders(headers);
+         *   res.writeHead(200, { 'Content-Type': 'text/plain' });
+         *   res.end('ok');
+         * });
+         * ```
+         *
+         * @since v19.6.0, v18.15.0
+         * @param name Header name
+         * @param value Header value
+         */
+        setHeaders(headers: Headers | Map<string, number | string | readonly string[]>): this;
+        /**
          * Append a single header value to the header object.
          *
          * If the value is an array, this is equivalent to calling this method multiple

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -214,6 +214,8 @@ import * as url from "node:url";
     res.setHeader("Content-Type", "text/plain")
         .setHeader("Return-Type", "this")
         .appendHeader("Content-Type", "text/html");
+    res.setHeaders(new Headers({ foo: "bar" }));
+    res.setHeaders(new Map([["foo", "bar"]]));
     const bool: boolean = res.hasHeader("Content-Type");
     const headers: string[] = res.getHeaderNames();
     const headerValue: string[] | undefined = incoming.headersDistinct["content-type"];

--- a/types/node/v18/http.d.ts
+++ b/types/node/v18/http.d.ts
@@ -588,6 +588,42 @@ declare module "http" {
          */
         setHeader(name: string, value: number | string | readonly string[]): this;
         /**
+         * Sets multiple header values for implicit headers. headers must be an instance of
+         * `Headers` or `Map`, if a header already exists in the to-be-sent headers, its
+         * value will be replaced.
+         *
+         * ```js
+         * const headers = new Headers({ foo: 'bar' });
+         * outgoingMessage.setHeaders(headers);
+         * ```
+         *
+         * or
+         *
+         * ```js
+         * const headers = new Map([['foo', 'bar']]);
+         * outgoingMessage.setHeaders(headers);
+         * ```
+         *
+         * When headers have been set with `outgoingMessage.setHeaders()`, they will be
+         * merged with any headers passed to `response.writeHead()`, with the headers passed
+         * to `response.writeHead()` given precedence.
+         *
+         * ```js
+         * // Returns content-type = text/plain
+         * const server = http.createServer((req, res) => {
+         *   const headers = new Headers({ 'Content-Type': 'text/html' });
+         *   res.setHeaders(headers);
+         *   res.writeHead(200, { 'Content-Type': 'text/plain' });
+         *   res.end('ok');
+         * });
+         * ```
+         *
+         * @since v19.6.0, v18.15.0
+         * @param name Header name
+         * @param value Header value
+         */
+        setHeaders(headers: Headers | Map<string, number | string | readonly string[]>): this;
+        /**
          * Append a single header value for the header object.
          *
          * If the value is an array, this is equivalent of calling this method multiple times.

--- a/types/node/v18/test/http.ts
+++ b/types/node/v18/test/http.ts
@@ -209,6 +209,8 @@ import * as url from "node:url";
     res.setHeader("Content-Type", "text/plain")
         .setHeader("Return-Type", "this")
         .appendHeader("Content-Type", "text/html");
+    res.setHeaders(new Headers({ foo: "bar" }));
+    res.setHeaders(new Map([["foo", "bar"]]));
     const bool: boolean = res.hasHeader("Content-Type");
     const headers: string[] = res.getHeaderNames();
     const headerValue: string[] | undefined = incoming.headersDistinct["content-type"];

--- a/types/node/v20/http.d.ts
+++ b/types/node/v20/http.d.ts
@@ -589,6 +589,42 @@ declare module "http" {
          */
         setHeader(name: string, value: number | string | readonly string[]): this;
         /**
+         * Sets multiple header values for implicit headers. headers must be an instance of
+         * `Headers` or `Map`, if a header already exists in the to-be-sent headers, its
+         * value will be replaced.
+         *
+         * ```js
+         * const headers = new Headers({ foo: 'bar' });
+         * outgoingMessage.setHeaders(headers);
+         * ```
+         *
+         * or
+         *
+         * ```js
+         * const headers = new Map([['foo', 'bar']]);
+         * outgoingMessage.setHeaders(headers);
+         * ```
+         *
+         * When headers have been set with `outgoingMessage.setHeaders()`, they will be
+         * merged with any headers passed to `response.writeHead()`, with the headers passed
+         * to `response.writeHead()` given precedence.
+         *
+         * ```js
+         * // Returns content-type = text/plain
+         * const server = http.createServer((req, res) => {
+         *   const headers = new Headers({ 'Content-Type': 'text/html' });
+         *   res.setHeaders(headers);
+         *   res.writeHead(200, { 'Content-Type': 'text/plain' });
+         *   res.end('ok');
+         * });
+         * ```
+         *
+         * @since v19.6.0, v18.15.0
+         * @param name Header name
+         * @param value Header value
+         */
+        setHeaders(headers: Headers | Map<string, number | string | readonly string[]>): this;
+        /**
          * Append a single header value to the header object.
          *
          * If the value is an array, this is equivalent to calling this method multiple

--- a/types/node/v20/test/http.ts
+++ b/types/node/v20/test/http.ts
@@ -209,6 +209,8 @@ import * as url from "node:url";
     res.setHeader("Content-Type", "text/plain")
         .setHeader("Return-Type", "this")
         .appendHeader("Content-Type", "text/html");
+    res.setHeaders(new Headers({ foo: "bar" }));
+    res.setHeaders(new Map([["foo", "bar"]]));
     const bool: boolean = res.hasHeader("Content-Type");
     const headers: string[] = res.getHeaderNames();
     const headerValue: string[] | undefined = incoming.headersDistinct["content-type"];


### PR DESCRIPTION
Add back missing method, `outgoingMessage.setHeaders(headers)`, which is added in v19.6.0, v18.15.0.
- See [the documentation](https://nodejs.org/api/http.html#outgoingmessagesetheadersheaders).
- Resolve [DT discussion 70737](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/70737).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
