### PR TITLE
Fix/ibm db/missing types

### DIFF
--- a/types/ibm_db/ibm_db-tests.ts
+++ b/types/ibm_db/ibm_db-tests.ts
@@ -73,9 +73,9 @@ service._executeSync(
     ["test"],
 );
 // $ExpectType true
-service.closeSync()
+service.closeSync();
 // $ExpectType void
-service.close()
+service.close();
 
 /** ibm.Database */
 new ibmdb.Database({

--- a/types/ibm_db/ibm_db-tests.ts
+++ b/types/ibm_db/ibm_db-tests.ts
@@ -72,6 +72,10 @@ service._executeSync();
 service._executeSync(
     ["test"],
 );
+// $ExpectType true
+service.closeSync()
+// $ExpectType void
+service.close()
 
 /** ibm.Database */
 new ibmdb.Database({

--- a/types/ibm_db/index.d.ts
+++ b/types/ibm_db/index.d.ts
@@ -190,7 +190,7 @@ export class ODBCStatement {
     close(cb: (err: Error, res: any[]) => void): void
     close(): Promise<void>
 
-    closeSync(): void
+    closeSync(): true
 
     prepare(sql: string, cb: (err: Error, result: any[]) => void): void;
 

--- a/types/ibm_db/index.d.ts
+++ b/types/ibm_db/index.d.ts
@@ -186,11 +186,11 @@ export class ODBCStatement {
 
     executeNonQuerySync(params?: any[]): number;
 
-    close(): void
-    close(cb: (err: Error, res: any[]) => void): void
-    close(): Promise<void>
+    close(): void;
+    close(cb: (err: Error, res: any[]) => void): void;
+    close(): Promise<void>;
 
-    closeSync(): true
+    closeSync(): true;
 
     prepare(sql: string, cb: (err: Error, result: any[]) => void): void;
 

--- a/types/ibm_db/index.d.ts
+++ b/types/ibm_db/index.d.ts
@@ -186,6 +186,12 @@ export class ODBCStatement {
 
     executeNonQuerySync(params?: any[]): number;
 
+    close(): void
+    close(cb: (err: Error, res: any[]) => void): void
+    close(): Promise<void>
+
+    closeSync(): void
+
     prepare(sql: string, cb: (err: Error, result: any[]) => void): void;
 
     bind(ary: any[], cb: (err: Error) => void): void;

--- a/types/ibm_db/package.json
+++ b/types/ibm_db/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/ibm_db",
-    "version": "3.2.4",
+    "version": "3.2.9999",
     "projects": [
         "https://github.com/ibmdb/node-ibm_db"
     ],

--- a/types/ibm_db/package.json
+++ b/types/ibm_db/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/ibm_db",
-    "version": "2.0.9999",
+    "version": "3.2.4",
     "projects": [
         "https://github.com/ibmdb/node-ibm_db"
     ],


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

CloseSync C++ implementation shows always returning true:
https://github.com/ibmdb/node-ibm_db/blob/52573c5a01a92c90ae8121d0115abab94fe215ff/src/odbc_statement.cpp#L1287-L1309

Close C++ implementation shows void return alongside a callback:
https://github.com/ibmdb/node-ibm_db/blob/52573c5a01a92c90ae8121d0115abab94fe215ff/src/odbc_statement.cpp#L1168-L1221

From ibm_db base library their docs show these methods do exist on an ODBCStatement:

Link: https://github.com/ibmdb/node-ibm_db/blob/master/APIDocumentation.md#-18-stmtclosecallback

![image](https://github.com/user-attachments/assets/e5656c2a-09b1-4ad6-a0d5-dca3abc5a25b)

