### PR TITLE
@types/json-schema: make JSONSchema6/7 assignable to JSONObject

### DIFF
--- a/types/json-schema/.eslintrc.json
+++ b/types/json-schema/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "@typescript-eslint/consistent-type-definitions": "off",
         "@typescript-eslint/no-empty-interface": "off"
     }
 }

--- a/types/json-schema/.eslintrc.json
+++ b/types/json-schema/.eslintrc.json
@@ -1,6 +1,5 @@
 {
     "rules": {
-        "@typescript-eslint/consistent-type-definitions": "off",
         "@typescript-eslint/no-empty-interface": "off"
     }
 }

--- a/types/json-schema/index.d.ts
+++ b/types/json-schema/index.d.ts
@@ -280,7 +280,7 @@ export type JSONSchema6Version = string;
  * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01
  */
 export type JSONSchema6Definition = JSONSchema6 | boolean;
-export type JSONSchema6 = {
+export interface JSONSchema6 {
     $id?: string | undefined;
     $ref?: string | undefined;
     $schema?: JSONSchema6Version | undefined;
@@ -545,7 +545,9 @@ export type JSONSchema6 = {
      * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-8
      */
     format?: string | undefined;
-};
+
+    [k: string]: any;
+}
 
 // ==================================================================================================
 // JSON Schema Draft 07
@@ -605,7 +607,7 @@ export type JSONSchema7Version = string;
  * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01
  */
 export type JSONSchema7Definition = JSONSchema7 | boolean;
-export type JSONSchema7 = {
+export interface JSONSchema7 {
     $id?: string | undefined;
     $ref?: string | undefined;
     $schema?: JSONSchema7Version | undefined;
@@ -712,7 +714,9 @@ export type JSONSchema7 = {
     readOnly?: boolean | undefined;
     writeOnly?: boolean | undefined;
     examples?: JSONSchema7Type | undefined;
-};
+    // "additional vocabularies can be defined for more complex annotation-based applications"
+    [k: string]: any;
+}
 
 export interface ValidationResult {
     valid: boolean;

--- a/types/json-schema/index.d.ts
+++ b/types/json-schema/index.d.ts
@@ -54,7 +54,7 @@ export type JSONSchema4Version = string;
  * JSON Schema V4
  * @see https://tools.ietf.org/html/draft-zyp-json-schema-04
  */
-export interface JSONSchema4 {
+export type JSONSchema4 = {
     id?: string | undefined;
     $ref?: string | undefined;
     $schema?: JSONSchema4Version | undefined;
@@ -280,7 +280,7 @@ export type JSONSchema6Version = string;
  * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01
  */
 export type JSONSchema6Definition = JSONSchema6 | boolean;
-export interface JSONSchema6 {
+export type JSONSchema6 = {
     $id?: string | undefined;
     $ref?: string | undefined;
     $schema?: JSONSchema6Version | undefined;
@@ -605,7 +605,7 @@ export type JSONSchema7Version = string;
  * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01
  */
 export type JSONSchema7Definition = JSONSchema7 | boolean;
-export interface JSONSchema7 {
+export type JSONSchema7 = {
     $id?: string | undefined;
     $ref?: string | undefined;
     $schema?: JSONSchema7Version | undefined;

--- a/types/json-schema/index.d.ts
+++ b/types/json-schema/index.d.ts
@@ -229,7 +229,7 @@ export type JSONSchema4 = {
     [k: string]: any;
 
     format?: string | undefined;
-}
+};
 
 // ==================================================================================================
 // JSON Schema Draft 06
@@ -545,7 +545,7 @@ export type JSONSchema6 = {
      * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-8
      */
     format?: string | undefined;
-}
+};
 
 // ==================================================================================================
 // JSON Schema Draft 07
@@ -712,7 +712,7 @@ export type JSONSchema7 = {
     readOnly?: boolean | undefined;
     writeOnly?: boolean | undefined;
     examples?: JSONSchema7Type | undefined;
-}
+};
 
 export interface ValidationResult {
     valid: boolean;

--- a/types/json-schema/index.d.ts
+++ b/types/json-schema/index.d.ts
@@ -54,7 +54,7 @@ export type JSONSchema4Version = string;
  * JSON Schema V4
  * @see https://tools.ietf.org/html/draft-zyp-json-schema-04
  */
-export type JSONSchema4 = {
+export interface JSONSchema4 {
     id?: string | undefined;
     $ref?: string | undefined;
     $schema?: JSONSchema4Version | undefined;
@@ -229,7 +229,7 @@ export type JSONSchema4 = {
     [k: string]: any;
 
     format?: string | undefined;
-};
+}
 
 // ==================================================================================================
 // JSON Schema Draft 06

--- a/types/json-schema/json-schema-tests.ts
+++ b/types/json-schema/json-schema-tests.ts
@@ -253,7 +253,9 @@ mustBeValid(result);
 result = checkPropertyChange({ foo: "bar" }, { $id: "schema-id" }, "foo");
 
 type JSONValue = string | number | boolean | null | JSONObject | JSONArray;
-interface JSONObject { [key: string]: JSONValue; }
+interface JSONObject {
+    [key: string]: JSONValue;
+}
 interface JSONArray extends Array<JSONValue> {}
 
 // JSONSchema4 should be assignable to JSON

--- a/types/json-schema/json-schema-tests.ts
+++ b/types/json-schema/json-schema-tests.ts
@@ -251,3 +251,25 @@ let result = validate({}, { $id: "schema-id" });
 mustBeValid(result);
 
 result = checkPropertyChange({ foo: "bar" }, { $id: "schema-id" }, "foo");
+
+type JSONValue = string | number | boolean | null | JSONObject | JSONArray;
+interface JSONObject { [key: string]: JSONValue; }
+interface JSONArray extends Array<JSONValue> {}
+
+// JSONSchema4 should be assignable to JSON
+(() => {
+    const schema: JSONSchema4 = {};
+    const json: JSONObject = schema;
+});
+
+// JSONSchema6 should be assignable to JSON
+(() => {
+    const schema: JSONSchema6 = {};
+    const json: JSONObject = schema;
+});
+
+// JSONSchema7 should be assignable to JSON
+(() => {
+    const schema: JSONSchema7 = {};
+    const json: JSONObject = schema;
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [json-schema](https://www.npmjs.com/package/json-schema) is a way of describing a schema in JSON. It is a subset of JSON, and should therefore be assignable to JSON.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

This PR enables `const json: JSONObject = schema` to work, where `schema` is a `JSONSchema7` object. The way the PR works is by changing from using an `interface` to using a `type` so that the error `Index signature for type 'string' is missing in type 'JSONSchema7'` is not produced when assigning to `JSONObject`.