### PR TITLE
Synced Diff package version

### DIFF
--- a/types/diff/package.json
+++ b/types/diff/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/diff",
-    "version": "6.0.9999",
+    "version": "7.0.9999",
     "projects": [
         "https://github.com/kpdecker/jsdiff"
     ],


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test diff`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/kpdecker/jsdiff/blob/master/release-notes.md>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

JsDiff version is on 7 and the newer version,

Just a single (breaking) bugfix, undoing a behaviour change introduced accidentally in 6.0.0:
-[#554](https://github.com/kpdecker/jsdiff/pull/554) ``diffWords`` treats numbers and underscores as word characters again. This behaviour was broken in v6.0.0.

