### PR TITLE
fix(phoenix-live-view): improve phoenix liveView hooks types

### DIFF
--- a/types/phoenix_live_view/README.md
+++ b/types/phoenix_live_view/README.md
@@ -1,0 +1,51 @@
+# @types/phoenix_live_view
+
+This package contains the type definitions for the [Phoenix LiveView](https://github.com/phoenixframework/phoenix_live_view) library.
+
+## Installation
+
+```bash
+npm install --save-dev @types/phoenix_live_view
+```
+
+## BREAKING CHANGE in 1.6.5
+
+The `ViewHook` interface has been modified to better reflect the type expected by developers writing their own hooks. It used to correspond to the type of the hook object as it is constructed by the Phoenix LiveView library internally, but it included properties which are not expected for developers to provide. This required casting or commenting to make the typescript compiler happy when declaring hooks.
+
+The new `ViewHook` interface is now correct and only expects the hook functions that developers are expected to provide given the public API. But it still provides the previous interface as `ViewHookInternal` for those who need to use it.
+
+Besides, and it correctly assigns the `ViewHookInternal` type to `this` when writing a hook, so properties like `el`, `viewName`, and functions like `push_event` are all there. The `ViewHook` interface can also now be used as a generic for developers who want to assign their own functions and properties to the hook object.
+
+```typescript
+const testHook: ViewHook = {
+    mounted() {
+        const hook = this;
+        console.log("TestHook mounted", { element: this.el, viewName: this.viewName });
+        hook.pushEvent("hook-mounted", { name: "testHook" }, (reply, ref) => {
+            console.log(`Got hook-mounted reply ${JSON.stringify(reply)} ref ${ref}`);
+        });
+    },
+};
+
+const testHookWithExtendedPrototype: ViewHook<{ handleClick: (event: MouseEvent) => void }> = {
+    mounted() {
+        this.handleClick = (event: MouseEvent) => {
+            console.log("click", event);
+            this.pushEvent("click", { x: event.clientX, y: event.clientY });
+        };
+        document.addEventListener("click", this.handleClick);
+    },
+    destroyed() {
+        document.removeEventListener("click", this.handleClick);
+    },
+};
+
+const MyHooks: HooksOptions = {
+    test: testHook,
+    testWithExtendedPrototype: testHookWithExtendedPrototype,
+};
+
+const liveSocket = new LiveSocket("/live", Socket, opts);
+
+```
+

--- a/types/phoenix_live_view/README.md
+++ b/types/phoenix_live_view/README.md
@@ -8,7 +8,7 @@ This package contains the type definitions for the [Phoenix LiveView](https://gi
 npm install --save-dev @types/phoenix_live_view
 ```
 
-## BREAKING CHANGE in 1.6.5
+## BREAKING CHANGE in 0.20.0
 
 The `ViewHook` interface has been modified to better reflect the type expected by developers writing their own hooks. It used to correspond to the type of the hook object as it is constructed by the Phoenix LiveView library internally, but it included properties which are not expected for developers to provide. This required casting or commenting to make the typescript compiler happy when declaring hooks.
 

--- a/types/phoenix_live_view/index.d.ts
+++ b/types/phoenix_live_view/index.d.ts
@@ -168,7 +168,7 @@ export interface ViewHookInternal {
     reconnected?: (() => void);
 }
 
-export interface ViewHook<T extends object = Object> {
+export interface ViewHook<T extends object = {}> {
     mounted?: ((this: T & ViewHookInternal) => void);
     beforeUpdate?: ((this: T & ViewHookInternal) => void);
     updated?: ((this: T & ViewHookInternal) => void);

--- a/types/phoenix_live_view/index.d.ts
+++ b/types/phoenix_live_view/index.d.ts
@@ -4,7 +4,7 @@
 // Version 0.17.0 added LiveSocket.execJS() method for executing JavaScript utility operations on the client
 // See: https://github.com/phoenixframework/phoenix_live_view/blob/master/CHANGELOG.md#enhancements-17
 
-import { Socket, SocketConnectOption } from "phoenix";
+import { Socket } from "phoenix";
 
 export interface Defaults {
     debounce?: number | undefined;
@@ -31,7 +31,7 @@ export interface SocketOptions {
     bindingPrefix?: string | undefined;
     defaults?: Defaults | undefined;
     dom?: DomOptions | undefined;
-    hooks?: object | undefined;
+    hooks?: HooksOptions | undefined;
     loaderTimeout?: number | undefined;
     params?: object | undefined;
     uploaders?: object | undefined;
@@ -47,6 +47,8 @@ export type BindCallback = (
     phxEvent: string,
     windowOwner?: string,
 ) => void;
+
+
 
 export class LiveSocket {
     // phxSocket should be the Socket class (LiveSocket will use the constructor)
@@ -144,7 +146,7 @@ export class Rendered {
     // toOutputBuffer(rendered: any, output: object): any;
 }
 
-export interface ViewHook {
+export interface ViewHookInternal {
     el: HTMLElement;
     viewName: string;
     pushEvent(event: string, payload: object, onReply?: (reply: any, ref: number) => any): void;
@@ -157,14 +159,26 @@ export interface ViewHook {
     handleEvent(event: string, callback: (payload: object) => void): void;
 
     // callbacks
-    mounted?: (() => void) | undefined;
-    beforeUpdate?: (() => void) | undefined;
-    updated?: (() => void) | undefined;
-    beforeDestroy?: (() => void) | undefined;
-    destroyed?: (() => void) | undefined;
-    disconnected?: (() => void) | undefined;
-    reconnected?: (() => void) | undefined;
+    mounted?: (() => void);
+    beforeUpdate?: (() => void);
+    updated?: (() => void);
+    beforeDestroy?: (() => void);
+    destroyed?: (() => void);
+    disconnected?: (() => void);
+    reconnected?: (() => void);
 }
+
+export interface ViewHook<T extends object = Object> {
+    mounted?: ((this: T & ViewHookInternal) => void);
+    beforeUpdate?: ((this: T & ViewHookInternal) => void);
+    updated?: ((this: T & ViewHookInternal) => void);
+    beforeDestroy?: ((this: T & ViewHookInternal) => void);
+    destroyed?: ((this: T & ViewHookInternal) => void);
+    disconnected?: ((this: T & ViewHookInternal) => void);
+    reconnected?: ((this: T & ViewHookInternal) => void);
+}
+
+export type HooksOptions = Record<string, ViewHook<any>>;
 
 export class View {
     constructor(el: HTMLElement, liveSocket: LiveSocket, parentView: View, href: string, flash: string);

--- a/types/phoenix_live_view/index.d.ts
+++ b/types/phoenix_live_view/index.d.ts
@@ -45,10 +45,8 @@ export type BindCallback = (
     el: HTMLElement,
     targetCtx: object,
     phxEvent: string,
-    windowOwner?: string,
+    windowOwner?: string
 ) => void;
-
-
 
 export class LiveSocket {
     // phxSocket should be the Socket class (LiveSocket will use the constructor)
@@ -154,28 +152,28 @@ export interface ViewHookInternal {
         selectorOrTarget: any,
         event: string,
         payload: object,
-        onReply?: (reply: any, ref: number) => any,
+        onReply?: (reply: any, ref: number) => any
     ): void;
     handleEvent(event: string, callback: (payload: object) => void): void;
 
     // callbacks
-    mounted?: (() => void);
-    beforeUpdate?: (() => void);
-    updated?: (() => void);
-    beforeDestroy?: (() => void);
-    destroyed?: (() => void);
-    disconnected?: (() => void);
-    reconnected?: (() => void);
+    mounted?: () => void;
+    beforeUpdate?: () => void;
+    updated?: () => void;
+    beforeDestroy?: () => void;
+    destroyed?: () => void;
+    disconnected?: () => void;
+    reconnected?: () => void;
 }
 
 export interface ViewHook<T extends object = {}> {
-    mounted?: ((this: T & ViewHookInternal) => void);
-    beforeUpdate?: ((this: T & ViewHookInternal) => void);
-    updated?: ((this: T & ViewHookInternal) => void);
-    beforeDestroy?: ((this: T & ViewHookInternal) => void);
-    destroyed?: ((this: T & ViewHookInternal) => void);
-    disconnected?: ((this: T & ViewHookInternal) => void);
-    reconnected?: ((this: T & ViewHookInternal) => void);
+    mounted?: (this: T & ViewHookInternal) => void;
+    beforeUpdate?: (this: T & ViewHookInternal) => void;
+    updated?: (this: T & ViewHookInternal) => void;
+    beforeDestroy?: (this: T & ViewHookInternal) => void;
+    destroyed?: (this: T & ViewHookInternal) => void;
+    disconnected?: (this: T & ViewHookInternal) => void;
+    reconnected?: (this: T & ViewHookInternal) => void;
 }
 
 export type HooksOptions = Record<string, ViewHook<any>>;
@@ -321,7 +319,7 @@ export namespace DOM {
         defaultDebounce: string | null,
         phxThrottle: string,
         defaultThrottle: string | null,
-        callback: () => any,
+        callback: () => any
     ): any;
     function deletePrivate(el: HTMLElement, key: string): void;
     function discardError(container: Node, el: HTMLElement, phxFeedbackFor: string): void;

--- a/types/phoenix_live_view/index.d.ts
+++ b/types/phoenix_live_view/index.d.ts
@@ -45,7 +45,7 @@ export type BindCallback = (
     el: HTMLElement,
     targetCtx: object,
     phxEvent: string,
-    windowOwner?: string
+    windowOwner?: string,
 ) => void;
 
 export class LiveSocket {
@@ -152,7 +152,7 @@ export interface ViewHookInternal {
         selectorOrTarget: any,
         event: string,
         payload: object,
-        onReply?: (reply: any, ref: number) => any
+        onReply?: (reply: any, ref: number) => any,
     ): void;
     handleEvent(event: string, callback: (payload: object) => void): void;
 
@@ -319,7 +319,7 @@ export namespace DOM {
         defaultDebounce: string | null,
         phxThrottle: string,
         defaultThrottle: string | null,
-        callback: () => any
+        callback: () => any,
     ): any;
     function deletePrivate(el: HTMLElement, key: string): void;
     function discardError(container: Node, el: HTMLElement, phxFeedbackFor: string): void;

--- a/types/phoenix_live_view/index.d.ts
+++ b/types/phoenix_live_view/index.d.ts
@@ -1,3 +1,18 @@
+// Project: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/phoenix_live_view
+// Definitions by: Peter Zingg <https://github.com/pzingg>
+//                 Igor Barchenkov <https://github.com/ibarchenkov>
+//                 Rodolfo Carvalho <https://github.com/rhcarvalho>
+//                 François Roland <https://github.com/francois-codes>
+//
+// Changelog:
+// Version 0.20 refactored ViewHook interface with generic type and
+// ViewHookInternal interface
+//
+// Version 0.17 added LiveSocket.execJS() method for executing JavaScript utility operations on the client
+// See: https://github.com/phoenixframework/phoenix_live_view/blob/master/CHANGELOG.md#enhancements-17
+//
+// Version 0.15 added options and interfaces for LiveView uploads
+// See: https://hexdocs.pm/phoenix_live_view/uploads.html
 // Version 0.15.4 added options and interfaces for LiveView uploads
 // See: https://hexdocs.pm/phoenix_live_view/uploads.html
 

--- a/types/phoenix_live_view/package.json
+++ b/types/phoenix_live_view/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/phoenix_live_view",
-    "version": "0.18.9999",
+    "version": "1.6.5",
     "projects": [
         "https://github.com/phoenixframework/phoenix_live_view"
     ],
@@ -15,6 +15,23 @@
         {
             "name": "Peter Zingg",
             "githubUsername": "pzingg"
+        }
+    ],
+    "contributors": [
+        {
+            "name": "Igor Barchenkov",
+            "githubUsername": "ibarchenkov",
+            "url": "https://github.com/ibarchenkov"
+        },
+        {
+            "name": "Rodolfo Carvalho",
+            "githubUsername": "rhcarvalho",
+            "url": "https://github.com/rhcarvalho"
+        },
+        {
+            "name": "François Roland",
+            "githubUsername": "francois-codes",
+            "url": "https://github.com/francois-codes"
         }
     ]
 }

--- a/types/phoenix_live_view/package.json
+++ b/types/phoenix_live_view/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/phoenix_live_view",
-    "version": "1.6.9999",
+    "version": "0.19.9999",
     "projects": [
         "https://github.com/phoenixframework/phoenix_live_view"
     ],

--- a/types/phoenix_live_view/package.json
+++ b/types/phoenix_live_view/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/phoenix_live_view",
-    "version": "0.19.9999",
+    "version": "0.20.9999",
     "projects": [
         "https://github.com/phoenixframework/phoenix_live_view"
     ],

--- a/types/phoenix_live_view/package.json
+++ b/types/phoenix_live_view/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/phoenix_live_view",
-    "version": "1.6.5",
+    "version": "1.6.9999",
     "projects": [
         "https://github.com/phoenixframework/phoenix_live_view"
     ],
@@ -15,23 +15,6 @@
         {
             "name": "Peter Zingg",
             "githubUsername": "pzingg"
-        }
-    ],
-    "contributors": [
-        {
-            "name": "Igor Barchenkov",
-            "githubUsername": "ibarchenkov",
-            "url": "https://github.com/ibarchenkov"
-        },
-        {
-            "name": "Rodolfo Carvalho",
-            "githubUsername": "rhcarvalho",
-            "url": "https://github.com/rhcarvalho"
-        },
-        {
-            "name": "François Roland",
-            "githubUsername": "francois-codes",
-            "url": "https://github.com/francois-codes"
         }
     ]
 }

--- a/types/phoenix_live_view/phoenix_live_view-tests.ts
+++ b/types/phoenix_live_view/phoenix_live_view-tests.ts
@@ -1,17 +1,30 @@
 import { Socket } from "phoenix";
-import { LiveSocket, SocketOptions, UploadEntry, ViewHook } from "phoenix_live_view";
+import { HooksOptions, LiveSocket, SocketOptions, UploadEntry, ViewHook } from "phoenix_live_view";
 
 function test_socket() {
     // Hooks
-    const testHook = {
+    const testHook: ViewHook = {
         mounted() {
-            const hook = this as unknown as ViewHook;
-            console.log("TestHook mounted");
+            const hook = this;
+            console.log("TestHook mounted", { element: this.el, viewName: this.viewName });
             hook.pushEvent("hook-mounted", { name: "testHook" }, (reply, ref) => {
                 console.log(`Got hook-mounted reply ${JSON.stringify(reply)} ref ${ref}`);
             });
         },
     };
+
+    const testHookWithExtendedPrototype: ViewHook<{handleClick: (event: MouseEvent) => void}> = {
+        mounted() {
+            this.handleClick = (event: MouseEvent) => {
+                console.log("click", event);
+                this.pushEvent("click", { x: event.clientX, y: event.clientY });
+            };
+            document.addEventListener("click", this.handleClick);
+        },
+        destroyed() {
+            document.removeEventListener("click", this.handleClick);
+        }
+    }
 
     // Uploaders
     function testUploader(entries: UploadEntry[], _onViewError: any) {
@@ -21,8 +34,9 @@ function test_socket() {
         });
     }
 
-    const MyHooks = {
+    const MyHooks: HooksOptions = {
         test: testHook,
+        testWithExtendedPrototype: testHookWithExtendedPrototype
     };
 
     const MyUploaders = {

--- a/types/phoenix_live_view/phoenix_live_view-tests.ts
+++ b/types/phoenix_live_view/phoenix_live_view-tests.ts
@@ -58,6 +58,6 @@ function test_socket() {
 
     const element = "dummyElement" as unknown as HTMLElement;
     // $ExpectType void
-    liveSocket.execJS(element, '[["patch",{"href":"/","replace":false}]]');
-    liveSocket.execJS(element, '[["navigate",{"href":"/","replace":false}]]', "submit");
+    liveSocket.execJS(element, "[[\"patch\",{\"href\":\"/\",\"replace\":false}]]");
+    liveSocket.execJS(element, "[[\"navigate\",{\"href\":\"/\",\"replace\":false}]]", "submit");
 }

--- a/types/phoenix_live_view/phoenix_live_view-tests.ts
+++ b/types/phoenix_live_view/phoenix_live_view-tests.ts
@@ -13,7 +13,7 @@ function test_socket() {
         },
     };
 
-    const testHookWithExtendedPrototype: ViewHook<{handleClick: (event: MouseEvent) => void}> = {
+    const testHookWithExtendedPrototype: ViewHook<{ handleClick: (event: MouseEvent) => void }> = {
         mounted() {
             this.handleClick = (event: MouseEvent) => {
                 console.log("click", event);
@@ -23,12 +23,12 @@ function test_socket() {
         },
         destroyed() {
             document.removeEventListener("click", this.handleClick);
-        }
-    }
+        },
+    };
 
     // Uploaders
     function testUploader(entries: UploadEntry[], _onViewError: any) {
-        entries.forEach(entry => {
+        entries.forEach((entry) => {
             console.log(`file: ${entry.file.name}`);
             console.log(`meta: ${JSON.stringify(entry.meta)}`);
         });
@@ -36,7 +36,7 @@ function test_socket() {
 
     const MyHooks: HooksOptions = {
         test: testHook,
-        testWithExtendedPrototype: testHookWithExtendedPrototype
+        testWithExtendedPrototype: testHookWithExtendedPrototype,
     };
 
     const MyUploaders = {
@@ -58,6 +58,6 @@ function test_socket() {
 
     const element = "dummyElement" as unknown as HTMLElement;
     // $ExpectType void
-    liveSocket.execJS(element, "[[\"patch\",{\"href\":\"/\",\"replace\":false}]]");
-    liveSocket.execJS(element, "[[\"navigate\",{\"href\":\"/\",\"replace\":false}]]", "submit");
+    liveSocket.execJS(element, '[["patch",{"href":"/","replace":false}]]');
+    liveSocket.execJS(element, '[["navigate",{"href":"/","replace":false}]]', "submit");
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.


Hi there 👋🏻 

As I started to work on Elixir & Phoenix, using LiveView, I noticed that the provided types are not really accurate.

The `ViewHook` interface is the internal type, the way phoenix_live_view builds the object internally. While it's used as the type for the hooks declared by consumers of the API, it is incorrect and requires users to use casts, or worst, ignore / expect-error comments for typescript to be happy

So I'm proposing to break this down in two parts:
- keep the existing ViewHook interface but rename it as `ViewHookInternal`
- create a new ViewHook interface that matches the valid type users have to match to register liveView hooks. As a bonus, I've added an option to pass a generic which allows to make typescript happy when binding functions to `this` inside the hook's methods
- I've added a `HooksOptions` type which can used to type a `hooks` object that would be created as a plain object before being passed to `LiveSocket` as an argument

basically you can now do this without any TS errors

```typescript
    const testHookWithExtendedPrototype: ViewHook<{handleClick: (event: MouseEvent) => void}> = {
        mounted() {
            this.handleClick = (event: MouseEvent) => {
                console.log("click", event);
                this.pushEvent("click", { x: event.clientX, y: event.clientY });
            };
            document.addEventListener("click", this.handleClick);
        },
        destroyed() {
            document.removeEventListener("click", this.handleClick);
        }
    }

    const testHook: ViewHook = {
        mounted() {
            const hook = this;
            console.log("TestHook mounted", { element: this.el, viewName: this.viewName });
            hook.pushEvent("hook-mounted", { name: "testHook" }, (reply, ref) => {
                console.log(`Got hook-mounted reply ${JSON.stringify(reply)} ref ${ref}`);
            });
        },
    };

    const MyHooks: HooksOptions = {
        test: testHook,
        testWithExtendedPrototype: testHookWithExtendedPrototype
    };

    const opts: SocketOptions = {
        params: {
            _csrf_token: "1234",
        },
        hooks: MyHooks,
    };

    const liveSocket = new LiveSocket("/live", Socket, opts);

```

I've also noticed that phx events are not typed correctly, but I couldn't find an option to do this without declaring all the events one by one like this

```typescript


interface CustomEventDetail extends CustomEvent {
  detail: { id: string }
}

declare global {
  interface WindowEventMap {
    'phx:custom-event': CustomEventDetail
  }

  interface Window {
    liveSocket: LiveSocket
  }
}

window.addEventListener('phx:custom-event', ({ detail }) => {
  // correct type for `detail` ☝🏻 
})


```

That could be neat, but  haven't figured it out so I left it out of this PR