### PR TITLE
[chrome] Add hasCrossSiteAncestor to CookiePartitionKey

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2006,6 +2006,11 @@ declare namespace chrome.cookies {
 
     /** Represents a partitioned cookie's partition key. */
     export interface CookiePartitionKey {
+        /**
+         * Indicates if the cookie was set in a cross-cross site context. This prevents a top-level site embedded in a cross-site context from accessing cookies set by the top-level site in a same-site context.
+         * @since Chrome 130
+         */
+        hasCrossSiteAncestor?: boolean | undefined;
         /** The top-level site the partitioned cookie is available in. */
         topLevelSite?: string | undefined;
     }

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1419,7 +1419,14 @@ async function testCookieForPromise() {
     await chrome.cookies.set({ url: "url1" });
     await chrome.cookies.set({ name: "test-cookie", url: "https://example.com", partitionKey: {} });
     await chrome.cookies.remove({ url: "url1", name: "name1" });
-    await chrome.cookies.remove({ name: "test-cookie", url: "https://example.com", partitionKey: {} });
+    await chrome.cookies.remove({
+        name: "test-cookie",
+        url: "https://example.com",
+        partitionKey: {
+            topLevelSite: "https://example.com",
+            hasCrossSiteAncestor: false,
+        },
+    });
     await chrome.cookies.get({ url: "url1", name: "name1" });
     await chrome.cookies.get({ url: "url1", name: "name1", partitionKey: {} });
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/cookies#type-CookiePartitionKey
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

This was previously descoped from the [original PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70502#discussion_r1779755396), since the property was marked as "pending.

Now, it has landed in Chrome 130 and is a part of the stable API.