### PR TITLE
plotly.js: Add missing histnorm, nbinsx, etc properties

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1529,6 +1529,11 @@ export interface PlotData {
     ncontours: number;
     uirevision: string | number;
     uid: string;
+    histnorm: "" | "percent" | "probability" | "density" | "probability density";
+    alignmentgroup: string;
+    offsetgroup: string;
+    nbinsx: number;
+    nbinsy: number;
 }
 
 /**


### PR DESCRIPTION
Some properties were missing from bar charts, starting from: https://plotly.com/javascript/reference/histogram/#histogram-histnorm

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://plotly.com/javascript/reference/histogram/#histogram-histnorm)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. -- it only adds some of the missing ones, I didn't check to see if all missing definitions are filled and up-to-date.

