### PR TITLE
fix(canvas-confetti): upgrade, add "flat" options & overload & jsdoc

### DIFF
--- a/types/canvas-confetti/canvas-confetti-tests.ts
+++ b/types/canvas-confetti/canvas-confetti-tests.ts
@@ -2,80 +2,119 @@ import confetti = require("canvas-confetti");
 
 confetti.Promise = null;
 
+declare const matrix: DOMMatrix;
+declare const bitmap: ImageBitmap;
+
 confetti();
-
+confetti({});
 confetti({
-    particleCount: 150,
-});
-
-confetti({
-    spread: 180,
-});
-
-confetti({
-    particleCount: 100,
-    startVelocity: 30,
-    spread: 360,
+    angle: 90,
+    colors: ["#bada55"],
+    decay: 0.9,
+    disableForReducedMotion: true,
+    drift: 0,
+    flat: true,
+    gravity: 1,
     origin: {
         x: Math.random(),
-        // since they fall down, start a bit higher than random
         y: Math.random() - 0.2,
     },
+    particleCount: 150,
+    scalar: 1,
+    shapes: [
+        {
+            type: "path",
+            path: "string",
+            matrix,
+        },
+        {
+            type: "bitmap",
+            bitmap,
+            matrix,
+        },
+        "square",
+        "circle",
+        "star",
+    ],
+    spread: 180,
+    startVelocity: 30,
+    ticks: 200,
+    zIndex: 100,
 });
 
-confetti({
-    particleCount: 100,
-    spread: 70,
-    drift: 1,
-    origin: {
-        y: 0.6,
-    },
+declare const canvas: HTMLCanvasElement;
+
+let customConfetti = confetti.create();
+customConfetti = confetti.create(canvas);
+customConfetti = confetti.create(canvas, {});
+customConfetti = confetti.create(canvas, {
+    disableForReducedMotion: true,
+    resize: true,
+    useWorker: true,
 });
 
-function r(min: number, max: number) {
-    return Math.random() * (max - min) + min;
-}
-
-confetti({
-    angle: r(55, 125),
-    spread: r(50, 70),
-    particleCount: r(50, 100),
+customConfetti();
+customConfetti({});
+customConfetti({
+    angle: 90,
+    colors: ["#bada55"],
+    decay: 0.9,
+    disableForReducedMotion: true,
     drift: 0,
+    flat: true,
+    gravity: 1,
     origin: {
-        y: 0.6,
+        x: Math.random(),
+        y: Math.random() - 0.2,
     },
-    shapes: ["square", "circle", "square", "star"],
+    particleCount: 150,
+    scalar: 1,
+    shapes: [
+        {
+            type: "path",
+            path: "string",
+            matrix,
+        },
+        {
+            type: "bitmap",
+            bitmap,
+            matrix,
+        },
+        "square",
+        "circle",
+        "star",
+    ],
+    spread: 180,
+    startVelocity: 30,
+    ticks: 200,
+    zIndex: 100,
 });
-
-const canvas = document.createElement("canvas");
-const myConfetti = confetti.create(canvas);
-
-myConfetti();
 
 confetti.reset();
 
-myConfetti.reset();
+customConfetti.reset();
 
-myConfetti({
-    particleCount: 150,
-});
-
-confetti()!.then(() => {
-    // ready
-});
 confetti()!.then(param => {
     param; // $ExpectType undefined
 });
 
-confetti.create(undefined, undefined);
+declare const path: string;
 
-confetti.shapeFromPath({
-    path:
-        "M0 2.51004C1.39 1.80004 2.85 1.22004 4.35 0.760044C5.88 0.430044 7.43 0.230044 9 0.170044C10.55 0.230044 12.11 0.430044 13.63 0.760044C15.13 1.21004 16.6 1.80004 18 2.51004C18 5.17004 18 7.83004 18 10.49C16.58 9.77004 15.14 9.20004 13.64 8.74004C12.11 8.41004 10.55 8.21004 8.98 8.15004C7.42 8.21004 5.88 8.42004 4.35 8.75004C2.84 9.21004 1.39 9.79004 0 10.51C0 7.83004 0 5.17004 0 2.51004Z",
-});
+// @ts-ignore - Need an argument
+confetti.shapeFromPath();
+confetti.shapeFromPath(path);
 
-confetti.shapeFromText({ text: "🎉" });
+// @ts-ignore - `pathData.path` is required
+confetti.shapeFromPath({});
+confetti.shapeFromPath({ path });
+confetti.shapeFromPath({ path, matrix });
 
-confetti.shapeFromText({ text: "🎉", fontFamily: "Apple Color Emoji" });
+declare const text: string;
+// @ts-ignore - Need an argument
+confetti.shapeFromText();
+confetti.shapeFromText(text);
 
-confetti.shapeFromText({ text: "✷", color: "hotpink", fontFamily: "Arial" });
+// @ts-ignore - `textData.text` is required
+confetti.shapeFromText({});
+confetti.shapeFromText({ text });
+confetti.shapeFromText({ text, scalar: 1, color: "hotpink", fontFamily: "Arial" });

--- a/types/canvas-confetti/index.d.ts
+++ b/types/canvas-confetti/index.d.ts
@@ -64,6 +64,12 @@ declare namespace confetti {
          */
         drift?: number | undefined;
         /**
+         * Optionally turns off the tilt and wobble that three dimensional confetti would have in the real world.
+         * Yeah, they look a little sad, but y'all asked for them, so don't blame me.
+         * @default false
+         */
+        flat?: boolean | undefined;
+        /**
          * How quickly the particles are pulled down. 1 is full gravity, 0.5 is half gravity, etc., but there are no limits.
          * @default 1
          */
@@ -127,6 +133,7 @@ declare namespace confetti {
         /**
          * Disables confetti entirely for users that prefer reduced motion. When set to true, use of this
          * confetti instance will always respect a user's request for reduced motion and disable confetti for them.
+         * @default false
          */
         disableForReducedMotion?: boolean | undefined;
         /**
@@ -144,20 +151,39 @@ declare namespace confetti {
     /**
      * This helper method lets you create a custom confetti shape using an SVG Path string.
      */
-    function shapeFromPath({ path, matrix }: { path: string; matrix?: DOMMatrix }): Shape;
+    function shapeFromPath(pathData: string): Shape;
+    function shapeFromPath(pathData: { path: string; matrix?: DOMMatrix }): Shape;
 
     /**
      * This is the highly anticipated feature to render emoji confetti! Use any standard unicode emoji. Or other text.
      */
-    function shapeFromText({
-        text,
-        scalar,
-        color,
-        fontFamily,
-    }: {
+    function shapeFromText(
+        /**
+         * The text to be rendered as a confetti. If you can't make up your mind, I suggest "🐈".
+         */
+        textData: string,
+    ): Shape;
+    function shapeFromText(textData: {
+        /**
+         * The text to be rendered as a confetti. If you can't make up your mind, I suggest "🐈".
+         */
         text: string;
+        /**
+         * A scale value relative to the default size. It matches the scalar value in the confetti options.
+         * @default 1
+         */
         scalar?: number;
+        /**
+         * The color used to render the text.
+         * @default '#000000'
+         */
         color?: string;
+        /**
+         * The font family name to use when rendering the text.
+         * The default follows [best practices for rendring the native OS emoji of the device](https://nolanlawson.com/2022/04/08/the-struggle-of-using-native-emoji-on-the-web/), falling back to sans-serif.
+         * If using a web font, make sure this [font is loaded](https://developer.mozilla.org/en-US/docs/Web/API/FontFace/load) before rendering your confetti.
+         * @default '"Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji", "EmojiOne Color", "Android Emoji", "Twemoji Mozilla", "system emoji", sans-serif'
+         */
         fontFamily?: string;
     }): Shape;
 

--- a/types/canvas-confetti/package.json
+++ b/types/canvas-confetti/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/canvas-confetti",
-    "version": "1.6.9999",
+    "version": "1.9.9999",
     "projects": [
         "https://github.com/catdad/canvas-confetti#readme"
     ],


### PR DESCRIPTION
- Added a `flat` option to allow rendering confetti without any tilt or wobble.
    - See [v1.7.0 release note](https://github.com/catdad/canvas-confetti/releases/tag/1.7.0).
    - Resolves [discussions/71328](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/71328).
- Add single-argument overloads for `shapeFromPath()` & `shapeFromText()`.
    - See [`shapeFromPath()` implementation](https://github.com/catdad/canvas-confetti/blob/master/src/confetti.js#L748-L760).
    - And see [`shapeFromText()` implementation](https://github.com/catdad/canvas-confetti/blob/master/src/confetti.js#L808-L822).
- Add back missing jsdoc (description, default value tag).
- Add & refine tests.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
