### PR TITLE
[node] fix types for glob exclude with file types

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -4314,29 +4314,35 @@ declare module "fs" {
      */
     export function cpSync(source: string | URL, destination: string | URL, opts?: CopySyncOptions): void;
 
-    export interface GlobOptions {
+    interface GlobOptionsBase {
         /**
          * Current working directory.
          * @default process.cwd()
          */
         cwd?: string | undefined;
         /**
-         * Function to filter out files/directories. Return true to exclude the item, false to include it.
-         */
-        exclude?: ((fileName: string) => boolean) | undefined;
-        /**
          * `true` if the glob should return paths as `Dirent`s, `false` otherwise.
          * @default false
          * @since v22.2.0
          */
         withFileTypes?: boolean | undefined;
+        /**
+         * Function to filter out files/directories. Return true to exclude the item, false to include it.
+         */
+        exclude?: ((fileName: any) => boolean) | undefined;
     }
-    export interface GlobOptionsWithFileTypes extends GlobOptions {
+    export interface GlobOptionsWithFileTypes extends GlobOptionsBase {
+        exclude?: ((fileName: Dirent) => boolean) | undefined;
         withFileTypes: true;
     }
-    export interface GlobOptionsWithoutFileTypes extends GlobOptions {
+    export interface GlobOptionsWithoutFileTypes extends GlobOptionsBase {
+        exclude?: ((fileName: string) => boolean) | undefined;
         withFileTypes?: false | undefined;
     }
+    export interface GlobOptions extends GlobOptionsBase {
+        exclude?: ((fileName: Dirent | string) => boolean) | undefined;
+    }
+
     /**
      * Retrieves the files matching the specified pattern.
      */

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -918,9 +918,49 @@ const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Ma
         entry; // $ExpectType Dirent | string
     }
 
+    for await (
+        const entry of globAsync("**/*.js", {
+            exclude(fileName) {
+                fileName; // $ExpectType string
+                return false;
+            },
+        })
+    ) {
+        entry; // $ExpectType string
+    }
+    for await (
+        const entry of globAsync("**/*.js", {
+            withFileTypes: true,
+            exclude(fileName) {
+                fileName; // $ExpectType Dirent
+                return false;
+            },
+        })
+    ) {
+        entry; // $ExpectType Dirent
+    }
+    for await (
+        const entry of globAsync("**/*.js", {
+            withFileTypes: Math.random() > 0.5,
+            exclude(fileName) {
+                fileName; // $ExpectType Dirent | string
+                return false;
+            },
+        })
+    ) {
+        entry; // $ExpectType Dirent | string
+    }
+
     glob("**/*.js", (err, matches) => {
         matches; // $ExpectType string[]
     });
+    glob("**/*.js", { withFileTypes: true }, (err, matches) => {
+        matches; // $ExpectType Dirent[]
+    });
+    glob("**/*.js", { withFileTypes: Math.random() > 0.5 }, (err, matches) => {
+        matches; // $ExpectType Dirent[] | string[]
+    });
+
     glob(
         "**/*.js",
         {
@@ -933,12 +973,32 @@ const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Ma
             matches; // $ExpectType string[]
         },
     );
-    glob("**/*.js", { withFileTypes: true }, (err, matches) => {
-        matches; // $ExpectType Dirent[]
-    });
-    glob("**/*.js", { withFileTypes: Math.random() > 0.5 }, (err, matches) => {
-        matches; // $ExpectType Dirent[] | string[]
-    });
+    glob(
+        "**/*.js",
+        {
+            withFileTypes: true,
+            exclude: (fileName) => {
+                fileName; // $ExpectType Dirent
+                return false;
+            },
+        },
+        (err, matches) => {
+            matches; // $ExpectType Dirent[]
+        },
+    );
+    glob(
+        "**/*.js",
+        {
+            withFileTypes: Math.random() > 0.5,
+            exclude: (fileName) => {
+                fileName; // $ExpectType Dirent | string
+                return false;
+            },
+        },
+        (err, matches) => {
+            matches; // $ExpectType Dirent[] | string[]
+        },
+    );
 
     for (const entry of globSync("**/*.js")) {
         entry; // $ExpectType string
@@ -950,6 +1010,39 @@ const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Ma
         entry; // $ExpectType Dirent
     }
     for (const entry of globSync("**/*.js", { withFileTypes: Math.random() > 0.5 })) {
+        entry; // $ExpectType Dirent | string
+    }
+
+    for (
+        const entry of globSync("**/*.js", {
+            exclude: (fileName) => {
+                fileName; // $ExpectType string
+                return false;
+            },
+        })
+    ) {
+        entry; // $ExpectType string
+    }
+    for (
+        const entry of globSync("**/*.js", {
+            withFileTypes: true,
+            exclude: (fileName) => {
+                fileName; // $ExpectType Dirent
+                return false;
+            },
+        })
+    ) {
+        entry; // $ExpectType Dirent
+    }
+    for (
+        const entry of globSync("**/*.js", {
+            withFileTypes: Math.random() > 0.5,
+            exclude: (fileName) => {
+                fileName; // $ExpectType Dirent | string
+                return false;
+            },
+        })
+    ) {
         entry; // $ExpectType Dirent | string
     }
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - https://github.com/nodejs/node/pull/52837
    - https://github.com/nodejs/node/blob/v22.9.0/lib/internal/fs/glob.js [Lines 350 and 545]
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
