### PR TITLE
Remove myself from cordova-plugin-qrscanner owners

### DIFF
--- a/types/cordova-plugin-qrscanner/package.json
+++ b/types/cordova-plugin-qrscanner/package.json
@@ -12,10 +12,6 @@
         {
             "name": "Jason Dreyzehner",
             "githubUsername": "bitjson"
-        },
-        {
-            "name": "Josh Bronson",
-            "githubUsername": "jab"
         }
     ]
 }


### PR DESCRIPTION
I haven't been involved in cordova-plugin-qrscanner development (nor been a member of any associated teams) in over 7 years, the only involvement I remember having was to submit a minor change, and don't remember ever agreeing to be an owner. (I checked the [commit history](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/master/types/cordova-plugin-qrscanner/package.json) but couldn't tell from that where my ownership claim came from.)

A bot recently [pinged me to take some action](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71015#issuecomment-2439491116) I think due to this inaccurate ownership claim, which I am not in a position to fulfill, so I am submitting this PR in an effort to correct the metadata here.