### PR TITLE
Change github username for Antonio Ivanovski

### DIFF
--- a/types/digitalbazaar__bitstring/package.json
+++ b/types/digitalbazaar__bitstring/package.json
@@ -13,7 +13,7 @@
     "owners": [
         {
             "name": "Antonio Ivanovski",
-            "githubUsername": "toteto"
+            "githubUsername": "antonio-ivanovski"
         }
     ]
 }


### PR DESCRIPTION
Alternative to #71306, which deletes the old username instead.