### PR TITLE
@types/qunit use same interface for skip, only, todo as for test.skip…

### DIFF
--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -582,12 +582,12 @@ declare global {
         }
 
         interface TodoFunction {
-            (name: string, callback: TestFunctionCallback): void;
+            (name: string, callback?: TestFunctionCallback): void;
             each: EachFunction;
         }
 
         interface SkipFunction {
-            (name: string, callback: TestFunctionCallback): void;
+            (name: string, callback?: TestFunctionCallback): void;
             each: EachFunction;
         }
 
@@ -768,7 +768,7 @@ declare global {
          * @param {string} name Title of unit being tested
          * @param callback Function to close over assertions
          */
-        only(name: string, callback: (assert: Assert) => void | Promise<void>): void;
+        only: QUnit.OnlyFunction;
 
         /**
          * Handle a global error that should result in a failed test run.
@@ -807,7 +807,7 @@ declare global {
          *
          * @param {string} Title of unit being tested
          */
-        skip(name: string, callback?: (assert: Assert) => void | Promise<void>): void;
+        skip: QUnit.SkipFunction;
 
         /**
          * Returns a single line string representing the stacktrace (call stack).
@@ -891,7 +891,7 @@ declare global {
          * @param {string} Title of unit being tested
          * @param callback Function to close over assertions
          */
-        todo(name: string, callback?: (assert: Assert) => void | Promise<void>): void;
+        todo: QUnit.TodoFunction;
 
         /**
          * Compares two values. Returns true if they are equivalent.


### PR DESCRIPTION
…, test.only, test.todo

Please fill in this template.

- [+] Use a meaningful title for the pull request. Include the name of the package modified.
- [+] Test the change in your own code. (Compile and run.)
- [+] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [+] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [+] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [+] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [+] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [+] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Since the [previous PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70946) actually broke overrides inside of `ember-qunit` the next steps are to fix the overrides over there.

First step is merging this PR

Second step in `ember-qunit/types/index.d.ts` we can just do

```typescript
 namespace QUnit {
    interface TestFunction {
      <TC extends TestContext>(
        name: string,
        callback: (this: TC, assert: Assert) => void | Promise<unknown>
      ): void;
    }

    interface SkipFunction {
      <TC extends TestContext>(
        name: string,
        callback?: (this: TC, assert: Assert) => void | Promise<unknown>
      ): void;
    }

    interface TodoFunction {
      <TC extends TestContext>(
        name: string,
        callback: (this: TC, assert: Assert) => void | Promise<unknown>
      ): void;
    }

    interface OnlyFunction {
      <TC extends TestContext>(
        name: string,
        callback: (this: TC, assert: Assert) => void | Promise<unknown>
      ): void;
    }
```

Which will extend the overloads properly again