### PR TITLE
Update wordpress__edit-post

### DIFF
--- a/types/wordpress__edit-post/package.json
+++ b/types/wordpress__edit-post/package.json
@@ -8,9 +8,9 @@
     "minimumTypeScriptVersion": "5.0",
     "dependencies": {
         "@types/react": "*",
-        "@types/wordpress__editor": "*",
         "@wordpress/components": "^28.4.0",
         "@wordpress/data": "^10.4.0",
+        "@wordpress/editor": "^14.13.0",
         "@wordpress/element": "^6.4.0"
     },
     "devDependencies": {

--- a/types/wordpress__edit-post/wordpress__edit-post-tests.tsx
+++ b/types/wordpress__edit-post/wordpress__edit-post-tests.tsx
@@ -38,66 +38,6 @@ ep.reinitializeEditor("post", 123, document.createElement("div"), { codeEditingE
 <ep.PluginBlockSettingsMenuItem label="Menu item text" onClick={() => console.log("clicked")} />;
 
 //
-// PluginDocumentSettingPanel
-//
-<ep.PluginDocumentSettingPanel name="my-panel" className="my-document-setting-plugin" title="My Panel">
-    <p>My Document Setting Panel</p>
-</ep.PluginDocumentSettingPanel>;
-
-<ep.PluginDocumentSettingPanel name="my-panel">
-    <p>My Document Setting Panel</p>
-</ep.PluginDocumentSettingPanel>;
-
-//
-// PluginMoreMenuItem
-//
-<ep.PluginMoreMenuItem icon="smiley" onClick={() => console.log("clicked!")}>
-    My button title
-</ep.PluginMoreMenuItem>;
-
-<ep.PluginMoreMenuItem href="https://foo.bar">My anchor title</ep.PluginMoreMenuItem>;
-
-//
-// PluginPostPublishPanel
-//
-<ep.PluginPostPublishPanel className="my-plugin-post-publish-panel" title="My panel title" initialOpen={true}>
-    My panel content
-</ep.PluginPostPublishPanel>;
-<ep.PluginPostPublishPanel>My panel content</ep.PluginPostPublishPanel>;
-
-//
-// PluginPostStatusInfo
-//
-<ep.PluginPostStatusInfo className="my-plugin-post-status-info">My post status info</ep.PluginPostStatusInfo>;
-<ep.PluginPostStatusInfo>My post status info</ep.PluginPostStatusInfo>;
-
-//
-// PluginPrePublishPanel
-//
-<ep.PluginPrePublishPanel className="my-plugin-pre-publish-panel" title="My panel title" initialOpen={true}>
-    My panel content
-</ep.PluginPrePublishPanel>;
-<ep.PluginPrePublishPanel>My panel content</ep.PluginPrePublishPanel>;
-
-//
-// PluginSidebar
-//
-<ep.PluginSidebar name="my-sidebar" isPinnable={false} title="My sidebar title" icon={<i>foo</i>}>
-    My sidebar content
-</ep.PluginSidebar>;
-<ep.PluginSidebar name="my-sidebar" title="My sidebar title">
-    My sidebar content
-</ep.PluginSidebar>;
-
-//
-// PluginSidebarMoreMenuItem
-//
-<ep.PluginSidebarMoreMenuItem target="my-sidebar" icon="smiley">
-    My sidebar title
-</ep.PluginSidebarMoreMenuItem>;
-<ep.PluginSidebarMoreMenuItem target="my-sidebar">My sidebar title</ep.PluginSidebarMoreMenuItem>;
-
-//
 // store
 //
 


### PR DESCRIPTION
Following the deprecation of `@types/wordpress__editor` in #71214, `@types/wordpress__edit-post` needs to be updated because it depends upon that package.

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
