### PR TITLE
[@mapbox/vector-tile] Update import method for "pbf" to ensure correct library is loaded in projects with multiple versions of pbf installed.

### DIFF
--- a/types/mapbox__vector-tile/index.d.ts
+++ b/types/mapbox__vector-tile/index.d.ts
@@ -1,6 +1,6 @@
-import Pbf = require("pbf");
+import Pbf from "pbf";
 import { Feature } from "geojson";
-import Point = require("@mapbox/point-geometry");
+import Point from "@mapbox/point-geometry";
 
 export class VectorTile {
     constructor(pbf: Pbf);


### PR DESCRIPTION
This PR changes the import method to pull in the version of `pbf` relative to the requiring package, instead of picking the version of `pbf` at the root of the dependency tree. This fixes projects using `plotly.js` and `mapbox` that requires `pbf ^3.3.0`, and also have a direct dependency on `pbf>=4.0`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
