### PR TITLE
[react] Added missing optional initialValue in useDeferredValue()

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1835,7 +1835,7 @@ declare namespace React {
      * A good example of this is a text input.
      *
      * @param value The value that is going to be deferred
-     * @param initialValue A value to use during the initial render of a component. If this option is omitted, useDeferredValue will not defer during the initial render, because there’s no previous version of value that it can render instead.
+     * @param initialValue A value to use during the initial render of a component. If this option is omitted, `useDeferredValue` will not defer during the initial render, because there’s no previous version of `value` that it can render instead.
      *
      * @see {@link https://react.dev/reference/react/useDeferredValue}
      */

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1838,7 +1838,7 @@ declare namespace React {
      *
      * @see {@link https://react.dev/reference/react/useDeferredValue}
      */
-    export function useDeferredValue<T>(value: T): T;
+    export function useDeferredValue<T>(value: T, initialValue?: T): T;
 
     /**
      * Allows components to avoid undesirable loading states by waiting for content to load

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1835,6 +1835,7 @@ declare namespace React {
      * A good example of this is a text input.
      *
      * @param value The value that is going to be deferred
+     * @param initialValue A value to use during the initial render of a component. If this option is omitted, useDeferredValue will not defer during the initial render, because there’s no previous version of value that it can render instead.
      *
      * @see {@link https://react.dev/reference/react/useDeferredValue}
      */

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -1834,10 +1834,11 @@ declare namespace React {
      * A good example of this is a text input.
      *
      * @param value The value that is going to be deferred
+     * @param initialValue A value to use during the initial render of a component. If this option is omitted, useDeferredValue will not defer during the initial render, because there’s no previous version of value that it can render instead.
      *
      * @see {@link https://react.dev/reference/react/useDeferredValue}
      */
-    export function useDeferredValue<T>(value: T): T;
+    export function useDeferredValue<T>(value: T, initialValue?: T): T;
 
     /**
      * Allows components to avoid undesirable loading states by waiting for content to load

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -1834,7 +1834,7 @@ declare namespace React {
      * A good example of this is a text input.
      *
      * @param value The value that is going to be deferred
-     * @param initialValue A value to use during the initial render of a component. If this option is omitted, useDeferredValue will not defer during the initial render, because there’s no previous version of value that it can render instead.
+     * @param initialValue A value to use during the initial render of a component. If this option is omitted, `useDeferredValue` will not defer during the initial render, because there’s no previous version of `value` that it can render instead.
      *
      * @see {@link https://react.dev/reference/react/useDeferredValue}
      */


### PR DESCRIPTION
Added the optional `initialValue `in `useDeferredValue()` introduced in React 19:

see: https://react.dev/reference/react/useDeferredValue#usedeferredvalue


`export function useDeferredValue<T>(value: T, initialValue?: T): T;`

