### PR TITLE
[serverless] Update the configurationVariablesSources resolver definition

### DIFF
--- a/types/serverless/classes/Plugin.d.ts
+++ b/types/serverless/classes/Plugin.d.ts
@@ -56,7 +56,7 @@ declare namespace Plugin {
             };
     }
 
-    type ConfigurationVariablesSource = (variableSource: any) => Promise<any>;
+    type ConfigurationVariablesSource = (variableSource: any) => any;
 
     interface ConfigurationVariablesSources {
         [variablePrefix: string]:

--- a/types/serverless/classes/Plugin.d.ts
+++ b/types/serverless/classes/Plugin.d.ts
@@ -56,7 +56,7 @@ declare namespace Plugin {
             };
     }
 
-    type ConfigurationVariablesSource = (variableSource: any) => any;
+    type ConfigurationVariablesSource = (variableSource: any) => Promise<any> | any;
 
     interface ConfigurationVariablesSources {
         [variablePrefix: string]:

--- a/types/serverless/classes/Plugin.d.ts
+++ b/types/serverless/classes/Plugin.d.ts
@@ -56,6 +56,7 @@ declare namespace Plugin {
             };
     }
 
+    // eslint-disable-next-line @definitelytyped/no-any-union
     type ConfigurationVariablesSource = (variableSource: any) => Promise<any> | any;
 
     interface ConfigurationVariablesSources {

--- a/types/serverless/serverless-tests.ts
+++ b/types/serverless/serverless-tests.ts
@@ -33,10 +33,20 @@ class CustomPlugin implements Plugin {
 
     hooks: Plugin.Hooks;
     variableResolvers: Plugin.VariableResolvers;
+    configurationVariablesSources: Plugin.ConfigurationVariablesSources;
 
     constructor(serverless: Serverless, options: Serverless.Options, logging: Plugin.Logging) {
         this.hooks = {
             "command:start": () => {},
+        };
+        // Both sync and async variable resolvers are supported
+        this.configurationVariablesSources = {
+            sync: {
+                resolve: () => {},
+            },
+            async: {
+                resolve: async () => {},
+            },
         };
         this.variableResolvers = {
             echo: async (source) => source.slice(5),


### PR DESCRIPTION
Serverless calls the resolver function with `await`:

https://github.com/serverless/serverless/blob/v3.39.0/lib/configuration/variables/resolve.js#L565

Since `await` works with both sync and async function, the resolver can be implemented using both methods.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
