### PR TITLE
[geojson] Fix nullable geometries & invalid properties generics

### DIFF
--- a/types/geobuf/geobuf-tests.ts
+++ b/types/geobuf/geobuf-tests.ts
@@ -2,7 +2,7 @@ import * as geobuf from "geobuf";
 import { GeoJSON } from "geojson";
 import Pbf = require("pbf");
 
-geobuf.decode(new Pbf(Uint8Array.from([]))); // $ExpectType GeoJSON
+geobuf.decode(new Pbf(Uint8Array.from([]))); // $ExpectType GeoJSON || GeoJSON<Geometry, GeoJsonProperties>
 const geojson: GeoJSON = {
     type: "Feature",
     properties: {},

--- a/types/geojson/geojson-tests.ts
+++ b/types/geojson/geojson-tests.ts
@@ -1,8 +1,10 @@
 import {
     Feature,
     FeatureCollection,
+    GeoJSON,
     GeoJsonGeometryTypes,
     GeoJsonTypes,
+    Geometry,
     GeometryCollection,
     GeometryObject,
     LineString,
@@ -479,3 +481,40 @@ for (const { geometry } of collectionDefault.features) {
             break;
     }
 }
+
+// Features & collections with null geometries should be assignable to GeoJSON
+const featureWithNullGeometry = {
+    type: "Feature" as const,
+    geometry: null,
+    properties: null,
+};
+const featureCollectionWithNullGeometry = {
+    type: "FeatureCollection" as const,
+    features: [featureWithNullGeometry],
+};
+const featureWithNullGeometryAsFeature: Feature<Geometry | null> = featureWithNullGeometry;
+const featureCollectionWithNullGeometryAsFeatureCollection: FeatureCollection<Geometry | null> =
+    featureCollectionWithNullGeometry;
+const featureWithNullGeometryAsGeoJSON: GeoJSON<Geometry | null> = featureWithNullGeometry;
+const featureCollectionWithNullGeometryAsGeoJSON: GeoJSON<Geometry | null> = featureCollectionWithNullGeometry;
+
+// Top level geojson should be generic to allow geometry and properties types to be modified
+const geoJsonWithSpecificGeometryAndProperties: GeoJSON<Point, { a: number }>[] = [
+    {
+        type: "Feature",
+        geometry: point,
+        properties: { a: 34 },
+    },
+    {
+        type: "FeatureCollection",
+        features: [
+            {
+                type: "Feature",
+                // @ts-expect-error -- Geometry does not adhere to the specified type
+                geometry: lineString,
+                // @ts-expect-error -- Properties does not adhere to the specified type
+                properties: {},
+            },
+        ],
+    },
+];

--- a/types/geojson/index.d.ts
+++ b/types/geojson/index.d.ts
@@ -60,7 +60,10 @@ export interface GeoJsonObject {
 /**
  * Union of GeoJSON objects.
  */
-export type GeoJSON = Geometry | Feature | FeatureCollection;
+export type GeoJSON<G extends Geometry | null = Geometry, P = GeoJsonProperties> =
+    | G
+    | Feature<G, P>
+    | FeatureCollection<G, P>;
 
 /**
  * Geometry object.

--- a/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
+++ b/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
@@ -238,7 +238,7 @@ drawFeature.updateCoordinate("", 0, 0);
 // $ExpectType void
 drawFeature.setProperty("", 0);
 
-// $ExpectType GeoJSON
+// $ExpectType GeoJSON || GeoJSON<Geometry, GeoJsonProperties>
 drawFeature.toGeoJSON();
 
 if (drawFeature.type === "Point") {

--- a/types/terraformer__wkt/terraformer__wkt-tests.ts
+++ b/types/terraformer__wkt/terraformer__wkt-tests.ts
@@ -1,7 +1,7 @@
 import { geojsonToWKT, wktToGeoJSON } from "@terraformer/wkt";
 import { GeoJSON } from "geojson";
 
-// $ExpectType GeoJSON
+// $ExpectType GeoJSON || GeoJSON<Geometry, GeoJsonProperties>
 wktToGeoJSON(
     "POINT (-122.6764 45.5165)",
 );


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://datatracker.ietf.org/doc/html/rfc7946#section-3.2 

This PR makes two main changes:
1. Make sure the properties object in a feature cannot be anything other than a JSON object (technically it can now still be an array but fixing this might be a bit overkill). There was a bug in the generics, the properties object was correctly assigned as default but not restricted with an `extends` so you could still just pass any random thing as the properties type. This has now been fixed. Quote from the RFC:
> A Feature object has a member with the name "properties".  The
      value of the properties member is an object (any JSON object or a
      JSON null value).

In the current version this would be "correctly typed". However, if you try to pass this into a GeoJSON validator it would not be allowed:
```typescript
const test: Feature<Geometry, number> = { type: "Feature", geometry: ..., properties: 567 }
```
2. Make sure that feature with null geometries can be assigned to the GeoJSON type. The default `G` type parameter in `Feature` and `FeatureCollection` was `Geometry` instead of `Geometry | null`. And since `GeoJSON` could also not take any generics this was not modifiable when using the `GeoJSON` type. I fixed both of these things by changing the default and by making GeoJSON generic so it can pass down the geometry type you want to use. Quote from the RFC:
> A Feature object has a member with the name "geometry".  The value
      of the geometry member SHALL be either a Geometry object as
      defined above or, in the case that the Feature is unlocated, a
      JSON null value.

With the way things were this was throwing a typing error, when in reality it should be allowed:
```typescript
function foo(geojson: GeoJSON) { ... };
foo({ type: "Feature", geometry: null, properties: null }); // TS2322: Type null is not assignable to type Geometry
```

NOTE: These changes could potentially be breaking if users have been reliant on the incorrect defaults & types. I'm not sure what you guys prefer, if we should keep it as-is so as not to annoy people, or if we should adhere to the RFC.

As a middle ground I would be willing to revert the property object and default geometry types change if this causes too much trouble for people. The main reason for this PR is to make GeoJSON generic so that we can use nullable geometries in GeoJSON.

