### PR TITLE
feat(preview-email): bump version, add missing opt, remove @types/node

### DIFF
--- a/types/preview-email/index.d.ts
+++ b/types/preview-email/index.d.ts
@@ -1,5 +1,3 @@
-/// <reference types="node" />
-
 import type { SimpleParserOptions } from "mailparser";
 import type { Options as NodeMailerOptions } from "nodemailer/lib/mailer";
 
@@ -29,7 +27,7 @@ declare namespace previewEmail {
          */
         open?: OpenOptions | boolean | undefined;
         /**
-         *  file path to a pug template file (defaults to preview-email's `template.pug` by default)
+         * file path to a pug template file (defaults to preview-email's `template.pug` by default)
          * - this is where you can pass a custom template for rendering email previews, e.g. your own stylesheet
          */
         template?: string | undefined;
@@ -56,6 +54,11 @@ declare namespace previewEmail {
          * @default false
          */
         returnHtml?: boolean | undefined;
+        /**
+         * whether or not to render a "Download Original" button to download via base64 inline onclick JavaScript.
+         * @default true
+         */
+        hasDownloadOriginalButton?: boolean | undefined;
     }
 
     interface OpenOptions {

--- a/types/preview-email/package.json
+++ b/types/preview-email/package.json
@@ -1,13 +1,12 @@
 {
     "private": true,
     "name": "@types/preview-email",
-    "version": "3.0.9999",
+    "version": "3.1.9999",
     "projects": [
         "https://github.com/niftylettuce/preview-email"
     ],
     "dependencies": {
         "@types/mailparser": "*",
-        "@types/node": "*",
         "@types/nodemailer": "*"
     },
     "devDependencies": {

--- a/types/preview-email/preview-email-tests.ts
+++ b/types/preview-email/preview-email-tests.ts
@@ -1,49 +1,58 @@
-import previewEmail = require("preview-email");
-import { Options } from "preview-email";
-import nodemailer = require("nodemailer");
-import { Options as NodeMailerOptions } from "nodemailer/lib/mailer";
+import type { Options as NodeMailerOptions } from "nodemailer/lib/mailer";
+import previewEmail, { OpenOptions, Options, UrlTransform } from "preview-email";
 
-// tests for `README Driven Development`
-const transport = nodemailer.createTransport({
-    jsonTransport: true,
-});
+declare const message: NodeMailerOptions;
 
-const message: NodeMailerOptions = {
-    from: "niftylettuce+from@gmail.com",
-    to: "niftylettuce+to@gmail.com",
-    subject: "Hello world",
-    html: "<p>Hello world</p>",
-    text: "Hello world",
-    attachments: [{ filename: "hello-world.txt", content: "Hello world" }],
-};
+// Without options
+// $ExpectType Promise<string>
+previewEmail(message);
 
-// note that `attachments` will not be parsed unless you use
-// `previewEmail` with the results of `transport.sendMail`
-// e.g. `previewEmail(JSON.parse(res.message));` where `res`
-// is `const res = await transport.sendMail(message);`
-previewEmail(message).then(console.log).catch(console.error);
-transport.sendMail(message).then(console.log).catch(console.error);
+// With empty options
+// $ExpectType Promise<string>
+previewEmail(message, {});
 
-// tests
-
-const options: Options = {
-    dir: "./dir",
+// With all available options
+// $ExpectType Promise<string>
+previewEmail(message, {
     id: "some-id",
-    open: true,
+    dir: "./dir",
     template: "./dir/template.pug",
     urlTransform: path => `./dir/${path}`,
     openSimulator: true,
-    simpleParser: {},
     returnHtml: true,
-};
+    hasDownloadOriginalButton: true,
+});
 
-// async/await
-(async () => {
-    try {
-        await previewEmail(message); // $ExpectType string
-        await previewEmail(message, {}); // $ExpectType string
-        await previewEmail(message, options); // $ExpectType string
-    } catch (error) {
-        //
-    }
-})();
+// With options.open
+{
+    // $ExpectType Promise<string>
+    previewEmail(message, { open: true });
+
+    // $ExpectType Promise<string>
+    previewEmail(message, { open: { wait: true } });
+}
+
+// With options.simpleParser
+{
+    // $ExpectType Promise<string>
+    previewEmail(message, { simpleParser: {} });
+
+    // $ExpectType Promise<string>
+    previewEmail(message, {
+        simpleParser: {
+            skipHtmlToText: true,
+            maxHtmlLengthToParse: 1,
+            formatDateString: (d) => {
+                d; // $ExpectType Date
+                return "";
+            },
+            skipImageLinks: true,
+            skipTextToHtml: true,
+            skipTextLinks: true,
+            keepCidLinks: true,
+        },
+    });
+
+    // @ts-expect-error `Iconv` is omitted in options.simpleParser
+    previewEmail(message, { Iconv: null });
+}


### PR DESCRIPTION
`options.hasDownloadOriginalButton` is added. See [repo readme](https://github.com/forwardemail/test-preview-emails-cross-browsers-ios-simulator-nodejs-javascript?tab=readme-ov-file#options).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
