### PR TITLE
[react] deprecate more factory-related types

### DIFF
--- a/types/react/v18/index.d.ts
+++ b/types/react/v18/index.d.ts
@@ -382,38 +382,44 @@ declare namespace React {
     // Factories
     // ----------------------------------------------------------------------
 
+    /** @deprecated */
     type Factory<P> = (props?: Attributes & P, ...children: ReactNode[]) => ReactElement<P>;
 
-    /**
-     * @deprecated Please use `FunctionComponentFactory`
-     */
+    /** @deprecated */
     type SFCFactory<P> = FunctionComponentFactory<P>;
 
+    /** @deprecated */
     type FunctionComponentFactory<P> = (
         props?: Attributes & P,
         ...children: ReactNode[]
     ) => FunctionComponentElement<P>;
 
+    /** @deprecated */
     type ComponentFactory<P, T extends Component<P, ComponentState>> = (
         props?: ClassAttributes<T> & P,
         ...children: ReactNode[]
     ) => CElement<P, T>;
 
+    /** @deprecated */
     type CFactory<P, T extends Component<P, ComponentState>> = ComponentFactory<P, T>;
     /** @deprecated */
     type ClassicFactory<P> = CFactory<P, ClassicComponent<P, ComponentState>>;
 
+    /** @deprecated */
     type DOMFactory<P extends DOMAttributes<T>, T extends Element> = (
         props?: ClassAttributes<T> & P | null,
         ...children: ReactNode[]
     ) => DOMElement<P, T>;
 
+    /** @deprecated */
     interface HTMLFactory<T extends HTMLElement> extends DetailedHTMLFactory<AllHTMLAttributes<T>, T> {}
 
+    /** @deprecated */
     interface DetailedHTMLFactory<P extends HTMLAttributes<T>, T extends HTMLElement> extends DOMFactory<P, T> {
         (props?: ClassAttributes<T> & P | null, ...children: ReactNode[]): DetailedReactHTMLElement<P, T>;
     }
 
+    /** @deprecated */
     interface SVGFactory extends DOMFactory<SVGAttributes<SVGElement>, SVGElement> {
         (
             props?: ClassAttributes<SVGElement> & SVGAttributes<SVGElement> | null,
@@ -3952,6 +3958,7 @@ declare namespace React {
     // React.DOM
     // ----------------------------------------------------------------------
 
+    /* deprecated */
     interface ReactHTML {
         a: DetailedHTMLFactory<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
         abbr: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
@@ -4073,6 +4080,7 @@ declare namespace React {
         webview: DetailedHTMLFactory<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement>;
     }
 
+    /* deprecated */
     interface ReactSVG {
         animate: SVGFactory;
         circle: SVGFactory;
@@ -4131,6 +4139,7 @@ declare namespace React {
         view: SVGFactory;
     }
 
+    /* deprecated */
     interface ReactDOM extends ReactHTML, ReactSVG {}
 
     //

--- a/types/react/v18/index.d.ts
+++ b/types/react/v18/index.d.ts
@@ -400,6 +400,7 @@ declare namespace React {
     ) => CElement<P, T>;
 
     type CFactory<P, T extends Component<P, ComponentState>> = ComponentFactory<P, T>;
+    /** @deprecated */
     type ClassicFactory<P> = CFactory<P, ClassicComponent<P, ComponentState>>;
 
     type DOMFactory<P extends DOMAttributes<T>, T extends Element> = (

--- a/types/react/v18/ts5.0/index.d.ts
+++ b/types/react/v18/ts5.0/index.d.ts
@@ -382,38 +382,44 @@ declare namespace React {
     // Factories
     // ----------------------------------------------------------------------
 
+    /** @deprecated */
     type Factory<P> = (props?: Attributes & P, ...children: ReactNode[]) => ReactElement<P>;
 
-    /**
-     * @deprecated Please use `FunctionComponentFactory`
-     */
+    /** @deprecated */
     type SFCFactory<P> = FunctionComponentFactory<P>;
 
+    /** @deprecated */
     type FunctionComponentFactory<P> = (
         props?: Attributes & P,
         ...children: ReactNode[]
     ) => FunctionComponentElement<P>;
 
+    /** @deprecated */
     type ComponentFactory<P, T extends Component<P, ComponentState>> = (
         props?: ClassAttributes<T> & P,
         ...children: ReactNode[]
     ) => CElement<P, T>;
 
+    /** @deprecated */
     type CFactory<P, T extends Component<P, ComponentState>> = ComponentFactory<P, T>;
     /** @deprecated */
     type ClassicFactory<P> = CFactory<P, ClassicComponent<P, ComponentState>>;
 
+    /** @deprecated */
     type DOMFactory<P extends DOMAttributes<T>, T extends Element> = (
         props?: ClassAttributes<T> & P | null,
         ...children: ReactNode[]
     ) => DOMElement<P, T>;
 
+    /** @deprecated */
     interface HTMLFactory<T extends HTMLElement> extends DetailedHTMLFactory<AllHTMLAttributes<T>, T> {}
 
+    /** @deprecated */
     interface DetailedHTMLFactory<P extends HTMLAttributes<T>, T extends HTMLElement> extends DOMFactory<P, T> {
         (props?: ClassAttributes<T> & P | null, ...children: ReactNode[]): DetailedReactHTMLElement<P, T>;
     }
 
+    /** @deprecated */
     interface SVGFactory extends DOMFactory<SVGAttributes<SVGElement>, SVGElement> {
         (
             props?: ClassAttributes<SVGElement> & SVGAttributes<SVGElement> | null,
@@ -3953,6 +3959,7 @@ declare namespace React {
     // React.DOM
     // ----------------------------------------------------------------------
 
+    /* deprecated */
     interface ReactHTML {
         a: DetailedHTMLFactory<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
         abbr: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
@@ -4074,6 +4081,7 @@ declare namespace React {
         webview: DetailedHTMLFactory<WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement>;
     }
 
+    /* deprecated */
     interface ReactSVG {
         animate: SVGFactory;
         circle: SVGFactory;
@@ -4132,6 +4140,7 @@ declare namespace React {
         view: SVGFactory;
     }
 
+    /* deprecated */
     interface ReactDOM extends ReactHTML, ReactSVG {}
 
     //

--- a/types/react/v18/ts5.0/index.d.ts
+++ b/types/react/v18/ts5.0/index.d.ts
@@ -400,6 +400,7 @@ declare namespace React {
     ) => CElement<P, T>;
 
     type CFactory<P, T extends Component<P, ComponentState>> = ComponentFactory<P, T>;
+    /** @deprecated */
     type ClassicFactory<P> = CFactory<P, ClassicComponent<P, ComponentState>>;
 
     type DOMFactory<P extends DOMAttributes<T>, T extends Element> = (


### PR DESCRIPTION
I noticed that `ClassicFactory` a bunch of other types werenot deprecated but is removed in the v19 types. This PR simply deprecates these in v18 types. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

