### PR TITLE
[node] Update typings to v22.8.0

### DIFF
--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -238,11 +238,65 @@ declare module "module" {
             context: LoadHookContext,
             nextLoad: (url: string, context?: LoadHookContext) => LoadFnOutput | Promise<LoadFnOutput>,
         ) => LoadFnOutput | Promise<LoadFnOutput>;
+        namespace constants {
+            /**
+             * The following constants are returned as the `status` field in the object returned by
+             * {@link enableCompileCache} to indicate the result of the attempt to enable the
+             * [module compile cache](https://nodejs.org/docs/latest-v22.x/api/module.html#module-compile-cache).
+             * @since v22.8.0
+             */
+            namespace compileCacheStatus {
+                /**
+                 * Node.js has enabled the compile cache successfully. The directory used to store the
+                 * compile cache will be returned in the `directory` field in the
+                 * returned object.
+                 */
+                const ENABLED: number;
+                /**
+                 * The compile cache has already been enabled before, either by a previous call to
+                 * {@link enableCompileCache}, or by the `NODE_COMPILE_CACHE=dir`
+                 * environment variable. The directory used to store the
+                 * compile cache will be returned in the `directory` field in the
+                 * returned object.
+                 */
+                const ALREADY_ENABLED: number;
+                /**
+                 * Node.js fails to enable the compile cache. This can be caused by the lack of
+                 * permission to use the specified directory, or various kinds of file system errors.
+                 * The detail of the failure will be returned in the `message` field in the
+                 * returned object.
+                 */
+                const FAILED: number;
+                /**
+                 * Node.js cannot enable the compile cache because the environment variable
+                 * `NODE_DISABLE_COMPILE_CACHE=1` has been set.
+                 */
+                const DISABLED: number;
+            }
+        }
     }
     interface RegisterOptions<Data> {
         parentURL: string | URL;
         data?: Data | undefined;
         transferList?: any[] | undefined;
+    }
+    interface EnableCompileCacheResult {
+        /**
+         * One of the {@link constants.compileCacheStatus}
+         */
+        status: number;
+        /**
+         * If Node.js cannot enable the compile cache, this contains
+         * the error message. Only set if `status` is `module.constants.compileCacheStatus.FAILED`.
+         */
+        message?: string;
+        /**
+         * If the compile cache is enabled, this contains the directory
+         * where the compile cache is stored. Only set if  `status` is
+         * `module.constants.compileCacheStatus.ENABLED` or
+         * `module.constants.compileCacheStatus.ALREADY_ENABLED`.
+         */
+        directory?: string;
     }
     interface Module extends NodeModule {}
     class Module {
@@ -258,6 +312,43 @@ declare module "module" {
             options?: RegisterOptions<Data>,
         ): void;
         static register<Data = any>(specifier: string | URL, options?: RegisterOptions<Data>): void;
+        /**
+         * Enable [module compile cache](https://nodejs.org/docs/latest-v22.x/api/module.html#module-compile-cache)
+         * in the current Node.js instance.
+         *
+         * If `cacheDir` is not specified, Node.js will either use the directory specified by the
+         * `NODE_COMPILE_CACHE=dir` environment variable if it's set, or use
+         * `path.join(os.tmpdir(), 'node-compile-cache')` otherwise. For general use cases, it's
+         * recommended to call `module.enableCompileCache()` without specifying the `cacheDir`,
+         * so that the directory can be overridden by the `NODE_COMPILE_CACHE` environment
+         * variable when necessary.
+         *
+         * Since compile cache is supposed to be a quiet optimization that is not required for the
+         * application to be functional, this method is designed to not throw any exception when the
+         * compile cache cannot be enabled. Instead, it will return an object containing an error
+         * message in the `message` field to aid debugging.
+         * If compile cache is enabled successfully, the `directory` field in the returned object
+         * contains the path to the directory where the compile cache is stored. The `status`
+         * field in the returned object would be one of the `module.constants.compileCacheStatus`
+         * values to indicate the result of the attempt to enable the
+         * [module compile cache](https://nodejs.org/docs/latest-v22.x/api/module.html#module-compile-cache).
+         *
+         * This method only affects the current Node.js instance. To enable it in child worker threads,
+         * either call this method in child worker threads too, or set the
+         * `process.env.NODE_COMPILE_CACHE` value to compile cache directory so the behavior can
+         * be inherited into the child workers. The directory can be obtained either from the
+         * `directory` field returned by this method, or with {@link getCompileCacheDir}.
+         * @since v22.8.0
+         * @param cacheDir Optional path to specify the directory where the compile cache
+         * will be stored/retrieved.
+         */
+        static enableCompileCache(cacheDir?: string): EnableCompileCacheResult;
+        /**
+         * @since v22.8.0
+         * @return Path to the [module compile cache](https://nodejs.org/docs/latest-v22.x/api/module.html#module-compile-cache)
+         * directory if it is enabled, or `undefined` otherwise.
+         */
+        static getCompileCacheDir(): string | undefined;
         constructor(id: string, parent?: Module);
     }
     global {

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "22.7.9999",
+    "version": "22.8.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -15,7 +15,7 @@
         }
     },
     "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.19.8"
     },
     "devDependencies": {
         "@types/node": "workspace:."

--- a/types/node/perf_hooks.d.ts
+++ b/types/node/perf_hooks.d.ts
@@ -116,6 +116,20 @@ declare module "perf_hooks" {
     class PerformanceMeasure extends PerformanceEntry {
         readonly entryType: "measure";
     }
+    interface UVMetrics {
+        /**
+         * Number of event loop iterations.
+         */
+        readonly loopCount: number;
+        /**
+         * Number of events that have been processed by the event handler.
+         */
+        readonly events: number;
+        /**
+         * Number of events that were waiting to be processed when the event provider was called.
+         */
+        readonly eventsWaiting: number;
+    }
     /**
      * _This property is an extension by Node.js. It is not available in Web browsers._
      *
@@ -166,6 +180,16 @@ declare module "perf_hooks" {
          * @since v8.5.0
          */
         readonly nodeStart: number;
+        /**
+         * This is a wrapper to the `uv_metrics_info` function.
+         * It returns the current set of event loop metrics.
+         *
+         * It is recommended to use this property inside a function whose execution was
+         * scheduled using `setImmediate` to avoid collecting metrics before finishing all
+         * operations scheduled during the current loop iteration.
+         * @since v22.8.0, v20.18.0
+         */
+        readonly uvMetricsInfo: UVMetrics;
         /**
          * The high resolution millisecond timestamp at which the V8 platform was
          * initialized.

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -340,11 +340,22 @@ declare module "node:test" {
         globPatterns?: readonly string[] | undefined;
         /**
          * Sets inspector port of test child process.
-         * If a nullish value is provided, each process gets its own port,
-         * incremented from the primary's `process.debugPort`.
+         * This can be a number, or a function that takes no arguments and returns a
+         * number. If a nullish value is provided, each process gets its own port,
+         * incremented from the primary's `process.debugPort`. This option is ignored
+         * if the `isolation` option is set to `'none'` as no child processes are
+         * spawned.
          * @default undefined
          */
         inspectPort?: number | (() => number) | undefined;
+        /**
+         * Configures the type of test isolation. If set to
+         * `'process'`, each test file is run in a separate child process. If set to
+         * `'none'`, all test files run in the current process.
+         * @default 'process'
+         * @since v22.8.0
+         */
+        isolation?: "process" | "none" | undefined;
         /**
          * If truthy, the test context will only run tests that have the `only` option set
          */
@@ -1635,9 +1646,10 @@ declare module "node:test" {
          * This function is used to set a custom resolver for the location of the snapshot file used for snapshot testing.
          * By default, the snapshot filename is the same as the entry point filename with `.snapshot` appended.
          * @since v22.3.0
-         * @param fn A function which returns a string specifying the location of the snapshot file.
-         * The function receives the path of the test file as its only argument.
-         * If `process.argv[1]` is not associated with a file (for example in the REPL), the input is undefined.
+         * @param fn A function used to compute the location of the snapshot file.
+         * The function receives the path of the test file as its only argument. If the
+         * test is not associated with a file (for example in the REPL), the input is
+         * undefined. `fn()` must return a string specifying the location of the snapshot file.
          */
         function setResolveSnapshotPath(fn: (path: string | undefined) => string): void;
     }

--- a/types/node/test/module.ts
+++ b/types/node/test/module.ts
@@ -144,3 +144,20 @@ const entry: Module.SourceMapping = smap.findEntry(1, 1);
         number; // $ExpectType number
     };
 }
+
+{
+    // $ExpectType EnableCompileCacheResult
+    Module.enableCompileCache();
+    // $ExpectType EnableCompileCacheResult
+    Module.enableCompileCache(`/var/run/nodejs/${process.pid}`);
+
+    const result = Module.enableCompileCache();
+    result.status; // $ExpectType number
+    result.message; // $ExpectType string | undefined
+    result.directory; // $ExpectType string | undefined
+
+    // $ExpectType string | undefined
+    Module.getCompileCacheDir();
+
+    const { ENABLED, ALREADY_ENABLED, FAILED, DISABLED } = Module.constants.compileCacheStatus;
+}

--- a/types/node/test/perf_hooks.ts
+++ b/types/node/test/perf_hooks.ts
@@ -154,3 +154,14 @@ const resource = NodePerf.markResourceTiming(
     "",
 );
 resource; // $ExpectType PerformanceResourceTiming
+
+{
+    const { nodeTiming } = NodePerf;
+
+    // $ExpectType UVMetrics
+    const uvMetrics = nodeTiming.uvMetricsInfo;
+
+    uvMetrics.loopCount; // $ExpectType number
+    uvMetrics.events; // $ExpectType number
+    uvMetrics.eventsWaiting; // $ExpectType number
+}

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -39,6 +39,7 @@ run({
     signal: new AbortController().signal,
     timeout: 100,
     inspectPort: () => 8081,
+    isolation: "process",
     testNamePatterns: ["executed", /^core-/],
     testSkipPatterns: ["excluded", /^lib-/],
     only: true,

--- a/types/node/v20/vm.d.ts
+++ b/types/node/v20/vm.d.ts
@@ -907,13 +907,12 @@ declare module "vm" {
      */
     namespace constants {
         /**
-         * Stability: 1.1 - Active development
-         *
          * A constant that can be used as the `importModuleDynamically` option to `vm.Script`
          * and `vm.compileFunction()` so that Node.js uses the default ESM loader from the main
          * context to load the requested module.
          *
          * For detailed information, see [Support of dynamic `import()` in compilation APIs](https://nodejs.org/docs/latest-v20.x/api/vm.html#support-of-dynamic-import-in-compilation-apis).
+         * @since v20.12.0
          */
         const USE_MAIN_CONTEXT_DEFAULT_LOADER: number;
     }


### PR DESCRIPTION
https://github.com/nodejs/node/releases/tag/v22.8.0

- deps: update undici to 6.19.8
- src: add JS APIs for compile cache and NODE_DISABLE_COMPILE_CACHE
- src,lib: add performance.uvMetricsInfo
- test_runner: support running tests in process
- vm: introduce vanilla contexts via vm.constants.DONT_CONTEXTIFY

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
