### PR TITLE
Updating akamai-edgeworkers to add getHeaders() to origin responses

### DIFF
--- a/types/akamai-edgeworkers/index.d.ts
+++ b/types/akamai-edgeworkers/index.d.ts
@@ -16,6 +16,14 @@ declare namespace EW {
     }
 
     interface ReadAllHeader {
+        /**
+         * Returns a JavaScript object that contains the HTTP headers 
+         * as properties.
+         * 
+         * The key for each property is the name of the HTTP header, 
+         * normalized to lower-case. The value is an array of strings, 
+         * containing one string for each HTTP header with the same name.
+         */
         getHeaders(): Headers;
     }
 
@@ -464,7 +472,7 @@ declare namespace EW {
     {
     }
 
-    interface EgressOriginResponse extends MutatesHeaders, ReadsHeaders, HasStatus {
+    interface EgressOriginResponse extends MutatesHeaders, ReadsHeaders, ReadAllHeader, HasStatus {
     }
 
     // onClientResponse
@@ -473,7 +481,7 @@ declare namespace EW {
     {
     }
 
-    interface EgressClientResponse extends MutatesHeaders, ReadsHeaders, HasStatus {
+    interface EgressClientResponse extends MutatesHeaders, ReadsHeaders, ReadAllHeader, HasStatus {
     }
 
     // responseProvider

--- a/types/akamai-edgeworkers/test/akamai-edgeworkers-global.test.ts
+++ b/types/akamai-edgeworkers/test/akamai-edgeworkers-global.test.ts
@@ -91,6 +91,9 @@ export function onOriginResponse(request: EW.EgressOriginRequest, response: EW.E
     }
     response.removeHeader("onOriginResponse-removeHeader-resp-bye");
 
+    // Resp- getHeaders
+    testHeaders(response.getHeaders());
+
     // EW.EgressOriginRequest.getHeaders()
     testHeaders(request.getHeaders());
 
@@ -143,6 +146,8 @@ export function onClientResponse(request: EW.EgressClientRequest, response: EW.E
     }
     response.removeHeader("onClientResponse-removeHeader-resp-bye");
 
+    testHeaders(response.getHeaders());
+
     // EW.EgressClientRequest.getHeaders()
     testHeaders(request.getHeaders());
 
@@ -172,6 +177,7 @@ export function responseProvider(request: EW.ResponseProviderRequest) {
     const arrayBufferBody = request.arrayBuffer();
 }
 
+// Verify the headers object
 function testHeaders(headers: EW.Headers) {
     Object.keys(headers).forEach(key => {
         key.toUpperCase();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://techdocs.akamai.com/edgeworkers/docs/request-object#getheaders (note that the changes to origin responses aren't documented yet)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
