### PR TITLE
[less]: allow export type and add v4 options

### DIFF
--- a/types/less/index.d.ts
+++ b/types/less/index.d.ts
@@ -220,8 +220,6 @@ interface LessStatic {
     PluginManager: typeof PluginManager;
 }
 
-
-
 declare class PluginManager {
     constructor(less: LessStatic);
 

--- a/types/less/index.d.ts
+++ b/types/less/index.d.ts
@@ -1,8 +1,13 @@
+export as namespace Less;
+
+declare var Less: LessStatic;
+export = Less;
+
 declare namespace Less {
     // https://github.com/less/less.js/blob/master/lib/less/import-manager.js#L10
     interface RootFileInfo {
         /** whether to adjust URL's to be relative */
-        rewriteUrls?: boolean | undefined;
+        rewriteUrls?: "all" | "local" | "off" | boolean | undefined;
         /** full resolved filename of current file */
         filename: string;
         relativeUrls: boolean;
@@ -16,14 +21,8 @@ declare namespace Less {
         rootFilename: string;
         /** whether the file should not be output and only output parts that are referenced */
         reference: boolean;
-    }
-
-    class PluginManager {
-        constructor(less: LessStatic);
-
-        addPreProcessor(preProcessor: PreProcessor, priority?: number): void;
-
-        addFileManager(fileManager: FileManager): void;
+        /** whether to use the file cache */
+        useFileCache?: boolean | undefined;
     }
 
     interface Plugin {
@@ -58,85 +57,6 @@ declare namespace Less {
     interface FileLoadError {
         /** Error object if an error occurs. */
         error: unknown;
-    }
-
-    class FileManager extends AbstractFileManager {
-        /**
-         * Returns whether this file manager supports this file for file retrieval
-         * If true is returned, loadFile will then be called with the file.
-         */
-        supports(
-            filename: string,
-            currentDirectory: string,
-            options: LoadFileOptions,
-            environment: Environment,
-        ): boolean;
-
-        /**
-         * Loads a file asynchronously. Expects a promise that either rejects with an error or fulfills with a FileLoadResult.
-         */
-        loadFile(
-            filename: string,
-            currentDirectory: string,
-            options: LoadFileOptions,
-            environment: Environment,
-        ): Promise<FileLoadResult>;
-
-        /**
-         * Loads a file synchronously. Expects an immediate return with wither a FileLoadResult or FileLoadError.
-         */
-        loadFileSync(
-            filename: string,
-            currentDirectory: string,
-            options: LoadFileOptions,
-            environment: Environment,
-        ): FileLoadResult | FileLoadError;
-    }
-
-    class AbstractFileManager {
-        /**
-         * Given the full path to a file, return the path component.
-         */
-        getPath(filename: string): string;
-
-        /**
-         * Append a .less extension if appropriate. Only called if less thinks one could be added.
-         */
-        tryAppendLessExtension(filename: string): string;
-
-        /**
-         * Whether the rootpath should be converted to be absolute.
-         * The browser ovverides this to return true because urls must be absolute.
-         */
-        alwaysMakePathsAbsolute(): boolean;
-
-        /**
-         * Returns whether a path is absolute.
-         */
-        isPathAbsolute(path: string): boolean;
-
-        /**
-         * Joins together 2 paths.
-         */
-        join(basePath: string, laterPath: string): string;
-
-        /**
-         * Returns the difference between 2 paths
-         * E.g. url = a/ baseUrl = a/b/ returns ../
-         * url = a/b/ baseUrl = a/ returns b/
-         */
-        pathDiff(url: string, baseUrl: string): string;
-
-        /**
-         * Returns whether this file manager supports this file for syncronous file retrieval
-         * If true is returned, loadFileSync will then be called with the file.
-         */
-        supportsSync(
-            filename: string,
-            currentDirectory: string,
-            options: LoadFileOptions,
-            environment: Environment,
-        ): boolean;
     }
 
     interface LoadFileOptions {
@@ -213,15 +133,13 @@ declare namespace Less {
         maxLineLen?: number | undefined;
         /** @deprecated If false, No color in compiling. */
         color?: boolean | undefined;
-        /** @deprecated False by default. */
-        ieCompat?: boolean | undefined;
         /** @deprecated If true, enable evaluation of JavaScript inline in `.less` files. */
         javascriptEnabled?: boolean | undefined;
         /** Whether output file information and line numbers in compiled CSS code. */
         dumpLineNumbers?: "comment" | string | undefined;
         /** Add a path to every generated import and url in output css files. */
         rootpath?: string | undefined;
-        /** Math mode options for avoiding symbol conficts on math expressions. */
+        /** Math mode options for avoiding symbol conflicts on math expressions. */
         math?: "always" | "strict" | "parens-division" | "parens" | "strict-legacy" | number | undefined;
         /** If true, stops any warnings from being shown. */
         silent?: boolean | undefined;
@@ -237,6 +155,12 @@ declare namespace Less {
         } | undefined;
         /** Read files synchronously in Node.js */
         syncImport?: boolean | undefined;
+        /** Adds params into url tokens (e.g. 42, cb=42 or 'a=1&b=2') */
+        urlArgs?: string | undefined;
+        /** Disallow @plugin statements */
+        disablePluginRule?: boolean | undefined;
+        /** @deprecated Legacy parens-only math. Use "math" option */
+        strictMath?: boolean | undefined;
     }
 
     interface RenderError {
@@ -262,7 +186,6 @@ declare namespace Less {
         totalMilliseconds: number;
     }
 }
-
 interface LessStatic {
     options: Less.StaticOptions;
 
@@ -293,12 +216,95 @@ interface LessStatic {
 
     watch(): void;
 
-    FileManager: typeof Less.FileManager;
-    PluginManager: typeof Less.PluginManager;
+    FileManager: typeof FileManager;
+    PluginManager: typeof PluginManager;
 }
 
-declare module "less" {
-    export = less;
+
+
+declare class PluginManager {
+    constructor(less: LessStatic);
+
+    addPreProcessor(preProcessor: Less.PreProcessor, priority?: number): void;
+
+    addFileManager(fileManager: FileManager): void;
 }
 
-declare var less: LessStatic;
+declare class FileManager extends AbstractFileManager {
+    /**
+     * Returns whether this file manager supports this file for file retrieval
+     * If true is returned, loadFile will then be called with the file.
+     */
+    supports(
+        filename: string,
+        currentDirectory: string,
+        options: Less.LoadFileOptions,
+        environment: Less.Environment,
+    ): boolean;
+
+    /**
+     * Loads a file asynchronously. Expects a promise that either rejects with an error or fulfills with a FileLoadResult.
+     */
+    loadFile(
+        filename: string,
+        currentDirectory: string,
+        options: Less.LoadFileOptions,
+        environment: Less.Environment,
+    ): Promise<Less.FileLoadResult>;
+
+    /**
+     * Loads a file synchronously. Expects an immediate return with wither a FileLoadResult or FileLoadError.
+     */
+    loadFileSync(
+        filename: string,
+        currentDirectory: string,
+        options: Less.LoadFileOptions,
+        environment: Less.Environment,
+    ): Less.FileLoadResult | Less.FileLoadError;
+}
+
+declare class AbstractFileManager {
+    /**
+     * Given the full path to a file, return the path component.
+     */
+    getPath(filename: string): string;
+
+    /**
+     * Append a .less extension if appropriate. Only called if less thinks one could be added.
+     */
+    tryAppendLessExtension(filename: string): string;
+
+    /**
+     * Whether the rootpath should be converted to be absolute.
+     * The browser overrides this to return true because urls must be absolute.
+     */
+    alwaysMakePathsAbsolute(): boolean;
+
+    /**
+     * Returns whether a path is absolute.
+     */
+    isPathAbsolute(path: string): boolean;
+
+    /**
+     * Joins together 2 paths.
+     */
+    join(basePath: string, laterPath: string): string;
+
+    /**
+     * Returns the difference between 2 paths
+     * E.g. url = a/ baseUrl = a/b/ returns ../
+     * url = a/b/ baseUrl = a/ returns b/
+     */
+    pathDiff(url: string, baseUrl: string): string;
+
+    /**
+     * Returns whether this file manager supports this file for synchronous file retrieval
+     * If true is returned, loadFileSync will then be called with the file.
+     */
+    supportsSync(
+        filename: string,
+        currentDirectory: string,
+        options: Less.LoadFileOptions,
+        environment: Less.Environment,
+    ): boolean;
+}

--- a/types/less/less-tests.ts
+++ b/types/less/less-tests.ts
@@ -109,4 +109,4 @@ if (less.importManager) {
     }
 }
 
-type Options = import('less').Options
+type Options = import("less").Options;

--- a/types/less/less-tests.ts
+++ b/types/less/less-tests.ts
@@ -44,15 +44,15 @@ var options: Less.Options = {
     plugins: [myPlugin],
     /** Tells less to generate a sourcemap. */
     sourceMap: {},
-    /* Inline Javascript - @plugin still allowed */
+    /** Inline Javascript - @plugin still allowed */
     javascriptEnabled: false,
     /* Outputs a makefile import dependency list to stdout. */
     depends: false,
-    /** (DEPRECATED) This does not utilise all the tricks of css compression. */
+    /** @deprecated (DEPRECATED) This does not utilise all the tricks of css compression. */
     compress: false,
     /* Runs the less parser and just reports errors without any output. */
     lint: false,
-    /** Less will look for the file in @import rules through locations here. */
+    /** Less will look  for the file in @import rules through locations here. */
     paths: [],
     /* color output in the terminal */
     color: true,
@@ -78,6 +78,10 @@ var options: Less.Options = {
     globalVars: null,
     /** Put the declaration at the end of base file. */
     modifyVars: null,
+    /* This option allows you to specify a argument to go on to every URL.  */
+    urlArgs: "",
+
+    disablePluginRule: true,
 };
 
 less.render("h1 { background: red; }", options);
@@ -104,3 +108,5 @@ if (less.importManager) {
         let fileContents = less.importManager.contents[fileName];
     }
 }
+
+type Options = import('less').Options

--- a/types/less/package.json
+++ b/types/less/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/less",
-    "version": "3.0.9999",
+    "version": "4.1.9999",
     "projects": [
         "http://lesscss.org/"
     ],


### PR DESCRIPTION
## Description
This PR let less could export type in node16/nodenext.

example
```cjs
/**
 * @type {import('less').Options}
 */
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
