### PR TITLE
fix viewDidMount defintion

### DIFF
--- a/types/event-calendar__core/index.d.ts
+++ b/types/event-calendar__core/index.d.ts
@@ -360,7 +360,7 @@ declare namespace Calendar {
         unselectAuto?: boolean;
         unselectCancel?: string;
         view?: string;
-        viewDidMount?: (info: { view: View }) => void;
+        viewDidMount?: (info: View ) => void;
         views?: Record<string, Options>;
     }
 }


### PR DESCRIPTION
viewDidMount was defined as having a view property pointing to an object, but there is no "view" property. All the properties are returned in the parent object (info).

[viewDidMount gets called](https://github.com/vkurko/calendar/blob/dd73f9ccbe0f4ba8173de7a7894768ba06901e7a/packages/core/src/storage/state.js#L123)

