### PR TITLE
Added Subpath to mount VolumeOptions

### DIFF
--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -1167,6 +1167,7 @@ declare namespace Dockerode {
                 DriverConfig: {
                     Name: string;
                     Options: { [option: string]: string };
+                    Subpath?: string;
                 };
             }
             | undefined;


### PR DESCRIPTION
As subpath are supported by docker, I added typing for this feature. I tested with Dockerode adding a //@ts-ignore, and it works fine.

Reference : https://docs.docker.com/reference/api/engine/version/v1.47/#tag/Container/operation/ContainerCreate

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
