### PR TITLE
`@types/chrome` make details parameter optional

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -5150,7 +5150,7 @@ declare namespace chrome.identity {
     export function getProfileUserInfo(details: ProfileDetails, callback: (userInfo: UserInfo) => void): void;
 
     /** @since Chrome 84 */
-    export function getProfileUserInfo(details: ProfileDetails): Promise<UserInfo>;
+    export function getProfileUserInfo(details?: ProfileDetails): Promise<UserInfo>;
 
     /**
      * Removes an OAuth2 access token from the Identity API's token cache.


### PR DESCRIPTION
If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/identity/#method-getProfileUserInfo
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.