### PR TITLE
[node] `node:module` cleanup

### DIFF
--- a/types/esm/esm-tests.ts
+++ b/types/esm/esm-tests.ts
@@ -1,3 +1,3 @@
 import esm = require("esm");
 
-esm(exports); // $ExpectType NodeRequire
+esm(exports); // $ExpectType Require

--- a/types/httptoolkit__esm/httptoolkit__esm-tests.ts
+++ b/types/httptoolkit__esm/httptoolkit__esm-tests.ts
@@ -1,14 +1,14 @@
 import esm = require("@httptoolkit/esm");
 
-// $ExpectType NodeRequire
+// $ExpectType Require
 esm(exports);
 
-// $ExpectType NodeRequire
+// $ExpectType Require
 esm(module, { cjs: true });
 // @ts-expect-error
 esm(module, { cjs: "1234" });
 
-// $ExpectType NodeRequire
+// $ExpectType Require
 esm(module, { mode: "auto" });
 // @ts-expect-error
 esm(module, { mode: "unknown" });

--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -151,24 +151,10 @@ declare global {
     *                                               *
     ------------------------------------------------*/
 
-    // For backwards compability
-    interface NodeRequire extends NodeJS.Require {}
-    interface RequireResolve extends NodeJS.RequireResolve {}
-    interface NodeModule extends NodeJS.Module {}
-
     var global: typeof globalThis;
 
     var process: NodeJS.Process;
     var console: Console;
-
-    var __filename: string;
-    var __dirname: string;
-
-    var require: NodeRequire;
-    var module: NodeModule;
-
-    // Same as module.exports
-    var exports: any;
 
     interface GCFunction {
         (options: {
@@ -438,49 +424,6 @@ declare global {
         interface RefCounted {
             ref(): this;
             unref(): this;
-        }
-
-        interface Require {
-            (id: string): any;
-            resolve: RequireResolve;
-            cache: Dict<NodeModule>;
-            /**
-             * @deprecated
-             */
-            extensions: RequireExtensions;
-            main: Module | undefined;
-        }
-
-        interface RequireResolve {
-            (id: string, options?: { paths?: string[] | undefined }): string;
-            paths(request: string): string[] | null;
-        }
-
-        interface RequireExtensions extends Dict<(m: Module, filename: string) => any> {
-            ".js": (m: Module, filename: string) => any;
-            ".json": (m: Module, filename: string) => any;
-            ".node": (m: Module, filename: string) => any;
-        }
-        interface Module {
-            /**
-             * `true` if the module is running during the Node.js preload
-             */
-            isPreloading: boolean;
-            exports: any;
-            require: Require;
-            id: string;
-            filename: string;
-            loaded: boolean;
-            /** @deprecated since v14.6.0 Please use `require.main` and `module.children` instead. */
-            parent: Module | null | undefined;
-            children: Module[];
-            /**
-             * @since v11.14.0
-             *
-             * The directory name of the module. This is usually the same as the path.dirname() of the module.id.
-             */
-            path: string;
-            paths: string[];
         }
 
         interface Dict<T> {

--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -1,6 +1,5 @@
 /**
  * @since v0.3.7
- * @experimental
  */
 declare module "module" {
     import { URL } from "node:url";

--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -48,7 +48,13 @@ declare module "module" {
          * @since v13.7.0, v12.17.0
          * @return Returns `module.SourceMap` if a source map is found, `undefined` otherwise.
          */
-        function findSourceMap(path: string, error?: Error): SourceMap | undefined;
+        function findSourceMap(path: string): SourceMap | undefined;
+        interface SourceMapConstructorOptions {
+            /**
+             * @since v21.0.0, v20.5.0
+             */
+            lineLengths?: readonly number[] | undefined;
+        }
         interface SourceMapPayload {
             file: string;
             version: number;
@@ -69,7 +75,7 @@ declare module "module" {
             /**
              * The name of the range in the source map, if one was provided
              */
-            name?: string;
+            name: string | undefined;
             /**
              * The file name of the original source, as reported in the SourceMap
              */
@@ -87,11 +93,11 @@ declare module "module" {
          * @since v13.7.0, v12.17.0
          */
         class SourceMap {
+            constructor(payload: SourceMapPayload, options?: SourceMapConstructorOptions);
             /**
              * Getter for the payload used to construct the `SourceMap` instance.
              */
             readonly payload: SourceMapPayload;
-            constructor(payload: SourceMapPayload);
             /**
              * Given a line offset and column offset in the generated source
              * file, returns an object representing the SourceMap range in the
@@ -110,7 +116,7 @@ declare module "module" {
              * @param lineOffset The zero-indexed line number offset in the generated source
              * @param columnOffset The zero-indexed column number offset in the generated source
              */
-            findEntry(lineOffset: number, columnOffset: number): SourceMapping;
+            findEntry(lineOffset: number, columnOffset: number): SourceMapping | {};
             /**
              * Given a 1-indexed `lineNumber` and `columnNumber` from a call site in the generated source,
              * find the corresponding call site location in the original source.

--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -312,7 +312,10 @@ declare module "module" {
         type LoadHook = (
             url: string,
             context: LoadHookContext,
-            nextLoad: (url: string, context?: Partial<LoadHookContext>) => LoadFnOutput | Promise<LoadFnOutput>,
+            nextLoad: (
+                url: string,
+                context?: Partial<LoadHookContext>,
+            ) => LoadFnOutput | Promise<LoadFnOutput>,
         ) => LoadFnOutput | Promise<LoadFnOutput>;
         /**
          * `path` is the resolved path for the file for which a corresponding source map

--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -209,13 +209,13 @@ declare module "module" {
             type?: string | undefined;
         }
         type ModuleFormat =
-        | "builtin"
-        | "commonjs"
-        | "commonjs-typescript"
-        | "json"
-        | "module"
-        | "module-typescript"
-        | "wasm";
+            | "builtin"
+            | "commonjs"
+            | "commonjs-typescript"
+            | "json"
+            | "module"
+            | "module-typescript"
+            | "wasm";
         type ModuleSource = string | ArrayBuffer | NodeJS.TypedArray;
         /**
          * The `initialize` hook provides a way to define a custom function that runs in

--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -311,11 +311,11 @@ declare module "module" {
          */
         directory?: string;
     }
-    interface Module extends NodeModule {}
+    interface Module extends NodeJS.Module {}
     class Module {
         static runMain(): void;
         static wrap(code: string): string;
-        static createRequire(path: string | URL): NodeRequire;
+        static createRequire(path: string | URL): NodeJS.Require;
         static builtinModules: string[];
         static isBuiltin(moduleName: string): boolean;
         static Module: typeof Module;
@@ -406,6 +406,180 @@ declare module "module" {
              */
             resolve(specifier: string, parent?: string | URL | undefined): string;
         }
+        namespace NodeJS {
+            interface Module {
+                /**
+                 * The module objects required for the first time by this one.
+                 * @since v0.1.16
+                 */
+                children: Module[];
+                /**
+                 * The `module.exports` object is created by the `Module` system. Sometimes this is
+                 * not acceptable; many want their module to be an instance of some class. To do
+                 * this, assign the desired export object to `module.exports`.
+                 * @since v0.1.16
+                 */
+                exports: any;
+                /**
+                 * The fully resolved filename of the module.
+                 * @since v0.1.16
+                 */
+                filename: string;
+                /**
+                 * The identifier for the module. Typically this is the fully resolved
+                 * filename.
+                 * @since v0.1.16
+                 */
+                id: string;
+                /**
+                 * `true` if the module is running during the Node.js preload
+                 * phase.
+                 * @since v15.4.0, v14.17.0
+                 */
+                isPreloading: boolean;
+                /**
+                 * Whether or not the module is done loading, or is in the process of
+                 * loading.
+                 * @since v0.1.16
+                 */
+                loaded: boolean;
+                /**
+                 * The module that first required this one, or `null` if the current module is the
+                 * entry point of the current process, or `undefined` if the module was loaded by
+                 * something that is not a CommonJS module (e.g. REPL or `import`).
+                 * @since v0.1.16
+                 * @deprecated Please use `require.main` and `module.children` instead.
+                 */
+                parent: Module | null | undefined;
+                /**
+                 * The directory name of the module. This is usually the same as the
+                 * `path.dirname()` of the `module.id`.
+                 * @since v11.14.0
+                 */
+                path: string;
+                /**
+                 * The search paths for the module.
+                 * @since v0.4.0
+                 */
+                paths: string[];
+                /**
+                 * The `module.require()` method provides a way to load a module as if
+                 * `require()` was called from the original module.
+                 * @since v0.5.1
+                 */
+                require(id: string): any;
+            }
+            interface Require {
+                /**
+                 * Used to import modules, `JSON`, and local files.
+                 * @since v0.1.13
+                 */
+                (id: string): any;
+                /**
+                 * Modules are cached in this object when they are required. By deleting a key
+                 * value from this object, the next `require` will reload the module.
+                 * This does not apply to
+                 * [native addons](https://nodejs.org/docs/latest-v22.x/api/addons.html),
+                 * for which reloading will result in an error.
+                 * @since v0.3.0
+                 */
+                cache: Dict<Module>;
+                /**
+                 * Instruct `require` on how to handle certain file extensions.
+                 * @since v0.3.0
+                 * @deprecated
+                 */
+                extensions: RequireExtensions;
+                /**
+                 * The `Module` object representing the entry script loaded when the Node.js
+                 * process launched, or `undefined` if the entry point of the program is not a
+                 * CommonJS module.
+                 * @since v0.1.17
+                 */
+                main: Module | undefined;
+                /**
+                 * @since v0.3.0
+                 */
+                resolve: RequireResolve;
+            }
+            /** @deprecated */
+            interface RequireExtensions extends Dict<(module: Module, filename: string) => any> {
+                ".js": (module: Module, filename: string) => any;
+                ".json": (module: Module, filename: string) => any;
+                ".node": (module: Module, filename: string) => any;
+            }
+            interface RequireResolveOptions {
+                /**
+                 * Paths to resolve module location from. If present, these
+                 * paths are used instead of the default resolution paths, with the exception
+                 * of
+                 * [GLOBAL\_FOLDERS](https://nodejs.org/docs/latest-v22.x/api/modules.html#loading-from-the-global-folders)
+                 * like `$HOME/.node_modules`, which are
+                 * always included. Each of these paths is used as a starting point for
+                 * the module resolution algorithm, meaning that the `node_modules` hierarchy
+                 * is checked from this location.
+                 * @since v8.9.0
+                 */
+                paths?: string[] | undefined;
+            }
+            interface RequireResolve {
+                /**
+                 * Use the internal `require()` machinery to look up the location of a module,
+                 * but rather than loading the module, just return the resolved filename.
+                 *
+                 * If the module can not be found, a `MODULE_NOT_FOUND` error is thrown.
+                 * @since v0.3.0
+                 * @param request The module path to resolve.
+                 */
+                (request: string, options?: RequireResolveOptions): string;
+                /**
+                 * Returns an array containing the paths searched during resolution of `request` or
+                 * `null` if the `request` string references a core module, for example `http` or
+                 * `fs`.
+                 * @since v8.9.0
+                 * @param request The module path whose lookup paths are being retrieved.
+                 */
+                paths(request: string): string[] | null;
+            }
+        }
+        /**
+         * The directory name of the current module. This is the same as the
+         * `path.dirname()` of the `__filename`.
+         * @since v0.1.27
+         */
+        var __dirname: string;
+        /**
+         * The file name of the current module. This is the current module file's absolute
+         * path with symlinks resolved.
+         *
+         * For a main program this is not necessarily the same as the file name used in the
+         * command line.
+         * @since v0.0.1
+         */
+        var __filename: string;
+        /**
+         * The `exports` variable is available within a module's file-level scope, and is
+         * assigned the value of `module.exports` before the module is evaluated.
+         * @since v0.1.16
+         */
+        var exports: NodeJS.Module["exports"];
+        /**
+         * A reference to the current module.
+         * @since v0.1.16
+         */
+        var module: NodeJS.Module;
+        /**
+         * @since v0.1.13
+         */
+        var require: NodeJS.Require;
+        // Global-scope aliases for backwards compatibility with @types/node <13.0.x
+        // TODO: consider removing in a future major version update
+        /** @deprecated Use `NodeJS.Module` instead. */
+        interface NodeModule extends NodeJS.Module {}
+        /** @deprecated Use `NodeJS.Require` instead. */
+        interface NodeRequire extends NodeJS.Require {}
+        /** @deprecated Use `NodeJS.RequireResolve` instead. */
+        interface RequireResolve extends NodeJS.RequireResolve {}
     }
     export = Module;
 }

--- a/types/node/test/globals.ts
+++ b/types/node/test/globals.ts
@@ -10,16 +10,6 @@
 
 declare var RANDOM_GLOBAL_VARIABLE: true;
 
-// global aliases for compatibility
-{
-    const x: NodeModule = {} as any;
-    const y: NodeModule = {} as any;
-    x.children.push(y);
-    x.parent = require.main!;
-    require.main = y;
-    x.path; // $ExpectType string
-}
-
 // exposed gc
 {
     if (gc) {

--- a/types/node/test/module.ts
+++ b/types/node/test/module.ts
@@ -1,6 +1,8 @@
 import Module = require("node:module");
 import { URL } from "node:url";
 
+Module.Module === Module;
+
 // Module class and NodeJS.Module
 {
     const module: NodeJS.Module = new Module("moduleId");

--- a/types/node/test/module.ts
+++ b/types/node/test/module.ts
@@ -31,6 +31,12 @@ Module.Module === Module;
     const require: NodeJS.Require = module.require;
 }
 
+// Deprecated global aliases
+{
+    ({} as NodeModule) satisfies NodeJS.Module;
+    ({} as NodeRequire) satisfies NodeJS.Require;
+}
+
 // Top-level properties/functions
 {
     // $ExpectType readonly string[]

--- a/types/node/test/module.ts
+++ b/types/node/test/module.ts
@@ -17,8 +17,8 @@ let rf: (m: string) => any;
 rf = Module.createRequire("mod");
 rf = Module.createRequire(new URL("file:///C:/path/"));
 
-const aModule: NodeModule = new Module("s");
-const bModule: NodeModule = new Module("b", aModule);
+const aModule: NodeJS.Module = new Module("s");
+const bModule: NodeJS.Module = new Module("b", aModule);
 
 const builtIn: string[] = Module.builtinModules;
 const builtinResult: boolean = Module.isBuiltin("node:fs");

--- a/types/node/test/module.ts
+++ b/types/node/test/module.ts
@@ -92,7 +92,7 @@ Module.findSourceMap("/path/to/file.js"); // $ExpectType SourceMap | undefined
     const load: Module.LoadHook = async (url, context, nextLoad) => {
         const { format } = context;
 
-        if (Math.random() > 0.5) {
+        if (format) {
             return {
                 format,
                 shortCircuit: true,
@@ -101,19 +101,6 @@ Module.findSourceMap("/path/to/file.js"); // $ExpectType SourceMap | undefined
         }
 
         return nextLoad(url);
-    };
-
-    const globalPreload: Module.GlobalPreloadHook = (context) => {
-        return `\
-            globalThis.someInjectedProperty = 42;
-            console.log('I just set some globals!');
-
-            const { createRequire } = getBuiltin('module');
-            const { cwd } = getBuiltin('process');
-
-            const require = createRequire(cwd() + '/<preload>');
-            // [...]
-        `;
     };
 }
 

--- a/types/node/test/module.ts
+++ b/types/node/test/module.ts
@@ -1,60 +1,91 @@
 import Module = require("node:module");
 import { URL } from "node:url";
-require.extensions[".ts"] = () => "";
 
-Module.runMain();
-const s: string = Module.wrap("some code");
-
-const m1: Module = new Module("moduleId");
-const m2: Module = new Module("moduleId");
-const b: string[] = Module.builtinModules;
-let paths: string[] = [];
-paths = m1.paths;
-m1 instanceof Module;
-
-let rf: (m: string) => any;
-
-rf = Module.createRequire("mod");
-rf = Module.createRequire(new URL("file:///C:/path/"));
-
-const aModule: NodeJS.Module = new Module("s");
-const bModule: NodeJS.Module = new Module("b", aModule);
-
-const builtIn: string[] = Module.builtinModules;
-const builtinResult: boolean = Module.isBuiltin("node:fs");
-
-const customRequire2 = Module.createRequire("node:./test");
-
-customRequire2("test");
-
-const resolved2: string = customRequire2.resolve("test");
-
-const paths2: string[] | null = customRequire2.resolve.paths("test");
-
-const cachedModule2: Module | undefined = customRequire2.cache["/path/to/module.js"];
-
-const main2: Module | undefined = customRequire2.main;
-
-Module.syncBuiltinESMExports();
-
-const smap = new Module.SourceMap({
-    file: "test.js",
-    mappings: "ASDASd",
-    names: [],
-    sourceRoot: "/",
-    sources: [],
-    version: 3,
-    sourcesContent: [],
-});
-const pl: Module.SourceMapPayload = smap.payload;
-const entry: Module.SourceMapping | {} = smap.findEntry(1, 1);
-const origin: Module.SourceOrigin | {} = smap.findOrigin(1, 1);
-
-Module.findSourceMap("/path/to/file.js"); // $ExpectType SourceMap | undefined
-
-// global
+// Module class and NodeJS.Module
 {
-    const importmeta: ImportMeta = {} as any; // Fake because we cannot really access the true `import.meta` with the current build target
+    const module: NodeJS.Module = new Module("moduleId");
+    new Module("childModuleId", module);
+
+    // $ExpectType Module[]
+    module.children;
+    // $ExpectType any
+    module.exports;
+    // $ExpectType string
+    module.filename;
+    // $ExpectType string
+    module.id;
+    // $ExpectType boolean
+    module.isPreloading;
+    // $ExpectType boolean
+    module.loaded;
+    // $ExpectType string
+    module.path;
+    // $ExpectType string[]
+    module.paths;
+
+    // $ExpectType any
+    module.require("moduleId");
+    // @ts-expect-error module.require() does not have the additional static properties of global require()
+    const require: NodeJS.Require = module.require;
+}
+
+// Top-level properties/functions
+{
+    // $ExpectType readonly string[]
+    Module.builtinModules;
+
+    // $ExpectType Require
+    Module.createRequire("/usr/lib/node");
+    // $ExpectType Require
+    Module.createRequire(new URL("file:///usr/lib/node"));
+
+    // $ExpectType boolean
+    Module.isBuiltin("process");
+
+    // $ExpectType void
+    Module.syncBuiltinESMExports();
+}
+
+// Undocumented monkeypatching definitions
+{
+    // $ExpectType void
+    Module.runMain(process.argv[1]);
+
+    // $ExpectType string
+    Module.wrap("assert(module.exports === exports)");
+}
+
+// Source maps
+{
+    const sourceMap = new Module.SourceMap(
+        {
+            file: "test.js",
+            mappings: "ASDF;GHJK",
+            names: [],
+            sourceRoot: "/",
+            sources: [],
+            version: 3,
+            sourcesContent: [],
+        },
+        {
+            lineLengths: [1, 2, 3],
+        },
+    );
+
+    // $ExpectType SourceMapPayload
+    sourceMap.payload;
+    // $ExpectType SourceMapping | {}
+    sourceMap.findEntry(1, 1);
+    // $ExpectType SourceOrigin | {}
+    sourceMap.findOrigin(1, 1);
+
+    // $ExpectType SourceMap | undefined
+    Module.findSourceMap("/path/to/file.js");
+}
+
+// import.meta
+{
+    let importmeta!: ImportMeta; // because we cannot access the true `import.meta` with module:commonjs
     importmeta.dirname; // $ExpectType string
     importmeta.filename; // $ExpectType string
     importmeta.url; // $ExpectType string
@@ -64,8 +95,68 @@ Module.findSourceMap("/path/to/file.js"); // $ExpectType SourceMap | undefined
     importmeta.resolve("local", new URL("https://parent.module")); // $ExpectType string
 }
 
+// Globals
+{
+    // $ExpectType string
+    __dirname;
+    // $ExpectType string
+    __filename;
+
+    // $ExpectType any
+    exports;
+
+    // $ExpectType Module
+    module;
+
+    // $ExpectType Require
+    require;
+
+    // $ExpectType any
+    require("moduleId");
+
+    // $ExpectType Dict<Module>
+    require.cache;
+    // $ExpectType Module | undefined
+    require.main;
+
+    // $ExpectType RequireResolve
+    require.resolve;
+
+    // $ExpectType string
+    require.resolve("moduleId");
+    // $ExpectType string
+    require.resolve("moduleId", { paths: ["/usr/lib/node"] });
+
+    // $ExpectType string[] | null
+    require.resolve.paths("process");
+}
+
 // Hooks
 {
+    const specifier = "./myLoader.js";
+    const parentURL = "some-url"; // import.meta.url
+    Module.register(specifier);
+    Module.register(specifier, { parentURL });
+    Module.register(specifier, { parentURL: new URL("data:") });
+    Module.register(specifier, parentURL);
+    Module.register(specifier, new URL("data:"));
+
+    const someArrayBuffer = new ArrayBuffer(100);
+    Module.register(specifier, {
+        parentURL,
+        data: someArrayBuffer,
+        transferList: [someArrayBuffer],
+    });
+
+    Module.register<{ number: number }>(specifier, {
+        parentURL,
+        data: { number: 1 },
+    });
+
+    const initialize: Module.InitializeHook<{ number: number }> = async ({ number }) => {
+        number; // $ExpectType number
+    };
+
     const resolve: Module.ResolveHook = async (specifier, context, nextResolve) => {
         const { parentURL = null } = context;
         console.log(context.importAttributes.type);
@@ -104,37 +195,7 @@ Module.findSourceMap("/path/to/file.js"); // $ExpectType SourceMap | undefined
     };
 }
 
-// Initialize hook
-{
-    const specifier = "./myLoader.js";
-    const parentURL = "some-url"; // import.meta.url
-    Module.register(specifier);
-    Module.register(specifier, { parentURL });
-    Module.register(specifier, { parentURL: new URL("data:") });
-    Module.register(specifier, parentURL);
-    Module.register(specifier, new URL("data:"));
-
-    const someArrayBuffer = new ArrayBuffer(100);
-    Module.register(specifier, {
-        parentURL,
-        data: someArrayBuffer,
-        transferList: [someArrayBuffer],
-    });
-
-    interface TransferableData {
-        number: number;
-    }
-    Module.register<TransferableData>(specifier, {
-        parentURL,
-        data: { number: 1 },
-    });
-
-    type MyInitializeHook = Module.InitializeHook<TransferableData>;
-    const initializeHook: MyInitializeHook = async ({ number }) => {
-        number; // $ExpectType number
-    };
-}
-
+// Compile cache
 {
     // $ExpectType EnableCompileCacheResult
     Module.enableCompileCache();

--- a/types/node/test/module.ts
+++ b/types/node/test/module.ts
@@ -47,10 +47,10 @@ const smap = new Module.SourceMap({
     sourcesContent: [],
 });
 const pl: Module.SourceMapPayload = smap.payload;
-const entry: Module.SourceMapping = smap.findEntry(1, 1);
+const entry: Module.SourceMapping | {} = smap.findEntry(1, 1);
+const origin: Module.SourceOrigin | {} = smap.findOrigin(1, 1);
 
 Module.findSourceMap("/path/to/file.js"); // $ExpectType SourceMap | undefined
-Module.findSourceMap("/path/to/file.js", new Error()); // $ExpectType SourceMap | undefined
 
 // global
 {

--- a/types/node/v18/globals.d.ts
+++ b/types/node/v18/globals.d.ts
@@ -106,24 +106,10 @@ declare global {
     *                                               *
     ------------------------------------------------*/
 
-    // For backwards compability
-    interface NodeRequire extends NodeJS.Require {}
-    interface RequireResolve extends NodeJS.RequireResolve {}
-    interface NodeModule extends NodeJS.Module {}
-
     var global: typeof globalThis;
 
     var process: NodeJS.Process;
     var console: Console;
-
-    var __filename: string;
-    var __dirname: string;
-
-    var require: NodeRequire;
-    var module: NodeModule;
-
-    // Same as module.exports
-    var exports: any;
 
     interface GCFunction {
         (options: {
@@ -327,49 +313,6 @@ declare global {
         interface RefCounted {
             ref(): this;
             unref(): this;
-        }
-
-        interface Require {
-            (id: string): any;
-            resolve: RequireResolve;
-            cache: Dict<NodeModule>;
-            /**
-             * @deprecated
-             */
-            extensions: RequireExtensions;
-            main: Module | undefined;
-        }
-
-        interface RequireResolve {
-            (id: string, options?: { paths?: string[] | undefined }): string;
-            paths(request: string): string[] | null;
-        }
-
-        interface RequireExtensions extends Dict<(m: Module, filename: string) => any> {
-            ".js": (m: Module, filename: string) => any;
-            ".json": (m: Module, filename: string) => any;
-            ".node": (m: Module, filename: string) => any;
-        }
-        interface Module {
-            /**
-             * `true` if the module is running during the Node.js preload
-             */
-            isPreloading: boolean;
-            exports: any;
-            require: Require;
-            id: string;
-            filename: string;
-            loaded: boolean;
-            /** @deprecated since v14.6.0 Please use `require.main` and `module.children` instead. */
-            parent: Module | null | undefined;
-            children: Module[];
-            /**
-             * @since v11.14.0
-             *
-             * The directory name of the module. This is usually the same as the path.dirname() of the module.id.
-             */
-            path: string;
-            paths: string[];
         }
 
         interface Dict<T> {

--- a/types/node/v18/module.d.ts
+++ b/types/node/v18/module.d.ts
@@ -5,6 +5,64 @@ declare module "module" {
     import { URL } from "node:url";
     import { MessagePort } from "node:worker_threads";
     namespace Module {
+        export { Module };
+    }
+    namespace Module {
+        /**
+         * A list of the names of all modules provided by Node.js. Can be used to verify
+         * if a module is maintained by a third party or not.
+         * @since v9.3.0, v8.10.0, v6.13.0
+         */
+        const builtinModules: readonly string[];
+        /**
+         * @since v12.2.0
+         * @param path Filename to be used to construct the require
+         * function. Must be a file URL object, file URL string, or absolute path
+         * string.
+         */
+        function createRequire(path: string | URL): NodeJS.Require;
+        /**
+         * @since v18.6.0, v16.17.0
+         */
+        function isBuiltin(moduleName: string): boolean;
+        interface RegisterOptions<Data> {
+            /**
+             * If you want to resolve `specifier` relative to a
+             * base URL, such as `import.meta.url`, you can pass that URL here. This
+             * property is ignored if the `parentURL` is supplied as the second argument.
+             * @default 'data:'
+             */
+            parentURL?: string | URL | undefined;
+            /**
+             * Any arbitrary, cloneable JavaScript value to pass into the
+             * `initialize` hook.
+             */
+            data?: Data | undefined;
+            /**
+             * [Transferable objects](https://nodejs.org/docs/latest-v18.x/api/worker_threads.html#portpostmessagevalue-transferlist)
+             * to be passed into the `initialize` hook.
+             */
+            transferList?: any[] | undefined;
+        }
+        /* eslint-disable @definitelytyped/no-unnecessary-generics */
+        /**
+         * Register a module that exports hooks that customize Node.js module
+         * resolution and loading behavior. See
+         * [Customization hooks](https://nodejs.org/docs/latest-v18.x/api/module.html#customization-hooks).
+         * @since v20.6.0, v18.19.0
+         * @param specifier Customization hooks to be registered; this should be
+         * the same string that would be passed to `import()`, except that if it is
+         * relative, it is resolved relative to `parentURL`.
+         * @param parentURL f you want to resolve `specifier` relative to a base
+         * URL, such as `import.meta.url`, you can pass that URL here.
+         */
+        function register<Data = any>(
+            specifier: string | URL,
+            parentURL?: string | URL,
+            options?: RegisterOptions<Data>,
+        ): void;
+        function register<Data = any>(specifier: string | URL, options?: RegisterOptions<Data>): void;
+        /* eslint-enable @definitelytyped/no-unnecessary-generics */
         /**
          * The `module.syncBuiltinESMExports()` method updates all the live bindings for
          * builtin `ES Modules` to match the properties of the `CommonJS` exports. It
@@ -250,26 +308,11 @@ declare module "module" {
             context: LoadHookContext,
             nextLoad: (url: string, context?: LoadHookContext) => LoadFnOutput | Promise<LoadFnOutput>,
         ) => LoadFnOutput | Promise<LoadFnOutput>;
-    }
-    interface RegisterOptions<Data> {
-        parentURL: string | URL;
-        data?: Data | undefined;
-        transferList?: any[] | undefined;
+        function runMain(main?: string): void;
+        function wrap(code: string): string;
     }
     interface Module extends NodeJS.Module {}
     class Module {
-        static runMain(): void;
-        static wrap(code: string): string;
-        static createRequire(path: string | URL): NodeJS.Require;
-        static builtinModules: string[];
-        static isBuiltin(moduleName: string): boolean;
-        static Module: typeof Module;
-        static register<Data = any>(
-            specifier: string | URL,
-            parentURL?: string | URL,
-            options?: RegisterOptions<Data>,
-        ): void;
-        static register<Data = any>(specifier: string | URL, options?: RegisterOptions<Data>): void;
         constructor(id: string, parent?: Module);
     }
     type ImportMetaDOMCompat = typeof globalThis extends { onmessage: any } ? {

--- a/types/node/v18/module.d.ts
+++ b/types/node/v18/module.d.ts
@@ -46,7 +46,7 @@ declare module "module" {
          * should be fetched.
          * @since v13.7.0, v12.17.0
          */
-        function findSourceMap(path: string, error?: Error): SourceMap | undefined;
+        function findSourceMap(path: string): SourceMap | undefined;
         interface SourceMapPayload {
             file: string;
             version: number;
@@ -67,7 +67,7 @@ declare module "module" {
             /**
              * The name of the range in the source map, if one was provided
              */
-            name?: string;
+            name: string | undefined;
             /**
              * The file name of the original source, as reported in the SourceMap
              */
@@ -85,11 +85,11 @@ declare module "module" {
          * @since v13.7.0, v12.17.0
          */
         class SourceMap {
+            constructor(payload: SourceMapPayload);
             /**
              * Getter for the payload used to construct the `SourceMap` instance.
              */
             readonly payload: SourceMapPayload;
-            constructor(payload: SourceMapPayload);
             /**
              * Given a line offset and column offset in the generated source
              * file, returns an object representing the SourceMap range in the
@@ -108,7 +108,7 @@ declare module "module" {
              * @param lineOffset The zero-indexed line number offset in the generated source
              * @param columnOffset The zero-indexed column number offset in the generated source
              */
-            findEntry(lineOffset: number, columnOffset: number): SourceMapping;
+            findEntry(lineOffset: number, columnOffset: number): SourceMapping | {};
             /**
              * Given a 1-indexed `lineNumber` and `columnNumber` from a call site in the generated source,
              * find the corresponding call site location in the original source.

--- a/types/node/v18/module.d.ts
+++ b/types/node/v18/module.d.ts
@@ -176,7 +176,7 @@ declare module "module" {
             context: ResolveHookContext,
             nextResolve: (
                 specifier: string,
-                context?: ResolveHookContext,
+                context?: Partial<ResolveHookContext>,
             ) => ResolveFnOutput | Promise<ResolveFnOutput>,
         ) => ResolveFnOutput | Promise<ResolveFnOutput>;
         interface LoadHookContext {
@@ -217,7 +217,10 @@ declare module "module" {
         type LoadHook = (
             url: string,
             context: LoadHookContext,
-            nextLoad: (url: string, context?: LoadHookContext) => LoadFnOutput | Promise<LoadFnOutput>,
+            nextLoad: (
+                url: string,
+                context?: Partial<LoadHookContext>,
+            ) => LoadFnOutput | Promise<LoadFnOutput>,
         ) => LoadFnOutput | Promise<LoadFnOutput>;
         interface GlobalPreloadContext {
             port: MessagePort;

--- a/types/node/v18/module.d.ts
+++ b/types/node/v18/module.d.ts
@@ -189,22 +189,23 @@ declare module "module" {
             port: MessagePort;
         }
         /**
-         * @deprecated This hook will be removed in a future version.
-         * Use `initialize` instead. When a loader has an `initialize` export, `globalPreload` will be ignored.
-         *
-         * Sometimes it might be necessary to run some code inside of the same global scope that the application runs in.
-         * This hook allows the return of a string that is run as a sloppy-mode script on startup.
-         *
-         * @param context Information to assist the preload code
-         * @return Code to run before application startup
+         * Sometimes it might be necessary to run some code inside of the same global
+         * scope that the application runs in. This hook allows the return of a string
+         * that is run as a sloppy-mode script on startup.
+         * @deprecated This hook will be removed in a future version. Use
+         * `initialize` instead. When a hooks module has an `initialize` export,
+         * `globalPreload` will be ignored.
          */
         type GlobalPreloadHook = (context: GlobalPreloadContext) => string;
         /**
-         * The `initialize` hook provides a way to define a custom function that runs in the hooks thread
-         * when the hooks module is initialized. Initialization happens when the hooks module is registered via `register`.
+         * The `initialize` hook provides a way to define a custom function that runs in
+         * the hooks thread when the hooks module is initialized. Initialization happens
+         * when the hooks module is registered via {@link register}.
          *
-         * This hook can receive data from a `register` invocation, including ports and other transferrable objects.
-         * The return value of `initialize` can be a `Promise`, in which case it will be awaited before the main application thread execution resumes.
+         * This hook can receive data from a {@link register} invocation, including
+         * ports and other transferable objects. The return value of `initialize` can be a
+         * `Promise`, in which case it will be awaited before the main application thread
+         * execution resumes.
          */
         type InitializeHook<Data = any> = (data: Data) => void | Promise<void>;
         interface ResolveHookContext {
@@ -249,13 +250,13 @@ declare module "module" {
             url: string;
         }
         /**
-         * The `resolve` hook chain is responsible for resolving file URL for a given module specifier and parent URL, and optionally its format (such as `'module'`) as a hint to the `load` hook.
-         * If a format is specified, the load hook is ultimately responsible for providing the final `format` value (and it is free to ignore the hint provided by `resolve`);
-         * if `resolve` provides a format, a custom `load` hook is required even if only to pass the value to the Node.js default `load` hook.
-         *
-         * @param specifier The specified URL path of the module to be resolved
-         * @param context
-         * @param nextResolve The subsequent `resolve` hook in the chain, or the Node.js default `resolve` hook after the last user-supplied resolve hook
+         * The `resolve` hook chain is responsible for telling Node.js where to find and
+         * how to cache a given `import` statement or expression, or `require` call. It can
+         * optionally return a format (such as `'module'`) as a hint to the `load` hook. If
+         * a format is specified, the `load` hook is ultimately responsible for providing
+         * the final `format` value (and it is free to ignore the hint provided by
+         * `resolve`); if `resolve` provides a `format`, a custom `load` hook is required
+         * even if only to pass the value to the Node.js default `load` hook.
          */
         type ResolveHook = (
             specifier: string,
@@ -273,7 +274,7 @@ declare module "module" {
             /**
              * The format optionally supplied by the `resolve` hook chain
              */
-            format: ModuleFormat;
+            format: ModuleFormat | null | undefined;
             /**
              * @deprecated Use `importAttributes` instead
              */
@@ -293,15 +294,12 @@ declare module "module" {
             /**
              * The source for Node.js to evaluate
              */
-            source?: ModuleSource;
+            source?: ModuleSource | undefined;
         }
         /**
-         * The `load` hook provides a way to define a custom method of determining how a URL should be interpreted, retrieved, and parsed.
-         * It is also in charge of validating the import assertion.
-         *
-         * @param url The URL/path of the module to be loaded
-         * @param context Metadata about the module
-         * @param nextLoad The subsequent `load` hook in the chain, or the Node.js default `load` hook after the last user-supplied `load` hook
+         * The `load` hook provides a way to define a custom method of determining how a
+         * URL should be interpreted, retrieved, and parsed. It is also in charge of
+         * validating the import attributes.
          */
         type LoadHook = (
             url: string,

--- a/types/node/v18/module.d.ts
+++ b/types/node/v18/module.d.ts
@@ -4,6 +4,10 @@
 declare module "module" {
     import { URL } from "node:url";
     import { MessagePort } from "node:worker_threads";
+    class Module {
+        constructor(id: string, parent?: Module);
+    }
+    interface Module extends NodeJS.Module {}
     namespace Module {
         export { Module };
     }
@@ -99,85 +103,6 @@ declare module "module" {
          * @since v12.12.0
          */
         function syncBuiltinESMExports(): void;
-        /**
-         * `path` is the resolved path for the file for which a corresponding source map
-         * should be fetched.
-         * @since v13.7.0, v12.17.0
-         */
-        function findSourceMap(path: string): SourceMap | undefined;
-        interface SourceMapPayload {
-            file: string;
-            version: number;
-            sources: string[];
-            sourcesContent: string[];
-            names: string[];
-            mappings: string;
-            sourceRoot: string;
-        }
-        interface SourceMapping {
-            generatedLine: number;
-            generatedColumn: number;
-            originalSource: string;
-            originalLine: number;
-            originalColumn: number;
-        }
-        interface SourceOrigin {
-            /**
-             * The name of the range in the source map, if one was provided
-             */
-            name: string | undefined;
-            /**
-             * The file name of the original source, as reported in the SourceMap
-             */
-            fileName: string;
-            /**
-             * The 1-indexed lineNumber of the corresponding call site in the original source
-             */
-            lineNumber: number;
-            /**
-             * The 1-indexed columnNumber of the corresponding call site in the original source
-             */
-            columnNumber: number;
-        }
-        /**
-         * @since v13.7.0, v12.17.0
-         */
-        class SourceMap {
-            constructor(payload: SourceMapPayload);
-            /**
-             * Getter for the payload used to construct the `SourceMap` instance.
-             */
-            readonly payload: SourceMapPayload;
-            /**
-             * Given a line offset and column offset in the generated source
-             * file, returns an object representing the SourceMap range in the
-             * original file if found, or an empty object if not.
-             *
-             * The object returned contains the following keys:
-             *
-             * The returned value represents the raw range as it appears in the
-             * SourceMap, based on zero-indexed offsets, _not_ 1-indexed line and
-             * column numbers as they appear in Error messages and CallSite
-             * objects.
-             *
-             * To get the corresponding 1-indexed line and column numbers from a
-             * lineNumber and columnNumber as they are reported by Error stacks
-             * and CallSite objects, use `sourceMap.findOrigin(lineNumber, columnNumber)`
-             * @param lineOffset The zero-indexed line number offset in the generated source
-             * @param columnOffset The zero-indexed column number offset in the generated source
-             */
-            findEntry(lineOffset: number, columnOffset: number): SourceMapping | {};
-            /**
-             * Given a 1-indexed `lineNumber` and `columnNumber` from a call site in the generated source,
-             * find the corresponding call site location in the original source.
-             *
-             * If the `lineNumber` and `columnNumber` provided are not found in any source map,
-             * then an empty object is returned.
-             * @param lineNumber The 1-indexed line number of the call site in the generated source
-             * @param columnNumber The 1-indexed column number of the call site in the generated source
-             */
-            findOrigin(lineNumber: number, columnNumber: number): SourceOrigin | {};
-        }
         /** @deprecated Use `ImportAttributes` instead */
         interface ImportAssertions extends ImportAttributes {}
         interface ImportAttributes extends NodeJS.Dict<string> {
@@ -185,18 +110,6 @@ declare module "module" {
         }
         type ModuleFormat = "builtin" | "commonjs" | "json" | "module" | "wasm";
         type ModuleSource = string | ArrayBuffer | NodeJS.TypedArray;
-        interface GlobalPreloadContext {
-            port: MessagePort;
-        }
-        /**
-         * Sometimes it might be necessary to run some code inside of the same global
-         * scope that the application runs in. This hook allows the return of a string
-         * that is run as a sloppy-mode script on startup.
-         * @deprecated This hook will be removed in a future version. Use
-         * `initialize` instead. When a hooks module has an `initialize` export,
-         * `globalPreload` will be ignored.
-         */
-        type GlobalPreloadHook = (context: GlobalPreloadContext) => string;
         /**
          * The `initialize` hook provides a way to define a custom function that runs in
          * the hooks thread when the hooks module is initialized. Initialization happens
@@ -306,12 +219,99 @@ declare module "module" {
             context: LoadHookContext,
             nextLoad: (url: string, context?: LoadHookContext) => LoadFnOutput | Promise<LoadFnOutput>,
         ) => LoadFnOutput | Promise<LoadFnOutput>;
+        interface GlobalPreloadContext {
+            port: MessagePort;
+        }
+        /**
+         * Sometimes it might be necessary to run some code inside of the same global
+         * scope that the application runs in. This hook allows the return of a string
+         * that is run as a sloppy-mode script on startup.
+         * @deprecated This hook will be removed in a future version. Use
+         * `initialize` instead. When a hooks module has an `initialize` export,
+         * `globalPreload` will be ignored.
+         */
+        type GlobalPreloadHook = (context: GlobalPreloadContext) => string;
+        /**
+         * `path` is the resolved path for the file for which a corresponding source map
+         * should be fetched.
+         * @since v13.7.0, v12.17.0
+         */
+        function findSourceMap(path: string): SourceMap | undefined;
+        interface SourceMapPayload {
+            file: string;
+            version: number;
+            sources: string[];
+            sourcesContent: string[];
+            names: string[];
+            mappings: string;
+            sourceRoot: string;
+        }
+        interface SourceMapping {
+            generatedLine: number;
+            generatedColumn: number;
+            originalSource: string;
+            originalLine: number;
+            originalColumn: number;
+        }
+        interface SourceOrigin {
+            /**
+             * The name of the range in the source map, if one was provided
+             */
+            name: string | undefined;
+            /**
+             * The file name of the original source, as reported in the SourceMap
+             */
+            fileName: string;
+            /**
+             * The 1-indexed lineNumber of the corresponding call site in the original source
+             */
+            lineNumber: number;
+            /**
+             * The 1-indexed columnNumber of the corresponding call site in the original source
+             */
+            columnNumber: number;
+        }
+        /**
+         * @since v13.7.0, v12.17.0
+         */
+        class SourceMap {
+            constructor(payload: SourceMapPayload);
+            /**
+             * Getter for the payload used to construct the `SourceMap` instance.
+             */
+            readonly payload: SourceMapPayload;
+            /**
+             * Given a line offset and column offset in the generated source
+             * file, returns an object representing the SourceMap range in the
+             * original file if found, or an empty object if not.
+             *
+             * The object returned contains the following keys:
+             *
+             * The returned value represents the raw range as it appears in the
+             * SourceMap, based on zero-indexed offsets, _not_ 1-indexed line and
+             * column numbers as they appear in Error messages and CallSite
+             * objects.
+             *
+             * To get the corresponding 1-indexed line and column numbers from a
+             * lineNumber and columnNumber as they are reported by Error stacks
+             * and CallSite objects, use `sourceMap.findOrigin(lineNumber, columnNumber)`
+             * @param lineOffset The zero-indexed line number offset in the generated source
+             * @param columnOffset The zero-indexed column number offset in the generated source
+             */
+            findEntry(lineOffset: number, columnOffset: number): SourceMapping | {};
+            /**
+             * Given a 1-indexed `lineNumber` and `columnNumber` from a call site in the generated source,
+             * find the corresponding call site location in the original source.
+             *
+             * If the `lineNumber` and `columnNumber` provided are not found in any source map,
+             * then an empty object is returned.
+             * @param lineNumber The 1-indexed line number of the call site in the generated source
+             * @param columnNumber The 1-indexed column number of the call site in the generated source
+             */
+            findOrigin(lineNumber: number, columnNumber: number): SourceOrigin | {};
+        }
         function runMain(main?: string): void;
         function wrap(code: string): string;
-    }
-    interface Module extends NodeJS.Module {}
-    class Module {
-        constructor(id: string, parent?: Module);
     }
     type ImportMetaDOMCompat = typeof globalThis extends { onmessage: any } ? {
             resolve(specifier: string): string;

--- a/types/node/v18/module.d.ts
+++ b/types/node/v18/module.d.ts
@@ -256,11 +256,11 @@ declare module "module" {
         data?: Data | undefined;
         transferList?: any[] | undefined;
     }
-    interface Module extends NodeModule {}
+    interface Module extends NodeJS.Module {}
     class Module {
         static runMain(): void;
         static wrap(code: string): string;
-        static createRequire(path: string | URL): NodeRequire;
+        static createRequire(path: string | URL): NodeJS.Require;
         static builtinModules: string[];
         static isBuiltin(moduleName: string): boolean;
         static Module: typeof Module;
@@ -282,6 +282,179 @@ declare module "module" {
         interface ImportMeta extends ImportMetaDOMCompat {
             url: string;
         }
+        namespace NodeJS {
+            interface Module {
+                /**
+                 * The module objects required for the first time by this one.
+                 * @since v0.1.16
+                 */
+                children: Module[];
+                /**
+                 * The `module.exports` object is created by the `Module` system. Sometimes this is
+                 * not acceptable; many want their module to be an instance of some class. To do
+                 * this, assign the desired export object to `module.exports`.
+                 * @since v0.1.16
+                 */
+                exports: any;
+                /**
+                 * The fully resolved filename of the module.
+                 * @since v0.1.16
+                 */
+                filename: string;
+                /**
+                 * The identifier for the module. Typically this is the fully resolved
+                 * filename.
+                 * @since v0.1.16
+                 */
+                id: string;
+                /**
+                 * `true` if the module is running during the Node.js preload
+                 * phase.
+                 * @since v15.4.0, v14.17.0
+                 */
+                isPreloading: boolean;
+                /**
+                 * Whether or not the module is done loading, or is in the process of
+                 * loading.
+                 * @since v0.1.16
+                 */
+                loaded: boolean;
+                /**
+                 * The module that first required this one, or `null` if the current module is the
+                 * entry point of the current process, or `undefined` if the module was loaded by
+                 * something that is not a CommonJS module (e.g. REPL or `import`).
+                 * @since v0.1.16
+                 * @deprecated Please use `require.main` and `module.children` instead.
+                 */
+                parent: Module | null | undefined;
+                /**
+                 * The directory name of the module. This is usually the same as the
+                 * `path.dirname()` of the `module.id`.
+                 * @since v11.14.0
+                 */
+                path: string;
+                /**
+                 * The search paths for the module.
+                 * @since v0.4.0
+                 */
+                paths: string[];
+                /**
+                 * The `module.require()` method provides a way to load a module as if
+                 * `require()` was called from the original module.
+                 * @since v0.5.1
+                 */
+                require(id: string): any;
+            }
+            interface Require {
+                /**
+                 * Used to import modules, `JSON`, and local files.
+                 * @since v0.1.13
+                 */
+                (id: string): any;
+                /**
+                 * Modules are cached in this object when they are required. By deleting a key
+                 * value from this object, the next `require` will reload the module.
+                 * This does not apply to
+                 * [native addons](https://nodejs.org/docs/latest-v18.x/api/addons.html),
+                 * for which reloading will result in an error.
+                 * @since v0.3.0
+                 */
+                cache: Dict<Module>;
+                /**
+                 * Instruct `require` on how to handle certain file extensions.
+                 * @since v0.3.0
+                 * @deprecated
+                 */
+                extensions: RequireExtensions;
+                /**
+                 * The `Module` object representing the entry script loaded when the Node.js
+                 * process launched, or `undefined` if the entry point of the program is not a
+                 * CommonJS module.
+                 * @since v0.1.17
+                 */
+                main: Module | undefined;
+                /**
+                 * @since v0.3.0
+                 */
+                resolve: RequireResolve;
+            }
+            /** @deprecated */
+            interface RequireExtensions extends Dict<(module: Module, filename: string) => any> {
+                ".js": (module: Module, filename: string) => any;
+                ".json": (module: Module, filename: string) => any;
+                ".node": (module: Module, filename: string) => any;
+            }
+            interface RequireResolveOptions {
+                /**
+                 * Paths to resolve module location from. If present, these
+                 * paths are used instead of the default resolution paths, with the exception
+                 * of
+                 * [GLOBAL\_FOLDERS](https://nodejs.org/docs/latest-v18.x/api/modules.html#loading-from-the-global-folders)
+                 * like `$HOME/.node_modules`, which are
+                 * always included. Each of these paths is used as a starting point for
+                 * the module resolution algorithm, meaning that the `node_modules` hierarchy
+                 * is checked from this location.
+                 * @since v8.9.0
+                 */
+                paths?: string[] | undefined;
+            }
+            interface RequireResolve {
+                /**
+                 * Use the internal `require()` machinery to look up the location of a module,
+                 * but rather than loading the module, just return the resolved filename.
+                 *
+                 * If the module can not be found, a `MODULE_NOT_FOUND` error is thrown.
+                 * @since v0.3.0
+                 * @param request The module path to resolve.
+                 */
+                (id: string, options?: RequireResolveOptions): string;
+                /**
+                 * Returns an array containing the paths searched during resolution of `request` or
+                 * `null` if the `request` string references a core module, for example `http` or
+                 * `fs`.
+                 * @since v8.9.0
+                 * @param request The module path whose lookup paths are being retrieved.
+                 */
+                paths(request: string): string[] | null;
+            }
+        }
+        /**
+         * The directory name of the current module. This is the same as the
+         * `path.dirname()` of the `__filename`.
+         * @since v0.1.27
+         */
+        var __dirname: string;
+        /**
+         * The file name of the current module. This is the current module file's absolute
+         * path with symlinks resolved.
+         *
+         * For a main program this is not necessarily the same as the file name used in the
+         * command line.
+         * @since v0.0.1
+         */
+        var __filename: string;
+        /**
+         * The `exports` variable is available within a module's file-level scope, and is
+         * assigned the value of `module.exports` before the module is evaluated.
+         * @since v0.1.16
+         */
+        var exports: NodeJS.Module["exports"];
+        /**
+         * A reference to the current module.
+         * @since v0.1.16
+         */
+        var module: NodeJS.Module;
+        /**
+         * @since v0.1.13
+         */
+        var require: NodeJS.Require;
+        // Global-scope aliases for backwards compatibility with @types/node <13.0.x
+        /** @deprecated Use `NodeJS.Module` instead. */
+        interface NodeModule extends NodeJS.Module {}
+        /** @deprecated Use `NodeJS.Require` instead. */
+        interface NodeRequire extends NodeJS.Require {}
+        /** @deprecated Use `NodeJS.RequireResolve` instead. */
+        interface RequireResolve extends NodeJS.RequireResolve {}
     }
     export = Module;
 }

--- a/types/node/v18/test/globals.ts
+++ b/types/node/v18/test/globals.ts
@@ -10,16 +10,6 @@
 
 declare var RANDOM_GLOBAL_VARIABLE: true;
 
-// global aliases for compatibility
-{
-    const x: NodeModule = {} as any;
-    const y: NodeModule = {} as any;
-    x.children.push(y);
-    x.parent = require.main!;
-    require.main = y;
-    x.path; // $ExpectType string
-}
-
 // exposed gc
 {
     if (gc) {

--- a/types/node/v18/test/module.ts
+++ b/types/node/v18/test/module.ts
@@ -1,6 +1,8 @@
 import Module = require("node:module");
 import { URL } from "node:url";
 
+Module.Module === Module;
+
 // Module class and NodeJS.Module
 {
     const module: NodeJS.Module = new Module("moduleId");

--- a/types/node/v18/test/module.ts
+++ b/types/node/v18/test/module.ts
@@ -31,6 +31,12 @@ Module.Module === Module;
     const require: NodeJS.Require = module.require;
 }
 
+// Deprecated global aliases
+{
+    ({} as NodeModule) satisfies NodeJS.Module;
+    ({} as NodeRequire) satisfies NodeJS.Require;
+}
+
 // Top-level properties/functions
 {
     // $ExpectType readonly string[]

--- a/types/node/v18/test/module.ts
+++ b/types/node/v18/test/module.ts
@@ -17,8 +17,8 @@ let rf: (m: string) => any;
 rf = Module.createRequire("mod");
 rf = Module.createRequire(new URL("file:///C:/path/"));
 
-const aModule: NodeModule = new Module("s");
-const bModule: NodeModule = new Module("b", aModule);
+const aModule: NodeJS.Module = new Module("s");
+const bModule: NodeJS.Module = new Module("b", aModule);
 
 const builtIn: string[] = Module.builtinModules;
 const builtinResult: boolean = Module.isBuiltin("node:fs");

--- a/types/node/v18/test/module.ts
+++ b/types/node/v18/test/module.ts
@@ -78,7 +78,7 @@ const origin: Module.SourceOrigin | {} = smap.findOrigin(1, 1);
     const load: Module.LoadHook = async (url, context, nextLoad) => {
         const { format } = context;
 
-        if (Math.random() > 0.5) {
+        if (format) {
             return {
                 format,
                 shortCircuit: true,

--- a/types/node/v18/test/module.ts
+++ b/types/node/v18/test/module.ts
@@ -47,7 +47,8 @@ const smap = new Module.SourceMap({
     sourcesContent: [],
 });
 const pl: Module.SourceMapPayload = smap.payload;
-const entry: Module.SourceMapping = smap.findEntry(1, 1);
+const entry: Module.SourceMapping | {} = smap.findEntry(1, 1);
+const origin: Module.SourceOrigin | {} = smap.findOrigin(1, 1);
 
 // global
 {

--- a/types/node/v18/test/module.ts
+++ b/types/node/v18/test/module.ts
@@ -1,57 +1,109 @@
 import Module = require("node:module");
 import { URL } from "node:url";
-require.extensions[".ts"] = () => "";
 
-Module.runMain();
-const s: string = Module.wrap("some code");
-
-const m1: Module = new Module("moduleId");
-const m2: Module = new Module("moduleId");
-const b: string[] = Module.builtinModules;
-let paths: string[] = [];
-paths = m1.paths;
-m1 instanceof Module;
-
-let rf: (m: string) => any;
-
-rf = Module.createRequire("mod");
-rf = Module.createRequire(new URL("file:///C:/path/"));
-
-const aModule: NodeJS.Module = new Module("s");
-const bModule: NodeJS.Module = new Module("b", aModule);
-
-const builtIn: string[] = Module.builtinModules;
-const builtinResult: boolean = Module.isBuiltin("node:fs");
-
-const customRequire2 = Module.createRequire("node:./test");
-
-customRequire2("test");
-
-const resolved2: string = customRequire2.resolve("test");
-
-const paths2: string[] | null = customRequire2.resolve.paths("test");
-
-const cachedModule2: Module | undefined = customRequire2.cache["/path/to/module.js"];
-
-const main2: Module | undefined = customRequire2.main;
-
-Module.syncBuiltinESMExports();
-
-const smap = new Module.SourceMap({
-    file: "test.js",
-    mappings: "ASDASd",
-    names: [],
-    sourceRoot: "/",
-    sources: [],
-    version: 3,
-    sourcesContent: [],
-});
-const pl: Module.SourceMapPayload = smap.payload;
-const entry: Module.SourceMapping | {} = smap.findEntry(1, 1);
-const origin: Module.SourceOrigin | {} = smap.findOrigin(1, 1);
-
-// global
+// Module class and NodeJS.Module
 {
+    const module: NodeJS.Module = new Module("moduleId");
+    new Module("childModuleId", module);
+
+    // $ExpectType Module[]
+    module.children;
+    // $ExpectType any
+    module.exports;
+    // $ExpectType string
+    module.filename;
+    // $ExpectType string
+    module.id;
+    // $ExpectType boolean
+    module.isPreloading;
+    // $ExpectType boolean
+    module.loaded;
+    // $ExpectType string
+    module.path;
+    // $ExpectType string[]
+    module.paths;
+
+    // $ExpectType any
+    module.require("moduleId");
+    // @ts-expect-error module.require() does not have the additional static properties of global require()
+    const require: NodeJS.Require = module.require;
+}
+
+// Top-level properties/functions
+{
+    // $ExpectType readonly string[]
+    Module.builtinModules;
+
+    // $ExpectType Require
+    Module.createRequire("/usr/lib/node");
+    // $ExpectType Require
+    Module.createRequire(new URL("file:///usr/lib/node"));
+
+    // $ExpectType boolean
+    Module.isBuiltin("process");
+
+    // $ExpectType void
+    Module.syncBuiltinESMExports();
+}
+
+// Undocumented monkeypatching definitions
+{
+    // $ExpectType void
+    Module.runMain(process.argv[1]);
+
+    // $ExpectType string
+    Module.wrap("assert(module.exports === exports)");
+}
+
+// Source maps
+{
+    const sourceMap = new Module.SourceMap({
+        file: "test.js",
+        mappings: "ASDF;GHJK",
+        names: [],
+        sourceRoot: "/",
+        sources: [],
+        version: 3,
+        sourcesContent: [],
+    });
+
+    // $ExpectType SourceMapPayload
+    sourceMap.payload;
+    // $ExpectType SourceMapping | {}
+    sourceMap.findEntry(1, 1);
+    // $ExpectType SourceOrigin | {}
+    sourceMap.findOrigin(1, 1);
+
+    // $ExpectType SourceMap | undefined
+    Module.findSourceMap("/path/to/file.js");
+}
+
+// Hooks
+{
+    const specifier = "./myLoader.js";
+    const parentURL = "some-url"; // import.meta.url
+    Module.register(specifier);
+    Module.register(specifier, { parentURL });
+    Module.register(specifier, { parentURL: new URL("data:") });
+    Module.register(specifier, parentURL);
+    Module.register(specifier, new URL("data:"));
+
+    const someArrayBuffer = new ArrayBuffer(100);
+    Module.register(specifier, {
+        parentURL,
+        data: someArrayBuffer,
+        transferList: [someArrayBuffer],
+    });
+
+    Module.register<{ number: number }>(specifier, {
+        parentURL,
+        data: { number: 1 },
+    });
+
+    const initialize: Module.InitializeHook<{ number: number }> = async ({ number }) => {
+        number; // $ExpectType number
+    };
+
     const resolve: Module.ResolveHook = async (specifier, context, nextResolve) => {
         const { parentURL = null } = context;
         console.log(context.importAttributes.type);
@@ -100,36 +152,5 @@ const origin: Module.SourceOrigin | {} = smap.findOrigin(1, 1);
             const require = createRequire(cwd() + '/<preload>');
             // [...]
         `;
-    };
-}
-
-// Initialize hook
-{
-    const specifier = "./myLoader.js";
-    const parentURL = "some-url"; // import.meta.url
-    Module.register(specifier);
-    Module.register(specifier, { parentURL });
-    Module.register(specifier, { parentURL: new URL("data:") });
-    Module.register(specifier, parentURL);
-    Module.register(specifier, new URL("data:"));
-
-    const someArrayBuffer = new ArrayBuffer(100);
-    Module.register(specifier, {
-        parentURL,
-        data: someArrayBuffer,
-        transferList: [someArrayBuffer],
-    });
-
-    interface TransferableData {
-        number: number;
-    }
-    Module.register<TransferableData>(specifier, {
-        parentURL,
-        data: { number: 1 },
-    });
-
-    type MyInitializeHook = Module.InitializeHook<TransferableData>;
-    const initializeHook: MyInitializeHook = async ({ number }) => {
-        number; // $ExpectType number
     };
 }

--- a/types/node/v20/globals.d.ts
+++ b/types/node/v20/globals.d.ts
@@ -106,24 +106,10 @@ declare global {
     *                                               *
     ------------------------------------------------*/
 
-    // For backwards compability
-    interface NodeRequire extends NodeJS.Require {}
-    interface RequireResolve extends NodeJS.RequireResolve {}
-    interface NodeModule extends NodeJS.Module {}
-
     var global: typeof globalThis;
 
     var process: NodeJS.Process;
     var console: Console;
-
-    var __filename: string;
-    var __dirname: string;
-
-    var require: NodeRequire;
-    var module: NodeModule;
-
-    // Same as module.exports
-    var exports: any;
 
     interface GCFunction {
         (options: {
@@ -353,49 +339,6 @@ declare global {
         interface RefCounted {
             ref(): this;
             unref(): this;
-        }
-
-        interface Require {
-            (id: string): any;
-            resolve: RequireResolve;
-            cache: Dict<NodeModule>;
-            /**
-             * @deprecated
-             */
-            extensions: RequireExtensions;
-            main: Module | undefined;
-        }
-
-        interface RequireResolve {
-            (id: string, options?: { paths?: string[] | undefined }): string;
-            paths(request: string): string[] | null;
-        }
-
-        interface RequireExtensions extends Dict<(m: Module, filename: string) => any> {
-            ".js": (m: Module, filename: string) => any;
-            ".json": (m: Module, filename: string) => any;
-            ".node": (m: Module, filename: string) => any;
-        }
-        interface Module {
-            /**
-             * `true` if the module is running during the Node.js preload
-             */
-            isPreloading: boolean;
-            exports: any;
-            require: Require;
-            id: string;
-            filename: string;
-            loaded: boolean;
-            /** @deprecated since v14.6.0 Please use `require.main` and `module.children` instead. */
-            parent: Module | null | undefined;
-            children: Module[];
-            /**
-             * @since v11.14.0
-             *
-             * The directory name of the module. This is usually the same as the path.dirname() of the module.id.
-             */
-            path: string;
-            paths: string[];
         }
 
         interface Dict<T> {

--- a/types/node/v20/module.d.ts
+++ b/types/node/v20/module.d.ts
@@ -1,6 +1,5 @@
 /**
  * @since v0.3.7
- * @experimental
  */
 declare module "module" {
     import { URL } from "node:url";

--- a/types/node/v20/module.d.ts
+++ b/types/node/v20/module.d.ts
@@ -198,22 +198,23 @@ declare module "module" {
             port: MessagePort;
         }
         /**
-         * @deprecated This hook will be removed in a future version.
-         * Use `initialize` instead. When a loader has an `initialize` export, `globalPreload` will be ignored.
-         *
-         * Sometimes it might be necessary to run some code inside of the same global scope that the application runs in.
-         * This hook allows the return of a string that is run as a sloppy-mode script on startup.
-         *
-         * @param context Information to assist the preload code
-         * @return Code to run before application startup
+         * Sometimes it might be necessary to run some code inside of the same global
+         * scope that the application runs in. This hook allows the return of a string
+         * that is run as a sloppy-mode script on startup.
+         * @deprecated This hook will be removed in a future version. Use
+         * `initialize` instead. When a hooks module has an `initialize` export,
+         * `globalPreload` will be ignored.
          */
         type GlobalPreloadHook = (context: GlobalPreloadContext) => string;
         /**
-         * The `initialize` hook provides a way to define a custom function that runs in the hooks thread
-         * when the hooks module is initialized. Initialization happens when the hooks module is registered via `register`.
+         * The `initialize` hook provides a way to define a custom function that runs in
+         * the hooks thread when the hooks module is initialized. Initialization happens
+         * when the hooks module is registered via {@link register}.
          *
-         * This hook can receive data from a `register` invocation, including ports and other transferrable objects.
-         * The return value of `initialize` can be a `Promise`, in which case it will be awaited before the main application thread execution resumes.
+         * This hook can receive data from a {@link register} invocation, including
+         * ports and other transferable objects. The return value of `initialize` can be a
+         * `Promise`, in which case it will be awaited before the main application thread
+         * execution resumes.
          */
         type InitializeHook<Data = any> = (data: Data) => void | Promise<void>;
         interface ResolveHookContext {
@@ -258,13 +259,13 @@ declare module "module" {
             url: string;
         }
         /**
-         * The `resolve` hook chain is responsible for resolving file URL for a given module specifier and parent URL, and optionally its format (such as `'module'`) as a hint to the `load` hook.
-         * If a format is specified, the load hook is ultimately responsible for providing the final `format` value (and it is free to ignore the hint provided by `resolve`);
-         * if `resolve` provides a format, a custom `load` hook is required even if only to pass the value to the Node.js default `load` hook.
-         *
-         * @param specifier The specified URL path of the module to be resolved
-         * @param context
-         * @param nextResolve The subsequent `resolve` hook in the chain, or the Node.js default `resolve` hook after the last user-supplied resolve hook
+         * The `resolve` hook chain is responsible for telling Node.js where to find and
+         * how to cache a given `import` statement or expression, or `require` call. It can
+         * optionally return a format (such as `'module'`) as a hint to the `load` hook. If
+         * a format is specified, the `load` hook is ultimately responsible for providing
+         * the final `format` value (and it is free to ignore the hint provided by
+         * `resolve`); if `resolve` provides a `format`, a custom `load` hook is required
+         * even if only to pass the value to the Node.js default `load` hook.
          */
         type ResolveHook = (
             specifier: string,
@@ -282,7 +283,7 @@ declare module "module" {
             /**
              * The format optionally supplied by the `resolve` hook chain
              */
-            format: ModuleFormat;
+            format: ModuleFormat | null | undefined;
             /**
              * @deprecated Use `importAttributes` instead
              */
@@ -302,15 +303,12 @@ declare module "module" {
             /**
              * The source for Node.js to evaluate
              */
-            source?: ModuleSource;
+            source?: ModuleSource | undefined;
         }
         /**
-         * The `load` hook provides a way to define a custom method of determining how a URL should be interpreted, retrieved, and parsed.
-         * It is also in charge of validating the import assertion.
-         *
-         * @param url The URL/path of the module to be loaded
-         * @param context Metadata about the module
-         * @param nextLoad The subsequent `load` hook in the chain, or the Node.js default `load` hook after the last user-supplied `load` hook
+         * The `load` hook provides a way to define a custom method of determining how a
+         * URL should be interpreted, retrieved, and parsed. It is also in charge of
+         * validating the import attributes.
          */
         type LoadHook = (
             url: string,

--- a/types/node/v20/module.d.ts
+++ b/types/node/v20/module.d.ts
@@ -178,7 +178,7 @@ declare module "module" {
             context: ResolveHookContext,
             nextResolve: (
                 specifier: string,
-                context?: ResolveHookContext,
+                context?: Partial<ResolveHookContext>,
             ) => ResolveFnOutput | Promise<ResolveFnOutput>,
         ) => ResolveFnOutput | Promise<ResolveFnOutput>;
         interface LoadHookContext {
@@ -219,7 +219,10 @@ declare module "module" {
         type LoadHook = (
             url: string,
             context: LoadHookContext,
-            nextLoad: (url: string, context?: LoadHookContext) => LoadFnOutput | Promise<LoadFnOutput>,
+            nextLoad: (
+                url: string,
+                context?: Partial<LoadHookContext>,
+            ) => LoadFnOutput | Promise<LoadFnOutput>,
         ) => LoadFnOutput | Promise<LoadFnOutput>;
         interface GlobalPreloadContext {
             port: MessagePort;

--- a/types/node/v20/module.d.ts
+++ b/types/node/v20/module.d.ts
@@ -264,11 +264,11 @@ declare module "module" {
         data?: Data | undefined;
         transferList?: any[] | undefined;
     }
-    interface Module extends NodeModule {}
+    interface Module extends NodeJS.Module {}
     class Module {
         static runMain(): void;
         static wrap(code: string): string;
-        static createRequire(path: string | URL): NodeRequire;
+        static createRequire(path: string | URL): NodeJS.Require;
         static builtinModules: string[];
         static isBuiltin(moduleName: string): boolean;
         static Module: typeof Module;
@@ -312,6 +312,179 @@ declare module "module" {
              */
             resolve(specifier: string, parent?: string | URL | undefined): string;
         }
+        namespace NodeJS {
+            interface Module {
+                /**
+                 * The module objects required for the first time by this one.
+                 * @since v0.1.16
+                 */
+                children: Module[];
+                /**
+                 * The `module.exports` object is created by the `Module` system. Sometimes this is
+                 * not acceptable; many want their module to be an instance of some class. To do
+                 * this, assign the desired export object to `module.exports`.
+                 * @since v0.1.16
+                 */
+                exports: any;
+                /**
+                 * The fully resolved filename of the module.
+                 * @since v0.1.16
+                 */
+                filename: string;
+                /**
+                 * The identifier for the module. Typically this is the fully resolved
+                 * filename.
+                 * @since v0.1.16
+                 */
+                id: string;
+                /**
+                 * `true` if the module is running during the Node.js preload
+                 * phase.
+                 * @since v15.4.0, v14.17.0
+                 */
+                isPreloading: boolean;
+                /**
+                 * Whether or not the module is done loading, or is in the process of
+                 * loading.
+                 * @since v0.1.16
+                 */
+                loaded: boolean;
+                /**
+                 * The module that first required this one, or `null` if the current module is the
+                 * entry point of the current process, or `undefined` if the module was loaded by
+                 * something that is not a CommonJS module (e.g. REPL or `import`).
+                 * @since v0.1.16
+                 * @deprecated Please use `require.main` and `module.children` instead.
+                 */
+                parent: Module | null | undefined;
+                /**
+                 * The directory name of the module. This is usually the same as the
+                 * `path.dirname()` of the `module.id`.
+                 * @since v11.14.0
+                 */
+                path: string;
+                /**
+                 * The search paths for the module.
+                 * @since v0.4.0
+                 */
+                paths: string[];
+                /**
+                 * The `module.require()` method provides a way to load a module as if
+                 * `require()` was called from the original module.
+                 * @since v0.5.1
+                 */
+                require(id: string): any;
+            }
+            interface Require {
+                /**
+                 * Used to import modules, `JSON`, and local files.
+                 * @since v0.1.13
+                 */
+                (id: string): any;
+                /**
+                 * Modules are cached in this object when they are required. By deleting a key
+                 * value from this object, the next `require` will reload the module.
+                 * This does not apply to
+                 * [native addons](https://nodejs.org/docs/latest-v20.x/api/addons.html),
+                 * for which reloading will result in an error.
+                 * @since v0.3.0
+                 */
+                cache: Dict<Module>;
+                /**
+                 * Instruct `require` on how to handle certain file extensions.
+                 * @since v0.3.0
+                 * @deprecated
+                 */
+                extensions: RequireExtensions;
+                /**
+                 * The `Module` object representing the entry script loaded when the Node.js
+                 * process launched, or `undefined` if the entry point of the program is not a
+                 * CommonJS module.
+                 * @since v0.1.17
+                 */
+                main: Module | undefined;
+                /**
+                 * @since v0.3.0
+                 */
+                resolve: RequireResolve;
+            }
+            /** @deprecated */
+            interface RequireExtensions extends Dict<(module: Module, filename: string) => any> {
+                ".js": (module: Module, filename: string) => any;
+                ".json": (module: Module, filename: string) => any;
+                ".node": (module: Module, filename: string) => any;
+            }
+            interface RequireResolveOptions {
+                /**
+                 * Paths to resolve module location from. If present, these
+                 * paths are used instead of the default resolution paths, with the exception
+                 * of
+                 * [GLOBAL\_FOLDERS](https://nodejs.org/docs/latest-v20.x/api/modules.html#loading-from-the-global-folders)
+                 * like `$HOME/.node_modules`, which are
+                 * always included. Each of these paths is used as a starting point for
+                 * the module resolution algorithm, meaning that the `node_modules` hierarchy
+                 * is checked from this location.
+                 * @since v8.9.0
+                 */
+                paths?: string[] | undefined;
+            }
+            interface RequireResolve {
+                /**
+                 * Use the internal `require()` machinery to look up the location of a module,
+                 * but rather than loading the module, just return the resolved filename.
+                 *
+                 * If the module can not be found, a `MODULE_NOT_FOUND` error is thrown.
+                 * @since v0.3.0
+                 * @param request The module path to resolve.
+                 */
+                (id: string, options?: RequireResolveOptions): string;
+                /**
+                 * Returns an array containing the paths searched during resolution of `request` or
+                 * `null` if the `request` string references a core module, for example `http` or
+                 * `fs`.
+                 * @since v8.9.0
+                 * @param request The module path whose lookup paths are being retrieved.
+                 */
+                paths(request: string): string[] | null;
+            }
+        }
+        /**
+         * The directory name of the current module. This is the same as the
+         * `path.dirname()` of the `__filename`.
+         * @since v0.1.27
+         */
+        var __dirname: string;
+        /**
+         * The file name of the current module. This is the current module file's absolute
+         * path with symlinks resolved.
+         *
+         * For a main program this is not necessarily the same as the file name used in the
+         * command line.
+         * @since v0.0.1
+         */
+        var __filename: string;
+        /**
+         * The `exports` variable is available within a module's file-level scope, and is
+         * assigned the value of `module.exports` before the module is evaluated.
+         * @since v0.1.16
+         */
+        var exports: NodeJS.Module["exports"];
+        /**
+         * A reference to the current module.
+         * @since v0.1.16
+         */
+        var module: NodeJS.Module;
+        /**
+         * @since v0.1.13
+         */
+        var require: NodeJS.Require;
+        // Global-scope aliases for backwards compatibility with @types/node <13.0.x
+        /** @deprecated Use `NodeJS.Module` instead. */
+        interface NodeModule extends NodeJS.Module {}
+        /** @deprecated Use `NodeJS.Require` instead. */
+        interface NodeRequire extends NodeJS.Require {}
+        /** @deprecated Use `NodeJS.RequireResolve` instead. */
+        interface RequireResolve extends NodeJS.RequireResolve {}
     }
     export = Module;
 }

--- a/types/node/v20/module.d.ts
+++ b/types/node/v20/module.d.ts
@@ -48,7 +48,13 @@ declare module "module" {
          * @since v13.7.0, v12.17.0
          * @return Returns `module.SourceMap` if a source map is found, `undefined` otherwise.
          */
-        function findSourceMap(path: string, error?: Error): SourceMap | undefined;
+        function findSourceMap(path: string): SourceMap | undefined;
+        interface SourceMapConstructorOptions {
+            /**
+             * @since v20.5.0
+             */
+            lineLengths?: readonly number[] | undefined;
+        }
         interface SourceMapPayload {
             file: string;
             version: number;
@@ -69,7 +75,7 @@ declare module "module" {
             /**
              * The name of the range in the source map, if one was provided
              */
-            name?: string;
+            name: string | undefined;
             /**
              * The file name of the original source, as reported in the SourceMap
              */
@@ -87,11 +93,11 @@ declare module "module" {
          * @since v13.7.0, v12.17.0
          */
         class SourceMap {
+            constructor(payload: SourceMapPayload, options?: SourceMapConstructorOptions);
             /**
              * Getter for the payload used to construct the `SourceMap` instance.
              */
             readonly payload: SourceMapPayload;
-            constructor(payload: SourceMapPayload);
             /**
              * Given a line offset and column offset in the generated source
              * file, returns an object representing the SourceMap range in the
@@ -110,7 +116,7 @@ declare module "module" {
              * @param lineOffset The zero-indexed line number offset in the generated source
              * @param columnOffset The zero-indexed column number offset in the generated source
              */
-            findEntry(lineOffset: number, columnOffset: number): SourceMapping;
+            findEntry(lineOffset: number, columnOffset: number): SourceMapping | {};
             /**
              * Given a 1-indexed `lineNumber` and `columnNumber` from a call site in the generated source,
              * find the corresponding call site location in the original source.

--- a/types/node/v20/module.d.ts
+++ b/types/node/v20/module.d.ts
@@ -6,6 +6,66 @@ declare module "module" {
     import { URL } from "node:url";
     import { MessagePort } from "node:worker_threads";
     namespace Module {
+        export { Module };
+    }
+    namespace Module {
+        /**
+         * A list of the names of all modules provided by Node.js. Can be used to verify
+         * if a module is maintained by a third party or not.
+         *
+         * Note: the list doesn't contain prefix-only modules like `node:test`.
+         * @since v9.3.0, v8.10.0, v6.13.0
+         */
+        const builtinModules: readonly string[];
+        /**
+         * @since v12.2.0
+         * @param path Filename to be used to construct the require
+         * function. Must be a file URL object, file URL string, or absolute path
+         * string.
+         */
+        function createRequire(path: string | URL): NodeJS.Require;
+        /**
+         * @since v18.6.0, v16.17.0
+         */
+        function isBuiltin(moduleName: string): boolean;
+        interface RegisterOptions<Data> {
+            /**
+             * If you want to resolve `specifier` relative to a
+             * base URL, such as `import.meta.url`, you can pass that URL here. This
+             * property is ignored if the `parentURL` is supplied as the second argument.
+             * @default 'data:'
+             */
+            parentURL?: string | URL | undefined;
+            /**
+             * Any arbitrary, cloneable JavaScript value to pass into the
+             * {@link initialize} hook.
+             */
+            data?: Data | undefined;
+            /**
+             * [Transferable objects](https://nodejs.org/docs/latest-v20.x/api/worker_threads.html#portpostmessagevalue-transferlist)
+             * to be passed into the `initialize` hook.
+             */
+            transferList?: any[] | undefined;
+        }
+        /* eslint-disable @definitelytyped/no-unnecessary-generics */
+        /**
+         * Register a module that exports hooks that customize Node.js module
+         * resolution and loading behavior. See
+         * [Customization hooks](https://nodejs.org/docs/latest-v20.x/api/module.html#customization-hooks).
+         * @since v20.6.0, v18.19.0
+         * @param specifier Customization hooks to be registered; this should be
+         * the same string that would be passed to `import()`, except that if it is
+         * relative, it is resolved relative to `parentURL`.
+         * @param parentURL f you want to resolve `specifier` relative to a base
+         * URL, such as `import.meta.url`, you can pass that URL here.
+         */
+        function register<Data = any>(
+            specifier: string | URL,
+            parentURL?: string | URL,
+            options?: RegisterOptions<Data>,
+        ): void;
+        function register<Data = any>(specifier: string | URL, options?: RegisterOptions<Data>): void;
+        /* eslint-enable @definitelytyped/no-unnecessary-generics */
         /**
          * The `module.syncBuiltinESMExports()` method updates all the live bindings for
          * builtin `ES Modules` to match the properties of the `CommonJS` exports. It
@@ -258,26 +318,11 @@ declare module "module" {
             context: LoadHookContext,
             nextLoad: (url: string, context?: LoadHookContext) => LoadFnOutput | Promise<LoadFnOutput>,
         ) => LoadFnOutput | Promise<LoadFnOutput>;
-    }
-    interface RegisterOptions<Data> {
-        parentURL: string | URL;
-        data?: Data | undefined;
-        transferList?: any[] | undefined;
+        function runMain(main?: string): void;
+        function wrap(script: string): string;
     }
     interface Module extends NodeJS.Module {}
     class Module {
-        static runMain(): void;
-        static wrap(code: string): string;
-        static createRequire(path: string | URL): NodeJS.Require;
-        static builtinModules: string[];
-        static isBuiltin(moduleName: string): boolean;
-        static Module: typeof Module;
-        static register<Data = any>(
-            specifier: string | URL,
-            parentURL?: string | URL,
-            options?: RegisterOptions<Data>,
-        ): void;
-        static register<Data = any>(specifier: string | URL, options?: RegisterOptions<Data>): void;
         constructor(id: string, parent?: Module);
     }
     global {

--- a/types/node/v20/test/globals.ts
+++ b/types/node/v20/test/globals.ts
@@ -10,16 +10,6 @@
 
 declare var RANDOM_GLOBAL_VARIABLE: true;
 
-// global aliases for compatibility
-{
-    const x: NodeModule = {} as any;
-    const y: NodeModule = {} as any;
-    x.children.push(y);
-    x.parent = require.main!;
-    require.main = y;
-    x.path; // $ExpectType string
-}
-
 // exposed gc
 {
     if (gc) {

--- a/types/node/v20/test/module.ts
+++ b/types/node/v20/test/module.ts
@@ -1,6 +1,8 @@
 import Module = require("node:module");
 import { URL } from "node:url";
 
+Module.Module === Module;
+
 // Module class and NodeJS.Module
 {
     const module: NodeJS.Module = new Module("moduleId");

--- a/types/node/v20/test/module.ts
+++ b/types/node/v20/test/module.ts
@@ -31,6 +31,12 @@ Module.Module === Module;
     const require: NodeJS.Require = module.require;
 }
 
+// Deprecated global aliases
+{
+    ({} as NodeModule) satisfies NodeJS.Module;
+    ({} as NodeRequire) satisfies NodeJS.Require;
+}
+
 // Top-level properties/functions
 {
     // $ExpectType readonly string[]

--- a/types/node/v20/test/module.ts
+++ b/types/node/v20/test/module.ts
@@ -17,8 +17,8 @@ let rf: (m: string) => any;
 rf = Module.createRequire("mod");
 rf = Module.createRequire(new URL("file:///C:/path/"));
 
-const aModule: NodeModule = new Module("s");
-const bModule: NodeModule = new Module("b", aModule);
+const aModule: NodeJS.Module = new Module("s");
+const bModule: NodeJS.Module = new Module("b", aModule);
 
 const builtIn: string[] = Module.builtinModules;
 const builtinResult: boolean = Module.isBuiltin("node:fs");

--- a/types/node/v20/test/module.ts
+++ b/types/node/v20/test/module.ts
@@ -1,58 +1,91 @@
 import Module = require("node:module");
 import { URL } from "node:url";
-require.extensions[".ts"] = () => "";
 
-Module.runMain();
-const s: string = Module.wrap("some code");
-
-const m1: Module = new Module("moduleId");
-const m2: Module = new Module("moduleId");
-const b: string[] = Module.builtinModules;
-let paths: string[] = [];
-paths = m1.paths;
-m1 instanceof Module;
-
-let rf: (m: string) => any;
-
-rf = Module.createRequire("mod");
-rf = Module.createRequire(new URL("file:///C:/path/"));
-
-const aModule: NodeJS.Module = new Module("s");
-const bModule: NodeJS.Module = new Module("b", aModule);
-
-const builtIn: string[] = Module.builtinModules;
-const builtinResult: boolean = Module.isBuiltin("node:fs");
-
-const customRequire2 = Module.createRequire("node:./test");
-
-customRequire2("test");
-
-const resolved2: string = customRequire2.resolve("test");
-
-const paths2: string[] | null = customRequire2.resolve.paths("test");
-
-const cachedModule2: Module | undefined = customRequire2.cache["/path/to/module.js"];
-
-const main2: Module | undefined = customRequire2.main;
-
-Module.syncBuiltinESMExports();
-
-const smap = new Module.SourceMap({
-    file: "test.js",
-    mappings: "ASDASd",
-    names: [],
-    sourceRoot: "/",
-    sources: [],
-    version: 3,
-    sourcesContent: [],
-});
-const pl: Module.SourceMapPayload = smap.payload;
-const entry: Module.SourceMapping | {} = smap.findEntry(1, 1);
-const origin: Module.SourceOrigin | {} = smap.findOrigin(1, 1);
-
-// global
+// Module class and NodeJS.Module
 {
-    const importmeta: ImportMeta = {} as any; // Fake because we cannot really access the true `import.meta` with the current build target
+    const module: NodeJS.Module = new Module("moduleId");
+    new Module("childModuleId", module);
+
+    // $ExpectType Module[]
+    module.children;
+    // $ExpectType any
+    module.exports;
+    // $ExpectType string
+    module.filename;
+    // $ExpectType string
+    module.id;
+    // $ExpectType boolean
+    module.isPreloading;
+    // $ExpectType boolean
+    module.loaded;
+    // $ExpectType string
+    module.path;
+    // $ExpectType string[]
+    module.paths;
+
+    // $ExpectType any
+    module.require("moduleId");
+    // @ts-expect-error module.require() does not have the additional static properties of global require()
+    const require: NodeJS.Require = module.require;
+}
+
+// Top-level properties/functions
+{
+    // $ExpectType readonly string[]
+    Module.builtinModules;
+
+    // $ExpectType Require
+    Module.createRequire("/usr/lib/node");
+    // $ExpectType Require
+    Module.createRequire(new URL("file:///usr/lib/node"));
+
+    // $ExpectType boolean
+    Module.isBuiltin("process");
+
+    // $ExpectType void
+    Module.syncBuiltinESMExports();
+}
+
+// Undocumented monkeypatching definitions
+{
+    // $ExpectType void
+    Module.runMain(process.argv[1]);
+
+    // $ExpectType string
+    Module.wrap("assert(module.exports === exports)");
+}
+
+// Source maps
+{
+    const sourceMap = new Module.SourceMap(
+        {
+            file: "test.js",
+            mappings: "ASDF;GHJK",
+            names: [],
+            sourceRoot: "/",
+            sources: [],
+            version: 3,
+            sourcesContent: [],
+        },
+        {
+            lineLengths: [1, 2, 3],
+        },
+    );
+
+    // $ExpectType SourceMapPayload
+    sourceMap.payload;
+    // $ExpectType SourceMapping | {}
+    sourceMap.findEntry(1, 1);
+    // $ExpectType SourceOrigin | {}
+    sourceMap.findOrigin(1, 1);
+
+    // $ExpectType SourceMap | undefined
+    Module.findSourceMap("/path/to/file.js");
+}
+
+// import.meta
+{
+    let importmeta!: ImportMeta; // because we cannot access the true `import.meta` with module:commonjs
     importmeta.dirname; // $ExpectType string
     importmeta.filename; // $ExpectType string
     importmeta.url; // $ExpectType string
@@ -64,6 +97,30 @@ const origin: Module.SourceOrigin | {} = smap.findOrigin(1, 1);
 
 // Hooks
 {
+    const specifier = "./myLoader.js";
+    const parentURL = "some-url"; // import.meta.url
+    Module.register(specifier);
+    Module.register(specifier, { parentURL });
+    Module.register(specifier, { parentURL: new URL("data:") });
+    Module.register(specifier, parentURL);
+    Module.register(specifier, new URL("data:"));
+
+    const someArrayBuffer = new ArrayBuffer(100);
+    Module.register(specifier, {
+        parentURL,
+        data: someArrayBuffer,
+        transferList: [someArrayBuffer],
+    });
+
+    Module.register<{ number: number }>(specifier, {
+        parentURL,
+        data: { number: 1 },
+    });
+
+    const initialize: Module.InitializeHook<{ number: number }> = async ({ number }) => {
+        number; // $ExpectType number
+    };
+
     const resolve: Module.ResolveHook = async (specifier, context, nextResolve) => {
         const { parentURL = null } = context;
         console.log(context.importAttributes.type);
@@ -112,36 +169,5 @@ const origin: Module.SourceOrigin | {} = smap.findOrigin(1, 1);
             const require = createRequire(cwd() + '/<preload>');
             // [...]
         `;
-    };
-}
-
-// Initialize hook
-{
-    const specifier = "./myLoader.js";
-    const parentURL = "some-url"; // import.meta.url
-    Module.register(specifier);
-    Module.register(specifier, { parentURL });
-    Module.register(specifier, { parentURL: new URL("data:") });
-    Module.register(specifier, parentURL);
-    Module.register(specifier, new URL("data:"));
-
-    const someArrayBuffer = new ArrayBuffer(100);
-    Module.register(specifier, {
-        parentURL,
-        data: someArrayBuffer,
-        transferList: [someArrayBuffer],
-    });
-
-    interface TransferableData {
-        number: number;
-    }
-    Module.register<TransferableData>(specifier, {
-        parentURL,
-        data: { number: 1 },
-    });
-
-    type MyInitializeHook = Module.InitializeHook<TransferableData>;
-    const initializeHook: MyInitializeHook = async ({ number }) => {
-        number; // $ExpectType number
     };
 }

--- a/types/node/v20/test/module.ts
+++ b/types/node/v20/test/module.ts
@@ -90,7 +90,7 @@ const origin: Module.SourceOrigin | {} = smap.findOrigin(1, 1);
     const load: Module.LoadHook = async (url, context, nextLoad) => {
         const { format } = context;
 
-        if (Math.random() > 0.5) {
+        if (format) {
             return {
                 format,
                 shortCircuit: true,

--- a/types/node/v20/test/module.ts
+++ b/types/node/v20/test/module.ts
@@ -47,7 +47,8 @@ const smap = new Module.SourceMap({
     sourcesContent: [],
 });
 const pl: Module.SourceMapPayload = smap.payload;
-const entry: Module.SourceMapping = smap.findEntry(1, 1);
+const entry: Module.SourceMapping | {} = smap.findEntry(1, 1);
+const origin: Module.SourceOrigin | {} = smap.findOrigin(1, 1);
 
 // global
 {


### PR DESCRIPTION
Was found to be structurally quite messy during recent definition updates. This changeset performs the following:

- Moves definitions for module-related globals (eg. `module`, `require`) and NodeJS-namespaced interfaces (eg. `NodeJS.Module`) into module.d.ts, which is in keeping with the paradigm of modules defining related globals where possible (eg. url, stream/web, etc.)
  - Also deprecates the global-scope `NodeModule` and `NodeRequire` aliases, which were used prior to @types/node v13; the modern equivalent is to use the the namespaced `NodeJS.Module` etc.
  - Removes the last couple of internal uses of the old global aliases. This necessitates a couple of cosmetic `$ExpectType` changes, but is otherwise a fully transparent change.
- Moves all top-level definitions to the `Module` namespace. Top-level `node:module` exports were previously haphazardly defined as either namespaced declarations or static elements on the `Module` class; this change doesn't affect the behaviour of any imports from `node:module`, but does improve readability and maintainability.
- Definition fixes:
  - `NodeJS.Module`:
    - `module.require` is a simple function, rather than a `NodeJS.Require` with its associated properties.
  - Hooks:
    - The `globalPreload` hook was removed in v22.
    - `LoadHookContext.format` may be null or undefined (corresponding to `ResolveFnOutput.format`)
    - `LoadFnOutput.source` may be undefined if the format does not require a source parameter (eg. builtin modules)
  - Source maps:
    - `findSourceMaps()` has not accepted an error parameter for quite some time.
    - Adds the options parameter to the `SourceMap` constructor in v20/v22.
    - `SourceMap#findEntry()` can return an empty object, similar to `SourceMap#findOrigin()`.
  - `Module.builtinModules` is immutable.
  - The undocumented `Module.runMain()` accepts an optional parameter.
- Backports #71492 to v18/v20.
- Focuses the tests, which were something of a mess beforehand.
- Reorders definitions to match the order of the node docs, for improved maintainability.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest/api/module.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
