### PR TITLE
[docusign-esign] make EnvelopeDefinition a class

### DIFF
--- a/types/docusign-esign/index.d.ts
+++ b/types/docusign-esign/index.d.ts
@@ -20759,7 +20759,7 @@ export interface EnvelopeCustomFields {
 /**
  * Envelope object definition.
  */
-export interface EnvelopeDefinition {
+export class EnvelopeDefinition {
     /**
      * Reserved for DocuSign.
      */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [N/A] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See below
- [?] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

# Context

docusign-esign types are two major versions behind the source https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/70018

In my project I was attempting to follow the current version's [example for creating and sending an envelope](https://developers.docusign.com/docs/esign-rest-api/how-to/embedded-sending/)

```
import docusign from 'docusign-esign'

let envelope = new docusign.EnvelopeDefinition();
```

> Property 'EnvelopeDefinition' does not exist on type 'typeof import("/Users/seport/1337HAX/MalamaGo/admin-api/node_modules/@types/docusign-esign/index")'.ts(2339)

Updating the typescript definition from interface to class fixes this issue

**This does not bring @types/docusign-esign up to date with the current version, it merely fixes this specific issue I had run into.** As such I'm not sure whether it is appropriate to update the version.