### PR TITLE
feat(css-tree): add support for `cssWideKeywords` in `fork()`

### DIFF
--- a/types/css-tree/css-tree-tests.ts
+++ b/types/css-tree/css-tree-tests.ts
@@ -729,7 +729,7 @@ csstree.url.decode("foo"); // $ExpectType string
 csstree.url.encode("foo"); // $ExpectType string
 
 csstree.fork({}); // $ExpectType { lexer: Lexer; }
-const { lexer } = csstree.fork({ atrules: {}, properties: {}, types: { foo: "<length>" } });
+const { lexer } = csstree.fork({ atrules: {}, properties: {}, types: { foo: "<length>" },  cssWideKeywords: ["initial"] });
 lexer; // $ExpectType Lexer
 lexer.matchAtruleDescriptor("foo", "bar", ast); // $ExpectType LexerMatchResult
 lexer.matchAtruleDescriptor("foo", "bar", "baz"); // $ExpectType LexerMatchResult

--- a/types/css-tree/css-tree-tests.ts
+++ b/types/css-tree/css-tree-tests.ts
@@ -729,7 +729,12 @@ csstree.url.decode("foo"); // $ExpectType string
 csstree.url.encode("foo"); // $ExpectType string
 
 csstree.fork({}); // $ExpectType { lexer: Lexer; }
-const { lexer } = csstree.fork({ atrules: {}, properties: {}, types: { foo: "<length>" },  cssWideKeywords: ["initial"] });
+const { lexer } = csstree.fork({
+    atrules: {},
+    properties: {},
+    types: { foo: "<length>" },
+    cssWideKeywords: ["initial"],
+});
 lexer; // $ExpectType Lexer
 lexer.matchAtruleDescriptor("foo", "bar", ast); // $ExpectType LexerMatchResult
 lexer.matchAtruleDescriptor("foo", "bar", "baz"); // $ExpectType LexerMatchResult

--- a/types/css-tree/index.d.ts
+++ b/types/css-tree/index.d.ts
@@ -911,4 +911,5 @@ export function fork(extension: {
     atrules?: Record<string, string> | undefined;
     properties?: Record<string, string> | undefined;
     types?: Record<string, string> | undefined;
+    cssWideKeywords?: Array<string> | undefined;
 }): { lexer: Lexer };


### PR DESCRIPTION
In css-tree v3.0.1, the `fork` method was updated to include the `cssWideKeywords` option.

Release notes: https://github.com/csstree/csstree/releases/tag/v3.0.1
Commit: https://github.com/csstree/csstree/commit/7e2611556a447864431c3ac7b2867c1e72ce6133

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/csstree/csstree/commit/7e2611556a447864431c3ac7b2867c1e72ce6133>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.