### PR TITLE
[sprintf-js] fix type of args in vsprintf()

### DIFF
--- a/types/sprintf-js/index.d.ts
+++ b/types/sprintf-js/index.d.ts
@@ -154,4 +154,4 @@ export function sprintf(format: string, ...args: any[]): string;
  *     * `j` — yields a JavaScript object or array as a JSON encoded string
  * @param args: the arguments for the format string
  */
-export function vsprintf(format: string, args: any[]): string;
+export function vsprintf(format: string, args: any): string;

--- a/types/sprintf-js/sprintf-js-tests.ts
+++ b/types/sprintf-js/sprintf-js-tests.ts
@@ -10,3 +10,4 @@ sprintf.sprintf(str, num, str);
 sprintf.vsprintf(str, [str]); // $ExpectType string
 sprintf.vsprintf(str, [str, num]);
 sprintf.vsprintf(str, [num, str]);
+sprintf.vsprintf(str, { x: num });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [source code](https://github.com/alexei/sprintf.js/blob/master/src/sprintf.js#L30), [sprintf-js test that passes an object to vsprintf()](https://github.com/alexei/sprintf.js/blob/master/test/test_validation.js#L62)
