### PR TITLE
Add the missing parameter type ArrayBuffer to SparkMD5

### DIFF
--- a/types/spark-md5/index.d.ts
+++ b/types/spark-md5/index.d.ts
@@ -7,7 +7,7 @@ declare class SparkMD5 {
     static hash(str: string, raw?: boolean): string;
     static hashBinary(content: string, raw?: boolean): string;
 
-    append(str: string): SparkMD5;
+    append(str: string | JsArrayBuffer): SparkMD5;
     appendBinary(contents: string): SparkMD5;
     destroy(): void;
     end(raw?: boolean): string;

--- a/types/spark-md5/spark-md5-tests.ts
+++ b/types/spark-md5/spark-md5-tests.ts
@@ -7,6 +7,10 @@ SparkMD5.hashBinary("");
 const spark = new SparkMD5();
 spark.append("Hi");
 spark.append(" there");
+
+var bytes = new ArrayBuffer(16);
+spark.append(bytes);
+
 let hexHash = spark.end();
 let rawHash = spark.end(true);
 


### PR DESCRIPTION
…5 class

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x]  Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x]  Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/satazor/js-spark-md5/blob/master/spark-md5.js#L452
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
