### PR TITLE
[react] Allow explicit `Promise<React.ReactNode>` return type in function components

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -132,7 +132,7 @@ declare namespace React {
     type JSXElementConstructor<P> =
         | ((
             props: P,
-        ) => ReactNode)
+        ) => ReactNode | Promise<ReactNode>)
         // constructor signature must match React.Component
         | (new(props: P) => Component<any, any>);
 
@@ -1036,7 +1036,7 @@ declare namespace React {
      * ```
      */
     interface FunctionComponent<P = {}> {
-        (props: P): ReactNode;
+        (props: P): ReactNode | Promise<ReactNode>;
         /**
          * Ignored by React.
          * @deprecated Only kept in types for backwards compatibility. Will be removed in a future major release.

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -711,7 +711,8 @@ function elementTypeTests() {
         }
     }
 
-    const ReturnPromiseReactNode = async ({ children }: { children?: React.ReactNode }) => children;
+    const ReturnPromiseReactNode = async ({ children }: { children?: React.ReactNode }): Promise<React.ReactNode> =>
+        children;
     const FCPromiseReactNode: React.FC = ReturnReactNode;
     class RenderPromiseReactNode extends React.Component<{ children?: React.ReactNode }> {
         // Undesired behavior.


### PR DESCRIPTION
Works around https://github.com/microsoft/TypeScript/issues/59111 by explicitly allowing `Promise<ReactNode>` as a return type of function component even though `ReactNode` already includes a promisified variant of `ReactNode`.

Closes https://github.com/vercel/next.js/discussions/67365