### PR TITLE
fix(run-sequence): Bump version, refine types, add back jsdoc

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -1565,7 +1565,6 @@
         "route-parser",
         "routie",
         "royalslider",
-        "run-sequence",
         "rx-jquery",
         "rx-node",
         "s3-uploader",

--- a/types/run-sequence/.eslintrc.json
+++ b/types/run-sequence/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-    "rules": {
-        "@typescript-eslint/naming-convention": "off"
-    }
-}

--- a/types/run-sequence/index.d.ts
+++ b/types/run-sequence/index.d.ts
@@ -1,12 +1,61 @@
 /// <reference types="node" />
 
 import gulp = require("gulp");
+import undertaker = require("undertaker");
 
-interface IRunSequence {
-    (...streams: Array<string | string[] | gulp.TaskCallback>): NodeJS.ReadWriteStream;
+declare namespace r {
+    type Task = string | string[] | null | undefined;
 
-    use(gulp: gulp.Gulp): IRunSequence;
+    interface RunSequence {
+        /**
+         * Runs a sequence of gulp tasks in the specified order.
+         * This function is designed to solve the situation where
+         * you have defined run-order, but choose not to or cannot use dependencies.
+         *
+         * Each argument to run-sequence is run in order.
+         * This works by listening to the `task_stop` and `task_err` events,
+         * and keeping track of which tasks have been completed.
+         * You can still run some of the tasks in parallel,
+         * by providing an array of task names for one or more of the arguments.
+         *
+         * If the final argument is a function, it will be used as a callback
+         * after all the functions are either finished or an error has occurred.
+         */
+        (...tasks: [...r.Task[], undertaker.TaskCallback]): NodeJS.ReadWriteStream;
+        (...tasks: r.Task[]): NodeJS.ReadWriteStream;
+
+        /**
+         * If you have a complex gulp setup with your tasks split up across different files,
+         * you may get the error that run-sequence is unable to find your tasks.
+         * In this case, you can configure run-sequence to look at the gulp within the submodule.
+         */
+        use(gulp: gulp.Gulp): RunSequence;
+
+        /**
+         * There are a few global options you can configure on the `runSequence` function.
+         *
+         * Please note these are **global to the module**,
+         * and once set will affect every use of `runSequence`.
+         */
+        options: {
+            /**
+             * When set to `false`, this suppresses the full stack trace from errors captured
+             * during a sequence.
+             *
+             * @default true
+             */
+            showErrorStackTrace: boolean;
+
+            /**
+             * When set to `true`, this enables you to pass falsey values
+             * in which will be stripped from the task set before validation and sequencing.
+             *
+             * @default false
+             */
+            ignoreUndefinedTasks: boolean;
+        };
+    }
 }
 
-declare var _tmp: IRunSequence;
-export = _tmp;
+declare const r: r.RunSequence;
+export = r;

--- a/types/run-sequence/package.json
+++ b/types/run-sequence/package.json
@@ -1,13 +1,14 @@
 {
     "private": true,
     "name": "@types/run-sequence",
-    "version": "0.0.9999",
+    "version": "2.2.9999",
     "projects": [
         "https://github.com/OverZealous/run-sequence"
     ],
     "dependencies": {
-        "@types/gulp": "*",
-        "@types/node": "*"
+        "@types/gulp": ">=3.8",
+        "@types/node": "*",
+        "@types/undertaker": ">=1.2.6"
     },
     "devDependencies": {
         "@types/run-sequence": "workspace:."

--- a/types/run-sequence/run-sequence-tests.ts
+++ b/types/run-sequence/run-sequence-tests.ts
@@ -1,27 +1,23 @@
-import gulp = require("gulp");
-import tmp = require("run-sequence");
-var runSequence = tmp.use(gulp);
+import gulp from "gulp";
+import tmp, { Task } from "run-sequence";
 
-gulp.task("run-sequence", (callback: any) => {
-    runSequence("task1", ["task2", "task3"], "taks4", callback);
-});
+const runSequence = tmp.use(gulp);
 
-gulp.task("task1", () => {
-    gulp.src("file1.txt")
-        .pipe(gulp.dest("build"));
-});
+{
+    gulp.task("run-sequence", (callback) => {
+        runSequence("task1", ["task2", "task3"], "task4");
+        runSequence("task1", ["task2", "task3"], "task4", callback);
+    });
 
-gulp.task("task2", () => {
-    gulp.src("file2.txt")
-        .pipe(gulp.dest("build"));
-});
+    gulp.task("task1", () => {});
+    gulp.task("task2", () => {});
+    gulp.task("task3", () => {});
+    gulp.task("task4", () => {});
+}
 
-gulp.task("task3", () => {
-    gulp.src("file3.txt")
-        .pipe(gulp.dest("build"));
-});
-
-gulp.task("task4", () => {
-    gulp.src("file4.txt")
-        .pipe(gulp.dest("build"));
-});
+{
+    runSequence.options.ignoreUndefinedTasks = true;
+    gulp.task("task", function() {
+        runSequence("foo", null, "bar"); // no longer errors on `null`
+    });
+}


### PR DESCRIPTION
- Bump version to fix attw error.
- Refine `RunSequence` callback type.
    - Previously missing `options` is added based on [doc](https://www.npmjs.com/package/run-sequence#options).
    - From the [doc](https://www.npmjs.com/package/run-sequence#options), `RunSequence` callback can accept nullish `task` when `options.ignoreUndefinedTasks = true`. The param type is hence modified.
    - An optional task callback can appear at the end, but not in other places in the task array. See the [source code](https://github.com/OverZealous/run-sequence/blob/31103da22f2e06a1b66af8fd7bee22d9a1ba0da1/index.js#L55). 
    - Here `@types/undertaker` is installed to reference the `gulp.task` callback type.
        - v4 is using this package for `gulp.task` callback type.
        - But v3 **is not**, and in fact its `gulp.task` callback type conflict with the v4 one.
        - Directly using the type from `@types/undertaker` help resolve type issue in both major version.
    - Since `gulp.TaskCallback` is used and the [original package](https://github.com/OverZealous/run-sequence/blob/master/package.json#L31) expects `"gulp": "^3.9.1",`, the `package.json` in this PR is hence modified accordingly, to use `>=3.8`.
- jsdoc is added, with most descriptions taken from the [npm page](https://www.npmjs.com/package/run-sequence).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
