### PR TITLE
Fix relay-runtime PreloadableQueryRegistry exporting class instead of a singleton

### DIFF
--- a/types/relay-runtime/lib/util/PreloadableQueryRegistry.d.ts
+++ b/types/relay-runtime/lib/util/PreloadableQueryRegistry.d.ts
@@ -1,9 +1,12 @@
 import type { ConcreteRequest } from "../util/RelayConcreteNode";
 import type { Disposable } from "../util/RelayRuntimeTypes";
 
-export default class PreloadableQueryRegistry {
+declare class PreloadableQueryRegistry {
     set(key: string, value: ConcreteRequest): void;
     get(key: string): ConcreteRequest | null | undefined;
     onLoad(key: string, callback: (concreteRequest: ConcreteRequest) => void): Disposable;
     clear(): void;
 }
+
+declare const preloadableQueryRegistry: PreloadableQueryRegistry;
+export default preloadableQueryRegistry;

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -18,6 +18,7 @@ import {
     LiveState,
     Network,
     PreloadableConcreteRequest,
+    PreloadableQueryRegistry,
     QueryResponseCache,
     ReaderFragment,
     ReaderInlineDataFragment,
@@ -375,6 +376,10 @@ const preloadableNode: PreloadableConcreteRequest<FooQuery> = {
         metadata: {},
     },
 };
+
+if (preloadableNode.params.id !== null) {
+    const module = PreloadableQueryRegistry.get(preloadableNode.params.id);
+}
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // ConcreteRequest


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/relay/blob/29b7a1e08c66aa49899a4858f4b1d7e06e35c66a/packages/relay-runtime/query/PreloadableQueryRegistry.js#L64-L67
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
