### PR TITLE
fix: node-fetch add arrayBuffer in Blob type

### DIFF
--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -121,6 +121,7 @@ declare class Blob {
     readonly size: number;
     slice(start?: number, end?: number): Blob;
     text(): Promise<string>;
+    arrayBuffer(): Promise<ArrayBuffer>;
 }
 
 declare class Body {


### PR DESCRIPTION
If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

You can find the documentation in:
https://github.com/node-fetch/fetch-blob
`await blob.arrayBuffer()` under Usage section.

Extract of `index.js` where you can find the implementation.
```js
 /**
   * The arrayBuffer() method in the Blob interface returns a
   * Promise that resolves with the contents of the blob as
   * binary data contained in an ArrayBuffer.
   *
   * @return {Promise<ArrayBuffer>}
   */
  async arrayBuffer () {
    const data = new Uint8Array(this.size)
    let offset = 0
    for await (const chunk of toIterator(this.#parts, false)) {
      data.set(chunk, offset)
      offset += chunk.length
    }

    return data.buffer
  }
```

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

This seems to be there since the version 1. So no need to update package.json