### PR TITLE
express-session: fix the `secret` option to allow buffers

### DIFF
--- a/types/express-session/express-session-tests.ts
+++ b/types/express-session/express-session-tests.ts
@@ -76,8 +76,8 @@ app.use(
 // Various `crypto.CipherKey` types
 app.use(session({ secret: Buffer.from("keyboard cat", "utf8") }));
 app.use(session({ secret: crypto.createSecretKey(Buffer.from("keyboard cat", "utf8")) }));
-app.use(session({ secret: new Uint8Array() }));
-app.use(session({ secret: new DataView(new ArrayBuffer()) }));
+app.use(session({ secret: new Uint8Array(32) }));
+app.use(session({ secret: new DataView(new ArrayBuffer(32)) }));
 
 // When constructed without arguments, `expires` and `originalMaxAge` are null.
 const emptyCookie: SessionData["cookie"] = { expires: null, originalMaxAge: null };

--- a/types/express-session/express-session-tests.ts
+++ b/types/express-session/express-session-tests.ts
@@ -1,5 +1,6 @@
 import express = require("express");
 import session = require("express-session");
+import crypto = require("crypto");
 import { MemoryStore, Session, SessionData, Store } from "express-session";
 
 const app = express();
@@ -71,6 +72,12 @@ app.use(
         unset: "keep",
     }),
 );
+
+// Various `crypto.CipherKey` types
+app.use(session({ secret: Buffer.from("keyboard cat", "utf8") }));
+app.use(session({ secret: crypto.createSecretKey(Buffer.from("keyboard cat", "utf8")) }));
+app.use(session({ secret: new Uint8Array() }));
+app.use(session({ secret: new DataView(new ArrayBuffer()) }));
 
 // When constructed without arguments, `expires` and `originalMaxAge` are null.
 const emptyCookie: SessionData["cookie"] = { expires: null, originalMaxAge: null };

--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -1,6 +1,6 @@
 import express = require("express");
-import { EventEmitter } from "events";
 import { CipherKey } from "crypto";
+import { EventEmitter } from "events";
 
 declare global {
     namespace Express {

--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -1,5 +1,6 @@
 import express = require("express");
 import { EventEmitter } from "events";
+import { CipherKey } from "crypto";
 
 declare global {
     namespace Express {
@@ -39,22 +40,24 @@ declare function session(options?: session.SessionOptions): express.RequestHandl
 declare namespace session {
     interface SessionOptions {
         /**
-         * This is the secret used to sign the session cookie. This can be either a string for a single secret, or an array of multiple secrets.
-         * If an array of secrets is provided, **only the first element will be used to sign** the session ID cookie,
-         *   while **all the elements will be considered when verifying the signature** in requests.
-         * The secret itself should be not easily parsed by a human and would best be a random set of characters
+         * This is the secret used to sign the session ID cookie.
+         * The secret can be any type of value that is supported by Node.js `crypto.createHmac` (like a string or a Buffer).
+         * This can be either a single secret, or an array of multiple secrets.
+         * If an array of secrets is provided, only the first element will be used to sign the session ID cookie, while all the elements will be considered when verifying the signature in requests.
+         * The secret itself should be not easily parsed by a human and would best be a random set of characters.
          *
-         * Best practices may include:
-         * - The use of environment variables to store the secret, ensuring the secret itself does not exist in your repository.
-         * - Periodic updates of the secret, while ensuring the previous secret is in the array.
+         * A best practice may include:
+         * * The use of environment variables to store the secret, ensuring the secret itself does not exist in your repository.
+         * * Periodic updates of the secret, while ensuring the previous secret is in the array.
          *
          * Using a secret that cannot be guessed will reduce the ability to hijack a session to only guessing the session ID (as determined by the `genid` option).
          *
          * Changing the secret value will invalidate all existing sessions.
-         * In order to rotate the secret without invalidating sessions, provide an array of secrets,
-         *   with the new secret as first element of the array, and including previous secrets as the later elements.
+         * In order to rotate the secret without invalidating sessions, provide an array of secrets, with the new secret as first element of the array, and including previous secrets as the later elements.
+         *
+         * Note HMAC-256 is used to sign the session ID. For this reason, the secret should contain at least 32 bytes of entropy.
          */
-        secret: string | string[];
+        secret: CipherKey | CipherKey[];
 
         /**
          * Function to call to generate a new session ID. Provide a function that returns a string that will be used as a session ID.


### PR DESCRIPTION
The `secret` option is passed to `cookie-signature`, which accepts any kind of cipher key supported by `node:crypto`:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/51f95cfc6bc9618f88812cdaee05501d158b5581/types/cookie-signature/index.d.ts#L3-L12

Also updates the comment with the latest docs from the express-session readme.

**General checklist**
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

**Edit checklist**
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/expressjs/session/tree/bbeca94e69b93d437c4ca300b111bd59169de925?tab=readme-ov-file#secret
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.