### PR TITLE
[node] Fix module.findSourceMap can return undefined

### DIFF
--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -48,7 +48,7 @@ declare module "module" {
          * @since v13.7.0, v12.17.0
          * @return Returns `module.SourceMap` if a source map is found, `undefined` otherwise.
          */
-        function findSourceMap(path: string, error?: Error): SourceMap;
+        function findSourceMap(path: string, error?: Error): SourceMap | undefined;
         interface SourceMapPayload {
             file: string;
             version: number;

--- a/types/node/test/module.ts
+++ b/types/node/test/module.ts
@@ -49,6 +49,9 @@ const smap = new Module.SourceMap({
 const pl: Module.SourceMapPayload = smap.payload;
 const entry: Module.SourceMapping = smap.findEntry(1, 1);
 
+Module.findSourceMap('/path/to/file.js'); // $ExpectType SourceMap | undefined
+Module.findSourceMap('/path/to/file.js', new Error()); // $ExpectType SourceMap | undefined
+
 // global
 {
     const importmeta: ImportMeta = {} as any; // Fake because we cannot really access the true `import.meta` with the current build target

--- a/types/node/test/module.ts
+++ b/types/node/test/module.ts
@@ -49,8 +49,8 @@ const smap = new Module.SourceMap({
 const pl: Module.SourceMapPayload = smap.payload;
 const entry: Module.SourceMapping = smap.findEntry(1, 1);
 
-Module.findSourceMap('/path/to/file.js'); // $ExpectType SourceMap | undefined
-Module.findSourceMap('/path/to/file.js', new Error()); // $ExpectType SourceMap | undefined
+Module.findSourceMap("/path/to/file.js"); // $ExpectType SourceMap | undefined
+Module.findSourceMap("/path/to/file.js", new Error()); // $ExpectType SourceMap | undefined
 
 // global
 {

--- a/types/node/v18/module.d.ts
+++ b/types/node/v18/module.d.ts
@@ -46,7 +46,7 @@ declare module "module" {
          * should be fetched.
          * @since v13.7.0, v12.17.0
          */
-        function findSourceMap(path: string, error?: Error): SourceMap;
+        function findSourceMap(path: string, error?: Error): SourceMap | undefined;
         interface SourceMapPayload {
             file: string;
             version: number;

--- a/types/node/v20/module.d.ts
+++ b/types/node/v20/module.d.ts
@@ -48,7 +48,7 @@ declare module "module" {
          * @since v13.7.0, v12.17.0
          * @return Returns `module.SourceMap` if a source map is found, `undefined` otherwise.
          */
-        function findSourceMap(path: string, error?: Error): SourceMap;
+        function findSourceMap(path: string, error?: Error): SourceMap | undefined;
         interface SourceMapPayload {
             file: string;
             version: number;


### PR DESCRIPTION
See:
- Comment: "@return Returns `module.SourceMap` if a source map is found, `undefined` otherwise."
- https://github.com/nodejs/node/pull/44397/files

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change - see https://github.com/nodejs/node/blob/5ba3b540d459a60c7edff5074073fb397be81e8a/test/parallel/test-source-map-api.js#L26
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
