### PR TITLE
feat(node): document `X509Certificate` constructor parameter

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -3531,7 +3531,7 @@ declare module "crypto" {
      * ```js
      * const { X509Certificate } = await import('node:crypto');
      *
-     * const x509 = new X509Certificate('{... pem encoded cert ...}');
+     * const x509 = new X509Certificate('{... pem/der encoded cert ...}');
      *
      * console.log(x509.subject);
      * ```
@@ -3654,6 +3654,10 @@ declare module "crypto" {
          * @since v15.6.0
          */
         readonly validTo: string;
+        /**
+         * @param buffer A PEM or DER encoded X509 Certificate.
+         * @since v15.6.0
+         */
         constructor(buffer: BinaryLike);
         /**
          * Checks whether the certificate matches the given email address.

--- a/types/node/v16/crypto.d.ts
+++ b/types/node/v16/crypto.d.ts
@@ -3524,7 +3524,7 @@ declare module "crypto" {
      * ```js
      * const { X509Certificate } = await import('crypto');
      *
-     * const x509 = new X509Certificate('{... pem encoded cert ...}');
+     * const x509 = new X509Certificate('{... pem/der encoded cert ...}');
      *
      * console.log(x509.subject);
      * ```
@@ -3609,6 +3609,10 @@ declare module "crypto" {
          * @since v15.6.0
          */
         readonly validTo: string;
+        /**
+         * @param buffer A PEM or DER encoded X509 Certificate.
+         * @since v15.6.0
+         */
         constructor(buffer: BinaryLike);
         /**
          * Checks whether the certificate matches the given email address.

--- a/types/node/v18/crypto.d.ts
+++ b/types/node/v18/crypto.d.ts
@@ -3563,7 +3563,7 @@ declare module "crypto" {
      * ```js
      * const { X509Certificate } = await import('crypto');
      *
-     * const x509 = new X509Certificate('{... pem encoded cert ...}');
+     * const x509 = new X509Certificate('{... pem/der encoded cert ...}');
      *
      * console.log(x509.subject);
      * ```
@@ -3656,6 +3656,10 @@ declare module "crypto" {
          * @since v15.6.0
          */
         readonly validTo: string;
+        /**
+         * @param buffer A PEM or DER encoded X509 Certificate.
+         * @since v15.6.0
+         */
         constructor(buffer: BinaryLike);
         /**
          * Checks whether the certificate matches the given email address.

--- a/types/node/v20/crypto.d.ts
+++ b/types/node/v20/crypto.d.ts
@@ -3598,7 +3598,7 @@ declare module "crypto" {
      * ```js
      * const { X509Certificate } = await import('node:crypto');
      *
-     * const x509 = new X509Certificate('{... pem encoded cert ...}');
+     * const x509 = new X509Certificate('{... pem/der encoded cert ...}');
      *
      * console.log(x509.subject);
      * ```
@@ -3721,6 +3721,10 @@ declare module "crypto" {
          * @since v15.6.0
          */
         readonly validTo: string;
+        /**
+         * @param buffer A PEM or DER encoded X509 Certificate.
+         * @since v15.6.0
+         */
         constructor(buffer: BinaryLike);
         /**
          * Checks whether the certificate matches the given email address.


### PR DESCRIPTION
Document the accepted certificate formats for instantiating `X509Certificate`, since the previous jsdoc would suggest that only PEM is allowed.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

---

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/crypto.html#class-x509certificate
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
