### PR TITLE
[react] Restore Canary and Experimental release channel typings for v18

### DIFF
--- a/types/react/v18/canary.d.ts
+++ b/types/react/v18/canary.d.ts
@@ -1,0 +1,166 @@
+/**
+ * These are types for things that are present in the React `canary` release channel.
+ *
+ * To load the types declared here in an actual project, there are three ways. The easiest one,
+ * if your `tsconfig.json` already has a `"types"` array in the `"compilerOptions"` section,
+ * is to add `"react/canary"` to the `"types"` array.
+ *
+ * Alternatively, a specific import syntax can to be used from a typescript file.
+ * This module does not exist in reality, which is why the {} is important:
+ *
+ * ```ts
+ * import {} from 'react/canary'
+ * ```
+ *
+ * It is also possible to include it through a triple-slash reference:
+ *
+ * ```ts
+ * /// <reference types="react/canary" />
+ * ```
+ *
+ * Either the import or the reference only needs to appear once, anywhere in the project.
+ */
+
+// See https://github.com/facebook/react/blob/main/packages/react/src/React.js to see how the exports are declared,
+
+import React = require(".");
+
+export {};
+
+declare const UNDEFINED_VOID_ONLY: unique symbol;
+type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
+
+type NativeToggleEvent = ToggleEvent;
+
+declare module "." {
+    export type Usable<T> = PromiseLike<T> | Context<T>;
+
+    export function use<T>(usable: Usable<T>): T;
+
+    interface ServerContextJSONArray extends ReadonlyArray<ServerContextJSONValue> {}
+    export type ServerContextJSONValue =
+        | string
+        | boolean
+        | number
+        | null
+        | ServerContextJSONArray
+        | { [key: string]: ServerContextJSONValue };
+    export interface ServerContext<T extends ServerContextJSONValue> {
+        Provider: Provider<T>;
+    }
+    /**
+     * Accepts a context object (the value returned from `React.createContext` or `React.createServerContext`) and returns the current
+     * context value, as given by the nearest context provider for the given context.
+     *
+     * @version 16.8.0
+     * @see https://react.dev/reference/react/useContext
+     */
+    function useContext<T extends ServerContextJSONValue>(context: ServerContext<T>): T;
+    export function createServerContext<T extends ServerContextJSONValue>(
+        globalName: string,
+        defaultValue: T,
+    ): ServerContext<T>;
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    export function cache<CachedFunction extends Function>(fn: CachedFunction): CachedFunction;
+
+    export function unstable_useCacheRefresh(): () => void;
+
+    interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS {
+        functions: (formData: FormData) => void | Promise<void>;
+    }
+
+    export interface TransitionStartFunction {
+        /**
+         * Marks all state updates inside the async function as transitions
+         *
+         * @see {https://react.dev/reference/react/useTransition#starttransition}
+         *
+         * @param callback
+         */
+        (callback: () => Promise<VoidOrUndefinedOnly>): void;
+    }
+
+    /**
+     * Similar to `useTransition` but allows uses where hooks are not available.
+     *
+     * @param callback An _asynchronous_ function which causes state updates that can be deferred.
+     */
+    export function startTransition(scope: () => Promise<VoidOrUndefinedOnly>): void;
+
+    export function useOptimistic<State>(
+        passthrough: State,
+    ): [State, (action: State | ((pendingState: State) => State)) => void];
+    export function useOptimistic<State, Action>(
+        passthrough: State,
+        reducer: (state: State, action: Action) => State,
+    ): [State, (action: Action) => void];
+
+    interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES {
+        cleanup: () => VoidOrUndefinedOnly;
+    }
+
+    export function useActionState<State>(
+        action: (state: Awaited<State>) => State | Promise<State>,
+        initialState: Awaited<State>,
+        permalink?: string,
+    ): [state: Awaited<State>, dispatch: () => void, isPending: boolean];
+    export function useActionState<State, Payload>(
+        action: (state: Awaited<State>, payload: Payload) => State | Promise<State>,
+        initialState: Awaited<State>,
+        permalink?: string,
+    ): [state: Awaited<State>, dispatch: (payload: Payload) => void, isPending: boolean];
+
+    interface DOMAttributes<T> {
+        // Transition Events
+        onTransitionCancel?: TransitionEventHandler<T> | undefined;
+        onTransitionCancelCapture?: TransitionEventHandler<T> | undefined;
+        onTransitionRun?: TransitionEventHandler<T> | undefined;
+        onTransitionRunCapture?: TransitionEventHandler<T> | undefined;
+        onTransitionStart?: TransitionEventHandler<T> | undefined;
+        onTransitionStartCapture?: TransitionEventHandler<T> | undefined;
+    }
+
+    type ToggleEventHandler<T = Element> = EventHandler<ToggleEvent<T>>;
+
+    interface HTMLAttributes<T> {
+        popover?: "" | "auto" | "manual" | undefined;
+        popoverTargetAction?: "toggle" | "show" | "hide" | undefined;
+        popoverTarget?: string | undefined;
+        onToggle?: ToggleEventHandler<T> | undefined;
+        onBeforeToggle?: ToggleEventHandler<T> | undefined;
+    }
+
+    interface ToggleEvent<T = Element> extends SyntheticEvent<T, NativeToggleEvent> {
+        oldState: "closed" | "open";
+        newState: "closed" | "open";
+    }
+
+    interface LinkHTMLAttributes<T> {
+        precedence?: string | undefined;
+    }
+
+    interface StyleHTMLAttributes<T> {
+        href?: string | undefined;
+        precedence?: string | undefined;
+    }
+
+    /**
+     * @internal Use `Awaited<ReactNode>` instead
+     */
+    // Helper type to enable `Awaited<ReactNode>`.
+    // Must be a copy of the non-thenables of `ReactNode`.
+    type AwaitedReactNode =
+        | ReactElement
+        | string
+        | number
+        | Iterable<AwaitedReactNode>
+        | ReactPortal
+        | boolean
+        | null
+        | undefined;
+    interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES {
+        promises: Promise<AwaitedReactNode>;
+        bigints: bigint;
+    }
+}

--- a/types/react/v18/experimental.d.ts
+++ b/types/react/v18/experimental.d.ts
@@ -1,0 +1,132 @@
+/**
+ * These are types for things that are present in the `experimental` builds of React but not yet
+ * on a stable build.
+ *
+ * Once they are promoted to stable they can just be moved to the main index file.
+ *
+ * To load the types declared here in an actual project, there are three ways. The easiest one,
+ * if your `tsconfig.json` already has a `"types"` array in the `"compilerOptions"` section,
+ * is to add `"react/experimental"` to the `"types"` array.
+ *
+ * Alternatively, a specific import syntax can to be used from a typescript file.
+ * This module does not exist in reality, which is why the {} is important:
+ *
+ * ```ts
+ * import {} from 'react/experimental'
+ * ```
+ *
+ * It is also possible to include it through a triple-slash reference:
+ *
+ * ```ts
+ * /// <reference types="react/experimental" />
+ * ```
+ *
+ * Either the import or the reference only needs to appear once, anywhere in the project.
+ */
+
+// See https://github.com/facebook/react/blob/master/packages/react/src/React.js to see how the exports are declared,
+// and https://github.com/facebook/react/blob/master/packages/shared/ReactFeatureFlags.js to verify which APIs are
+// flagged experimental or not. Experimental APIs will be tagged with `__EXPERIMENTAL__`.
+//
+// For the inputs of types exported as simply a fiber tag, the `beginWork` function of ReactFiberBeginWork.js
+// is a good place to start looking for details; it generally calls prop validation functions or delegates
+// all tasks done as part of the render phase (the concurrent part of the React update cycle).
+//
+// Suspense-related handling can be found in ReactFiberThrow.js.
+
+import React = require("./canary");
+
+export {};
+
+declare const UNDEFINED_VOID_ONLY: unique symbol;
+type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
+
+declare module "." {
+    export interface SuspenseProps {
+        /**
+         * The presence of this prop indicates that the content is computationally expensive to render.
+         * In other words, the tree is CPU bound and not I/O bound (e.g. due to fetching data).
+         * @see {@link https://github.com/facebook/react/pull/19936}
+         */
+        unstable_expectedLoadTime?: number | undefined;
+    }
+
+    export type SuspenseListRevealOrder = "forwards" | "backwards" | "together";
+    export type SuspenseListTailMode = "collapsed" | "hidden";
+
+    export interface SuspenseListCommonProps {
+        /**
+         * Note that SuspenseList require more than one child;
+         * it is a runtime warning to provide only a single child.
+         *
+         * It does, however, allow those children to be wrapped inside a single
+         * level of `<React.Fragment>`.
+         */
+        children: ReactElement | Iterable<ReactElement>;
+    }
+
+    interface DirectionalSuspenseListProps extends SuspenseListCommonProps {
+        /**
+         * Defines the order in which the `SuspenseList` children should be revealed.
+         */
+        revealOrder: "forwards" | "backwards";
+        /**
+         * Dictates how unloaded items in a SuspenseList is shown.
+         *
+         * - By default, `SuspenseList` will show all fallbacks in the list.
+         * - `collapsed` shows only the next fallback in the list.
+         * - `hidden` doesn’t show any unloaded items.
+         */
+        tail?: SuspenseListTailMode | undefined;
+    }
+
+    interface NonDirectionalSuspenseListProps extends SuspenseListCommonProps {
+        /**
+         * Defines the order in which the `SuspenseList` children should be revealed.
+         */
+        revealOrder?: Exclude<SuspenseListRevealOrder, DirectionalSuspenseListProps["revealOrder"]> | undefined;
+        /**
+         * The tail property is invalid when not using the `forwards` or `backwards` reveal orders.
+         */
+        tail?: never | undefined;
+    }
+
+    export type SuspenseListProps = DirectionalSuspenseListProps | NonDirectionalSuspenseListProps;
+
+    /**
+     * `SuspenseList` helps coordinate many components that can suspend by orchestrating the order
+     * in which these components are revealed to the user.
+     *
+     * When multiple components need to fetch data, this data may arrive in an unpredictable order.
+     * However, if you wrap these items in a `SuspenseList`, React will not show an item in the list
+     * until previous items have been displayed (this behavior is adjustable).
+     *
+     * @see https://reactjs.org/docs/concurrent-mode-reference.html#suspenselist
+     * @see https://reactjs.org/docs/concurrent-mode-patterns.html#suspenselist
+     */
+    export const unstable_SuspenseList: ExoticComponent<SuspenseListProps>;
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    export function experimental_useEffectEvent<T extends Function>(event: T): T;
+
+    /**
+     * Warning: Only available in development builds.
+     */
+    function captureOwnerStack(): string | null;
+
+    type Reference = object;
+    type TaintableUniqueValue = string | bigint | ArrayBufferView;
+    function experimental_taintUniqueValue(
+        message: string | undefined,
+        lifetime: Reference,
+        value: TaintableUniqueValue,
+    ): void;
+    function experimental_taintObjectReference(message: string | undefined, object: Reference): void;
+
+    export interface HTMLAttributes<T> {
+        /**
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert
+         */
+        inert?: boolean | undefined;
+    }
+}

--- a/types/react/v18/test/canary.tsx
+++ b/types/react/v18/test/canary.tsx
@@ -1,0 +1,461 @@
+/// <reference types="../canary"/>
+
+// NOTE: forward declarations for tests
+declare var console: Console;
+interface Console {
+    log(...args: any[]): void;
+}
+
+const contextUsers = React.createContext(["HAL"]);
+const promisedUsers = Promise.resolve(["Dave"]);
+
+function useUse() {
+    // @ts-expect-error Missing value
+    React.use();
+
+    // $ExpectType string[]
+    const users = React.use(promisedUsers);
+    // @ts-expect-error incompatible type. Mainly to potentially inspect TypeScript error message
+    React.use({});
+
+    // $ExpectType string[]
+    const contextValue = React.use(contextUsers);
+}
+
+function serverContextTest() {
+    const ServerContext = React.createServerContext<string>("ServerContext", "default");
+
+    function ServerContextUser() {
+        const context = React.useContext(ServerContext);
+        return <React.Fragment>{context}</React.Fragment>;
+    }
+    // @ts-expect-error Consumer pattern is not supported on server context
+    ServerContext.Consumer;
+
+    function ServerContextProivder() {
+        return (
+            <ServerContext.Provider value="provided">
+                <ServerContextUser />
+            </ServerContext.Provider>
+        );
+    }
+
+    const ClientContext = React.createContext<string>("default");
+    function ClientContextUser() {
+        const context = React.useContext(ClientContext);
+        return <React.Fragment>{context}</React.Fragment>;
+    }
+
+    // plain objects work
+    React.createServerContext("PlainObjectContext", { foo: 1 });
+    // readonly arrays work
+    React.createServerContext("ReadonlyArrayContext", ["foo", "bar"] as const);
+    // nested readonly arrays work
+    React.createServerContext("ReadonlyArrayContext", ["foo", ["bar"]] as const);
+    // @ts-expect-error Incompatible with JSON stringify+parse
+    React.createServerContext("DateContext", new Date());
+    // @ts-expect-error Incompatible with JSON stringify+parse
+    React.createServerContext("SetContext", new Set());
+}
+
+function cacheTest() {
+    const getLength = React.cache((a: string) => a.length);
+    const fooLength: number = getLength("foo");
+    getLength(
+        // @ts-expect-error -- number not assignable to string
+        133,
+    );
+
+    React.cache(
+        // @ts-expect-error implicit any
+        a => a,
+    );
+}
+
+function useCacheTest() {
+    const useCacheRefresh = React.unstable_useCacheRefresh;
+
+    const refresh = useCacheRefresh();
+
+    function handleRefresh() {
+        // @ts-expect-error -- experimental only
+        refresh(() => "refresh", "initial");
+        // @ts-expect-error -- experimental only
+        refresh(() => "refresh");
+        refresh();
+
+        // @ts-expect-error -- experimental only
+        refresh(() => "refresh", 0);
+
+        // @ts-expect-error -- experimental only
+        refresh(() => "refresh");
+    }
+}
+
+function useAsyncAction() {
+    const [isPending, startTransition] = React.useTransition();
+
+    function handleClick() {
+        // $ExpectType void
+        startTransition(async () => {});
+        React.startTransition(async () => {});
+    }
+}
+
+function formActionsTest() {
+    <form
+        action={formData => {
+            // $ExpectType FormData
+            formData;
+        }}
+    >
+        <input type="text" name="title" defaultValue="Hello" />
+        <input
+            type="submit"
+            formAction={formData => {
+                // $ExpectType FormData
+                formData;
+            }}
+            value="Save"
+        />
+        <button
+            formAction={formData => {
+                // $ExpectType FormData
+                formData;
+            }}
+        >
+            Delete
+        </button>
+    </form>;
+
+    <form
+        action={async (formData) => {
+            // $ExpectType FormData
+            formData;
+        }}
+    />;
+
+    <form
+        // @ts-expect-error -- Type 'Promise<number>' is not assignable to type 'Promise<void>'
+        action={async () => {
+            return 1;
+        }}
+    />;
+}
+
+const useOptimistic = React.useOptimistic;
+function Optimistic() {
+    const savedCartSize = 0;
+    const [optimisticCartSize, addToOptimisticCart] = useOptimistic(savedCartSize, (prevSize, newItem) => {
+        // This is the default type for un-inferrable generics in TypeScript.
+        // To have a concrete type either type the second parameter in the reducer (see addToOptimisticCartTyped)
+        // or declare the type of the generic (see addToOptimisticCartTyped2)
+        // $ExpectType unknown
+        newItem;
+        console.log("Increment optimistic cart size for " + newItem);
+        return prevSize + 1;
+    });
+    // $ExpectType number
+    optimisticCartSize;
+
+    const [, addToOptimisticCartTyped] = useOptimistic(savedCartSize, (prevSize, newItem: string) => {
+        // $ExpectType string
+        newItem;
+        console.log("Increment optimistic cart size for " + newItem);
+        return prevSize + 1;
+    });
+    const [, addToOptimisticCartTyped2] = useOptimistic<number, string>(savedCartSize, (prevSize, newItem) => {
+        // $ExpectType string
+        newItem;
+        console.log("Increment optimistic cart size for " + newItem);
+        return prevSize + 1;
+    });
+
+    const addItemToCart = (item: unknown) => {
+        addToOptimisticCart(item);
+        addToOptimisticCartTyped(
+            // @ts-expect-error unknown is not assignable to string
+            item,
+        );
+        addToOptimisticCartTyped(String(item));
+        addToOptimisticCartTyped2(
+            // @ts-expect-error unknown is not assignable to string
+            item,
+        );
+        addToOptimisticCartTyped2(String(item));
+    };
+
+    const [state, setStateDefaultAction] = useOptimistic(1);
+    const handleClick = () => {
+        setStateDefaultAction(2);
+        setStateDefaultAction(() => 3);
+        setStateDefaultAction(n => n + 1);
+        // @ts-expect-error string is not assignable to number
+        setStateDefaultAction("4");
+    };
+}
+
+// ref cleanup
+const ref: React.RefCallback<HTMLDivElement> = current => {
+    // Should be non-nullable
+    // $ExpectType HTMLDivElement | null
+    current;
+    return function refCleanup() {
+    };
+};
+<div
+    ref={current => {
+        // Should be non-nullable
+        // $ExpectType HTMLDivElement | null
+        current;
+        return function refCleanup() {
+        };
+    }}
+/>;
+<div
+    // @ts-expect-error ref cleanup does not accept arguments
+    ref={current => {
+        // @ts-expect-error
+        return function refCleanup(implicitAny) {
+        };
+    }}
+/>;
+<div
+    // @ts-expect-error ref cleanup does not accept arguments
+    ref={current => {
+        return function refCleanup(neverPassed: string) {
+        };
+    }}
+/>;
+
+const useActionState = React.useActionState;
+// Keep in sync with ReactDOM.useFormState tests
+function formTest() {
+    function Page1() {
+        async function action(state: number) {
+            return state + 1;
+        }
+
+        const [
+            // $ExpectType number
+            state,
+            dispatch,
+            // $ExpectType boolean
+            isPending,
+        ] = useActionState(action, 1);
+
+        function actionExpectingPromiseState(state: Promise<number>) {
+            return state.then((s) => s + 1);
+        }
+
+        useActionState(
+            // @ts-expect-error
+            actionExpectingPromiseState,
+            Promise.resolve(1),
+        );
+        useActionState(
+            action,
+            // @ts-expect-error
+            Promise.resolve(1),
+        );
+        // $ExpectType number
+        useActionState<Promise<number>>(action, 1)[0];
+
+        useActionState(
+            async (
+                prevState: // only needed in TypeScript 4.9
+                    // 5.0 infers `number` whereas 4.9 infers `0`
+                    number,
+            ) => prevState + 1,
+            0,
+        )[0];
+        // $ExpectType number
+        useActionState(
+            async (prevState) => prevState + 1,
+            // @ts-expect-error
+            Promise.resolve(0),
+        )[0];
+
+        const [
+            state2,
+            action2,
+            // $ExpectType boolean
+            isPending2,
+        ] = useActionState(
+            async (state: React.ReactNode, payload: FormData): Promise<React.ReactNode> => {
+                return state;
+            },
+            (
+                <button>
+                    New Project
+                </button>
+            ),
+        );
+
+        return (
+            <button
+                onClick={() => {
+                    dispatch();
+                }}
+            >
+                count: {state}
+            </button>
+        );
+    }
+
+    function Page2() {
+        async function action(state: number) {
+            return state + 1;
+        }
+
+        const [
+            // $ExpectType number
+            state,
+            dispatch,
+        ] = useActionState(action, 1, "/permalink");
+        return (
+            <form action={dispatch}>
+                <span>Count: {state}</span>
+                <input type="text" name="incrementAmount" defaultValue="5" />
+            </form>
+        );
+    }
+
+    function Page3() {
+        function actionSync(state: number, type: "increment" | "decrement") {
+            return state + (type === "increment" ? 1 : -1);
+        }
+
+        const [
+            // $ExpectType number
+            state,
+            dispatch,
+        ] = useActionState(actionSync, 1, "/permalink");
+        return (
+            <button
+                onClick={() => {
+                    dispatch("decrement");
+                }}
+            >
+                count: {state}
+            </button>
+        );
+    }
+
+    function Page4() {
+        async function action(state: number, type: "increment" | "decrement") {
+            return state + (type === "increment" ? 1 : -1);
+        }
+
+        const [
+            // $ExpectType number
+            state,
+            dispatch,
+        ] = useActionState(action, 1, "/permalink");
+        return (
+            <button
+                onClick={() => {
+                    dispatch("decrement");
+                }}
+            >
+                count: {state}
+            </button>
+        );
+    }
+}
+
+// New transition events
+<div
+    onTransitionStart={event => {
+        // $ExpectType TransitionEvent<HTMLDivElement>
+        event;
+    }}
+    onTransitionRun={event => {
+        // $ExpectType TransitionEvent<HTMLDivElement>
+        event;
+    }}
+    onTransitionCancel={event => {
+        // $ExpectType TransitionEvent<HTMLDivElement>
+        event;
+    }}
+    onTransitionEnd={event => {
+        // $ExpectType TransitionEvent<HTMLDivElement>
+        event;
+    }}
+/>;
+
+// ReactNode tests
+{
+    // @ts-expect-error
+    const render: React.ReactNode = () => React.createElement("div");
+    // @ts-expect-error
+    const emptyObject: React.ReactNode = {};
+    // @ts-expect-error
+    const plainObject: React.ReactNode = { dave: true };
+    const promise: React.ReactNode = Promise.resolve("React");
+    // @ts-expect-error plain objects are not allowed
+    <div>{{ dave: true }}</div>;
+    <div>{Promise.resolve("React")}</div>;
+
+    const asyncTests = async function asyncTests() {
+        const node: Awaited<React.ReactNode> = await Promise.resolve("React");
+    };
+
+    const RenderableContext = React.createContext<React.ReactNode>("HAL");
+    const NestedContext = React.createContext(RenderableContext);
+    // @ts-expect-error TODO Is supported in Canary release channel
+    let node: React.ReactNode = RenderableContext;
+    // @ts-expect-error TODO context values are recursively unwrapped so this should be allowed by types.
+    node = NestedContext;
+
+    const NotRenderableContext = React.createContext(() => {});
+    // @ts-expect-error
+    node = NotRenderableContext;
+
+    node = BigInt(10);
+}
+
+function PopoverAPI() {
+    return (
+        <>
+            <div
+                id="popover-target"
+                popover=""
+                onBeforeToggle={event => {
+                    // $ExpectType 'open' | 'closed'
+                    event.newState;
+                    // $ExpectType 'open' | 'closed'
+                    event.oldState;
+                }}
+                onToggle={event => {
+                    // $ExpectType 'open' | 'closed'
+                    event.newState;
+                    // $ExpectType 'open' | 'closed'
+                    event.oldState;
+                }}
+            >
+            </div>
+            <div popover="auto" />
+            <div popover="manual" />
+            <div
+                // @ts-expect-error accidental boolean
+                popover
+            />
+            <button popoverTarget="popover-target">Toggle</button>
+            <button popoverTarget="popover-target" popoverTargetAction="toggle">Toggle</button>
+            <button popoverTarget="popover-target" popoverTargetAction="show">Show</button>
+            <button popoverTarget="popover-target" popoverTargetAction="hide">Hide</button>
+            <button
+                popoverTarget="popover-target"
+                // @ts-expect-error
+                popoverTargetAction="bad"
+            >
+                Hide
+            </button>
+        </>
+    );
+}
+
+// New <link> and <style> props
+<link href="https://foo.bar" precedence="medium" rel="canonical" />;
+<style href="unique-style-hash" precedence="anything">{` p { color: red; } `}</style>;

--- a/types/react/v18/test/experimental.tsx
+++ b/types/react/v18/test/experimental.tsx
@@ -1,0 +1,145 @@
+/// <reference types="../experimental"/>
+
+import React = require("react");
+
+// NOTE: forward declarations for tests
+declare var console: Console;
+interface Console {
+    log(...args: any[]): void;
+}
+
+function suspenseTest() {
+    function DisplayData() {
+        return null;
+    }
+
+    function FlameChart() {
+        return (
+            <React.Suspense fallback="computing..." unstable_expectedLoadTime={2000}>
+                <DisplayData />
+            </React.Suspense>
+        );
+    }
+}
+
+// Unsupported `revealOrder` triggers a runtime warning
+// @ts-expect-error
+<React.unstable_SuspenseList revealOrder="something">
+    <React.Suspense fallback="Loading">Content</React.Suspense>
+</React.unstable_SuspenseList>;
+
+<React.unstable_SuspenseList revealOrder="backwards">
+    <React.Suspense fallback="Loading">A</React.Suspense>
+    <React.Suspense fallback="Loading">B</React.Suspense>
+</React.unstable_SuspenseList>;
+
+<React.unstable_SuspenseList revealOrder="forwards">
+    <React.Suspense fallback="Loading">A</React.Suspense>
+    <React.Suspense fallback="Loading">B</React.Suspense>
+</React.unstable_SuspenseList>;
+
+<React.unstable_SuspenseList revealOrder="together">
+    <React.Suspense fallback="Loading">A</React.Suspense>
+    <React.Suspense fallback="Loading">B</React.Suspense>
+</React.unstable_SuspenseList>;
+
+function ownerStacks() {
+    // $ExpectType string | null
+    const ownerStack = React.captureOwnerStack();
+}
+
+function useEvent() {
+    // Implicit any
+    // @ts-expect-error
+    const anyEvent = React.experimental_useEffectEvent(value => {
+        // $ExpectType any
+        return value;
+    });
+    // $ExpectType any
+    anyEvent({});
+    // $ExpectType (value: string) => number
+    const typedEvent = React.experimental_useEffectEvent((value: string) => {
+        return Number(value);
+    });
+    // $ExpectType number
+    typedEvent("1");
+    // Argument of type '{}' is not assignable to parameter of type 'string'.
+    // @ts-expect-error
+    typedEvent({});
+
+    function useContextuallyTypedEvent(fn: (event: Event) => string) {}
+    useContextuallyTypedEvent(
+        React.experimental_useEffectEvent(event => {
+            // $ExpectType Event
+            event;
+            return String(event);
+        }),
+    );
+}
+
+function elementTypeTests() {
+    const ReturnPromise = () => Promise.resolve("React");
+    const FCPromise: React.FC = ReturnPromise;
+    class RenderPromise extends React.Component {
+        render() {
+            return Promise.resolve("React");
+        }
+    }
+
+    <ReturnPromise />;
+    React.createElement(ReturnPromise);
+    <RenderPromise />;
+    React.createElement(RenderPromise);
+}
+
+function taintTests() {
+    const taintUniqueValue = React.experimental_taintUniqueValue;
+    const taintObjectReference = React.experimental_taintObjectReference;
+
+    const process = {
+        env: {
+            SECRET: "0967af1802d2a516e88c7c42e0b8ef95",
+        },
+    };
+    const user = {
+        name: "Sebbie",
+    };
+
+    taintUniqueValue("Cannot pass a secret token to the client", process, process.env.SECRET);
+    taintUniqueValue(undefined, process, process.env.SECRET);
+    // @ts-expect-error Probably meant `taintObjectReference`
+    taintUniqueValue(
+        undefined,
+        user,
+    );
+    taintUniqueValue(
+        undefined,
+        process,
+        // @ts-expect-error should use taintObjectReference instead
+        process.env,
+    );
+    taintUniqueValue(
+        undefined,
+        process,
+        // @ts-expect-error Not unique
+        5,
+    );
+
+    taintObjectReference("Don't pass the raw user object to the client", user);
+    taintObjectReference(undefined, user);
+    taintObjectReference(
+        undefined,
+        // @ts-expect-error Not a reference
+        process.env.SECRET,
+    );
+    taintObjectReference(
+        undefined,
+        // @ts-expect-error Not a reference
+        true,
+    );
+}
+
+<div inert={true} />;
+<div inert={false} />;
+<div // @ts-expect-error Old workaround that used to result in `element.inert = true` but would now result in `element.inert = false`
+ inert="" />;

--- a/types/react/v18/ts5.0/canary.d.ts
+++ b/types/react/v18/ts5.0/canary.d.ts
@@ -1,0 +1,166 @@
+/**
+ * These are types for things that are present in the React `canary` release channel.
+ *
+ * To load the types declared here in an actual project, there are three ways. The easiest one,
+ * if your `tsconfig.json` already has a `"types"` array in the `"compilerOptions"` section,
+ * is to add `"react/canary"` to the `"types"` array.
+ *
+ * Alternatively, a specific import syntax can to be used from a typescript file.
+ * This module does not exist in reality, which is why the {} is important:
+ *
+ * ```ts
+ * import {} from 'react/canary'
+ * ```
+ *
+ * It is also possible to include it through a triple-slash reference:
+ *
+ * ```ts
+ * /// <reference types="react/canary" />
+ * ```
+ *
+ * Either the import or the reference only needs to appear once, anywhere in the project.
+ */
+
+// See https://github.com/facebook/react/blob/main/packages/react/src/React.js to see how the exports are declared,
+
+import React = require(".");
+
+export {};
+
+declare const UNDEFINED_VOID_ONLY: unique symbol;
+type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
+
+type NativeToggleEvent = ToggleEvent;
+
+declare module "." {
+    export type Usable<T> = PromiseLike<T> | Context<T>;
+
+    export function use<T>(usable: Usable<T>): T;
+
+    interface ServerContextJSONArray extends ReadonlyArray<ServerContextJSONValue> {}
+    export type ServerContextJSONValue =
+        | string
+        | boolean
+        | number
+        | null
+        | ServerContextJSONArray
+        | { [key: string]: ServerContextJSONValue };
+    export interface ServerContext<T extends ServerContextJSONValue> {
+        Provider: Provider<T>;
+    }
+    /**
+     * Accepts a context object (the value returned from `React.createContext` or `React.createServerContext`) and returns the current
+     * context value, as given by the nearest context provider for the given context.
+     *
+     * @version 16.8.0
+     * @see https://react.dev/reference/react/useContext
+     */
+    function useContext<T extends ServerContextJSONValue>(context: ServerContext<T>): T;
+    export function createServerContext<T extends ServerContextJSONValue>(
+        globalName: string,
+        defaultValue: T,
+    ): ServerContext<T>;
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    export function cache<CachedFunction extends Function>(fn: CachedFunction): CachedFunction;
+
+    export function unstable_useCacheRefresh(): () => void;
+
+    interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS {
+        functions: (formData: FormData) => void | Promise<void>;
+    }
+
+    export interface TransitionStartFunction {
+        /**
+         * Marks all state updates inside the async function as transitions
+         *
+         * @see {https://react.dev/reference/react/useTransition#starttransition}
+         *
+         * @param callback
+         */
+        (callback: () => Promise<VoidOrUndefinedOnly>): void;
+    }
+
+    /**
+     * Similar to `useTransition` but allows uses where hooks are not available.
+     *
+     * @param callback An _asynchronous_ function which causes state updates that can be deferred.
+     */
+    export function startTransition(scope: () => Promise<VoidOrUndefinedOnly>): void;
+
+    export function useOptimistic<State>(
+        passthrough: State,
+    ): [State, (action: State | ((pendingState: State) => State)) => void];
+    export function useOptimistic<State, Action>(
+        passthrough: State,
+        reducer: (state: State, action: Action) => State,
+    ): [State, (action: Action) => void];
+
+    interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES {
+        cleanup: () => VoidOrUndefinedOnly;
+    }
+
+    export function useActionState<State>(
+        action: (state: Awaited<State>) => State | Promise<State>,
+        initialState: Awaited<State>,
+        permalink?: string,
+    ): [state: Awaited<State>, dispatch: () => void, isPending: boolean];
+    export function useActionState<State, Payload>(
+        action: (state: Awaited<State>, payload: Payload) => State | Promise<State>,
+        initialState: Awaited<State>,
+        permalink?: string,
+    ): [state: Awaited<State>, dispatch: (payload: Payload) => void, isPending: boolean];
+
+    interface DOMAttributes<T> {
+        // Transition Events
+        onTransitionCancel?: TransitionEventHandler<T> | undefined;
+        onTransitionCancelCapture?: TransitionEventHandler<T> | undefined;
+        onTransitionRun?: TransitionEventHandler<T> | undefined;
+        onTransitionRunCapture?: TransitionEventHandler<T> | undefined;
+        onTransitionStart?: TransitionEventHandler<T> | undefined;
+        onTransitionStartCapture?: TransitionEventHandler<T> | undefined;
+    }
+
+    type ToggleEventHandler<T = Element> = EventHandler<ToggleEvent<T>>;
+
+    interface HTMLAttributes<T> {
+        popover?: "" | "auto" | "manual" | undefined;
+        popoverTargetAction?: "toggle" | "show" | "hide" | undefined;
+        popoverTarget?: string | undefined;
+        onToggle?: ToggleEventHandler<T> | undefined;
+        onBeforeToggle?: ToggleEventHandler<T> | undefined;
+    }
+
+    interface ToggleEvent<T = Element> extends SyntheticEvent<T, NativeToggleEvent> {
+        oldState: "closed" | "open";
+        newState: "closed" | "open";
+    }
+
+    interface LinkHTMLAttributes<T> {
+        precedence?: string | undefined;
+    }
+
+    interface StyleHTMLAttributes<T> {
+        href?: string | undefined;
+        precedence?: string | undefined;
+    }
+
+    /**
+     * @internal Use `Awaited<ReactNode>` instead
+     */
+    // Helper type to enable `Awaited<ReactNode>`.
+    // Must be a copy of the non-thenables of `ReactNode`.
+    type AwaitedReactNode =
+        | ReactElement
+        | string
+        | number
+        | Iterable<AwaitedReactNode>
+        | ReactPortal
+        | boolean
+        | null
+        | undefined;
+    interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES {
+        promises: Promise<AwaitedReactNode>;
+        bigints: bigint;
+    }
+}

--- a/types/react/v18/ts5.0/experimental.d.ts
+++ b/types/react/v18/ts5.0/experimental.d.ts
@@ -1,0 +1,132 @@
+/**
+ * These are types for things that are present in the `experimental` builds of React but not yet
+ * on a stable build.
+ *
+ * Once they are promoted to stable they can just be moved to the main index file.
+ *
+ * To load the types declared here in an actual project, there are three ways. The easiest one,
+ * if your `tsconfig.json` already has a `"types"` array in the `"compilerOptions"` section,
+ * is to add `"react/experimental"` to the `"types"` array.
+ *
+ * Alternatively, a specific import syntax can to be used from a typescript file.
+ * This module does not exist in reality, which is why the {} is important:
+ *
+ * ```ts
+ * import {} from 'react/experimental'
+ * ```
+ *
+ * It is also possible to include it through a triple-slash reference:
+ *
+ * ```ts
+ * /// <reference types="react/experimental" />
+ * ```
+ *
+ * Either the import or the reference only needs to appear once, anywhere in the project.
+ */
+
+// See https://github.com/facebook/react/blob/master/packages/react/src/React.js to see how the exports are declared,
+// and https://github.com/facebook/react/blob/master/packages/shared/ReactFeatureFlags.js to verify which APIs are
+// flagged experimental or not. Experimental APIs will be tagged with `__EXPERIMENTAL__`.
+//
+// For the inputs of types exported as simply a fiber tag, the `beginWork` function of ReactFiberBeginWork.js
+// is a good place to start looking for details; it generally calls prop validation functions or delegates
+// all tasks done as part of the render phase (the concurrent part of the React update cycle).
+//
+// Suspense-related handling can be found in ReactFiberThrow.js.
+
+import React = require("./canary");
+
+export {};
+
+declare const UNDEFINED_VOID_ONLY: unique symbol;
+type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
+
+declare module "." {
+    export interface SuspenseProps {
+        /**
+         * The presence of this prop indicates that the content is computationally expensive to render.
+         * In other words, the tree is CPU bound and not I/O bound (e.g. due to fetching data).
+         * @see {@link https://github.com/facebook/react/pull/19936}
+         */
+        unstable_expectedLoadTime?: number | undefined;
+    }
+
+    export type SuspenseListRevealOrder = "forwards" | "backwards" | "together";
+    export type SuspenseListTailMode = "collapsed" | "hidden";
+
+    export interface SuspenseListCommonProps {
+        /**
+         * Note that SuspenseList require more than one child;
+         * it is a runtime warning to provide only a single child.
+         *
+         * It does, however, allow those children to be wrapped inside a single
+         * level of `<React.Fragment>`.
+         */
+        children: ReactElement | Iterable<ReactElement>;
+    }
+
+    interface DirectionalSuspenseListProps extends SuspenseListCommonProps {
+        /**
+         * Defines the order in which the `SuspenseList` children should be revealed.
+         */
+        revealOrder: "forwards" | "backwards";
+        /**
+         * Dictates how unloaded items in a SuspenseList is shown.
+         *
+         * - By default, `SuspenseList` will show all fallbacks in the list.
+         * - `collapsed` shows only the next fallback in the list.
+         * - `hidden` doesn’t show any unloaded items.
+         */
+        tail?: SuspenseListTailMode | undefined;
+    }
+
+    interface NonDirectionalSuspenseListProps extends SuspenseListCommonProps {
+        /**
+         * Defines the order in which the `SuspenseList` children should be revealed.
+         */
+        revealOrder?: Exclude<SuspenseListRevealOrder, DirectionalSuspenseListProps["revealOrder"]> | undefined;
+        /**
+         * The tail property is invalid when not using the `forwards` or `backwards` reveal orders.
+         */
+        tail?: never | undefined;
+    }
+
+    export type SuspenseListProps = DirectionalSuspenseListProps | NonDirectionalSuspenseListProps;
+
+    /**
+     * `SuspenseList` helps coordinate many components that can suspend by orchestrating the order
+     * in which these components are revealed to the user.
+     *
+     * When multiple components need to fetch data, this data may arrive in an unpredictable order.
+     * However, if you wrap these items in a `SuspenseList`, React will not show an item in the list
+     * until previous items have been displayed (this behavior is adjustable).
+     *
+     * @see https://reactjs.org/docs/concurrent-mode-reference.html#suspenselist
+     * @see https://reactjs.org/docs/concurrent-mode-patterns.html#suspenselist
+     */
+    export const unstable_SuspenseList: ExoticComponent<SuspenseListProps>;
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    export function experimental_useEffectEvent<T extends Function>(event: T): T;
+
+    /**
+     * Warning: Only available in development builds.
+     */
+    function captureOwnerStack(): string | null;
+
+    type Reference = object;
+    type TaintableUniqueValue = string | bigint | ArrayBufferView;
+    function experimental_taintUniqueValue(
+        message: string | undefined,
+        lifetime: Reference,
+        value: TaintableUniqueValue,
+    ): void;
+    function experimental_taintObjectReference(message: string | undefined, object: Reference): void;
+
+    export interface HTMLAttributes<T> {
+        /**
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert
+         */
+        inert?: boolean | undefined;
+    }
+}

--- a/types/react/v18/ts5.0/test/canary.tsx
+++ b/types/react/v18/ts5.0/test/canary.tsx
@@ -1,0 +1,461 @@
+/// <reference types="../canary"/>
+
+// NOTE: forward declarations for tests
+declare var console: Console;
+interface Console {
+    log(...args: any[]): void;
+}
+
+const contextUsers = React.createContext(["HAL"]);
+const promisedUsers = Promise.resolve(["Dave"]);
+
+function useUse() {
+    // @ts-expect-error Missing value
+    React.use();
+
+    // $ExpectType string[]
+    const users = React.use(promisedUsers);
+    // @ts-expect-error incompatible type. Mainly to potentially inspect TypeScript error message
+    React.use({});
+
+    // $ExpectType string[]
+    const contextValue = React.use(contextUsers);
+}
+
+function serverContextTest() {
+    const ServerContext = React.createServerContext<string>("ServerContext", "default");
+
+    function ServerContextUser() {
+        const context = React.useContext(ServerContext);
+        return <React.Fragment>{context}</React.Fragment>;
+    }
+    // @ts-expect-error Consumer pattern is not supported on server context
+    ServerContext.Consumer;
+
+    function ServerContextProivder() {
+        return (
+            <ServerContext.Provider value="provided">
+                <ServerContextUser />
+            </ServerContext.Provider>
+        );
+    }
+
+    const ClientContext = React.createContext<string>("default");
+    function ClientContextUser() {
+        const context = React.useContext(ClientContext);
+        return <React.Fragment>{context}</React.Fragment>;
+    }
+
+    // plain objects work
+    React.createServerContext("PlainObjectContext", { foo: 1 });
+    // readonly arrays work
+    React.createServerContext("ReadonlyArrayContext", ["foo", "bar"] as const);
+    // nested readonly arrays work
+    React.createServerContext("ReadonlyArrayContext", ["foo", ["bar"]] as const);
+    // @ts-expect-error Incompatible with JSON stringify+parse
+    React.createServerContext("DateContext", new Date());
+    // @ts-expect-error Incompatible with JSON stringify+parse
+    React.createServerContext("SetContext", new Set());
+}
+
+function cacheTest() {
+    const getLength = React.cache((a: string) => a.length);
+    const fooLength: number = getLength("foo");
+    getLength(
+        // @ts-expect-error -- number not assignable to string
+        133,
+    );
+
+    React.cache(
+        // @ts-expect-error implicit any
+        a => a,
+    );
+}
+
+function useCacheTest() {
+    const useCacheRefresh = React.unstable_useCacheRefresh;
+
+    const refresh = useCacheRefresh();
+
+    function handleRefresh() {
+        // @ts-expect-error -- experimental only
+        refresh(() => "refresh", "initial");
+        // @ts-expect-error -- experimental only
+        refresh(() => "refresh");
+        refresh();
+
+        // @ts-expect-error -- experimental only
+        refresh(() => "refresh", 0);
+
+        // @ts-expect-error -- experimental only
+        refresh(() => "refresh");
+    }
+}
+
+function useAsyncAction() {
+    const [isPending, startTransition] = React.useTransition();
+
+    function handleClick() {
+        // $ExpectType void
+        startTransition(async () => {});
+        React.startTransition(async () => {});
+    }
+}
+
+function formActionsTest() {
+    <form
+        action={formData => {
+            // $ExpectType FormData
+            formData;
+        }}
+    >
+        <input type="text" name="title" defaultValue="Hello" />
+        <input
+            type="submit"
+            formAction={formData => {
+                // $ExpectType FormData
+                formData;
+            }}
+            value="Save"
+        />
+        <button
+            formAction={formData => {
+                // $ExpectType FormData
+                formData;
+            }}
+        >
+            Delete
+        </button>
+    </form>;
+
+    <form
+        action={async (formData) => {
+            // $ExpectType FormData
+            formData;
+        }}
+    />;
+
+    <form
+        // @ts-expect-error -- Type 'Promise<number>' is not assignable to type 'Promise<void>'
+        action={async () => {
+            return 1;
+        }}
+    />;
+}
+
+const useOptimistic = React.useOptimistic;
+function Optimistic() {
+    const savedCartSize = 0;
+    const [optimisticCartSize, addToOptimisticCart] = useOptimistic(savedCartSize, (prevSize, newItem) => {
+        // This is the default type for un-inferrable generics in TypeScript.
+        // To have a concrete type either type the second parameter in the reducer (see addToOptimisticCartTyped)
+        // or declare the type of the generic (see addToOptimisticCartTyped2)
+        // $ExpectType unknown
+        newItem;
+        console.log("Increment optimistic cart size for " + newItem);
+        return prevSize + 1;
+    });
+    // $ExpectType number
+    optimisticCartSize;
+
+    const [, addToOptimisticCartTyped] = useOptimistic(savedCartSize, (prevSize, newItem: string) => {
+        // $ExpectType string
+        newItem;
+        console.log("Increment optimistic cart size for " + newItem);
+        return prevSize + 1;
+    });
+    const [, addToOptimisticCartTyped2] = useOptimistic<number, string>(savedCartSize, (prevSize, newItem) => {
+        // $ExpectType string
+        newItem;
+        console.log("Increment optimistic cart size for " + newItem);
+        return prevSize + 1;
+    });
+
+    const addItemToCart = (item: unknown) => {
+        addToOptimisticCart(item);
+        addToOptimisticCartTyped(
+            // @ts-expect-error unknown is not assignable to string
+            item,
+        );
+        addToOptimisticCartTyped(String(item));
+        addToOptimisticCartTyped2(
+            // @ts-expect-error unknown is not assignable to string
+            item,
+        );
+        addToOptimisticCartTyped2(String(item));
+    };
+
+    const [state, setStateDefaultAction] = useOptimistic(1);
+    const handleClick = () => {
+        setStateDefaultAction(2);
+        setStateDefaultAction(() => 3);
+        setStateDefaultAction(n => n + 1);
+        // @ts-expect-error string is not assignable to number
+        setStateDefaultAction("4");
+    };
+}
+
+// ref cleanup
+const ref: React.RefCallback<HTMLDivElement> = current => {
+    // Should be non-nullable
+    // $ExpectType HTMLDivElement | null
+    current;
+    return function refCleanup() {
+    };
+};
+<div
+    ref={current => {
+        // Should be non-nullable
+        // $ExpectType HTMLDivElement | null
+        current;
+        return function refCleanup() {
+        };
+    }}
+/>;
+<div
+    // @ts-expect-error ref cleanup does not accept arguments
+    ref={current => {
+        // @ts-expect-error
+        return function refCleanup(implicitAny) {
+        };
+    }}
+/>;
+<div
+    // @ts-expect-error ref cleanup does not accept arguments
+    ref={current => {
+        return function refCleanup(neverPassed: string) {
+        };
+    }}
+/>;
+
+const useActionState = React.useActionState;
+// Keep in sync with ReactDOM.useFormState tests
+function formTest() {
+    function Page1() {
+        async function action(state: number) {
+            return state + 1;
+        }
+
+        const [
+            // $ExpectType number
+            state,
+            dispatch,
+            // $ExpectType boolean
+            isPending,
+        ] = useActionState(action, 1);
+
+        function actionExpectingPromiseState(state: Promise<number>) {
+            return state.then((s) => s + 1);
+        }
+
+        useActionState(
+            // @ts-expect-error
+            actionExpectingPromiseState,
+            Promise.resolve(1),
+        );
+        useActionState(
+            action,
+            // @ts-expect-error
+            Promise.resolve(1),
+        );
+        // $ExpectType number
+        useActionState<Promise<number>>(action, 1)[0];
+
+        useActionState(
+            async (
+                prevState: // only needed in TypeScript 4.9
+                    // 5.0 infers `number` whereas 4.9 infers `0`
+                    number,
+            ) => prevState + 1,
+            0,
+        )[0];
+        // $ExpectType number
+        useActionState(
+            async (prevState) => prevState + 1,
+            // @ts-expect-error
+            Promise.resolve(0),
+        )[0];
+
+        const [
+            state2,
+            action2,
+            // $ExpectType boolean
+            isPending2,
+        ] = useActionState(
+            async (state: React.ReactNode, payload: FormData): Promise<React.ReactNode> => {
+                return state;
+            },
+            (
+                <button>
+                    New Project
+                </button>
+            ),
+        );
+
+        return (
+            <button
+                onClick={() => {
+                    dispatch();
+                }}
+            >
+                count: {state}
+            </button>
+        );
+    }
+
+    function Page2() {
+        async function action(state: number) {
+            return state + 1;
+        }
+
+        const [
+            // $ExpectType number
+            state,
+            dispatch,
+        ] = useActionState(action, 1, "/permalink");
+        return (
+            <form action={dispatch}>
+                <span>Count: {state}</span>
+                <input type="text" name="incrementAmount" defaultValue="5" />
+            </form>
+        );
+    }
+
+    function Page3() {
+        function actionSync(state: number, type: "increment" | "decrement") {
+            return state + (type === "increment" ? 1 : -1);
+        }
+
+        const [
+            // $ExpectType number
+            state,
+            dispatch,
+        ] = useActionState(actionSync, 1, "/permalink");
+        return (
+            <button
+                onClick={() => {
+                    dispatch("decrement");
+                }}
+            >
+                count: {state}
+            </button>
+        );
+    }
+
+    function Page4() {
+        async function action(state: number, type: "increment" | "decrement") {
+            return state + (type === "increment" ? 1 : -1);
+        }
+
+        const [
+            // $ExpectType number
+            state,
+            dispatch,
+        ] = useActionState(action, 1, "/permalink");
+        return (
+            <button
+                onClick={() => {
+                    dispatch("decrement");
+                }}
+            >
+                count: {state}
+            </button>
+        );
+    }
+}
+
+// New transition events
+<div
+    onTransitionStart={event => {
+        // $ExpectType TransitionEvent<HTMLDivElement>
+        event;
+    }}
+    onTransitionRun={event => {
+        // $ExpectType TransitionEvent<HTMLDivElement>
+        event;
+    }}
+    onTransitionCancel={event => {
+        // $ExpectType TransitionEvent<HTMLDivElement>
+        event;
+    }}
+    onTransitionEnd={event => {
+        // $ExpectType TransitionEvent<HTMLDivElement>
+        event;
+    }}
+/>;
+
+// ReactNode tests
+{
+    // @ts-expect-error
+    const render: React.ReactNode = () => React.createElement("div");
+    // @ts-expect-error
+    const emptyObject: React.ReactNode = {};
+    // @ts-expect-error
+    const plainObject: React.ReactNode = { dave: true };
+    const promise: React.ReactNode = Promise.resolve("React");
+    // @ts-expect-error plain objects are not allowed
+    <div>{{ dave: true }}</div>;
+    <div>{Promise.resolve("React")}</div>;
+
+    const asyncTests = async function asyncTests() {
+        const node: Awaited<React.ReactNode> = await Promise.resolve("React");
+    };
+
+    const RenderableContext = React.createContext<React.ReactNode>("HAL");
+    const NestedContext = React.createContext(RenderableContext);
+    // @ts-expect-error TODO Is supported in Canary release channel
+    let node: React.ReactNode = RenderableContext;
+    // @ts-expect-error TODO context values are recursively unwrapped so this should be allowed by types.
+    node = NestedContext;
+
+    const NotRenderableContext = React.createContext(() => {});
+    // @ts-expect-error
+    node = NotRenderableContext;
+
+    node = BigInt(10);
+}
+
+function PopoverAPI() {
+    return (
+        <>
+            <div
+                id="popover-target"
+                popover=""
+                onBeforeToggle={event => {
+                    // $ExpectType 'open' | 'closed'
+                    event.newState;
+                    // $ExpectType 'open' | 'closed'
+                    event.oldState;
+                }}
+                onToggle={event => {
+                    // $ExpectType 'open' | 'closed'
+                    event.newState;
+                    // $ExpectType 'open' | 'closed'
+                    event.oldState;
+                }}
+            >
+            </div>
+            <div popover="auto" />
+            <div popover="manual" />
+            <div
+                // @ts-expect-error accidental boolean
+                popover
+            />
+            <button popoverTarget="popover-target">Toggle</button>
+            <button popoverTarget="popover-target" popoverTargetAction="toggle">Toggle</button>
+            <button popoverTarget="popover-target" popoverTargetAction="show">Show</button>
+            <button popoverTarget="popover-target" popoverTargetAction="hide">Hide</button>
+            <button
+                popoverTarget="popover-target"
+                // @ts-expect-error
+                popoverTargetAction="bad"
+            >
+                Hide
+            </button>
+        </>
+    );
+}
+
+// New <link> and <style> props
+<link href="https://foo.bar" precedence="medium" rel="canonical" />;
+<style href="unique-style-hash" precedence="anything">{` p { color: red; } `}</style>;

--- a/types/react/v18/ts5.0/test/experimental.tsx
+++ b/types/react/v18/ts5.0/test/experimental.tsx
@@ -1,0 +1,148 @@
+/// <reference types="../experimental"/>
+
+import React = require("react");
+
+// NOTE: forward declarations for tests
+declare var console: Console;
+interface Console {
+    log(...args: any[]): void;
+}
+
+function suspenseTest() {
+    function DisplayData() {
+        return null;
+    }
+
+    function FlameChart() {
+        return (
+            <React.Suspense fallback="computing..." unstable_expectedLoadTime={2000}>
+                <DisplayData />
+            </React.Suspense>
+        );
+    }
+}
+
+// Unsupported `revealOrder` triggers a runtime warning
+// @ts-expect-error
+<React.unstable_SuspenseList revealOrder="something">
+    <React.Suspense fallback="Loading">Content</React.Suspense>
+</React.unstable_SuspenseList>;
+
+<React.unstable_SuspenseList revealOrder="backwards">
+    <React.Suspense fallback="Loading">A</React.Suspense>
+    <React.Suspense fallback="Loading">B</React.Suspense>
+</React.unstable_SuspenseList>;
+
+<React.unstable_SuspenseList revealOrder="forwards">
+    <React.Suspense fallback="Loading">A</React.Suspense>
+    <React.Suspense fallback="Loading">B</React.Suspense>
+</React.unstable_SuspenseList>;
+
+<React.unstable_SuspenseList revealOrder="together">
+    <React.Suspense fallback="Loading">A</React.Suspense>
+    <React.Suspense fallback="Loading">B</React.Suspense>
+</React.unstable_SuspenseList>;
+
+function ownerStacks() {
+    // $ExpectType string | null
+    const ownerStack = React.captureOwnerStack();
+}
+
+function useEvent() {
+    // Implicit any
+    // @ts-expect-error
+    const anyEvent = React.experimental_useEffectEvent(value => {
+        // $ExpectType any
+        return value;
+    });
+    // $ExpectType any
+    anyEvent({});
+    // $ExpectType (value: string) => number
+    const typedEvent = React.experimental_useEffectEvent((value: string) => {
+        return Number(value);
+    });
+    // $ExpectType number
+    typedEvent("1");
+    // Argument of type '{}' is not assignable to parameter of type 'string'.
+    // @ts-expect-error
+    typedEvent({});
+
+    function useContextuallyTypedEvent(fn: (event: Event) => string) {}
+    useContextuallyTypedEvent(
+        React.experimental_useEffectEvent(event => {
+            // $ExpectType Event
+            event;
+            return String(event);
+        }),
+    );
+}
+
+function elementTypeTests() {
+    const ReturnPromise = () => Promise.resolve("React");
+    // @ts-expect-error Needs https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65135
+    const FCPromise: React.FC = ReturnPromise;
+    class RenderPromise extends React.Component {
+        render() {
+            return Promise.resolve("React");
+        }
+    }
+
+    // @ts-expect-error Needs https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65135
+    <ReturnPromise />;
+    // @ts-expect-error Needs https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65135
+    React.createElement(ReturnPromise);
+    <RenderPromise />;
+    React.createElement(RenderPromise);
+}
+
+function taintTests() {
+    const taintUniqueValue = React.experimental_taintUniqueValue;
+    const taintObjectReference = React.experimental_taintObjectReference;
+
+    const process = {
+        env: {
+            SECRET: "0967af1802d2a516e88c7c42e0b8ef95",
+        },
+    };
+    const user = {
+        name: "Sebbie",
+    };
+
+    taintUniqueValue("Cannot pass a secret token to the client", process, process.env.SECRET);
+    taintUniqueValue(undefined, process, process.env.SECRET);
+    // @ts-expect-error Probably meant `taintObjectReference`
+    taintUniqueValue(
+        undefined,
+        user,
+    );
+    taintUniqueValue(
+        undefined,
+        process,
+        // @ts-expect-error should use taintObjectReference instead
+        process.env,
+    );
+    taintUniqueValue(
+        undefined,
+        process,
+        // @ts-expect-error Not unique
+        5,
+    );
+
+    taintObjectReference("Don't pass the raw user object to the client", user);
+    taintObjectReference(undefined, user);
+    taintObjectReference(
+        undefined,
+        // @ts-expect-error Not a reference
+        process.env.SECRET,
+    );
+    taintObjectReference(
+        undefined,
+        // @ts-expect-error Not a reference
+        true,
+    );
+}
+
+<div inert={true} />;
+<div inert={false} />;
+<div // @ts-expect-error Old workaround that used to result in `element.inert = true` but would now result in `element.inert = false`
+ inert="" />;


### PR DESCRIPTION
Canary and Experimental typings are taken from before they were removed when introducing v19.

They're still relevant for people on v18 Canary and Experimental release channels e.g. Next.js 14.

Follow-up to https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69022
Closes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/71363
Closes https://github.com/vercel/next.js/discussions/73581
