### PR TITLE
feat(subset-font): add `variationAxes` option introduced in v2.2.0

### DIFF
--- a/types/subset-font/index.d.ts
+++ b/types/subset-font/index.d.ts
@@ -12,6 +12,13 @@ interface SubsetFontOptions {
      * An array of numbers specifying the extra name ids to preserve in the name table. See README for details.
      */
     preserveNameIds?: number[];
+    /**
+     * An object specifying a full or partial instancing of variation axes in the font.
+     * Only works with variable fonts. See README's example for details.
+     */
+    variationAxes?: {
+        [axeName: string]: number | { min: number; max: number; default?: number };
+    };
 }
 
 /**

--- a/types/subset-font/package.json
+++ b/types/subset-font/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/subset-font",
-    "version": "1.4.9999",
+    "version": "2.2.9999",
     "projects": [
         "https://github.com/papandreou/subset-font"
     ],

--- a/types/subset-font/subset-font-tests.ts
+++ b/types/subset-font/subset-font-tests.ts
@@ -27,4 +27,12 @@ import subsetFont = require("subset-font");
         // @ts-expect-error
         targetFormat: "eot",
     });
+
+    const variationAxes = await subsetFont(mySfntFontBuffer, "1234", {
+        variationAxes: {
+            wght: 200,
+            GRAD: { min: -50, max: 50, default: 25 },
+            slnt: { min: -9, max: 0 },
+        },
+    });
 })();


### PR DESCRIPTION
> [!NOTE]
> Another definition is introduced in #71189 , for a later version of the lib

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [CHANGELOG](https://github.com/papandreou/subset-font/blob/v2.4.0/CHANGELOG.md)
  - [README](https://github.com/papandreou/subset-font/blob/v2.4.0/README.md)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
