### PR TITLE
fix(newrelic): correct recordCustomEvent return type

### DIFF
--- a/types/newrelic/index.d.ts
+++ b/types/newrelic/index.d.ts
@@ -326,7 +326,10 @@ export function incrementMetric(name: string, value?: number): void;
  * `eventType` must be an alphanumeric string less than 255 characters.
  * The keys of `attributes` must be shorter than 255 characters.
  */
-export function recordCustomEvent(eventType: string, attributes: { [keys: string]: boolean | number | string }): void;
+export function recordCustomEvent(
+    eventType: string,
+    attributes: { [keys: string]: boolean | number | string },
+): undefined | false;
 
 /**
  * Registers an instrumentation function.


### PR DESCRIPTION
This corrects the return type for `recordCustomEvent` from being `void` to `undefined|false`. This function explicitly returns `false` when an error occurs, otherwise returns `undefined`.

https://github.com/newrelic/node-newrelic/blob/0ccee8e471b5568a36a5ef755f83f0da513548c8/api.js#L1223-L1232

---

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`node-newrelic/api.js#L1223-L1232`](https://github.com/newrelic/node-newrelic/blob/0ccee8e471b5568a36a5ef755f83f0da513548c8/api.js#L1223-L1232)
