### PR TITLE
[cookie-parser] Move @types/express to peerDependencies

### DIFF
--- a/types/cookie-parser/package.json
+++ b/types/cookie-parser/package.json
@@ -5,7 +5,7 @@
     "projects": [
         "https://github.com/expressjs/cookie-parser"
     ],
-    "dependencies": {
+    "peerDependencies": {
         "@types/express": "*"
     },
     "devDependencies": {


### PR DESCRIPTION
Now that `@types/express@5` has [breaking changes](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71024), it causes issues to have both `@types/express@4` and `@types/express@5` installed at the same time. This PR attempts to prevent `@types/express@5` from being automatically installed by using peerDependencies instead of normal dependencies for the reasons described [here](https://github.com/DefinitelyTyped/DefinitelyTyped?tab=readme-ov-file#peer-dependencies).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
