### PR TITLE
@types/qunit - Add types for test.each for qunit

### DIFF
--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -559,10 +559,45 @@ declare global {
             assert: Assert;
         }
 
+        type TestFunctionCallback = (assert: Assert) => void | Promise<void>;
+        type EachFunction = <T>(
+            name: string,
+            dataset: T[] | { [key: string]: T },
+            callback: (assert: Assert, data: T) => void,
+        ) => void;
+
+        interface IfFunction {
+            (name: string, condition: boolean, callback: TestFunctionCallback): void;
+            each: <T>(
+                name: string,
+                condition: boolean,
+                dataset: T[] | { [key: string]: T },
+                callback: (assert: Assert, data: T) => void,
+            ) => void;
+        }
+
+        interface OnlyFunction {
+            (name: string, callback: TestFunctionCallback): void;
+            each: EachFunction;
+        }
+
+        interface TodoFunction {
+            (name: string, callback: TestFunctionCallback): void;
+            each: EachFunction;
+        }
+
+        interface SkipFunction {
+            (name: string, callback: TestFunctionCallback): void;
+            each: EachFunction;
+        }
+
         interface TestFunction {
-            (name: string, callback: (assert: Assert) => void | Promise<void>): void;
-            skip: (name: string, callback: (assert: Assert) => void | Promise<void>) => void;
-            each:  <T>(name: string, dataset: T[] | { [key: string]: T}, callback: (assert: Assert, data: T) => void) => void;
+            (name: string, callback: TestFunctionCallback): void;
+            each: EachFunction;
+            if: IfFunction;
+            only: OnlyFunction;
+            skip: SkipFunction;
+            todo: TodoFunction;
         }
 
         type Test = AssertionTest | SkipTest | TodoTest;
@@ -818,7 +853,7 @@ declare global {
          * @param {string} Title of unit being tested
          * @param callback Function to close over assertions
          */
-        test: QUnit.TestFunction,
+        test: QUnit.TestFunction;
 
         /**
          * Register a callback to fire whenever a test ends.

--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -559,6 +559,12 @@ declare global {
             assert: Assert;
         }
 
+        interface TestFunction {
+            (name: string, callback: (assert: Assert) => void | Promise<void>): void;
+            skip: (name: string, callback: (assert: Assert) => void | Promise<void>) => void;
+            each:  <T>(name: string, dataset: T[] | { [key: string]: T}, callback: (assert: Assert, data: T) => void) => void;
+        }
+
         type Test = AssertionTest | SkipTest | TodoTest;
     }
 
@@ -812,7 +818,7 @@ declare global {
          * @param {string} Title of unit being tested
          * @param callback Function to close over assertions
          */
-        test(name: string, callback: (assert: Assert) => void | Promise<void>): void;
+        test: QUnit.TestFunction,
 
         /**
          * Register a callback to fire whenever a test ends.

--- a/types/qunit/test/global-test.ts
+++ b/types/qunit/test/global-test.ts
@@ -54,22 +54,22 @@ QUnit.module("skip", function() {
         assert.strictEqual(data, 3);
     });
 
-    QUnit.test.if.each("if.each with strng array example", true, ["foo", "bar"], function(assert, data) {
+    QUnit.test.if.each("if.each with string array example", true, ["foo", "bar"], function(assert, data) {
         assert.expect(3);
         assert.strictEqual(data, "foo");
     });
 
-    QUnit.test.skip.each("if.each with strng array example", ["foo", "bar"], function(assert, data) {
+    QUnit.test.skip.each("skip.each with string array example", ["foo", "bar"], function(assert, data) {
         assert.expect(3);
         assert.strictEqual(data, "foo");
     });
 
-    QUnit.test.todo.each("if.each with strng array example", ["foo", "bar"], function(assert, data) {
+    QUnit.test.todo.each("todo.each with string array example", ["foo", "bar"], function(assert, data) {
         assert.expect(3);
         assert.strictEqual(data, "foo");
     });
 
-    QUnit.test.only.each("if.each with strng array example", ["foo", "bar"], function(assert, data) {
+    QUnit.test.only.each("only.each with string array example", ["foo", "bar"], function(assert, data) {
         assert.expect(3);
         assert.strictEqual(data, "foo");
     });

--- a/types/qunit/test/global-test.ts
+++ b/types/qunit/test/global-test.ts
@@ -17,6 +17,30 @@ QUnit.test("a basic test example 4", function(assert) {
     assert.ok(true, "this test is fine");
 });
 
+QUnit.test.skip("skip test example", function(assert) {
+    assert.ok(true, "this is skiped");
+});
+
+QUnit.test.each("each with string array example", ['foo', 'bar'],function(assert, data) {
+    assert.expect(3);
+    assert.strictEqual(data, 'string value');
+});
+
+QUnit.test.each("each with string object example", { case1: 'foo', case2: 'bar' },function(assert, data) {
+    assert.expect(3);
+    assert.strictEqual(data, 'string value');
+});
+
+QUnit.test.each("each with number array example", [1, 2],function(assert, data) {
+    assert.expect(3);
+    assert.strictEqual(data, 3);
+});
+
+QUnit.test.each("each with number object example", { case1: 1, case2: 2 },function(assert, data) {
+    assert.expect(3);
+    assert.strictEqual(data, 3);
+});
+
 QUnit.module("module a", function() {
     QUnit.test("a basic test example", function(assert) {
         assert.ok(true, "this test is fine");

--- a/types/qunit/test/global-test.ts
+++ b/types/qunit/test/global-test.ts
@@ -17,28 +17,62 @@ QUnit.test("a basic test example 4", function(assert) {
     assert.ok(true, "this test is fine");
 });
 
+QUnit.test.todo("todo test example", function(assert) {
+    assert.ok(true, "this is a todo");
+});
+
+QUnit.test.only("only test example", function(assert) {
+    assert.ok(true, "only this is called");
+});
+
 QUnit.test.skip("skip test example", function(assert) {
     assert.ok(true, "this is skiped");
 });
 
-QUnit.test.each("each with string array example", ['foo', 'bar'],function(assert, data) {
-    assert.expect(3);
-    assert.strictEqual(data, 'string value');
+QUnit.test.if("if test example", true, function(assert) {
+    assert.ok(true, "this is called if true");
 });
 
-QUnit.test.each("each with string object example", { case1: 'foo', case2: 'bar' },function(assert, data) {
-    assert.expect(3);
-    assert.strictEqual(data, 'string value');
-});
+QUnit.module("skip", function() {
+    QUnit.test.each("each with string array example", ["foo", "bar"], function(assert, data) {
+        assert.expect(3);
+        assert.strictEqual(data, "string value");
+    });
 
-QUnit.test.each("each with number array example", [1, 2],function(assert, data) {
-    assert.expect(3);
-    assert.strictEqual(data, 3);
-});
+    QUnit.test.each("each with string object example", { case1: "foo", case2: "bar" }, function(assert, data) {
+        assert.expect(3);
+        assert.strictEqual(data, "string value");
+    });
 
-QUnit.test.each("each with number object example", { case1: 1, case2: 2 },function(assert, data) {
-    assert.expect(3);
-    assert.strictEqual(data, 3);
+    QUnit.test.each("each with number array example", [1, 2], function(assert, data) {
+        assert.expect(3);
+        assert.strictEqual(data, 3);
+    });
+
+    QUnit.test.each("each with number object example", { case1: 1, case2: 2 }, function(assert, data) {
+        assert.expect(3);
+        assert.strictEqual(data, 3);
+    });
+
+    QUnit.test.if.each("if.each with strng array example", true, ["foo", "bar"], function(assert, data) {
+        assert.expect(3);
+        assert.strictEqual(data, "foo");
+    });
+
+    QUnit.test.skip.each("if.each with strng array example", ["foo", "bar"], function(assert, data) {
+        assert.expect(3);
+        assert.strictEqual(data, "foo");
+    });
+
+    QUnit.test.todo.each("if.each with strng array example", ["foo", "bar"], function(assert, data) {
+        assert.expect(3);
+        assert.strictEqual(data, "foo");
+    });
+
+    QUnit.test.only.each("if.each with strng array example", ["foo", "bar"], function(assert, data) {
+        assert.expect(3);
+        assert.strictEqual(data, "foo");
+    });
 });
 
 QUnit.module("module a", function() {

--- a/types/qunit/test/module-test.ts
+++ b/types/qunit/test/module-test.ts
@@ -13,28 +13,62 @@ QUnit.module("basic tests for importing QUnit", function(hooks) {
         assert.expect(2);
     });
 
-    QUnit.test.skip("skip test", function(assert) {
-        assert.expect(3);
+    QUnit.test.todo("todo test example", function(assert) {
+        assert.ok(true, "this is a todo");
     });
-
-    QUnit.test.each("each with string array", ["foo", "bar"], function(assert, data) {
-        assert.expect(3);
-        assert.strictEqual(data, "string value");
+    
+    QUnit.test.only("only test example", function(assert) {
+        assert.ok(true, "only this is called");
     });
-
-    QUnit.test.each("each with string object example", { case1: "foo", case2: "bar" }, function(assert, data) {
-        assert.expect(3);
-        assert.strictEqual(data, "string value");
+    
+    QUnit.test.skip("skip test example", function(assert) {
+        assert.ok(true, "this is skiped");
     });
-
-    QUnit.test.each("each with number array", [1, 2], function(assert, data) {
-        assert.expect(3);
-        assert.strictEqual(data, 3);
+    
+    QUnit.test.if("if test example", true, function(assert) {
+        assert.ok(true, "this is called if true");
     });
-
-    QUnit.test.each("each with number object example", { case1: 1, case2: 2 }, function(assert, data) {
-        assert.expect(3);
-        assert.strictEqual(data, 3);
+    
+    QUnit.module("skip", function() {
+        QUnit.test.each("each with string array example", ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "string value");
+        });
+    
+        QUnit.test.each("each with string object example", { case1: "foo", case2: "bar" }, function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "string value");
+        });
+    
+        QUnit.test.each("each with number array example", [1, 2], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, 3);
+        });
+    
+        QUnit.test.each("each with number object example", { case1: 1, case2: 2 }, function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, 3);
+        });
+    
+        QUnit.test.if.each("if.each with string array example", true, ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "foo");
+        });
+    
+        QUnit.test.skip.each("skip.each with string array example", ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "foo");
+        });
+    
+        QUnit.test.todo.each("todo.each with string array example", ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "foo");
+        });
+    
+        QUnit.test.only.each("only.each with string array example", ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "foo");
+        });
     });
 
     QUnit.module("stacked hooks", function(hooks) {

--- a/types/qunit/test/module-test.ts
+++ b/types/qunit/test/module-test.ts
@@ -17,22 +17,22 @@ QUnit.module("basic tests for importing QUnit", function(hooks) {
         assert.expect(3);
     });
 
-    QUnit.test.each("each with string array", ['foo', 'bar'],function(assert, data) {
+    QUnit.test.each("each with string array", ["foo", "bar"], function(assert, data) {
         assert.expect(3);
-        assert.strictEqual(data, 'string value');
+        assert.strictEqual(data, "string value");
     });
 
-    QUnit.test.each("each with string object example", { case1: 'foo', case2: 'bar' },function(assert, data) {
+    QUnit.test.each("each with string object example", { case1: "foo", case2: "bar" }, function(assert, data) {
         assert.expect(3);
-        assert.strictEqual(data, 'string value');
+        assert.strictEqual(data, "string value");
     });
 
-    QUnit.test.each("each with number array", [1, 2],function(assert, data) {
+    QUnit.test.each("each with number array", [1, 2], function(assert, data) {
         assert.expect(3);
         assert.strictEqual(data, 3);
     });
 
-    QUnit.test.each("each with number object example", { case1: 1, case2: 2 },function(assert, data) {
+    QUnit.test.each("each with number object example", { case1: 1, case2: 2 }, function(assert, data) {
         assert.expect(3);
         assert.strictEqual(data, 3);
     });

--- a/types/qunit/test/module-test.ts
+++ b/types/qunit/test/module-test.ts
@@ -16,55 +16,55 @@ QUnit.module("basic tests for importing QUnit", function(hooks) {
     QUnit.test.todo("todo test example", function(assert) {
         assert.ok(true, "this is a todo");
     });
-    
+
     QUnit.test.only("only test example", function(assert) {
         assert.ok(true, "only this is called");
     });
-    
+
     QUnit.test.skip("skip test example", function(assert) {
         assert.ok(true, "this is skiped");
     });
-    
+
     QUnit.test.if("if test example", true, function(assert) {
         assert.ok(true, "this is called if true");
     });
-    
+
     QUnit.module("skip", function() {
         QUnit.test.each("each with string array example", ["foo", "bar"], function(assert, data) {
             assert.expect(3);
             assert.strictEqual(data, "string value");
         });
-    
+
         QUnit.test.each("each with string object example", { case1: "foo", case2: "bar" }, function(assert, data) {
             assert.expect(3);
             assert.strictEqual(data, "string value");
         });
-    
+
         QUnit.test.each("each with number array example", [1, 2], function(assert, data) {
             assert.expect(3);
             assert.strictEqual(data, 3);
         });
-    
+
         QUnit.test.each("each with number object example", { case1: 1, case2: 2 }, function(assert, data) {
             assert.expect(3);
             assert.strictEqual(data, 3);
         });
-    
+
         QUnit.test.if.each("if.each with string array example", true, ["foo", "bar"], function(assert, data) {
             assert.expect(3);
             assert.strictEqual(data, "foo");
         });
-    
+
         QUnit.test.skip.each("skip.each with string array example", ["foo", "bar"], function(assert, data) {
             assert.expect(3);
             assert.strictEqual(data, "foo");
         });
-    
+
         QUnit.test.todo.each("todo.each with string array example", ["foo", "bar"], function(assert, data) {
             assert.expect(3);
             assert.strictEqual(data, "foo");
         });
-    
+
         QUnit.test.only.each("only.each with string array example", ["foo", "bar"], function(assert, data) {
             assert.expect(3);
             assert.strictEqual(data, "foo");

--- a/types/qunit/test/module-test.ts
+++ b/types/qunit/test/module-test.ts
@@ -13,6 +13,30 @@ QUnit.module("basic tests for importing QUnit", function(hooks) {
         assert.expect(2);
     });
 
+    QUnit.test.skip("skip test", function(assert) {
+        assert.expect(3);
+    });
+
+    QUnit.test.each("each with string array", ['foo', 'bar'],function(assert, data) {
+        assert.expect(3);
+        assert.strictEqual(data, 'string value');
+    });
+
+    QUnit.test.each("each with string object example", { case1: 'foo', case2: 'bar' },function(assert, data) {
+        assert.expect(3);
+        assert.strictEqual(data, 'string value');
+    });
+
+    QUnit.test.each("each with number array", [1, 2],function(assert, data) {
+        assert.expect(3);
+        assert.strictEqual(data, 3);
+    });
+
+    QUnit.test.each("each with number object example", { case1: 1, case2: 2 },function(assert, data) {
+        assert.expect(3);
+        assert.strictEqual(data, 3);
+    });
+
     QUnit.module("stacked hooks", function(hooks) {
         // This will run after the parent module's beforeEach hook
         hooks.beforeEach(function(assert) {


### PR DESCRIPTION
Please fill in this template.

- [+] Use a meaningful title for the pull request. Include the name of the package modified.
- [+] Test the change in your own code. (Compile and run.)
- [+] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [+] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [+] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [+] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [+] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [+] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Basically this PR adds types for `test.each` which seems to be missing.
The method is documented here https://qunitjs.com/api/QUnit/test.each but it's missing from the types
