### PR TITLE
Grunt: Fix type of this.flags

### DIFF
--- a/types/grunt/grunt-tests.ts
+++ b/types/grunt/grunt-tests.ts
@@ -146,3 +146,9 @@ let mytest = function(grunt: IGrunt) {
     };
     grunt.file.copy("./test.file", "./testcopy.file", opt);
 };
+let flagtest = function(grunt: IGrunt) {
+    grunt.registerTask("flagtest", function() {
+        // $ExpectType IFlag
+        const flags = this.flags;
+    });
+};

--- a/types/grunt/index.d.ts
+++ b/types/grunt/index.d.ts
@@ -928,7 +928,7 @@ const copyOptions: grunt.file.IFileWriteStringOption = {
              * For example, if a "sample" task was run as grunt sample:foo:bar,
              * inside the task function, this.flags would be {foo: true, bar: true}.
              */
-            flags: grunt.IFlag[];
+            flags: grunt.IFlag;
 
             /**
              * The number of grunt.log.error calls that occurred during this task.


### PR DESCRIPTION
JsDoc also explains that this is an object and no array of objects.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
