### PR TITLE
fix(relay-test-utils): make types for generateWithDefer stronger and fix tests

### DIFF
--- a/types/relay-test-utils/lib/RelayMockPayloadGenerator.d.ts
+++ b/types/relay-test-utils/lib/RelayMockPayloadGenerator.d.ts
@@ -9,8 +9,8 @@ export interface MockResolverContext {
 }
 
 export type DeepPartial<T> = T extends object ? {
-    [P in keyof T]?: DeepPartial<T[P]>;
-}
+        [P in keyof T]?: DeepPartial<T[P]>;
+    }
     : T;
 
 export type MockResolver<T = unknown> = (
@@ -29,8 +29,8 @@ export type DefaultMockResolvers = Partial<{
 export type MockResolvers<
     TypeMap extends DefaultMockResolvers = DefaultMockResolvers,
 > = {
-        [K in keyof TypeMap]?: MockResolver<TypeMap[K]>;
-    };
+    [K in keyof TypeMap]?: MockResolver<TypeMap[K]>;
+};
 
 export function generate(
     operation: OperationDescriptor,
@@ -42,10 +42,10 @@ export function generateWithDefer(
     operation: OperationDescriptor,
     mockResolvers: MockResolvers | null,
     options: { mockClientData?: boolean; generateDeferredPayload: true } | null,
-): readonly GraphQLSingularResponse[]
+): readonly GraphQLSingularResponse[];
 
 export function generateWithDefer(
     operation: OperationDescriptor,
     mockResolvers?: MockResolvers | null,
     options?: { mockClientData?: boolean; generateDeferredPayload?: false } | null,
-): GraphQLSingularResponse
+): GraphQLSingularResponse;

--- a/types/relay-test-utils/lib/RelayMockPayloadGenerator.d.ts
+++ b/types/relay-test-utils/lib/RelayMockPayloadGenerator.d.ts
@@ -9,8 +9,8 @@ export interface MockResolverContext {
 }
 
 export type DeepPartial<T> = T extends object ? {
-        [P in keyof T]?: DeepPartial<T[P]>;
-    }
+    [P in keyof T]?: DeepPartial<T[P]>;
+}
     : T;
 
 export type MockResolver<T = unknown> = (
@@ -29,8 +29,8 @@ export type DefaultMockResolvers = Partial<{
 export type MockResolvers<
     TypeMap extends DefaultMockResolvers = DefaultMockResolvers,
 > = {
-    [K in keyof TypeMap]?: MockResolver<TypeMap[K]>;
-};
+        [K in keyof TypeMap]?: MockResolver<TypeMap[K]>;
+    };
 
 export function generate(
     operation: OperationDescriptor,
@@ -40,6 +40,12 @@ export function generate(
 
 export function generateWithDefer(
     operation: OperationDescriptor,
+    mockResolvers: MockResolvers | null,
+    options: { mockClientData?: boolean; generateDeferredPayload: true } | null,
+): readonly GraphQLSingularResponse[]
+
+export function generateWithDefer(
+    operation: OperationDescriptor,
     mockResolvers?: MockResolvers | null,
-    options?: { mockClientData?: boolean; generateDeferredPayload?: boolean } | null,
-): GraphQLResponse;
+    options?: { mockClientData?: boolean; generateDeferredPayload?: false } | null,
+): GraphQLSingularResponse

--- a/types/relay-test-utils/package.json
+++ b/types/relay-test-utils/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/relay-test-utils",
-    "version": "17.0.9999",
+    "version": "18.0.9999",
     "projects": [
         "https://relay.dev"
     ],

--- a/types/relay-test-utils/test/classical.tsx
+++ b/types/relay-test-utils/test/classical.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay";
 import { createMockEnvironment, MockPayloadGenerator, unwrapContainer } from "relay-test-utils";
 
-// @ExpectType MockEnvironment
+// $ExpectType RelayMockEnvironment
 const environment = createMockEnvironment();
 
 environment.mock.resolveMostRecentOperation(operation => {

--- a/types/relay-test-utils/test/index.tsx
+++ b/types/relay-test-utils/test/index.tsx
@@ -149,27 +149,27 @@ function environmentTests() {
 
     environment.mock.resolve(
         operation,
-        mockDataWithoutDeferredPayload1
+        mockDataWithoutDeferredPayload1,
     );
 
     environment.mock.resolve(
         operation,
-        mockDataWithoutDeferredPayload2
+        mockDataWithoutDeferredPayload2,
     );
 
     environment.mock.resolve(
         operation,
-        mockDataWithoutDeferredPayload3
+        mockDataWithoutDeferredPayload3,
     );
 
     environment.mock.resolve(
         operation,
-        mockDataWithDeferredPayload1
+        mockDataWithDeferredPayload1,
     );
 
     environment.mock.resolve(
         operation,
-        mockDataWithDeferredPayload2
+        mockDataWithDeferredPayload2,
     );
 }
 

--- a/types/relay-test-utils/test/index.tsx
+++ b/types/relay-test-utils/test/index.tsx
@@ -58,7 +58,7 @@ const UserComponent = ({ userKey }: { userKey: UserComponent_user$key }) => {
 };
 
 function MockPayloadGeneratorTests() {
-    // @ExpectType MockEnvironment
+    // $ExpectType RelayMockEnvironment
     const environment = createMockEnvironment();
 
     // to get an operation type
@@ -97,7 +97,7 @@ function MockPayloadGeneratorTests() {
 }
 
 function environmentTests() {
-    // @ExpectType MockEnvironment
+    // $ExpectType RelayMockEnvironment
     const environment = createMockEnvironment();
 
     const queryRef = loadQuery(environment, userQuery, {});
@@ -119,15 +119,57 @@ function environmentTests() {
     environment.mock.resolve(operation, { data: {} });
     environment.mock.queuePendingOperation(userQuery, {});
 
-    // @ExpectType OperationDescriptor
+    // $ExpectType OperationDescriptor
     const newOperation = environment.mock.getMostRecentOperation();
+
+    // $ExpectType readonly GraphQLSingularResponse[]
+    const mockDataWithDeferredPayload1 = MockPayloadGenerator.generateWithDefer(newOperation, null, {
+        generateDeferredPayload: true,
+        mockClientData: true,
+    });
+
+    // $ExpectType readonly GraphQLSingularResponse[]
+    const mockDataWithDeferredPayload2 = MockPayloadGenerator.generateWithDefer(newOperation, null, {
+        generateDeferredPayload: true,
+    });
+
+    // $ExpectType GraphQLSingularResponse
+    const mockDataWithoutDeferredPayload1 = MockPayloadGenerator.generateWithDefer(newOperation, null, {
+        generateDeferredPayload: false,
+        mockClientData: true,
+    });
+
+    // $ExpectType GraphQLSingularResponse
+    const mockDataWithoutDeferredPayload2 = MockPayloadGenerator.generateWithDefer(newOperation, null, {
+        mockClientData: true,
+    });
+
+    // $ExpectType GraphQLSingularResponse
+    const mockDataWithoutDeferredPayload3 = MockPayloadGenerator.generateWithDefer(newOperation, null);
 
     environment.mock.resolve(
         operation,
-        MockPayloadGenerator.generateWithDefer(newOperation, null, {
-            generateDeferredPayload: true,
-            mockClientData: true,
-        }),
+        mockDataWithoutDeferredPayload1
+    );
+
+    environment.mock.resolve(
+        operation,
+        mockDataWithoutDeferredPayload2
+    );
+
+    environment.mock.resolve(
+        operation,
+        mockDataWithoutDeferredPayload3
+    );
+
+    environment.mock.resolve(
+        operation,
+        mockDataWithDeferredPayload1
+    );
+
+    environment.mock.resolve(
+        operation,
+        mockDataWithDeferredPayload2
     );
 }
 


### PR DESCRIPTION
Scope of this change is to make types for `generateWithDefer` stricter. We can see in `relay-test-utils` code 
![image](https://github.com/user-attachments/assets/37707aae-6e01-4660-81ef-a9715802e0f0)
that it returns array of response only if `generateDeferredPayload` is true and single response otherwise.

Additionally, we realized all tests were broken, as they were using `@ExpectType` instead of `$ExpectType`, fixed this too.
We also bump the version to 18.0.0


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).



- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/relay/blob/ec2e3bc05dc4647fbfe95969648b99ce124f6dc7/packages/relay-test-utils/RelayMockPayloadGenerator.js#L1055
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

