### PR TITLE
[arangodb] mark as conflicting on npm

### DIFF
--- a/types/arangodb/package.json
+++ b/types/arangodb/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "@types/arangodb",
     "version": "3.5.9999",
-    "nonNpm": true,
+    "nonNpm": "conflict",
     "nonNpmDescription": "ArangoDB",
     "projects": [
         "https://github.com/arangodb/arangodb"


### PR DESCRIPTION
An`arangodb` package was made on npm; that package has since been taken down (it was malware), but we still need to mark this package as conflicting since npm still has an empty security stub.