### PR TITLE
Add `react-dom/static` types for React 19

### DIFF
--- a/types/react-dom/package.json
+++ b/types/react-dom/package.json
@@ -26,6 +26,11 @@
                 "default": "./server.d.ts"
             }
         },
+        "./static": {
+            "types": {
+                "default": "./static.d.ts"
+            }
+        },
         "./experimental": {
             "types": {
                 "default": "./experimental.d.ts"

--- a/types/react-dom/static.d.ts
+++ b/types/react-dom/static.d.ts
@@ -1,0 +1,72 @@
+// forward declarations
+declare global {
+    namespace NodeJS {
+        // eslint-disable-next-line @typescript-eslint/no-empty-interface
+        interface ReadableStream {}
+    }
+
+    /**
+     * Stub for https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+     */
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface AbortSignal {}
+
+    /**
+     * Stub for https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream
+     */
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface ReadableStream<R = any> {}
+
+    /**
+     * Stub for https://developer.mozilla.org/en-US/docs/Web/API/Uint8Array
+     */
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface Uint8Array {}
+}
+
+import { ReactNode } from "react";
+import { ErrorInfo } from "./client";
+
+export interface PrerenderOptions {
+    bootstrapScriptContent?: string;
+    bootstrapScripts?: string[];
+    bootstrapModules?: string[];
+    identifierPrefix?: string;
+    namespaceURI?: string;
+    onError?: (error: unknown, errorInfo: ErrorInfo) => string | void;
+    progressiveChunkSize?: number;
+    signal?: AbortSignal;
+}
+
+export interface PrerenderResult {
+    prelude: ReadableStream<Uint8Array>;
+}
+
+/**
+ * Only available in the environments with [Web Streams](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) (this includes browsers, Deno, and some modern edge runtimes).
+ *
+ * @see [API](https://react.dev/reference/react-dom/static/prerender)
+ */
+export function prerender(
+    reactNode: ReactNode,
+    options?: PrerenderOptions,
+): Promise<PrerenderResult>;
+
+export interface PrerenderToNodeStreamResult {
+    prelude: NodeJS.ReadableStream;
+}
+
+/**
+ * Only available in the environments with [Node.js Streams](https://nodejs.dev/learn/nodejs-streams).
+ *
+ * @see [API](https://react.dev/reference/react-dom/static/prerenderToNodeStream)
+ *
+ * @param children
+ * @param options
+ */
+export function prerenderToNodeStream(
+    reactNode: ReactNode,
+    options?: PrerenderOptions,
+): Promise<PrerenderToNodeStreamResult>;
+
+export const version: string;

--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as ReactDOMClient from "react-dom/client";
 import * as ReactDOMServer from "react-dom/server";
+import * as ReactDOMStatic from "react-dom/static";
 import * as ReactTestUtils from "react-dom/test-utils";
 
 declare function describe(desc: string, f: () => void): void;
@@ -53,6 +54,20 @@ describe("ReactDOMServer", () => {
     it("renderToStaticMarkup", () => {
         const content: string = ReactDOMServer.renderToStaticMarkup(React.createElement("div"));
         ReactDOMServer.renderToStaticMarkup(React.createElement("div"), { identifierPrefix: "react-18-app" });
+    });
+});
+
+describe("ReactDOMStatic", () => {
+    it("prerender", async () => {
+        const prelude: ReadableStream<Uint8Array> =
+            (await ReactDOMStatic.prerender(React.createElement("div"))).prelude;
+        ReactDOMStatic.prerender(React.createElement("div"), { bootstrapScripts: ["./my-script.js"] });
+    });
+
+    it("prerenderToNodeStream", async () => {
+        const prelude: NodeJS.ReadableStream =
+            (await ReactDOMStatic.prerenderToNodeStream(React.createElement("div"))).prelude;
+        ReactDOMStatic.prerenderToNodeStream(React.createElement("div"), { bootstrapScripts: ["./my-script.js"] });
     });
 });
 


### PR DESCRIPTION
The new types for ReactDOM 19 did not include the `static` exports.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react.dev/reference/react-dom/static
