### PR TITLE
[hasura] Update Equals type to use weaker comparison

### DIFF
--- a/types/hasura/index.d.ts
+++ b/types/hasura/index.d.ts
@@ -33,7 +33,7 @@ export interface JSONBColumnBoolExp extends ColumnBoolExp<string> {
     _has_keys_any?: string | undefined;
 }
 
-type Equals<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+type Equals<X, Y> = [X, Y, keyof X, keyof Y] extends [Y, X, keyof Y, keyof X] ? true : false;
 type ScalarType = string | number | boolean | ScalarJSON<unknown> | ScalarJSONB<unknown>;
 type ObjectType = Record<string, ScalarType | Record<string, ScalarType> | Array<Record<string, ScalarType>>>;
 export type ScalarJSON<T> = T & {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/microsoft/TypeScript/pull/60726

The use of identical type comparison for the `Equals` type will not work with an [upcoming adjustment](https://github.com/microsoft/TypeScript/pull/60726) to identical type comparison and is also overkill for the intended use case. The intended use case is for a given type, determine if it was constructed with a type like
```ts
export type ScalarJSON<T> = T & {
    __type?: "json" | undefined;
};
```
by checking whether `Equals<T, ScalarJson<T>>`. I've updated the type to be forwards-compatible with the upcoming change.

