### PR TITLE
[lodash] fix _.map to choose array overload signature given an array instead of tuple signature

### DIFF
--- a/types/lodash/common/collection.d.ts
+++ b/types/lodash/common/collection.d.ts
@@ -1153,7 +1153,7 @@ declare module "../index" {
          * @param iteratee The function invoked per iteration.
          * @return Returns the new mapped array.
          */
-        map<T extends readonly unknown[], TResult>(collection: IsTuple<T>, iteratee: TupleIterator<T, TResult>): { [K in keyof T]: TResult };
+        map<T extends readonly [unknown, ...unknown[]], TResult>(collection: T, iteratee: TupleIterator<T, TResult>): { [K in keyof T]: TResult };
         /**
          * @see _.map
          */

--- a/types/lodash/common/collection.d.ts
+++ b/types/lodash/common/collection.d.ts
@@ -1153,7 +1153,7 @@ declare module "../index" {
          * @param iteratee The function invoked per iteration.
          * @return Returns the new mapped array.
          */
-        map<T extends readonly unknown[], TResult>(collection: T, iteratee: TupleIterator<T, TResult>): { [K in keyof T]: TResult };
+        map<T extends readonly unknown[], TResult>(collection: IsTuple<T>, iteratee: TupleIterator<T, TResult>): { [K in keyof T]: TResult };
         /**
          * @see _.map
          */

--- a/types/lodash/common/common.d.ts
+++ b/types/lodash/common/common.d.ts
@@ -210,6 +210,7 @@ declare module "../index" {
     }
     interface PrimitiveChain<T> extends LoDashExplicitWrapper<T> {
     }
+    type IsTuple<T> = T extends readonly [unknown, ...unknown[]] ? T : never;
     type NotVoid = unknown;
     type IterateeShorthand<T> = PropertyName | [PropertyName, any] | PartialShallow<T>;
     type ArrayIterator<T, TResult> = (value: T, index: number, collection: T[]) => TResult;

--- a/types/lodash/common/common.d.ts
+++ b/types/lodash/common/common.d.ts
@@ -210,7 +210,6 @@ declare module "../index" {
     }
     interface PrimitiveChain<T> extends LoDashExplicitWrapper<T> {
     }
-    type IsTuple<T> = T extends readonly [unknown, ...unknown[]] ? T : never;
     type NotVoid = unknown;
     type IterateeShorthand<T> = PropertyName | [PropertyName, any] | PartialShallow<T>;
     type ArrayIterator<T, TResult> = (value: T, index: number, collection: T[]) => TResult;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -2752,6 +2752,13 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType CollectionChain<number>
 
 // _.map
 {
+    _.map([] as AbcObject[]); // $ExpectType AbcObject[]
+    _.map([] as AbcObject[], (value, index, collection) => {
+        value; // $ExpectType AbcObject
+        index; // $ExpectType number
+        collection; // $ExpectType AbcObject[]
+        return 0;
+    });
     _.map(list);  // $ExpectType AbcObject[]
     // $ExpectType number[]
     _.map(list, (value, index, collection) => {

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -5064,7 +5064,7 @@ fp.now(); // $ExpectType number
     fp.random(1, 2); // $ExpectType number
     fp.random(1)(2); // $ExpectType number
 
-    _.map([5, 5], _.random); // $ExpectType number[]
+    _.map([5, 5], _.random); // $ExpectType [number, number]
 }
 
 /**********
@@ -6831,7 +6831,7 @@ fp.now(); // $ExpectType number
     fp.split("-")(null); // $ExpectType string[]
     fp.split("-")("a-b-c"); // $ExpectType string[]
 
-    _.map(["abc", "def"], _.split); // $ExpectType string[][]
+    _.map(["abc", "def"], _.split); // $ExpectType [string[], string[]]
 }
 
 // _.startCase
@@ -6910,7 +6910,7 @@ fp.now(); // $ExpectType number
     fp.trimChars(" ", "  abc  "); // $ExpectType string
     fp.trimChars(" ")("  abc  "); // $ExpectType string
 
-    _.map(["  foo  ", "  bar  "], _.trim); // $ExpectType string[]
+    _.map(["  foo  ", "  bar  "], _.trim); // $ExpectType [string, string]
 }
 
 // _.trimEnd
@@ -6998,7 +6998,7 @@ fp.now(); // $ExpectType number
     _.chain("fred, barney, & pebbles").words(/[^, ]+/g); // $ExpectType CollectionChain<string>
     fp.words("fred, barney, & pebbles"); // $ExpectType string[]
 
-    _.map(["fred, barney", "pebbles"], _.words); // $ExpectType string[][]
+    _.map(["fred, barney", "pebbles"], _.words); // $ExpectType [string[], string[]]
 }
 
 /********
@@ -7364,8 +7364,8 @@ fp.now(); // $ExpectType number
     fp.rangeRight(1, 11); // $ExpectType number[]
     fp.rangeRight(1)(11); // $ExpectType number[]
 
-    _.map([5, 5], _.range); // $ExpectType number[][]
-    _.map([5, 5], _.rangeRight); // $ExpectType number[][]
+    _.map([5, 5], _.range); // $ExpectType [number[], number[]]
+    _.map([5, 5], _.rangeRight); // $ExpectType [number[], number[]]
 }
 
 // _.runInContext


### PR DESCRIPTION
Since #70840, _.map's overload signature couldn't differentiate between array and tuple. So `_.map(array)` was matched to tuple signature, resulting in the iteratee being `TupleIterator` instead of `ArrayIterator` .

![image](https://github.com/user-attachments/assets/b30d8ae2-6532-4e3d-9a3d-d70dce5e10e3)

This PR fixes the problem. Now it works as intended.

![image](https://github.com/user-attachments/assets/574a864d-2530-4d84-8bf4-3efc209afb15)


See: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70840#issuecomment-2431359820



Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://lodash.com/docs/4.17.15#map>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
