### PR TITLE
[@types/oracledb] Add privilege property for createPool API

### DIFF
--- a/types/oracledb/index.d.ts
+++ b/types/oracledb/index.d.ts
@@ -2965,6 +2965,15 @@ declare namespace OracleDB {
          * Statistics can be output to the console by calling the pool.logStatistics() method.
          */
         enableStatistics?: boolean | undefined;
+        /**
+         * The privilege to use when establishing connection to the database.
+         * This optional property should be one of the privileged connection constants.
+         * For Thin mode only, privilege is applicable in createPool. Thick mode
+         * still needs to pass it in pool.getConnection.
+         *
+         * @since 6.5.1
+         */
+        privilege?: number | undefined;
     }
 
     /**

--- a/types/oracledb/oracledb-tests.ts
+++ b/types/oracledb/oracledb-tests.ts
@@ -710,4 +710,20 @@ export const version6Tests = async (): Promise<void> => {
     // by DB for SODA document.
     const key = new oracledb.JsonId([102, 241, 117, 85, 174, 103, 204, 25, 15, 172, 252, 47]);
     console.log(key.toJSON()); // 66f17555ae67cc190facfc2f
+
+    console.log("Testing createPool() with privilege parameter applicable for Thin mode...");
+
+    await oracledb.createPool({
+        connectString: DB_CONNECTION_STRING,
+        privilege: oracledb.SYSDBA,
+        homogeneous: true,
+        password: DB_PASSWORD,
+        poolIncrement: 1,
+        poolMax: 5,
+        poolMin: 3,
+        poolPingInterval: 60,
+        poolTimeout: 60,
+        queueTimeout: 60000,
+        user: DB_USER,
+    });
 };


### PR DESCRIPTION
 The `privilege` propery can be passed in `oracledb.createPool` from node-oracledb 6.5.1 version. Updated the poolAttributes for the same.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
