### PR TITLE
[react/v18] Expose Canary and Experimental release channel entrypoints

### DIFF
--- a/types/react-dom/v18/package.json
+++ b/types/react-dom/v18/package.json
@@ -11,6 +11,11 @@
                 "default": "./index.d.ts"
             }
         },
+        "./canary": {
+            "types": {
+                "default": "./canary.d.ts"
+            }
+        },
         "./client": {
             "types": {
                 "default": "./client.d.ts"
@@ -19,6 +24,11 @@
         "./server": {
             "types": {
                 "default": "./server.d.ts"
+            }
+        },
+        "./experimental": {
+            "types": {
+                "default": "./experimental.d.ts"
             }
         },
         "./test-utils": {

--- a/types/react-dom/v18/test/react-dom-tests.tsx
+++ b/types/react-dom/v18/test/react-dom-tests.tsx
@@ -371,7 +371,7 @@ function createRoot() {
     root.render(<div>initial render</div>);
     root.render(false);
 
-    // @ts-expect-error React 19 feature
+    // Will not type-check in a real project but accepted in DT tests since canary.d.ts is part of compilation.
     ReactDOMClient.createRoot(document);
 }
 

--- a/types/react-dom/v18/tsconfig.json
+++ b/types/react-dom/v18/tsconfig.json
@@ -1,6 +1,8 @@
 {
     "files": [
         "index.d.ts",
+        "test/canary-tests.tsx",
+        "test/experimental-tests.tsx",
         "test/react-dom-tests.tsx"
     ],
     "compilerOptions": {

--- a/types/react/v18/package.json
+++ b/types/react/v18/package.json
@@ -14,6 +14,22 @@
                 "default": "./index.d.ts"
             }
         },
+        "./canary": {
+            "types@<=5.0": {
+                "default": "./ts5.0/canary.d.ts"
+            },
+            "types": {
+                "default": "./canary.d.ts"
+            }
+        },
+        "./experimental": {
+            "types@<=5.0": {
+                "default": "./ts5.0/experimental.d.ts"
+            },
+            "types": {
+                "default": "./experimental.d.ts"
+            }
+        },
         "./jsx-runtime": {
             "types@<=5.0": {
                 "default": "./ts5.0/jsx-runtime.d.ts"

--- a/types/react/v18/test/elementAttributes.tsx
+++ b/types/react/v18/test/elementAttributes.tsx
@@ -133,26 +133,26 @@ const eventCallbacksTestCases = [
 
 function formActionsTest() {
     <form
-        // @ts-expect-error Form Actions are not supported in React 18.
+        // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
         action={formData => {
-            // $ExpectType any
+            // $ExpectType FormData
             formData;
         }}
     >
         <input type="text" name="title" defaultValue="Hello" />
         <input
             type="submit"
-            // @ts-expect-error Form Actions are not supported in React 18.
+            // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
             formAction={formData => {
-                // $ExpectType any
+                // $ExpectType FormData
                 formData;
             }}
             value="Save"
         />
         <button
-            // @ts-expect-error Form Actions are not supported in React 18.
+            // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
             formAction={formData => {
-                // $ExpectType any
+                // $ExpectType FormData
                 formData;
             }}
         >

--- a/types/react/v18/test/hooks.tsx
+++ b/types/react/v18/test/hooks.tsx
@@ -371,7 +371,7 @@ function useConcurrentHooks() {
 
         // The function must be synchronous, even if it can start an asynchronous update
         // it's no different from an useEffect callback in this respect
-        // @ts-expect-error
+        // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
         startTransition(async () => {});
 
         // Unlike Effect callbacks, though, there is no possible destructor to return
@@ -392,7 +392,7 @@ function startTransitionTest() {
     });
 
     // callback must be synchronous
-    // @ts-expect-error
+    // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
     React.startTransition(async () => {});
 }
 

--- a/types/react/v18/test/index.ts
+++ b/types/react/v18/test/index.ts
@@ -768,7 +768,7 @@ class RenderChildren extends React.Component<{ children?: React.ReactNode }> {
     const emptyObject: React.ReactNode = {};
     // @ts-expect-error
     const plainObject: React.ReactNode = { dave: true };
-    // @ts-expect-error Promises as ReactNode is not supported in React 18.
+    // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
     const promise: React.ReactNode = Promise.resolve("React");
 
     const asyncTests = async function asyncTests() {

--- a/types/react/v18/test/tsx.tsx
+++ b/types/react/v18/test/tsx.tsx
@@ -561,7 +561,8 @@ imgProps.loading = "nonsense";
 // @ts-expect-error
 imgProps.decoding = "nonsense";
 type ImgPropsWithRef = React.ComponentPropsWithRef<"img">;
-// $ExpectType ((instance: HTMLImageElement | null) => void) | RefObject<HTMLImageElement> | null | undefined
+// Ref cleanups only appear because Canary types are part of compilation.
+// $ExpectType ((instance: HTMLImageElement | null) => void | (() => VoidOrUndefinedOnly)) | RefObject<HTMLImageElement> | null | undefined
 type ImgPropsWithRefRef = ImgPropsWithRef["ref"];
 type ImgPropsWithoutRef = React.ComponentPropsWithoutRef<"img">;
 // $ExpectType false
@@ -691,7 +692,7 @@ function reactNodeTests() {
     <div>{createChildren()}</div>;
     // @ts-expect-error plain objects are not allowed
     <div>{{ dave: true }}</div>;
-    // @ts-expect-error Promises as ReactNode is not supported in React 18.
+    // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
     <div>{Promise.resolve("React")}</div>;
 }
 
@@ -771,10 +772,10 @@ function elementTypeTests() {
     }
 
     const ReturnPromise = () => Promise.resolve("React");
-    // @ts-expect-error Async components are not supported in React 18.
+    // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
     const FCPromise: React.FC = ReturnPromise;
     class RenderPromise extends React.Component {
-        // @ts-expect-error Async components are not supported in React 18.
+        // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
         render() {
             return Promise.resolve("React");
         }
@@ -874,13 +875,13 @@ function elementTypeTests() {
     <RenderReactNode />;
     React.createElement(RenderReactNode);
 
-    // @ts-expect-error Async components are not supported in React 18.
+    // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
     <ReturnPromise />;
-    // @ts-expect-error Async components are not supported in React 18.
+    // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
     React.createElement(ReturnPromise);
-    // @ts-expect-error Async components are not supported in React 18.
+    // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
     <RenderPromise />;
-    // @ts-expect-error Async components are not supported in React 18.
+    // Will not type-check in a real project but accepted in DT tests since experimental.d.ts is part of compilation.
     React.createElement(RenderPromise);
 
     // @ts-expect-error See https://github.com/microsoft/TypeScript/issues/59111
@@ -949,7 +950,8 @@ function managingRefs() {
         }}
     />;
     <div
-        // Ref cleanup is accidentally supported in React 18.
+        // Will not issue an error in a real project but does here since canary.d.ts is part of compilation.
+        // @ts-expect-error
         ref={current => {
             // @ts-expect-error
             return function refCleanup(implicitAny) {
@@ -957,7 +959,8 @@ function managingRefs() {
         }}
     />;
     <div
-        // Ref cleanup is accidentally supported in React 18.
+        // Will not issue an error in a real project but does here since canary.d.ts is part of compilation.
+        // @ts-expect-error
         ref={current => {
             return function refCleanup(neverPassed: string) {
             };

--- a/types/react/v18/tsconfig.json
+++ b/types/react/v18/tsconfig.json
@@ -4,6 +4,8 @@
         "jsx-dev-runtime.d.ts",
         "jsx-runtime.d.ts",
         "test/index.ts",
+        "test/canary.tsx",
+        "test/experimental.tsx",
         "test/tsx.tsx",
         "test/cssProperties.tsx",
         "test/elementAttributes.tsx",


### PR DESCRIPTION
I didn't see a new relase of `@types/react-dom` published. Probably because the changed files weren't automatically considered for publishing.

Oversight in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71399 and https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71388