### PR TITLE
fix: 类型“"play"”的参数不能赋给类型“DPlayerEvents”的参数。

### DIFF
--- a/types/dplayer/index.d.ts
+++ b/types/dplayer/index.d.ts
@@ -172,7 +172,7 @@ export default class DPlayer {
 
     toggle(): void;
 
-    on(event: DPlayerEvents, handler: () => void): void;
+    on(event: keyof typeof DPlayerEvents, handler: () => void): void;
 
     switchVideo(video: DPlayerVideo, danmaku: DPlayerDanmaku): void;
 


### PR DESCRIPTION
类型“"play"”的参数不能赋给类型“DPlayerEvents”的参数。
Uncaught TypeError: Cannot read properties of undefined (reading 'play')