### PR TITLE
fix(redux-mock-store): Fix export equal & remove invalid typedef in v0

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -1539,7 +1539,6 @@
         "redux-form/v7",
         "redux-localstorage-debounce",
         "redux-localstorage",
-        "redux-mock-store/v0",
         "redux-persist-transform-encrypt",
         "redux-storage",
         "remotedev-serialize",

--- a/types/redux-mock-store/v0/.eslintrc.json
+++ b/types/redux-mock-store/v0/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-    "rules": {
-        "@definitelytyped/no-unnecessary-generics": "off"
-    }
-}

--- a/types/redux-mock-store/v0/index.d.ts
+++ b/types/redux-mock-store/v0/index.d.ts
@@ -1,12 +1,14 @@
 import * as Redux from "redux";
 
-export interface MockStore<T> extends Redux.Store<T> {
-    getActions(): any[];
-    clearActions(): void;
+declare namespace reduxMockStore {
+    type MockStore<T> = Redux.Store<T>;
+    type MockStoreCreator<T = {}> = (state?: T) => MockStore<T>;
+
+    interface ConfigureStore {
+        <T>(middlewares?: Redux.Middleware[]): MockStoreCreator<T>;
+    }
 }
 
-export type MockStoreCreator<T = {}> = (state?: T) => MockStore<T>;
+declare const reduxMockStore: reduxMockStore.ConfigureStore;
 
-declare function createMockStore<T>(middlewares?: Redux.Middleware[]): MockStoreCreator<T>;
-
-export default createMockStore;
+export = reduxMockStore;

--- a/types/redux-mock-store/v0/redux-mock-store-tests.ts
+++ b/types/redux-mock-store/v0/redux-mock-store-tests.ts
@@ -34,12 +34,3 @@ store.subscribe(() => {
 });
 
 store.dispatch({ type: "INCREMENT" });
-
-// Additional mock store API tests
-const actions: any[] = store.getActions();
-
-store.clearActions();
-
-// actions access without the need to cast
-const actions2 = store.getActions();
-actions2[10].payload.id;


### PR DESCRIPTION
`getActions()` & `clearActions()` are removed from `MockStore`, because they do not yet exist in v0.0.x. See [v0.0.6 source code](https://github.com/reduxjs/redux-mock-store/blob/0b74cca488220d8731b6b57eabbdb91105cca686/src/index.js).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
