### PR TITLE
fix: filestack-react onUploadDone callback parameter type

### DIFF
--- a/types/filestack-react/filestack-react-tests.tsx
+++ b/types/filestack-react/filestack-react-tests.tsx
@@ -1,10 +1,14 @@
-import type { ClientOptions, PickerFileMetadata, PickerOptions } from "filestack-js";
+import type { ClientOptions, PickerFileMetadata, PickerOptions, PickerResponse } from "filestack-js";
 import { client, PickerDropPane, PickerInline, PickerOverlay } from "filestack-react";
 import * as React from "react";
 
 const mockClientOptions: ClientOptions = {};
 const mockPickerOptions: PickerOptions = {};
 const mockApiKey = "API_KEY";
+
+const mockOnUploadDone = (result: PickerResponse) => {
+    /* do nothing */
+};
 
 const mockAction = (result: PickerFileMetadata) => {
     /* do nothing */
@@ -16,7 +20,7 @@ export const MockInline = () => (
         pickerOptions={mockPickerOptions}
         clientOptions={mockClientOptions}
         onSuccess={mockAction}
-        onUploadDone={mockAction}
+        onUploadDone={mockOnUploadDone}
         onError={mockAction}
     />
 );
@@ -27,7 +31,7 @@ export const MockOverlay = () => (
         pickerOptions={mockPickerOptions}
         clientOptions={mockClientOptions}
         onSuccess={mockAction}
-        onUploadDone={mockAction}
+        onUploadDone={mockOnUploadDone}
         onError={mockAction}
     />
 );
@@ -38,7 +42,7 @@ export const MockDropPane = () => (
         pickerOptions={mockPickerOptions}
         clientOptions={mockClientOptions}
         onSuccess={mockAction}
-        onUploadDone={mockAction}
+        onUploadDone={mockOnUploadDone}
         onError={mockAction}
     />
 );

--- a/types/filestack-react/index.d.ts
+++ b/types/filestack-react/index.d.ts
@@ -1,4 +1,4 @@
-import { ClientOptions, PickerFileMetadata, PickerOptions } from "filestack-js";
+import { ClientOptions, PickerFileMetadata, PickerOptions, PickerResponse } from "filestack-js";
 import * as React from "react";
 
 export * as client from "filestack-js";
@@ -24,7 +24,7 @@ interface PickerBaseProps {
     /**
      * Called when all files have been uploaded
      */
-    onUploadDone?: (result: PickerFileMetadata) => void;
+    onUploadDone?: (result: PickerResponse) => void;
     /**
      * A function to be called when error occurs
      */

--- a/types/filestack-react/package.json
+++ b/types/filestack-react/package.json
@@ -8,7 +8,7 @@
     "dependencies": {
         "@types/node": "*",
         "@types/react": "*",
-        "filestack-js": "^3.20.0"
+        "filestack-js": "^3.35.4"
     },
     "devDependencies": {
         "@types/filestack-react": "workspace:."


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/filestack/filestack-js/blob/dbcc50e5fe368f6254945de74f1663d520964039/src/lib/picker.ts#L671
https://github.com/filestack/filestack-js/blob/dbcc50e5fe368f6254945de74f1663d520964039/src/lib/picker.ts#L200
https://github.com/filestack/filestack-react/blob/dcb81fbf07b406837cf9e78bbcac93f12d2f989f/src/picker/use-picker.jsx#L29
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.


