### PR TITLE
[ember__helper] set type=module

### DIFF
--- a/types/ember__helper/package.json
+++ b/types/ember__helper/package.json
@@ -2,6 +2,7 @@
     "private": true,
     "name": "@types/ember__helper",
     "version": "4.0.9999",
+    "type": "module",
     "nonNpm": true,
     "nonNpmDescription": "@ember/helper",
     "projects": [

--- a/types/ember__helper/tsconfig.json
+++ b/types/ember__helper/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "node16",
         "lib": [
             "es6"
         ],


### PR DESCRIPTION
Alternative to https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71275

https://github.com/emberjs/ember.js/blob/main/packages/%40ember/helper/package.json says this is a module, so it should be on DT.

But, I have absolutely no idea what version number this package should have. The other ember scoped packages appear to all be 4.0, so changing this to 5.0 seems off, but, surely their packages did not change from CJS to ESM in a minor release?