### PR TITLE
[Chrome] Add chrome.storage.getKeys() API

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -8887,7 +8887,7 @@ declare namespace chrome.storage {
          * Parameter keys: Array of keys in storage.
          * @since Chrome 130
          */
-        getKeys(callback: (keys:string[]) => void): void;
+        getKeys(callback: (keys: string[]) => void): void;
     }
 
     export interface StorageChange {

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -8875,6 +8875,19 @@ declare namespace chrome.storage {
          * Parameter items: Object with items in their key-value mappings.
          */
         onChanged: StorageAreaChangedEvent;
+        /**
+         * Gets all keys from storage.
+         * @return A Promise that resolves with an array of keys.
+         * @since Chrome 130
+         */
+        getKeys(): Promise<string[]>;
+        /**
+         * Gets all keys from storage.
+         * @param callback Callback with storage keys.
+         * Parameter keys: Array of keys in storage.
+         * @since Chrome 130
+         */
+        getKeys(callback: (keys:string[]) => void): void;
     }
 
     export interface StorageChange {

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -848,6 +848,12 @@ function testStorage() {
         var myNewValue: { x: number } = changes["myKey"].newValue;
         var myOldValue: { x: number } = changes["myKey"].oldValue;
     });
+
+    function getKeysCallback(keys: string[]) {
+        console.log(keys);
+    }
+    chrome.storage.sync.getKeys();
+    chrome.storage.sync.getKeys(getKeysCallback);
 }
 
 // https://developer.chrome.com/apps/tts#type-TtsVoice

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -852,6 +852,7 @@ function testStorage() {
     function getKeysCallback(keys: string[]) {
         console.log(keys);
     }
+
     chrome.storage.sync.getKeys();
     chrome.storage.sync.getKeys(getKeysCallback);
 }

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -849,12 +849,12 @@ function testStorage() {
         var myOldValue: { x: number } = changes["myKey"].oldValue;
     });
 
-    function getKeysCallback(keys: string[]) {
-        console.log(keys);
-    }
-
-    chrome.storage.sync.getKeys();
-    chrome.storage.sync.getKeys(getKeysCallback);
+    chrome.storage.sync.getKeys(); // $ExpectType Promise<string[]>
+    chrome.storage.sync.getKeys((keys) => { // $ExpectType void
+      keys;  // $ExpectType string[]
+    });
+    // @ts-expect-error
+    chrome.storage.sync.getKeys(() => {}).then(() => {});
 }
 
 // https://developer.chrome.com/apps/tts#type-TtsVoice

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -851,7 +851,7 @@ function testStorage() {
 
     chrome.storage.sync.getKeys(); // $ExpectType Promise<string[]>
     chrome.storage.sync.getKeys((keys) => { // $ExpectType void
-      keys;  // $ExpectType string[]
+        keys;  // $ExpectType string[]
     });
     // @ts-expect-error
     chrome.storage.sync.getKeys(() => {}).then(() => {});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Chrome Developers reference](https://developer.chrome.com/docs/extensions/reference/api/storage#method-StorageArea-getKeys)
