### PR TITLE
fix(node): v8 deserialize accepts Buffer, TypedArray and DataView as input

### DIFF
--- a/types/node/test/v8.ts
+++ b/types/node/test/v8.ts
@@ -90,5 +90,3 @@ v8.deserialize(new DataView(new ArrayBuffer(1)));
 v8.deserialize(new ArrayBuffer(1));
 // @ts-expect-error String is not a valid deserialize parameter
 v8.deserialize("Hello World!");
-// @ts-expect-error Number is not a valid deserialize parameter
-v8.deserialize(5);

--- a/types/node/test/v8.ts
+++ b/types/node/test/v8.ts
@@ -81,3 +81,14 @@ const a = new A();
 v8.queryObjects(A); // $ExpectType number | string[]
 v8.queryObjects(A, { format: "count" }); // $ExpectType number
 v8.queryObjects(A, { format: "summary" }); // $ExpectType string[]
+
+v8.deserialize(Buffer.from([0]));
+v8.deserialize(new Uint8Array());
+v8.deserialize(new DataView(new ArrayBuffer(1)));
+
+// @ts-expect-error ArrayBuffer is not a valid deserialize parameter
+v8.deserialize(new ArrayBuffer(1));
+// @ts-expect-error String is not a valid deserialize parameter
+v8.deserialize("Hello World!");
+// @ts-expect-error Number is not a valid deserialize parameter
+v8.deserialize(5);

--- a/types/node/v16/test/v8.ts
+++ b/types/node/v16/test/v8.ts
@@ -64,3 +64,12 @@ v8.startupSnapshot.setDeserializeMainFunction((shelf: BookShelf): void => {
     const name = `${book}.${lang}`;
     console.log(shelf.storage.get(name));
 }, shelf);
+
+v8.deserialize(Buffer.from([0]));
+v8.deserialize(new Uint8Array());
+v8.deserialize(new DataView(new ArrayBuffer(1)));
+
+// @ts-expect-error ArrayBuffer is not a valid deserialize parameter
+v8.deserialize(new ArrayBuffer(1));
+// @ts-expect-error String is not a valid deserialize parameter
+v8.deserialize("Hello World!");

--- a/types/node/v16/v8.d.ts
+++ b/types/node/v16/v8.d.ts
@@ -389,7 +389,7 @@ declare module "v8" {
      * @since v8.0.0
      * @param buffer A buffer returned by {@link serialize}.
      */
-    function deserialize(buffer: NodeJS.TypedArray): any;
+    function deserialize(buffer: NodeJS.ArrayBufferView): any;
     /**
      * The `v8.takeCoverage()` method allows the user to write the coverage started by `NODE_V8_COVERAGE` to disk on demand. This method can be invoked multiple
      * times during the lifetime of the process. Each time the execution counter will

--- a/types/node/v18/test/v8.ts
+++ b/types/node/v18/test/v8.ts
@@ -72,3 +72,12 @@ v8.startupSnapshot.setDeserializeMainFunction((shelf: BookShelf): void => {
     const name = `${book}.${lang}`;
     console.log(shelf.storage.get(name));
 }, shelf);
+
+v8.deserialize(Buffer.from([0]));
+v8.deserialize(new Uint8Array());
+v8.deserialize(new DataView(new ArrayBuffer(1)));
+
+// @ts-expect-error ArrayBuffer is not a valid deserialize parameter
+v8.deserialize(new ArrayBuffer(1));
+// @ts-expect-error String is not a valid deserialize parameter
+v8.deserialize("Hello World!");

--- a/types/node/v18/v8.d.ts
+++ b/types/node/v18/v8.d.ts
@@ -389,7 +389,7 @@ declare module "v8" {
      * @since v8.0.0
      * @param buffer A buffer returned by {@link serialize}.
      */
-    function deserialize(buffer: NodeJS.TypedArray): any;
+    function deserialize(buffer: NodeJS.ArrayBufferView): any;
     /**
      * The `v8.takeCoverage()` method allows the user to write the coverage started by `NODE_V8_COVERAGE` to disk on demand. This method can be invoked multiple
      * times during the lifetime of the process. Each time the execution counter will

--- a/types/node/v20/test/v8.ts
+++ b/types/node/v20/test/v8.ts
@@ -81,3 +81,12 @@ const a = new A();
 v8.queryObjects(A); // $ExpectType number | string[]
 v8.queryObjects(A, { format: "count" }); // $ExpectType number
 v8.queryObjects(A, { format: "summary" }); // $ExpectType string[]
+
+v8.deserialize(Buffer.from([0]));
+v8.deserialize(new Uint8Array());
+v8.deserialize(new DataView(new ArrayBuffer(1)));
+
+// @ts-expect-error ArrayBuffer is not a valid deserialize parameter
+v8.deserialize(new ArrayBuffer(1));
+// @ts-expect-error String is not a valid deserialize parameter
+v8.deserialize("Hello World!");

--- a/types/node/v20/v8.d.ts
+++ b/types/node/v20/v8.d.ts
@@ -445,7 +445,7 @@ declare module "v8" {
      * @since v8.0.0
      * @param buffer A buffer returned by {@link serialize}.
      */
-    function deserialize(buffer: NodeJS.TypedArray): any;
+    function deserialize(buffer: NodeJS.ArrayBufferView): any;
     /**
      * The `v8.takeCoverage()` method allows the user to write the coverage started by `NODE_V8_COVERAGE` to disk on demand. This method can be invoked multiple
      * times during the lifetime of the process. Each time the execution counter will

--- a/types/node/v8.d.ts
+++ b/types/node/v8.d.ts
@@ -445,7 +445,7 @@ declare module "v8" {
      * @since v8.0.0
      * @param buffer A buffer returned by {@link serialize}.
      */
-    function deserialize(buffer: NodeJS.TypedArray): any;
+    function deserialize(buffer: Buffer | NodeJS.TypedArray | DataView): any;
     /**
      * The `v8.takeCoverage()` method allows the user to write the coverage started by `NODE_V8_COVERAGE` to disk on demand. This method can be invoked multiple
      * times during the lifetime of the process. Each time the execution counter will

--- a/types/node/v8.d.ts
+++ b/types/node/v8.d.ts
@@ -445,7 +445,7 @@ declare module "v8" {
      * @since v8.0.0
      * @param buffer A buffer returned by {@link serialize}.
      */
-    function deserialize(buffer: Buffer | NodeJS.TypedArray | DataView): any;
+    function deserialize(buffer: NodeJS.ArrayBufferView): any;
     /**
      * The `v8.takeCoverage()` method allows the user to write the coverage started by `NODE_V8_COVERAGE` to disk on demand. This method can be invoked multiple
      * times during the lifetime of the process. Each time the execution counter will


### PR DESCRIPTION
fix(node): v8 deserialize accepts Buffer, TypedArray and DataView as input

see https://nodejs.org/api/v8.html#v8deserializebuffer

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/v8.html#v8deserializebuffer
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
