### PR TITLE
feat(chromecast-caf-receiver): add ErrorSeverity enum and severity property to ErrorEvent

### DIFF
--- a/types/chromecast-caf-receiver/cast.framework.events.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.events.d.ts
@@ -140,6 +140,15 @@ export enum DetailedErrorCode {
     GENERIC = 999,
 }
 
+/**
+ * The error severity. Follows the same naming scheme and numbering as Shaka Player.
+ * https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.events#.EventType
+ */
+export enum ErrorSeverity {
+    RECOVERABLE = 1,
+    CRITICAL = 2,
+}
+
 export type EndedReason = "END_OF_STREAM" | "ERROR" | "STOPPED" | "INTERRUPTED" | "SKIPPED" | "BREAK_SWITCH";
 
 /**
@@ -447,7 +456,7 @@ export class BitrateChangedEvent extends Event {
  * Event data for @see{@link EventType.ERROR} event.
  */
 export class ErrorEvent extends Event {
-    constructor(detailedErrorCode?: DetailedErrorCode, error?: any, reason?: ErrorReason);
+    constructor(detailedErrorCode?: DetailedErrorCode, error?: any, reason?: ErrorReason, severity?: ErrorSeverity);
 
     /**
      * An error code representing the cause of the error.
@@ -463,6 +472,11 @@ export class ErrorEvent extends Event {
      * Optional error reason.
      */
     reason?: ErrorReason | undefined;
+
+    /**
+     * Optional error severity.
+     */
+    severity?: ErrorSeverity | undefined;
 }
 
 /**

--- a/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
+++ b/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
@@ -265,6 +265,13 @@ playerManager.setMessageInterceptor(
     },
 );
 
+playerManager.addEventListener(cast.framework.events.EventType.ERROR, (event) => {
+    if (event.severity !== undefined) {
+        // $ExpectType ErrorSeverity
+        const severity = event.severity;
+    }
+});
+
 const queueItem = new cast.framework.messages.QueueItem();
 queueItem.activeTrackIds = [1, 2];
 queueItem.autoplay = false;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.events.ErrorEvent
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
