### PR TITLE
Adding allowedCommands type at line 98 in the FTPD package types

### DIFF
--- a/types/ftpd/index.d.ts
+++ b/types/ftpd/index.d.ts
@@ -92,6 +92,10 @@ export interface FtpServerOptions {
      * Integer from 0-4 representing the Log Level to show.
      */
     logLevel?: LogLevel | undefined;
+    /**
+     * String array, specifies FTP commands that the client can execute (e.g: XMKD, AUTH, etc...)
+     */
+    allowedCommands: string[] | undefined;
 }
 
 /**


### PR DESCRIPTION
Adding allowedCommands string array in index.d.ts at line 98, avoiding TypeScript to throw an error because the allowedCommands argument type not found in index.d.ts.

Package modified: @types/ftpd
Modifications: Added allowedCommands to the FtpServerOptions interface declared at line 19 of index.d.ts