### PR TITLE
fix: add allowTransactionlessInjection as an option for getBrowserTimingHeader

### DIFF
--- a/types/newrelic/index.d.ts
+++ b/types/newrelic/index.d.ts
@@ -193,10 +193,10 @@ export function addIgnoringRule(pattern: RegExp | string): void;
  *
  * Do *not* reuse the headers between users, or even between requests.
  */
-export function getBrowserTimingHeader(options?: { 
-    nonce?: string; 
-    hasToRemoveScriptWrapper?: boolean; 
-    allowTransactionlessInjection?: boolean; 
+export function getBrowserTimingHeader(options?: {
+    nonce?: string;
+    hasToRemoveScriptWrapper?: boolean;
+    allowTransactionlessInjection?: boolean;
 }): string;
 
 /**

--- a/types/newrelic/index.d.ts
+++ b/types/newrelic/index.d.ts
@@ -193,7 +193,11 @@ export function addIgnoringRule(pattern: RegExp | string): void;
  *
  * Do *not* reuse the headers between users, or even between requests.
  */
-export function getBrowserTimingHeader(options?: { nonce?: string; hasToRemoveScriptWrapper?: boolean }): string;
+export function getBrowserTimingHeader(options?: { 
+    nonce?: string; 
+    hasToRemoveScriptWrapper?: boolean; 
+    allowTransactionlessInjection?: boolean; 
+}): string;
 
 /**
  * Instrument a particular method to improve visibility into a transaction,

--- a/types/newrelic/newrelic-tests.ts
+++ b/types/newrelic/newrelic-tests.ts
@@ -50,7 +50,8 @@ newrelic.addIgnoringRule(/^[0-9]+$/); // $ExpectType void
 newrelic.getBrowserTimingHeader(); // $ExpectType string
 newrelic.getBrowserTimingHeader({ nonce: "foo" }); // $ExpectType string
 newrelic.getBrowserTimingHeader({ hasToRemoveScriptWrapper: true }); // $ExpectType string
-newrelic.getBrowserTimingHeader({ hasToRemoveScriptWrapper: true, nonce: "foo" }); // $ExpectType string
+newrelic.getBrowserTimingHeader({ allowTransactionlessInjection: true }); // $ExpectType string
+newrelic.getBrowserTimingHeader({ nonce: "foo", hasToRemoveScriptWrapper: true, allowTransactionlessInjection: true }); // $ExpectType string
 
 newrelic.startSegment("foo", false, () => "bar"); // $ExpectType string
 newrelic.startSegment("foo", false, () => "bar", () => "baz"); // $ExpectType string


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://newrelic.com/blog/how-to-relic/how-to-monitor-app-based-router-nextjs-application
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

