### PR TITLE
[react-virtualized] `registerChild` render prop is not optional

### DIFF
--- a/types/react-virtualized/dist/es/CellMeasurer.d.ts
+++ b/types/react-virtualized/dist/es/CellMeasurer.d.ts
@@ -48,7 +48,7 @@ export type MeasuredCellParent = {
 
 export type CellMeasurerChildProps = {
     measure: () => void;
-    registerChild?: (element?: Element) => void;
+    registerChild: (element?: Element | null) => void;
 };
 
 export type CellMeasurerProps = {

--- a/types/react-virtualized/package.json
+++ b/types/react-virtualized/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/react-virtualized",
-    "version": "9.21.9999",
+    "version": "9.22.9999",
     "projects": [
         "https://github.com/bvaughn/react-virtualized"
     ],

--- a/types/react-virtualized/react-virtualized-tests.tsx
+++ b/types/react-virtualized/react-virtualized-tests.tsx
@@ -347,7 +347,7 @@ export class DynamicHeightList extends PureComponent<any> {
         return (
             <CellMeasurer cache={this._cache} columnIndex={0} key={key} rowIndex={index} parent={parent}>
                 {({ measure, registerChild }) => (
-                    <div ref={registerChild as React.Ref<HTMLDivElement>} className={classNames} style={style}>
+                    <div ref={registerChild} className={classNames} style={style}>
                         <img
                             onLoad={measure}
                             src={source}


### PR DESCRIPTION
The `registerChild` render prop is not optional in the actual implementation but it is in the types (See [original PR](https://github.com/bvaughn/react-virtualized/pull/1477)). This PR fixes the types and updates the version to 9.22. It's unclear why that wasn't done in the past as that version has been [out for a while](https://github.com/bvaughn/react-virtualized/commit/743f10d799820dc85a6838e63ef3135344999cba).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bvaughn/react-virtualized/blob/2f6ff33dd9ce5b149a2767144a847f1705fb7bc0/source/CellMeasurer/CellMeasurer.js#L49
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
