### PR TITLE
fix(stream-meter): make default export new-able, bump version, jsdoc

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -1629,7 +1629,6 @@
         "srtparsejs",
         "stampit",
         "stamplay-js-sdk",
-        "stream-meter",
         "stream-series",
         "stream-to-array/v0",
         "stripe-v2",

--- a/types/stream-meter/.eslintrc.json
+++ b/types/stream-meter/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-    "rules": {
-        "@definitelytyped/strict-export-declare-modifiers": "off"
-    }
-}

--- a/types/stream-meter/index.d.ts
+++ b/types/stream-meter/index.d.ts
@@ -2,14 +2,45 @@
 
 import { Transform } from "stream";
 
-declare function m(maxBytes?: number): m.StreamMeter;
-
 declare namespace m {
-    export class StreamMeter extends Transform {
-        constructor(maxBytes?: number);
+    interface StreamMeterConstruct {
+        (
+            /**
+             * Size (in bytes) to trigger the stream to abort.
+             * It will complete whatever frame it aborted in, so the size streamed
+             * will still be >= size but no more than size + highWaterMark
+             * @default Number.MAX_VALUE
+             */
+            maxBytes?: number,
+        ): StreamMeter;
+
+        new(
+            /**
+             * Size (in bytes) to trigger the stream to abort.
+             * It will complete whatever frame it aborted in, so the size streamed
+             * will still be >= size but no more than size + highWaterMark
+             * @default Number.MAX_VALUE
+             */
+            maxBytes?: number,
+        ): StreamMeter;
+    }
+
+    interface StreamMeter extends Transform {
+        /**
+         * Number of bytes handled and passed through the meter.
+         */
         bytes: number;
+
+        /**
+         * Size (in bytes) to trigger the stream to abort.
+         * It will complete whatever frame it aborted in, so the size streamed
+         * will still be >= size but no more than size + highWaterMark
+         * @default Number.MAX_VALUE
+         */
         maxBytes: number;
     }
 }
+
+declare const m: m.StreamMeterConstruct;
 
 export = m;

--- a/types/stream-meter/package.json
+++ b/types/stream-meter/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/stream-meter",
-    "version": "0.0.9999",
+    "version": "1.0.9999",
     "projects": [
         "https://github.com/brycebaril/node-stream-meter"
     ],

--- a/types/stream-meter/stream-meter-tests.ts
+++ b/types/stream-meter/stream-meter-tests.ts
@@ -1,9 +1,14 @@
-import meter = require("stream-meter");
+import process from "node:process";
+import meter, { StreamMeter, StreamMeterConstruct } from "stream-meter";
 
-var m: meter.StreamMeter = meter();
+// $ExpectType StreamMeterConstruct
+meter;
+
+// $ExpectType StreamMeter
+let m = meter();
 process.stdin.pipe(m).pipe(process.stdout);
 
-var bytes: number;
+let bytes: number;
 bytes = m.bytes;
 bytes = m.maxBytes;
 m.on("error", () => {});
@@ -11,8 +16,7 @@ m.on("error", () => {});
 // with argument
 m = meter(129);
 
-// stream-meter support following constructing
-// but i cannot declare such object in typescript
-
-// m = new meter();
-// m = new meter(123);
+// $ExpectType StreamMeter
+m = new meter();
+// $ExpectType StreamMeter
+m = new meter(123);


### PR DESCRIPTION
- Make default export new-able
    - From the [implementation](https://github.com/brycebaril/node-stream-meter/blob/master/index.js), the default export can be used as a factory or a constructor.
    - Current typedef only allows default export to be used as a factory, which is incorrect.
- Change the named-export `StreamMeter` from `class` to `interface`.
    - Original implementation never exposes the class directly, hence exporting it as such in typedef will misled consumer into believing that `StreamMeter` is new-able.
- Bump version to fix attw error.
- Modify test accordingly.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
