### PR TITLE
fix leaflet MapOptions

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -2491,7 +2491,7 @@ export interface MapOptions {
     wheelPxPerZoomLevel?: number | undefined;
 
     // Touch interaction options
-    tap?: boolean | undefined;
+    tapHold?: boolean | undefined;
     tapTolerance?: number | undefined;
     touchZoom?: Zoom | undefined;
     bounceAtZoomLimits?: boolean | undefined;

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -2969,7 +2969,7 @@ export class Map extends Evented {
     dragging: Handler;
     keyboard: Handler;
     scrollWheelZoom: Handler;
-    tap?: Handler | undefined;
+    tapHold?: Handler | undefined;
     touchZoom: Handler;
     zoomControl: Control.Zoom;
 

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -137,7 +137,7 @@ mapOptions = {
     keyboardPanDelta: 100,
     wheelDebounceTime: 30,
     wheelPxPerZoomLevel: 25,
-    tap: false,
+    tapHold: false,
     tapTolerance: 10,
     bounceAtZoomLimits: false,
 };


### PR DESCRIPTION
The property `tap` does not exists in MapOptions, it is named `tapHold`, as shown [in the documentation](https://leafletjs.com/reference.html#map-taphold) and [in the actual source code](https://github.com/Leaflet/Leaflet/blob/main/src/map/handler/Map.TapHold.js)

Edit : I also updated Map because the Handler is also named `tapHold` and not `tap`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://leafletjs.com/reference.html#map-taphold)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

