### PR TITLE
[threejs] Add missing onUploadCallback and onUpload definitions for InterleavedBuffer

### DIFF
--- a/types/three/src/core/InterleavedBuffer.d.ts
+++ b/types/three/src/core/InterleavedBuffer.d.ts
@@ -117,6 +117,19 @@ export class InterleavedBuffer {
     clearUpdateRanges(): void;
 
     /**
+     * A callback function that is executed after the Renderer has transferred the attribute array data to the GPU.
+     */
+    onUploadCallback: () => void;
+
+    /**
+     * Sets the value of the {@link onUploadCallback} property.
+     * @see Example: {@link https://threejs.org/examples/#webgl_buffergeometry | WebGL / BufferGeometry} this is used to free memory after the buffer has been transferred to the GPU.
+     * @see {@link onUploadCallback}
+     * @param callback function that is executed after the Renderer has transferred the attribute array data to the GPU.
+     */
+    onUpload(callback: () => void): this;
+
+    /**
      * Copies another {@link InterleavedBuffer} to this {@link InterleavedBuffer} instance.
      * @param source
      */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/mrdoob/three.js/blob/3c2c9303fae36a2289374753e010374477104c4f/src/core/InterleavedBuffer.js#L23
  - https://github.com/mrdoob/three.js/blob/3c2c9303fae36a2289374753e010374477104c4f/src/core/InterleavedBuffer.js#L114
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

