### PR TITLE
[tsscmp] fix timeSafeCompare() argument types

### DIFF
--- a/types/tsscmp/index.d.ts
+++ b/types/tsscmp/index.d.ts
@@ -1,4 +1,3 @@
 export = timeSafeCompare;
 
-declare function timeSafeCompare(a: number, b: number): boolean;
-declare function timeSafeCompare(a: string, b: string): boolean;
+declare function timeSafeCompare(a: any, b: any): boolean;

--- a/types/tsscmp/tsscmp-tests.ts
+++ b/types/tsscmp/tsscmp-tests.ts
@@ -9,33 +9,30 @@ timeSafeCompare(1);
 
 timeSafeCompare("", ""); // $ExpectType boolean
 timeSafeCompare(1, 1); // $ExpectType boolean
+timeSafeCompare(undefined, undefined); // $ExpectType boolean
+timeSafeCompare(true, true); // $ExpectType boolean
+timeSafeCompare(false, false); // $ExpectType boolean
+var a = { a: 1 };
+timeSafeCompare(a, a); // $ExpectType boolean
+function f1() {
+    return 1;
+}
+timeSafeCompare(f1, f1); // $ExpectType boolean
 
-// @ts-expect-error
-timeSafeCompare("", 1);
-// @ts-expect-error
-timeSafeCompare(1, "");
+timeSafeCompare("", 1); // $ExpectType boolean
+timeSafeCompare(1, ""); // $ExpectType boolean
 
-// @ts-expect-error
-timeSafeCompare({}, {});
-// @ts-expect-error
-timeSafeCompare([], []);
+timeSafeCompare({}, {}); // $ExpectType boolean
+timeSafeCompare([], []); // $ExpectType boolean
 
-// @ts-expect-error
-timeSafeCompare({}, "");
-// @ts-expect-error
-timeSafeCompare([], "");
+timeSafeCompare({}, ""); // $ExpectType boolean
+timeSafeCompare([], ""); // $ExpectType boolean
 
-// @ts-expect-error
-timeSafeCompare([], 1);
-// @ts-expect-error
-timeSafeCompare({}, 1);
+timeSafeCompare([], 1); // $ExpectType boolean
+timeSafeCompare({}, 1); // $ExpectType boolean
 
-// @ts-expect-error
-timeSafeCompare("", {});
-// @ts-expect-error
-timeSafeCompare("", []);
+timeSafeCompare("", {}); // $ExpectType boolean
+timeSafeCompare("", []); // $ExpectType boolean
 
-// @ts-expect-error
-timeSafeCompare(1, []);
-// @ts-expect-error
-timeSafeCompare(1, {});
+timeSafeCompare(1, []); // $ExpectType boolean
+timeSafeCompare(1, {}); // $ExpectType boolean


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [timeSafeCompare() uses String() which takes argument of any](https://github.com/suryagh/tsscmp/blob/master/lib/index.js#L29-L30)
