### PR TITLE
[react] Declare React packages as `peerDependencies`

### DIFF
--- a/types/react-dom/package.json
+++ b/types/react-dom/package.json
@@ -42,8 +42,8 @@
             }
         }
     },
-    "dependencies": {
-        "@types/react": "*"
+    "peerDependencies": {
+        "@types/react": "^19.0.0"
     },
     "devDependencies": {
         "@types/react-dom": "workspace:."

--- a/types/react-dom/v15/package.json
+++ b/types/react-dom/v15/package.json
@@ -5,8 +5,8 @@
     "projects": [
         "http://facebook.github.io/react/"
     ],
-    "dependencies": {
-        "@types/react": "^15"
+    "peerDependencies": {
+        "@types/react": "^15.0.0"
     },
     "devDependencies": {
         "@types/react-dom": "workspace:."

--- a/types/react-dom/v16/package.json
+++ b/types/react-dom/v16/package.json
@@ -5,8 +5,8 @@
     "projects": [
         "https://reactjs.org"
     ],
-    "dependencies": {
-        "@types/react": "^16"
+    "peerDependencies": {
+        "@types/react": "^16.0.0"
     },
     "devDependencies": {
         "@types/react-dom": "workspace:."

--- a/types/react-dom/v17/package.json
+++ b/types/react-dom/v17/package.json
@@ -5,8 +5,8 @@
     "projects": [
         "https://reactjs.org"
     ],
-    "dependencies": {
-        "@types/react": "^17"
+    "peerDependencies": {
+        "@types/react": "^17.0.0"
     },
     "devDependencies": {
         "@types/react-dom": "workspace:."

--- a/types/react-dom/v18/package.json
+++ b/types/react-dom/v18/package.json
@@ -27,8 +27,8 @@
             }
         }
     },
-    "dependencies": {
-        "@types/react": "^18"
+    "peerDependencies": {
+        "@types/react": "^18.0.0"
     },
     "devDependencies": {
         "@types/react-dom": "workspace:."


### PR DESCRIPTION
Possible now that https://github.com/microsoft/DefinitelyTyped-tools/issues/433 has been implemented.

This should reduce the risk of installing duplicate versions of `@types/react`.

Will release this and let it soak a bit for testing and then file against all packages.
