### PR TITLE
(fix): CloudfrontHeaders now handles strict mode

### DIFF
--- a/types/aws-lambda/common/cloudfront.d.ts
+++ b/types/aws-lambda/common/cloudfront.d.ts
@@ -9,7 +9,7 @@ export interface CloudFrontHeaders {
     [name: string]: Array<{
         key?: string | undefined;
         value: string;
-    }>;
+    }> | undefined;
 }
 
 export type CloudFrontOrigin =


### PR DESCRIPTION
As of now when you use strict null check it does not give an error when you access a header that might not exist. By adding the possibility of it being undefined, typescript will now show an error in compile time instead of error in runtime:
`Object is possibly 'undefined'.ts(2532)`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[TS Playground](https://www.typescriptlang.org/play/?#code/JYOwLgpgTgZghgYwgAgMIBsD2BXAJgMSk3AAkI5doBnZAbwFgAoZF5AbRDgFsIAuZKmCigA5gF1+AQShQ4ATwA8DZq1UBrCHID8-QcJAjkAH2TYQlGKAi4A3E1WqAbnHTY+AoaLsqWAXwB83r5MTAjEgsgAFuSUUFT8GDgERKQx1MgAvHT2yADk0RTQufxsyk4ubvz5aVAAtM6uELkANDksGnJVBbG5Ob5iTL7e3dRsuSCYYLVwtSNQuWIAdGCYAMqeBgAUAJTeIYygkLCIKIl4hMRgZIVx+MAAHtbZPuycPLob4lIy8kptDh0dB59IYTGYLFZbP9yo0PiDvKoAsZTOYIJYQNYgvswiAInMqHdHrgElhzikrjUCQ8nlkynk5sV2HSWA1KvSavUKk1Wi8Ol0ar0VP1BsNKYTrGMJlMZgylit1iCdt4gA)>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
