### PR TITLE
[node] remove asymmetricKeySize from crypto.KeyObject

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -610,11 +610,6 @@ declare module "crypto" {
          */
         asymmetricKeyType?: KeyType | undefined;
         /**
-         * For asymmetric keys, this property represents the size of the embedded key in
-         * bytes. This property is `undefined` for symmetric keys.
-         */
-        asymmetricKeySize?: number | undefined;
-        /**
          * This property exists only on asymmetric keys. Depending on the type of the key,
          * this object contains information about the key. None of the information obtained
          * through this property can be used to uniquely identify a key or to compromise

--- a/types/node/v16/crypto.d.ts
+++ b/types/node/v16/crypto.d.ts
@@ -584,11 +584,6 @@ declare module "crypto" {
          */
         asymmetricKeyType?: KeyType | undefined;
         /**
-         * For asymmetric keys, this property represents the size of the embedded key in
-         * bytes. This property is `undefined` for symmetric keys.
-         */
-        asymmetricKeySize?: number | undefined;
-        /**
          * This property exists only on asymmetric keys. Depending on the type of the key,
          * this object contains information about the key. None of the information obtained
          * through this property can be used to uniquely identify a key or to compromise

--- a/types/node/v18/crypto.d.ts
+++ b/types/node/v18/crypto.d.ts
@@ -611,11 +611,6 @@ declare module "crypto" {
          */
         asymmetricKeyType?: KeyType | undefined;
         /**
-         * For asymmetric keys, this property represents the size of the embedded key in
-         * bytes. This property is `undefined` for symmetric keys.
-         */
-        asymmetricKeySize?: number | undefined;
-        /**
          * This property exists only on asymmetric keys. Depending on the type of the key,
          * this object contains information about the key. None of the information obtained
          * through this property can be used to uniquely identify a key or to compromise

--- a/types/node/v20/crypto.d.ts
+++ b/types/node/v20/crypto.d.ts
@@ -610,11 +610,6 @@ declare module "crypto" {
          */
         asymmetricKeyType?: KeyType | undefined;
         /**
-         * For asymmetric keys, this property represents the size of the embedded key in
-         * bytes. This property is `undefined` for symmetric keys.
-         */
-        asymmetricKeySize?: number | undefined;
-        /**
          * This property exists only on asymmetric keys. Depending on the type of the key,
          * this object contains information about the key. None of the information obtained
          * through this property can be used to uniquely identify a key or to compromise


### PR DESCRIPTION
There is not, and never was, an `asymmetricKeySize` property on a `crypto.KeyObject`. This PR removes that from the types.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/crypto.html#class-keyobject
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.