### PR TITLE
[mjml-core] use Record instead of object

### DIFF
--- a/types/mjml-core/index.d.ts
+++ b/types/mjml-core/index.d.ts
@@ -134,19 +134,19 @@ export type MJMLJsonObject = MJMLJsonWithChildren | MJMLJsonWithContent | MJMLJs
 
 export interface MJMLJsonWithChildren {
     tagName: string;
-    attributes: object;
+    attributes: Record<string, unknown>;
     children: MJMLJsonObject[];
 }
 
 export interface MJMLJsonWithContent {
     tagName: string;
-    attributes: object;
+    attributes: Record<string, unknown>;
     content: string;
 }
 
 export interface MJMLJsonSelfClosingTag {
     tagName: string;
-    attributes: object;
+    attributes: Record<string, unknown>;
 }
 
 /**

--- a/types/mjml-core/mjml-core-tests.ts
+++ b/types/mjml-core/mjml-core-tests.ts
@@ -1,4 +1,4 @@
-import mjml2html, { BodyComponent, Component, HeadComponent, registerComponent } from "mjml-core";
+import mjml2html, { BodyComponent, Component, HeadComponent, MJMLJsonObject, registerComponent } from "mjml-core";
 
 const simple_test = mjml2html("<mjml>");
 const html = simple_test.html;
@@ -40,3 +40,15 @@ class MjBreakpoint extends HeadComponent {
 
 registerComponent(MjBreakpoint);
 registerComponent(NewBodyComponent);
+
+const skeleton: MJMLJsonObject = {
+    tagName: "mjml",
+    attributes: {
+        "lang": "en"
+    }
+}
+
+skeleton.attributes.foo = "bar"
+
+// $ExpectType Record<string,unknown>
+const attrs = skeleton.attributes

--- a/types/mjml-core/mjml-core-tests.ts
+++ b/types/mjml-core/mjml-core-tests.ts
@@ -44,11 +44,11 @@ registerComponent(NewBodyComponent);
 const skeleton: MJMLJsonObject = {
     tagName: "mjml",
     attributes: {
-        "lang": "en"
-    }
-}
+        "lang": "en",
+    },
+};
 
-skeleton.attributes.foo = "bar"
+skeleton.attributes.foo = "bar";
 
 // $ExpectType Record<string,unknown>
-const attrs = skeleton.attributes
+const attrs = skeleton.attributes;


### PR DESCRIPTION
## Context

I built an image inliner for a project. Trying to assign an attribute programmatically before compiling an MJML JSON object to HTML, results in the error [`TS2339`](https://typescript.tv/errors/#ts2339): `Property 'src' does not exist on type 'object'.`

The following StackOverflow comment provides a good explanation of the problem: https://stackoverflow.com/a/52246786/5423625

Thus I'd like to propose the following changes:

- Use a `Record` instead of an `object` type in the `MJMLJsonObject` union types.
 
## Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stackoverflow.com/questions/52245366/in-typescript-is-there-a-difference-between-types-object-and-recordany-any
