### PR TITLE
[lodash] convert _.includes to type guard

### DIFF
--- a/types/lodash/common/collection.d.ts
+++ b/types/lodash/common/collection.d.ts
@@ -1,4 +1,5 @@
 import _ = require("../index");
+import { uniqueSymbol } from "./common";
 declare module "../index" {
     interface LoDashStatic {
         /**
@@ -1004,25 +1005,25 @@ declare module "../index" {
          * @param fromIndex The index to search from.
          * @return True if the target element is found, else false.
          */
-        includes<T>(collection: Dictionary<T> | NumericDictionary<T> | null | undefined, target: T, fromIndex?: number): boolean;
+        includes<T>(collection: Dictionary<T> | NumericDictionary<T> | null | undefined, target: unknown, fromIndex?: number): target is T & { [uniqueSymbol]?: unknown };
     }
     interface Object<T> {
         /**
          * @see _.includes
          */
-        includes(target: T[keyof T], fromIndex?: number): boolean;
+        includes(target: unknown, fromIndex?: number): target is T[keyof T] & { [uniqueSymbol]?: unknown };
     }
     interface Collection<T> {
         /**
          * @see _.includes
          */
-        includes(target: T, fromIndex?: number): boolean;
+        includes(target: unknown, fromIndex?: number): target is T & { [uniqueSymbol]?: unknown };
     }
     interface String {
         /**
          * @see _.includes
          */
-        includes(target: string, fromIndex?: number): boolean;
+        includes(target: unknown, fromIndex?: number): target is string & { [uniqueSymbol]?: unknown };
     }
     interface ObjectChain<T> {
         /**

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -2580,17 +2580,154 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType CollectionChain<number>
 
 // _.includes
 {
+    const unknownValue: unknown = anything;
+    const numberValue: number = anything;
+    const unionValue: 1 | "a" = anything;
+    const stringValue: string = anything;
+    const numberArray: number[] = anything;
+
+    _.includes(numberArray, numberValue); // $ExpectType boolean
+    _.includes(numberArray, numberValue, 42); // $ExpectType boolean
+    if (_.includes(numberArray, numberValue)) {
+        const x: number = numberValue;
+    } else {
+        numberValue; // $ExpectType number
+    }
+    if (_.includes(numberArray, unknownValue)) {
+        const x: number = unknownValue;
+    } else {
+        unknownValue; // $ExpectType unknown
+    }
+
     _.includes(list, abcObject); // $ExpectType boolean
     _.includes(list, abcObject, 42); // $ExpectType boolean
+    if (_.includes(list, abcObject)) {
+        const x: AbcObject = abcObject;
+    } else {
+        abcObject; // $ExpectType AbcObject
+    }
+    if (_.includes(list, unknownValue)) {
+        const x: AbcObject = unknownValue;
+    } else {
+        unknownValue; // $ExpectType unknown
+    }
+
     _.includes(dictionary, abcObject); // $ExpectType boolean
     _.includes(dictionary, abcObject, 42); // $ExpectType boolean
+    if (_.includes(dictionary, abcObject)) {
+        const x: AbcObject = abcObject;
+    } else {
+        abcObject; // $ExpectType AbcObject
+    }
+    if (_.includes(dictionary, unknownValue)) {
+        const x: AbcObject = unknownValue;
+    } else {
+        unknownValue; // $ExpectType unknown
+    }
+
+    _.includes(anything as [1, "a"], unionValue); // $ExpectType boolean
+    _.includes(anything as [1, "a"], unionValue, 42); // $ExpectType boolean
+    if (_.includes(anything as [1, "a"], unionValue)) {
+        const x: 1 | "a" = unionValue;
+    } else {
+        unionValue; // $ExpectType 1 | "a"
+    }
+    if (_.includes(anything as [1, "a"], unknownValue)) {
+        const x: 1 | "a" = unknownValue;
+    } else {
+        unknownValue; // $ExpectType unknown
+    }
+
+    _.includes([1, "a"] as const, unionValue); // $ExpectType boolean
+    _.includes([1, "a"] as const, unionValue, 42); // $ExpectType boolean
+    if (_.includes([1, "a"] as const, unionValue)) {
+        const x: 1 | "a" = unionValue;
+    } else {
+        unionValue; // $ExpectType 1 | "a"
+    }
+    if (_.includes([1, "a"] as const, unknownValue)) {
+        const x: 1 | "a" = unknownValue;
+    } else {
+        unknownValue; // $ExpectType unknown
+    }
+
+    _(numberArray).includes(numberValue); // $ExpectType boolean
+    _(numberArray).includes(numberValue, 42); // $ExpectType boolean
+    if (_(numberArray).includes(numberValue)) {
+        const x: number = numberValue;
+    } else {
+        numberValue; // $ExpectType number
+    }
+    if (_(numberArray).includes(unknownValue)) {
+        const x: number = unknownValue;
+    } else {
+        unknownValue; // $ExpectType unknown
+    }
 
     _(list).includes(abcObject); // $ExpectType boolean
     _(list).includes(abcObject, 42); // $ExpectType boolean
+    if (_(list).includes(abcObject)) {
+        const x: AbcObject = abcObject;
+    } else {
+        abcObject; // $ExpectType AbcObject
+    }
+    if (_(list).includes(unknownValue)) {
+        const x: AbcObject = unknownValue;
+    } else {
+        unknownValue; // $ExpectType unknown
+    }
+
     _(dictionary).includes(abcObject); // $ExpectType boolean
     _(dictionary).includes(abcObject, 42); // $ExpectType boolean
+    if (_(dictionary).includes(abcObject)) {
+        const x: AbcObject = abcObject;
+    } else {
+        abcObject; // $ExpectType AbcObject
+    }
+    if (_(dictionary).includes(unknownValue)) {
+        const x: AbcObject = unknownValue;
+    } else {
+        unknownValue; // $ExpectType unknown
+    }
+
     _('hi').includes('h'); // $ExpectType boolean
     _('hi').includes('h', 0); // $ExpectType boolean
+    if (_('hi').includes(stringValue)) {
+        const x: string = stringValue;
+    } else {
+        stringValue; // $ExpectType string
+    }
+    if (_('hi').includes(unknownValue)) {
+        const x: string = unknownValue;
+    } else {
+        unknownValue; // $ExpectType unknown
+    }
+    
+    _(anything as [1, "a"]).includes(unionValue); // $ExpectType boolean
+    _(anything as [1, "a"]).includes(unionValue, 42); // $ExpectType boolean
+    if (_(anything as [1, "a"]).includes(unionValue)) {
+        const x: 1 | "a" = unionValue;
+    } else {
+        unionValue; // $ExpectType 1 | "a"
+    }
+    if (_(anything as [1, "a"]).includes(unknownValue)) {
+        const x: 1 | "a" = unknownValue;
+    } else {
+        unknownValue; // $ExpectType unknown
+    }
+
+    _([1, "a"] as const).includes(unionValue); // $ExpectType boolean
+    _([1, "a"] as const).includes(unionValue, 42); // $ExpectType boolean
+    if (_([1, "a"] as const).includes(unionValue)) {
+        const x: 1 | "a" = unionValue;
+    } else {
+        unionValue; // $ExpectType 1 | "a"
+    }
+    if (_([1, "a"] as const).includes(unknownValue)) {
+        const x: 1 | "a" = unknownValue;
+    } else {
+        unknownValue; // $ExpectType unknown
+    }
 
     _.chain(list).includes(abcObject); // $ExpectType PrimitiveChain<boolean>
     _.chain(list).includes(abcObject, 42); // $ExpectType PrimitiveChain<boolean>


### PR DESCRIPTION
Let's assume that we want to implement a radio group using react. We have two radio items: "coding" and "music". In this case, I want to store the option selected by user, so I'll add `onChange listener` to the form element and set state to `event.target.value`. We know that `event.target.value` is `"coding" | "music"` but TS doesn't.

```tsx
import { useState } from "react";

const items = ["coding", "music"] as const;

type Item = (typeof items)[number];
//    ^? type Item = "coding" | "music"

function App() {
  const [selectedItem, setSelectedItem] = useState<Item>("coding");

  return (
    <>
      <form
        onChange={(e) => {
          if (e.target instanceof HTMLInputElement) {
            // @ts-expect-error
            setSelectedItem(e.target.value);
          }
        }}
      >
        {items.map((item) => (
          <div key={item}>
            <input type="radio" id={item} name="interest" value={item} />
            <label htmlFor={item}>{item}</label>
          </div>
        ))}
      </form>

      <p>{`checked: ${selectedItem}`}</p>
    </>
  );
}

export default App;
```

So, I have to check the value is one of the items one by one to resolve the type error like this.

```tsx
onChange={(e) => {
  if (e.target instanceof HTMLInputElement) {
    const newValue = e.target.value;
    if (newValue === "coding" || newValue === "music") {
      setSelectedItem(newValue);
    }
  }
}}
```

Currently, it's just tedious job, but if we have 10 or more items to check, it's painful. That's why I suggest converting `_.includes` to type guard. If `_.includes` is type guard, I can rewrite the code like this.

```diff
 onChange={(e) => {
   if (e.target instanceof HTMLInputElement) {
     const newValue = e.target.value;
-    if (newValue === "coding" || newValue === "music") {
-      setSelectedItem(newValue);
-    }
+    if (_.includes(items, newValue)) {
+      setSelectedItem(newValue);
+    }
   }
 }}
```

It's much simpler and I don't need to add new condition when new option is added.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://lodash.com/docs/4.17.15#includes>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
