### PR TITLE
Move @types/react to peerDependencies for several packages

### DIFF
--- a/types/react-color/package.json
+++ b/types/react-color/package.json
@@ -7,8 +7,10 @@
         "http://casesandberg.github.io/react-color"
     ],
     "dependencies": {
-        "@types/react": "*",
         "@types/reactcss": "*"
+    },
+    "peerDependencies": {
+        "@types/react": "*"
     },
     "devDependencies": {
         "@types/react-color": "workspace:."

--- a/types/react-color/v2/package.json
+++ b/types/react-color/v2/package.json
@@ -7,8 +7,10 @@
         "http://casesandberg.github.io/react-color"
     ],
     "dependencies": {
-        "@types/react": "*",
         "@types/reactcss": "*"
+    },
+    "peerDependencies": {
+        "@types/react": "*"
     },
     "devDependencies": {
         "@types/react-color": "workspace:."

--- a/types/react-reconciler/package.json
+++ b/types/react-reconciler/package.json
@@ -5,7 +5,7 @@
     "projects": [
         "https://reactjs.org/"
     ],
-    "dependencies": {
+    "peerDependencies": {
         "@types/react": "*"
     },
     "devDependencies": {

--- a/types/react-transition-group/package.json
+++ b/types/react-transition-group/package.json
@@ -5,7 +5,7 @@
     "projects": [
         "https://github.com/reactjs/react-transition-group"
     ],
-    "dependencies": {
+    "peerDependencies": {
         "@types/react": "*"
     },
     "devDependencies": {

--- a/types/reactcss/package.json
+++ b/types/reactcss/package.json
@@ -5,7 +5,7 @@
     "projects": [
         "http://reactcss.com/"
     ],
-    "dependencies": {
+    "peerDependencies": {
         "@types/react": "*"
     },
     "devDependencies": {


### PR DESCRIPTION
With the release of @types/react@19, my package manager tries to install the latest version of @types/react instead of using the version I already have installed (i.e., @types/react@18). This PR resolves that by making @types/react a peer dependency.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
