### PR TITLE
[amap-js-api] fix: add rectangleEditor types and fix lanlag type loss

### DIFF
--- a/types/amap-js-api/amap-js-api-tests.ts
+++ b/types/amap-js-api/amap-js-api-tests.ts
@@ -2853,7 +2853,7 @@ testMarker.setLabel({
         // $ExpectType string | undefined
         testMarkerLabel.content;
 
-        // $ExpectType Pixel | undefined
+        // $ExpectType number[] | Pixel |  undefined
         testMarkerLabel.offset;
 
         type TempLabelDirection = "top" | "right" | "bottom" | "left" | "center" | undefined;

--- a/types/amap-js-api/bounds.d.ts
+++ b/types/amap-js-api/bounds.d.ts
@@ -1,5 +1,7 @@
 declare namespace AMap {
     class Bounds {
+        southWest: LocationValue
+        northEast: LocationValue
         /**
          * 地物对象的经纬度矩形范围。
          * @param coords 由西南角，东北角经纬度组成的数组，分别是[西南角经度， 西南角纬度，东北角经度，东北角纬度]

--- a/types/amap-js-api/index.d.ts
+++ b/types/amap-js-api/index.d.ts
@@ -43,3 +43,4 @@
 /// <reference path="overlay/rectangle.d.ts" />
 /// <reference path="overlay/shapeOverlay.d.ts" />
 /// <reference path="overlay/text.d.ts" />
+/// <reference path="overlay/rectangleEditor.d.ts" />

--- a/types/amap-js-api/lngLat.d.ts
+++ b/types/amap-js-api/lngLat.d.ts
@@ -1,5 +1,9 @@
 declare namespace AMap {
     class LngLat {
+        lng: number;
+        lat: number;
+        noAutofix?: boolean;
+
         /**
          * 构造一个地理坐标对象
          * @param lng 经度

--- a/types/amap-js-api/overlay/marker.d.ts
+++ b/types/amap-js-api/overlay/marker.d.ts
@@ -29,7 +29,7 @@ declare namespace AMap {
             /**
              * offset为偏移量。如设置了 direction，以 direction 方位为基准点进行偏移。
              */
-            offset?: Pixel | Array<number>|  undefined;
+            offset?: Pixel | number[] |  undefined;
             /**
              * 文本标注方位 可选值：'top'|'right'|'bottom'|'left'|'center'，默认值: 'right'。
              */
@@ -70,7 +70,7 @@ declare namespace AMap {
              * - 点标记显示位置偏移量，默认值为 [0,0] 。
              * - Marker指定position后，默认以marker左上角位置为基准点（若设置了anchor，则以anchor设置位置为基准点），对准所给定的position位置，若需使marker指定位置对准在position处，需根据marker的尺寸设置一定的偏移量。
              */
-            offset?: Pixel | undefined;
+            offset?: Pixel | number[] | undefined;
             /**
              * 在点标记中显示的图标。可以传一个图标地址，也可以传Icon对象。有合法的content内容设置时，此属性无效。
              */
@@ -151,7 +151,7 @@ declare namespace AMap {
             /**
              * 点标记是否可点击，默认值: true
              */
-            clickable: boolean
+            clickable?: boolean
         }
     }
 

--- a/types/amap-js-api/overlay/marker.d.ts
+++ b/types/amap-js-api/overlay/marker.d.ts
@@ -22,8 +22,17 @@ declare namespace AMap {
 
         type LabelDirection = "top" | "right" | "bottom" | "left" | "center";
         interface Label {
+          /**
+           * 文本标注的内容
+           */
             content?: string | undefined;
-            offset?: Pixel | undefined;
+            /**
+             * offset为偏移量。如设置了 direction，以 direction 方位为基准点进行偏移。
+             */
+            offset?: Pixel | Array<number>|  undefined;
+            /**
+             * 文本标注方位 可选值：'top'|'right'|'bottom'|'left'|'center'，默认值: 'right'。
+             */
             direction?: LabelDirection | undefined;
         }
 
@@ -42,33 +51,45 @@ declare namespace AMap {
             /**
              * 点标记在地图上显示的位置
              */
-            position?: LocationValue | undefined;
+            position?: LocationValue | undefined
             /**
-             * 标记锚点
+             * 设置点标记锚点, 可选值：
+             * - 'top-left'
+             * - 'top-center'
+             * - 'top-right'
+             * - 'middle-left'
+             * - 'center'
+             * - 'middle-right'
+             * - 'bottom-left'
+             * - 'bottom-center'
+             * - 'bottom-right'
+             * @link https://lbs.amap.com/demo/javascript-api-v2/example/marker/marker-anchor
              */
             anchor?: Anchor | undefined;
             /**
-             * 点标记显示位置偏移量
+             * - 点标记显示位置偏移量，默认值为 [0,0] 。
+             * - Marker指定position后，默认以marker左上角位置为基准点（若设置了anchor，则以anchor设置位置为基准点），对准所给定的position位置，若需使marker指定位置对准在position处，需根据marker的尺寸设置一定的偏移量。
              */
             offset?: Pixel | undefined;
             /**
-             * 需在点标记中显示的图标
+             * 在点标记中显示的图标。可以传一个图标地址，也可以传Icon对象。有合法的content内容设置时，此属性无效。
              */
             icon?: string | Icon | undefined;
             /**
-             * 点标记显示内容
+             * 点标记显示内容。可以是HTML要素字符串或者HTML DOM对象。content有效时，icon属性将被覆盖。
              */
             content?: string | HTMLElement | undefined;
             /**
-             * 鼠标点击时marker是否置顶
+             * 鼠标点击时marker是否置顶,默认false ，不置顶
              */
             topWhenClick?: boolean | undefined;
             /**
+             * 事件是否冒泡，默认为 false
              * 是否将覆盖物的鼠标或touch等事件冒泡到地图上
              */
             bubble?: boolean | undefined;
             /**
-             * 点标记是否可拖拽移动
+             * 点标记是否可拖拽移动, 默认值：false
              */
             draggable?: boolean | undefined;
             /**
@@ -76,19 +97,20 @@ declare namespace AMap {
              */
             raiseOnDrag?: boolean | undefined;
             /**
-             * 鼠标悬停时的鼠标样式
+             * 鼠标悬停时的鼠标样式; 默认值：'pointer'
              */
             cursor?: string | undefined;
             /**
-             * 点标记是否可见
+             * 点标记是否可见，默认值：true
              */
             visible?: boolean | undefined;
             /**
              * 点标记的叠加顺序
+             * 地图上存在多个点标记叠加时，通过该属性使级别较高的点标记在上层显示，默认zIndex：12
              */
             zIndex?: number | undefined;
             /**
-             * 点标记的旋转角度
+             * 点标记的旋转角度； 广泛用于改变车辆行驶方向。默认值：0
              */
             angle?: number | undefined;
             /**
@@ -104,7 +126,7 @@ declare namespace AMap {
              */
             shadow?: Icon | string | undefined;
             /**
-             * 鼠标滑过点标记时的文字提示
+             * 鼠标滑过点标记时的文字提示。不设置则鼠标滑过点标无文字提示。
              */
             title?: string | undefined;
             /**
@@ -116,13 +138,32 @@ declare namespace AMap {
              */
             label?: Label | undefined;
 
-            // internal
+            /**
+             * 类型：Vector2	点标记显示的层级范围，超过范围不显示。默认值：zooms: [2, 20]
+             */
             zooms?: [number, number] | undefined;
             topWhenMouseOver?: boolean | undefined;
+            /**
+             * 设置Marker点是否离地绘制，默认值为0，等于0时贴地绘制。大于0时离地绘制，此时Marker点高度等于height值加Marker点高程值（JSAPI v2.1新增属性目前只适用于v2.1版本）。
+             */
             height?: number | undefined;
+
+            /**
+             * 点标记是否可点击，默认值: true
+             */
+            clickable: boolean
         }
     }
 
+    /**
+     * @example
+     * var marker = new AMap.Marker({
+            position: new AMap.LngLat(116.397428, 39.90923),
+            icon: 'https://a.amap.com/jsapi_demos/static/demo-center/icons/poi-marker-default.png',
+            anchor: 'bottom-center',
+        });
+        map.add(marker);
+     */
     class Marker<ExtraData = any> extends Overlay<ExtraData> {
         /**
          * 点标记
@@ -189,7 +230,7 @@ declare namespace AMap {
          */
         setLabel(label?: Marker.Label): void;
         /**
-         *     获取点标记文本标签内容
+         * 获取点标记文本标签内容
          */
         getLabel(): Marker.Label | undefined;
         /**
@@ -211,7 +252,7 @@ declare namespace AMap {
          */
         setIcon(content: string | Icon): void;
         /**
-         * 获取Icon内容
+         * 当点标记未自定义图标时，获取Icon内容
          */
         getIcon(): string | Icon | undefined;
         /**

--- a/types/amap-js-api/overlay/overlay.d.ts
+++ b/types/amap-js-api/overlay/overlay.d.ts
@@ -70,6 +70,9 @@ declare namespace AMap {
 
         // internal
         setHeight(height?: number | string): void;
+        /**
+         * 获取 Marker 离地高度 （此方法适用于 JSAPI v2.1Beta 及以上版本）
+         */
         getHeight(): number | string;
     }
 }

--- a/types/amap-js-api/overlay/rectangleEditor.d.ts
+++ b/types/amap-js-api/overlay/rectangleEditor.d.ts
@@ -1,0 +1,89 @@
+/**
+ * 矩形编辑器
+ * @link https://lbs.amap.com/api/javascript-api-v2/documentation#rectangleeditor
+ */
+declare namespace AMap {
+  namespace RectangleEditor {
+
+    interface MarkerOptions {}
+
+    /**
+    * 矩形编辑器的配置项
+    */
+    interface RectangleEditorOptions {
+      /**
+       * 新创建的对象样式
+       */
+      createOptions?: Object
+      /**
+       * 	编辑样式
+       */
+      editOptions?: Object
+      /**
+       * 西南点样式 MarkerOptions
+       */
+      southWestPoint?: Marker.Options
+      /**
+       * 东北点样式 MarkerOptions
+       */
+      northEastPoint?: Marker.Options
+    }
+
+    interface EventMap<I = RectangleEditor> {
+      /**
+       * 增加一个节点时触发此事件
+       */
+      addnode: MapsEvent<'addnode', I>
+      /**
+       * 调整折线上某个点时触发此事件
+       */
+      adjust: MapsEvent<'adjust', I>
+      /**
+       * 移动覆盖物时触发此事件
+       */
+      move: MapsEvent<'move', I>
+      /**
+       * 创建一个覆盖物之后触发该事件，target即为创建对象。当editor编辑对象为空时，调用open接口，再点击一次屏幕就会创建新的覆盖物对象
+       */
+      add: MapsEvent<'add', I>
+      /**
+       * 调用close之后触发该事件，target即为编辑后的覆盖物对象
+       */
+      end: MapsEvent<'end', I>
+    }
+  }
+
+    /**
+     * @link https://lbs.amap.com/api/javascript-api-v2/documentation#rectangleeditor
+     */
+    class RectangleEditor<ExtraData = any> extends Overlay<ExtraData> {
+      /**
+       *
+       * @param map AMap.Map 的实例
+       * @param rect AMap.Rectangle 的实例
+       * @param opt 设置参数
+       */
+      constructor(map: Map, rect?: Rectangle, opt?: RectangleEditor.RectangleEditorOptions)
+
+      /**
+       * 打开编辑功能
+       */
+      open(): void
+      /**
+       * 关闭编辑功能
+       */
+      close(): void
+
+      /**
+       * 设置编辑对象
+       * @param overlay
+       */
+      setTarget(overlay?: Rectangle): void
+
+      /**
+       * 获取编辑对象
+       */
+      getTarget(): Rectangle | undefined
+    }
+
+}

--- a/types/amap-js-api/overlay/rectangleEditor.d.ts
+++ b/types/amap-js-api/overlay/rectangleEditor.d.ts
@@ -14,11 +14,11 @@ declare namespace AMap {
       /**
        * 新创建的对象样式
        */
-      createOptions?: Object
+      createOptions?: any
       /**
        * 	编辑样式
        */
-      editOptions?: Object
+      editOptions?: any
       /**
        * 西南点样式 MarkerOptions
        */

--- a/types/amap-js-api/package.json
+++ b/types/amap-js-api/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@types/amap-js-api",
-  "version": "1.5.0",
+  "version": "1.5.9999",
   "nonNpm": true,
   "nonNpmDescription": "amap-js-api",
   "projects": [

--- a/types/amap-js-api/package.json
+++ b/types/amap-js-api/package.json
@@ -1,19 +1,19 @@
 {
-    "private": true,
-    "name": "@types/amap-js-api",
-    "version": "1.4.9999",
-    "nonNpm": true,
-    "nonNpmDescription": "amap-js-api",
-    "projects": [
-        "https://lbs.amap.com/api/javascript-api/summary"
-    ],
-    "devDependencies": {
-        "@types/amap-js-api": "workspace:."
-    },
-    "owners": [
-        {
-            "name": "breeze9527",
-            "githubUsername": "breeze9527"
-        }
-    ]
+  "private": true,
+  "name": "@types/amap-js-api",
+  "version": "1.5.0",
+  "nonNpm": true,
+  "nonNpmDescription": "amap-js-api",
+  "projects": [
+    "https://lbs.amap.com/api/javascript-api/summary"
+  ],
+  "devDependencies": {
+    "@types/amap-js-api": "workspace:."
+  },
+  "owners": [
+    {
+      "name": "breeze9527",
+      "githubUsername": "breeze9527"
+    }
+  ]
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.


