### PR TITLE
Update pnpm to v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "bugs": {
         "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/issues"
     },
-    "packageManager": "pnpm@8.15.1",
+    "packageManager": "pnpm@9.14.2",
     "engines": {
-        "pnpm": ">=8.9.2",
-        "node": ">=7.8.0"
+        "pnpm": ">=9.14.2",
+        "node": ">=18.12"
     },
     "scripts": {
         "preinstall": "npx only-allow pnpm",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "bugs": {
         "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/issues"
     },
-    "packageManager": "pnpm@9.14.2",
+    "packageManager": "pnpm@9.14.4",
     "engines": {
-        "pnpm": ">=9.14.2",
+        "pnpm": ">=9.14.4",
         "node": ">=18.12"
     },
     "scripts": {


### PR DESCRIPTION
This fixes some issues we've been seeing with peer dependencies.

This PR is obviously going to pass because it touches nothing, so I'll be running all of DT locally or something.