### PR TITLE
Remove ambient module declaration of `@wordpress/blocks`

### DIFF
--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -15,10 +15,7 @@ export interface BlocksStoreDescriptor extends StoreDescriptor {
     name: "core/blocks";
 }
 
-// eslint-disable-next-line @definitelytyped/no-declare-current-package
-declare module "@wordpress/blocks" {
-    const store: BlocksStoreDescriptor;
-}
+export const store: BlocksStoreDescriptor;
 
 export type AxialDirection = "horizontal" | "vertical";
 


### PR DESCRIPTION
## Description

As suggested by the overridden lint rule, a module declaration for the current package is an antipattern that prevents consumers from declaring the module themselves to provide new types:

> [T]he declarations in an augmentation are merged as if they were declared in the same file as the original. [...] However ... you can’t declare new top-level declarations in the augmentation — just patches to existing declarations.
> 
> https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation

This ambient module declaration provides no value and the effect is the same when it is omitted and the types are directly exported. This also matches the approach taken in other `@wordpress` DefinitelyTyped packages.

## Checklist 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
