### PR TITLE
fix(relay-runtime): RelayDefaultHandlerProvider is the default export

### DIFF
--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -187,7 +187,8 @@ export {
 } from "./lib/store/RelayStoreUtils";
 
 // Extensions
-export { RelayDefaultHandlerProvider as DefaultHandlerProvider } from "./lib/handlers/RelayDefaultHandlerProvider";
+import RelayDefaultHandlerProvider from "./lib/handlers/RelayDefaultHandlerProvider";
+export { RelayDefaultHandlerProvider as DefaultHandlerProvider };
 
 import getDefaultMissingFieldHandlers from "./lib/handlers/getRelayDefaultMissingFieldHandlers";
 export { getDefaultMissingFieldHandlers };

--- a/types/relay-runtime/lib/handlers/RelayDefaultHandlerProvider.d.ts
+++ b/types/relay-runtime/lib/handlers/RelayDefaultHandlerProvider.d.ts
@@ -2,4 +2,4 @@ import { Handler } from "../store/RelayStoreTypes";
 
 export type HandlerProvider = (handle: string) => any;
 
-export function RelayDefaultHandlerProvider(handle: string): Handler;
+export default function RelayDefaultHandlerProvider(handle: string): Handler;

--- a/types/relay-runtime/package.json
+++ b/types/relay-runtime/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/relay-runtime",
-    "version": "18.0.9999",
+    "version": "18.1.0",
     "projects": [
         "https://github.com/facebook/relay",
         "https://facebook.github.io/relay"

--- a/types/relay-runtime/package.json
+++ b/types/relay-runtime/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/relay-runtime",
-    "version": "18.1.0",
+    "version": "18.1.9999",
     "projects": [
         "https://github.com/facebook/relay",
         "https://facebook.github.io/relay"


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/relay/blob/main/packages/relay-runtime/handlers/RelayDefaultHandlerProvider.js#L46
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
