### PR TITLE
fix(trayballoon): bump version, change to esm, modify type & test

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -1673,7 +1673,6 @@
         "topojson",
         "torrent-stream",
         "tpdirect",
-        "trayballoon",
         "trim",
         "tryghost__content-api",
         "twine-sugarcube",

--- a/types/trayballoon/.eslintrc.json
+++ b/types/trayballoon/.eslintrc.json
@@ -1,9 +1,0 @@
-{
-    "rules": {
-        "@definitelytyped/no-declare-current-package": "off",
-        "@definitelytyped/strict-export-declare-modifiers": "off",
-        "@definitelytyped/no-single-declare-module": "off",
-        "@typescript-eslint/no-unsafe-function-type": "off",
-        "@typescript-eslint/no-wrapper-object-types": "off"
-    }
-}

--- a/types/trayballoon/index.d.ts
+++ b/types/trayballoon/index.d.ts
@@ -1,12 +1,21 @@
-declare interface TrayballoonOptions {
+export interface TrayballoonOptions {
+    /**
+     * The body text.
+     */
     text: string;
+    /**
+     * The title text.
+     */
     title?: string | undefined;
+    /**
+     * The path to a `.ico` file or a `.exe`/`.dll` file with icon resource index (eg: `shell32.dll,-154`).
+     */
     icon?: string | undefined;
+    /**
+     * The duration to show the balloon in milliseconds.
+     * @default 5000
+     */
     timeout?: number | undefined;
-    wait?: boolean | undefined;
 }
 
-declare function trayballoonFn(opts: TrayballoonOptions, fn: Function): void;
-declare module "trayballoon" {
-    export = trayballoonFn;
-}
+export default function trayballoonFn(options?: TrayballoonOptions): Promise<void>;

--- a/types/trayballoon/package.json
+++ b/types/trayballoon/package.json
@@ -1,7 +1,8 @@
 {
     "private": true,
     "name": "@types/trayballoon",
-    "version": "0.0.9999",
+    "version": "2.0.9999",
+    "type": "module",
     "projects": [
         "https://github.com/sindresorhus/trayballoon"
     ],

--- a/types/trayballoon/trayballoon-tests.ts
+++ b/types/trayballoon/trayballoon-tests.ts
@@ -1,12 +1,20 @@
-import trayballoon = require("trayballoon");
+import trayballoon from "trayballoon";
 
-function testTrayballoon() {
-    trayballoon({
-        text: "text",
-        title: "title",
-        icon: "icon",
-        timeout: 5000,
-        wait: true,
-    }, () => {
-    });
-}
+// $ExpectType Promise<void>
+trayballoon();
+
+// @ts-expect-error - `options.text` is required.
+trayballoon({});
+
+// $ExpectType Promise<void>
+trayballoon({
+    text: "text",
+});
+
+// $ExpectType Promise<void>
+trayballoon({
+    text: "text",
+    title: "title",
+    icon: "icon.ico",
+    timeout: 5000,
+});


### PR DESCRIPTION
- `TrayballoonOptions.wait` is removed, because it no longer exists in [readme doc](https://github.com/sindresorhus/trayballoon/tree/c4de3bb241213368386b379c1e0bff414fc18cf9?tab=readme-ov-file#api) or [source code implementation](https://github.com/sindresorhus/trayballoon/blob/c4de3bb241213368386b379c1e0bff414fc18cf9/index.js).
- `options` in `trayballoonFn(options?: TrayballoonOptions)` is made optional, since the [library implementation](https://github.com/sindresorhus/trayballoon/blob/c4de3bb241213368386b379c1e0bff414fc18cf9/index.js#L5) allows it to be `undefined`.
- `trayballoonFn()` is changed to async function, and the type library is changed to esm, based on latest version implementation.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
