### PR TITLE
fix(phoenix-live-view): add metadata to SocketOptions

### DIFF
--- a/types/phoenix_live_view/index.d.ts
+++ b/types/phoenix_live_view/index.d.ts
@@ -5,7 +5,7 @@
 //                 François Roland <https://github.com/francois-codes>
 //
 // Changelog:
-// Version 0.21 added metadata property to SocketOptions
+// added metadata property to SocketOptions
 // See: https://hexdocs.pm/phoenix_live_view/bindings.html#click-events
 // Version 0.20 refactored ViewHook interface with generic type and
 // ViewHookInternal interface
@@ -43,6 +43,13 @@ export interface DomOptions {
 
 export type ViewLogger = (view: View, kind: string, msg: any, obj: any) => void;
 
+export type EventCallback =
+    ((e: KeyboardEvent, el: Element) => Record<string, unknown>) |
+    ((e: MouseEvent, el: Element) => Record<string, unknown>) |
+    ((e: FocusEvent, el: Element) => Record<string, unknown>)
+
+export type Metadata = Record<string, EventCallback>
+
 export interface SocketOptions {
     longPollFallbackMs?: number | undefined;
     bindingPrefix?: string | undefined;
@@ -53,7 +60,7 @@ export interface SocketOptions {
     params?: object | undefined;
     uploaders?: object | undefined;
     viewLogger?: ViewLogger | undefined;
-    metadata?: object | undefined;
+    metadata?: Metadata | undefined;
 }
 
 export type BindCallback = (

--- a/types/phoenix_live_view/index.d.ts
+++ b/types/phoenix_live_view/index.d.ts
@@ -5,6 +5,8 @@
 //                 François Roland <https://github.com/francois-codes>
 //
 // Changelog:
+// Version 0.21 added metadata property to SocketOptions
+// See: https://hexdocs.pm/phoenix_live_view/bindings.html#click-events
 // Version 0.20 refactored ViewHook interface with generic type and
 // ViewHookInternal interface
 //
@@ -51,6 +53,7 @@ export interface SocketOptions {
     params?: object | undefined;
     uploaders?: object | undefined;
     viewLogger?: ViewLogger | undefined;
+    metadata?: object | undefined;
 }
 
 export type BindCallback = (

--- a/types/phoenix_live_view/phoenix_live_view-tests.ts
+++ b/types/phoenix_live_view/phoenix_live_view-tests.ts
@@ -43,12 +43,15 @@ function test_socket() {
         test: testUploader,
     };
 
+    const MyMetadata = {};
+
     const opts: SocketOptions = {
         params: {
             _csrf_token: "1234",
         },
         hooks: MyHooks,
         uploaders: MyUploaders,
+        metadata: MyMetadata,
     };
 
     const liveSocket = new LiveSocket("/live", Socket, opts);

--- a/types/phoenix_live_view/phoenix_live_view-tests.ts
+++ b/types/phoenix_live_view/phoenix_live_view-tests.ts
@@ -43,7 +43,26 @@ function test_socket() {
         test: testUploader,
     };
 
-    const MyMetadata = {};
+    const MyMetadata = {
+        click: (e: MouseEvent, el: Element) => {
+            return {
+                el: el,
+                ctrlKey: e.ctrlKey,
+            };
+        },
+        keydown: (e: KeyboardEvent, _el: Element) => {
+            return {
+                ctrlKey: e.ctrlKey,
+                detail: e.detail || 1
+            }
+        },
+        focus: (e: FocusEvent, el: Element) => {
+            return {
+                el,
+                detail: e.detail
+            }
+        },
+    };
 
     const opts: SocketOptions = {
         params: {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

Adds the `metadata` property to `SocketOptions` which can be found here: https://github.com/phoenixframework/phoenix_live_view/blob/main/assets/js/phoenix_live_view/live_socket.js#L39 and here https://hexdocs.pm/phoenix_live_view/bindings.html#click-events

@francois-codes , @pzingg 