### PR TITLE
[react-dom] Restore Canary and Experimental release channel typings for v18

### DIFF
--- a/types/react-dom/v18/canary.d.ts
+++ b/types/react-dom/v18/canary.d.ts
@@ -1,0 +1,184 @@
+/**
+ * These are types for things that are present in the upcoming React 18 release.
+ *
+ * Once React 18 is released they can just be moved to the main index file.
+ *
+ * To load the types declared here in an actual project, there are three ways. The easiest one,
+ * if your `tsconfig.json` already has a `"types"` array in the `"compilerOptions"` section,
+ * is to add `"react-dom/canary"` to the `"types"` array.
+ *
+ * Alternatively, a specific import syntax can to be used from a typescript file.
+ * This module does not exist in reality, which is why the {} is important:
+ *
+ * ```ts
+ * import {} from 'react-dom/canary'
+ * ```
+ *
+ * It is also possible to include it through a triple-slash reference:
+ *
+ * ```ts
+ * /// <reference types="react-dom/canary" />
+ * ```
+ *
+ * Either the import or the reference only needs to appear once, anywhere in the project.
+ */
+
+// See https://github.com/facebook/react/blob/main/packages/react-dom/index.js to see how the exports are declared,
+// but confirm with published source code (e.g. https://unpkg.com/react-dom@canary) that these exports end up in the published code
+
+import React = require("react");
+import ReactDOM = require(".");
+
+export {};
+
+declare const REACT_FORM_STATE_SIGIL: unique symbol;
+
+declare module "." {
+    function prefetchDNS(href: string): void;
+
+    interface PreconnectOptions {
+        // Don't create a helper type.
+        // It would have to be in module scope to be inlined in TS tooltips.
+        // But then it becomes part of the public API.
+        // TODO: Upstream to microsoft/TypeScript-DOM-lib-generator -> w3c/webref
+        // since the spec has a notion of a dedicated type: https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attribute
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+    }
+    function preconnect(href: string, options?: PreconnectOptions): void;
+
+    type PreloadAs =
+        | "audio"
+        | "document"
+        | "embed"
+        | "fetch"
+        | "font"
+        | "image"
+        | "object"
+        | "track"
+        | "script"
+        | "style"
+        | "video"
+        | "worker";
+    interface PreloadOptions {
+        as: PreloadAs;
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+        fetchPriority?: "high" | "low" | "auto" | undefined;
+        // TODO: These should only be allowed with `as: 'image'` but it's not trivial to write tests against the full TS support matrix.
+        imageSizes?: string | undefined;
+        imageSrcSet?: string | undefined;
+        integrity?: string | undefined;
+        type?: string | undefined;
+        nonce?: string | undefined;
+        referrerPolicy?: ReferrerPolicy | undefined;
+    }
+    function preload(href: string, options?: PreloadOptions): void;
+
+    // https://html.spec.whatwg.org/multipage/links.html#link-type-modulepreload
+    type PreloadModuleAs = RequestDestination;
+    interface PreloadModuleOptions {
+        /**
+         * @default "script"
+         */
+        as: PreloadModuleAs;
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+        integrity?: string | undefined;
+        nonce?: string | undefined;
+    }
+    function preloadModule(href: string, options?: PreloadModuleOptions): void;
+
+    type PreinitAs = "script" | "style";
+    interface PreinitOptions {
+        as: PreinitAs;
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+        fetchPriority?: "high" | "low" | "auto" | undefined;
+        precedence?: string | undefined;
+        integrity?: string | undefined;
+        nonce?: string | undefined;
+    }
+    function preinit(href: string, options?: PreinitOptions): void;
+
+    // Will be expanded to include all of https://github.com/tc39/proposal-import-attributes
+    type PreinitModuleAs = "script";
+    interface PreinitModuleOptions {
+        /**
+         * @default "script"
+         */
+        as?: PreinitModuleAs;
+        crossOrigin?: "anonymous" | "use-credentials" | "" | undefined;
+        integrity?: string | undefined;
+        nonce?: string | undefined;
+    }
+    function preinitModule(href: string, options?: PreinitModuleOptions): void;
+
+    interface FormStatusNotPending {
+        pending: false;
+        data: null;
+        method: null;
+        action: null;
+    }
+
+    interface FormStatusPending {
+        pending: true;
+        data: FormData;
+        method: string;
+        action: string | ((formData: FormData) => void | Promise<void>);
+    }
+
+    type FormStatus = FormStatusPending | FormStatusNotPending;
+
+    function useFormStatus(): FormStatus;
+
+    function useFormState<State>(
+        action: (state: Awaited<State>) => State | Promise<State>,
+        initialState: Awaited<State>,
+        permalink?: string,
+    ): [state: Awaited<State>, dispatch: () => void, isPending: boolean];
+    function useFormState<State, Payload>(
+        action: (state: Awaited<State>, payload: Payload) => State | Promise<State>,
+        initialState: Awaited<State>,
+        permalink?: string,
+    ): [state: Awaited<State>, dispatch: (payload: Payload) => void, isPending: boolean];
+
+    function requestFormReset(form: HTMLFormElement): void;
+}
+
+declare module "./client" {
+    interface ReactFormState {
+        [REACT_FORM_STATE_SIGIL]: never;
+    }
+
+    interface RootOptions {
+        onUncaughtError?:
+            | ((error: unknown, errorInfo: { componentStack?: string | undefined }) => void)
+            | undefined;
+        onCaughtError?:
+            | ((
+                error: unknown,
+                errorInfo: {
+                    componentStack?: string | undefined;
+                    errorBoundary?: React.Component<unknown> | undefined;
+                },
+            ) => void)
+            | undefined;
+    }
+
+    interface HydrationOptions {
+        formState?: ReactFormState | null;
+        onUncaughtError?:
+            | ((error: unknown, errorInfo: { componentStack?: string | undefined }) => void)
+            | undefined;
+        onCaughtError?:
+            | ((
+                error: unknown,
+                errorInfo: {
+                    componentStack?: string | undefined;
+                    errorBoundary?: React.Component<unknown> | undefined;
+                },
+            ) => void)
+            | undefined;
+    }
+
+    interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_CREATE_ROOT_CONTAINERS {
+        document: Document;
+    }
+}

--- a/types/react-dom/v18/experimental.d.ts
+++ b/types/react-dom/v18/experimental.d.ts
@@ -1,0 +1,36 @@
+/**
+ * These are types for things that are present in the `experimental` builds of React but not yet
+ * on a stable build.
+ *
+ * Once they are promoted to stable they can just be moved to the main index file.
+ *
+ * To load the types declared here in an actual project, there are three ways. The easiest one,
+ * if your `tsconfig.json` already has a `"types"` array in the `"compilerOptions"` section,
+ * is to add `"react-dom/experimental"` to the `"types"` array.
+ *
+ * Alternatively, a specific import syntax can to be used from a typescript file.
+ * This module does not exist in reality, which is why the {} is important:
+ *
+ * ```ts
+ * import {} from 'react-dom/experimental'
+ * ```
+ *
+ * It is also possible to include it through a triple-slash reference:
+ *
+ * ```ts
+ * /// <reference types="react-dom/experimental" />
+ * ```
+ *
+ * Either the import or the reference only needs to appear once, anywhere in the project.
+ */
+
+// See https://github.com/facebook/react/blob/main/packages/react-dom/index.experimental.js to see how the exports are declared,
+// but confirm with published source code (e.g. https://unpkg.com/react-dom@experimental) that these exports end up in the published code
+
+import React = require("react");
+import ReactDOM = require("./canary");
+
+export {};
+
+declare module "." {
+}

--- a/types/react-dom/v18/test/canary-tests.tsx
+++ b/types/react-dom/v18/test/canary-tests.tsx
@@ -1,0 +1,322 @@
+/// <reference types="../canary"/>
+import React = require("react");
+import ReactDOM = require("react-dom");
+import ReactDOMClient = require("react-dom/client");
+
+function preloadTest() {
+    function Component() {
+        ReactDOM.preload("foo", { as: "style", fetchPriority: "high", integrity: "sad" });
+        ReactDOM.preload("bar", {
+            as: "font",
+            type: "font/woff2",
+            // @ts-expect-error Unknown fetch priority
+            fetchPriority: "unknown",
+        });
+        ReactDOM.preload("baz", { as: "script", crossOrigin: "use-credentials" });
+        ReactDOM.preload("baz", {
+            // @ts-expect-error
+            as: "title",
+        });
+        ReactDOM.preload("bar", {
+            as: "font",
+            nonce: "0xeac1",
+        });
+        ReactDOM.preload("foo", {
+            as: "image",
+            imageSrcSet: "fooset",
+            imageSizes: "foosizes",
+            referrerPolicy: "no-referrer",
+        });
+        ReactDOM.preload("foo", {
+            as: "image",
+            // @ts-expect-error Not specified in https://w3c.github.io/webappsec-referrer-policy/#referrer-policy
+            referrerPolicy: "unknown-policy",
+        });
+        ReactDOM.preload("foo", {
+            as: "script",
+            // Undesired. Should not typecheck.
+            imageSrcSet: "fooset",
+            imageSizes: "foosizes",
+        });
+
+        ReactDOM.preinit("foo", {
+            as: "style",
+            crossOrigin: "anonymous",
+            fetchPriority: "high",
+            precedence: "high",
+            integrity: "sad",
+            nonce: "0xeac1",
+        });
+        ReactDOM.preinit("bar", {
+            // @ts-expect-error Only available in preload
+            as: "font",
+        });
+        ReactDOM.preinit("baz", {
+            as: "script",
+            // @ts-expect-error Unknown fetch priority
+            fetchPriority: "unknown",
+        });
+        ReactDOM.preinit("baz", {
+            // @ts-expect-error
+            as: "title",
+        });
+        ReactDOM.preinit("baz", {
+            as: "script",
+            nonce: "0xeac1",
+        });
+
+        // @ts-expect-error
+        ReactDOM.preconnect();
+        ReactDOM.preconnect("foo");
+        ReactDOM.preconnect("bar", { crossOrigin: "anonymous" });
+
+        // @ts-expect-error
+        ReactDOM.prefetchDNS();
+        ReactDOM.prefetchDNS("foo");
+        ReactDOM.prefetchDNS(
+            "bar", // @ts-expect-error prefetchDNS does not accept any options at the moment
+            {},
+        );
+
+        // @ts-expect-error
+        ReactDOM.preloadModule();
+        ReactDOM.preloadModule("browserdefault");
+        ReactDOM.preloadModule("browserdefault", {
+            as: "script",
+            crossOrigin: "use-credentials",
+            integrity: "0xeac1",
+            nonce: "secret",
+        });
+        ReactDOM.preloadModule("worker", { as: "worker" });
+        ReactDOM.preloadModule("worker", {
+            // @ts-expect-error Unknown request destination
+            as: "serviceworker",
+        });
+
+        // @ts-expect-error
+        ReactDOM.preinitModule();
+        ReactDOM.preinitModule("browserdefault");
+        ReactDOM.preinitModule("browserdefault", { as: "script", crossOrigin: "use-credentials", integrity: "0xeac1" });
+        ReactDOM.preinitModule("data", {
+            // @ts-expect-error Not supported (yet)
+            as: "json",
+        });
+    }
+}
+
+const useFormState = ReactDOM.useFormState;
+const useFormStatus = ReactDOM.useFormStatus;
+
+function Status() {
+    const status = useFormStatus();
+    if (!status.pending) {
+        return <div>No pending action</div>;
+    } else {
+        const { action, data, method } = status;
+        const foo = data.get("foo");
+        return (
+            <div>
+                {`Pending action ${
+                    typeof action === "string" ? action : action.name
+                }: foo is ${foo}, method is ${method}`}
+            </div>
+        );
+    }
+}
+
+// Keep in sync with React.useActionState tests
+function formTest() {
+    function Page1() {
+        async function action(state: number) {
+            return state + 1;
+        }
+
+        const [
+            // $ExpectType number
+            state,
+            dispatch,
+            // $ExpectType boolean
+            isPending,
+        ] = useFormState(action, 1);
+
+        function actionExpectingPromiseState(state: Promise<number>) {
+            return state.then((s) => s + 1);
+        }
+
+        useFormState(
+            // @ts-expect-error
+            actionExpectingPromiseState,
+            Promise.resolve(1),
+        );
+        useFormState(
+            action,
+            // @ts-expect-error
+            Promise.resolve(1),
+        );
+        // $ExpectType number
+        useFormState<Promise<number>>(action, 1)[0];
+
+        useFormState(
+            async (
+                prevState: // only needed in TypeScript 4.9
+                    // 5.0 infers `number` whereas 4.9 infers `0`
+                    number,
+            ) => prevState + 1,
+            0,
+        )[0];
+        // $ExpectType number
+        useFormState(
+            async (prevState) => prevState + 1,
+            // @ts-expect-error
+            Promise.resolve(0),
+        )[0];
+
+        const [
+            state2,
+            action2,
+            // $ExpectType boolean
+            isPending2,
+        ] = useFormState(
+            async (state: React.ReactNode, payload: FormData): Promise<React.ReactNode> => {
+                return state;
+            },
+            (
+                <button>
+                    New Project
+                </button>
+            ),
+        );
+
+        return (
+            <button
+                onClick={() => {
+                    dispatch();
+                }}
+            >
+                count: {state}
+            </button>
+        );
+    }
+
+    function Page2() {
+        async function action(state: number) {
+            return state + 1;
+        }
+
+        const [
+            // $ExpectType number
+            state,
+            dispatch,
+        ] = useFormState(action, 1, "/permalink");
+        return (
+            <form action={dispatch}>
+                <span>Count: {state}</span>
+                <input type="text" name="incrementAmount" defaultValue="5" />
+            </form>
+        );
+    }
+
+    function Page3() {
+        function actionSync(state: number, type: "increment" | "decrement") {
+            return state + (type === "increment" ? 1 : -1);
+        }
+
+        const [
+            // $ExpectType number
+            state,
+            dispatch,
+        ] = useFormState(actionSync, 1, "/permalink");
+        return (
+            <button
+                onClick={() => {
+                    dispatch("decrement");
+                }}
+            >
+                count: {state}
+            </button>
+        );
+    }
+
+    function Page4() {
+        async function action(state: number, type: "increment" | "decrement") {
+            return state + (type === "increment" ? 1 : -1);
+        }
+
+        const [
+            // $ExpectType number
+            state,
+            dispatch,
+        ] = useFormState(action, 1, "/permalink");
+        return (
+            <button
+                onClick={() => {
+                    dispatch("decrement");
+                }}
+            >
+                count: {state}
+            </button>
+        );
+    }
+
+    const formState = [1, "", "", 0] as unknown as ReactDOMClient.ReactFormState;
+    ReactDOMClient.hydrateRoot(document.body, <Page1 />, { formState });
+}
+
+function createRoot(validContainer: Element | DocumentFragment | Document) {
+    ReactDOMClient.createRoot(document);
+    ReactDOMClient.createRoot(validContainer);
+
+    ReactDOMClient.createRoot(document, {
+        onUncaughtError: (error, errorInfo) => {
+            // $ExpectType unknown
+            error;
+            // $ExpectType string | undefined
+            errorInfo.componentStack;
+            // @ts-expect-error -- only on onRecoverableError
+            errorInfo.digest;
+            // @ts-expect-error -- only on onCaughtError
+            errorInfo.errorBoundary;
+        },
+        onCaughtError: (error, errorInfo) => {
+            // $ExpectType unknown
+            error;
+            // $ExpectType string | undefined
+            errorInfo.componentStack;
+            // @ts-expect-error -- only on onRecoverableError
+            errorInfo.digest;
+            // $ExpectType Component<unknown, {}, any> | undefined
+            errorInfo.errorBoundary;
+        },
+    });
+
+    ReactDOMClient.hydrateRoot(document.body, null, {
+        onUncaughtError: (error, errorInfo) => {
+            // $ExpectType unknown
+            error;
+            // $ExpectType string | undefined
+            errorInfo.componentStack;
+            // @ts-expect-error -- only on onRecoverableError
+            errorInfo.digest;
+            // @ts-expect-error -- only on onCaughtError
+            errorInfo.errorBoundary;
+        },
+        onCaughtError: (error, errorInfo) => {
+            // $ExpectType unknown
+            error;
+            // $ExpectType string | undefined
+            errorInfo.componentStack;
+            // @ts-expect-error -- only on onRecoverableError
+            errorInfo.digest;
+            // $ExpectType Component<unknown, {}, any> | undefined
+            errorInfo.errorBoundary;
+        },
+    });
+}
+
+function requestFormResetTest(form: HTMLFormElement, button: HTMLButtonElement) {
+    ReactDOM.requestFormReset(form);
+    // @ts-expect-error
+    ReactDOM.requestFormReset(button);
+    // @ts-expect-error
+    ReactDOM.requestFormReset(null);
+}

--- a/types/react-dom/v18/test/experimental-tests.tsx
+++ b/types/react-dom/v18/test/experimental-tests.tsx
@@ -1,0 +1,4 @@
+import ReactDOM = require("react-dom");
+import ReactDOMClient = require("react-dom/client");
+import "react/experimental";
+import "react-dom/experimental";


### PR DESCRIPTION
Oversight in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71388
Closes https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/71398