### PR TITLE
[@uswds/uswds] Bump version to 3.11.x

### DIFF
--- a/types/uswds__uswds/package.json
+++ b/types/uswds__uswds/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/uswds__uswds",
-    "version": "3.10.9999",
+    "version": "3.11.9999",
     "projects": [
         "https://github.com/uswds/uswds"
     ],


### PR DESCRIPTION
Updates package version to bring in line with [@uswds/uswds](https://www.npmjs.com/package/@uswds/uswds) 3.11.0, after confirming [no changes to public interfaces](https://github.com/uswds/uswds/compare/v3.10.0...v3.11.0) in latest version.

This is similar to #71210, where the idea is to keep the DefinitelyTyped types package in lock-step `@uswds/uswds` to reduce future maintenance effort of accounting for changes in a larger version drift, and to increase end-user confidence that the types are accurate to the latest version of the main package.

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/uswds/uswds/compare/v3.10.0...v3.11.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
