### PR TITLE
[react/v18] allow `undefined` argument in useRef for forward compat

### DIFF
--- a/types/react/v18/index.d.ts
+++ b/types/react/v18/index.d.ts
@@ -2010,7 +2010,7 @@ declare namespace React {
      * @version 16.8.0
      * @see {@link https://react.dev/reference/react/useRef}
      */
-    function useRef<T = undefined>(): MutableRefObject<T | undefined>;
+    function useRef<T = undefined>(initialValue?: undefined): MutableRefObject<T | undefined>;
     /**
      * The signature is identical to `useEffect`, but it fires synchronously after all DOM mutations.
      * Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside

--- a/types/react/v18/test/hooks.tsx
+++ b/types/react/v18/test/hooks.tsx
@@ -179,8 +179,7 @@ function useEveryHook(ref: React.Ref<{ id: number }> | undefined): () => boolean
     React.useRef();
     // $ExpectType MutableRefObject<number | undefined>
     React.useRef<number>();
-    // don't just accept a potential undefined if there is a generic argument
-    // @ts-expect-error
+    // $ExpectType MutableRefObject<number | undefined>
     React.useRef<number>(undefined);
     // make sure once again there's no |undefined if the initial value doesn't either
     // $ExpectType MutableRefObject<number>

--- a/types/react/v18/ts5.0/index.d.ts
+++ b/types/react/v18/ts5.0/index.d.ts
@@ -2011,7 +2011,7 @@ declare namespace React {
      * @version 16.8.0
      * @see {@link https://react.dev/reference/react/useRef}
      */
-    function useRef<T = undefined>(): MutableRefObject<T | undefined>;
+    function useRef<T = undefined>(initialValue?: undefined): MutableRefObject<T | undefined>;
     /**
      * The signature is identical to `useEffect`, but it fires synchronously after all DOM mutations.
      * Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside

--- a/types/react/v18/ts5.0/test/hooks.tsx
+++ b/types/react/v18/ts5.0/test/hooks.tsx
@@ -179,8 +179,7 @@ function useEveryHook(ref: React.Ref<{ id: number }> | undefined): () => boolean
     React.useRef();
     // $ExpectType MutableRefObject<number | undefined>
     React.useRef<number>();
-    // don't just accept a potential undefined if there is a generic argument
-    // @ts-expect-error
+    // $ExpectType MutableRefObject<number | undefined>
     React.useRef<number>(undefined);
     // make sure once again there's no |undefined if the initial value doesn't either
     // $ExpectType MutableRefObject<number>


### PR DESCRIPTION
I have been working on making a fairly large codebase compatible with React 19 and we recently ran the [`useRef-required-initial` codemod](https://github.com/eps1lon/types-react-codemod/tree/main?tab=readme-ov-file#useref-required-initial-react-19) at scale (over 200 repos with changes) and encountered `No overload matches this call` errors. I fully acknowledge that the codemod is meant to be run while actually upgrading to React 19 and not while making a React 18 codebase forwards compatible but it seemed like this _could_ be done in backwards compatible way.

Example codemod output:

```diff
-useRef<number>()
+useRef<number>(undefined)
```

My PR updates the `useRef<T>()` overload in React 18 to accept an optional `undefined` parameter which would allow the codemod's out to type check against both the React 18 an 19 types. It's not clear why an `undefined` argument was originally restricted as the runtime behavior will be the same as no arguments. As you can see in the updated tests, this change result is some `@ts-expect-error` becoming unused but I'm not sure if that is generally considered a breaking change. 

If this change is not acceptable do you think a codemod like this would be better for my specific use case?

```diff
-useRef<number>()
+useRef<number | undefined>(undefined)
```

Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>


