### PR TITLE
fix(node): Add signal & fix completer in ReadLineOptions, add jsdoc

### DIFF
--- a/types/node/readline.d.ts
+++ b/types/node/readline.d.ts
@@ -314,29 +314,78 @@ declare module "readline" {
     ) => void;
     export type CompleterResult = [string[], string];
     export interface ReadLineOptions {
+        /**
+         * The [`Readable`](https://nodejs.org/docs/latest-v22.x/api/stream.html#readable-streams) stream to listen to
+         */
         input: NodeJS.ReadableStream;
+        /**
+         * The [`Writable`](https://nodejs.org/docs/latest-v22.x/api/stream.html#writable-streams) stream to write readline data to.
+         */
         output?: NodeJS.WritableStream | undefined;
+        /**
+         * An optional function used for Tab autocompletion.
+         */
         completer?: Completer | AsyncCompleter | undefined;
+        /**
+         * `true` if the `input` and `output` streams should be treated like a TTY,
+         * and have ANSI/VT100 escape codes written to it.
+         * Default: checking `isTTY` on the `output` stream upon instantiation.
+         */
         terminal?: boolean | undefined;
         /**
-         *  Initial list of history lines. This option makes sense
-         * only if `terminal` is set to `true` by the user or by an internal `output`
-         * check, otherwise the history caching mechanism is not initialized at all.
+         * Initial list of history lines.
+         * This option makes sense only if `terminal` is set to `true` by the user or by an internal `output` check,
+         * otherwise the history caching mechanism is not initialized at all.
          * @default []
          */
         history?: string[] | undefined;
-        historySize?: number | undefined;
-        prompt?: string | undefined;
-        crlfDelay?: number | undefined;
         /**
-         * If `true`, when a new input line added
-         * to the history list duplicates an older one, this removes the older line
-         * from the list.
+         * Maximum number of history lines retained.
+         * To disable the history set this value to `0`.
+         * This option makes sense only if `terminal` is set to `true` by the user or by an internal `output` check,
+         * otherwise the history caching mechanism is not initialized at all.
+         * @default 30
+         */
+        historySize?: number | undefined;
+        /**
+         * If `true`, when a new input line added to the history list duplicates an older one,
+         * this removes the older line from the list.
          * @default false
          */
         removeHistoryDuplicates?: boolean | undefined;
+        /**
+         * The prompt string to use.
+         * @default "> "
+         */
+        prompt?: string | undefined;
+        /**
+         * If the delay between `\r` and `\n` exceeds `crlfDelay` milliseconds,
+         * both `\r` and `\n` will be treated as separate end-of-line input.
+         * `crlfDelay` will be coerced to a number no less than `100`.
+         * It can be set to `Infinity`, in which case
+         * `\r` followed by `\n` will always be considered a single newline
+         * (which may be reasonable for [reading files](https://nodejs.org/docs/latest-v22.x/api/readline.html#example-read-file-stream-line-by-line) with `\r\n` line delimiter).
+         * @default 100
+         */
+        crlfDelay?: number | undefined;
+        /**
+         * The duration `readline` will wait for a character
+         * (when reading an ambiguous key sequence in milliseconds
+         * one that can both form a complete key sequence using the input read so far
+         * and can take additional input to complete a longer key sequence).
+         * @default 500
+         */
         escapeCodeTimeout?: number | undefined;
+        /**
+         * The number of spaces a tab is equal to (minimum 1).
+         * @default 8
+         */
         tabSize?: number | undefined;
+        /**
+         * Allows closing the interface using an AbortSignal.
+         * Aborting the signal will internally call `close` on the interface.
+         */
+        signal?: AbortSignal | undefined;
     }
     /**
      * The `readline.createInterface()` method creates a new `readline.Interface` instance.

--- a/types/node/readline/promises.d.ts
+++ b/types/node/readline/promises.d.ts
@@ -3,8 +3,13 @@
  * @experimental
  */
 declare module "readline/promises" {
-    import { AsyncCompleter, Completer, Direction, Interface as _Interface, ReadLineOptions } from "node:readline";
     import { Abortable } from "node:events";
+    import {
+        CompleterResult,
+        Direction,
+        Interface as _Interface,
+        ReadLineOptions as _ReadLineOptions,
+    } from "node:readline";
     /**
      * Instances of the `readlinePromises.Interface` class are constructed using the `readlinePromises.createInterface()` method. Every instance is associated with a
      * single `input` `Readable` stream and a single `output` `Writable` stream.
@@ -111,6 +116,13 @@ declare module "readline/promises" {
          */
         rollback(): this;
     }
+    type Completer = (line: string) => CompleterResult | Promise<CompleterResult>;
+    interface ReadLineOptions extends Omit<_ReadLineOptions, "completer"> {
+        /**
+         * An optional function used for Tab autocompletion.
+         */
+        completer?: Completer | undefined;
+    }
     /**
      * The `readlinePromises.createInterface()` method creates a new `readlinePromises.Interface` instance.
      *
@@ -140,7 +152,7 @@ declare module "readline/promises" {
     function createInterface(
         input: NodeJS.ReadableStream,
         output?: NodeJS.WritableStream,
-        completer?: Completer | AsyncCompleter,
+        completer?: Completer,
         terminal?: boolean,
     ): Interface;
     function createInterface(options: ReadLineOptions): Interface;

--- a/types/node/test/readline.ts
+++ b/types/node/test/readline.ts
@@ -1,4 +1,3 @@
-import * as fs from "node:fs";
 import * as readline from "node:readline";
 import * as readlinePromises from "node:readline/promises";
 import * as stream from "node:stream";
@@ -6,37 +5,43 @@ import * as stream from "node:stream";
 const rl: readline.ReadLine = readline.createInterface(new stream.Readable());
 
 {
-    const options: readline.ReadLineOptions = {
-        input: new fs.ReadStream(),
-    };
     const input: NodeJS.ReadableStream = new stream.Readable();
     const output: NodeJS.WritableStream = new stream.Writable();
-    const completer: readline.Completer = str => [["asd"], "asd"];
+    const syncCompleter: readline.Completer = function(str) {
+        // $ExpectType string
+        str;
+        return [["test"], "test"];
+    };
+    const asyncCompleter: readline.AsyncCompleter = function(str, callback) {
+        // $ExpectType string
+        str;
+        // $ExpectType (err?: Error | null | undefined, result?: CompleterResult | undefined) => void
+        callback;
+    };
     const terminal = false;
 
     let result: readline.ReadLine;
 
-    result = readline.createInterface(options);
     result = readline.createInterface(input);
     result = readline.createInterface(input, output);
-    result = readline.createInterface(input, output, completer);
-    result = readline.createInterface(input, output, completer, terminal);
-    result = readline.createInterface({
-        input,
-        completer(str: string): readline.CompleterResult {
-            return [["test"], "test"];
-        },
-    });
-    result = readline.createInterface({
-        input,
-        completer(str: string, callback: (err: any, result: readline.CompleterResult) => void): any {
-            callback(null, [["test"], "test"]);
-        },
-    });
-    result = readline.createInterface({
-        input,
-        tabSize: 4,
-    });
+    result = readline.createInterface(input, output, syncCompleter);
+    result = readline.createInterface(input, output, asyncCompleter);
+    result = readline.createInterface(input, output, syncCompleter, terminal);
+    result = readline.createInterface(input, output, asyncCompleter, terminal);
+
+    result = readline.createInterface({ input });
+    result = readline.createInterface({ input, output });
+    result = readline.createInterface({ input, completer: syncCompleter });
+    result = readline.createInterface({ input, completer: asyncCompleter });
+    result = readline.createInterface({ input, terminal });
+    result = readline.createInterface({ input, history: ["foo"] });
+    result = readline.createInterface({ input, historySize: 20 });
+    result = readline.createInterface({ input, removeHistoryDuplicates: true });
+    result = readline.createInterface({ input, prompt: "prompt >" });
+    result = readline.createInterface({ input, crlfDelay: 200 });
+    result = readline.createInterface({ input, escapeCodeTimeout: 200 });
+    result = readline.createInterface({ input, tabSize: 4 });
+    result = readline.createInterface({ input, signal: new AbortSignal() });
 }
 
 {
@@ -321,35 +326,39 @@ const readlineInstance = new readlinePromises.Readline(new stream.Writable());
 }
 
 {
-    const options: readline.ReadLineOptions = {
-        input: new fs.ReadStream(),
-    };
     const input: NodeJS.ReadableStream = new stream.Readable();
     const output: NodeJS.WritableStream = new stream.Writable();
-    const completer: readline.Completer = str => [["asd"], "asd"];
+    const syncCompleter: readlinePromises.Completer = function(str) {
+        // $ExpectType string
+        str;
+        return [["test"], "test"];
+    };
+    const asyncCompleter: readlinePromises.Completer = async function(str) {
+        // $ExpectType string
+        str;
+        return [["test"], "test"];
+    };
     const terminal = false;
 
     let result: readlinePromises.Interface;
 
-    result = readlinePromises.createInterface(options);
     result = readlinePromises.createInterface(input);
     result = readlinePromises.createInterface(input, output);
-    result = readlinePromises.createInterface(input, output, completer);
-    result = readlinePromises.createInterface(input, output, completer, terminal);
-    result = readlinePromises.createInterface({
-        input,
-        completer(str: string): readline.CompleterResult {
-            return [["test"], "test"];
-        },
-    });
-    result = readlinePromises.createInterface({
-        input,
-        completer(str: string, callback: (err: any, result: readline.CompleterResult) => void): any {
-            callback(null, [["test"], "test"]);
-        },
-    });
-    result = readlinePromises.createInterface({
-        input,
-        tabSize: 4,
-    });
+    result = readlinePromises.createInterface(input, output, syncCompleter);
+    result = readlinePromises.createInterface(input, output, asyncCompleter);
+    result = readlinePromises.createInterface(input, output, syncCompleter, terminal);
+    result = readlinePromises.createInterface(input, output, asyncCompleter, terminal);
+
+    result = readlinePromises.createInterface({ input, output });
+    result = readlinePromises.createInterface({ input, completer: syncCompleter });
+    result = readlinePromises.createInterface({ input, completer: asyncCompleter });
+    result = readlinePromises.createInterface({ input, terminal });
+    result = readlinePromises.createInterface({ input, history: ["foo"] });
+    result = readlinePromises.createInterface({ input, historySize: 20 });
+    result = readlinePromises.createInterface({ input, removeHistoryDuplicates: true });
+    result = readlinePromises.createInterface({ input, prompt: "prompt >" });
+    result = readlinePromises.createInterface({ input, crlfDelay: 200 });
+    result = readlinePromises.createInterface({ input, escapeCodeTimeout: 200 });
+    result = readlinePromises.createInterface({ input, tabSize: 4 });
+    result = readlinePromises.createInterface({ input, signal: new AbortSignal() });
 }

--- a/types/node/v16/readline.d.ts
+++ b/types/node/v16/readline.d.ts
@@ -93,7 +93,7 @@ declare module "readline" {
          * > Instances of the `readline.Interface` class are constructed using the
          * > `readline.createInterface()` method.
          *
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/readline.html#readline_class_interface
+         * @see https://nodejs.org/dist/latest-v16.x/docs/api/readline.html#readline_class_interface
          */
         protected constructor(
             input: NodeJS.ReadableStream,
@@ -107,7 +107,7 @@ declare module "readline" {
          * > Instances of the `readline.Interface` class are constructed using the
          * > `readline.createInterface()` method.
          *
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/readline.html#readline_class_interface
+         * @see https://nodejs.org/dist/latest-v16.x/docs/api/readline.html#readline_class_interface
          */
         protected constructor(options: ReadLineOptions);
         /**
@@ -321,32 +321,81 @@ declare module "readline" {
     type AsyncCompleter = (line: string, callback: (err?: null | Error, result?: CompleterResult) => void) => void;
     type CompleterResult = [string[], string];
     interface ReadLineOptions {
+        /**
+         * The [`Readable`](https://nodejs.org/docs/latest-v16.x/api/stream.html#readable-streams) stream to listen to
+         */
         input: NodeJS.ReadableStream;
+        /**
+         * The [`Writable`](https://nodejs.org/docs/latest-v16.x/api/stream.html#writable-streams) stream to write readline data to.
+         */
         output?: NodeJS.WritableStream | undefined;
+        /**
+         * An optional function used for Tab autocompletion.
+         */
         completer?: Completer | AsyncCompleter | undefined;
+        /**
+         * `true` if the `input` and `output` streams should be treated like a TTY,
+         * and have ANSI/VT100 escape codes written to it.
+         * Default: checking `isTTY` on the `output` stream upon instantiation.
+         */
         terminal?: boolean | undefined;
         /**
-         *  Initial list of history lines. This option makes sense
-         * only if `terminal` is set to `true` by the user or by an internal `output`
-         * check, otherwise the history caching mechanism is not initialized at all.
+         * Initial list of history lines.
+         * This option makes sense only if `terminal` is set to `true` by the user or by an internal `output` check,
+         * otherwise the history caching mechanism is not initialized at all.
          * @default []
          */
         history?: string[] | undefined;
-        historySize?: number | undefined;
-        prompt?: string | undefined;
-        crlfDelay?: number | undefined;
         /**
-         * If `true`, when a new input line added
-         * to the history list duplicates an older one, this removes the older line
-         * from the list.
+         * Maximum number of history lines retained.
+         * To disable the history set this value to `0`.
+         * This option makes sense only if `terminal` is set to `true` by the user or by an internal `output` check,
+         * otherwise the history caching mechanism is not initialized at all.
+         * @default 30
+         */
+        historySize?: number | undefined;
+        /**
+         * If `true`, when a new input line added to the history list duplicates an older one,
+         * this removes the older line from the list.
          * @default false
          */
         removeHistoryDuplicates?: boolean | undefined;
+        /**
+         * The prompt string to use.
+         * @default "> "
+         */
+        prompt?: string | undefined;
+        /**
+         * If the delay between `\r` and `\n` exceeds `crlfDelay` milliseconds,
+         * both `\r` and `\n` will be treated as separate end-of-line input.
+         * `crlfDelay` will be coerced to a number no less than `100`.
+         * It can be set to `Infinity`, in which case
+         * `\r` followed by `\n` will always be considered a single newline
+         * (which may be reasonable for [reading files](https://nodejs.org/docs/latest-v16.x/api/readline.html#example-read-file-stream-line-by-line) with `\r\n` line delimiter).
+         * @default 100
+         */
+        crlfDelay?: number | undefined;
+        /**
+         * The duration `readline` will wait for a character
+         * (when reading an ambiguous key sequence in milliseconds
+         * one that can both form a complete key sequence using the input read so far
+         * and can take additional input to complete a longer key sequence).
+         * @default 500
+         */
         escapeCodeTimeout?: number | undefined;
+        /**
+         * The number of spaces a tab is equal to (minimum 1).
+         * @default 8
+         */
         tabSize?: number | undefined;
+        /**
+         * Allows closing the interface using an AbortSignal.
+         * Aborting the signal will internally call `close` on the interface.
+         */
+        signal?: AbortSignal | undefined;
     }
     /**
-     * The `readline.createInterface()` method creates a new `readline.Interface`instance.
+     * The `readline.createInterface()` method creates a new `readline.Interface` instance.
      *
      * ```js
      * import readline from 'node:readline';

--- a/types/node/v16/test/readline.ts
+++ b/types/node/v16/test/readline.ts
@@ -1,41 +1,46 @@
-import * as fs from "node:fs";
 import * as readline from "node:readline";
 import * as stream from "node:stream";
 
 const rl: readline.ReadLine = readline.createInterface(new stream.Readable());
 
 {
-    const options: readline.ReadLineOptions = {
-        input: new fs.ReadStream(),
-    };
     const input: NodeJS.ReadableStream = new stream.Readable();
     const output: NodeJS.WritableStream = new stream.Writable();
-    const completer: readline.Completer = str => [["asd"], "asd"];
+    const syncCompleter: readline.Completer = function(str) {
+        // $ExpectType string
+        str;
+        return [["test"], "test"];
+    };
+    const asyncCompleter: readline.AsyncCompleter = function(str, callback) {
+        // $ExpectType string
+        str;
+        // $ExpectType (err?: Error | null | undefined, result?: CompleterResult | undefined) => void
+        callback;
+    };
     const terminal = false;
 
     let result: readline.ReadLine;
 
-    result = readline.createInterface(options);
     result = readline.createInterface(input);
     result = readline.createInterface(input, output);
-    result = readline.createInterface(input, output, completer);
-    result = readline.createInterface(input, output, completer, terminal);
-    result = readline.createInterface({
-        input,
-        completer(str: string): readline.CompleterResult {
-            return [["test"], "test"];
-        },
-    });
-    result = readline.createInterface({
-        input,
-        completer(str: string, callback: (err: any, result: readline.CompleterResult) => void): any {
-            callback(null, [["test"], "test"]);
-        },
-    });
-    result = readline.createInterface({
-        input,
-        tabSize: 4,
-    });
+    result = readline.createInterface(input, output, syncCompleter);
+    result = readline.createInterface(input, output, asyncCompleter);
+    result = readline.createInterface(input, output, syncCompleter, terminal);
+    result = readline.createInterface(input, output, asyncCompleter, terminal);
+
+    result = readline.createInterface({ input });
+    result = readline.createInterface({ input, output });
+    result = readline.createInterface({ input, completer: syncCompleter });
+    result = readline.createInterface({ input, completer: asyncCompleter });
+    result = readline.createInterface({ input, terminal });
+    result = readline.createInterface({ input, history: ["foo"] });
+    result = readline.createInterface({ input, historySize: 20 });
+    result = readline.createInterface({ input, removeHistoryDuplicates: true });
+    result = readline.createInterface({ input, prompt: "prompt >" });
+    result = readline.createInterface({ input, crlfDelay: 200 });
+    result = readline.createInterface({ input, escapeCodeTimeout: 200 });
+    result = readline.createInterface({ input, tabSize: 4 });
+    result = readline.createInterface({ input, signal: new AbortSignal() });
 }
 
 {

--- a/types/node/v18/readline.d.ts
+++ b/types/node/v18/readline.d.ts
@@ -100,7 +100,7 @@ declare module "readline" {
          * > Instances of the `readline.Interface` class are constructed using the
          * > `readline.createInterface()` method.
          *
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/readline.html#readline_class_interface
+         * @see https://nodejs.org/docs/latest-v18.x/api/readline.html#readline_class_interface
          */
         protected constructor(
             input: NodeJS.ReadableStream,
@@ -114,7 +114,7 @@ declare module "readline" {
          * > Instances of the `readline.Interface` class are constructed using the
          * > `readline.createInterface()` method.
          *
-         * @see https://nodejs.org/dist/latest-v10.x/docs/api/readline.html#readline_class_interface
+         * @see https://nodejs.org/docs/latest-v18.x/api/readline.html#readline_class_interface
          */
         protected constructor(options: ReadLineOptions);
         /**
@@ -331,29 +331,78 @@ declare module "readline" {
     ) => void;
     export type CompleterResult = [string[], string];
     export interface ReadLineOptions {
+        /**
+         * The [`Readable`](https://nodejs.org/docs/latest-v18.x/api/stream.html#readable-streams) stream to listen to
+         */
         input: NodeJS.ReadableStream;
+        /**
+         * The [`Writable`](https://nodejs.org/docs/latest-v18.x/api/stream.html#writable-streams) stream to write readline data to.
+         */
         output?: NodeJS.WritableStream | undefined;
+        /**
+         * An optional function used for Tab autocompletion.
+         */
         completer?: Completer | AsyncCompleter | undefined;
+        /**
+         * `true` if the `input` and `output` streams should be treated like a TTY,
+         * and have ANSI/VT100 escape codes written to it.
+         * Default: checking `isTTY` on the `output` stream upon instantiation.
+         */
         terminal?: boolean | undefined;
         /**
-         *  Initial list of history lines. This option makes sense
-         * only if `terminal` is set to `true` by the user or by an internal `output`
-         * check, otherwise the history caching mechanism is not initialized at all.
+         * Initial list of history lines.
+         * This option makes sense only if `terminal` is set to `true` by the user or by an internal `output` check,
+         * otherwise the history caching mechanism is not initialized at all.
          * @default []
          */
         history?: string[] | undefined;
-        historySize?: number | undefined;
-        prompt?: string | undefined;
-        crlfDelay?: number | undefined;
         /**
-         * If `true`, when a new input line added
-         * to the history list duplicates an older one, this removes the older line
-         * from the list.
+         * Maximum number of history lines retained.
+         * To disable the history set this value to `0`.
+         * This option makes sense only if `terminal` is set to `true` by the user or by an internal `output` check,
+         * otherwise the history caching mechanism is not initialized at all.
+         * @default 30
+         */
+        historySize?: number | undefined;
+        /**
+         * If `true`, when a new input line added to the history list duplicates an older one,
+         * this removes the older line from the list.
          * @default false
          */
         removeHistoryDuplicates?: boolean | undefined;
+        /**
+         * The prompt string to use.
+         * @default "> "
+         */
+        prompt?: string | undefined;
+        /**
+         * If the delay between `\r` and `\n` exceeds `crlfDelay` milliseconds,
+         * both `\r` and `\n` will be treated as separate end-of-line input.
+         * `crlfDelay` will be coerced to a number no less than `100`.
+         * It can be set to `Infinity`, in which case
+         * `\r` followed by `\n` will always be considered a single newline
+         * (which may be reasonable for [reading files](https://nodejs.org/docs/latest-v18.x/api/readline.html#example-read-file-stream-line-by-line) with `\r\n` line delimiter).
+         * @default 100
+         */
+        crlfDelay?: number | undefined;
+        /**
+         * The duration `readline` will wait for a character
+         * (when reading an ambiguous key sequence in milliseconds
+         * one that can both form a complete key sequence using the input read so far
+         * and can take additional input to complete a longer key sequence).
+         * @default 500
+         */
         escapeCodeTimeout?: number | undefined;
+        /**
+         * The number of spaces a tab is equal to (minimum 1).
+         * @default 8
+         */
         tabSize?: number | undefined;
+        /**
+         * Allows closing the interface using an AbortSignal.
+         * Aborting the signal will internally call `close` on the interface.
+         */
+        signal?: AbortSignal | undefined;
     }
     /**
      * The `readline.createInterface()` method creates a new `readline.Interface`instance.

--- a/types/node/v18/readline/promises.d.ts
+++ b/types/node/v18/readline/promises.d.ts
@@ -5,8 +5,13 @@
  * @since v17.0.0
  */
 declare module "readline/promises" {
-    import { AsyncCompleter, Completer, Direction, Interface as _Interface, ReadLineOptions } from "node:readline";
     import { Abortable } from "node:events";
+    import {
+        CompleterResult,
+        Direction,
+        Interface as _Interface,
+        ReadLineOptions as _ReadLineOptions,
+    } from "node:readline";
 
     class Interface extends _Interface {
         /**
@@ -80,7 +85,13 @@ declare module "readline/promises" {
          */
         rollback(): this;
     }
-
+    type Completer = (line: string) => CompleterResult | Promise<CompleterResult>;
+    interface ReadLineOptions extends Omit<_ReadLineOptions, "completer"> {
+        /**
+         * An optional function used for Tab autocompletion.
+         */
+        completer?: Completer | undefined;
+    }
     /**
      * The `readlinePromises.createInterface()` method creates a new `readlinePromises.Interface` instance.
      *
@@ -133,7 +144,7 @@ declare module "readline/promises" {
     function createInterface(
         input: NodeJS.ReadableStream,
         output?: NodeJS.WritableStream,
-        completer?: Completer | AsyncCompleter,
+        completer?: Completer,
         terminal?: boolean,
     ): Interface;
     function createInterface(options: ReadLineOptions): Interface;

--- a/types/node/v18/test/readline.ts
+++ b/types/node/v18/test/readline.ts
@@ -1,4 +1,3 @@
-import * as fs from "node:fs";
 import * as readline from "node:readline";
 import * as readlinePromises from "node:readline/promises";
 import * as stream from "node:stream";
@@ -6,37 +5,43 @@ import * as stream from "node:stream";
 const rl: readline.ReadLine = readline.createInterface(new stream.Readable());
 
 {
-    const options: readline.ReadLineOptions = {
-        input: new fs.ReadStream(),
-    };
     const input: NodeJS.ReadableStream = new stream.Readable();
     const output: NodeJS.WritableStream = new stream.Writable();
-    const completer: readline.Completer = str => [["asd"], "asd"];
+    const syncCompleter: readline.Completer = function(str) {
+        // $ExpectType string
+        str;
+        return [["test"], "test"];
+    };
+    const asyncCompleter: readline.AsyncCompleter = function(str, callback) {
+        // $ExpectType string
+        str;
+        // $ExpectType (err?: Error | null | undefined, result?: CompleterResult | undefined) => void
+        callback;
+    };
     const terminal = false;
 
     let result: readline.ReadLine;
 
-    result = readline.createInterface(options);
     result = readline.createInterface(input);
     result = readline.createInterface(input, output);
-    result = readline.createInterface(input, output, completer);
-    result = readline.createInterface(input, output, completer, terminal);
-    result = readline.createInterface({
-        input,
-        completer(str: string): readline.CompleterResult {
-            return [["test"], "test"];
-        },
-    });
-    result = readline.createInterface({
-        input,
-        completer(str: string, callback: (err: any, result: readline.CompleterResult) => void): any {
-            callback(null, [["test"], "test"]);
-        },
-    });
-    result = readline.createInterface({
-        input,
-        tabSize: 4,
-    });
+    result = readline.createInterface(input, output, syncCompleter);
+    result = readline.createInterface(input, output, asyncCompleter);
+    result = readline.createInterface(input, output, syncCompleter, terminal);
+    result = readline.createInterface(input, output, asyncCompleter, terminal);
+
+    result = readline.createInterface({ input });
+    result = readline.createInterface({ input, output });
+    result = readline.createInterface({ input, completer: syncCompleter });
+    result = readline.createInterface({ input, completer: asyncCompleter });
+    result = readline.createInterface({ input, terminal });
+    result = readline.createInterface({ input, history: ["foo"] });
+    result = readline.createInterface({ input, historySize: 20 });
+    result = readline.createInterface({ input, removeHistoryDuplicates: true });
+    result = readline.createInterface({ input, prompt: "prompt >" });
+    result = readline.createInterface({ input, crlfDelay: 200 });
+    result = readline.createInterface({ input, escapeCodeTimeout: 200 });
+    result = readline.createInterface({ input, tabSize: 4 });
+    result = readline.createInterface({ input, signal: new AbortSignal() });
 }
 
 {
@@ -321,35 +326,39 @@ const readlineInstance = new readlinePromises.Readline(new stream.Writable());
 }
 
 {
-    const options: readline.ReadLineOptions = {
-        input: new fs.ReadStream(),
-    };
     const input: NodeJS.ReadableStream = new stream.Readable();
     const output: NodeJS.WritableStream = new stream.Writable();
-    const completer: readline.Completer = str => [["asd"], "asd"];
+    const syncCompleter: readlinePromises.Completer = function(str) {
+        // $ExpectType string
+        str;
+        return [["test"], "test"];
+    };
+    const asyncCompleter: readlinePromises.Completer = async function(str) {
+        // $ExpectType string
+        str;
+        return [["test"], "test"];
+    };
     const terminal = false;
 
     let result: readlinePromises.Interface;
 
-    result = readlinePromises.createInterface(options);
     result = readlinePromises.createInterface(input);
     result = readlinePromises.createInterface(input, output);
-    result = readlinePromises.createInterface(input, output, completer);
-    result = readlinePromises.createInterface(input, output, completer, terminal);
-    result = readlinePromises.createInterface({
-        input,
-        completer(str: string): readline.CompleterResult {
-            return [["test"], "test"];
-        },
-    });
-    result = readlinePromises.createInterface({
-        input,
-        completer(str: string, callback: (err: any, result: readline.CompleterResult) => void): any {
-            callback(null, [["test"], "test"]);
-        },
-    });
-    result = readlinePromises.createInterface({
-        input,
-        tabSize: 4,
-    });
+    result = readlinePromises.createInterface(input, output, syncCompleter);
+    result = readlinePromises.createInterface(input, output, asyncCompleter);
+    result = readlinePromises.createInterface(input, output, syncCompleter, terminal);
+    result = readlinePromises.createInterface(input, output, asyncCompleter, terminal);
+
+    result = readlinePromises.createInterface({ input, output });
+    result = readlinePromises.createInterface({ input, completer: syncCompleter });
+    result = readlinePromises.createInterface({ input, completer: asyncCompleter });
+    result = readlinePromises.createInterface({ input, terminal });
+    result = readlinePromises.createInterface({ input, history: ["foo"] });
+    result = readlinePromises.createInterface({ input, historySize: 20 });
+    result = readlinePromises.createInterface({ input, removeHistoryDuplicates: true });
+    result = readlinePromises.createInterface({ input, prompt: "prompt >" });
+    result = readlinePromises.createInterface({ input, crlfDelay: 200 });
+    result = readlinePromises.createInterface({ input, escapeCodeTimeout: 200 });
+    result = readlinePromises.createInterface({ input, tabSize: 4 });
+    result = readlinePromises.createInterface({ input, signal: new AbortSignal() });
 }

--- a/types/node/v20/readline.d.ts
+++ b/types/node/v20/readline.d.ts
@@ -1,6 +1,6 @@
 /**
- * The `node:readline` module provides an interface for reading data from a [Readable](https://nodejs.org/docs/latest-v20.x/api/stream.html#readable-streams) stream
- * (such as [`process.stdin`](https://nodejs.org/docs/latest-v20.x/api/process.html#processstdin)) one line at a time.
+ * The `node:readline` module provides an interface for reading data from a [Readable](https://nodejs.org/docs/https://nodejs.org/docs/latest-v20.x/api/stream.html#readable-streams) stream
+ * (such as [`process.stdin`](https://nodejs.org/docs/https://nodejs.org/docs/latest-v20.x/api/process.html#processstdin)) one line at a time.
  *
  * To use the promise-based APIs:
  *
@@ -46,7 +46,7 @@ declare module "readline" {
     }
     /**
      * Instances of the `readline.Interface` class are constructed using the `readline.createInterface()` method. Every instance is associated with a
-     * single `input` [Readable](https://nodejs.org/docs/latest-v20.x/api/stream.html#readable-streams) stream and a single `output` [Writable](https://nodejs.org/docs/latest-v20.x/api/stream.html#writable-streams) stream.
+     * single `input` [Readable](https://nodejs.org/docs/https://nodejs.org/docs/latest-v20.x/api/stream.html#readable-streams) stream and a single `output` [Writable](https://nodejs.org/docs/https://nodejs.org/docs/latest-v20.x/api/stream.html#writable-streams) stream.
      * The `output` stream is used to print prompts for user input that arrives on,
      * and is read from, the `input` stream.
      * @since v0.1.104
@@ -100,7 +100,7 @@ declare module "readline" {
          * > Instances of the `readline.Interface` class are constructed using the
          * > `readline.createInterface()` method.
          *
-         * @see https://nodejs.org/dist/latest-v20.x/docs/api/readline.html#class-interfaceconstructor
+         * @see https://nodejs.org/docs/latest-v20.x/api/readline.html#class-interfaceconstructor
          */
         protected constructor(
             input: NodeJS.ReadableStream,
@@ -114,7 +114,7 @@ declare module "readline" {
          * > Instances of the `readline.Interface` class are constructed using the
          * > `readline.createInterface()` method.
          *
-         * @see https://nodejs.org/dist/latest-v20.x/docs/api/readline.html#class-interfaceconstructor
+         * @see https://nodejs.org/docs/latest-v20.x/api/readline.html#class-interfaceconstructor
          */
         protected constructor(options: ReadLineOptions);
         /**
@@ -314,29 +314,78 @@ declare module "readline" {
     ) => void;
     export type CompleterResult = [string[], string];
     export interface ReadLineOptions {
+        /**
+         * The [`Readable`](https://nodejs.org/docs/latest-v20.x/api/stream.html#readable-streams) stream to listen to
+         */
         input: NodeJS.ReadableStream;
+        /**
+         * The [`Writable`](https://nodejs.org/docs/latest-v20.x/api/stream.html#writable-streams) stream to write readline data to.
+         */
         output?: NodeJS.WritableStream | undefined;
+        /**
+         * An optional function used for Tab autocompletion.
+         */
         completer?: Completer | AsyncCompleter | undefined;
+        /**
+         * `true` if the `input` and `output` streams should be treated like a TTY,
+         * and have ANSI/VT100 escape codes written to it.
+         * Default: checking `isTTY` on the `output` stream upon instantiation.
+         */
         terminal?: boolean | undefined;
         /**
-         *  Initial list of history lines. This option makes sense
-         * only if `terminal` is set to `true` by the user or by an internal `output`
-         * check, otherwise the history caching mechanism is not initialized at all.
+         * Initial list of history lines.
+         * This option makes sense only if `terminal` is set to `true` by the user or by an internal `output` check,
+         * otherwise the history caching mechanism is not initialized at all.
          * @default []
          */
         history?: string[] | undefined;
-        historySize?: number | undefined;
-        prompt?: string | undefined;
-        crlfDelay?: number | undefined;
         /**
-         * If `true`, when a new input line added
-         * to the history list duplicates an older one, this removes the older line
-         * from the list.
+         * Maximum number of history lines retained.
+         * To disable the history set this value to `0`.
+         * This option makes sense only if `terminal` is set to `true` by the user or by an internal `output` check,
+         * otherwise the history caching mechanism is not initialized at all.
+         * @default 30
+         */
+        historySize?: number | undefined;
+        /**
+         * If `true`, when a new input line added to the history list duplicates an older one,
+         * this removes the older line from the list.
          * @default false
          */
         removeHistoryDuplicates?: boolean | undefined;
+        /**
+         * The prompt string to use.
+         * @default "> "
+         */
+        prompt?: string | undefined;
+        /**
+         * If the delay between `\r` and `\n` exceeds `crlfDelay` milliseconds,
+         * both `\r` and `\n` will be treated as separate end-of-line input.
+         * `crlfDelay` will be coerced to a number no less than `100`.
+         * It can be set to `Infinity`, in which case
+         * `\r` followed by `\n` will always be considered a single newline
+         * (which may be reasonable for [reading files](https://nodejs.org/docs/latest-v20.x/api/readline.html#example-read-file-stream-line-by-line) with `\r\n` line delimiter).
+         * @default 100
+         */
+        crlfDelay?: number | undefined;
+        /**
+         * The duration `readline` will wait for a character
+         * (when reading an ambiguous key sequence in milliseconds
+         * one that can both form a complete key sequence using the input read so far
+         * and can take additional input to complete a longer key sequence).
+         * @default 500
+         */
         escapeCodeTimeout?: number | undefined;
+        /**
+         * The number of spaces a tab is equal to (minimum 1).
+         * @default 8
+         */
         tabSize?: number | undefined;
+        /**
+         * Allows closing the interface using an AbortSignal.
+         * Aborting the signal will internally call `close` on the interface.
+         */
+        signal?: AbortSignal | undefined;
     }
     /**
      * The `readline.createInterface()` method creates a new `readline.Interface` instance.
@@ -503,7 +552,7 @@ declare module "readline" {
         cols: number;
     }
     /**
-     * The `readline.clearLine()` method clears current line of given [TTY](https://nodejs.org/docs/latest-v20.x/api/tty.html) stream
+     * The `readline.clearLine()` method clears current line of given [TTY](https://nodejs.org/docs/https://nodejs.org/docs/latest-v20.x/api/tty.html) stream
      * in a specified direction identified by `dir`.
      * @since v0.7.7
      * @param callback Invoked once the operation completes.
@@ -511,7 +560,7 @@ declare module "readline" {
      */
     export function clearLine(stream: NodeJS.WritableStream, dir: Direction, callback?: () => void): boolean;
     /**
-     * The `readline.clearScreenDown()` method clears the given [TTY](https://nodejs.org/docs/latest-v20.x/api/tty.html) stream from
+     * The `readline.clearScreenDown()` method clears the given [TTY](https://nodejs.org/docs/https://nodejs.org/docs/latest-v20.x/api/tty.html) stream from
      * the current position of the cursor down.
      * @since v0.7.7
      * @param callback Invoked once the operation completes.
@@ -520,7 +569,7 @@ declare module "readline" {
     export function clearScreenDown(stream: NodeJS.WritableStream, callback?: () => void): boolean;
     /**
      * The `readline.cursorTo()` method moves cursor to the specified position in a
-     * given [TTY](https://nodejs.org/docs/latest-v20.x/api/tty.html) `stream`.
+     * given [TTY](https://nodejs.org/docs/https://nodejs.org/docs/latest-v20.x/api/tty.html) `stream`.
      * @since v0.7.7
      * @param callback Invoked once the operation completes.
      * @return `false` if `stream` wishes for the calling code to wait for the `'drain'` event to be emitted before continuing to write additional data; otherwise `true`.
@@ -528,7 +577,7 @@ declare module "readline" {
     export function cursorTo(stream: NodeJS.WritableStream, x: number, y?: number, callback?: () => void): boolean;
     /**
      * The `readline.moveCursor()` method moves the cursor _relative_ to its current
-     * position in a given [TTY](https://nodejs.org/docs/latest-v20.x/api/tty.html) `stream`.
+     * position in a given [TTY](https://nodejs.org/docs/https://nodejs.org/docs/latest-v20.x/api/tty.html) `stream`.
      * @since v0.7.7
      * @param callback Invoked once the operation completes.
      * @return `false` if `stream` wishes for the calling code to wait for the `'drain'` event to be emitted before continuing to write additional data; otherwise `true`.

--- a/types/node/v20/readline/promises.d.ts
+++ b/types/node/v20/readline/promises.d.ts
@@ -3,8 +3,13 @@
  * @experimental
  */
 declare module "readline/promises" {
-    import { AsyncCompleter, Completer, Direction, Interface as _Interface, ReadLineOptions } from "node:readline";
     import { Abortable } from "node:events";
+    import {
+        CompleterResult,
+        Direction,
+        Interface as _Interface,
+        ReadLineOptions as _ReadLineOptions,
+    } from "node:readline";
     /**
      * Instances of the `readlinePromises.Interface` class are constructed using the `readlinePromises.createInterface()` method. Every instance is associated with a
      * single `input` `Readable` stream and a single `output` `Writable` stream.
@@ -111,6 +116,13 @@ declare module "readline/promises" {
          */
         rollback(): this;
     }
+    type Completer = (line: string) => CompleterResult | Promise<CompleterResult>;
+    interface ReadLineOptions extends Omit<_ReadLineOptions, "completer"> {
+        /**
+         * An optional function used for Tab autocompletion.
+         */
+        completer?: Completer | undefined;
+    }
     /**
      * The `readlinePromises.createInterface()` method creates a new `readlinePromises.Interface` instance.
      *
@@ -140,7 +152,7 @@ declare module "readline/promises" {
     function createInterface(
         input: NodeJS.ReadableStream,
         output?: NodeJS.WritableStream,
-        completer?: Completer | AsyncCompleter,
+        completer?: Completer,
         terminal?: boolean,
     ): Interface;
     function createInterface(options: ReadLineOptions): Interface;

--- a/types/node/v20/test/readline.ts
+++ b/types/node/v20/test/readline.ts
@@ -1,4 +1,3 @@
-import * as fs from "node:fs";
 import * as readline from "node:readline";
 import * as readlinePromises from "node:readline/promises";
 import * as stream from "node:stream";
@@ -6,37 +5,43 @@ import * as stream from "node:stream";
 const rl: readline.ReadLine = readline.createInterface(new stream.Readable());
 
 {
-    const options: readline.ReadLineOptions = {
-        input: new fs.ReadStream(),
-    };
     const input: NodeJS.ReadableStream = new stream.Readable();
     const output: NodeJS.WritableStream = new stream.Writable();
-    const completer: readline.Completer = str => [["asd"], "asd"];
+    const syncCompleter: readline.Completer = function(str) {
+        // $ExpectType string
+        str;
+        return [["test"], "test"];
+    };
+    const asyncCompleter: readline.AsyncCompleter = function(str, callback) {
+        // $ExpectType string
+        str;
+        // $ExpectType (err?: Error | null | undefined, result?: CompleterResult | undefined) => void
+        callback;
+    };
     const terminal = false;
 
     let result: readline.ReadLine;
 
-    result = readline.createInterface(options);
     result = readline.createInterface(input);
     result = readline.createInterface(input, output);
-    result = readline.createInterface(input, output, completer);
-    result = readline.createInterface(input, output, completer, terminal);
-    result = readline.createInterface({
-        input,
-        completer(str: string): readline.CompleterResult {
-            return [["test"], "test"];
-        },
-    });
-    result = readline.createInterface({
-        input,
-        completer(str: string, callback: (err: any, result: readline.CompleterResult) => void): any {
-            callback(null, [["test"], "test"]);
-        },
-    });
-    result = readline.createInterface({
-        input,
-        tabSize: 4,
-    });
+    result = readline.createInterface(input, output, syncCompleter);
+    result = readline.createInterface(input, output, asyncCompleter);
+    result = readline.createInterface(input, output, syncCompleter, terminal);
+    result = readline.createInterface(input, output, asyncCompleter, terminal);
+
+    result = readline.createInterface({ input });
+    result = readline.createInterface({ input, output });
+    result = readline.createInterface({ input, completer: syncCompleter });
+    result = readline.createInterface({ input, completer: asyncCompleter });
+    result = readline.createInterface({ input, terminal });
+    result = readline.createInterface({ input, history: ["foo"] });
+    result = readline.createInterface({ input, historySize: 20 });
+    result = readline.createInterface({ input, removeHistoryDuplicates: true });
+    result = readline.createInterface({ input, prompt: "prompt >" });
+    result = readline.createInterface({ input, crlfDelay: 200 });
+    result = readline.createInterface({ input, escapeCodeTimeout: 200 });
+    result = readline.createInterface({ input, tabSize: 4 });
+    result = readline.createInterface({ input, signal: new AbortSignal() });
 }
 
 {
@@ -321,35 +326,39 @@ const readlineInstance = new readlinePromises.Readline(new stream.Writable());
 }
 
 {
-    const options: readline.ReadLineOptions = {
-        input: new fs.ReadStream(),
-    };
     const input: NodeJS.ReadableStream = new stream.Readable();
     const output: NodeJS.WritableStream = new stream.Writable();
-    const completer: readline.Completer = str => [["asd"], "asd"];
+    const syncCompleter: readlinePromises.Completer = function(str) {
+        // $ExpectType string
+        str;
+        return [["test"], "test"];
+    };
+    const asyncCompleter: readlinePromises.Completer = async function(str) {
+        // $ExpectType string
+        str;
+        return [["test"], "test"];
+    };
     const terminal = false;
 
     let result: readlinePromises.Interface;
 
-    result = readlinePromises.createInterface(options);
     result = readlinePromises.createInterface(input);
     result = readlinePromises.createInterface(input, output);
-    result = readlinePromises.createInterface(input, output, completer);
-    result = readlinePromises.createInterface(input, output, completer, terminal);
-    result = readlinePromises.createInterface({
-        input,
-        completer(str: string): readline.CompleterResult {
-            return [["test"], "test"];
-        },
-    });
-    result = readlinePromises.createInterface({
-        input,
-        completer(str: string, callback: (err: any, result: readline.CompleterResult) => void): any {
-            callback(null, [["test"], "test"]);
-        },
-    });
-    result = readlinePromises.createInterface({
-        input,
-        tabSize: 4,
-    });
+    result = readlinePromises.createInterface(input, output, syncCompleter);
+    result = readlinePromises.createInterface(input, output, asyncCompleter);
+    result = readlinePromises.createInterface(input, output, syncCompleter, terminal);
+    result = readlinePromises.createInterface(input, output, asyncCompleter, terminal);
+
+    result = readlinePromises.createInterface({ input, output });
+    result = readlinePromises.createInterface({ input, completer: syncCompleter });
+    result = readlinePromises.createInterface({ input, completer: asyncCompleter });
+    result = readlinePromises.createInterface({ input, terminal });
+    result = readlinePromises.createInterface({ input, history: ["foo"] });
+    result = readlinePromises.createInterface({ input, historySize: 20 });
+    result = readlinePromises.createInterface({ input, removeHistoryDuplicates: true });
+    result = readlinePromises.createInterface({ input, prompt: "prompt >" });
+    result = readlinePromises.createInterface({ input, crlfDelay: 200 });
+    result = readlinePromises.createInterface({ input, escapeCodeTimeout: 200 });
+    result = readlinePromises.createInterface({ input, tabSize: 4 });
+    result = readlinePromises.createInterface({ input, signal: new AbortSignal() });
 }


### PR DESCRIPTION
- Add `signal` to `ReadLineOptions` in `node:readline` and `node:readline/promises`
    - `signal` is added since v15.14.0, v14.18.0. See the history tab in [here](https://nodejs.org/docs/latest/api/readline.html#readlinecreateinterfaceoptions).
    - `signal` is missing in the promise version of the doc.
        - There is an ongoing [node PR 55456](https://github.com/nodejs/node/pull/55456) opened by me to add it back.
        - But source code implementation already allows `signal` to be used.
    - Resolves [DT discussion 70281](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/70281).
- Fix `completer` type for `ReadLineOptions` in `node:readline/promises`.
    - In the promise module, `completer` should be a "true" async function with `Promise` return, but not an error-first callback.
    - This can be seen in [doc](https://nodejs.org/docs/latest/api/readline.html#use-of-the-completer-function), and also in [source code test cases](https://github.com/nodejs/node/blob/78b72ca7ba69eb61dcb9307a6c49c5f34fc00f65/test/parallel/test-readline-promises-tab-complete.js#L31-L38).
- Modify DT tests to reflect all these changes.
- Add back (a lot of) jsdoc to `ReadLineOptions` based on [node doc](https://nodejs.org/docs/latest/api/readline.html#readlinecreateinterfaceoptions).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
