### PR TITLE
[bytes] Add `null` to return type of "bytes" functions

### DIFF
--- a/types/bytes/index.d.ts
+++ b/types/bytes/index.d.ts
@@ -1,12 +1,12 @@
 /**
  * Convert the given value in bytes into a string.
  */
-declare function bytes(value: number, options?: bytes.BytesOptions): string;
+declare function bytes(value: number, options?: bytes.BytesOptions): string | null;
 
 /**
  * Parse string to an integer in bytes.
  */
-declare function bytes(value: string): number;
+declare function bytes(value: string): number | null;
 
 declare namespace bytes {
     type Unit = "b" | "gb" | "kb" | "mb" | "pb" | "tb" | "B" | "GB" | "KB" | "MB" | "PB" | "TB";
@@ -25,14 +25,14 @@ declare namespace bytes {
      * If the value is negative, it is kept as such.
      * If it is a float, it is rounded.
      */
-    function format(value: number, options?: BytesOptions): string;
+    function format(value: number, options?: BytesOptions): string | null;
 
     /**
      * Parse the string value into an integer in bytes.
      *
      * If no unit is given, it is assumed the value is in bytes.
      */
-    function parse(value: string | number): number;
+    function parse(value: string | number): number | null;
 }
 
 export = bytes;


### PR DESCRIPTION
The two functions of the "bytes" package return `null` on error. For example, parsing a string that is not parseable as a bytes value, or formatting Infinity results in `null`. This adds `null` to the return type of the two functions.

Based on documentation in https://github.com/visionmedia/bytes.js#readme and source code in https://github.com/visionmedia/bytes.js/blob/master/index.js