### PR TITLE
[@types/pdfkit] Fix for https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/71172#discussion-7478559

### DIFF
--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -649,14 +649,14 @@ declare module "pdfkit/js/data" {
 
 declare namespace PDFKit {
     interface DocumentInfo {
-        Producer?: string | undefined;
-        Creator?: string | undefined;
-        CreationDate?: Date | undefined;
-        Title?: string | undefined;
-        Author?: string | undefined;
-        Subject?: string | undefined;
-        Keywords?: string | undefined;
-        ModDate?: Date | undefined;
+        Producer?: string;
+        Creator?: string;
+        CreationDate?: Date;
+        Title?: string;
+        Author?: string;
+        Subject?: string;
+        Keywords?: string;
+        ModDate?: Date;
     }
 
     interface DocumentPermissions {

--- a/types/pdfkit/pdfkit-tests.ts
+++ b/types/pdfkit/pdfkit-tests.ts
@@ -19,7 +19,7 @@ font.registerFont("CustomFont", "path/to/font.ttf");
 font.registerFont("CustomFontWithBuffer", Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]));
 text.widthOfString("Kila", { ellipsis: true });
 
-var doc = new PDFDocument({
+var doc: PDFKit.PDFDocument = new PDFDocument({
     compress: false,
     size: [526, 525],
     autoFirstPage: true,
@@ -31,6 +31,11 @@ var doc = new PDFDocument({
     },
     font: "Arial",
     fontLayoutCache: true,
+    info: {
+        Author: "John Doe",
+        Producer: "Johny Doe",
+        Title: "John Doe's PDF",
+    }
 });
 
 doc.addPage({

--- a/types/pdfkit/pdfkit-tests.ts
+++ b/types/pdfkit/pdfkit-tests.ts
@@ -19,7 +19,7 @@ font.registerFont("CustomFont", "path/to/font.ttf");
 font.registerFont("CustomFontWithBuffer", Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]));
 text.widthOfString("Kila", { ellipsis: true });
 
-var doc: PDFKit.PDFDocument = new PDFDocument({
+var doc = new PDFDocument({
     compress: false,
     size: [526, 525],
     autoFirstPage: true,
@@ -31,11 +31,6 @@ var doc: PDFKit.PDFDocument = new PDFDocument({
     },
     font: "Arial",
     fontLayoutCache: true,
-    info: {
-        Author: "John Doe",
-        Producer: "Johny Doe",
-        Title: "John Doe's PDF",
-    }
 });
 
 doc.addPage({

--- a/types/pdfkit/pdfkit-tests.ts
+++ b/types/pdfkit/pdfkit-tests.ts
@@ -19,7 +19,7 @@ font.registerFont("CustomFont", "path/to/font.ttf");
 font.registerFont("CustomFontWithBuffer", Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]));
 text.widthOfString("Kila", { ellipsis: true });
 
-var doc = new PDFDocument({
+var doc: PDFKit.PDFDocument = new PDFDocument({
     compress: false,
     size: [526, 525],
     autoFirstPage: true,
@@ -338,3 +338,12 @@ structureElement.add(structureContent);
 structureElement.setAttached();
 structureElement.setParent(doc.ref({}));
 structureElement.end();
+
+
+// Test optional info types can not be undefined in PDFDocument (See PullRequest 71195)
+const optionalPDF: PDFKit.PDFDocument = new PDFDocument({
+    // @ts-expect-error
+    info: {
+        Title: undefined
+    }
+});

--- a/types/pdfkit/pdfkit-tests.ts
+++ b/types/pdfkit/pdfkit-tests.ts
@@ -344,6 +344,13 @@ structureElement.end();
 const optionalPDF: PDFKit.PDFDocument = new PDFDocument({
     // @ts-expect-error
     info: {
-        Title: undefined
+        Producer: undefined,
+        Creator: undefined,
+        CreationDate: undefined,
+        Title: undefined,
+        Author: undefined,
+        Subject: undefined,
+        Keywords: undefined,
+        ModDate: undefined,
     }
 });

--- a/types/pdfkit/tsconfig.json
+++ b/types/pdfkit/tsconfig.json
@@ -10,7 +10,8 @@
         "strictFunctionTypes": true,
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "exactOptionalPropertyTypes": true
     },
     "files": [
         "index.d.ts",


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
    - ~~I get erros like this~~
    ```
    Cannot find type definition file for 'node'                                                                                                                              @definitelytyped/expect
    84:19  error  TypeScript@4.9, 5.0, 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8 compile error: 
    Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig  @definitelytyped/expect
    ```
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
    - ~~How can I test it? I mean this fix is suppose to show an error if unknown is given. Is there a function which allows to expect an error if unknown is given?~~
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
