### PR TITLE
[json-stable-stringify] fix: add type for optional Comparator argument

### DIFF
--- a/types/json-stable-stringify/index.d.ts
+++ b/types/json-stable-stringify/index.d.ts
@@ -11,7 +11,7 @@ declare namespace stringify {
         value: any;
     }
 
-    type Comparator = (a: Element, b: Element) => number;
+    type Comparator = (a: Element, b: Element, opts?: { get(k: string): any }) => number;
 
     type Replacer = (key: string, value: any) => any;
 

--- a/types/json-stable-stringify/json-stable-stringify-tests.ts
+++ b/types/json-stable-stringify/json-stable-stringify-tests.ts
@@ -50,3 +50,16 @@ const obj = { c: 8, b: [{ z: 6, y: 5, x: 4 }, 7], a: 3 };
     // We can specify the cycles
     stringify(obj, { cycles: true }); // $ExpectType string
 }
+
+{
+    // Third argument in a Comparator function
+    const s: string = stringify(
+        obj,
+        (a: stringify.Element, b: stringify.Element, opts: { get(k: string): any } | undefined): number => {
+            return opts
+                ? opts.get(a.key) < opts.get(b.key) ? 1 : -1
+                : -1;
+        },
+    );
+    console.log(s);
+}

--- a/types/json-stable-stringify/package.json
+++ b/types/json-stable-stringify/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/json-stable-stringify",
-    "version": "1.0.9999",
+    "version": "1.1.9999",
     "projects": [
         "https://github.com/substack/json-stable-stringify"
     ],


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [link to docs](https://www.npmjs.com/package/json-stable-stringify#cmp)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.