### PR TITLE
Add RequestInfo to @types/node

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -518,6 +518,8 @@ declare global {
     } ? T
         : typeof import("undici-types").Request;
 
+    type RequestInfo = Request | string;
+
     interface ResponseInit extends _ResponseInit {}
 
     interface Response extends _Response {}


### PR DESCRIPTION
This type alias is based on a typedef in the Fetch Standard, and it is also exposed in the dom lib of TypeScript. Adding it here brings parity between @types/node and "dom".

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://fetch.spec.whatwg.org/#requestinfo
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
