### PR TITLE
chore(ltx): bump version, remove it from attw

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -1212,7 +1212,6 @@
         "logg",
         "login-with-amazon-sdk-browser",
         "lowlight",
-        "ltx",
         "luxon",
         "macaca-circular-json",
         "magic-number",

--- a/types/ltx/package.json
+++ b/types/ltx/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/ltx",
-    "version": "3.0.9999",
+    "version": "3.1.9999",
     "projects": [
         "http://github.com/node-xmpp/ltx"
     ],


### PR DESCRIPTION
[Latest v3.1.x release](https://github.com/xmppjs/ltx/releases/tag/v3.1.0) of the library has resolved its own attw issue, hence it can be safely removed from attw.

I believe this is blocking ongoing or any further PR to `@types/node`. Maintainers may want to take a look on this. @jakebailey

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
