### PR TITLE
[ftpd] Added allowedCommands to the FtpServerOptions interface

### DIFF
--- a/types/ftpd/ftpd-tests.ts
+++ b/types/ftpd/ftpd-tests.ts
@@ -10,6 +10,7 @@ var options: ftpd.FtpServerOptions = {
         return "/";
     },
     logLevel: ftpd.LogLevel.ERROR,
+    allowedCommands: []
 };
 
 var host: string = "10.0.0.42";

--- a/types/ftpd/index.d.ts
+++ b/types/ftpd/index.d.ts
@@ -92,6 +92,10 @@ export interface FtpServerOptions {
      * Integer from 0-4 representing the Log Level to show.
      */
     logLevel?: LogLevel | undefined;
+    /**
+     * String array, specifies commands that the FTP client can execute (e.g: XMKD, AUTH, etc...)
+     */
+    allowedCommands?: string[] | undefined;
 }
 
 /**


### PR DESCRIPTION
Package modified: @types/ftpd
Modifications: Added allowedCommands argument to FtpServerOptions interface in index.d.ts, added at line 98 and added allowedCommands argument to ftp-tests.ts