### PR TITLE
Leaflet: fix L.LatLngBounds constructor types

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -177,7 +177,7 @@ export function latLng(
 
 export class LatLngBounds {
     constructor(southWest: LatLngExpression, northEast: LatLngExpression);
-    constructor(latlngs: LatLngBoundsLiteral);
+    constructor(latlngs: LatLngExpression[]);
     extend(latlngOrBounds: LatLngExpression | LatLngBoundsExpression): this;
     pad(bufferRatio: number): LatLngBounds; // Returns a new LatLngBounds
     getCenter(): LatLng;

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -36,6 +36,9 @@ latLngBounds = L.latLngBounds([latLng, latLng, latLng]);
 latLngBounds = new L.LatLngBounds(latLng, latLng);
 latLngBounds = new L.LatLngBounds(latLngLiteral, latLngLiteral);
 latLngBounds = new L.LatLngBounds(latLngTuple, latLngTuple);
+latLngBounds = new L.LatLngBounds(latLngBoundsLiteral);
+latLngBounds = new L.LatLngBounds([latLngLiteral, latLngLiteral, latLngLiteral]);
+latLngBounds = new L.LatLngBounds([latLng, latLng, latLng]);
 
 latLngBounds.equals(latLngBounds); // $ExpectType boolean
 latLngBounds.equals(latLngBounds, 3); // $ExpectType boolean


### PR DESCRIPTION
The non-constructor version was already fixed in 4e3f4267c469e794316c8227c58fdd9baaa3cf26 7 years ago, might as well fix this :D

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://leafletjs.com/reference.html#latlngbounds
