### PR TITLE
Add Cast owners (castv2, chromecast-caf-receiver, and chromecast-caf-sender)

### DIFF
--- a/types/castv2/package.json
+++ b/types/castv2/package.json
@@ -15,8 +15,20 @@
     },
     "owners": [
         {
+            "name": "Thibaut Séguy",
+            "githubUsername": "thibauts"
+        },
+        {
             "name": "Joey Parrish",
             "githubUsername": "joeyparrish"
+        },
+        {
+            "name": "Julian Domingo",
+            "githubUsername": "juliandomingo"
+        },
+        {
+            "name": "Theodore Abshire",
+            "githubUsername": "theodab"
         }
     ]
 }

--- a/types/chromecast-caf-receiver/package.json
+++ b/types/chromecast-caf-receiver/package.json
@@ -12,6 +12,18 @@
     },
     "owners": [
         {
+            "name": "Joey Parrish",
+            "githubUsername": "joeyparrish"
+        },
+        {
+            "name": "Julian Domingo",
+            "githubUsername": "juliandomingo"
+        },
+        {
+            "name": "Theodore Abshire",
+            "githubUsername": "theodab"
+        },
+        {
             "name": "Sergio Arbeo",
             "githubUsername": "Serabe"
         },

--- a/types/chromecast-caf-sender/package.json
+++ b/types/chromecast-caf-sender/package.json
@@ -15,6 +15,18 @@
     },
     "owners": [
         {
+            "name": "Joey Parrish",
+            "githubUsername": "joeyparrish"
+        },
+        {
+            "name": "Julian Domingo",
+            "githubUsername": "juliandomingo"
+        },
+        {
+            "name": "Theodore Abshire",
+            "githubUsername": "theodab"
+        },
+        {
             "name": "Samuel Maddock",
             "githubUsername": "samuelmaddock"
         }


### PR DESCRIPTION
@thibauts is the author of the castv2 package, and so should have ownership rights over the TS types for that package.

@juliandomingo, @joeyparrish, and @theodab are members of the Chromecast team at Google, who are responsible for the protocol (which you can interact with via the third-party castv2 package) and the SDKs (represented by types in chromecast-caf-receiver and chromecast-caf-sender), and so should have ownership rights over the types of all three packages.

We will try to keep APIs and protocol messages here in sync with upstream changes in the future.

-----

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition: N/A
If changing an existing definition: N/A
If removing a declaration: N/A
