### PR TITLE
fix(node): Correct the signature of finished() in stream/promises

### DIFF
--- a/types/node/stream/promises.d.ts
+++ b/types/node/stream/promises.d.ts
@@ -1,12 +1,19 @@
 declare module "stream/promises" {
     import {
-        FinishedOptions,
+        FinishedOptions as _FinishedOptions,
         PipelineDestination,
         PipelineOptions,
         PipelinePromise,
         PipelineSource,
         PipelineTransform,
     } from "node:stream";
+    interface FinishedOptions extends _FinishedOptions {
+        /**
+         * If true, removes the listeners registered by this function before the promise is fulfilled.
+         * @default false
+         */
+        cleanup?: boolean | undefined;
+    }
     function finished(
         stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream,
         options?: FinishedOptions,

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -19,7 +19,7 @@ import { Http2ServerResponse } from "node:http2";
 import { performance } from "node:perf_hooks";
 import { stdout } from "node:process";
 import { arrayBuffer, blob, buffer, json, text } from "node:stream/consumers";
-import { pipeline as pipelinePromise } from "node:stream/promises";
+import { finished as finishedPromise, pipeline as pipelinePromise } from "node:stream/promises";
 import { ReadableStream, TransformStream, WritableStream } from "node:stream/web";
 import { setInterval as every, setTimeout as wait } from "node:timers/promises";
 import { MessageChannel as NodeMC } from "node:worker_threads";
@@ -221,7 +221,19 @@ function streamPipelineFinished() {
 async function asyncStreamPipelineFinished() {
     const fin = promisify(finished);
     await fin(process.stdin);
+    await fin(process.stdin, { error: false });
     await fin(process.stdin, { readable: false });
+    await fin(process.stdin, { writable: false });
+    await fin(process.stdin, { signal: new AbortSignal() });
+    // @ts-expect-error -- callback version does not allow `options.cleanup`
+    await fin(process.stdin, { cleanup: false });
+
+    await finishedPromise(process.stdin);
+    await finishedPromise(process.stdin, { error: false });
+    await finishedPromise(process.stdin, { readable: false });
+    await finishedPromise(process.stdin, { writable: false });
+    await finishedPromise(process.stdin, { signal: new AbortSignal() });
+    await finishedPromise(process.stdin, { cleanup: false });
 
     const pipe = promisify(pipeline);
     await pipe(process.stdin, process.stdout);

--- a/types/node/v18/stream/promises.d.ts
+++ b/types/node/v18/stream/promises.d.ts
@@ -1,12 +1,19 @@
 declare module "stream/promises" {
     import {
-        FinishedOptions,
+        FinishedOptions as _FinishedOptions,
         PipelineDestination,
         PipelineOptions,
         PipelinePromise,
         PipelineSource,
         PipelineTransform,
     } from "node:stream";
+    interface FinishedOptions extends _FinishedOptions {
+        /**
+         * If true, removes the listeners registered by this function before the promise is fulfilled.
+         * @default false
+         */
+        cleanup?: boolean | undefined;
+    }
     function finished(
         stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream,
         options?: FinishedOptions,

--- a/types/node/v18/test/stream.ts
+++ b/types/node/v18/test/stream.ts
@@ -17,7 +17,7 @@ import { Http2ServerResponse } from "node:http2";
 import { performance } from "node:perf_hooks";
 import { stdout } from "node:process";
 import { arrayBuffer, blob, buffer, json, text } from "node:stream/consumers";
-import { pipeline as pipelinePromise } from "node:stream/promises";
+import { finished as finishedPromise, pipeline as pipelinePromise } from "node:stream/promises";
 import { ReadableStream, TransformStream, WritableStream } from "node:stream/web";
 import { setInterval as every } from "node:timers/promises";
 import { MessageChannel as NodeMC } from "node:worker_threads";
@@ -219,7 +219,19 @@ function streamPipelineFinished() {
 async function asyncStreamPipelineFinished() {
     const fin = promisify(finished);
     await fin(process.stdin);
+    await fin(process.stdin, { error: false });
     await fin(process.stdin, { readable: false });
+    await fin(process.stdin, { writable: false });
+    await fin(process.stdin, { signal: new AbortSignal() });
+    // @ts-expect-error -- callback version does not allow `options.cleanup`
+    await fin(process.stdin, { cleanup: false });
+
+    await finishedPromise(process.stdin);
+    await finishedPromise(process.stdin, { error: false });
+    await finishedPromise(process.stdin, { readable: false });
+    await finishedPromise(process.stdin, { writable: false });
+    await finishedPromise(process.stdin, { signal: new AbortSignal() });
+    await finishedPromise(process.stdin, { cleanup: false });
 
     const pipe = promisify(pipeline);
     await pipe(process.stdin, process.stdout);

--- a/types/node/v20/stream/promises.d.ts
+++ b/types/node/v20/stream/promises.d.ts
@@ -1,12 +1,19 @@
 declare module "stream/promises" {
     import {
-        FinishedOptions,
+        FinishedOptions as _FinishedOptions,
         PipelineDestination,
         PipelineOptions,
         PipelinePromise,
         PipelineSource,
         PipelineTransform,
     } from "node:stream";
+    interface FinishedOptions extends _FinishedOptions {
+        /**
+         * If true, removes the listeners registered by this function before the promise is fulfilled.
+         * @default false
+         */
+        cleanup?: boolean | undefined;
+    }
     function finished(
         stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream,
         options?: FinishedOptions,

--- a/types/node/v20/test/stream.ts
+++ b/types/node/v20/test/stream.ts
@@ -18,7 +18,7 @@ import { Http2ServerResponse } from "node:http2";
 import { performance } from "node:perf_hooks";
 import { stdout } from "node:process";
 import { arrayBuffer, blob, buffer, json, text } from "node:stream/consumers";
-import { pipeline as pipelinePromise } from "node:stream/promises";
+import { finished as finishedPromise, pipeline as pipelinePromise } from "node:stream/promises";
 import { ReadableStream, TransformStream, WritableStream } from "node:stream/web";
 import { setInterval as every, setTimeout as wait } from "node:timers/promises";
 import { MessageChannel as NodeMC } from "node:worker_threads";
@@ -220,7 +220,19 @@ function streamPipelineFinished() {
 async function asyncStreamPipelineFinished() {
     const fin = promisify(finished);
     await fin(process.stdin);
+    await fin(process.stdin, { error: false });
     await fin(process.stdin, { readable: false });
+    await fin(process.stdin, { writable: false });
+    await fin(process.stdin, { signal: new AbortSignal() });
+    // @ts-expect-error -- callback version does not allow `options.cleanup`
+    await fin(process.stdin, { cleanup: false });
+
+    await finishedPromise(process.stdin);
+    await finishedPromise(process.stdin, { error: false });
+    await finishedPromise(process.stdin, { readable: false });
+    await finishedPromise(process.stdin, { writable: false });
+    await finishedPromise(process.stdin, { signal: new AbortSignal() });
+    await finishedPromise(process.stdin, { cleanup: false });
 
     const pipe = promisify(pipeline);
     await pipe(process.stdin, process.stdout);


### PR DESCRIPTION
The `cleanup` option is added to the promise version of `stream.finished(stream[, options])` since v19.1.0, v18.13.0. DT type should hence reflect this change.
- See [the documentation](https://nodejs.org/api/stream.html#streamfinishedstream-options).
- Resolve [DT discussion 70164](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/70164) and [DT issue 70621](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/70621).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
