### PR TITLE
[atlassian-connect-js] Fix Confluence navigator target type

### DIFF
--- a/types/atlassian-connect-js/atlassian-connect-js-tests.ts
+++ b/types/atlassian-connect-js/atlassian-connect-js-tests.ts
@@ -139,6 +139,7 @@ AP.jira.isNativeApp(isNative => console.log(isNative)); // $ExpectType void
 
 AP.navigator.getLocation(location => console.log(location)); // $ExpectType void
 AP.navigator.getLocation(location => console.log(location.target)); // $ExpectType void
+AP.navigator.getLocation(location => console.log(location.target === "contentcreate")); // $ExpectType void
 AP.navigator.getLocation(location => console.log(location.context)); // $ExpectType void
 AP.navigator.go("contentview", {}); // $ExpectType void
 AP.navigator.go("issue", {}); // $ExpectType void

--- a/types/atlassian-connect-js/index.d.ts
+++ b/types/atlassian-connect-js/index.d.ts
@@ -1176,6 +1176,11 @@ declare namespace AP {
              */
             | "contentedit"
             /**
+             * The create page for pages, blogs and custom content. Takes a `contentId` to identify the content.
+             * Undocumented but can be returned by `location.target`.
+             */
+            | "contentcreate"
+            /**
              * The space view page. Takes a `spaceKey` to identify the space.
              */
             | "spaceview"


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.atlassian.com/cloud/confluence/about-the-connect-javascript-api/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

This PR adds the `contentcreate` target to the `NavigatorTargetConfluence` type.
Indeed, when using `AP.navigator.getLocation()`, the `target` property of the received `location` object can be `contentcreate` (for example, when creating a new page, before publishing it).
This is not documented but has been detected in production.