### PR TITLE
fix(tz-format): Bump version, rewrite format() as overloaded function

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -1683,7 +1683,6 @@
         "twitch-ext",
         "twitter-for-web",
         "typography",
-        "tz-format",
         "uikit",
         "umami-browser",
         "umbraco",

--- a/types/tz-format/index.d.ts
+++ b/types/tz-format/index.d.ts
@@ -1,3 +1,20 @@
-declare function format(date?: Date | number, offset?: number): string;
-declare namespace format {}
+declare function format(): string;
+declare function format(
+    /**
+     * Offset from UTC in hours.
+     */
+    offset: number,
+): string;
+declare function format(
+    /**
+     * Date to be formatted
+     * @default new Date()
+     */
+    date: Date,
+    /**
+     * Offset from UTC in hours.
+     */
+    offset?: number,
+): string;
+
 export = format;

--- a/types/tz-format/package.json
+++ b/types/tz-format/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/tz-format",
-    "version": "0.0.9999",
+    "version": "1.1.9999",
     "projects": [
         "https://github.com/SamVerschueren/tz-format"
     ],

--- a/types/tz-format/tz-format-tests.ts
+++ b/types/tz-format/tz-format-tests.ts
@@ -1,6 +1,10 @@
-import format = require("tz-format");
+import format from "tz-format";
 
+// $ExpectType string
 format();
+// $ExpectType string
 format(1);
+// $ExpectType string
 format(new Date());
+// $ExpectType string
 format(new Date(), 1);


### PR DESCRIPTION
The rewritten `format()` type as an overloaded function can be verified via [test codes in the original repo](https://github.com/SamVerschueren/tz-format/blob/master/test.js).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
