### PR TITLE
fix(nodemailer): Add back missing type for MimeNode

### DIFF
--- a/types/nodemailer/lib/mime-node/index.d.ts
+++ b/types/nodemailer/lib/mime-node/index.d.ts
@@ -3,7 +3,6 @@
 import { Readable, ReadableOptions, Transform } from "stream";
 
 import Mail = require("../mailer");
-import SMTPConnection = require("../smtp-connection");
 
 declare namespace MimeNode {
     interface Addresses {
@@ -25,18 +24,43 @@ declare namespace MimeNode {
     interface Options {
         /** root node for this tree */
         rootNode?: MimeNode | undefined;
+
         /** immediate parent for this node */
         parentNode?: MimeNode | undefined;
+
         /** filename for an attachment node */
         filename?: string | undefined;
+
+        /** Hostname for default message-id values */
+        hostname?: string | undefined;
+
         /** shared part of the unique multipart boundary */
         baseBoundary?: string | undefined;
+
         /** If true, do not exclude Bcc from the generated headers */
         keepBcc?: boolean | undefined;
+
+        /**
+         * If set to 'win' then uses \r\n,
+         * if 'linux' then \n.
+         * If not set (or `raw` is used) then newlines are kept as is.
+         */
+        newline?: string | undefined;
+
         /** either 'Q' (the default) or 'B' */
         textEncoding?: "B" | "Q" | undefined;
+
         /** method to normalize header keys for custom caseing */
         normalizeHeaderKey?(key: string): string;
+
+        /** undocumented */
+        boundaryPrefix?: string | undefined;
+
+        /** Undocumented */
+        disableFileAccess?: boolean | undefined;
+
+        /** Undocumented */
+        disableUrlAccess?: boolean | undefined;
     }
 }
 
@@ -132,6 +156,69 @@ declare class MimeNode {
 
     /** Sets pregenerated content that will be used as the output of this node */
     setRaw(raw: string | Buffer | Readable): this;
+
+    /** shared part of the unique multipart boundary */
+    baseBoundary: string;
+
+    /** a multipart boundary value */
+    boundary?: string | false | undefined;
+
+    /** Undocumented */
+    boundaryPrefix: string;
+
+    /* An array for possible child nodes */
+    childNodes: MimeNode[];
+
+    /** body content for current node */
+    content?: string | Buffer | Readable | undefined;
+
+    /** Undocumented */
+    contentType?: string | undefined;
+
+    /**
+     * If date headers is missing and current node is the root, this value is used instead
+     */
+    date: Date;
+
+    /** Undocumented */
+    disableFileAccess: boolean;
+
+    /** Undocumented */
+    disableUrlAccess: boolean;
+
+    /** filename for an attachment node */
+    filename?: string | undefined;
+
+    /** Hostname for default message-id values */
+    hostname?: string | undefined;
+
+    /** If true, do not exclude Bcc from the generated headers */
+    keepBcc: boolean;
+
+    /** Undocumented */
+    multipart?: boolean | undefined;
+
+    /**
+     * If set to 'win' then uses \r\n,
+     * if 'linux' then \n.
+     * If not set (or `raw` is used) then newlines are kept as is.
+     */
+    newline?: string | undefined;
+
+    /** Undocumented */
+    nodeCounter: number;
+
+    /** method to normalize header keys for custom caseing */
+    normalizeHeaderKey?: ((key: string) => string) | undefined;
+
+    /* Immediate parent for this node (or undefined if not set) */
+    parentNode?: MimeNode | undefined;
+
+    /** root node for this tree */
+    rootNode: MimeNode;
+
+    /** either 'Q' (the default) or 'B' */
+    textEncoding: "B" | "Q" | "";
 }
 
 export = MimeNode;

--- a/types/nodemailer/nodemailer-tests.ts
+++ b/types/nodemailer/nodemailer-tests.ts
@@ -1720,23 +1720,50 @@ function mime_funcs_test() {
 // mime-node
 
 function mime_node_test() {
-    const mb = new MimeNode("text/plain", {
-        normalizeHeaderKey: key => key.toUpperCase(),
-    });
+    let mb: MimeNode;
+
+    // constructor
+    {
+        mb = new MimeNode();
+
+        mb = new MimeNode("text/plain");
+
+        mb = new MimeNode("text/plain", {});
+
+        mb = new MimeNode("text/plain", {
+            rootNode: mb,
+            parentNode: mb,
+            filename: "filename",
+            hostname: "hostname",
+            baseBoundary: "baseBoundary",
+            keepBcc: true,
+            newline: "win",
+            normalizeHeaderKey: key => key.toUpperCase(),
+            boundaryPrefix: "boundaryPrefix",
+            disableFileAccess: true,
+            disableUrlAccess: true,
+        });
+
+        mb = new MimeNode("text/plain", { textEncoding: "B" });
+        mb = new MimeNode("text/plain", { textEncoding: "Q" });
+    }
 
     const child = mb.createChild("multipart/mixed");
-    mb.appendChild(child);
-    child.replace(child);
+    mb = mb.appendChild(child);
+    mb = child.replace(child);
 
-    mb.setHeader("key", "value");
-    const value: string = mb.getHeader("key");
+    mb = mb.setHeader("key", "value");
 
-    mb.addHeader({
+    // $ExpectType string
+    mb.getHeader("key");
+
+    mb = mb.addHeader("key", "value1");
+    mb = mb.addHeader({
         key: "value4",
         key2: "value5",
     });
 
-    mb.setHeader([
+    mb = mb.setHeader([
         {
             key: "key",
             value: "value2",
@@ -1747,18 +1774,153 @@ function mime_node_test() {
         },
     ]);
 
-    mb.setHeader("key", ["value1", "value2", "value3"]);
+    mb = mb.setHeader("key", ["value1", "value2", "value3"]);
 
-    mb.setContent("abc");
+    mb = mb.setContent("abc");
 
-    mb.build((err, msg) => {
-        const msgAsString: string = msg.toString();
+    // $ExpectType void
+    mb.build((err, buf) => {
+        // $ExpectType Error | null
+        err;
+        // $ExpectType Buffer || Buffer<ArrayBufferLike>
+        buf;
     });
 
+    // $ExpectType Promise<Buffer> || Promise<Buffer<ArrayBufferLike>>
+    mb.build();
+
+    // $ExpectType string
+    mb.getTransferEncoding();
+
+    // $ExpectType string
+    mb.buildHeaders();
+
+    {
+        // $ExpectType Readable
+        mb.createReadStream();
+
+        const options: stream.ReadableOptions = {};
+        // $ExpectType Readable
+        mb.createReadStream(options);
+    }
+
+    // $ExpectType void
+    mb.transform(new stream.Transform());
+
+    // $ExpectType void
     mb.processFunc(input => {
-        const isReadable: boolean = input.readable;
+        // $ExpectType Readable
+        input;
         return input;
     });
+
+    {
+        const outputStream = new stream.Readable();
+        const options: stream.ReadableOptions = {};
+
+        // $ExpectType void
+        mb.stream(outputStream, options, err => {
+            // $ExpectType Error | null | undefined
+            err;
+        });
+    }
+
+    {
+        let envelope: Mail.Envelope = {};
+        mb = mb.setEnvelope(envelope);
+    }
+
+    {
+        const addresses = mb.getAddresses();
+
+        // $ExpectType string[] | undefined
+        addresses.bcc;
+        // $ExpectType string[] | undefined
+        addresses.cc;
+        // $ExpectType string[] | undefined
+        addresses.from;
+        // $ExpectType string[] | undefined
+        addresses["reply-to"];
+        // $ExpectType string[] | undefined
+        addresses.sender;
+        // $ExpectType string[] | undefined
+        addresses.to;
+    }
+
+    {
+        const envelope = mb.getEnvelope();
+
+        // $ExpectType string | false
+        envelope.from;
+        // $ExpectType string[]
+        envelope.to;
+    }
+
+    // $ExpectType string
+    mb.messageId();
+
+    {
+        mb = mb.setRaw("raw");
+        mb = mb.setRaw(Buffer.from(""));
+        mb = mb.setRaw(new stream.Readable());
+    }
+
+    // $ExpectType string
+    mb.baseBoundary;
+
+    // $ExpectType string | false | undefined
+    mb.boundary;
+
+    // $ExpectType string
+    mb.boundaryPrefix;
+
+    // $ExpectType MimeNode[]
+    mb.childNodes;
+
+    // $ExpectType string | Buffer | Readable | undefined || string | Buffer<ArrayBufferLike> | Readable | undefined
+    mb.content;
+
+    // $ExpectType string | undefined
+    mb.contentType;
+
+    // $ExpectType Date
+    mb.date;
+
+    // $ExpectType boolean
+    mb.disableFileAccess;
+
+    // $ExpectType boolean
+    mb.disableUrlAccess;
+
+    // $ExpectType string | undefined
+    mb.filename;
+
+    // $ExpectType string | undefined
+    mb.hostname;
+
+    // $ExpectType boolean
+    mb.keepBcc;
+
+    // $ExpectType boolean | undefined
+    mb.multipart;
+
+    // $ExpectType string | undefined
+    mb.newline;
+
+    // $ExpectType number
+    mb.nodeCounter;
+
+    // $ExpectType ((key: string) => string) | undefined
+    mb.normalizeHeaderKey;
+
+    // $ExpectType MimeNode | undefined
+    mb.parentNode;
+
+    // $ExpectType MimeNode
+    mb.rootNode;
+
+    // $ExpectType "B" | "Q" | ""
+    mb.textEncoding;
 }
 
 // mime-types


### PR DESCRIPTION
- Resolves https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69409.
- For other added attributes, see the implementation.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodemailer/nodemailer/blob/4ae5fadeaac70ba91abf529fcaae65f829a39101/lib/mime-node/index.js#L36-L1312
