### PR TITLE
Improve @phc/format::serialize input type

### DIFF
--- a/types/phc__format/index.d.ts
+++ b/types/phc__format/index.d.ts
@@ -1,29 +1,34 @@
 /// <reference types="node" />
 
-export interface PhcFormatObject {
+export interface PhcShared {
+    /** Symbolic name for the function. */
     id: string;
+    /** The version of the function. */
     version?: number;
-    params?: Record<string, string | number>;
+    /** The salt as a binary buffer. */
     salt?: Buffer;
+    /** The hash as a binary buffer. */
     hash?: Buffer;
+}
+
+export interface PhcInput extends PhcShared {
+    /** Parameters of the function. */
+    params?: Record<string, string | number | Buffer>;
+}
+
+export interface PhcOutput extends PhcShared {
+    /** Parameters of the function. */
+    params?: Record<string, string | number>;
 }
 
 /**
  * Generates a PHC string using the data provided.
- * @param  {PhcFormatObject} opts Object that holds the data needed to generate the PHC
- * string.
- * @param  {string} opts.id Symbolic name for the function.
- * @param  {Number} [opts.version] The version of the function.
- * @param  {Object} [opts.params] Parameters of the function.
- * @param  {Buffer} [opts.salt] The salt as a binary buffer.
- * @param  {Buffer} [opts.hash] The hash as a binary buffer.
- * @return {string} The hash string adhering to the PHC format.
+ * @return The hash string adhering to the PHC format.
  */
-export function serialize(opts: PhcFormatObject): string;
+export function serialize(opts: PhcInput): string;
 
 /**
  * Parses data from a PHC string.
- * @param  {string} phcstr A PHC string to parse.
- * @return {Object} The object containing the data parsed from the PHC string.
+ * @return The object containing the data parsed from the PHC string.
  */
-export function deserialize(phcstr: string): PhcFormatObject;
+export function deserialize(phcstr: string): PhcOutput;

--- a/types/phc__format/phc__format-tests.ts
+++ b/types/phc__format/phc__format-tests.ts
@@ -1,4 +1,4 @@
-import { deserialize, serialize } from "@phc/format";
+import { deserialize, PhcInput, PhcOutput, serialize } from "@phc/format";
 
 // same cases from https://github.com/simonepri/phc-format/blob/master/test/fixtures/serialize-deserialize.js
 function test_serialize() {
@@ -63,10 +63,7 @@ function test_serialize() {
     serialize({
         id: "argon2i",
         params: { m: 120, t: 5000, p: 2 },
-        salt: Buffer.from(
-            "BwUgJHHQaynE+a4nZrYRzOllGSjjxuxNXxyNRUtI6Dlw/zlbt6PzOL8Onfqs6TcG",
-            "base64",
-        ),
+        salt: Buffer.from("BwUgJHHQaynE+a4nZrYRzOllGSjjxuxNXxyNRUtI6Dlw/zlbt6PzOL8Onfqs6TcG", "base64"),
     });
 
     serialize({
@@ -186,9 +183,28 @@ function test_serialize() {
             "base64",
         ),
     });
+
+    // $ExpectType string
+    serialize({
+        id: "argon2i",
+        version: 19,
+        params: {
+            m: 120,
+            t: 5000,
+            p: 2,
+            keyid: "Hj5+dsK0",
+            data: Buffer.from("sRlHhRmKUGzdOmXn01XmXygd5Kc", "base64"),
+        },
+        salt: Buffer.from("iHSDPHzUhPzK7rCcJgOFfg", "base64"),
+        hash: Buffer.from(
+            "J4moa2MM0/6uf3HbY2Tf5Fux8JIBTwIhmhxGRbsY14qhTltQt+Vw3b7tcJNEbk8ium8AQfZeD4tabCnNqfkD1g",
+            "base64",
+        ),
+    });
 }
 
 // same cases from https://github.com/simonepri/phc-format/blob/master/test/fixtures/serialize-deserialize.js
 function test_deserialize() {
+    // $ExpectType PhcOutput
     deserialize("$argon2i$m=120,t=5000,p=2,keyid=Hj5+dsK0,data=sRlHhRmKUGzdOmXn01XmXygd5Kc");
 }


### PR DESCRIPTION
Update the type of @phc/format::serialize to indicate it accepts Buffer-valued params. This functionality has been in place since 2018.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.) 
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [source link](https://github.com/simonepri/phc-format/blob/6a60f3d679cef7a11bc085bb335126ee601cdea4/index.js#L95) [Here is the commit](https://github.com/simonepri/phc-format/commit/3d944a9646121ae493bcdb11228bfe64973e5e76) adding this functionality in 2018
- [N/A] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
