### PR TITLE
[reflexbox] downgrade deps, don't deep import StyledComponent

### DIFF
--- a/types/reflexbox/index.d.ts
+++ b/types/reflexbox/index.d.ts
@@ -1,4 +1,4 @@
-import { StyledComponent } from "@emotion/styled/types/index";
+import { StyledComponent } from "@emotion/styled";
 import * as React from "react";
 import * as StyledSystem from "styled-system";
 

--- a/types/reflexbox/index.d.ts
+++ b/types/reflexbox/index.d.ts
@@ -1,4 +1,4 @@
-import { StyledComponent } from "@emotion/styled";
+import { StyledComponent } from "@emotion/styled/types/index";
 import * as React from "react";
 import * as StyledSystem from "styled-system";
 
@@ -15,7 +15,8 @@ export interface BoxProps
 
 export type BoxType = StyledComponent<
     React.JSX.IntrinsicElements["div"],
-    Omit<React.JSX.IntrinsicElements["div"] & BoxProps, keyof React.ClassAttributes<any>>
+    Omit<React.JSX.IntrinsicElements["div"] & BoxProps, keyof React.ClassAttributes<any>>,
+    {}
 >;
 
 export const Box: BoxType;

--- a/types/reflexbox/package.json
+++ b/types/reflexbox/package.json
@@ -6,10 +6,11 @@
         "https://github.com/rebassjs/rebass/tree/master/packages/reflexbox"
     ],
     "dependencies": {
-        "@emotion/react": "*",
-        "@emotion/styled": "*",
-        "@types/react": "*",
+        "@emotion/styled": "^10",
         "@types/styled-system": "*"
+    },
+    "peerDependencies": {
+        "@types/react": "^16"
     },
     "devDependencies": {
         "@types/reflexbox": "workspace:."


### PR DESCRIPTION
The structure of `@emtion/styled` changed in https://github.com/emotion-js/emotion/pull/3284. This type doesn't need to be deep imported (and probably never did).

Alternatively, `reflexbox` actually depends on `@emotion/styled@^10`, so that may be a more reasonable choice.

See also: https://github.com/DefinitelyTyped/DefinitelyTyped/actions/runs/12235827566/job/34127982886?pr=71379