### PR TITLE
Fix outdated param type of relay-runtime fetchQueryDeduped

### DIFF
--- a/types/relay-runtime/lib/query/fetchQueryInternal.d.ts
+++ b/types/relay-runtime/lib/query/fetchQueryInternal.d.ts
@@ -1,12 +1,13 @@
 import { GraphQLResponse } from "../network/RelayNetworkTypes";
 import { RelayObservable as Observable } from "../network/RelayObservable";
 import { Environment, OperationDescriptor, RequestDescriptor } from "../store/RelayStoreTypes";
+import { RequestIdentifier } from "../util/getRequestIdentifier";
 
 export function fetchQuery(environment: Environment, operation: OperationDescriptor): Observable<GraphQLResponse>;
 
 export function fetchQueryDeduped(
     environment: Environment,
-    request: RequestDescriptor,
+    identifier: RequestIdentifier,
     fetchFn: () => Observable<GraphQLResponse>,
 ): Observable<GraphQLResponse>;
 

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -646,6 +646,12 @@ const operationWithCacheConfig = createOperationDescriptor(request, variables, c
 const operationWithDataID = createOperationDescriptor(request, variables, undefined, dataID);
 const operationWithAll = createOperationDescriptor(request, variables, cacheConfig, dataID);
 
+__internal.fetchQueryDeduped(
+    environment,
+    operation.request.identifier,
+    () => environment.execute({ operation }),
+);
+
 // ~~~~~~~~~~~~~~~~~~~~~~~
 // MULTI ACTOR ENVIRONMENT
 // ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/relay/commit/041c6ecf70decaac8ef21c63110e729eb4aead94
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
