### PR TITLE
feat(mdx/types): enhance MDXComponents type annotations to be more intellisense-friendly

### DIFF
--- a/types/mdx/types.d.ts
+++ b/types/mdx/types.d.ts
@@ -20,7 +20,7 @@ type ClassElementType = Extract<ElementType, new(props: Record<string, any>) => 
 /**
  * A valid JSX string component.
  */
-type StringComponent = Extract<keyof JSX.IntrinsicElements, ElementType extends never ? string : ElementType>;
+type StringComponent = Extract<keyof JSX.IntrinsicElements, ElementType extends never ? string & {} : ElementType>;
 
 /**
  * A JSX element returned by MDX content.
@@ -57,7 +57,7 @@ type ClassComponent<Props> = ElementType extends never
 type Component<Props> = FunctionComponent<Props> | ClassComponent<Props> | StringComponent;
 
 interface NestedMDXComponents {
-    [key: string]: NestedMDXComponents | Component<any>;
+    [key: string & {}]: NestedMDXComponents | Component<any>;
 }
 
 // Public MDX helper types


### PR DESCRIPTION
# What's this about?

Working on a Next.JS project w/ MDX, following the instructions for [the latest MDX Docs Available](https://nextjs.org/docs/app/building-your-application/configuring/mdx), until I notice the example for `mdx-components.tsx` (You can find it [here](https://nextjs.org/docs/app/building-your-application/configuring/mdx#add-an-mdx-componentstsx-file)):

```tsx
import type { MDXComponents } from 'mdx/types'
 
export function useMDXComponents(components: MDXComponents): MDXComponents {
  return {
    ...components,
  }
}
```

While implementing my own version of this, I notice how easy it is to do typos (since IDE does not show because `string` type generalizes the named key annotations into `string` as well).

What I did is to use `string & {}` instead, which enables named annotations to be shown by your IDE, avoiding this kind of problem.

Applied the same for the `StringComponent` type annotation!

# Checklist

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
