### PR TITLE
fix(sparqljs): more accurate path types

### DIFF
--- a/types/sparqljs/index.d.ts
+++ b/types/sparqljs/index.d.ts
@@ -284,10 +284,22 @@ export interface Triple {
     object: Term;
 }
 
-export interface PropertyPath {
+export type PropertyPath = NegatedPropertySet | {
     type: "path";
-    pathType: "|" | "/" | "^" | "+" | "*" | "!" | "?";
+    pathType: "|" | "/" | "^" | "+" | "*" | "?";
     items: Array<IriTerm | PropertyPath>;
+};
+
+export interface InversePathInPropertySet {
+    type: "path";
+    pathType: "^";
+    items: [IriTerm];
+}
+
+export interface NegatedPropertySet {
+    type: "path";
+    pathType: "!";
+    items: Array<IriTerm | InversePathInPropertySet>;
 }
 
 export type Expression =

--- a/types/sparqljs/index.d.ts
+++ b/types/sparqljs/index.d.ts
@@ -290,16 +290,16 @@ export type PropertyPath = NegatedPropertySet | {
     items: Array<IriTerm | PropertyPath>;
 };
 
-export interface InversePathInPropertySet {
-    type: "path";
-    pathType: "^";
-    items: [IriTerm];
-}
-
 export interface NegatedPropertySet {
     type: "path";
     pathType: "!";
-    items: Array<IriTerm | InversePathInPropertySet>;
+    items: Array<
+        IriTerm | {
+            type: "path";
+            pathType: "^";
+            items: [IriTerm];
+        }
+    >;
 }
 
 export type Expression =

--- a/types/sparqljs/sparqljs-tests.ts
+++ b/types/sparqljs/sparqljs-tests.ts
@@ -196,3 +196,47 @@ function sparqlStarAst() {
         ],
     };
 }
+
+function negatedPropertySets() {
+    const negatedIri: SparqlJs.PropertyPath = {
+        type: "path",
+        pathType: "!",
+        items: [
+            DataFactory.namedNode("http://example.com/p1"),
+        ],
+    };
+    const negatedInverse: SparqlJs.PropertyPath = {
+        type: "path",
+        pathType: "!",
+        items: [{
+            type: "path",
+            pathType: "^",
+            items: [DataFactory.namedNode("http://example.com/p2")],
+        }],
+    };
+
+    const negatedInverseMustBeSingleIri: SparqlJs.NegatedPropertySet = {
+        type: "path",
+        pathType: "!",
+        items: [{
+            type: "path",
+            pathType: "^",
+            // @ts-expect-error
+            items: [
+                DataFactory.namedNode("http://example.com/p1"),
+                DataFactory.namedNode("http://example.com/p2"),
+            ],
+        }],
+    };
+
+    const OnyIriAndSimpleInverseCanBeNegated: SparqlJs.NegatedPropertySet = {
+        type: "path",
+        pathType: "!",
+        items: [{
+            type: "path",
+            // @ts-expect-error
+            pathType: "?",
+            items: [DataFactory.namedNode("http://example.com/p2")],
+        }],
+    };
+}


### PR DESCRIPTION
Negated paths only allow a single or multiple `iri` and `^iri`. This PR extracts a more specific `NegatedPropertySet` subtype of path which restricts its items to reflect the spec.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://www.w3.org/TR/sparql11-query/#pp-language>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

