### PR TITLE
[compress-commons] Correct issues with initial PR

### DIFF
--- a/types/compress-commons/archivers/archive-output-stream.d.ts
+++ b/types/compress-commons/archivers/archive-output-stream.d.ts
@@ -1,5 +1,7 @@
 import { Stream, Transform } from "readable-stream";
 
+import { Stream as NodeStream } from "node:stream";
+
 import ArchiveEntry from "./archive-entry.js";
 import ZipArchiveEntry from "./zip/zip-archive-entry.js";
 
@@ -7,13 +9,25 @@ import ZipArchiveEntry from "./zip/zip-archive-entry.js";
 export default class ArchiveOutputStream extends Transform {
     _archive: { finish: boolean; finished: boolean; processing: boolean };
 
-    _appendBuffer(zae: ZipArchiveEntry, source?: string | Stream | null, callback?: (error: Error) => void): void;
-    _appendStream(zae: ZipArchiveEntry, source?: string | Stream | null, callback?: (error: Error) => void): void;
+    _appendBuffer(
+        ae: ArchiveEntry,
+        source?: string | Stream | null,
+        callback?: (error: Error | null, ae?: ArchiveEntry) => void,
+    ): void;
+    _appendStream(
+        ae: ArchiveEntry,
+        source?: string | Stream | null,
+        callback?: (error: Error | null, ae?: ArchiveEntry) => void,
+    ): void;
     _emitErrorCallback(err: Error): void;
     _finish(ae: ArchiveEntry): void;
     _normalizeEntry(ae: ArchiveEntry): void;
 
-    entry(ae: ArchiveEntry, source?: string | Stream | null, callback?: (error: Error) => void): this;
+    entry(
+        ae: ArchiveEntry,
+        source?: Buffer | Stream | NodeStream | string | null,
+        callback?: (error: Error | null, ae?: ArchiveEntry) => void,
+    ): this;
     finish(): void;
     getBytesWritten(): number;
 }

--- a/types/compress-commons/archivers/zip/zip-archive-output-stream.d.ts
+++ b/types/compress-commons/archivers/zip/zip-archive-output-stream.d.ts
@@ -1,26 +1,46 @@
 import { CRC32Stream, DeflateCRC32Stream } from "crc32-stream";
-import { TransformOptions } from "readable-stream";
+import { Stream, TransformOptions } from "readable-stream";
+
+import { Stream as NodeStream } from "node:stream";
 
 // eslint-disable-next-line @definitelytyped/no-bad-reference
-import ArchiveEntry from "../archive-entry.js";
-// eslint-disable-next-line @definitelytyped/no-bad-reference
 import ArchiveOutputStream from "../archive-output-stream.js";
+import ZipArchiveEntry from "./zip-archive-entry.js";
 
 export default class ZipArchiveOutputStream extends ArchiveOutputStream {
     _options: TransformOptions;
 
-    _afterAppend(ae: ArchiveEntry): void;
+    _appendBuffer(
+        ae: ZipArchiveEntry,
+        source?: string | Stream | null,
+        callback?: (error: Error | null, ae?: ZipArchiveEntry) => void,
+    ): void;
+    _appendStream(
+        ae: ZipArchiveEntry,
+        source?: string | Stream | null,
+        callback?: (error: Error | null, ae?: ZipArchiveEntry) => void,
+    ): void;
+    _finish(): void;
+    _normalizeEntry(ae: ZipArchiveEntry): void;
+
+    entry(
+        ae: ZipArchiveEntry,
+        source?: Buffer | Stream | NodeStream | string | null,
+        callback?: (error: Error | null, ae?: ZipArchiveEntry) => void,
+    ): this;
+
+    _afterAppend(ae: ZipArchiveEntry): void;
 
     _smartStream(
-        ae: ArchiveEntry,
-        callback: (error: Error, ae: ArchiveEntry) => void,
+        ae: ZipArchiveEntry,
+        callback: (error: Error | null, ae?: ZipArchiveEntry) => void,
     ): CRC32Stream | DeflateCRC32Stream;
 
     _writeCentralDirectoryEnd(): void;
     _writeCentralDirectoryZip64(): void;
-    _writeCentralFileHeader(ae: ArchiveEntry): void;
-    _writeDataDescriptor(ae: ArchiveEntry): void;
-    _writeLocalFileHeader(ae: ArchiveEntry): void;
+    _writeCentralFileHeader(ae: ZipArchiveEntry): void;
+    _writeDataDescriptor(ae: ZipArchiveEntry): void;
+    _writeLocalFileHeader(ae: ZipArchiveEntry): void;
 
     setComment(comment: string): void;
     getComment(): string;

--- a/types/compress-commons/compress-commons-tests.ts
+++ b/types/compress-commons/compress-commons-tests.ts
@@ -15,7 +15,10 @@ aos.entry(ae);
 aos.entry(ae, null);
 aos.entry(ae, "test");
 aos.entry(ae, new Stream());
-aos.entry(ae, "test", err => err);
+aos.entry(ae, "test", (err, ae) => {
+    if (err) throw err;
+    ae!; // $ExpectType ArchiveEntry
+});
 
 aos._emitErrorCallback(new Error());
 aos._finish(ae);
@@ -28,23 +31,43 @@ aos._appendBuffer(zae);
 aos._appendBuffer(zae, null);
 aos._appendBuffer(zae, "test");
 aos._appendBuffer(zae, new Stream());
-aos._appendBuffer(zae, "test", err => err);
+aos._appendBuffer(zae, "test", (err, ae) => {
+    if (err) throw err;
+    ae!; // $ExpectType ArchiveEntry
+});
 
 aos._appendStream(zae);
 aos._appendStream(zae, null);
 aos._appendStream(zae, "test");
 aos._appendStream(zae, new Stream());
-aos._appendStream(zae, "test", err => err);
+aos._appendStream(zae, "test", (err, ae) => {
+    if (err) throw err;
+    ae!; // $ExpectType ArchiveEntry
+});
 
 const zaos = new ZipArchiveOutputStream();
 
-zaos._afterAppend(ae);
-zaos._smartStream(ae, err => err);
+// @ts-expect-error Must be a ZipArchiveEntry
+zaos._appendBuffer(ae);
+// @ts-expect-error Must be a ZipArchiveEntry
+zaos._appendStream(ae);
+// @ts-expect-error Must be a ZipArchiveEntry
+zaos._normalizeEntry(ae);
+// @ts-expect-error No arguments
+zaos._finish(ae);
+// @ts-expect-error No arguments
+zaos._finish(zae);
+
+zaos._afterAppend(zae);
+zaos._smartStream(zae, (err, ae) => {
+    if (err) throw err;
+    ae!; // $ExpectType ZipArchiveEntry
+});
 zaos._writeCentralDirectoryEnd();
 zaos._writeCentralDirectoryZip64();
-zaos._writeCentralFileHeader(ae);
-zaos._writeDataDescriptor(ae);
-zaos._writeLocalFileHeader(ae);
+zaos._writeCentralFileHeader(zae);
+zaos._writeDataDescriptor(zae);
+zaos._writeLocalFileHeader(zae);
 zaos.setComment("foobar");
 zaos.getComment();
 zaos.isZip64();


### PR DESCRIPTION
This PR fixes some issues in my initial PR for compress-commons.
Some internal names for parameters were misleading and the proper types needed to be found with context.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
      <https://github.com/archiverjs/node-compress-commons/blob/master/lib/archivers/archive-output-stream.js>
      <https://github.com/archiverjs/node-compress-commons/blob/master/lib/archivers/zip/zip-archive-output-stream.js>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.