### PR TITLE
feat(subset-font): add `noLayoutClosure` flag introduced in v2.3.0

### DIFF
--- a/types/subset-font/index.d.ts
+++ b/types/subset-font/index.d.ts
@@ -19,6 +19,11 @@ interface SubsetFontOptions {
     variationAxes?: {
         [axeName: string]: number | { min: number; max: number; default?: number };
     };
+    /**
+     * Don't perform glyph closure for layout substitution (GSUB).
+     * Equivalent to `hb-subset --no-layout-closure` and `pyftsubset --no-layout-closure`.
+     */
+    noLayoutClosure?: boolean;
 }
 
 /**

--- a/types/subset-font/package.json
+++ b/types/subset-font/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/subset-font",
-    "version": "2.2.9999",
+    "version": "2.3.9999",
     "projects": [
         "https://github.com/papandreou/subset-font"
     ],

--- a/types/subset-font/subset-font-tests.ts
+++ b/types/subset-font/subset-font-tests.ts
@@ -35,4 +35,8 @@ import subsetFont = require("subset-font");
             slnt: { min: -9, max: 0 },
         },
     });
+
+    const noLayoutClosure = await subsetFont(mySfntFontBuffer, "1234", {
+        noLayoutClosure: true,
+    });
 })();


### PR DESCRIPTION
> [!NOTE]
> See #71188 for adding `variationAxes`, which was introduced first

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [CHANGELOG](https://github.com/papandreou/subset-font/blob/v2.4.0/CHANGELOG.md)
  - [README](https://github.com/papandreou/subset-font/blob/v2.4.0/README.md)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

