### PR TITLE
fix(friendly-errors-webpack-plugin): bump version, modify types, test

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -474,7 +474,6 @@
         "frctl__fractal",
         "frecency",
         "frida-gum",
-        "friendly-errors-webpack-plugin",
         "fs-extra",
         "ftdomdelegate",
         "fuzzy-finder",

--- a/types/friendly-errors-webpack-plugin/friendly-errors-webpack-plugin-tests.ts
+++ b/types/friendly-errors-webpack-plugin/friendly-errors-webpack-plugin-tests.ts
@@ -1,8 +1,43 @@
-import webpack = require("webpack");
-import FriendlyErrorsPlugin = require("friendly-errors-webpack-plugin");
+import FriendlyErrorsPlugin from "friendly-errors-webpack-plugin";
+import webpack from "webpack";
 
-const compiler = webpack({
+webpack({
     plugins: [
         new FriendlyErrorsPlugin(),
+        new FriendlyErrorsPlugin({
+            compilationSuccessInfo: {
+                messages: ["You application is running here http://localhost:3000"],
+                notes: ["Some additional notes to be displayed upon successful compilation"],
+            },
+
+            onErrors: function(severity, errors) {
+                // $ExpectType Severity
+                severity;
+                // $ExpectType WebpackError[]
+                errors;
+            },
+
+            clearConsole: true,
+
+            additionalFormatters: [
+                (errors, type) => {
+                    // $ExpectType WebpackError[]
+                    errors;
+                    // $ExpectType Severity
+                    type;
+
+                    return [""];
+                },
+            ],
+
+            additionalTransformers: [
+                (error) => {
+                    // $ExpectType any
+                    error;
+
+                    return error;
+                },
+            ],
+        }),
     ],
 });

--- a/types/friendly-errors-webpack-plugin/index.d.ts
+++ b/types/friendly-errors-webpack-plugin/index.d.ts
@@ -1,27 +1,33 @@
-import { Compiler, Plugin } from "webpack";
+import { Plugin } from "webpack";
 
 export = FriendlyErrorsWebpackPlugin;
 
 declare class FriendlyErrorsWebpackPlugin extends Plugin {
     constructor(options?: FriendlyErrorsWebpackPlugin.Options);
-
-    apply(compiler: Compiler): void;
 }
 
 declare namespace FriendlyErrorsWebpackPlugin {
-    enum Severity {
-        Error = "error",
-        Warning = "warning",
-    }
+    type Severity = "error" | "warning";
 
     interface Options {
         compilationSuccessInfo?: {
             messages: string[];
             notes: string[];
         } | undefined;
-        onErrors?(severity: Severity, errors: string): void;
+
+        /**
+         * You can listen to errors transformed and prioritized by the plugin.
+         */
+        onErrors?(severity: Severity, errors: WebpackError[]): void;
+
+        /**
+         * Whether the console should be cleared between each compilation.
+         * @default true
+         */
         clearConsole?: boolean | undefined;
+
         additionalFormatters?: Array<(errors: WebpackError[], type: Severity) => string[]> | undefined;
+
         additionalTransformers?: Array<(error: any) => any> | undefined;
     }
 

--- a/types/friendly-errors-webpack-plugin/package.json
+++ b/types/friendly-errors-webpack-plugin/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/friendly-errors-webpack-plugin",
-    "version": "0.1.9999",
+    "version": "1.7.9999",
     "projects": [
         "https://github.com/geowarin/friendly-errors-webpack-plugin"
     ],


### PR DESCRIPTION
- `Severity` is changed from `enum` to string union, because such enum variable does not exist on the actual js code.
- `errors` parameter in `onErrors()` is changed to `WebpackError[]` according to [doc](https://github.com/geowarin/friendly-errors-webpack-plugin?tab=readme-ov-file#adding-desktop-notifications).
- `apply()` is removed, because `Plugin` from `webpack` already contain the typedef.
- jsdoc and tests are added or modified accordingly.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.