### PR TITLE
[xrm] Add nonNpm info

### DIFF
--- a/types/xrm/package.json
+++ b/types/xrm/package.json
@@ -2,8 +2,10 @@
     "private": true,
     "name": "@types/xrm",
     "version": "9.0.9999",
+    "nonNpm": true,
+    "nonNpmDescription": "Javascript APIs available in Microsoft Dataverse/PowerApps model-driven apps and Dynamics 365 Customer Engagement (previously known as CRM).",
     "projects": [
-        "https://learn.microsoft.com/en-us/dynamics365/customerengagement/on-premises/developer/overview"
+        "https://learn.microsoft.com/power-apps/developer/model-driven-apps/clientapi/reference"
     ],
     "devDependencies": {
         "@types/xrm": "workspace:."

--- a/types/xrm/package.json
+++ b/types/xrm/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "@types/xrm",
     "version": "9.0.9999",
-    "nonNpm": true,
+    "nonNpm": "conflict",
     "nonNpmDescription": "Javascript APIs available in Microsoft Dataverse/PowerApps model-driven apps and Dynamics 365 Customer Engagement (previously known as CRM).",
     "projects": [
         "https://learn.microsoft.com/power-apps/developer/model-driven-apps/clientapi/reference"

--- a/types/xrm/v6/package.json
+++ b/types/xrm/v6/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "@types/xrm",
     "version": "6.0.9999",
-    "nonNpm": true,
+    "nonNpm": "conflict",
     "nonNpmDescription": "Javascript APIs available in Microsoft Dataverse/PowerApps model-driven apps and Dynamics 365 Customer Engagement (previously known as CRM).",
     "projects": [
         "http://msdn.microsoft.com/en-us/library/gg328255.aspx"

--- a/types/xrm/v6/package.json
+++ b/types/xrm/v6/package.json
@@ -2,6 +2,8 @@
     "private": true,
     "name": "@types/xrm",
     "version": "6.0.9999",
+    "nonNpm": true,
+    "nonNpmDescription": "Javascript APIs available in Microsoft Dataverse/PowerApps model-driven apps and Dynamics 365 Customer Engagement (previously known as CRM).",
     "projects": [
         "http://msdn.microsoft.com/en-us/library/gg328255.aspx"
     ],

--- a/types/xrm/v7/package.json
+++ b/types/xrm/v7/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "@types/xrm",
     "version": "7.1.9999",
-    "nonNpm": true,
+    "nonNpm": "conflict",
     "nonNpmDescription": "Javascript APIs available in Microsoft Dataverse/PowerApps model-driven apps and Dynamics 365 Customer Engagement (previously known as CRM).",
     "projects": [
         "http://www.microsoft.com/en-us/download/details.aspx?id=44567"

--- a/types/xrm/v7/package.json
+++ b/types/xrm/v7/package.json
@@ -2,6 +2,8 @@
     "private": true,
     "name": "@types/xrm",
     "version": "7.1.9999",
+    "nonNpm": true,
+    "nonNpmDescription": "Javascript APIs available in Microsoft Dataverse/PowerApps model-driven apps and Dynamics 365 Customer Engagement (previously known as CRM).",
     "projects": [
         "http://www.microsoft.com/en-us/download/details.aspx?id=44567"
     ],

--- a/types/xrm/v8/package.json
+++ b/types/xrm/v8/package.json
@@ -2,6 +2,8 @@
     "private": true,
     "name": "@types/xrm",
     "version": "8.2.9999",
+    "nonNpm": true,
+    "nonNpmDescription": "Javascript APIs available in Microsoft Dataverse/PowerApps model-driven apps and Dynamics 365 Customer Engagement (previously known as CRM).",
     "projects": [
         "http://www.microsoft.com/en-us/download/details.aspx?id=44567"
     ],

--- a/types/xrm/v8/package.json
+++ b/types/xrm/v8/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "@types/xrm",
     "version": "8.2.9999",
-    "nonNpm": true,
+    "nonNpm": "conflict",
     "nonNpmDescription": "Javascript APIs available in Microsoft Dataverse/PowerApps model-driven apps and Dynamics 365 Customer Engagement (previously known as CRM).",
     "projects": [
         "http://www.microsoft.com/en-us/download/details.aspx?id=44567"


### PR DESCRIPTION
These types are for APIs available inside Microsoft Dataverse, the "xrm" [NPM package](https://www.npmjs.com/package/xrm) looks like it was intended to be some kind of wrapper, but is unrelated in the sense that it doesn't provide the APIs that `@types/xrm` describes.