### PR TITLE
In Lodash template settings, allow `null` to disable escape/evaluate/interpolate

### DIFF
--- a/types/lodash/common/common.d.ts
+++ b/types/lodash/common/common.d.ts
@@ -117,11 +117,11 @@ declare module "../index" {
         /**
         * The "escape" delimiter.
         **/
-        escape?: RegExp | undefined;
+        escape?: RegExp | null | undefined;
         /**
         * The "evaluate" delimiter.
         **/
-        evaluate?: RegExp | undefined;
+        evaluate?: RegExp | null | undefined;
         /**
         * An object to import into the template as local variables.
         */
@@ -129,7 +129,7 @@ declare module "../index" {
         /**
         * The "interpolate" delimiter.
         */
-        interpolate?: RegExp | undefined;
+        interpolate?: RegExp | null | undefined;
         /**
         * Used to reference the data object in the template text.
         */

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -6892,6 +6892,8 @@ fp.now(); // $ExpectType number
     _("").template(options); // $ExpectType TemplateExecutor
     _.chain("").template(); // $ExpectType FunctionChain<TemplateExecutor>
     _.chain("").template(options); // $ExpectType FunctionChain<TemplateExecutor>
+    _.template("", {escape: null, evaluate: null, interpolate: / /}); // $ExpectType TemplateExecutor
+    _.template("", {escape: null, evaluate: / /, interpolate: null}); // $ExpectType TemplateExecutor
 
     const result2 = fp.template("");
     result2(); // $ExpectType string


### PR DESCRIPTION
in `_.template`, it's possible to disable the `escape` and `evaluate` behavior by passing `null`. It's also possible to disable `interpolate`, though less common.

Here is my use case: I just want to do some interpolation and I don't want any evaluation to happen. So I want to disable the lodash `evaluate` option. I could construct a regex that matches nothing, or I could pass `null` (`undefined` doesn't work). But the types don't include `null`.

This seems like an intentional API surface, based on the source code [here](https://github.com/lodash/lodash/blob/f299b52f39486275a9e6483b60a410e06520c538/lodash.js#L14857) where these options have a fallback to `reNoMatch`. This means that if these options have no value, they should match nothing.

Passing `undefined` does not work, because the `undefined` options get overridden by defaults, so the only way to disable these options is to pass `null`.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/lodash/lodash/blob/f299b52f39486275a9e6483b60a410e06520c538/lodash.js#L14857
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
