### PR TITLE
fix(@types/node): Node GlobOptions exclude (Dirent type when withFileTypes true)

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -4323,7 +4323,7 @@ declare module "fs" {
         /**
          * Function to filter out files/directories. Return true to exclude the item, false to include it.
          */
-        exclude?: ((fileName: string) => boolean) | undefined;
+        exclude?: ((fileName: Dirent | string) => boolean) | undefined;
         /**
          * `true` if the glob should return paths as `Dirent`s, `false` otherwise.
          * @default false
@@ -4331,10 +4331,18 @@ declare module "fs" {
          */
         withFileTypes?: boolean | undefined;
     }
-    export interface GlobOptionsWithFileTypes extends GlobOptions {
+    export interface GlobOptionsWithFileTypes extends Omit<GlobOptions, "exclude"> {
+        /**
+         * Function to filter out files/directories. Return true to exclude the item, false to include it.
+         */
+        exclude?: ((fileName: Dirent) => boolean) | undefined;
         withFileTypes: true;
     }
-    export interface GlobOptionsWithoutFileTypes extends GlobOptions {
+    export interface GlobOptionsWithoutFileTypes extends Omit<GlobOptions, "exclude"> {
+        /**
+         * Function to filter out files/directories. Return true to exclude the item, false to include it.
+         */
+        exclude?: ((fileName: string) => boolean) | undefined;
         withFileTypes?: false | undefined;
     }
     /**

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -933,7 +933,13 @@ const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Ma
             matches; // $ExpectType string[]
         },
     );
-    glob("**/*.js", { withFileTypes: true }, (err, matches) => {
+    glob("**/*.js", {
+        withFileTypes: true,
+        exclude: (fileName) => {
+            fileName; // $ExpectType Dirent
+            return false;
+        },
+    }, (err, matches) => {
         matches; // $ExpectType Dirent[]
     });
     glob("**/*.js", { withFileTypes: Math.random() > 0.5 }, (err, matches) => {


### PR DESCRIPTION
## Summary

Exclude gives Dirent types back when withFileTypes is set to true

## Checklist

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <https://nodejs.org/api/fs.html#fsglobsyncpattern-options>
<https://github.com/nodejs/node/pull/52837>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
