### PR TITLE
fix(stream-series): Add missing typedef, bump version for attw

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -1627,7 +1627,6 @@
         "srtparsejs",
         "stampit",
         "stamplay-js-sdk",
-        "stream-series",
         "stream-to-array/v0",
         "stripe-v2",
         "stripe-v3",

--- a/types/stream-series/index.d.ts
+++ b/types/stream-series/index.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="node" />
 
 declare function series<T extends NodeJS.ReadableStream>(...streams: T[]): NodeJS.ReadWriteStream;
+declare function series<T extends NodeJS.ReadableStream>(streams: T[]): NodeJS.ReadWriteStream;
 export = series;

--- a/types/stream-series/package.json
+++ b/types/stream-series/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/stream-series",
-    "version": "0.0.9999",
+    "version": "0.1.9999",
     "projects": [
         "https://github.com/rschmukler/stream-series"
     ],

--- a/types/stream-series/stream-series-tests.ts
+++ b/types/stream-series/stream-series-tests.ts
@@ -1,10 +1,12 @@
-import stream = require("stream");
-import Stream = stream.Duplex;
-import series = require("stream-series");
+import { Duplex as Stream } from "node:stream";
+import series from "stream-series";
 
-var stream1 = new Stream();
-var stream2 = new Stream();
-var stream3 = new Stream();
+const stream1 = new Stream();
+const stream2 = new Stream();
+const stream3 = new Stream();
 
-var orderedStream = series(stream1, stream3, stream2);
-console.log(orderedStream.toString());
+// $ExpectType ReadWriteStream
+series(stream1, stream3, stream2);
+
+// $ExpectType ReadWriteStream
+series([stream1, stream3, stream2]);


### PR DESCRIPTION
The added typedef is based on [source code](https://github.com/rschmukler/stream-series/blob/b1c448117be4da5458f9ad8c89a49ebe7b03e8d8/index.js#L4-L11).

--- 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
