### PR TITLE
[node] Cleanup generics of EventEmitter and correct types

### DIFF
--- a/types/airbnb__node-memwatch/airbnb__node-memwatch-tests.ts
+++ b/types/airbnb__node-memwatch/airbnb__node-memwatch-tests.ts
@@ -4,7 +4,7 @@ import * as memwatch from "@airbnb/node-memwatch";
 memwatch.on("foobar");
 // @ts-expect-error
 memwatch.on("stats", "baz");
-// $ExpectType EventEmitter<DefaultEventMap>
+// $ExpectType EventEmitter<{}>
 memwatch.on("stats", (
     result, // $ExpectType GcStats
 ) => {

--- a/types/airbnb__node-memwatch/airbnb__node-memwatch-tests.ts
+++ b/types/airbnb__node-memwatch/airbnb__node-memwatch-tests.ts
@@ -4,7 +4,7 @@ import * as memwatch from "@airbnb/node-memwatch";
 memwatch.on("foobar");
 // @ts-expect-error
 memwatch.on("stats", "baz");
-// $ExpectType EventEmitter<{}>
+// $ExpectType EventEmitter<NoEventMap>
 memwatch.on("stats", (
     result, // $ExpectType GcStats
 ) => {

--- a/types/hubot/hubot-tests.ts
+++ b/types/hubot/hubot-tests.ts
@@ -6,7 +6,7 @@ const message = new Message(user);
 const robot = new Robot<Adapter>("src/adapters", false, "hubot");
 robot; // $ExpectType Robot<Adapter>
 robot.name; // $ExpectType string
-robot.events; // $ExpectType EventEmitter<DefaultEventMap>
+robot.events; // $ExpectType EventEmitter<{}>
 robot.brain; // $ExpectType Brain<Adapter>
 robot.alias; // $ExpectType string
 robot.adapterName; // $ExpectType string

--- a/types/hubot/hubot-tests.ts
+++ b/types/hubot/hubot-tests.ts
@@ -6,7 +6,7 @@ const message = new Message(user);
 const robot = new Robot<Adapter>("src/adapters", false, "hubot");
 robot; // $ExpectType Robot<Adapter>
 robot.name; // $ExpectType string
-robot.events; // $ExpectType EventEmitter<{}>
+robot.events; // $ExpectType EventEmitter<NoEventMap>
 robot.brain; // $ExpectType Brain<Adapter>
 robot.alias; // $ExpectType string
 robot.adapterName; // $ExpectType string

--- a/types/imap/index.d.ts
+++ b/types/imap/index.d.ts
@@ -267,18 +267,6 @@ declare namespace Connection {
 declare class Connection extends EventEmitter implements Connection.MessageFunctions {
     constructor(config: Connection.Config);
 
-    // from NodeJS.EventEmitter
-    addListener(event: string, listener: Function): this;
-    on(event: string, listener: Function): this;
-    once(event: string, listener: Function): this;
-    removeListener(event: string, listener: Function): this;
-    removeAllListeners(event?: string): this;
-    setMaxListeners(n: number): this;
-    getMaxListeners(): number;
-    listeners(event: string): Function[];
-    emit(event: string, ...args: any[]): boolean;
-    listenerCount(type: string): number;
-
     // from MessageFunctions
     /** Searches the currently open mailbox for messages using given criteria. criteria is a list describing what you want to find. For criteria types that require arguments, use an array instead of just the string criteria type name (e.g. ['FROM', 'foo@bar.com']). Prefix criteria types with an "!" to negate. */
     search(criteria: any[], callback: (error: Error, uids: number[]) => void): void;

--- a/types/jake/index.d.ts
+++ b/types/jake/index.d.ts
@@ -241,16 +241,6 @@ declare global {
              */
             reenable(): void;
 
-            addListener(event: string, listener: Function): this;
-            on(event: string, listener: Function): this;
-            once(event: string, listener: Function): this;
-            removeListener(event: string, listener: Function): this;
-            removeAllListeners(event?: string): this;
-            setMaxListeners(n: number): this;
-            getMaxListeners(): number;
-            listeners(event: string): Function[];
-            emit(event: string, ...args: any[]): boolean;
-            listenerCount(type: string): number;
             complete(value?: any): void;
             value: any;
 

--- a/types/newman/newman-tests.ts
+++ b/types/newman/newman-tests.ts
@@ -23,7 +23,7 @@ const workingDir = "path/to/working/directory";
 const insecureFileRead = true;
 const requestAgent = new http.Agent();
 
-// $ExpectType EventEmitter<DefaultEventMap>
+// $ExpectType EventEmitter<{}>
 run(
     {
         collection,

--- a/types/newman/newman-tests.ts
+++ b/types/newman/newman-tests.ts
@@ -23,7 +23,7 @@ const workingDir = "path/to/working/directory";
 const insecureFileRead = true;
 const requestAgent = new http.Agent();
 
-// $ExpectType EventEmitter<{}>
+// $ExpectType EventEmitter<NoEventMap>
 run(
     {
         collection,

--- a/types/node-red/node-red-tests.ts
+++ b/types/node-red/node-red-tests.ts
@@ -23,7 +23,7 @@ async function REDTests() {
     // $ExpectType Util
     RED.util;
 
-    // $ExpectType EventEmitter<DefaultEventMap>
+    // $ExpectType EventEmitter<{}>
     RED.events;
 
     // $ExpectType Hooks

--- a/types/node-red/node-red-tests.ts
+++ b/types/node-red/node-red-tests.ts
@@ -23,7 +23,7 @@ async function REDTests() {
     // $ExpectType Util
     RED.util;
 
-    // $ExpectType EventEmitter<{}>
+    // $ExpectType EventEmitter<NoEventMap>
     RED.events;
 
     // $ExpectType Hooks

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -138,11 +138,6 @@ declare module "events" {
     class EventEmitter<Events extends EventMap<Events> = {}> {
         constructor(options?: EventEmitterOptions);
 
-        // This "property" is used to brand a specific instance of the EventEmitter class with its Event map, which is needed
-        // in order to infer the map if we have a chain like `class A extends EventEmitter<{}>` (or many levels deep)
-        // It is also marked as possibly undefined in order to allow something like `const t: NodeJS.EventEmitter<{}> = { <insert implementation here> };`
-        readonly #internalTypeOnlyBrand?: Events;
-
         [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
             error: Error,
             event: EventName,
@@ -229,11 +224,6 @@ declare module "events" {
          * ```
          * @since v11.13.0, v10.16.0
          */
-        static once<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
-            emitter: EventEmitter<Events>,
-            eventName: EventName,
-            options?: StaticEventEmitterOptions,
-        ): Promise<Args<Events, EventName>>;
         static once(
             emitter: NodeJS.EventEmitter,
             eventName: string | symbol,
@@ -320,11 +310,6 @@ declare module "events" {
          * @since v13.6.0, v12.16.0
          * @return An `AsyncIterator` that iterates `eventName` events emitted by the `emitter`
          */
-        static on<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
-            emitter: EventEmitter<Events>,
-            eventName: EventName,
-            options?: StaticEventEmitterIteratorOptions,
-        ): NodeJS.AsyncIterator<Args<Events, EventName>>;
         static on(
             emitter: NodeJS.EventEmitter,
             eventName: string | symbol,
@@ -335,27 +320,6 @@ declare module "events" {
             eventName: string,
             options?: StaticEventEmitterIteratorOptions,
         ): NodeJS.AsyncIterator<any[]>;
-        /**
-         * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
-         *
-         * ```js
-         * import { EventEmitter, listenerCount } from 'node:events';
-         *
-         * const myEmitter = new EventEmitter();
-         * myEmitter.on('event', () => {});
-         * myEmitter.on('event', () => {});
-         * console.log(listenerCount(myEmitter, 'event'));
-         * // Prints: 2
-         * ```
-         * @since v0.9.12
-         * @deprecated Since v3.2.0 - Use `listenerCount` instead.
-         * @param emitter The emitter to query
-         * @param eventName The event name
-         */
-        static listenerCount<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
-            emitter: EventEmitter<Events>,
-            eventName: EventName,
-        ): number;
         /**
          * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
          *
@@ -401,10 +365,6 @@ declare module "events" {
          * ```
          * @since v15.2.0, v14.17.0
          */
-        static getEventListeners<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
-            emitter: EventEmitter<Events>,
-            name: EventName,
-        ): Array<Listener<Events, EventName>>;
         static getEventListeners(
             emitter: EventTarget | NodeJS.EventEmitter,
             name: string | symbol,

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -1,3 +1,5 @@
+declare const internalTypeOnlyBrandSymbol: unique symbol;
+
 /**
  * Much of the Node.js core API is built around an idiomatic asynchronous
  * event-driven architecture in which certain kinds of objects (called "emitters")
@@ -34,6 +36,7 @@
  * ```
  * @see [source](https://github.com/nodejs/node/blob/v24.x/lib/events.js)
  */
+
 declare module "events" {
     import { AsyncResource, AsyncResourceOptions } from "node:async_hooks";
     // NOTE: This class is in the docs but is **not actually exported** by Node.
@@ -120,6 +123,7 @@ declare module "events" {
         : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
             ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
             : (...args: any[]) => void);
+
     /**
      * The `EventEmitter` class is defined and exposed by the `node:events` module:
      *
@@ -639,6 +643,11 @@ declare module "events" {
     global {
         namespace NodeJS {
             interface EventEmitter<Events extends EventMap<Events> = {}> {
+                // This "property" is used to brand a specific instance of the EventEmitter class with its Event map, which is needed
+                // in order to infer the map if we have a chain like `class A extends EventEmitter<{}>` (or many levels deep)
+                // It is also marked as possibly undefined in order to allow something like `const t: NodeJS.EventEmitter<{}> = { <insert implementation here> };`
+                readonly [internalTypeOnlyBrandSymbol]?: Events;
+
                 [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
                     error: Error,
                     event: EventName,

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -113,15 +113,17 @@ declare module "events" {
         : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
             ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
             : any[]);
-    type EventNames<Events extends EventMap<Events>> = keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap;
-    type EventNameParam<Events extends EventMap<Events>, EventName> = EventName | EventNames<Events>;
-    type Listener<Events extends EventMap<Events>, EventName> = EventName extends
-        (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap) ?
-            | (EventName extends keyof Events ? ((...args: Events[EventName]) => void) : never)
-            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
-                ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
-                : never)
-        : ((...args: any[]) => void);
+    type EventNames<Events extends EventMap<Events>> = {} extends Events ? (string | symbol)
+        : (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap);
+    type EventNameParam<Events extends EventMap<Events>, EventName> = {} extends Events ? string | symbol
+        : EventName | EventNames<Events>;
+    type Listener<Events extends EventMap<Events>, EventName> = {} extends Events ? ((...args: any[]) => void)
+        : (EventName extends (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap) ?
+                | (EventName extends keyof Events ? ((...args: Events[EventName]) => void) : never)
+                | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                    ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
+                    : never)
+            : ((...args: any[]) => void));
     /**
      * The `EventEmitter` class is defined and exposed by the `node:events` module:
      *
@@ -598,7 +600,7 @@ declare module "events" {
             readonly asyncResource: EventEmitterReferencingAsyncResource;
         }
 
-        export type NoEventMap = Record<string | symbol, any[]>;
+        export interface NoEventMap {}
 
         /** The events always emitted by EventEmitter itself */
         export interface EventEmitterBuiltInEventMap {

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -1,5 +1,3 @@
-declare const internalTypeOnlyBrandSymbol: unique symbol;
-
 /**
  * Much of the Node.js core API is built around an idiomatic asynchronous
  * event-driven architecture in which certain kinds of objects (called "emitters")
@@ -139,6 +137,11 @@ declare module "events" {
      */
     class EventEmitter<Events extends EventMap<Events> = {}> {
         constructor(options?: EventEmitterOptions);
+
+        // This "property" is used to brand a specific instance of the EventEmitter class with its Event map, which is needed
+        // in order to infer the map if we have a chain like `class A extends EventEmitter<{}>` (or many levels deep)
+        // It is also marked as possibly undefined in order to allow something like `const t: NodeJS.EventEmitter<{}> = { <insert implementation here> };`
+        readonly #internalTypeOnlyBrand?: Events;
 
         [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
             error: Error,
@@ -643,11 +646,6 @@ declare module "events" {
     global {
         namespace NodeJS {
             interface EventEmitter<Events extends EventMap<Events> = {}> {
-                // This "property" is used to brand a specific instance of the EventEmitter class with its Event map, which is needed
-                // in order to infer the map if we have a chain like `class A extends EventEmitter<{}>` (or many levels deep)
-                // It is also marked as possibly undefined in order to allow something like `const t: NodeJS.EventEmitter<{}> = { <insert implementation here> };`
-                readonly [internalTypeOnlyBrandSymbol]?: Events;
-
                 [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
                     error: Error,
                     event: EventName,

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -627,7 +627,7 @@ declare module "events" {
                  * Alias for `emitter.on(eventName, listener)`.
                  * @since v0.1.26
                  */
-                addListener<EventName>(
+                addListener<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -662,7 +662,7 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                on<EventName>(
+                on<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -695,7 +695,7 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                once<EventName>(
+                once<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -781,7 +781,7 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeListener<EventName>(
+                removeListener<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -789,7 +789,7 @@ declare module "events" {
                  * Alias for `emitter.removeListener()`.
                  * @since v10.0.0
                  */
-                off<EventName>(
+                off<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -804,8 +804,9 @@ declare module "events" {
                  * @since v0.1.26
                  */
                 /* eslint-disable @definitelytyped/no-unnecessary-generics */
-                removeAllListeners<EventName extends EventNames<Events>>(eventName: EventName): this;
-                removeAllListeners<EventName extends string | symbol>(eventName?: EventName): this;
+                removeAllListeners<EventName extends string | symbol>(
+                    eventName?: EventNameParam<Events, EventName>,
+                ): this;
                 /* eslint-enable @definitelytyped/no-unnecessary-generics */
                 /**
                  * By default `EventEmitter`s will print a warning if more than `10` listeners are
@@ -835,7 +836,7 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                listeners<EventName>(
+                listeners<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                 ): Array<Listener<Events, EventName>>;
                 /**
@@ -868,7 +869,7 @@ declare module "events" {
                  * ```
                  * @since v9.4.0
                  */
-                rawListeners<EventName>(
+                rawListeners<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                 ): Array<Listener<Events, EventName>>;
                 /**
@@ -927,7 +928,7 @@ declare module "events" {
                  * @param eventName The name of the event being listened for
                  * @param listener The event handler function
                  */
-                listenerCount<EventName>(
+                listenerCount<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                     listener?: Listener<Events, EventName>,
                 ): number;
@@ -948,7 +949,7 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependListener<EventName>(
+                prependListener<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -967,7 +968,7 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependOnceListener<EventName>(
+                prependOnceListener<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -990,7 +991,7 @@ declare module "events" {
                  * ```
                  * @since v6.0.0
                  */
-                eventNames(): Array<(string | symbol)> & Array<EventNames<Events>>;
+                eventNames(): Array<(string | symbol)>;
             }
         }
     }

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -620,7 +620,11 @@ declare module "events" {
                  * Alias for `emitter.on(eventName, listener)`.
                  * @since v0.1.26
                  */
-                addListener<EventName extends EventNames<Events> | string & {} | symbol>(
+                addListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                addListener<EventName extends string | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -655,7 +659,11 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                on<EventName extends EventNames<Events> | string & {} | symbol>(
+                on<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                on<EventName extends string | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -688,7 +696,11 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                once<EventName extends EventNames<Events> | string & {} | symbol>(
+                once<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                once<EventName extends string | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -774,7 +786,11 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeListener<EventName extends EventNames<Events> | string & {} | symbol>(
+                removeListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                removeListener<EventName extends string | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -782,7 +798,11 @@ declare module "events" {
                  * Alias for `emitter.removeListener()`.
                  * @since v10.0.0
                  */
-                off<EventName extends EventNames<Events> | string & {} | symbol>(
+                off<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                off<EventName extends string | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -797,7 +817,8 @@ declare module "events" {
                  * @since v0.1.26
                  */
                 /* eslint-disable @definitelytyped/no-unnecessary-generics */
-                removeAllListeners<EventName extends EventNames<Events> | string & {} | symbol>(eventName?: EventName): this;
+                removeAllListeners<EventName extends EventNames<Events>>(eventName: EventName): this;
+                removeAllListeners<EventName extends string | symbol>(eventName?: EventName): this;
                 /* eslint-enable @definitelytyped/no-unnecessary-generics */
                 /**
                  * By default `EventEmitter`s will print a warning if more than `10` listeners are
@@ -830,9 +851,9 @@ declare module "events" {
                 listeners<EventName extends EventNames<Events>>(
                     eventName: EventName,
                 ): Array<Listener<Events, EventName>>;
-                listeners(
-                    eventName: string | symbol,
-                ): Array<Listener<Events, string | symbol>>;
+                listeners<EventName extends string | symbol>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
                  * including any wrappers (such as those created by `.once()`).
@@ -866,9 +887,9 @@ declare module "events" {
                 rawListeners<EventName extends EventNames<Events>>(
                     eventName: EventName,
                 ): Array<Listener<Events, EventName>>;
-                rawListeners(
-                    eventName: string | symbol,
-                ): Array<Listener<Events, string | symbol>>;
+                rawListeners<EventName extends string | symbol>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
                 /**
                  * Synchronously calls each of the listeners registered for the event named `eventName`, in the order they were registered, passing the supplied arguments
                  * to each.
@@ -909,7 +930,11 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                emit<EventName extends EventNames<Events> | string & {} | symbol>(
+                emit<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    ...args: Args<Events, EventName>
+                ): boolean;
+                emit<EventName extends string | symbol>(
                     eventName: EventName,
                     ...args: Args<Events, EventName>
                 ): boolean;
@@ -921,7 +946,11 @@ declare module "events" {
                  * @param eventName The name of the event being listened for
                  * @param listener The event handler function
                  */
-                listenerCount<EventName extends EventNames<Events> | string & {} | symbol>(
+                listenerCount<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener?: Listener<Events, EventName>,
+                ): number;
+                listenerCount<EventName extends string | symbol>(
                     eventName: EventName,
                     listener?: Listener<Events, EventName>,
                 ): number;
@@ -942,7 +971,11 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependListener<EventName extends EventNames<Events> | string & {} | symbol>(
+                prependListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                prependListener<EventName extends string | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -961,7 +994,11 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependOnceListener<EventName extends EventNames<Events> | string & {} | symbol>(
+                prependOnceListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                prependOnceListener<EventName extends string | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -99,24 +99,27 @@ declare module "events" {
          */
         lowWaterMark?: number | undefined;
     }
-    interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
-    type EventMap<T> = Record<keyof T, any[]> | DefaultEventMap;
-    type DefaultEventMap = [never];
-    type AnyRest = [...args: any[]];
-    type Args<K, T> = T extends DefaultEventMap ? AnyRest : (
-        K extends keyof T ? T[K] : never
-    );
-    type Key<K, T> = T extends DefaultEventMap ? string | symbol : K | keyof T;
-    type Key2<K, T> = T extends DefaultEventMap ? string | symbol : K & keyof T;
-    type Listener<K, T, F> = T extends DefaultEventMap ? F : (
-        K extends keyof T ? (
-                T[K] extends unknown[] ? (...args: T[K]) => void : never
-            )
-            : never
-    );
-    type Listener1<K, T> = Listener<K, T, (...args: any[]) => void>;
-    type Listener2<K, T> = Listener<K, T, Function>;
-
+    interface EventEmitter<Events extends EventMap<Events> = {}> extends NodeJS.EventEmitter<Events> {}
+    type EventMap<Events> = Record<keyof Events, unknown[]>;
+    type Args<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ? (
+            | Events[EventName]
+            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
+                : never)
+        )
+        : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+            ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
+            : any[]);
+    type EventNames<Events extends EventMap<Events>> = {} extends Events ? (string | symbol)
+        : (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap);
+    type Listener<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ?
+            | ((...args: Events[EventName]) => void)
+            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
+                : never)
+        : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+            ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
+            : (...args: any[]) => void);
     /**
      * The `EventEmitter` class is defined and exposed by the `node:events` module:
      *
@@ -130,10 +133,15 @@ declare module "events" {
      * It supports the following option:
      * @since v0.1.26
      */
-    class EventEmitter<T extends EventMap<T> = DefaultEventMap> {
+    class EventEmitter<Events extends EventMap<Events> = {}> {
         constructor(options?: EventEmitterOptions);
 
-        [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
+        [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
+            error: Error,
+            event: EventName,
+            ...args: Args<Events, EventName>
+        ): void;
+        [EventEmitter.captureRejectionSymbol]?(error: Error, event: string | symbol, ...args: any[]): void;
 
         /**
          * Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
@@ -214,6 +222,11 @@ declare module "events" {
          * ```
          * @since v11.13.0, v10.16.0
          */
+        static once<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            eventName: EventName,
+            options?: StaticEventEmitterOptions,
+        ): Promise<Args<Events, EventName>>;
         static once(
             emitter: NodeJS.EventEmitter,
             eventName: string | symbol,
@@ -300,6 +313,11 @@ declare module "events" {
          * @since v13.6.0, v12.16.0
          * @return An `AsyncIterator` that iterates `eventName` events emitted by the `emitter`
          */
+        static on<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            eventName: EventName,
+            options?: StaticEventEmitterIteratorOptions,
+        ): NodeJS.AsyncIterator<Args<Events, EventName>>;
         static on(
             emitter: NodeJS.EventEmitter,
             eventName: string | symbol,
@@ -310,6 +328,27 @@ declare module "events" {
             eventName: string,
             options?: StaticEventEmitterIteratorOptions,
         ): NodeJS.AsyncIterator<any[]>;
+        /**
+         * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
+         *
+         * ```js
+         * import { EventEmitter, listenerCount } from 'node:events';
+         *
+         * const myEmitter = new EventEmitter();
+         * myEmitter.on('event', () => {});
+         * myEmitter.on('event', () => {});
+         * console.log(listenerCount(myEmitter, 'event'));
+         * // Prints: 2
+         * ```
+         * @since v0.9.12
+         * @deprecated Since v3.2.0 - Use `listenerCount` instead.
+         * @param emitter The emitter to query
+         * @param eventName The event name
+         */
+        static listenerCount<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            eventName: EventName,
+        ): number;
         /**
          * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
          *
@@ -355,7 +394,14 @@ declare module "events" {
          * ```
          * @since v15.2.0, v14.17.0
          */
-        static getEventListeners(emitter: EventTarget | NodeJS.EventEmitter, name: string | symbol): Function[];
+        static getEventListeners<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            name: EventName,
+        ): Array<Listener<Events, EventName>>;
+        static getEventListeners(
+            emitter: EventTarget | NodeJS.EventEmitter,
+            name: string | symbol,
+        ): Function[];
         /**
          * Returns the currently set max amount of listeners.
          *
@@ -584,16 +630,37 @@ declare module "events" {
              */
             readonly asyncResource: EventEmitterReferencingAsyncResource;
         }
+
+        export interface EventEmitterBuiltInEventMap {
+            newListener: [eventName: string | symbol, listener: Function];
+            removeListener: [eventName: string | symbol, listener: Function];
+        }
     }
     global {
         namespace NodeJS {
-            interface EventEmitter<T extends EventMap<T> = DefaultEventMap> {
-                [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
+            interface EventEmitter<Events extends EventMap<Events> = {}> {
+                [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
+                    error: Error,
+                    event: EventName,
+                    ...args: Args<Events, EventName>
+                ): void;
+                [EventEmitter.captureRejectionSymbol]?<EventName extends string | symbol>(
+                    error: Error,
+                    event: EventName,
+                    ...args: Args<Events, EventName>
+                ): void;
                 /**
                  * Alias for `emitter.on(eventName, listener)`.
                  * @since v0.1.26
                  */
-                addListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                addListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                addListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Adds the `listener` function to the end of the listeners array for the event
                  * named `eventName`. No checks are made to see if the `listener` has already
@@ -625,7 +692,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                on<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                on<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                on<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Adds a **one-time** `listener` function for the event named `eventName`. The
                  * next time `eventName` is triggered, this listener is removed and then invoked.
@@ -655,7 +729,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                once<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                once<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                once<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Removes the specified `listener` from the listener array for the event named `eventName`.
                  *
@@ -738,12 +819,26 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                removeListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                removeListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Alias for `emitter.removeListener()`.
                  * @since v10.0.0
                  */
-                off<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                off<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                off<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Removes all listeners, or those of the specified `eventName`.
                  *
@@ -754,7 +849,10 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeAllListeners(eventName?: Key<unknown, T>): this;
+                /* eslint-disable @definitelytyped/no-unnecessary-generics */
+                removeAllListeners<EventName extends EventNames<Events>>(eventName: EventName): this;
+                removeAllListeners<EventName extends string | symbol>(eventName?: EventName): this;
+                /* eslint-enable @definitelytyped/no-unnecessary-generics */
                 /**
                  * By default `EventEmitter`s will print a warning if more than `10` listeners are
                  * added for a particular event. This is a useful default that helps finding
@@ -783,7 +881,12 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                listeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
+                listeners<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
+                listeners<EventName extends string | symbol>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
                  * including any wrappers (such as those created by `.once()`).
@@ -814,7 +917,12 @@ declare module "events" {
                  * ```
                  * @since v9.4.0
                  */
-                rawListeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
+                rawListeners<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
+                rawListeners<EventName extends string | symbol>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
                 /**
                  * Synchronously calls each of the listeners registered for the event named `eventName`, in the order they were registered, passing the supplied arguments
                  * to each.
@@ -855,7 +963,14 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                emit<K>(eventName: Key<K, T>, ...args: Args<K, T>): boolean;
+                emit<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    ...args: Args<Events, EventName>
+                ): boolean;
+                emit<EventName extends string | symbol>(
+                    eventName: EventName,
+                    ...args: Args<Events, EventName>
+                ): boolean;
                 /**
                  * Returns the number of listeners listening for the event named `eventName`.
                  * If `listener` is provided, it will return how many times the listener is found
@@ -864,7 +979,14 @@ declare module "events" {
                  * @param eventName The name of the event being listened for
                  * @param listener The event handler function
                  */
-                listenerCount<K>(eventName: Key<K, T>, listener?: Listener2<K, T>): number;
+                listenerCount<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener?: Listener<Events, EventName>,
+                ): number;
+                listenerCount<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener?: Listener<Events, EventName>,
+                ): number;
                 /**
                  * Adds the `listener` function to the _beginning_ of the listeners array for the
                  * event named `eventName`. No checks are made to see if the `listener` has
@@ -882,7 +1004,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                prependListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                prependListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Adds a **one-time**`listener` function for the event named `eventName` to the _beginning_ of the listeners array. The next time `eventName` is triggered, this
                  * listener is removed, and then invoked.
@@ -898,7 +1027,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependOnceListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                prependOnceListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                prependOnceListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Returns an array listing the events for which the emitter has registered
                  * listeners. The values in the array are strings or `Symbol`s.
@@ -918,7 +1054,7 @@ declare module "events" {
                  * ```
                  * @since v6.0.0
                  */
-                eventNames(): Array<(string | symbol) & Key2<unknown, T>>;
+                eventNames(): Array<(string | symbol)> & Array<EventNames<Events>>;
             }
         }
     }

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -103,26 +103,25 @@ declare module "events" {
     interface EventEmitter<Events extends EventMap<Events> = {}> extends NodeJS.EventEmitter<Events> {}
     type EventMap<Events> = Record<keyof Events, unknown[]>;
     type Args<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ? (
-        | Events[EventName]
-        | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
-            ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
-            : never)
+            | Events[EventName]
+            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
+                : never)
         )
         : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
             ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
             : any[]);
-            type EventNames<Events extends EventMap<Events>> = {} extends Events ? (string | symbol)
-            : (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap);
-    type EventNameParam<Events extends EventMap<Events>, EventName> = {} extends Events ? string | symbol : EventName | EventNames<Events>;
-    type Listener<Events extends EventMap<Events>, EventName> = {} extends Events ? ((...args: any[]) => void) | ((...args: never) => void): (EventName extends keyof Events ?
-            | ((...args: Events[EventName]) => void)
-            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
-                ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
-                : never)
-        : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
-            ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
-            : ((...args: any[]) => void))
-);
+    type EventNames<Events extends EventMap<Events>> = {} extends Events ? (string | symbol)
+        : (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap);
+    type EventNameParam<Events extends EventMap<Events>, EventName> = {} extends Events ? string | symbol
+        : EventName | EventNames<Events>;
+    type Listener<Events extends EventMap<Events>, EventName> = {} extends Events ? ((...args: any[]) => void)
+        : (EventName extends (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap) ?
+                | (EventName extends keyof Events ? ((...args: Events[EventName]) => void) : never)
+                | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                    ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
+                    : never)
+            : ((...args: any[]) => void));
     /**
      * The `EventEmitter` class is defined and exposed by the `node:events` module:
      *
@@ -599,10 +598,17 @@ declare module "events" {
             readonly asyncResource: EventEmitterReferencingAsyncResource;
         }
 
+        /** The events always emitted by EventEmitter itself */
         export interface EventEmitterBuiltInEventMap {
             newListener: [eventName: string | symbol, listener: Function];
             removeListener: [eventName: string | symbol, listener: Function];
         }
+
+        /** Helper type for building functions that take a listener as a paramater when working with event maps */
+        export type EventEmitterEventMapListener<Events extends EventMap<Events>, EventName> = Listener<
+            Events,
+            EventName
+        >;
     }
     global {
         namespace NodeJS {

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -620,11 +620,7 @@ declare module "events" {
                  * Alias for `emitter.on(eventName, listener)`.
                  * @since v0.1.26
                  */
-                addListener<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                addListener<EventName extends string | symbol>(
+                addListener<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -659,11 +655,7 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                on<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                on<EventName extends string | symbol>(
+                on<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -696,11 +688,7 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                once<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                once<EventName extends string | symbol>(
+                once<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -786,11 +774,7 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeListener<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                removeListener<EventName extends string | symbol>(
+                removeListener<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -798,11 +782,7 @@ declare module "events" {
                  * Alias for `emitter.removeListener()`.
                  * @since v10.0.0
                  */
-                off<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                off<EventName extends string | symbol>(
+                off<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -817,8 +797,7 @@ declare module "events" {
                  * @since v0.1.26
                  */
                 /* eslint-disable @definitelytyped/no-unnecessary-generics */
-                removeAllListeners<EventName extends EventNames<Events>>(eventName: EventName): this;
-                removeAllListeners<EventName extends string | symbol>(eventName?: EventName): this;
+                removeAllListeners<EventName extends EventNames<Events> | string & {} | symbol>(eventName?: EventName): this;
                 /* eslint-enable @definitelytyped/no-unnecessary-generics */
                 /**
                  * By default `EventEmitter`s will print a warning if more than `10` listeners are
@@ -851,9 +830,9 @@ declare module "events" {
                 listeners<EventName extends EventNames<Events>>(
                     eventName: EventName,
                 ): Array<Listener<Events, EventName>>;
-                listeners<EventName extends string | symbol>(
-                    eventName: EventName,
-                ): Array<Listener<Events, EventName>>;
+                listeners(
+                    eventName: string | symbol,
+                ): Array<Listener<Events, string | symbol>>;
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
                  * including any wrappers (such as those created by `.once()`).
@@ -887,9 +866,9 @@ declare module "events" {
                 rawListeners<EventName extends EventNames<Events>>(
                     eventName: EventName,
                 ): Array<Listener<Events, EventName>>;
-                rawListeners<EventName extends string | symbol>(
-                    eventName: EventName,
-                ): Array<Listener<Events, EventName>>;
+                rawListeners(
+                    eventName: string | symbol,
+                ): Array<Listener<Events, string | symbol>>;
                 /**
                  * Synchronously calls each of the listeners registered for the event named `eventName`, in the order they were registered, passing the supplied arguments
                  * to each.
@@ -930,11 +909,7 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                emit<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    ...args: Args<Events, EventName>
-                ): boolean;
-                emit<EventName extends string | symbol>(
+                emit<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     ...args: Args<Events, EventName>
                 ): boolean;
@@ -946,11 +921,7 @@ declare module "events" {
                  * @param eventName The name of the event being listened for
                  * @param listener The event handler function
                  */
-                listenerCount<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener?: Listener<Events, EventName>,
-                ): number;
-                listenerCount<EventName extends string | symbol>(
+                listenerCount<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     listener?: Listener<Events, EventName>,
                 ): number;
@@ -971,11 +942,7 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependListener<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                prependListener<EventName extends string | symbol>(
+                prependListener<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -994,11 +961,7 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependOnceListener<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                prependOnceListener<EventName extends string | symbol>(
+                prependOnceListener<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -103,25 +103,26 @@ declare module "events" {
     interface EventEmitter<Events extends EventMap<Events> = {}> extends NodeJS.EventEmitter<Events> {}
     type EventMap<Events> = Record<keyof Events, unknown[]>;
     type Args<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ? (
-            | Events[EventName]
-            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
-                ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
-                : never)
+        | Events[EventName]
+        | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+            ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
+            : never)
         )
         : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
             ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
             : any[]);
-    type EventNames<Events extends EventMap<Events>> = {} extends Events ? (string | symbol)
-        : (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap);
-    type Listener<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ?
+            type EventNames<Events extends EventMap<Events>> = {} extends Events ? (string | symbol)
+            : (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap);
+    type EventNameParam<Events extends EventMap<Events>, EventName> = {} extends Events ? string | symbol : EventName | EventNames<Events>;
+    type Listener<Events extends EventMap<Events>, EventName> = {} extends Events ? ((...args: any[]) => void) | ((...args: never) => void): (EventName extends keyof Events ?
             | ((...args: Events[EventName]) => void)
             | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
                 ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
                 : never)
         : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
             ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
-            : (...args: any[]) => void);
-
+            : ((...args: any[]) => void))
+);
     /**
      * The `EventEmitter` class is defined and exposed by the `node:events` module:
      *
@@ -620,12 +621,8 @@ declare module "events" {
                  * Alias for `emitter.on(eventName, listener)`.
                  * @since v0.1.26
                  */
-                addListener<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                addListener<EventName extends string | symbol>(
-                    eventName: EventName,
+                addListener<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
@@ -659,12 +656,8 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                on<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                on<EventName extends string | symbol>(
-                    eventName: EventName,
+                on<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
@@ -696,12 +689,8 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                once<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                once<EventName extends string | symbol>(
-                    eventName: EventName,
+                once<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
@@ -786,24 +775,16 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeListener<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                removeListener<EventName extends string | symbol>(
-                    eventName: EventName,
+                removeListener<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
                  * Alias for `emitter.removeListener()`.
                  * @since v10.0.0
                  */
-                off<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                off<EventName extends string | symbol>(
-                    eventName: EventName,
+                off<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
@@ -848,11 +829,8 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                listeners<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                ): Array<Listener<Events, EventName>>;
-                listeners<EventName extends string | symbol>(
-                    eventName: EventName,
+                listeners<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                 ): Array<Listener<Events, EventName>>;
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
@@ -884,11 +862,8 @@ declare module "events" {
                  * ```
                  * @since v9.4.0
                  */
-                rawListeners<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                ): Array<Listener<Events, EventName>>;
-                rawListeners<EventName extends string | symbol>(
-                    eventName: EventName,
+                rawListeners<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                 ): Array<Listener<Events, EventName>>;
                 /**
                  * Synchronously calls each of the listeners registered for the event named `eventName`, in the order they were registered, passing the supplied arguments
@@ -946,12 +921,8 @@ declare module "events" {
                  * @param eventName The name of the event being listened for
                  * @param listener The event handler function
                  */
-                listenerCount<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener?: Listener<Events, EventName>,
-                ): number;
-                listenerCount<EventName extends string | symbol>(
-                    eventName: EventName,
+                listenerCount<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                     listener?: Listener<Events, EventName>,
                 ): number;
                 /**
@@ -971,12 +942,8 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependListener<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                prependListener<EventName extends string | symbol>(
-                    eventName: EventName,
+                prependListener<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
@@ -994,12 +961,8 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependOnceListener<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                prependOnceListener<EventName extends string | symbol>(
-                    eventName: EventName,
+                prependOnceListener<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -841,7 +841,7 @@ declare module "events" {
                 // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
                 listeners<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
-                ): Array<() => void>;
+                ): Array<(...args: any[]) => void>;
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
                  * including any wrappers (such as those created by `.once()`).
@@ -875,7 +875,7 @@ declare module "events" {
                 // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
                 rawListeners<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
-                ): Array<() => void>;
+                ): Array<(...args: any[]) => void>;
                 /**
                  * Synchronously calls each of the listeners registered for the event named `eventName`, in the order they were registered, passing the supplied arguments
                  * to each.

--- a/types/node/test/events.ts
+++ b/types/node/test/events.ts
@@ -31,7 +31,7 @@ declare const any: any;
     result = emitter.getMaxListeners();
     result = emitter.listenerCount(event);
 
-    const handler: Function = () => {};
+    const handler = () => {};
     result = emitter.listenerCount(event, handler);
 }
 
@@ -141,7 +141,7 @@ async function testEventTarget() {
     captureRejectionSymbol2 = events.captureRejectionSymbol;
 
     const emitter = new events.EventEmitter();
-    emitter[events.captureRejectionSymbol] = (err: Error, name: string, ...args: any[]) => {};
+    emitter[events.captureRejectionSymbol] = (err: Error, name: string | symbol, ...args: any[]) => {};
 }
 
 {
@@ -193,16 +193,16 @@ async function testEventTarget() {
 
 {
     class MyEmitter extends events.EventEmitter {
-        addListener(event: string, listener: () => void): this {
+        addListener(event: string | symbol, listener: () => void): this {
             return this;
         }
-        listeners(event: string): Array<() => void> {
+        listeners(event: string | symbol): Array<() => void> {
             return [];
         }
-        emit(event: string, ...args: any[]): boolean {
+        emit(event: string | symbol, ...args: any[]): boolean {
             return true;
         }
-        listenerCount(type: string): number {
+        listenerCount(type: string | symbol): number {
             return 0;
         }
     }

--- a/types/node/test/events_generic.ts
+++ b/types/node/test/events_generic.ts
@@ -299,4 +299,18 @@ declare const event5: "event5";
 
     events.on(doubleExtended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
     events.once(doubleExtended, "unknown"); // $ExpectType Promise<any[]>
+
+    extended.addListener(event1, (a: string, b: number | boolean): number => 1);
+    doubleExtended.addListener(event1, (a: string, b: number | boolean): number => 1);
+    // @ts-expect-error
+    extended.addListener(event1, (a: string, b: boolean): number => 1);
+    // @ts-expect-error
+    doubleExtended.addListener(event1, (a: string, b: boolean): number => 1);
+
+    extended.emit("event1", "hello", 42);
+    doubleExtended.emit("event1", "hello", 42);
+    // @ts-expect-error
+    extended.emit("event1", 123);
+    // @ts-expect-error
+    doubleExtended.emit("event1", 123);
 }

--- a/types/node/test/events_generic.ts
+++ b/types/node/test/events_generic.ts
@@ -110,13 +110,17 @@ declare const event5: "event5";
 }
 
 {
-    let result: Promise<number[]>;
+    let result1: Promise<T["event1"]>;
+    let result2: Promise<T["event2"]>;
+    let result3: Promise<T["event3"]>;
+    let result4: Promise<T["event4"]>;
+    let result5: Promise<T["event5"]>;
 
-    result = events.once(emitter, event1);
-    result = events.once(emitter, event2);
-    result = events.once(emitter, event3);
-    result = events.once(emitter, event4);
-    result = events.once(emitter, event5);
+    result1 = events.once(emitter, event1);
+    result2 = events.once(emitter, event2);
+    result3 = events.once(emitter, event3);
+    result4 = events.once(emitter, event4);
+    result5 = events.once(emitter, event5);
 
     emitter.emit("event1", "hello", 42);
     emitter.emit("event2", true);
@@ -146,7 +150,7 @@ declare const event5: "event5";
 }
 
 {
-    let result: Array<keyof T>;
+    let result: Array<keyof T | keyof events.EventEmitterBuiltInEventMap>;
 
     result = emitter.eventNames();
 }
@@ -157,12 +161,12 @@ declare const event5: "event5";
         )
         : never;
 
-    function on1<K>(event: K, listener: Listener<K>): void {
+    function on1<K extends keyof T>(event: K, listener: Listener<K>): void {
         emitter.on(event, listener);
     }
 
     // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-    function on2<K>(...args: Parameters<typeof emitter.on<K>>): void {
+    function on2<K extends keyof T>(...args: Parameters<typeof emitter.on<K>>): void {
         emitter.on(...args);
     }
 
@@ -204,7 +208,6 @@ declare const event5: "event5";
     emitter.emit("abc", "hello", 123);
     // @ts-expect-error
     emitter.emit("abc", 123, false);
-    // @ts-expect-error
     emitter.emit("def", "hello", 123);
 }
 
@@ -226,7 +229,6 @@ declare const event5: "event5";
     emitter.emit(s1, "hello", 123);
     // @ts-expect-error
     emitter.emit(s1, 123, false);
-    // @ts-expect-error
     emitter.emit(s2, "hello", 123);
 }
 
@@ -244,6 +246,36 @@ declare const event5: "event5";
     emitter.emit(789, 123, false);
     // @ts-expect-error
     emitter.emit(s1, "hello", false);
-    // @ts-expect-error
     emitter.emit(s2, "hello", false);
+}
+
+{
+    const promise1: Promise<[string, number]> = events.once(new events.EventEmitter<T>(), "event1");
+    const promise2: Promise<[boolean]> = events.once(new events.EventEmitter<T>(), "event2");
+    const promise3: Promise<[]> = events.once(new events.EventEmitter<T>(), "event3");
+    const promise4: Promise<string[]> = events.once(new events.EventEmitter<T>(), "event4");
+    const promise5: Promise<unknown[]> = events.once(new events.EventEmitter<T>(), "event5");
+    // @ts-expect-error
+    const promise6: Promise<[string, string]> = events.once(new events.EventEmitter<T>(), "event1");
+    const promise7: Promise<any[]> = events.once(new events.EventEmitter<T>(), "event");
+
+    const iterable1: NodeJS.AsyncIterator<[string, number]> = events.on(new events.EventEmitter<T>(), "event1");
+    const iterable2: NodeJS.AsyncIterator<[boolean]> = events.on(new events.EventEmitter<T>(), "event2");
+    const iterable3: NodeJS.AsyncIterator<[]> = events.on(new events.EventEmitter<T>(), "event3");
+    const iterable4: NodeJS.AsyncIterator<string[]> = events.on(new events.EventEmitter<T>(), "event4");
+    const iterable5: NodeJS.AsyncIterator<unknown[]> = events.on(new events.EventEmitter<T>(), "event5");
+    // @ts-expect-error
+    const iterable6: NodeJS.AsyncIterator<[string, string]> = events.on(new events.EventEmitter<T>(), "event1");
+    const iterable7: NodeJS.AsyncIterator<any[]> = events.on(new events.EventEmitter<T>(), "event");
+}
+
+{
+    function acceptsEventEmitterInterface(eventEmitter: NodeJS.EventEmitter) {
+    }
+
+    function acceptsEventEmitterClass(eventEmitter: events.EventEmitter) {
+    }
+
+    acceptsEventEmitterInterface(emitter);
+    acceptsEventEmitterClass(emitter);
 }

--- a/types/node/test/events_generic.ts
+++ b/types/node/test/events_generic.ts
@@ -110,17 +110,18 @@ declare const event5: "event5";
 }
 
 {
-    let result1: Promise<T["event1"]>;
-    let result2: Promise<T["event2"]>;
-    let result3: Promise<T["event3"]>;
-    let result4: Promise<T["event4"]>;
-    let result5: Promise<T["event5"]>;
+    // Uncomment once static events are generic
+    // let result1: Promise<T["event1"]>;
+    // let result2: Promise<T["event2"]>;
+    // let result3: Promise<T["event3"]>;
+    // let result4: Promise<T["event4"]>;
+    // let result5: Promise<T["event5"]>;
 
-    result1 = events.once(emitter, event1);
-    result2 = events.once(emitter, event2);
-    result3 = events.once(emitter, event3);
-    result4 = events.once(emitter, event4);
-    result5 = events.once(emitter, event5);
+    // result1 = events.once(emitter, event1);
+    // result2 = events.once(emitter, event2);
+    // result3 = events.once(emitter, event3);
+    // result4 = events.once(emitter, event4);
+    // result5 = events.once(emitter, event5);
 
     emitter.emit("event1", "hello", 42);
     emitter.emit("event2", true);
@@ -249,25 +250,26 @@ declare const event5: "event5";
     emitter.emit(s2, "hello", false);
 }
 
-{
-    const promise1: Promise<[string, number]> = events.once(new events.EventEmitter<T>(), "event1");
-    const promise2: Promise<[boolean]> = events.once(new events.EventEmitter<T>(), "event2");
-    const promise3: Promise<[]> = events.once(new events.EventEmitter<T>(), "event3");
-    const promise4: Promise<string[]> = events.once(new events.EventEmitter<T>(), "event4");
-    const promise5: Promise<unknown[]> = events.once(new events.EventEmitter<T>(), "event5");
-    // @ts-expect-error
-    const promise6: Promise<[string, string]> = events.once(new events.EventEmitter<T>(), "event1");
-    const promise7: Promise<any[]> = events.once(new events.EventEmitter<T>(), "event");
+// Uncomment once static methods are generic
+// {
+//     const promise1: Promise<[string, number]> = events.once(new events.EventEmitter<T>(), "event1");
+//     const promise2: Promise<[boolean]> = events.once(new events.EventEmitter<T>(), "event2");
+//     const promise3: Promise<[]> = events.once(new events.EventEmitter<T>(), "event3");
+//     const promise4: Promise<string[]> = events.once(new events.EventEmitter<T>(), "event4");
+//     const promise5: Promise<unknown[]> = events.once(new events.EventEmitter<T>(), "event5");
+//     // @ts-expect-error
+//     const promise6: Promise<[string, string]> = events.once(new events.EventEmitter<T>(), "event1");
+//     const promise7: Promise<any[]> = events.once(new events.EventEmitter<T>(), "event");
 
-    const iterable1: NodeJS.AsyncIterator<[string, number]> = events.on(new events.EventEmitter<T>(), "event1");
-    const iterable2: NodeJS.AsyncIterator<[boolean]> = events.on(new events.EventEmitter<T>(), "event2");
-    const iterable3: NodeJS.AsyncIterator<[]> = events.on(new events.EventEmitter<T>(), "event3");
-    const iterable4: NodeJS.AsyncIterator<string[]> = events.on(new events.EventEmitter<T>(), "event4");
-    const iterable5: NodeJS.AsyncIterator<unknown[]> = events.on(new events.EventEmitter<T>(), "event5");
-    // @ts-expect-error
-    const iterable6: NodeJS.AsyncIterator<[string, string]> = events.on(new events.EventEmitter<T>(), "event1");
-    const iterable7: NodeJS.AsyncIterator<any[]> = events.on(new events.EventEmitter<T>(), "event");
-}
+//     const iterable1: NodeJS.AsyncIterator<[string, number]> = events.on(new events.EventEmitter<T>(), "event1");
+//     const iterable2: NodeJS.AsyncIterator<[boolean]> = events.on(new events.EventEmitter<T>(), "event2");
+//     const iterable3: NodeJS.AsyncIterator<[]> = events.on(new events.EventEmitter<T>(), "event3");
+//     const iterable4: NodeJS.AsyncIterator<string[]> = events.on(new events.EventEmitter<T>(), "event4");
+//     const iterable5: NodeJS.AsyncIterator<unknown[]> = events.on(new events.EventEmitter<T>(), "event5");
+//     // @ts-expect-error
+//     const iterable6: NodeJS.AsyncIterator<[string, string]> = events.on(new events.EventEmitter<T>(), "event1");
+//     const iterable7: NodeJS.AsyncIterator<any[]> = events.on(new events.EventEmitter<T>(), "event");
+// }
 
 {
     function acceptsEventEmitterInterface(eventEmitter: NodeJS.EventEmitter) {
@@ -288,17 +290,18 @@ declare const event5: "event5";
     const extended = new Extended();
     const doubleExtended = new DoubleExtension();
 
-    events.on(extended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
-    events.once(extended, "event1"); // $ExpectType Promise<[string, number]>
+    // Uncomment once static methods are generic
+    // events.on(extended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
+    // events.once(extended, "event1"); // $ExpectType Promise<[string, number]>
 
-    events.on(extended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
-    events.once(extended, "unknown"); // $ExpectType Promise<any[]>
+    // events.on(extended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
+    // events.once(extended, "unknown"); // $ExpectType Promise<any[]>
 
-    events.on(doubleExtended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
-    events.once(doubleExtended, "event1"); // $ExpectType Promise<[string, number]>
+    // events.on(doubleExtended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
+    // events.once(doubleExtended, "event1"); // $ExpectType Promise<[string, number]>
 
-    events.on(doubleExtended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
-    events.once(doubleExtended, "unknown"); // $ExpectType Promise<any[]>
+    // events.on(doubleExtended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
+    // events.once(doubleExtended, "unknown"); // $ExpectType Promise<any[]>
 
     extended.addListener(event1, (a: string, b: number | boolean): number => 1);
     doubleExtended.addListener(event1, (a: string, b: number | boolean): number => 1);

--- a/types/node/test/events_generic.ts
+++ b/types/node/test/events_generic.ts
@@ -279,3 +279,24 @@ declare const event5: "event5";
     acceptsEventEmitterInterface(emitter);
     acceptsEventEmitterClass(emitter);
 }
+
+{
+    class Extended extends events.EventEmitter<T> {}
+
+    class DoubleExtension extends Extended {}
+
+    const extended = new Extended();
+    const doubleExtended = new DoubleExtension();
+
+    events.on(extended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
+    events.once(extended, "event1"); // $ExpectType Promise<[string, number]>
+
+    events.on(extended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
+    events.once(extended, "unknown"); // $ExpectType Promise<any[]>
+
+    events.on(doubleExtended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
+    events.once(doubleExtended, "event1"); // $ExpectType Promise<[string, number]>
+
+    events.on(doubleExtended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
+    events.once(doubleExtended, "unknown"); // $ExpectType Promise<any[]>
+}

--- a/types/node/test/events_generic.ts
+++ b/types/node/test/events_generic.ts
@@ -339,3 +339,8 @@ declare const event5: "event5";
     emitter.prependOnceListener('error', onError);
     emitter.removeListener('error', onError);
 }
+
+interface Implementing extends events.EventEmitter {}
+declare class Implementing implements events.EventEmitter {        
+    addListener(eventName: 'event', listener: (arg: boolean) => void): this;
+}

--- a/types/node/test/events_generic.ts
+++ b/types/node/test/events_generic.ts
@@ -317,3 +317,25 @@ declare const event5: "event5";
     // @ts-expect-error
     doubleExtended.emit("event1", 123);
 }
+
+{
+    function onError(err: any) {
+        console.log(err);
+    }
+
+    class Test extends events.EventEmitter {
+        // The union was only uncallable when an instance method exists.
+        test() { return true; }
+    }
+    
+    class Test2 extends events.EventEmitter {}
+
+    const emitter = {} as Test | Test2
+    emitter.addListener('error', onError);
+    emitter.on("error", onError);
+    emitter.off('error', onError);
+    emitter.once('error', onError);
+    emitter.prependListener('error', onError);
+    emitter.prependOnceListener('error', onError);
+    emitter.removeListener('error', onError);
+}

--- a/types/node/test/events_generic.ts
+++ b/types/node/test/events_generic.ts
@@ -157,10 +157,7 @@ declare const event5: "event5";
 }
 
 {
-    type Listener<K> = K extends keyof T ? (
-            (...args: T[K]) => void
-        )
-        : never;
+    type Listener<K> = events.EventEmitterEventMapListener<T, K>;
 
     function on1<K extends keyof T>(event: K, listener: Listener<K>): void {
         emitter.on(event, listener);
@@ -325,22 +322,24 @@ declare const event5: "event5";
 
     class Test extends events.EventEmitter {
         // The union was only uncallable when an instance method exists.
-        test() { return true; }
+        test() {
+            return true;
+        }
     }
-    
+
     class Test2 extends events.EventEmitter {}
 
-    const emitter = {} as Test | Test2
-    emitter.addListener('error', onError);
+    const emitter = {} as Test | Test2;
+    emitter.addListener("error", onError);
     emitter.on("error", onError);
-    emitter.off('error', onError);
-    emitter.once('error', onError);
-    emitter.prependListener('error', onError);
-    emitter.prependOnceListener('error', onError);
-    emitter.removeListener('error', onError);
+    emitter.off("error", onError);
+    emitter.once("error", onError);
+    emitter.prependListener("error", onError);
+    emitter.prependOnceListener("error", onError);
+    emitter.removeListener("error", onError);
 }
 
 interface Implementing extends events.EventEmitter {}
-declare class Implementing implements events.EventEmitter {        
-    addListener(eventName: 'event', listener: (arg: boolean) => void): this;
+declare class Implementing implements events.EventEmitter {
+    addListener(eventName: "event", listener: (arg: boolean) => void): this;
 }

--- a/types/node/test/events_generic.ts
+++ b/types/node/test/events_generic.ts
@@ -151,7 +151,7 @@ declare const event5: "event5";
 }
 
 {
-    let result: Array<keyof T | keyof events.EventEmitterBuiltInEventMap>;
+    let result: Array<string | symbol>;
 
     result = emitter.eventNames();
 }
@@ -337,9 +337,19 @@ declare const event5: "event5";
     emitter.prependListener("error", onError);
     emitter.prependOnceListener("error", onError);
     emitter.removeListener("error", onError);
+    emitter.removeAllListeners();
+    emitter.removeAllListeners("error");
+    emitter.emit("error");
 }
 
 interface Implementing extends events.EventEmitter {}
 declare class Implementing implements events.EventEmitter {
     addListener(eventName: "event", listener: (arg: boolean) => void): this;
+}
+
+{
+    // @ts-expect-error
+    emitter.on({}, () => {});
+    // @ts-expect-error
+    new EventEmitter().on({}, () => {});
 }

--- a/types/node/v18/events.d.ts
+++ b/types/node/v18/events.d.ts
@@ -1,3 +1,5 @@
+declare const internalTypeOnlyBrandSymbol: unique symbol;
+
 /**
  * Much of the Node.js core API is built around an idiomatic asynchronous
  * event-driven architecture in which certain kinds of objects (called "emitters")
@@ -34,13 +36,12 @@
  * ```
  * @see [source](https://github.com/nodejs/node/blob/v18.0.0/lib/events.js)
  */
+
 declare module "events" {
     import { AsyncResource, AsyncResourceOptions } from "node:async_hooks";
-
     // NOTE: This class is in the docs but is **not actually exported** by Node.
     // If https://github.com/nodejs/node/issues/39903 gets resolved and Node
     // actually starts exporting the class, uncomment below.
-
     // import { EventListener, EventListenerObject } from '__dom-events';
     // /** The NodeEventTarget is a Node.js-specific extension to EventTarget that emulates a subset of the EventEmitter API. */
     // interface NodeEventTarget extends EventTarget {
@@ -71,7 +72,6 @@ declare module "events" {
     //      */
     //     removeListener(type: string, listener: EventListener | EventListenerObject): this;
     // }
-
     interface EventEmitterOptions {
         /**
          * Enables automatic capturing of promise rejection.
@@ -93,6 +93,9 @@ declare module "events" {
         ): any;
     }
     interface StaticEventEmitterOptions {
+        /**
+         * Can be used to cancel awaiting events.
+         */
         signal?: AbortSignal | undefined;
     }
     interface EventEmitter<Events extends EventMap<Events> = {}> extends NodeJS.EventEmitter<Events> {}
@@ -116,6 +119,7 @@ declare module "events" {
         : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
             ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
             : (...args: any[]) => void);
+
     /**
      * The `EventEmitter` class is defined and exposed by the `events` module:
      *
@@ -224,7 +228,7 @@ declare module "events" {
         static once<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
             emitter: EventEmitter<Events>,
             eventName: EventName,
-            options?: Pick<StaticEventEmitterOptions, "signal">,
+            options?: StaticEventEmitterOptions,
         ): Promise<Args<Events, EventName>>;
         static once(
             emitter: _NodeEventTarget,
@@ -287,8 +291,7 @@ declare module "events" {
          * process.nextTick(() => ac.abort());
          * ```
          * @since v13.6.0, v12.16.0
-         * @param eventName The name of the event being listened for
-         * @return that iterates `eventName` events emitted by the `emitter`
+         * @return An `AsyncIterator` that iterates `eventName` events emitted by the `emitter`
          */
         static on<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
             emitter: EventEmitter<Events>,
@@ -297,11 +300,11 @@ declare module "events" {
         ): NodeJS.AsyncIterator<Args<Events, EventName>>;
         static on(
             emitter: NodeJS.EventEmitter,
-            eventName: string,
+            eventName: string | symbol,
             options?: StaticEventEmitterOptions,
-        ): NodeJS.AsyncIterator<any>;
+        ): NodeJS.AsyncIterator<any[]>;
         /**
-         * A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
+         * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
          *
          * ```js
          * import { EventEmitter, listenerCount } from 'node:events';
@@ -321,10 +324,11 @@ declare module "events" {
             eventName: EventName,
         ): number;
         /**
-         * A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
+         * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
          *
          * ```js
          * const { EventEmitter, listenerCount } = require('events');
+         *
          * const myEmitter = new EventEmitter();
          * myEmitter.on('event', () => {});
          * myEmitter.on('event', () => {});
@@ -353,13 +357,13 @@ declare module "events" {
          *   const ee = new EventEmitter();
          *   const listener = () => console.log('Events are fun');
          *   ee.on('foo', listener);
-         *   getEventListeners(ee, 'foo'); // [listener]
+         *   console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
          * }
          * {
          *   const et = new EventTarget();
          *   const listener = () => console.log('Events are fun');
          *   et.addEventListener('foo', listener);
-         *   getEventListeners(et, 'foo'); // [listener]
+         *   console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
          * }
          * ```
          * @since v15.2.0, v14.17.0
@@ -380,7 +384,7 @@ declare module "events" {
          * the max set, the EventTarget will print a warning.
          *
          * ```js
-         * import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
+         * const { getMaxListeners, setMaxListeners, EventEmitter } = require('events');
          *
          * {
          *   const ee = new EventEmitter();
@@ -432,7 +436,7 @@ declare module "events" {
          * Returns a disposable so that it may be unsubscribed from more easily.
          *
          * ```js
-         * import { addAbortListener } from 'node:events';
+         * const { addAbortListener } = require('events');
          *
          * function example(signal) {
          *   let disposable;
@@ -461,12 +465,58 @@ declare module "events" {
          * regular `'error'` listener is installed.
          */
         static readonly errorMonitor: unique symbol;
+        /**
+         * Value: `Symbol.for('nodejs.rejection')`
+         *
+         * See how to write a custom `rejection handler`.
+         * @since v13.4.0, v12.16.0
+         */
         static readonly captureRejectionSymbol: unique symbol;
         /**
-         * Sets or gets the default captureRejection value for all emitters.
+         * Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+         *
+         * Change the default `captureRejections` option on all new `EventEmitter` objects.
+         * @since v13.4.0, v12.16.0
          */
-        // TODO: These should be described using static getter/setter pairs:
         static captureRejections: boolean;
+        /**
+         * By default, a maximum of `10` listeners can be registered for any single
+         * event. This limit can be changed for individual `EventEmitter` instances
+         * using the `emitter.setMaxListeners(n)` method. To change the default
+         * for _all_`EventEmitter` instances, the `events.defaultMaxListeners` property
+         * can be used. If this value is not a positive number, a `RangeError` is thrown.
+         *
+         * Take caution when setting the `events.defaultMaxListeners` because the
+         * change affects _all_ `EventEmitter` instances, including those created before
+         * the change is made. However, calling `emitter.setMaxListeners(n)` still has
+         * precedence over `events.defaultMaxListeners`.
+         *
+         * This is not a hard limit. The `EventEmitter` instance will allow
+         * more listeners to be added but will output a trace warning to stderr indicating
+         * that a "possible EventEmitter memory leak" has been detected. For any single
+         * `EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()` methods can be used to
+         * temporarily avoid this warning:
+         *
+         * ```js
+         * const EventEmitter = require('events');
+         * const emitter = new EventEmitter();
+         * emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+         * emitter.once('event', () => {
+         *   // do stuff
+         *   emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+         * });
+         * ```
+         *
+         * The `--trace-warnings` command-line flag can be used to display the
+         * stack trace for such warnings.
+         *
+         * The emitted warning can be inspected with `process.on('warning')` and will
+         * have the additional `emitter`, `type`, and `count` properties, referring to
+         * the event emitter instance, the event's name and the number of attached
+         * listeners, respectively.
+         * Its `name` property is set to `'MaxListenersExceededWarning'`.
+         * @since v0.11.2
+         */
         static defaultMaxListeners: number;
     }
     import internal = require("node:events");
@@ -494,13 +544,41 @@ declare module "events" {
         }
 
         /**
-         * Integrates `EventEmitter` with `AsyncResource` for `EventEmitter`s that require
-         * manual async tracking. Specifically, all events emitted by instances of
-         * `EventEmitterAsyncResource` will run within its async context.
+         * Integrates `EventEmitter` with `AsyncResource` for `EventEmitter`s that
+         * require manual async tracking. Specifically, all events emitted by instances
+         * of `events.EventEmitterAsyncResource` will run within its `async context`.
          *
-         * The EventEmitterAsyncResource class has the same methods and takes the
-         * same options as EventEmitter and AsyncResource themselves.
-         * @throws if `options.name` is not provided when instantiated directly.
+         * ```js
+         * const { EventEmitterAsyncResource, EventEmitter } = require('events');
+         * const { notStrictEqual, strictEqual } = require('assert');
+         * const { executionAsyncId, triggerAsyncId } = require('async_hooks');
+         *
+         * // Async tracking tooling will identify this as 'Q'.
+         * const ee1 = new EventEmitterAsyncResource({ name: 'Q' });
+         *
+         * // 'foo' listeners will run in the EventEmitters async context.
+         * ee1.on('foo', () => {
+         *   strictEqual(executionAsyncId(), ee1.asyncId);
+         *   strictEqual(triggerAsyncId(), ee1.triggerAsyncId);
+         * });
+         *
+         * const ee2 = new EventEmitter();
+         *
+         * // 'foo' listeners on ordinary EventEmitters that do not track async
+         * // context, however, run in the same async context as the emit().
+         * ee2.on('foo', () => {
+         *   notStrictEqual(executionAsyncId(), ee2.asyncId);
+         *   notStrictEqual(triggerAsyncId(), ee2.triggerAsyncId);
+         * });
+         *
+         * Promise.resolve().then(() => {
+         *   ee1.emit('foo');
+         *   ee2.emit('foo');
+         * });
+         * ```
+         *
+         * The `EventEmitterAsyncResource` class has the same methods and takes the
+         * same options as `EventEmitter` and `AsyncResource` themselves.
          * @since v17.4.0, v16.14.0
          */
         export class EventEmitterAsyncResource extends EventEmitter {
@@ -509,17 +587,24 @@ declare module "events" {
              */
             constructor(options?: EventEmitterAsyncResourceOptions);
             /**
-             * Call all destroy hooks. This should only ever be called once. An
-             * error will be thrown if it is called more than once. This must be
-             * manually called. If the resource is left to be collected by the GC then
-             * the destroy hooks will never be called.
+             * Call all `destroy` hooks. This should only ever be called once. An error will
+             * be thrown if it is called more than once. This **must** be manually called. If
+             * the resource is left to be collected by the GC then the `destroy` hooks will
+             * never be called.
              */
             emitDestroy(): void;
-            /** The unique asyncId assigned to the resource. */
+            /**
+             * The unique `asyncId` assigned to the resource.
+             */
             readonly asyncId: number;
-            /** The same triggerAsyncId that is passed to the AsyncResource constructor. */
+            /**
+             * The same triggerAsyncId that is passed to the AsyncResource constructor.
+             */
             readonly triggerAsyncId: number;
-            /** The underlying AsyncResource */
+            /**
+             * The returned `AsyncResource` object has an additional `eventEmitter` property
+             * that provides a reference to this `EventEmitterAsyncResource`.
+             */
             readonly asyncResource: EventEmitterReferencingAsyncResource;
         }
 
@@ -531,6 +616,11 @@ declare module "events" {
     global {
         namespace NodeJS {
             interface EventEmitter<Events extends EventMap<Events> = {}> {
+                // This "property" is used to brand a specific instance of the EventEmitter class with its Event map, which is needed
+                // in order to infer the map if we have a chain like `class A extends EventEmitter<{}>` (or many levels deep)
+                // It is also marked as possibly undefined in order to allow something like `const t: NodeJS.EventEmitter<{}> = { <insert implementation here> };`
+                readonly [internalTypeOnlyBrandSymbol]?: Events;
+
                 [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
                     error: Error,
                     event: EventName,
@@ -554,10 +644,10 @@ declare module "events" {
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
-                 * Adds the `listener` function to the end of the listeners array for the
-                 * event named `eventName`. No checks are made to see if the `listener` has
-                 * already been added. Multiple calls passing the same combination of `eventName` and `listener` will result in the `listener` being added, and called, multiple
-                 * times.
+                 * Adds the `listener` function to the end of the listeners array for the event
+                 * named `eventName`. No checks are made to see if the `listener` has already
+                 * been added. Multiple calls passing the same combination of `eventName` and
+                 * `listener` will result in the `listener` being added, and called, multiple times.
                  *
                  * ```js
                  * server.on('connection', (stream) => {
@@ -567,10 +657,11 @@ declare module "events" {
                  *
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  *
-                 * By default, event listeners are invoked in the order they are added. The`emitter.prependListener()` method can be used as an alternative to add the
+                 * By default, event listeners are invoked in the order they are added. The `emitter.prependListener()` method can be used as an alternative to add the
                  * event listener to the beginning of the listeners array.
                  *
                  * ```js
+                 * const EventEmitter = require('events');
                  * const myEE = new EventEmitter();
                  * myEE.on('foo', () => console.log('a'));
                  * myEE.prependListener('foo', () => console.log('b'));
@@ -592,7 +683,7 @@ declare module "events" {
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
-                 * Adds a **one-time**`listener` function for the event named `eventName`. The
+                 * Adds a **one-time** `listener` function for the event named `eventName`. The
                  * next time `eventName` is triggered, this listener is removed and then invoked.
                  *
                  * ```js
@@ -603,10 +694,11 @@ declare module "events" {
                  *
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  *
-                 * By default, event listeners are invoked in the order they are added. The`emitter.prependOnceListener()` method can be used as an alternative to add the
+                 * By default, event listeners are invoked in the order they are added. The `emitter.prependOnceListener()` method can be used as an alternative to add the
                  * event listener to the beginning of the listeners array.
                  *
                  * ```js
+                 * const EventEmitter = require('events');
                  * const myEE = new EventEmitter();
                  * myEE.once('foo', () => console.log('a'));
                  * myEE.prependOnceListener('foo', () => console.log('b'));
@@ -628,7 +720,7 @@ declare module "events" {
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
-                 * Removes the specified `listener` from the listener array for the event named`eventName`.
+                 * Removes the specified `listener` from the listener array for the event named `eventName`.
                  *
                  * ```js
                  * const callback = (stream) => {
@@ -645,10 +737,12 @@ declare module "events" {
                  * called multiple times to remove each instance.
                  *
                  * Once an event is emitted, all listeners attached to it at the
-                 * time of emitting are called in order. This implies that any`removeListener()` or `removeAllListeners()` calls _after_ emitting and _before_ the last listener finishes execution
+                 * time of emitting are called in order. This implies that any `removeListener()` or `removeAllListeners()` calls _after_ emitting and _before_ the last listener finishes execution
                  * will not remove them from`emit()` in progress. Subsequent events behave as expected.
                  *
                  * ```js
+                 * const EventEmitter = require('events');
+                 * class MyEmitter extends EventEmitter {}
                  * const myEmitter = new MyEmitter();
                  *
                  * const callbackA = () => {
@@ -686,9 +780,10 @@ declare module "events" {
                  *
                  * When a single function has been added as a handler multiple times for a single
                  * event (as in the example below), `removeListener()` will remove the most
-                 * recently added instance. In the example the `once('ping')`listener is removed:
+                 * recently added instance. In the example the `once('ping')` listener is removed:
                  *
                  * ```js
+                 * const EventEmitter = require('events');
                  * const ee = new EventEmitter();
                  *
                  * function pong() {
@@ -744,7 +839,7 @@ declare module "events" {
                  * By default `EventEmitter`s will print a warning if more than `10` listeners are
                  * added for a particular event. This is a useful default that helps finding
                  * memory leaks. The `emitter.setMaxListeners()` method allows the limit to be
-                 * modified for this specific `EventEmitter` instance. The value can be set to`Infinity` (or `0`) to indicate an unlimited number of listeners.
+                 * modified for this specific `EventEmitter` instance. The value can be set to `Infinity` (or `0`) to indicate an unlimited number of listeners.
                  *
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.3.5
@@ -779,6 +874,7 @@ declare module "events" {
                  * including any wrappers (such as those created by `.once()`).
                  *
                  * ```js
+                 * const EventEmitter = require('events');
                  * const emitter = new EventEmitter();
                  * emitter.once('log', () => console.log('log once'));
                  *
@@ -810,7 +906,7 @@ declare module "events" {
                     eventName: EventName,
                 ): Array<Listener<Events, EventName>>;
                 /**
-                 * Synchronously calls each of the listeners registered for the event named`eventName`, in the order they were registered, passing the supplied arguments
+                 * Synchronously calls each of the listeners registered for the event named `eventName`, in the order they were registered, passing the supplied arguments
                  * to each.
                  *
                  * Returns `true` if the event had listeners, `false` otherwise.
@@ -858,10 +954,9 @@ declare module "events" {
                     ...args: Args<Events, EventName>
                 ): boolean;
                 /**
-                 * Returns the number of listeners listening to the event named `eventName`.
-                 *
-                 * If `listener` is provided, it will return how many times the listener
-                 * is found in the list of the listeners of the event.
+                 * Returns the number of listeners listening for the event named `eventName`.
+                 * If `listener` is provided, it will return how many times the listener is found
+                 * in the list of the listeners of the event.
                  * @since v3.2.0
                  * @param eventName The name of the event being listened for
                  * @param listener The event handler function
@@ -877,8 +972,8 @@ declare module "events" {
                 /**
                  * Adds the `listener` function to the _beginning_ of the listeners array for the
                  * event named `eventName`. No checks are made to see if the `listener` has
-                 * already been added. Multiple calls passing the same combination of `eventName` and `listener` will result in the `listener` being added, and called, multiple
-                 * times.
+                 * already been added. Multiple calls passing the same combination of `eventName`
+                 * and `listener` will result in the `listener` being added, and called, multiple times.
                  *
                  * ```js
                  * server.prependListener('connection', (stream) => {

--- a/types/node/v18/events.d.ts
+++ b/types/node/v18/events.d.ts
@@ -1,5 +1,3 @@
-declare const internalTypeOnlyBrandSymbol: unique symbol;
-
 /**
  * Much of the Node.js core API is built around an idiomatic asynchronous
  * event-driven architecture in which certain kinds of objects (called "emitters")
@@ -135,6 +133,11 @@ declare module "events" {
      */
     class EventEmitter<Events extends EventMap<Events> = {}> {
         constructor(options?: EventEmitterOptions);
+
+        // This "property" is used to brand a specific instance of the EventEmitter class with its Event map, which is needed
+        // in order to infer the map if we have a chain like `class A extends EventEmitter<{}>` (or many levels deep)
+        // It is also marked as possibly undefined in order to allow something like `const t: NodeJS.EventEmitter<{}> = { <insert implementation here> };`
+        readonly #internalTypeOnlyBrand?: Events;
 
         [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
             error: Error,
@@ -616,11 +619,6 @@ declare module "events" {
     global {
         namespace NodeJS {
             interface EventEmitter<Events extends EventMap<Events> = {}> {
-                // This "property" is used to brand a specific instance of the EventEmitter class with its Event map, which is needed
-                // in order to infer the map if we have a chain like `class A extends EventEmitter<{}>` (or many levels deep)
-                // It is also marked as possibly undefined in order to allow something like `const t: NodeJS.EventEmitter<{}> = { <insert implementation here> };`
-                readonly [internalTypeOnlyBrandSymbol]?: Events;
-
                 [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
                     error: Error,
                     event: EventName,

--- a/types/node/v18/events.d.ts
+++ b/types/node/v18/events.d.ts
@@ -95,23 +95,27 @@ declare module "events" {
     interface StaticEventEmitterOptions {
         signal?: AbortSignal | undefined;
     }
-    interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
-    type EventMap<T> = Record<keyof T, any[]> | DefaultEventMap;
-    type DefaultEventMap = [never];
-    type AnyRest = [...args: any[]];
-    type Args<K, T> = T extends DefaultEventMap ? AnyRest : (
-        K extends keyof T ? T[K] : never
-    );
-    type Key<K, T> = T extends DefaultEventMap ? string | symbol : K | keyof T;
-    type Key2<K, T> = T extends DefaultEventMap ? string | symbol : K & keyof T;
-    type Listener<K, T, F> = T extends DefaultEventMap ? F : (
-        K extends keyof T ? (
-                T[K] extends unknown[] ? (...args: T[K]) => void : never
-            )
-            : never
-    );
-    type Listener1<K, T> = Listener<K, T, (...args: any[]) => void>;
-    type Listener2<K, T> = Listener<K, T, Function>;
+    interface EventEmitter<Events extends EventMap<Events> = {}> extends NodeJS.EventEmitter<Events> {}
+    type EventMap<Events> = Record<keyof Events, unknown[]>;
+    type Args<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ? (
+            | Events[EventName]
+            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
+                : never)
+        )
+        : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+            ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
+            : any[]);
+    type EventNames<Events extends EventMap<Events>> = {} extends Events ? (string | symbol)
+        : (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap);
+    type Listener<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ?
+            | ((...args: Events[EventName]) => void)
+            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
+                : never)
+        : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+            ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
+            : (...args: any[]) => void);
     /**
      * The `EventEmitter` class is defined and exposed by the `events` module:
      *
@@ -125,10 +129,15 @@ declare module "events" {
      * It supports the following option:
      * @since v0.1.26
      */
-    class EventEmitter<T extends EventMap<T> = DefaultEventMap> {
+    class EventEmitter<Events extends EventMap<Events> = {}> {
         constructor(options?: EventEmitterOptions);
 
-        [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
+        [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
+            error: Error,
+            event: EventName,
+            ...args: Args<Events, EventName>
+        ): void;
+        [EventEmitter.captureRejectionSymbol]?(error: Error, event: string | symbol, ...args: any[]): void;
 
         /**
          * Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
@@ -212,6 +221,11 @@ declare module "events" {
          * ```
          * @since v11.13.0, v10.16.0
          */
+        static once<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            eventName: EventName,
+            options?: Pick<StaticEventEmitterOptions, "signal">,
+        ): Promise<Args<Events, EventName>>;
         static once(
             emitter: _NodeEventTarget,
             eventName: string | symbol,
@@ -276,6 +290,11 @@ declare module "events" {
          * @param eventName The name of the event being listened for
          * @return that iterates `eventName` events emitted by the `emitter`
          */
+        static on<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            eventName: EventName,
+            options?: StaticEventEmitterOptions,
+        ): NodeJS.AsyncIterator<Args<Events, EventName>>;
         static on(
             emitter: NodeJS.EventEmitter,
             eventName: string,
@@ -286,6 +305,26 @@ declare module "events" {
          *
          * ```js
          * import { EventEmitter, listenerCount } from 'node:events';
+         * const myEmitter = new EventEmitter();
+         * myEmitter.on('event', () => {});
+         * myEmitter.on('event', () => {});
+         * console.log(listenerCount(myEmitter, 'event'));
+         * // Prints: 2
+         * ```
+         * @since v0.9.12
+         * @deprecated Since v3.2.0 - Use `listenerCount` instead.
+         * @param emitter The emitter to query
+         * @param eventName The event name
+         */
+        static listenerCount<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            eventName: EventName,
+        ): number;
+        /**
+         * A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
+         *
+         * ```js
+         * const { EventEmitter, listenerCount } = require('events');
          * const myEmitter = new EventEmitter();
          * myEmitter.on('event', () => {});
          * myEmitter.on('event', () => {});
@@ -325,6 +364,10 @@ declare module "events" {
          * ```
          * @since v15.2.0, v14.17.0
          */
+        static getEventListeners<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            name: EventName,
+        ): Array<Listener<Events, EventName>>;
         static getEventListeners(emitter: _DOMEventTarget | NodeJS.EventEmitter, name: string | symbol): Function[];
         /**
          * Returns the currently set max amount of listeners.
@@ -479,16 +522,37 @@ declare module "events" {
             /** The underlying AsyncResource */
             readonly asyncResource: EventEmitterReferencingAsyncResource;
         }
+
+        export interface EventEmitterBuiltInEventMap {
+            newListener: [eventName: string | symbol, listener: Function];
+            removeListener: [eventName: string | symbol, listener: Function];
+        }
     }
     global {
         namespace NodeJS {
-            interface EventEmitter<T extends EventMap<T> = DefaultEventMap> {
-                [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
+            interface EventEmitter<Events extends EventMap<Events> = {}> {
+                [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
+                    error: Error,
+                    event: EventName,
+                    ...args: Args<Events, EventName>
+                ): void;
+                [EventEmitter.captureRejectionSymbol]?<EventName extends string | symbol>(
+                    error: Error,
+                    event: EventName,
+                    ...args: Args<Events, EventName>
+                ): void;
                 /**
                  * Alias for `emitter.on(eventName, listener)`.
                  * @since v0.1.26
                  */
-                addListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                addListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                addListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Adds the `listener` function to the end of the listeners array for the
                  * event named `eventName`. No checks are made to see if the `listener` has
@@ -519,7 +583,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                on<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                on<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                on<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Adds a **one-time**`listener` function for the event named `eventName`. The
                  * next time `eventName` is triggered, this listener is removed and then invoked.
@@ -548,7 +619,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                once<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                once<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                once<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Removes the specified `listener` from the listener array for the event named`eventName`.
                  *
@@ -628,12 +706,26 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                removeListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                removeListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Alias for `emitter.removeListener()`.
                  * @since v10.0.0
                  */
-                off<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                off<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                off<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Removes all listeners, or those of the specified `eventName`.
                  *
@@ -644,7 +736,10 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeAllListeners(event?: Key<unknown, T>): this;
+                /* eslint-disable @definitelytyped/no-unnecessary-generics */
+                removeAllListeners<EventName extends EventNames<Events>>(eventName: EventName): this;
+                removeAllListeners<EventName extends string | symbol>(eventName?: EventName): this;
+                /* eslint-enable @definitelytyped/no-unnecessary-generics */
                 /**
                  * By default `EventEmitter`s will print a warning if more than `10` listeners are
                  * added for a particular event. This is a useful default that helps finding
@@ -673,7 +768,12 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                listeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
+                listeners<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
+                listeners<EventName extends string | symbol>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
                  * including any wrappers (such as those created by `.once()`).
@@ -703,7 +803,12 @@ declare module "events" {
                  * ```
                  * @since v9.4.0
                  */
-                rawListeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
+                rawListeners<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
+                rawListeners<EventName extends string | symbol>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
                 /**
                  * Synchronously calls each of the listeners registered for the event named`eventName`, in the order they were registered, passing the supplied arguments
                  * to each.
@@ -744,7 +849,14 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                emit<K>(eventName: Key<K, T>, ...args: Args<K, T>): boolean;
+                emit<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    ...args: Args<Events, EventName>
+                ): boolean;
+                emit<EventName extends string | symbol>(
+                    eventName: EventName,
+                    ...args: Args<Events, EventName>
+                ): boolean;
                 /**
                  * Returns the number of listeners listening to the event named `eventName`.
                  *
@@ -754,7 +866,14 @@ declare module "events" {
                  * @param eventName The name of the event being listened for
                  * @param listener The event handler function
                  */
-                listenerCount<K>(eventName: Key<K, T>, listener?: Listener2<K, T>): number;
+                listenerCount<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener?: Listener<Events, EventName>,
+                ): number;
+                listenerCount<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener?: Listener<Events, EventName>,
+                ): number;
                 /**
                  * Adds the `listener` function to the _beginning_ of the listeners array for the
                  * event named `eventName`. No checks are made to see if the `listener` has
@@ -772,7 +891,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                prependListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                prependListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Adds a **one-time**`listener` function for the event named `eventName` to the _beginning_ of the listeners array. The next time `eventName` is triggered, this
                  * listener is removed, and then invoked.
@@ -788,7 +914,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependOnceListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                prependOnceListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                prependOnceListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Returns an array listing the events for which the emitter has registered
                  * listeners. The values in the array are strings or `Symbol`s.
@@ -807,7 +940,7 @@ declare module "events" {
                  * ```
                  * @since v6.0.0
                  */
-                eventNames(): Array<(string | symbol) & Key2<unknown, T>>;
+                eventNames(): Array<(string | symbol)> & Array<EventNames<Events>>;
             }
         }
     }

--- a/types/node/v18/events.d.ts
+++ b/types/node/v18/events.d.ts
@@ -134,11 +134,6 @@ declare module "events" {
     class EventEmitter<Events extends EventMap<Events> = {}> {
         constructor(options?: EventEmitterOptions);
 
-        // This "property" is used to brand a specific instance of the EventEmitter class with its Event map, which is needed
-        // in order to infer the map if we have a chain like `class A extends EventEmitter<{}>` (or many levels deep)
-        // It is also marked as possibly undefined in order to allow something like `const t: NodeJS.EventEmitter<{}> = { <insert implementation here> };`
-        readonly #internalTypeOnlyBrand?: Events;
-
         [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
             error: Error,
             event: EventName,
@@ -228,11 +223,6 @@ declare module "events" {
          * ```
          * @since v11.13.0, v10.16.0
          */
-        static once<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
-            emitter: EventEmitter<Events>,
-            eventName: EventName,
-            options?: StaticEventEmitterOptions,
-        ): Promise<Args<Events, EventName>>;
         static once(
             emitter: _NodeEventTarget,
             eventName: string | symbol,
@@ -296,36 +286,11 @@ declare module "events" {
          * @since v13.6.0, v12.16.0
          * @return An `AsyncIterator` that iterates `eventName` events emitted by the `emitter`
          */
-        static on<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
-            emitter: EventEmitter<Events>,
-            eventName: EventName,
-            options?: StaticEventEmitterOptions,
-        ): NodeJS.AsyncIterator<Args<Events, EventName>>;
         static on(
             emitter: NodeJS.EventEmitter,
             eventName: string | symbol,
             options?: StaticEventEmitterOptions,
         ): NodeJS.AsyncIterator<any[]>;
-        /**
-         * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
-         *
-         * ```js
-         * import { EventEmitter, listenerCount } from 'node:events';
-         * const myEmitter = new EventEmitter();
-         * myEmitter.on('event', () => {});
-         * myEmitter.on('event', () => {});
-         * console.log(listenerCount(myEmitter, 'event'));
-         * // Prints: 2
-         * ```
-         * @since v0.9.12
-         * @deprecated Since v3.2.0 - Use `listenerCount` instead.
-         * @param emitter The emitter to query
-         * @param eventName The event name
-         */
-        static listenerCount<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
-            emitter: EventEmitter<Events>,
-            eventName: EventName,
-        ): number;
         /**
          * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
          *
@@ -371,10 +336,6 @@ declare module "events" {
          * ```
          * @since v15.2.0, v14.17.0
          */
-        static getEventListeners<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
-            emitter: EventEmitter<Events>,
-            name: EventName,
-        ): Array<Listener<Events, EventName>>;
         static getEventListeners(emitter: _DOMEventTarget | NodeJS.EventEmitter, name: string | symbol): Function[];
         /**
          * Returns the currently set max amount of listeners.

--- a/types/node/v18/events.d.ts
+++ b/types/node/v18/events.d.ts
@@ -99,25 +99,26 @@ declare module "events" {
     interface EventEmitter<Events extends EventMap<Events> = {}> extends NodeJS.EventEmitter<Events> {}
     type EventMap<Events> = Record<keyof Events, unknown[]>;
     type Args<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ? (
-            | Events[EventName]
-            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
-                ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
-                : never)
+        | Events[EventName]
+        | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+            ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
+            : never)
         )
         : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
             ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
             : any[]);
-    type EventNames<Events extends EventMap<Events>> = {} extends Events ? (string | symbol)
-        : (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap);
-    type Listener<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ?
+            type EventNames<Events extends EventMap<Events>> = {} extends Events ? (string | symbol)
+            : (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap);
+    type EventNameParam<Events extends EventMap<Events>, EventName> = {} extends Events ? string | symbol : EventName | EventNames<Events>;
+    type Listener<Events extends EventMap<Events>, EventName> = {} extends Events ? ((...args: any[]) => void) | ((...args: never) => void): (EventName extends keyof Events ?
             | ((...args: Events[EventName]) => void)
             | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
                 ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
                 : never)
         : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
             ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
-            : (...args: any[]) => void);
-
+            : ((...args: any[]) => void))
+);
     /**
      * The `EventEmitter` class is defined and exposed by the `events` module:
      *
@@ -594,12 +595,8 @@ declare module "events" {
                  * Alias for `emitter.on(eventName, listener)`.
                  * @since v0.1.26
                  */
-                addListener<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                addListener<EventName extends string | symbol>(
-                    eventName: EventName,
+                addListener<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
@@ -633,12 +630,8 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                on<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                on<EventName extends string | symbol>(
-                    eventName: EventName,
+                on<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
@@ -670,12 +663,8 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                once<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                once<EventName extends string | symbol>(
-                    eventName: EventName,
+                once<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
@@ -760,24 +749,16 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeListener<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                removeListener<EventName extends string | symbol>(
-                    eventName: EventName,
+                removeListener<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
                  * Alias for `emitter.removeListener()`.
                  * @since v10.0.0
                  */
-                off<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                off<EventName extends string | symbol>(
-                    eventName: EventName,
+                off<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
@@ -822,11 +803,8 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                listeners<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                ): Array<Listener<Events, EventName>>;
-                listeners<EventName extends string | symbol>(
-                    eventName: EventName,
+                listeners<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                 ): Array<Listener<Events, EventName>>;
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
@@ -858,11 +836,8 @@ declare module "events" {
                  * ```
                  * @since v9.4.0
                  */
-                rawListeners<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                ): Array<Listener<Events, EventName>>;
-                rawListeners<EventName extends string | symbol>(
-                    eventName: EventName,
+                rawListeners<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                 ): Array<Listener<Events, EventName>>;
                 /**
                  * Synchronously calls each of the listeners registered for the event named `eventName`, in the order they were registered, passing the supplied arguments
@@ -920,12 +895,8 @@ declare module "events" {
                  * @param eventName The name of the event being listened for
                  * @param listener The event handler function
                  */
-                listenerCount<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener?: Listener<Events, EventName>,
-                ): number;
-                listenerCount<EventName extends string | symbol>(
-                    eventName: EventName,
+                listenerCount<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                     listener?: Listener<Events, EventName>,
                 ): number;
                 /**
@@ -945,12 +916,8 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependListener<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                prependListener<EventName extends string | symbol>(
-                    eventName: EventName,
+                prependListener<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
@@ -968,12 +935,8 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependOnceListener<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                prependOnceListener<EventName extends string | symbol>(
-                    eventName: EventName,
+                prependOnceListener<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**

--- a/types/node/v18/events.d.ts
+++ b/types/node/v18/events.d.ts
@@ -594,11 +594,7 @@ declare module "events" {
                  * Alias for `emitter.on(eventName, listener)`.
                  * @since v0.1.26
                  */
-                addListener<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                addListener<EventName extends string | symbol>(
+                addListener<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -633,11 +629,7 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                on<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                on<EventName extends string | symbol>(
+                on<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -670,11 +662,7 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                once<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                once<EventName extends string | symbol>(
+                once<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -760,11 +748,7 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeListener<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                removeListener<EventName extends string | symbol>(
+                removeListener<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -772,11 +756,7 @@ declare module "events" {
                  * Alias for `emitter.removeListener()`.
                  * @since v10.0.0
                  */
-                off<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                off<EventName extends string | symbol>(
+                off<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -791,8 +771,7 @@ declare module "events" {
                  * @since v0.1.26
                  */
                 /* eslint-disable @definitelytyped/no-unnecessary-generics */
-                removeAllListeners<EventName extends EventNames<Events>>(eventName: EventName): this;
-                removeAllListeners<EventName extends string | symbol>(eventName?: EventName): this;
+                removeAllListeners<EventName extends EventNames<Events> | string & {} | symbol>(eventName?: EventName): this;
                 /* eslint-enable @definitelytyped/no-unnecessary-generics */
                 /**
                  * By default `EventEmitter`s will print a warning if more than `10` listeners are
@@ -825,9 +804,9 @@ declare module "events" {
                 listeners<EventName extends EventNames<Events>>(
                     eventName: EventName,
                 ): Array<Listener<Events, EventName>>;
-                listeners<EventName extends string | symbol>(
-                    eventName: EventName,
-                ): Array<Listener<Events, EventName>>;
+                listeners(
+                    eventName: string | symbol,
+                ): Array<Listener<Events, string | symbol>>;
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
                  * including any wrappers (such as those created by `.once()`).
@@ -861,9 +840,9 @@ declare module "events" {
                 rawListeners<EventName extends EventNames<Events>>(
                     eventName: EventName,
                 ): Array<Listener<Events, EventName>>;
-                rawListeners<EventName extends string | symbol>(
-                    eventName: EventName,
-                ): Array<Listener<Events, EventName>>;
+                rawListeners(
+                    eventName: string | symbol,
+                ): Array<Listener<Events, string | symbol>>;
                 /**
                  * Synchronously calls each of the listeners registered for the event named `eventName`, in the order they were registered, passing the supplied arguments
                  * to each.
@@ -904,11 +883,7 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                emit<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    ...args: Args<Events, EventName>
-                ): boolean;
-                emit<EventName extends string | symbol>(
+                emit<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     ...args: Args<Events, EventName>
                 ): boolean;
@@ -920,11 +895,7 @@ declare module "events" {
                  * @param eventName The name of the event being listened for
                  * @param listener The event handler function
                  */
-                listenerCount<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener?: Listener<Events, EventName>,
-                ): number;
-                listenerCount<EventName extends string | symbol>(
+                listenerCount<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     listener?: Listener<Events, EventName>,
                 ): number;
@@ -945,11 +916,7 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependListener<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                prependListener<EventName extends string | symbol>(
+                prependListener<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -968,11 +935,7 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependOnceListener<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                prependOnceListener<EventName extends string | symbol>(
+                prependOnceListener<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;

--- a/types/node/v18/events.d.ts
+++ b/types/node/v18/events.d.ts
@@ -99,26 +99,25 @@ declare module "events" {
     interface EventEmitter<Events extends EventMap<Events> = {}> extends NodeJS.EventEmitter<Events> {}
     type EventMap<Events> = Record<keyof Events, unknown[]>;
     type Args<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ? (
-        | Events[EventName]
-        | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
-            ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
-            : never)
+            | Events[EventName]
+            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
+                : never)
         )
         : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
             ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
             : any[]);
-            type EventNames<Events extends EventMap<Events>> = {} extends Events ? (string | symbol)
-            : (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap);
-    type EventNameParam<Events extends EventMap<Events>, EventName> = {} extends Events ? string | symbol : EventName | EventNames<Events>;
-    type Listener<Events extends EventMap<Events>, EventName> = {} extends Events ? ((...args: any[]) => void) | ((...args: never) => void): (EventName extends keyof Events ?
-            | ((...args: Events[EventName]) => void)
-            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
-                ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
-                : never)
-        : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
-            ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
-            : ((...args: any[]) => void))
-);
+    type EventNames<Events extends EventMap<Events>> = {} extends Events ? (string | symbol)
+        : (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap);
+    type EventNameParam<Events extends EventMap<Events>, EventName> = {} extends Events ? string | symbol
+        : EventName | EventNames<Events>;
+    type Listener<Events extends EventMap<Events>, EventName> = {} extends Events ? ((...args: any[]) => void)
+        : (EventName extends (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap) ?
+                | (EventName extends keyof Events ? ((...args: Events[EventName]) => void) : never)
+                | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                    ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
+                    : never)
+            : ((...args: any[]) => void));
     /**
      * The `EventEmitter` class is defined and exposed by the `events` module:
      *
@@ -573,10 +572,17 @@ declare module "events" {
             readonly asyncResource: EventEmitterReferencingAsyncResource;
         }
 
+        /** The events always emitted by EventEmitter itself */
         export interface EventEmitterBuiltInEventMap {
             newListener: [eventName: string | symbol, listener: Function];
             removeListener: [eventName: string | symbol, listener: Function];
         }
+
+        /** Helper type for building functions that take a listener as a paramater when working with event maps */
+        export type EventEmitterEventMapListener<Events extends EventMap<Events>, EventName> = Listener<
+            Events,
+            EventName
+        >;
     }
     global {
         namespace NodeJS {

--- a/types/node/v18/events.d.ts
+++ b/types/node/v18/events.d.ts
@@ -594,7 +594,11 @@ declare module "events" {
                  * Alias for `emitter.on(eventName, listener)`.
                  * @since v0.1.26
                  */
-                addListener<EventName extends EventNames<Events> | string & {} | symbol>(
+                addListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                addListener<EventName extends string | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -629,7 +633,11 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                on<EventName extends EventNames<Events> | string & {} | symbol>(
+                on<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                on<EventName extends string | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -662,7 +670,11 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                once<EventName extends EventNames<Events> | string & {} | symbol>(
+                once<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                once<EventName extends string | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -748,7 +760,11 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeListener<EventName extends EventNames<Events> | string & {} | symbol>(
+                removeListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                removeListener<EventName extends string | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -756,7 +772,11 @@ declare module "events" {
                  * Alias for `emitter.removeListener()`.
                  * @since v10.0.0
                  */
-                off<EventName extends EventNames<Events> | string & {} | symbol>(
+                off<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                off<EventName extends string | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -771,7 +791,8 @@ declare module "events" {
                  * @since v0.1.26
                  */
                 /* eslint-disable @definitelytyped/no-unnecessary-generics */
-                removeAllListeners<EventName extends EventNames<Events> | string & {} | symbol>(eventName?: EventName): this;
+                removeAllListeners<EventName extends EventNames<Events>>(eventName: EventName): this;
+                removeAllListeners<EventName extends string | symbol>(eventName?: EventName): this;
                 /* eslint-enable @definitelytyped/no-unnecessary-generics */
                 /**
                  * By default `EventEmitter`s will print a warning if more than `10` listeners are
@@ -804,9 +825,9 @@ declare module "events" {
                 listeners<EventName extends EventNames<Events>>(
                     eventName: EventName,
                 ): Array<Listener<Events, EventName>>;
-                listeners(
-                    eventName: string | symbol,
-                ): Array<Listener<Events, string | symbol>>;
+                listeners<EventName extends string | symbol>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
                  * including any wrappers (such as those created by `.once()`).
@@ -840,9 +861,9 @@ declare module "events" {
                 rawListeners<EventName extends EventNames<Events>>(
                     eventName: EventName,
                 ): Array<Listener<Events, EventName>>;
-                rawListeners(
-                    eventName: string | symbol,
-                ): Array<Listener<Events, string | symbol>>;
+                rawListeners<EventName extends string | symbol>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
                 /**
                  * Synchronously calls each of the listeners registered for the event named `eventName`, in the order they were registered, passing the supplied arguments
                  * to each.
@@ -883,7 +904,11 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                emit<EventName extends EventNames<Events> | string & {} | symbol>(
+                emit<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    ...args: Args<Events, EventName>
+                ): boolean;
+                emit<EventName extends string | symbol>(
                     eventName: EventName,
                     ...args: Args<Events, EventName>
                 ): boolean;
@@ -895,7 +920,11 @@ declare module "events" {
                  * @param eventName The name of the event being listened for
                  * @param listener The event handler function
                  */
-                listenerCount<EventName extends EventNames<Events> | string & {} | symbol>(
+                listenerCount<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener?: Listener<Events, EventName>,
+                ): number;
+                listenerCount<EventName extends string | symbol>(
                     eventName: EventName,
                     listener?: Listener<Events, EventName>,
                 ): number;
@@ -916,7 +945,11 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependListener<EventName extends EventNames<Events> | string & {} | symbol>(
+                prependListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                prependListener<EventName extends string | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -935,7 +968,11 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependOnceListener<EventName extends EventNames<Events> | string & {} | symbol>(
+                prependOnceListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                prependOnceListener<EventName extends string | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;

--- a/types/node/v18/events.d.ts
+++ b/types/node/v18/events.d.ts
@@ -109,15 +109,17 @@ declare module "events" {
         : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
             ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
             : any[]);
-    type EventNames<Events extends EventMap<Events>> = keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap;
-    type EventNameParam<Events extends EventMap<Events>, EventName> = EventName | EventNames<Events>;
-    type Listener<Events extends EventMap<Events>, EventName> = EventName extends
-        (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap) ?
-            | (EventName extends keyof Events ? ((...args: Events[EventName]) => void) : never)
-            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
-                ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
-                : never)
-        : ((...args: any[]) => void);
+    type EventNames<Events extends EventMap<Events>> = {} extends Events ? (string | symbol)
+        : (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap);
+    type EventNameParam<Events extends EventMap<Events>, EventName> = {} extends Events ? string | symbol
+        : EventName | EventNames<Events>;
+    type Listener<Events extends EventMap<Events>, EventName> = {} extends Events ? ((...args: any[]) => void)
+        : (EventName extends (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap) ?
+                | (EventName extends keyof Events ? ((...args: Events[EventName]) => void) : never)
+                | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                    ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
+                    : never)
+            : ((...args: any[]) => void));
     /**
      * The `EventEmitter` class is defined and exposed by the `events` module:
      *
@@ -572,7 +574,7 @@ declare module "events" {
             readonly asyncResource: EventEmitterReferencingAsyncResource;
         }
 
-        export type NoEventMap = Record<string | symbol, any[]>;
+        export interface NoEventMap {}
 
         /** The events always emitted by EventEmitter itself */
         export interface EventEmitterBuiltInEventMap {

--- a/types/node/v18/events.d.ts
+++ b/types/node/v18/events.d.ts
@@ -815,7 +815,7 @@ declare module "events" {
                 // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
                 listeners<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
-                ): Array<() => void>;
+                ): Array<(...args: any[]) => void>;
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
                  * including any wrappers (such as those created by `.once()`).
@@ -849,7 +849,7 @@ declare module "events" {
                 // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
                 rawListeners<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
-                ): Array<() => void>;
+                ): Array<(...args: any[]) => void>;
                 /**
                  * Synchronously calls each of the listeners registered for the event named `eventName`, in the order they were registered, passing the supplied arguments
                  * to each.

--- a/types/node/v18/events.d.ts
+++ b/types/node/v18/events.d.ts
@@ -601,7 +601,7 @@ declare module "events" {
                  * Alias for `emitter.on(eventName, listener)`.
                  * @since v0.1.26
                  */
-                addListener<EventName>(
+                addListener<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -636,7 +636,7 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                on<EventName>(
+                on<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -669,7 +669,7 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                once<EventName>(
+                once<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -755,7 +755,7 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeListener<EventName>(
+                removeListener<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -763,7 +763,7 @@ declare module "events" {
                  * Alias for `emitter.removeListener()`.
                  * @since v10.0.0
                  */
-                off<EventName>(
+                off<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -778,8 +778,9 @@ declare module "events" {
                  * @since v0.1.26
                  */
                 /* eslint-disable @definitelytyped/no-unnecessary-generics */
-                removeAllListeners<EventName extends EventNames<Events>>(eventName: EventName): this;
-                removeAllListeners<EventName extends string | symbol>(eventName?: EventName): this;
+                removeAllListeners<EventName extends string | symbol>(
+                    eventName?: EventNameParam<Events, EventName>,
+                ): this;
                 /* eslint-enable @definitelytyped/no-unnecessary-generics */
                 /**
                  * By default `EventEmitter`s will print a warning if more than `10` listeners are
@@ -809,7 +810,7 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                listeners<EventName>(
+                listeners<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                 ): Array<Listener<Events, EventName>>;
                 /**
@@ -842,7 +843,7 @@ declare module "events" {
                  * ```
                  * @since v9.4.0
                  */
-                rawListeners<EventName>(
+                rawListeners<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                 ): Array<Listener<Events, EventName>>;
                 /**
@@ -901,7 +902,7 @@ declare module "events" {
                  * @param eventName The name of the event being listened for
                  * @param listener The event handler function
                  */
-                listenerCount<EventName>(
+                listenerCount<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                     listener?: Listener<Events, EventName>,
                 ): number;
@@ -922,7 +923,7 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependListener<EventName>(
+                prependListener<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -941,7 +942,7 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependOnceListener<EventName>(
+                prependOnceListener<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -963,7 +964,7 @@ declare module "events" {
                  * ```
                  * @since v6.0.0
                  */
-                eventNames(): Array<(string | symbol)> & Array<EventNames<Events>>;
+                eventNames(): Array<(string | symbol)>;
             }
         }
     }

--- a/types/node/v18/test/events.ts
+++ b/types/node/v18/test/events.ts
@@ -31,7 +31,7 @@ declare const any: any;
     result = emitter.getMaxListeners();
     result = emitter.listenerCount(event);
 
-    const handler: Function = () => {};
+    const handler = () => {};
     result = emitter.listenerCount(event, handler);
 }
 

--- a/types/node/v18/test/events.ts
+++ b/types/node/v18/test/events.ts
@@ -167,16 +167,16 @@ async function test() {
 
 {
     class MyEmitter extends events.EventEmitter {
-        addListener(event: string, listener: () => void): this {
+        addListener(event: string | symbol, listener: () => void): this {
             return this;
         }
-        listeners(event: string): Array<() => void> {
+        listeners(event: string | symbol): Array<() => void> {
             return [];
         }
-        emit(event: string, ...args: any[]): boolean {
+        emit(event: string | symbol, ...args: any[]): boolean {
             return true;
         }
-        listenerCount(type: string): number {
+        listenerCount(type: string | symbol): number {
             return 0;
         }
     }

--- a/types/node/v18/test/events_generic.ts
+++ b/types/node/v18/test/events_generic.ts
@@ -299,4 +299,18 @@ declare const event5: "event5";
 
     events.on(doubleExtended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
     events.once(doubleExtended, "unknown"); // $ExpectType Promise<any[]>
+
+    extended.addListener(event1, (a: string, b: number | boolean): number => 1);
+    doubleExtended.addListener(event1, (a: string, b: number | boolean): number => 1);
+    // @ts-expect-error
+    extended.addListener(event1, (a: string, b: boolean): number => 1);
+    // @ts-expect-error
+    doubleExtended.addListener(event1, (a: string, b: boolean): number => 1);
+
+    extended.emit("event1", "hello", 42);
+    doubleExtended.emit("event1", "hello", 42);
+    // @ts-expect-error
+    extended.emit("event1", 123);
+    // @ts-expect-error
+    doubleExtended.emit("event1", 123);
 }

--- a/types/node/v18/test/events_generic.ts
+++ b/types/node/v18/test/events_generic.ts
@@ -248,3 +248,55 @@ declare const event5: "event5";
     emitter.emit(s1, "hello", false);
     emitter.emit(s2, "hello", false);
 }
+
+{
+    const promise1: Promise<[string, number]> = events.once(new events.EventEmitter<T>(), "event1");
+    const promise2: Promise<[boolean]> = events.once(new events.EventEmitter<T>(), "event2");
+    const promise3: Promise<[]> = events.once(new events.EventEmitter<T>(), "event3");
+    const promise4: Promise<string[]> = events.once(new events.EventEmitter<T>(), "event4");
+    const promise5: Promise<unknown[]> = events.once(new events.EventEmitter<T>(), "event5");
+    // @ts-expect-error
+    const promise6: Promise<[string, string]> = events.once(new events.EventEmitter<T>(), "event1");
+    const promise7: Promise<any[]> = events.once(new events.EventEmitter<T>(), "event");
+
+    const iterable1: NodeJS.AsyncIterator<[string, number]> = events.on(new events.EventEmitter<T>(), "event1");
+    const iterable2: NodeJS.AsyncIterator<[boolean]> = events.on(new events.EventEmitter<T>(), "event2");
+    const iterable3: NodeJS.AsyncIterator<[]> = events.on(new events.EventEmitter<T>(), "event3");
+    const iterable4: NodeJS.AsyncIterator<string[]> = events.on(new events.EventEmitter<T>(), "event4");
+    const iterable5: NodeJS.AsyncIterator<unknown[]> = events.on(new events.EventEmitter<T>(), "event5");
+    // @ts-expect-error
+    const iterable6: NodeJS.AsyncIterator<[string, string]> = events.on(new events.EventEmitter<T>(), "event1");
+    const iterable7: NodeJS.AsyncIterator<any[]> = events.on(new events.EventEmitter<T>(), "event");
+}
+
+{
+    function acceptsEventEmitterInterface(eventEmitter: NodeJS.EventEmitter) {
+    }
+
+    function acceptsEventEmitterClass(eventEmitter: events.EventEmitter) {
+    }
+
+    acceptsEventEmitterInterface(emitter);
+    acceptsEventEmitterClass(emitter);
+}
+
+{
+    class Extended extends events.EventEmitter<T> {}
+
+    class DoubleExtension extends Extended {}
+
+    const extended = new Extended();
+    const doubleExtended = new DoubleExtension();
+
+    events.on(extended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
+    events.once(extended, "event1"); // $ExpectType Promise<[string, number]>
+
+    events.on(extended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
+    events.once(extended, "unknown"); // $ExpectType Promise<any[]>
+
+    events.on(doubleExtended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
+    events.once(doubleExtended, "event1"); // $ExpectType Promise<[string, number]>
+
+    events.on(doubleExtended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
+    events.once(doubleExtended, "unknown"); // $ExpectType Promise<any[]>
+}

--- a/types/node/v18/test/events_generic.ts
+++ b/types/node/v18/test/events_generic.ts
@@ -116,11 +116,12 @@ declare const event5: "event5";
     let result4: Promise<T["event4"]>;
     let result5: Promise<T["event5"]>;
 
-    result1 = events.once(emitter, event1);
-    result2 = events.once(emitter, event2);
-    result3 = events.once(emitter, event3);
-    result4 = events.once(emitter, event4);
-    result5 = events.once(emitter, event5);
+    // Uncomment once static methods are generic
+    // result1 = events.once(emitter, event1);
+    // result2 = events.once(emitter, event2);
+    // result3 = events.once(emitter, event3);
+    // result4 = events.once(emitter, event4);
+    // result5 = events.once(emitter, event5);
 
     emitter.emit("event1", "hello", 42);
     emitter.emit("event2", true);
@@ -249,25 +250,26 @@ declare const event5: "event5";
     emitter.emit(s2, "hello", false);
 }
 
-{
-    const promise1: Promise<[string, number]> = events.once(new events.EventEmitter<T>(), "event1");
-    const promise2: Promise<[boolean]> = events.once(new events.EventEmitter<T>(), "event2");
-    const promise3: Promise<[]> = events.once(new events.EventEmitter<T>(), "event3");
-    const promise4: Promise<string[]> = events.once(new events.EventEmitter<T>(), "event4");
-    const promise5: Promise<unknown[]> = events.once(new events.EventEmitter<T>(), "event5");
-    // @ts-expect-error
-    const promise6: Promise<[string, string]> = events.once(new events.EventEmitter<T>(), "event1");
-    const promise7: Promise<any[]> = events.once(new events.EventEmitter<T>(), "event");
+// Uncomment once static methods are generic
+// {
+//     const promise1: Promise<[string, number]> = events.once(new events.EventEmitter<T>(), "event1");
+//     const promise2: Promise<[boolean]> = events.once(new events.EventEmitter<T>(), "event2");
+//     const promise3: Promise<[]> = events.once(new events.EventEmitter<T>(), "event3");
+//     const promise4: Promise<string[]> = events.once(new events.EventEmitter<T>(), "event4");
+//     const promise5: Promise<unknown[]> = events.once(new events.EventEmitter<T>(), "event5");
+//     // @ts-expect-error
+//     const promise6: Promise<[string, string]> = events.once(new events.EventEmitter<T>(), "event1");
+//     const promise7: Promise<any[]> = events.once(new events.EventEmitter<T>(), "event");
 
-    const iterable1: NodeJS.AsyncIterator<[string, number]> = events.on(new events.EventEmitter<T>(), "event1");
-    const iterable2: NodeJS.AsyncIterator<[boolean]> = events.on(new events.EventEmitter<T>(), "event2");
-    const iterable3: NodeJS.AsyncIterator<[]> = events.on(new events.EventEmitter<T>(), "event3");
-    const iterable4: NodeJS.AsyncIterator<string[]> = events.on(new events.EventEmitter<T>(), "event4");
-    const iterable5: NodeJS.AsyncIterator<unknown[]> = events.on(new events.EventEmitter<T>(), "event5");
-    // @ts-expect-error
-    const iterable6: NodeJS.AsyncIterator<[string, string]> = events.on(new events.EventEmitter<T>(), "event1");
-    const iterable7: NodeJS.AsyncIterator<any[]> = events.on(new events.EventEmitter<T>(), "event");
-}
+//     const iterable1: NodeJS.AsyncIterator<[string, number]> = events.on(new events.EventEmitter<T>(), "event1");
+//     const iterable2: NodeJS.AsyncIterator<[boolean]> = events.on(new events.EventEmitter<T>(), "event2");
+//     const iterable3: NodeJS.AsyncIterator<[]> = events.on(new events.EventEmitter<T>(), "event3");
+//     const iterable4: NodeJS.AsyncIterator<string[]> = events.on(new events.EventEmitter<T>(), "event4");
+//     const iterable5: NodeJS.AsyncIterator<unknown[]> = events.on(new events.EventEmitter<T>(), "event5");
+//     // @ts-expect-error
+//     const iterable6: NodeJS.AsyncIterator<[string, string]> = events.on(new events.EventEmitter<T>(), "event1");
+//     const iterable7: NodeJS.AsyncIterator<any[]> = events.on(new events.EventEmitter<T>(), "event");
+// }
 
 {
     function acceptsEventEmitterInterface(eventEmitter: NodeJS.EventEmitter) {
@@ -288,17 +290,18 @@ declare const event5: "event5";
     const extended = new Extended();
     const doubleExtended = new DoubleExtension();
 
-    events.on(extended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
-    events.once(extended, "event1"); // $ExpectType Promise<[string, number]>
+    // Uncomment once static methods are generic
+    // events.on(extended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
+    // events.once(extended, "event1"); // $ExpectType Promise<[string, number]>
 
-    events.on(extended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
-    events.once(extended, "unknown"); // $ExpectType Promise<any[]>
+    // events.on(extended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
+    // events.once(extended, "unknown"); // $ExpectType Promise<any[]>
 
-    events.on(doubleExtended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
-    events.once(doubleExtended, "event1"); // $ExpectType Promise<[string, number]>
+    // events.on(doubleExtended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
+    // events.once(doubleExtended, "event1"); // $ExpectType Promise<[string, number]>
 
-    events.on(doubleExtended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
-    events.once(doubleExtended, "unknown"); // $ExpectType Promise<any[]>
+    // events.on(doubleExtended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
+    // events.once(doubleExtended, "unknown"); // $ExpectType Promise<any[]>
 
     extended.addListener(event1, (a: string, b: number | boolean): number => 1);
     doubleExtended.addListener(event1, (a: string, b: number | boolean): number => 1);

--- a/types/node/v18/test/events_generic.ts
+++ b/types/node/v18/test/events_generic.ts
@@ -110,13 +110,17 @@ declare const event5: "event5";
 }
 
 {
-    let result: Promise<number[]>;
+    let result1: Promise<T["event1"]>;
+    let result2: Promise<T["event2"]>;
+    let result3: Promise<T["event3"]>;
+    let result4: Promise<T["event4"]>;
+    let result5: Promise<T["event5"]>;
 
-    result = events.once(emitter, event1);
-    result = events.once(emitter, event2);
-    result = events.once(emitter, event3);
-    result = events.once(emitter, event4);
-    result = events.once(emitter, event5);
+    result1 = events.once(emitter, event1);
+    result2 = events.once(emitter, event2);
+    result3 = events.once(emitter, event3);
+    result4 = events.once(emitter, event4);
+    result5 = events.once(emitter, event5);
 
     emitter.emit("event1", "hello", 42);
     emitter.emit("event2", true);
@@ -146,7 +150,7 @@ declare const event5: "event5";
 }
 
 {
-    let result: Array<keyof T>;
+    let result: Array<keyof T | keyof events.EventEmitterBuiltInEventMap>;
 
     result = emitter.eventNames();
 }
@@ -157,12 +161,12 @@ declare const event5: "event5";
         )
         : never;
 
-    function on1<K>(event: K, listener: Listener<K>): void {
+    function on1<K extends keyof T>(event: K, listener: Listener<K>): void {
         emitter.on(event, listener);
     }
 
     // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-    function on2<K>(...args: Parameters<typeof emitter.on<K>>): void {
+    function on2<K extends keyof T>(...args: Parameters<typeof emitter.on<K>>): void {
         emitter.on(...args);
     }
 
@@ -204,7 +208,6 @@ declare const event5: "event5";
     emitter.emit("abc", "hello", 123);
     // @ts-expect-error
     emitter.emit("abc", 123, false);
-    // @ts-expect-error
     emitter.emit("def", "hello", 123);
 }
 
@@ -226,7 +229,6 @@ declare const event5: "event5";
     emitter.emit(s1, "hello", 123);
     // @ts-expect-error
     emitter.emit(s1, 123, false);
-    // @ts-expect-error
     emitter.emit(s2, "hello", 123);
 }
 
@@ -244,6 +246,5 @@ declare const event5: "event5";
     emitter.emit(789, 123, false);
     // @ts-expect-error
     emitter.emit(s1, "hello", false);
-    // @ts-expect-error
     emitter.emit(s2, "hello", false);
 }

--- a/types/node/v18/test/events_generic.ts
+++ b/types/node/v18/test/events_generic.ts
@@ -339,3 +339,8 @@ declare const event5: "event5";
     emitter.prependOnceListener('error', onError);
     emitter.removeListener('error', onError);
 }
+
+interface Implementing extends events.EventEmitter {}
+declare class Implementing implements events.EventEmitter {        
+    addListener(eventName: 'event', listener: (arg: boolean) => void): this;
+}

--- a/types/node/v18/test/events_generic.ts
+++ b/types/node/v18/test/events_generic.ts
@@ -317,3 +317,25 @@ declare const event5: "event5";
     // @ts-expect-error
     doubleExtended.emit("event1", 123);
 }
+
+{
+    function onError(err: any) {
+        console.log(err);
+    }
+
+    class Test extends events.EventEmitter {
+        // The union was only uncallable when an instance method exists.
+        test() { return true; }
+    }
+    
+    class Test2 extends events.EventEmitter {}
+
+    const emitter = {} as Test | Test2
+    emitter.addListener('error', onError);
+    emitter.on("error", onError);
+    emitter.off('error', onError);
+    emitter.once('error', onError);
+    emitter.prependListener('error', onError);
+    emitter.prependOnceListener('error', onError);
+    emitter.removeListener('error', onError);
+}

--- a/types/node/v18/test/events_generic.ts
+++ b/types/node/v18/test/events_generic.ts
@@ -157,10 +157,7 @@ declare const event5: "event5";
 }
 
 {
-    type Listener<K> = K extends keyof T ? (
-            (...args: T[K]) => void
-        )
-        : never;
+    type Listener<K> = events.EventEmitterEventMapListener<T, K>;
 
     function on1<K extends keyof T>(event: K, listener: Listener<K>): void {
         emitter.on(event, listener);
@@ -325,22 +322,24 @@ declare const event5: "event5";
 
     class Test extends events.EventEmitter {
         // The union was only uncallable when an instance method exists.
-        test() { return true; }
+        test() {
+            return true;
+        }
     }
-    
+
     class Test2 extends events.EventEmitter {}
 
-    const emitter = {} as Test | Test2
-    emitter.addListener('error', onError);
+    const emitter = {} as Test | Test2;
+    emitter.addListener("error", onError);
     emitter.on("error", onError);
-    emitter.off('error', onError);
-    emitter.once('error', onError);
-    emitter.prependListener('error', onError);
-    emitter.prependOnceListener('error', onError);
-    emitter.removeListener('error', onError);
+    emitter.off("error", onError);
+    emitter.once("error", onError);
+    emitter.prependListener("error", onError);
+    emitter.prependOnceListener("error", onError);
+    emitter.removeListener("error", onError);
 }
 
 interface Implementing extends events.EventEmitter {}
-declare class Implementing implements events.EventEmitter {        
-    addListener(eventName: 'event', listener: (arg: boolean) => void): this;
+declare class Implementing implements events.EventEmitter {
+    addListener(eventName: "event", listener: (arg: boolean) => void): this;
 }

--- a/types/node/v18/test/events_generic.ts
+++ b/types/node/v18/test/events_generic.ts
@@ -151,7 +151,7 @@ declare const event5: "event5";
 }
 
 {
-    let result: Array<keyof T | keyof events.EventEmitterBuiltInEventMap>;
+    let result: Array<string | symbol>;
 
     result = emitter.eventNames();
 }
@@ -337,9 +337,19 @@ declare const event5: "event5";
     emitter.prependListener("error", onError);
     emitter.prependOnceListener("error", onError);
     emitter.removeListener("error", onError);
+    emitter.removeAllListeners();
+    emitter.removeAllListeners("error");
+    emitter.emit("error");
 }
 
 interface Implementing extends events.EventEmitter {}
 declare class Implementing implements events.EventEmitter {
     addListener(eventName: "event", listener: (arg: boolean) => void): this;
+}
+
+{
+    // @ts-expect-error
+    emitter.on({}, () => {});
+    // @ts-expect-error
+    new EventEmitter().on({}, () => {});
 }

--- a/types/node/v20/events.d.ts
+++ b/types/node/v20/events.d.ts
@@ -1,5 +1,3 @@
-declare const internalTypeOnlyBrandSymbol: unique symbol;
-
 /**
  * Much of the Node.js core API is built around an idiomatic asynchronous
  * event-driven architecture in which certain kinds of objects (called "emitters")
@@ -139,6 +137,11 @@ declare module "events" {
      */
     class EventEmitter<Events extends EventMap<Events> = {}> {
         constructor(options?: EventEmitterOptions);
+
+        // This "property" is used to brand a specific instance of the EventEmitter class with its Event map, which is needed
+        // in order to infer the map if we have a chain like `class A extends EventEmitter<{}>` (or many levels deep)
+        // It is also marked as possibly undefined in order to allow something like `const t: NodeJS.EventEmitter<{}> = { <insert implementation here> };`
+        readonly #internalTypeOnlyBrand?: Events;
 
         [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
             error: Error,
@@ -644,11 +647,6 @@ declare module "events" {
     global {
         namespace NodeJS {
             interface EventEmitter<Events extends EventMap<Events> = {}> {
-                // This "property" is used to brand a specific instance of the EventEmitter class with its Event map, which is needed
-                // in order to infer the map if we have a chain like `class A extends EventEmitter<{}>` (or many levels deep)
-                // It is also marked as possibly undefined in order to allow something like `const t: NodeJS.EventEmitter<{}> = { <insert implementation here> };`
-                readonly [internalTypeOnlyBrandSymbol]?: Events;
-
                 [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
                     error: Error,
                     event: EventName,

--- a/types/node/v20/events.d.ts
+++ b/types/node/v20/events.d.ts
@@ -1,3 +1,5 @@
+declare const internalTypeOnlyBrandSymbol: unique symbol;
+
 /**
  * Much of the Node.js core API is built around an idiomatic asynchronous
  * event-driven architecture in which certain kinds of objects (called "emitters")
@@ -34,6 +36,7 @@
  * ```
  * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/events.js)
  */
+
 declare module "events" {
     import { AsyncResource, AsyncResourceOptions } from "node:async_hooks";
     // NOTE: This class is in the docs but is **not actually exported** by Node.
@@ -120,6 +123,7 @@ declare module "events" {
         : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
             ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
             : (...args: any[]) => void);
+
     /**
      * The `EventEmitter` class is defined and exposed by the `node:events` module:
      *
@@ -640,6 +644,11 @@ declare module "events" {
     global {
         namespace NodeJS {
             interface EventEmitter<Events extends EventMap<Events> = {}> {
+                // This "property" is used to brand a specific instance of the EventEmitter class with its Event map, which is needed
+                // in order to infer the map if we have a chain like `class A extends EventEmitter<{}>` (or many levels deep)
+                // It is also marked as possibly undefined in order to allow something like `const t: NodeJS.EventEmitter<{}> = { <insert implementation here> };`
+                readonly [internalTypeOnlyBrandSymbol]?: Events;
+
                 [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
                     error: Error,
                     event: EventName,

--- a/types/node/v20/events.d.ts
+++ b/types/node/v20/events.d.ts
@@ -99,24 +99,27 @@ declare module "events" {
          */
         lowWaterMark?: number | undefined;
     }
-    interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
-    type EventMap<T> = Record<keyof T, any[]> | DefaultEventMap;
-    type DefaultEventMap = [never];
-    type AnyRest = [...args: any[]];
-    type Args<K, T> = T extends DefaultEventMap ? AnyRest : (
-        K extends keyof T ? T[K] : never
-    );
-    type Key<K, T> = T extends DefaultEventMap ? string | symbol : K | keyof T;
-    type Key2<K, T> = T extends DefaultEventMap ? string | symbol : K & keyof T;
-    type Listener<K, T, F> = T extends DefaultEventMap ? F : (
-        K extends keyof T ? (
-                T[K] extends unknown[] ? (...args: T[K]) => void : never
-            )
-            : never
-    );
-    type Listener1<K, T> = Listener<K, T, (...args: any[]) => void>;
-    type Listener2<K, T> = Listener<K, T, Function>;
-
+    interface EventEmitter<Events extends EventMap<Events> = {}> extends NodeJS.EventEmitter<Events> {}
+    type EventMap<Events> = Record<keyof Events, unknown[]>;
+    type Args<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ? (
+            | Events[EventName]
+            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
+                : never)
+        )
+        : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+            ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
+            : any[]);
+    type EventNames<Events extends EventMap<Events>> = {} extends Events ? (string | symbol)
+        : (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap);
+    type Listener<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ?
+            | ((...args: Events[EventName]) => void)
+            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
+                : never)
+        : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+            ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
+            : (...args: any[]) => void);
     /**
      * The `EventEmitter` class is defined and exposed by the `node:events` module:
      *
@@ -130,10 +133,15 @@ declare module "events" {
      * It supports the following option:
      * @since v0.1.26
      */
-    class EventEmitter<T extends EventMap<T> = DefaultEventMap> {
+    class EventEmitter<Events extends EventMap<Events> = {}> {
         constructor(options?: EventEmitterOptions);
 
-        [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
+        [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
+            error: Error,
+            event: EventName,
+            ...args: Args<Events, EventName>
+        ): void;
+        [EventEmitter.captureRejectionSymbol]?(error: Error, event: string | symbol, ...args: any[]): void;
 
         /**
          * Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
@@ -214,6 +222,11 @@ declare module "events" {
          * ```
          * @since v11.13.0, v10.16.0
          */
+        static once<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            eventName: EventName,
+            options?: StaticEventEmitterOptions,
+        ): Promise<Args<Events, EventName>>;
         static once(
             emitter: NodeJS.EventEmitter,
             eventName: string | symbol,
@@ -300,6 +313,11 @@ declare module "events" {
          * @since v13.6.0, v12.16.0
          * @return An `AsyncIterator` that iterates `eventName` events emitted by the `emitter`
          */
+        static on<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            eventName: EventName,
+            options?: StaticEventEmitterIteratorOptions,
+        ): NodeJS.AsyncIterator<Args<Events, EventName>>;
         static on(
             emitter: NodeJS.EventEmitter,
             eventName: string | symbol,
@@ -310,6 +328,27 @@ declare module "events" {
             eventName: string,
             options?: StaticEventEmitterIteratorOptions,
         ): NodeJS.AsyncIterator<any[]>;
+        /**
+         * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
+         *
+         * ```js
+         * import { EventEmitter, listenerCount } from 'node:events';
+         *
+         * const myEmitter = new EventEmitter();
+         * myEmitter.on('event', () => {});
+         * myEmitter.on('event', () => {});
+         * console.log(listenerCount(myEmitter, 'event'));
+         * // Prints: 2
+         * ```
+         * @since v0.9.12
+         * @deprecated Since v3.2.0 - Use `listenerCount` instead.
+         * @param emitter The emitter to query
+         * @param eventName The event name
+         */
+        static listenerCount<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            eventName: EventName,
+        ): number;
         /**
          * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
          *
@@ -355,7 +394,14 @@ declare module "events" {
          * ```
          * @since v15.2.0, v14.17.0
          */
-        static getEventListeners(emitter: EventTarget | NodeJS.EventEmitter, name: string | symbol): Function[];
+        static getEventListeners<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
+            emitter: EventEmitter<Events>,
+            name: EventName,
+        ): Array<Listener<Events, EventName>>;
+        static getEventListeners(
+            emitter: EventTarget | NodeJS.EventEmitter,
+            name: string | symbol,
+        ): Function[];
         /**
          * Returns the currently set max amount of listeners.
          *
@@ -585,16 +631,37 @@ declare module "events" {
              */
             readonly asyncResource: EventEmitterReferencingAsyncResource;
         }
+
+        export interface EventEmitterBuiltInEventMap {
+            newListener: [eventName: string | symbol, listener: Function];
+            removeListener: [eventName: string | symbol, listener: Function];
+        }
     }
     global {
         namespace NodeJS {
-            interface EventEmitter<T extends EventMap<T> = DefaultEventMap> {
-                [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
+            interface EventEmitter<Events extends EventMap<Events> = {}> {
+                [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
+                    error: Error,
+                    event: EventName,
+                    ...args: Args<Events, EventName>
+                ): void;
+                [EventEmitter.captureRejectionSymbol]?<EventName extends string | symbol>(
+                    error: Error,
+                    event: EventName,
+                    ...args: Args<Events, EventName>
+                ): void;
                 /**
                  * Alias for `emitter.on(eventName, listener)`.
                  * @since v0.1.26
                  */
-                addListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                addListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                addListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Adds the `listener` function to the end of the listeners array for the event
                  * named `eventName`. No checks are made to see if the `listener` has already
@@ -626,7 +693,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                on<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                on<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                on<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Adds a **one-time** `listener` function for the event named `eventName`. The
                  * next time `eventName` is triggered, this listener is removed and then invoked.
@@ -656,7 +730,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                once<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                once<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                once<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Removes the specified `listener` from the listener array for the event named `eventName`.
                  *
@@ -739,12 +820,26 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                removeListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                removeListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Alias for `emitter.removeListener()`.
                  * @since v10.0.0
                  */
-                off<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                off<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                off<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Removes all listeners, or those of the specified `eventName`.
                  *
@@ -755,7 +850,10 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeAllListeners(eventName?: Key<unknown, T>): this;
+                /* eslint-disable @definitelytyped/no-unnecessary-generics */
+                removeAllListeners<EventName extends EventNames<Events>>(eventName: EventName): this;
+                removeAllListeners<EventName extends string | symbol>(eventName?: EventName): this;
+                /* eslint-enable @definitelytyped/no-unnecessary-generics */
                 /**
                  * By default `EventEmitter`s will print a warning if more than `10` listeners are
                  * added for a particular event. This is a useful default that helps finding
@@ -784,7 +882,12 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                listeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
+                listeners<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
+                listeners<EventName extends string | symbol>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
                  * including any wrappers (such as those created by `.once()`).
@@ -815,7 +918,12 @@ declare module "events" {
                  * ```
                  * @since v9.4.0
                  */
-                rawListeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
+                rawListeners<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
+                rawListeners<EventName extends string | symbol>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
                 /**
                  * Synchronously calls each of the listeners registered for the event named `eventName`, in the order they were registered, passing the supplied arguments
                  * to each.
@@ -856,7 +964,14 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                emit<K>(eventName: Key<K, T>, ...args: Args<K, T>): boolean;
+                emit<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    ...args: Args<Events, EventName>
+                ): boolean;
+                emit<EventName extends string | symbol>(
+                    eventName: EventName,
+                    ...args: Args<Events, EventName>
+                ): boolean;
                 /**
                  * Returns the number of listeners listening for the event named `eventName`.
                  * If `listener` is provided, it will return how many times the listener is found
@@ -865,7 +980,14 @@ declare module "events" {
                  * @param eventName The name of the event being listened for
                  * @param listener The event handler function
                  */
-                listenerCount<K>(eventName: Key<K, T>, listener?: Listener2<K, T>): number;
+                listenerCount<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener?: Listener<Events, EventName>,
+                ): number;
+                listenerCount<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener?: Listener<Events, EventName>,
+                ): number;
                 /**
                  * Adds the `listener` function to the _beginning_ of the listeners array for the
                  * event named `eventName`. No checks are made to see if the `listener` has
@@ -883,7 +1005,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                prependListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                prependListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Adds a **one-time**`listener` function for the event named `eventName` to the _beginning_ of the listeners array. The next time `eventName` is triggered, this
                  * listener is removed, and then invoked.
@@ -899,7 +1028,14 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependOnceListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                prependOnceListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                prependOnceListener<EventName extends string | symbol>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Returns an array listing the events for which the emitter has registered
                  * listeners. The values in the array are strings or `Symbol`s.
@@ -919,7 +1055,7 @@ declare module "events" {
                  * ```
                  * @since v6.0.0
                  */
-                eventNames(): Array<(string | symbol) & Key2<unknown, T>>;
+                eventNames(): Array<(string | symbol)> & Array<EventNames<Events>>;
             }
         }
     }

--- a/types/node/v20/events.d.ts
+++ b/types/node/v20/events.d.ts
@@ -138,11 +138,6 @@ declare module "events" {
     class EventEmitter<Events extends EventMap<Events> = {}> {
         constructor(options?: EventEmitterOptions);
 
-        // This "property" is used to brand a specific instance of the EventEmitter class with its Event map, which is needed
-        // in order to infer the map if we have a chain like `class A extends EventEmitter<{}>` (or many levels deep)
-        // It is also marked as possibly undefined in order to allow something like `const t: NodeJS.EventEmitter<{}> = { <insert implementation here> };`
-        readonly #internalTypeOnlyBrand?: Events;
-
         [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
             error: Error,
             event: EventName,
@@ -229,11 +224,6 @@ declare module "events" {
          * ```
          * @since v11.13.0, v10.16.0
          */
-        static once<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
-            emitter: EventEmitter<Events>,
-            eventName: EventName,
-            options?: StaticEventEmitterOptions,
-        ): Promise<Args<Events, EventName>>;
         static once(
             emitter: NodeJS.EventEmitter,
             eventName: string | symbol,
@@ -320,11 +310,6 @@ declare module "events" {
          * @since v13.6.0, v12.16.0
          * @return An `AsyncIterator` that iterates `eventName` events emitted by the `emitter`
          */
-        static on<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
-            emitter: EventEmitter<Events>,
-            eventName: EventName,
-            options?: StaticEventEmitterIteratorOptions,
-        ): NodeJS.AsyncIterator<Args<Events, EventName>>;
         static on(
             emitter: NodeJS.EventEmitter,
             eventName: string | symbol,
@@ -335,27 +320,6 @@ declare module "events" {
             eventName: string,
             options?: StaticEventEmitterIteratorOptions,
         ): NodeJS.AsyncIterator<any[]>;
-        /**
-         * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
-         *
-         * ```js
-         * import { EventEmitter, listenerCount } from 'node:events';
-         *
-         * const myEmitter = new EventEmitter();
-         * myEmitter.on('event', () => {});
-         * myEmitter.on('event', () => {});
-         * console.log(listenerCount(myEmitter, 'event'));
-         * // Prints: 2
-         * ```
-         * @since v0.9.12
-         * @deprecated Since v3.2.0 - Use `listenerCount` instead.
-         * @param emitter The emitter to query
-         * @param eventName The event name
-         */
-        static listenerCount<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
-            emitter: EventEmitter<Events>,
-            eventName: EventName,
-        ): number;
         /**
          * A class method that returns the number of listeners for the given `eventName` registered on the given `emitter`.
          *
@@ -401,10 +365,6 @@ declare module "events" {
          * ```
          * @since v15.2.0, v14.17.0
          */
-        static getEventListeners<Events extends EventMap<Events>, EventName extends EventNames<Events>>(
-            emitter: EventEmitter<Events>,
-            name: EventName,
-        ): Array<Listener<Events, EventName>>;
         static getEventListeners(
             emitter: EventTarget | NodeJS.EventEmitter,
             name: string | symbol,

--- a/types/node/v20/events.d.ts
+++ b/types/node/v20/events.d.ts
@@ -103,26 +103,25 @@ declare module "events" {
     interface EventEmitter<Events extends EventMap<Events> = {}> extends NodeJS.EventEmitter<Events> {}
     type EventMap<Events> = Record<keyof Events, unknown[]>;
     type Args<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ? (
-        | Events[EventName]
-        | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
-            ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
-            : never)
+            | Events[EventName]
+            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
+                : never)
         )
         : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
             ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
             : any[]);
-            type EventNames<Events extends EventMap<Events>> = {} extends Events ? (string | symbol)
-            : (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap);
-    type EventNameParam<Events extends EventMap<Events>, EventName> = {} extends Events ? string | symbol : EventName | EventNames<Events>;
-    type Listener<Events extends EventMap<Events>, EventName> = {} extends Events ? ((...args: any[]) => void) | ((...args: never) => void): (EventName extends keyof Events ?
-            | ((...args: Events[EventName]) => void)
-            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
-                ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
-                : never)
-        : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
-            ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
-            : ((...args: any[]) => void))
-);
+    type EventNames<Events extends EventMap<Events>> = {} extends Events ? (string | symbol)
+        : (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap);
+    type EventNameParam<Events extends EventMap<Events>, EventName> = {} extends Events ? string | symbol
+        : EventName | EventNames<Events>;
+    type Listener<Events extends EventMap<Events>, EventName> = {} extends Events ? ((...args: any[]) => void)
+        : (EventName extends (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap) ?
+                | (EventName extends keyof Events ? ((...args: Events[EventName]) => void) : never)
+                | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                    ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
+                    : never)
+            : ((...args: any[]) => void));
     /**
      * The `EventEmitter` class is defined and exposed by the `node:events` module:
      *
@@ -600,10 +599,17 @@ declare module "events" {
             readonly asyncResource: EventEmitterReferencingAsyncResource;
         }
 
+        /** The events always emitted by EventEmitter itself */
         export interface EventEmitterBuiltInEventMap {
             newListener: [eventName: string | symbol, listener: Function];
             removeListener: [eventName: string | symbol, listener: Function];
         }
+
+        /** Helper type for building functions that take a listener as a paramater when working with event maps */
+        export type EventEmitterEventMapListener<Events extends EventMap<Events>, EventName> = Listener<
+            Events,
+            EventName
+        >;
     }
     global {
         namespace NodeJS {

--- a/types/node/v20/events.d.ts
+++ b/types/node/v20/events.d.ts
@@ -621,7 +621,11 @@ declare module "events" {
                  * Alias for `emitter.on(eventName, listener)`.
                  * @since v0.1.26
                  */
-                addListener<EventName extends EventNames<Events> | string & {} | symbol>(
+                addListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                addListener<EventName extends string | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -656,7 +660,11 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                on<EventName extends EventNames<Events> | string & {} | symbol>(
+                on<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                on<EventName extends string | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -689,7 +697,11 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                once<EventName extends EventNames<Events> | string & {} | symbol>(
+                once<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                once<EventName extends string | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -775,7 +787,11 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeListener<EventName extends EventNames<Events> | string & {} | symbol>(
+                removeListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                removeListener<EventName extends string | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -783,7 +799,11 @@ declare module "events" {
                  * Alias for `emitter.removeListener()`.
                  * @since v10.0.0
                  */
-                off<EventName extends EventNames<Events> | string & {} | symbol>(
+                off<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                off<EventName extends string | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -798,7 +818,8 @@ declare module "events" {
                  * @since v0.1.26
                  */
                 /* eslint-disable @definitelytyped/no-unnecessary-generics */
-                removeAllListeners<EventName extends EventNames<Events> | string & {} | symbol>(eventName?: EventName): this;
+                removeAllListeners<EventName extends EventNames<Events>>(eventName: EventName): this;
+                removeAllListeners<EventName extends string | symbol>(eventName?: EventName): this;
                 /* eslint-enable @definitelytyped/no-unnecessary-generics */
                 /**
                  * By default `EventEmitter`s will print a warning if more than `10` listeners are
@@ -831,9 +852,9 @@ declare module "events" {
                 listeners<EventName extends EventNames<Events>>(
                     eventName: EventName,
                 ): Array<Listener<Events, EventName>>;
-                listeners(
-                    eventName: string | symbol,
-                ): Array<Listener<Events, string | symbol>>;
+                listeners<EventName extends string | symbol>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
                  * including any wrappers (such as those created by `.once()`).
@@ -867,9 +888,9 @@ declare module "events" {
                 rawListeners<EventName extends EventNames<Events>>(
                     eventName: EventName,
                 ): Array<Listener<Events, EventName>>;
-                rawListeners(
-                    eventName: string | symbol,
-                ): Array<Listener<Events, string | symbol>>;
+                rawListeners<EventName extends string | symbol>(
+                    eventName: EventName,
+                ): Array<Listener<Events, EventName>>;
                 /**
                  * Synchronously calls each of the listeners registered for the event named `eventName`, in the order they were registered, passing the supplied arguments
                  * to each.
@@ -910,7 +931,11 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                emit<EventName extends EventNames<Events> | string & {} | symbol>(
+                emit<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    ...args: Args<Events, EventName>
+                ): boolean;
+                emit<EventName extends string | symbol>(
                     eventName: EventName,
                     ...args: Args<Events, EventName>
                 ): boolean;
@@ -922,7 +947,11 @@ declare module "events" {
                  * @param eventName The name of the event being listened for
                  * @param listener The event handler function
                  */
-                listenerCount<EventName extends EventNames<Events> | string & {} | symbol>(
+                listenerCount<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener?: Listener<Events, EventName>,
+                ): number;
+                listenerCount<EventName extends string | symbol>(
                     eventName: EventName,
                     listener?: Listener<Events, EventName>,
                 ): number;
@@ -943,7 +972,11 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependListener<EventName extends EventNames<Events> | string & {} | symbol>(
+                prependListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                prependListener<EventName extends string | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -962,7 +995,11 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependOnceListener<EventName extends EventNames<Events> | string & {} | symbol>(
+                prependOnceListener<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    listener: Listener<Events, EventName>,
+                ): this;
+                prependOnceListener<EventName extends string | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;

--- a/types/node/v20/events.d.ts
+++ b/types/node/v20/events.d.ts
@@ -621,11 +621,7 @@ declare module "events" {
                  * Alias for `emitter.on(eventName, listener)`.
                  * @since v0.1.26
                  */
-                addListener<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                addListener<EventName extends string | symbol>(
+                addListener<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -660,11 +656,7 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                on<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                on<EventName extends string | symbol>(
+                on<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -697,11 +689,7 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                once<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                once<EventName extends string | symbol>(
+                once<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -787,11 +775,7 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeListener<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                removeListener<EventName extends string | symbol>(
+                removeListener<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -799,11 +783,7 @@ declare module "events" {
                  * Alias for `emitter.removeListener()`.
                  * @since v10.0.0
                  */
-                off<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                off<EventName extends string | symbol>(
+                off<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -818,8 +798,7 @@ declare module "events" {
                  * @since v0.1.26
                  */
                 /* eslint-disable @definitelytyped/no-unnecessary-generics */
-                removeAllListeners<EventName extends EventNames<Events>>(eventName: EventName): this;
-                removeAllListeners<EventName extends string | symbol>(eventName?: EventName): this;
+                removeAllListeners<EventName extends EventNames<Events> | string & {} | symbol>(eventName?: EventName): this;
                 /* eslint-enable @definitelytyped/no-unnecessary-generics */
                 /**
                  * By default `EventEmitter`s will print a warning if more than `10` listeners are
@@ -852,9 +831,9 @@ declare module "events" {
                 listeners<EventName extends EventNames<Events>>(
                     eventName: EventName,
                 ): Array<Listener<Events, EventName>>;
-                listeners<EventName extends string | symbol>(
-                    eventName: EventName,
-                ): Array<Listener<Events, EventName>>;
+                listeners(
+                    eventName: string | symbol,
+                ): Array<Listener<Events, string | symbol>>;
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
                  * including any wrappers (such as those created by `.once()`).
@@ -888,9 +867,9 @@ declare module "events" {
                 rawListeners<EventName extends EventNames<Events>>(
                     eventName: EventName,
                 ): Array<Listener<Events, EventName>>;
-                rawListeners<EventName extends string | symbol>(
-                    eventName: EventName,
-                ): Array<Listener<Events, EventName>>;
+                rawListeners(
+                    eventName: string | symbol,
+                ): Array<Listener<Events, string | symbol>>;
                 /**
                  * Synchronously calls each of the listeners registered for the event named `eventName`, in the order they were registered, passing the supplied arguments
                  * to each.
@@ -931,11 +910,7 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                emit<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    ...args: Args<Events, EventName>
-                ): boolean;
-                emit<EventName extends string | symbol>(
+                emit<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     ...args: Args<Events, EventName>
                 ): boolean;
@@ -947,11 +922,7 @@ declare module "events" {
                  * @param eventName The name of the event being listened for
                  * @param listener The event handler function
                  */
-                listenerCount<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener?: Listener<Events, EventName>,
-                ): number;
-                listenerCount<EventName extends string | symbol>(
+                listenerCount<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     listener?: Listener<Events, EventName>,
                 ): number;
@@ -972,11 +943,7 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependListener<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                prependListener<EventName extends string | symbol>(
+                prependListener<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -995,11 +962,7 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependOnceListener<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                prependOnceListener<EventName extends string | symbol>(
+                prependOnceListener<EventName extends EventNames<Events> | string & {} | symbol>(
                     eventName: EventName,
                     listener: Listener<Events, EventName>,
                 ): this;

--- a/types/node/v20/events.d.ts
+++ b/types/node/v20/events.d.ts
@@ -103,25 +103,26 @@ declare module "events" {
     interface EventEmitter<Events extends EventMap<Events> = {}> extends NodeJS.EventEmitter<Events> {}
     type EventMap<Events> = Record<keyof Events, unknown[]>;
     type Args<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ? (
-            | Events[EventName]
-            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
-                ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
-                : never)
+        | Events[EventName]
+        | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+            ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
+            : never)
         )
         : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
             ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
             : any[]);
-    type EventNames<Events extends EventMap<Events>> = {} extends Events ? (string | symbol)
-        : (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap);
-    type Listener<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ?
+            type EventNames<Events extends EventMap<Events>> = {} extends Events ? (string | symbol)
+            : (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap);
+    type EventNameParam<Events extends EventMap<Events>, EventName> = {} extends Events ? string | symbol : EventName | EventNames<Events>;
+    type Listener<Events extends EventMap<Events>, EventName> = {} extends Events ? ((...args: any[]) => void) | ((...args: never) => void): (EventName extends keyof Events ?
             | ((...args: Events[EventName]) => void)
             | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
                 ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
                 : never)
         : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
             ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
-            : (...args: any[]) => void);
-
+            : ((...args: any[]) => void))
+);
     /**
      * The `EventEmitter` class is defined and exposed by the `node:events` module:
      *
@@ -621,12 +622,8 @@ declare module "events" {
                  * Alias for `emitter.on(eventName, listener)`.
                  * @since v0.1.26
                  */
-                addListener<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                addListener<EventName extends string | symbol>(
-                    eventName: EventName,
+                addListener<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
@@ -660,12 +657,8 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                on<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                on<EventName extends string | symbol>(
-                    eventName: EventName,
+                on<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
@@ -697,12 +690,8 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                once<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                once<EventName extends string | symbol>(
-                    eventName: EventName,
+                once<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
@@ -787,24 +776,16 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeListener<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                removeListener<EventName extends string | symbol>(
-                    eventName: EventName,
+                removeListener<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
                  * Alias for `emitter.removeListener()`.
                  * @since v10.0.0
                  */
-                off<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                off<EventName extends string | symbol>(
-                    eventName: EventName,
+                off<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
@@ -849,11 +830,8 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                listeners<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                ): Array<Listener<Events, EventName>>;
-                listeners<EventName extends string | symbol>(
-                    eventName: EventName,
+                listeners<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                 ): Array<Listener<Events, EventName>>;
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
@@ -885,11 +863,8 @@ declare module "events" {
                  * ```
                  * @since v9.4.0
                  */
-                rawListeners<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                ): Array<Listener<Events, EventName>>;
-                rawListeners<EventName extends string | symbol>(
-                    eventName: EventName,
+                rawListeners<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                 ): Array<Listener<Events, EventName>>;
                 /**
                  * Synchronously calls each of the listeners registered for the event named `eventName`, in the order they were registered, passing the supplied arguments
@@ -947,12 +922,8 @@ declare module "events" {
                  * @param eventName The name of the event being listened for
                  * @param listener The event handler function
                  */
-                listenerCount<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener?: Listener<Events, EventName>,
-                ): number;
-                listenerCount<EventName extends string | symbol>(
-                    eventName: EventName,
+                listenerCount<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                     listener?: Listener<Events, EventName>,
                 ): number;
                 /**
@@ -972,12 +943,8 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependListener<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                prependListener<EventName extends string | symbol>(
-                    eventName: EventName,
+                prependListener<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**
@@ -995,12 +962,8 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependOnceListener<EventName extends EventNames<Events>>(
-                    eventName: EventName,
-                    listener: Listener<Events, EventName>,
-                ): this;
-                prependOnceListener<EventName extends string | symbol>(
-                    eventName: EventName,
+                prependOnceListener<EventName>(
+                    eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
                 /**

--- a/types/node/v20/events.d.ts
+++ b/types/node/v20/events.d.ts
@@ -842,7 +842,7 @@ declare module "events" {
                 // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
                 listeners<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
-                ): Array<() => void>;
+                ): Array<(...args: any[]) => void>;
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
                  * including any wrappers (such as those created by `.once()`).
@@ -876,7 +876,7 @@ declare module "events" {
                 // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
                 rawListeners<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
-                ): Array<() => void>;
+                ): Array<(...args: any[]) => void>;
                 /**
                  * Synchronously calls each of the listeners registered for the event named `eventName`, in the order they were registered, passing the supplied arguments
                  * to each.

--- a/types/node/v20/events.d.ts
+++ b/types/node/v20/events.d.ts
@@ -628,7 +628,7 @@ declare module "events" {
                  * Alias for `emitter.on(eventName, listener)`.
                  * @since v0.1.26
                  */
-                addListener<EventName>(
+                addListener<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -663,7 +663,7 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                on<EventName>(
+                on<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -696,7 +696,7 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                once<EventName>(
+                once<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -782,7 +782,7 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeListener<EventName>(
+                removeListener<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -790,7 +790,7 @@ declare module "events" {
                  * Alias for `emitter.removeListener()`.
                  * @since v10.0.0
                  */
-                off<EventName>(
+                off<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -805,8 +805,9 @@ declare module "events" {
                  * @since v0.1.26
                  */
                 /* eslint-disable @definitelytyped/no-unnecessary-generics */
-                removeAllListeners<EventName extends EventNames<Events>>(eventName: EventName): this;
-                removeAllListeners<EventName extends string | symbol>(eventName?: EventName): this;
+                removeAllListeners<EventName extends string | symbol>(
+                    eventName?: EventNameParam<Events, EventName>,
+                ): this;
                 /* eslint-enable @definitelytyped/no-unnecessary-generics */
                 /**
                  * By default `EventEmitter`s will print a warning if more than `10` listeners are
@@ -836,7 +837,7 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                listeners<EventName>(
+                listeners<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                 ): Array<Listener<Events, EventName>>;
                 /**
@@ -869,7 +870,7 @@ declare module "events" {
                  * ```
                  * @since v9.4.0
                  */
-                rawListeners<EventName>(
+                rawListeners<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                 ): Array<Listener<Events, EventName>>;
                 /**
@@ -928,7 +929,7 @@ declare module "events" {
                  * @param eventName The name of the event being listened for
                  * @param listener The event handler function
                  */
-                listenerCount<EventName>(
+                listenerCount<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                     listener?: Listener<Events, EventName>,
                 ): number;
@@ -949,7 +950,7 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependListener<EventName>(
+                prependListener<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -968,7 +969,7 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependOnceListener<EventName>(
+                prependOnceListener<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
                     listener: Listener<Events, EventName>,
                 ): this;
@@ -991,7 +992,7 @@ declare module "events" {
                  * ```
                  * @since v6.0.0
                  */
-                eventNames(): Array<(string | symbol)> & Array<EventNames<Events>>;
+                eventNames(): Array<(string | symbol)>;
             }
         }
     }

--- a/types/node/v20/events.d.ts
+++ b/types/node/v20/events.d.ts
@@ -100,7 +100,9 @@ declare module "events" {
          */
         lowWaterMark?: number | undefined;
     }
-    interface EventEmitter<Events extends EventMap<Events> = {}> extends NodeJS.EventEmitter<Events> {}
+    interface EventEmitter<Events extends EventMap<Events> = EventEmitter.NoEventMap>
+        extends NodeJS.EventEmitter<Events>
+    {}
     type EventMap<Events> = Record<keyof Events, unknown[]>;
     type Args<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ? (
             | Events[EventName]
@@ -111,17 +113,15 @@ declare module "events" {
         : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
             ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
             : any[]);
-    type EventNames<Events extends EventMap<Events>> = {} extends Events ? (string | symbol)
-        : (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap);
-    type EventNameParam<Events extends EventMap<Events>, EventName> = {} extends Events ? string | symbol
-        : EventName | EventNames<Events>;
-    type Listener<Events extends EventMap<Events>, EventName> = {} extends Events ? ((...args: any[]) => void)
-        : (EventName extends (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap) ?
-                | (EventName extends keyof Events ? ((...args: Events[EventName]) => void) : never)
-                | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
-                    ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
-                    : never)
-            : ((...args: any[]) => void));
+    type EventNames<Events extends EventMap<Events>> = keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap;
+    type EventNameParam<Events extends EventMap<Events>, EventName> = EventName | EventNames<Events>;
+    type Listener<Events extends EventMap<Events>, EventName> = EventName extends
+        (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap) ?
+            | (EventName extends keyof Events ? ((...args: Events[EventName]) => void) : never)
+            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
+                : never)
+        : ((...args: any[]) => void);
     /**
      * The `EventEmitter` class is defined and exposed by the `node:events` module:
      *
@@ -135,7 +135,7 @@ declare module "events" {
      * It supports the following option:
      * @since v0.1.26
      */
-    class EventEmitter<Events extends EventMap<Events> = {}> {
+    class EventEmitter<Events extends EventMap<Events> = EventEmitter.NoEventMap> {
         constructor(options?: EventEmitterOptions);
 
         [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
@@ -599,6 +599,8 @@ declare module "events" {
             readonly asyncResource: EventEmitterReferencingAsyncResource;
         }
 
+        export type NoEventMap = Record<string | symbol, any[]>;
+
         /** The events always emitted by EventEmitter itself */
         export interface EventEmitterBuiltInEventMap {
             newListener: [eventName: string | symbol, listener: Function];
@@ -613,7 +615,7 @@ declare module "events" {
     }
     global {
         namespace NodeJS {
-            interface EventEmitter<Events extends EventMap<Events> = {}> {
+            interface EventEmitter<Events extends EventMap<Events> = EventEmitter.NoEventMap> {
                 [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
                     error: Error,
                     event: EventName,
@@ -837,9 +839,10 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
+                // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
                 listeners<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
-                ): Array<Listener<Events, EventName>>;
+                ): Array<() => void>;
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
                  * including any wrappers (such as those created by `.once()`).
@@ -870,9 +873,10 @@ declare module "events" {
                  * ```
                  * @since v9.4.0
                  */
+                // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
                 rawListeners<EventName extends string | symbol>(
                     eventName: EventNameParam<Events, EventName>,
-                ): Array<Listener<Events, EventName>>;
+                ): Array<() => void>;
                 /**
                  * Synchronously calls each of the listeners registered for the event named `eventName`, in the order they were registered, passing the supplied arguments
                  * to each.

--- a/types/node/v20/events.d.ts
+++ b/types/node/v20/events.d.ts
@@ -113,15 +113,17 @@ declare module "events" {
         : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
             ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
             : any[]);
-    type EventNames<Events extends EventMap<Events>> = keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap;
-    type EventNameParam<Events extends EventMap<Events>, EventName> = EventName | EventNames<Events>;
-    type Listener<Events extends EventMap<Events>, EventName> = EventName extends
-        (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap) ?
-            | (EventName extends keyof Events ? ((...args: Events[EventName]) => void) : never)
-            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
-                ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
-                : never)
-        : ((...args: any[]) => void);
+    type EventNames<Events extends EventMap<Events>> = {} extends Events ? (string | symbol)
+        : (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap);
+    type EventNameParam<Events extends EventMap<Events>, EventName> = {} extends Events ? string | symbol
+        : EventName | EventNames<Events>;
+    type Listener<Events extends EventMap<Events>, EventName> = {} extends Events ? ((...args: any[]) => void)
+        : (EventName extends (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap) ?
+                | (EventName extends keyof Events ? ((...args: Events[EventName]) => void) : never)
+                | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                    ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
+                    : never)
+            : ((...args: any[]) => void));
     /**
      * The `EventEmitter` class is defined and exposed by the `node:events` module:
      *
@@ -599,7 +601,7 @@ declare module "events" {
             readonly asyncResource: EventEmitterReferencingAsyncResource;
         }
 
-        export type NoEventMap = Record<string | symbol, any[]>;
+        export interface NoEventMap {}
 
         /** The events always emitted by EventEmitter itself */
         export interface EventEmitterBuiltInEventMap {

--- a/types/node/v20/test/events.ts
+++ b/types/node/v20/test/events.ts
@@ -31,7 +31,7 @@ declare const any: any;
     result = emitter.getMaxListeners();
     result = emitter.listenerCount(event);
 
-    const handler: Function = () => {};
+    const handler = () => {};
     result = emitter.listenerCount(event, handler);
 }
 
@@ -141,7 +141,7 @@ async function testEventTarget() {
     captureRejectionSymbol2 = events.captureRejectionSymbol;
 
     const emitter = new events.EventEmitter();
-    emitter[events.captureRejectionSymbol] = (err: Error, name: string, ...args: any[]) => {};
+    emitter[events.captureRejectionSymbol] = (err: Error, name: string | symbol, ...args: any[]) => {};
 }
 
 {
@@ -193,16 +193,16 @@ async function testEventTarget() {
 
 {
     class MyEmitter extends events.EventEmitter {
-        addListener(event: string, listener: () => void): this {
+        addListener(event: string | symbol, listener: () => void): this {
             return this;
         }
-        listeners(event: string): Array<() => void> {
+        listeners(event: string | symbol): Array<() => void> {
             return [];
         }
-        emit(event: string, ...args: any[]): boolean {
+        emit(event: string | symbol, ...args: any[]): boolean {
             return true;
         }
-        listenerCount(type: string): number {
+        listenerCount(type: string | symbol): number {
             return 0;
         }
     }

--- a/types/node/v20/test/events_generic.ts
+++ b/types/node/v20/test/events_generic.ts
@@ -299,4 +299,18 @@ declare const event5: "event5";
 
     events.on(doubleExtended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
     events.once(doubleExtended, "unknown"); // $ExpectType Promise<any[]>
+
+    extended.addListener(event1, (a: string, b: number | boolean): number => 1);
+    doubleExtended.addListener(event1, (a: string, b: number | boolean): number => 1);
+    // @ts-expect-error
+    extended.addListener(event1, (a: string, b: boolean): number => 1);
+    // @ts-expect-error
+    doubleExtended.addListener(event1, (a: string, b: boolean): number => 1);
+
+    extended.emit("event1", "hello", 42);
+    doubleExtended.emit("event1", "hello", 42);
+    // @ts-expect-error
+    extended.emit("event1", 123);
+    // @ts-expect-error
+    doubleExtended.emit("event1", 123);
 }

--- a/types/node/v20/test/events_generic.ts
+++ b/types/node/v20/test/events_generic.ts
@@ -110,13 +110,17 @@ declare const event5: "event5";
 }
 
 {
-    let result: Promise<number[]>;
+    let result1: Promise<T["event1"]>;
+    let result2: Promise<T["event2"]>;
+    let result3: Promise<T["event3"]>;
+    let result4: Promise<T["event4"]>;
+    let result5: Promise<T["event5"]>;
 
-    result = events.once(emitter, event1);
-    result = events.once(emitter, event2);
-    result = events.once(emitter, event3);
-    result = events.once(emitter, event4);
-    result = events.once(emitter, event5);
+    result1 = events.once(emitter, event1);
+    result2 = events.once(emitter, event2);
+    result3 = events.once(emitter, event3);
+    result4 = events.once(emitter, event4);
+    result5 = events.once(emitter, event5);
 
     emitter.emit("event1", "hello", 42);
     emitter.emit("event2", true);
@@ -146,7 +150,7 @@ declare const event5: "event5";
 }
 
 {
-    let result: Array<keyof T>;
+    let result: Array<keyof T | keyof events.EventEmitterBuiltInEventMap>;
 
     result = emitter.eventNames();
 }
@@ -157,12 +161,12 @@ declare const event5: "event5";
         )
         : never;
 
-    function on1<K>(event: K, listener: Listener<K>): void {
+    function on1<K extends keyof T>(event: K, listener: Listener<K>): void {
         emitter.on(event, listener);
     }
 
     // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-    function on2<K>(...args: Parameters<typeof emitter.on<K>>): void {
+    function on2<K extends keyof T>(...args: Parameters<typeof emitter.on<K>>): void {
         emitter.on(...args);
     }
 
@@ -204,7 +208,6 @@ declare const event5: "event5";
     emitter.emit("abc", "hello", 123);
     // @ts-expect-error
     emitter.emit("abc", 123, false);
-    // @ts-expect-error
     emitter.emit("def", "hello", 123);
 }
 
@@ -226,7 +229,6 @@ declare const event5: "event5";
     emitter.emit(s1, "hello", 123);
     // @ts-expect-error
     emitter.emit(s1, 123, false);
-    // @ts-expect-error
     emitter.emit(s2, "hello", 123);
 }
 
@@ -244,6 +246,36 @@ declare const event5: "event5";
     emitter.emit(789, 123, false);
     // @ts-expect-error
     emitter.emit(s1, "hello", false);
-    // @ts-expect-error
     emitter.emit(s2, "hello", false);
+}
+
+{
+    const promise1: Promise<[string, number]> = events.once(new events.EventEmitter<T>(), "event1");
+    const promise2: Promise<[boolean]> = events.once(new events.EventEmitter<T>(), "event2");
+    const promise3: Promise<[]> = events.once(new events.EventEmitter<T>(), "event3");
+    const promise4: Promise<string[]> = events.once(new events.EventEmitter<T>(), "event4");
+    const promise5: Promise<unknown[]> = events.once(new events.EventEmitter<T>(), "event5");
+    // @ts-expect-error
+    const promise6: Promise<[string, string]> = events.once(new events.EventEmitter<T>(), "event1");
+    const promise7: Promise<any[]> = events.once(new events.EventEmitter<T>(), "event");
+
+    const iterable1: NodeJS.AsyncIterator<[string, number]> = events.on(new events.EventEmitter<T>(), "event1");
+    const iterable2: NodeJS.AsyncIterator<[boolean]> = events.on(new events.EventEmitter<T>(), "event2");
+    const iterable3: NodeJS.AsyncIterator<[]> = events.on(new events.EventEmitter<T>(), "event3");
+    const iterable4: NodeJS.AsyncIterator<string[]> = events.on(new events.EventEmitter<T>(), "event4");
+    const iterable5: NodeJS.AsyncIterator<unknown[]> = events.on(new events.EventEmitter<T>(), "event5");
+    // @ts-expect-error
+    const iterable6: NodeJS.AsyncIterator<[string, string]> = events.on(new events.EventEmitter<T>(), "event1");
+    const iterable7: NodeJS.AsyncIterator<any[]> = events.on(new events.EventEmitter<T>(), "event");
+}
+
+{
+    function acceptsEventEmitterInterface(eventEmitter: NodeJS.EventEmitter) {
+    }
+
+    function acceptsEventEmitterClass(eventEmitter: events.EventEmitter) {
+    }
+
+    acceptsEventEmitterInterface(emitter);
+    acceptsEventEmitterClass(emitter);
 }

--- a/types/node/v20/test/events_generic.ts
+++ b/types/node/v20/test/events_generic.ts
@@ -110,17 +110,18 @@ declare const event5: "event5";
 }
 
 {
-    let result1: Promise<T["event1"]>;
-    let result2: Promise<T["event2"]>;
-    let result3: Promise<T["event3"]>;
-    let result4: Promise<T["event4"]>;
-    let result5: Promise<T["event5"]>;
+    // Uncomment once static methods are generic
+    // let result1: Promise<T["event1"]>;
+    // let result2: Promise<T["event2"]>;
+    // let result3: Promise<T["event3"]>;
+    // let result4: Promise<T["event4"]>;
+    // let result5: Promise<T["event5"]>;
 
-    result1 = events.once(emitter, event1);
-    result2 = events.once(emitter, event2);
-    result3 = events.once(emitter, event3);
-    result4 = events.once(emitter, event4);
-    result5 = events.once(emitter, event5);
+    // result1 = events.once(emitter, event1);
+    // result2 = events.once(emitter, event2);
+    // result3 = events.once(emitter, event3);
+    // result4 = events.once(emitter, event4);
+    // result5 = events.once(emitter, event5);
 
     emitter.emit("event1", "hello", 42);
     emitter.emit("event2", true);
@@ -249,25 +250,26 @@ declare const event5: "event5";
     emitter.emit(s2, "hello", false);
 }
 
-{
-    const promise1: Promise<[string, number]> = events.once(new events.EventEmitter<T>(), "event1");
-    const promise2: Promise<[boolean]> = events.once(new events.EventEmitter<T>(), "event2");
-    const promise3: Promise<[]> = events.once(new events.EventEmitter<T>(), "event3");
-    const promise4: Promise<string[]> = events.once(new events.EventEmitter<T>(), "event4");
-    const promise5: Promise<unknown[]> = events.once(new events.EventEmitter<T>(), "event5");
-    // @ts-expect-error
-    const promise6: Promise<[string, string]> = events.once(new events.EventEmitter<T>(), "event1");
-    const promise7: Promise<any[]> = events.once(new events.EventEmitter<T>(), "event");
+// Uncomment once static methods are generic
+// {
+//     const promise1: Promise<[string, number]> = events.once(new events.EventEmitter<T>(), "event1");
+//     const promise2: Promise<[boolean]> = events.once(new events.EventEmitter<T>(), "event2");
+//     const promise3: Promise<[]> = events.once(new events.EventEmitter<T>(), "event3");
+//     const promise4: Promise<string[]> = events.once(new events.EventEmitter<T>(), "event4");
+//     const promise5: Promise<unknown[]> = events.once(new events.EventEmitter<T>(), "event5");
+//     // @ts-expect-error
+//     const promise6: Promise<[string, string]> = events.once(new events.EventEmitter<T>(), "event1");
+//     const promise7: Promise<any[]> = events.once(new events.EventEmitter<T>(), "event");
 
-    const iterable1: NodeJS.AsyncIterator<[string, number]> = events.on(new events.EventEmitter<T>(), "event1");
-    const iterable2: NodeJS.AsyncIterator<[boolean]> = events.on(new events.EventEmitter<T>(), "event2");
-    const iterable3: NodeJS.AsyncIterator<[]> = events.on(new events.EventEmitter<T>(), "event3");
-    const iterable4: NodeJS.AsyncIterator<string[]> = events.on(new events.EventEmitter<T>(), "event4");
-    const iterable5: NodeJS.AsyncIterator<unknown[]> = events.on(new events.EventEmitter<T>(), "event5");
-    // @ts-expect-error
-    const iterable6: NodeJS.AsyncIterator<[string, string]> = events.on(new events.EventEmitter<T>(), "event1");
-    const iterable7: NodeJS.AsyncIterator<any[]> = events.on(new events.EventEmitter<T>(), "event");
-}
+//     const iterable1: NodeJS.AsyncIterator<[string, number]> = events.on(new events.EventEmitter<T>(), "event1");
+//     const iterable2: NodeJS.AsyncIterator<[boolean]> = events.on(new events.EventEmitter<T>(), "event2");
+//     const iterable3: NodeJS.AsyncIterator<[]> = events.on(new events.EventEmitter<T>(), "event3");
+//     const iterable4: NodeJS.AsyncIterator<string[]> = events.on(new events.EventEmitter<T>(), "event4");
+//     const iterable5: NodeJS.AsyncIterator<unknown[]> = events.on(new events.EventEmitter<T>(), "event5");
+//     // @ts-expect-error
+//     const iterable6: NodeJS.AsyncIterator<[string, string]> = events.on(new events.EventEmitter<T>(), "event1");
+//     const iterable7: NodeJS.AsyncIterator<any[]> = events.on(new events.EventEmitter<T>(), "event");
+// }
 
 {
     function acceptsEventEmitterInterface(eventEmitter: NodeJS.EventEmitter) {
@@ -288,17 +290,18 @@ declare const event5: "event5";
     const extended = new Extended();
     const doubleExtended = new DoubleExtension();
 
-    events.on(extended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
-    events.once(extended, "event1"); // $ExpectType Promise<[string, number]>
+    // Uncomment once static methods are generic
+    // events.on(extended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
+    // events.once(extended, "event1"); // $ExpectType Promise<[string, number]>
 
-    events.on(extended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
-    events.once(extended, "unknown"); // $ExpectType Promise<any[]>
+    // events.on(extended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
+    // events.once(extended, "unknown"); // $ExpectType Promise<any[]>
 
-    events.on(doubleExtended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
-    events.once(doubleExtended, "event1"); // $ExpectType Promise<[string, number]>
+    // events.on(doubleExtended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
+    // events.once(doubleExtended, "event1"); // $ExpectType Promise<[string, number]>
 
-    events.on(doubleExtended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
-    events.once(doubleExtended, "unknown"); // $ExpectType Promise<any[]>
+    // events.on(doubleExtended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
+    // events.once(doubleExtended, "unknown"); // $ExpectType Promise<any[]>
 
     extended.addListener(event1, (a: string, b: number | boolean): number => 1);
     doubleExtended.addListener(event1, (a: string, b: number | boolean): number => 1);

--- a/types/node/v20/test/events_generic.ts
+++ b/types/node/v20/test/events_generic.ts
@@ -279,3 +279,24 @@ declare const event5: "event5";
     acceptsEventEmitterInterface(emitter);
     acceptsEventEmitterClass(emitter);
 }
+
+{
+    class Extended extends events.EventEmitter<T> {}
+
+    class DoubleExtension extends Extended {}
+
+    const extended = new Extended();
+    const doubleExtended = new DoubleExtension();
+
+    events.on(extended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
+    events.once(extended, "event1"); // $ExpectType Promise<[string, number]>
+
+    events.on(extended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
+    events.once(extended, "unknown"); // $ExpectType Promise<any[]>
+
+    events.on(doubleExtended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
+    events.once(doubleExtended, "event1"); // $ExpectType Promise<[string, number]>
+
+    events.on(doubleExtended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
+    events.once(doubleExtended, "unknown"); // $ExpectType Promise<any[]>
+}

--- a/types/node/v20/test/events_generic.ts
+++ b/types/node/v20/test/events_generic.ts
@@ -339,3 +339,8 @@ declare const event5: "event5";
     emitter.prependOnceListener('error', onError);
     emitter.removeListener('error', onError);
 }
+
+interface Implementing extends events.EventEmitter {}
+declare class Implementing implements events.EventEmitter {        
+    addListener(eventName: 'event', listener: (arg: boolean) => void): this;
+}

--- a/types/node/v20/test/events_generic.ts
+++ b/types/node/v20/test/events_generic.ts
@@ -317,3 +317,25 @@ declare const event5: "event5";
     // @ts-expect-error
     doubleExtended.emit("event1", 123);
 }
+
+{
+    function onError(err: any) {
+        console.log(err);
+    }
+
+    class Test extends events.EventEmitter {
+        // The union was only uncallable when an instance method exists.
+        test() { return true; }
+    }
+    
+    class Test2 extends events.EventEmitter {}
+
+    const emitter = {} as Test | Test2
+    emitter.addListener('error', onError);
+    emitter.on("error", onError);
+    emitter.off('error', onError);
+    emitter.once('error', onError);
+    emitter.prependListener('error', onError);
+    emitter.prependOnceListener('error', onError);
+    emitter.removeListener('error', onError);
+}

--- a/types/node/v20/test/events_generic.ts
+++ b/types/node/v20/test/events_generic.ts
@@ -157,10 +157,7 @@ declare const event5: "event5";
 }
 
 {
-    type Listener<K> = K extends keyof T ? (
-            (...args: T[K]) => void
-        )
-        : never;
+    type Listener<K> = events.EventEmitterEventMapListener<T, K>;
 
     function on1<K extends keyof T>(event: K, listener: Listener<K>): void {
         emitter.on(event, listener);
@@ -325,22 +322,24 @@ declare const event5: "event5";
 
     class Test extends events.EventEmitter {
         // The union was only uncallable when an instance method exists.
-        test() { return true; }
+        test() {
+            return true;
+        }
     }
-    
+
     class Test2 extends events.EventEmitter {}
 
-    const emitter = {} as Test | Test2
-    emitter.addListener('error', onError);
+    const emitter = {} as Test | Test2;
+    emitter.addListener("error", onError);
     emitter.on("error", onError);
-    emitter.off('error', onError);
-    emitter.once('error', onError);
-    emitter.prependListener('error', onError);
-    emitter.prependOnceListener('error', onError);
-    emitter.removeListener('error', onError);
+    emitter.off("error", onError);
+    emitter.once("error", onError);
+    emitter.prependListener("error", onError);
+    emitter.prependOnceListener("error", onError);
+    emitter.removeListener("error", onError);
 }
 
 interface Implementing extends events.EventEmitter {}
-declare class Implementing implements events.EventEmitter {        
-    addListener(eventName: 'event', listener: (arg: boolean) => void): this;
+declare class Implementing implements events.EventEmitter {
+    addListener(eventName: "event", listener: (arg: boolean) => void): this;
 }

--- a/types/node/v20/test/events_generic.ts
+++ b/types/node/v20/test/events_generic.ts
@@ -151,7 +151,7 @@ declare const event5: "event5";
 }
 
 {
-    let result: Array<keyof T | keyof events.EventEmitterBuiltInEventMap>;
+    let result: Array<string | symbol>;
 
     result = emitter.eventNames();
 }
@@ -337,9 +337,19 @@ declare const event5: "event5";
     emitter.prependListener("error", onError);
     emitter.prependOnceListener("error", onError);
     emitter.removeListener("error", onError);
+    emitter.removeAllListeners();
+    emitter.removeAllListeners("error");
+    emitter.emit("error");
 }
 
 interface Implementing extends events.EventEmitter {}
 declare class Implementing implements events.EventEmitter {
     addListener(eventName: "event", listener: (arg: boolean) => void): this;
+}
+
+{
+    // @ts-expect-error
+    emitter.on({}, () => {});
+    // @ts-expect-error
+    new EventEmitter().on({}, () => {});
 }

--- a/types/node/v22/events.d.ts
+++ b/types/node/v22/events.d.ts
@@ -99,24 +99,30 @@ declare module "events" {
          */
         lowWaterMark?: number | undefined;
     }
-    interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
-    type EventMap<T> = Record<keyof T, any[]> | DefaultEventMap;
-    type DefaultEventMap = [never];
-    type AnyRest = [...args: any[]];
-    type Args<K, T> = T extends DefaultEventMap ? AnyRest : (
-        K extends keyof T ? T[K] : never
-    );
-    type Key<K, T> = T extends DefaultEventMap ? string | symbol : K | keyof T;
-    type Key2<K, T> = T extends DefaultEventMap ? string | symbol : K & keyof T;
-    type Listener<K, T, F> = T extends DefaultEventMap ? F : (
-        K extends keyof T ? (
-                T[K] extends unknown[] ? (...args: T[K]) => void : never
-            )
-            : never
-    );
-    type Listener1<K, T> = Listener<K, T, (...args: any[]) => void>;
-    type Listener2<K, T> = Listener<K, T, Function>;
-
+    interface EventEmitter<Events extends EventMap<Events> = EventEmitter.NoEventMap>
+        extends NodeJS.EventEmitter<Events>
+    {}
+    type EventMap<Events> = Record<keyof Events, unknown[]>;
+    type Args<Events extends EventMap<Events>, EventName> = EventName extends keyof Events ? (
+            | Events[EventName]
+            | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
+                : never)
+        )
+        : (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+            ? EventEmitter.EventEmitterBuiltInEventMap[EventName]
+            : any[]);
+    type EventNames<Events extends EventMap<Events>> = {} extends Events ? (string | symbol)
+        : (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap);
+    type EventNameParam<Events extends EventMap<Events>, EventName> = {} extends Events ? string | symbol
+        : EventName | EventNames<Events>;
+    type Listener<Events extends EventMap<Events>, EventName> = {} extends Events ? ((...args: any[]) => void)
+        : (EventName extends (keyof Events | keyof EventEmitter.EventEmitterBuiltInEventMap) ?
+                | (EventName extends keyof Events ? ((...args: Events[EventName]) => void) : never)
+                | (EventName extends keyof EventEmitter.EventEmitterBuiltInEventMap
+                    ? (...args: EventEmitter.EventEmitterBuiltInEventMap[EventName]) => void
+                    : never)
+            : ((...args: any[]) => void));
     /**
      * The `EventEmitter` class is defined and exposed by the `node:events` module:
      *
@@ -130,10 +136,15 @@ declare module "events" {
      * It supports the following option:
      * @since v0.1.26
      */
-    class EventEmitter<T extends EventMap<T> = DefaultEventMap> {
+    class EventEmitter<Events extends EventMap<Events> = EventEmitter.NoEventMap> {
         constructor(options?: EventEmitterOptions);
 
-        [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
+        [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
+            error: Error,
+            event: EventName,
+            ...args: Args<Events, EventName>
+        ): void;
+        [EventEmitter.captureRejectionSymbol]?(error: Error, event: string | symbol, ...args: any[]): void;
 
         /**
          * Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
@@ -355,7 +366,10 @@ declare module "events" {
          * ```
          * @since v15.2.0, v14.17.0
          */
-        static getEventListeners(emitter: EventTarget | NodeJS.EventEmitter, name: string | symbol): Function[];
+        static getEventListeners(
+            emitter: EventTarget | NodeJS.EventEmitter,
+            name: string | symbol,
+        ): Function[];
         /**
          * Returns the currently set max amount of listeners.
          *
@@ -584,16 +598,42 @@ declare module "events" {
              */
             readonly asyncResource: EventEmitterReferencingAsyncResource;
         }
+
+        export interface NoEventMap {}
+
+        /** The events always emitted by EventEmitter itself */
+        export interface EventEmitterBuiltInEventMap {
+            newListener: [eventName: string | symbol, listener: Function];
+            removeListener: [eventName: string | symbol, listener: Function];
+        }
+
+        /** Helper type for building functions that take a listener as a paramater when working with event maps */
+        export type EventEmitterEventMapListener<Events extends EventMap<Events>, EventName> = Listener<
+            Events,
+            EventName
+        >;
     }
     global {
         namespace NodeJS {
-            interface EventEmitter<T extends EventMap<T> = DefaultEventMap> {
-                [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;
+            interface EventEmitter<Events extends EventMap<Events> = EventEmitter.NoEventMap> {
+                [EventEmitter.captureRejectionSymbol]?<EventName extends EventNames<Events>>(
+                    error: Error,
+                    event: EventName,
+                    ...args: Args<Events, EventName>
+                ): void;
+                [EventEmitter.captureRejectionSymbol]?<EventName extends string | symbol>(
+                    error: Error,
+                    event: EventName,
+                    ...args: Args<Events, EventName>
+                ): void;
                 /**
                  * Alias for `emitter.on(eventName, listener)`.
                  * @since v0.1.26
                  */
-                addListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                addListener<EventName extends string | symbol>(
+                    eventName: EventNameParam<Events, EventName>,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Adds the `listener` function to the end of the listeners array for the event
                  * named `eventName`. No checks are made to see if the `listener` has already
@@ -625,7 +665,10 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                on<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                on<EventName extends string | symbol>(
+                    eventName: EventNameParam<Events, EventName>,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Adds a **one-time** `listener` function for the event named `eventName`. The
                  * next time `eventName` is triggered, this listener is removed and then invoked.
@@ -655,7 +698,10 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                once<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                once<EventName extends string | symbol>(
+                    eventName: EventNameParam<Events, EventName>,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Removes the specified `listener` from the listener array for the event named `eventName`.
                  *
@@ -738,12 +784,18 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                removeListener<EventName extends string | symbol>(
+                    eventName: EventNameParam<Events, EventName>,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Alias for `emitter.removeListener()`.
                  * @since v10.0.0
                  */
-                off<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                off<EventName extends string | symbol>(
+                    eventName: EventNameParam<Events, EventName>,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Removes all listeners, or those of the specified `eventName`.
                  *
@@ -754,7 +806,11 @@ declare module "events" {
                  * Returns a reference to the `EventEmitter`, so that calls can be chained.
                  * @since v0.1.26
                  */
-                removeAllListeners(eventName?: Key<unknown, T>): this;
+                /* eslint-disable @definitelytyped/no-unnecessary-generics */
+                removeAllListeners<EventName extends string | symbol>(
+                    eventName?: EventNameParam<Events, EventName>,
+                ): this;
+                /* eslint-enable @definitelytyped/no-unnecessary-generics */
                 /**
                  * By default `EventEmitter`s will print a warning if more than `10` listeners are
                  * added for a particular event. This is a useful default that helps finding
@@ -783,7 +839,10 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                listeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
+                // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+                listeners<EventName extends string | symbol>(
+                    eventName: EventNameParam<Events, EventName>,
+                ): Array<(...args: any[]) => void>;
                 /**
                  * Returns a copy of the array of listeners for the event named `eventName`,
                  * including any wrappers (such as those created by `.once()`).
@@ -814,7 +873,10 @@ declare module "events" {
                  * ```
                  * @since v9.4.0
                  */
-                rawListeners<K>(eventName: Key<K, T>): Array<Listener2<K, T>>;
+                // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+                rawListeners<EventName extends string | symbol>(
+                    eventName: EventNameParam<Events, EventName>,
+                ): Array<(...args: any[]) => void>;
                 /**
                  * Synchronously calls each of the listeners registered for the event named `eventName`, in the order they were registered, passing the supplied arguments
                  * to each.
@@ -855,7 +917,14 @@ declare module "events" {
                  * ```
                  * @since v0.1.26
                  */
-                emit<K>(eventName: Key<K, T>, ...args: Args<K, T>): boolean;
+                emit<EventName extends EventNames<Events>>(
+                    eventName: EventName,
+                    ...args: Args<Events, EventName>
+                ): boolean;
+                emit<EventName extends string | symbol>(
+                    eventName: EventName,
+                    ...args: Args<Events, EventName>
+                ): boolean;
                 /**
                  * Returns the number of listeners listening for the event named `eventName`.
                  * If `listener` is provided, it will return how many times the listener is found
@@ -864,7 +933,10 @@ declare module "events" {
                  * @param eventName The name of the event being listened for
                  * @param listener The event handler function
                  */
-                listenerCount<K>(eventName: Key<K, T>, listener?: Listener2<K, T>): number;
+                listenerCount<EventName extends string | symbol>(
+                    eventName: EventNameParam<Events, EventName>,
+                    listener?: Listener<Events, EventName>,
+                ): number;
                 /**
                  * Adds the `listener` function to the _beginning_ of the listeners array for the
                  * event named `eventName`. No checks are made to see if the `listener` has
@@ -882,7 +954,10 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                prependListener<EventName extends string | symbol>(
+                    eventName: EventNameParam<Events, EventName>,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Adds a **one-time**`listener` function for the event named `eventName` to the _beginning_ of the listeners array. The next time `eventName` is triggered, this
                  * listener is removed, and then invoked.
@@ -898,7 +973,10 @@ declare module "events" {
                  * @param eventName The name of the event.
                  * @param listener The callback function
                  */
-                prependOnceListener<K>(eventName: Key<K, T>, listener: Listener1<K, T>): this;
+                prependOnceListener<EventName extends string | symbol>(
+                    eventName: EventNameParam<Events, EventName>,
+                    listener: Listener<Events, EventName>,
+                ): this;
                 /**
                  * Returns an array listing the events for which the emitter has registered
                  * listeners. The values in the array are strings or `Symbol`s.
@@ -918,7 +996,7 @@ declare module "events" {
                  * ```
                  * @since v6.0.0
                  */
-                eventNames(): Array<(string | symbol) & Key2<unknown, T>>;
+                eventNames(): Array<(string | symbol)>;
             }
         }
     }

--- a/types/node/v22/test/events.ts
+++ b/types/node/v22/test/events.ts
@@ -31,7 +31,7 @@ declare const any: any;
     result = emitter.getMaxListeners();
     result = emitter.listenerCount(event);
 
-    const handler: Function = () => {};
+    const handler = () => {};
     result = emitter.listenerCount(event, handler);
 }
 
@@ -141,7 +141,7 @@ async function testEventTarget() {
     captureRejectionSymbol2 = events.captureRejectionSymbol;
 
     const emitter = new events.EventEmitter();
-    emitter[events.captureRejectionSymbol] = (err: Error, name: string, ...args: any[]) => {};
+    emitter[events.captureRejectionSymbol] = (err: Error, name: string | symbol, ...args: any[]) => {};
 }
 
 {
@@ -193,16 +193,16 @@ async function testEventTarget() {
 
 {
     class MyEmitter extends events.EventEmitter {
-        addListener(event: string, listener: () => void): this {
+        addListener(event: string | symbol, listener: () => void): this {
             return this;
         }
-        listeners(event: string): Array<() => void> {
+        listeners(event: string | symbol): Array<() => void> {
             return [];
         }
-        emit(event: string, ...args: any[]): boolean {
+        emit(event: string | symbol, ...args: any[]): boolean {
             return true;
         }
-        listenerCount(type: string): number {
+        listenerCount(type: string | symbol): number {
             return 0;
         }
     }

--- a/types/node/v22/test/events_generic.ts
+++ b/types/node/v22/test/events_generic.ts
@@ -110,13 +110,18 @@ declare const event5: "event5";
 }
 
 {
-    let result: Promise<number[]>;
+    // Uncomment once static events are generic
+    // let result1: Promise<T["event1"]>;
+    // let result2: Promise<T["event2"]>;
+    // let result3: Promise<T["event3"]>;
+    // let result4: Promise<T["event4"]>;
+    // let result5: Promise<T["event5"]>;
 
-    result = events.once(emitter, event1);
-    result = events.once(emitter, event2);
-    result = events.once(emitter, event3);
-    result = events.once(emitter, event4);
-    result = events.once(emitter, event5);
+    // result1 = events.once(emitter, event1);
+    // result2 = events.once(emitter, event2);
+    // result3 = events.once(emitter, event3);
+    // result4 = events.once(emitter, event4);
+    // result5 = events.once(emitter, event5);
 
     emitter.emit("event1", "hello", 42);
     emitter.emit("event2", true);
@@ -146,23 +151,20 @@ declare const event5: "event5";
 }
 
 {
-    let result: Array<keyof T>;
+    let result: Array<string | symbol>;
 
     result = emitter.eventNames();
 }
 
 {
-    type Listener<K> = K extends keyof T ? (
-            (...args: T[K]) => void
-        )
-        : never;
+    type Listener<K> = events.EventEmitterEventMapListener<T, K>;
 
-    function on1<K>(event: K, listener: Listener<K>): void {
+    function on1<K extends keyof T>(event: K, listener: Listener<K>): void {
         emitter.on(event, listener);
     }
 
     // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-    function on2<K>(...args: Parameters<typeof emitter.on<K>>): void {
+    function on2<K extends keyof T>(...args: Parameters<typeof emitter.on<K>>): void {
         emitter.on(...args);
     }
 
@@ -204,7 +206,6 @@ declare const event5: "event5";
     emitter.emit("abc", "hello", 123);
     // @ts-expect-error
     emitter.emit("abc", 123, false);
-    // @ts-expect-error
     emitter.emit("def", "hello", 123);
 }
 
@@ -226,7 +227,6 @@ declare const event5: "event5";
     emitter.emit(s1, "hello", 123);
     // @ts-expect-error
     emitter.emit(s1, 123, false);
-    // @ts-expect-error
     emitter.emit(s2, "hello", 123);
 }
 
@@ -244,6 +244,112 @@ declare const event5: "event5";
     emitter.emit(789, 123, false);
     // @ts-expect-error
     emitter.emit(s1, "hello", false);
-    // @ts-expect-error
     emitter.emit(s2, "hello", false);
+}
+
+// Uncomment once static methods are generic
+// {
+//     const promise1: Promise<[string, number]> = events.once(new events.EventEmitter<T>(), "event1");
+//     const promise2: Promise<[boolean]> = events.once(new events.EventEmitter<T>(), "event2");
+//     const promise3: Promise<[]> = events.once(new events.EventEmitter<T>(), "event3");
+//     const promise4: Promise<string[]> = events.once(new events.EventEmitter<T>(), "event4");
+//     const promise5: Promise<unknown[]> = events.once(new events.EventEmitter<T>(), "event5");
+//     // @ts-expect-error
+//     const promise6: Promise<[string, string]> = events.once(new events.EventEmitter<T>(), "event1");
+//     const promise7: Promise<any[]> = events.once(new events.EventEmitter<T>(), "event");
+
+//     const iterable1: NodeJS.AsyncIterator<[string, number]> = events.on(new events.EventEmitter<T>(), "event1");
+//     const iterable2: NodeJS.AsyncIterator<[boolean]> = events.on(new events.EventEmitter<T>(), "event2");
+//     const iterable3: NodeJS.AsyncIterator<[]> = events.on(new events.EventEmitter<T>(), "event3");
+//     const iterable4: NodeJS.AsyncIterator<string[]> = events.on(new events.EventEmitter<T>(), "event4");
+//     const iterable5: NodeJS.AsyncIterator<unknown[]> = events.on(new events.EventEmitter<T>(), "event5");
+//     // @ts-expect-error
+//     const iterable6: NodeJS.AsyncIterator<[string, string]> = events.on(new events.EventEmitter<T>(), "event1");
+//     const iterable7: NodeJS.AsyncIterator<any[]> = events.on(new events.EventEmitter<T>(), "event");
+// }
+
+{
+    function acceptsEventEmitterInterface(eventEmitter: NodeJS.EventEmitter) {
+    }
+
+    function acceptsEventEmitterClass(eventEmitter: events.EventEmitter) {
+    }
+
+    acceptsEventEmitterInterface(emitter);
+    acceptsEventEmitterClass(emitter);
+}
+
+{
+    class Extended extends events.EventEmitter<T> {}
+
+    class DoubleExtension extends Extended {}
+
+    const extended = new Extended();
+    const doubleExtended = new DoubleExtension();
+
+    // Uncomment once static methods are generic
+    // events.on(extended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
+    // events.once(extended, "event1"); // $ExpectType Promise<[string, number]>
+
+    // events.on(extended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
+    // events.once(extended, "unknown"); // $ExpectType Promise<any[]>
+
+    // events.on(doubleExtended, "event1"); // $ExpectType AsyncIterator<[string, number], any, any>
+    // events.once(doubleExtended, "event1"); // $ExpectType Promise<[string, number]>
+
+    // events.on(doubleExtended, "unknown"); // $ExpectType AsyncIterator<any[], any, any>
+    // events.once(doubleExtended, "unknown"); // $ExpectType Promise<any[]>
+
+    extended.addListener(event1, (a: string, b: number | boolean): number => 1);
+    doubleExtended.addListener(event1, (a: string, b: number | boolean): number => 1);
+    // @ts-expect-error
+    extended.addListener(event1, (a: string, b: boolean): number => 1);
+    // @ts-expect-error
+    doubleExtended.addListener(event1, (a: string, b: boolean): number => 1);
+
+    extended.emit("event1", "hello", 42);
+    doubleExtended.emit("event1", "hello", 42);
+    // @ts-expect-error
+    extended.emit("event1", 123);
+    // @ts-expect-error
+    doubleExtended.emit("event1", 123);
+}
+
+{
+    function onError(err: any) {
+        console.log(err);
+    }
+
+    class Test extends events.EventEmitter {
+        // The union was only uncallable when an instance method exists.
+        test() {
+            return true;
+        }
+    }
+
+    class Test2 extends events.EventEmitter {}
+
+    const emitter = {} as Test | Test2;
+    emitter.addListener("error", onError);
+    emitter.on("error", onError);
+    emitter.off("error", onError);
+    emitter.once("error", onError);
+    emitter.prependListener("error", onError);
+    emitter.prependOnceListener("error", onError);
+    emitter.removeListener("error", onError);
+    emitter.removeAllListeners();
+    emitter.removeAllListeners("error");
+    emitter.emit("error");
+}
+
+interface Implementing extends events.EventEmitter {}
+declare class Implementing implements events.EventEmitter {
+    addListener(eventName: "event", listener: (arg: boolean) => void): this;
+}
+
+{
+    // @ts-expect-error
+    emitter.on({}, () => {});
+    // @ts-expect-error
+    new EventEmitter().on({}, () => {});
 }

--- a/types/opossum/opossum-tests.ts
+++ b/types/opossum/opossum-tests.ts
@@ -145,7 +145,7 @@ const options: CircuitBreaker.Options = {
     resetTimeout: 30000, // After 30 seconds, try again.
 };
 options.enableSnapshots; // $ExpectType boolean | undefined
-options.rotateBucketController; // $ExpectType EventEmitter<{}> | undefined
+options.rotateBucketController; // $ExpectType EventEmitter<NoEventMap> | undefined
 breaker = new CircuitBreaker(asyncFunctionThatCouldFail, options);
 
 breaker

--- a/types/opossum/opossum-tests.ts
+++ b/types/opossum/opossum-tests.ts
@@ -145,7 +145,7 @@ const options: CircuitBreaker.Options = {
     resetTimeout: 30000, // After 30 seconds, try again.
 };
 options.enableSnapshots; // $ExpectType boolean | undefined
-options.rotateBucketController; // $ExpectType EventEmitter<DefaultEventMap> | undefined
+options.rotateBucketController; // $ExpectType EventEmitter<{}> | undefined
 breaker = new CircuitBreaker(asyncFunctionThatCouldFail, options);
 
 breaker

--- a/types/rdf-store-fs/rdf-store-fs-tests.ts
+++ b/types/rdf-store-fs/rdf-store-fs-tests.ts
@@ -45,20 +45,20 @@ function store_match() {
 
 function store_import() {
     const stream: Stream = <any> {};
-    // $ExpectType EventEmitter<DefaultEventMap>
+    // $ExpectType EventEmitter<{}>
     let imported = flatStore.import(stream);
     imported = flatStore.import(stream, { truncate: true });
 }
 
 function store_remove() {
     const stream: Stream = <any> {};
-    // $ExpectType EventEmitter<DefaultEventMap>
+    // $ExpectType EventEmitter<{}>
     const event = flatStore.remove(stream);
 }
 
 function store_removeMatches() {
     const term: Term = <any> {};
-    // $ExpectType EventEmitter<DefaultEventMap>
+    // $ExpectType EventEmitter<{}>
     let event = flatStore.removeMatches();
     event = flatStore.removeMatches(term);
     event = flatStore.removeMatches(term, term);
@@ -68,7 +68,7 @@ function store_removeMatches() {
 
 function store_deleteGraph() {
     const graph: Quad_Graph = <any> {};
-    // $ExpectType EventEmitter<DefaultEventMap>
+    // $ExpectType EventEmitter<{}>
     const event = flatStore.deleteGraph(graph);
 }
 

--- a/types/rdf-store-fs/rdf-store-fs-tests.ts
+++ b/types/rdf-store-fs/rdf-store-fs-tests.ts
@@ -45,20 +45,20 @@ function store_match() {
 
 function store_import() {
     const stream: Stream = <any> {};
-    // $ExpectType EventEmitter<{}>
+    // $ExpectType EventEmitter<NoEventMap>
     let imported = flatStore.import(stream);
     imported = flatStore.import(stream, { truncate: true });
 }
 
 function store_remove() {
     const stream: Stream = <any> {};
-    // $ExpectType EventEmitter<{}>
+    // $ExpectType EventEmitter<NoEventMap>
     const event = flatStore.remove(stream);
 }
 
 function store_removeMatches() {
     const term: Term = <any> {};
-    // $ExpectType EventEmitter<{}>
+    // $ExpectType EventEmitter<NoEventMap>
     let event = flatStore.removeMatches();
     event = flatStore.removeMatches(term);
     event = flatStore.removeMatches(term, term);
@@ -68,7 +68,7 @@ function store_removeMatches() {
 
 function store_deleteGraph() {
     const graph: Quad_Graph = <any> {};
-    // $ExpectType EventEmitter<{}>
+    // $ExpectType EventEmitter<NoEventMap>
     const event = flatStore.deleteGraph(graph);
 }
 

--- a/types/readable-stream/index.d.ts
+++ b/types/readable-stream/index.d.ts
@@ -217,10 +217,8 @@ declare class _Readable extends NoAsyncDispose implements _IReadable {
     off(eventName: string | symbol, listener: (...args: any[]) => void): this;
     setMaxListeners(n: number): this;
     getMaxListeners(): number;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    listeners(eventName: string | symbol): Function[];
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    rawListeners(eventName: string | symbol): Function[];
+    listeners(eventName: string | symbol): Array<(...args: any[]) => void>;
+    rawListeners(eventName: string | symbol): Array<(...args: any[]) => void>;
     listenerCount(eventName: string | symbol): number;
     eventNames(): Array<string | symbol>;
 

--- a/types/sane/index.d.ts
+++ b/types/sane/index.d.ts
@@ -80,8 +80,7 @@ declare class SaneWatcher extends EventEmitter {
     removeListener(event: "add" | "change", listener: (path: string, root: string, stat: Stats) => void): this;
     removeListener(event: "delete", listener: (path: string, root: string) => void): this;
     removeAllListeners(event?: EventType): this;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    listeners(event: EventType): Function[];
+    listeners(event: EventType): Array<(...args: any[]) => void>;
     emit(event: "ready"): boolean;
     emit(event: "error", error: Error): boolean;
     emit(event: "all", eventType: AllEventType, path: string, root: string, stat?: Stats): boolean;

--- a/types/sse/sse-tests.ts
+++ b/types/sse/sse-tests.ts
@@ -17,7 +17,7 @@ new SSE(expressApp, options); // $ExpectType SSE
 const sse = new SSE(expressApp); // $ExpectType SSE
 sse.handleRequest(expressApp.request, expressApp.response, "query"); // $ExpectType void
 sse.matchesPath("/sse", "/sse"); // $ExpectType boolean
-sse.server; // $ExpectType EventEmitter<DefaultEventMap>
+sse.server; // $ExpectType EventEmitter<{}>
 
 SSE.Client; // $ExpectType typeof Client
 const sseClient = new SSE.Client(expressApp.request, expressApp.response); // $ExpectType Client

--- a/types/sse/sse-tests.ts
+++ b/types/sse/sse-tests.ts
@@ -17,7 +17,7 @@ new SSE(expressApp, options); // $ExpectType SSE
 const sse = new SSE(expressApp); // $ExpectType SSE
 sse.handleRequest(expressApp.request, expressApp.response, "query"); // $ExpectType void
 sse.matchesPath("/sse", "/sse"); // $ExpectType boolean
-sse.server; // $ExpectType EventEmitter<{}>
+sse.server; // $ExpectType EventEmitter<NoEventMap>
 
 SSE.Client; // $ExpectType typeof Client
 const sseClient = new SSE.Client(expressApp.request, expressApp.response); // $ExpectType Client

--- a/types/steam/index.d.ts
+++ b/types/steam/index.d.ts
@@ -44,17 +44,5 @@ declare namespace Steam {
 
         setPersonaState(state: EPersonaState): void;
         setPersonaName(name: string): void;
-
-        // Event emitter
-        addListener(event: string, listener: Function): this;
-        on(event: string, listener: Function): this;
-        once(event: string, listener: Function): this;
-        removeListener(event: string, listener: Function): this;
-        removeAllListeners(event?: string): this;
-        setMaxListeners(n: number): this;
-        getMaxListeners(): number;
-        listeners(event: string): Function[];
-        emit(event: string, ...args: any[]): boolean;
-        listenerCount(type: string): number;
     }
 }

--- a/types/twitter/twitter-tests.ts
+++ b/types/twitter/twitter-tests.ts
@@ -53,7 +53,7 @@ stream.on("error", error => {
 });
 
 client.stream("statuses/filter", { track: "javascript" }, stream => {
-    // $ExpectType EventEmitter<DefaultEventMap>
+    // $ExpectType EventEmitter<{}>
     stream;
 
     stream.on("data", (event: any) => {
@@ -65,6 +65,6 @@ client.stream("statuses/filter", { track: "javascript" }, stream => {
     });
 });
 client.stream("statuses/filter", stream => {
-    // $ExpectType EventEmitter<DefaultEventMap>
+    // $ExpectType EventEmitter<{}>
     stream;
 });

--- a/types/twitter/twitter-tests.ts
+++ b/types/twitter/twitter-tests.ts
@@ -53,7 +53,7 @@ stream.on("error", error => {
 });
 
 client.stream("statuses/filter", { track: "javascript" }, stream => {
-    // $ExpectType EventEmitter<{}>
+    // $ExpectType EventEmitter<NoEventMap>
     stream;
 
     stream.on("data", (event: any) => {
@@ -65,6 +65,6 @@ client.stream("statuses/filter", { track: "javascript" }, stream => {
     });
 });
 client.stream("statuses/filter", stream => {
-    // $ExpectType EventEmitter<{}>
+    // $ExpectType EventEmitter<NoEventMap>
     stream;
 });

--- a/types/xml-flow/xml-flow-tests.ts
+++ b/types/xml-flow/xml-flow-tests.ts
@@ -8,7 +8,7 @@ fs.writeFileSync("./test.xml", "<head><childOne>text</childOne><childTwo>text</c
 const readStreamOne = fs.createReadStream("./test.xml", "utf8");
 const readStreamTwo = fs.createReadStream("./test.xml", "utf8");
 
-// $ExpectType EventEmitter<DefaultEventMap>
+// $ExpectType EventEmitter<{}>
 const myFlow = flow(readStreamOne);
 
 const myOptions = {
@@ -22,7 +22,7 @@ const myOptions = {
     strict: true,
 };
 
-// $ExpectType EventEmitter<DefaultEventMap>
+// $ExpectType EventEmitter<{}>
 const myFlowWithOptions = flow(readStreamTwo, myOptions);
 
 // Create object to xml-ise

--- a/types/xml-flow/xml-flow-tests.ts
+++ b/types/xml-flow/xml-flow-tests.ts
@@ -8,7 +8,7 @@ fs.writeFileSync("./test.xml", "<head><childOne>text</childOne><childTwo>text</c
 const readStreamOne = fs.createReadStream("./test.xml", "utf8");
 const readStreamTwo = fs.createReadStream("./test.xml", "utf8");
 
-// $ExpectType EventEmitter<{}>
+// $ExpectType EventEmitter<NoEventMap>
 const myFlow = flow(readStreamOne);
 
 const myOptions = {
@@ -22,7 +22,7 @@ const myOptions = {
     strict: true,
 };
 
-// $ExpectType EventEmitter<{}>
+// $ExpectType EventEmitter<NoEventMap>
 const myFlowWithOptions = flow(readStreamTwo, myOptions);
 
 // Create object to xml-ise


### PR DESCRIPTION
Reverts #71054 removing the static changes that require further review. `<Future PR number>` will cover that while this recovers the other major improvements.