### PR TITLE
Update type for Usercentrics Browser UI

### DIFF
--- a/types/usercentrics-browser-ui/integration-interfaces.d.ts
+++ b/types/usercentrics-browser-ui/integration-interfaces.d.ts
@@ -25,8 +25,13 @@ export interface BaseTCFUserDecision {
     /** Indicates if the user gave consent (true) or denied consent (false) */
     consent?: boolean;
 
-    /** The id of the purpose/vendor the consent decision belongs to */
-    id: number;
+    /**
+     * The id of the purpose/vendor the consent decision belongs to.
+     * Note: Different pages in the Usercentrics docs disagree on the type, so both are allowed:
+     * https://usercentrics.com/docs/web/implementation/ui/interfaces/#basetcfuserdecision (number)
+     * https://usercentrics.com/docs/web/features/api/control-functionality/#updatecategoriesconsents (string)
+     */
+    id: number | string;
 }
 
 /**

--- a/types/usercentrics-browser-ui/usercentrics-browser-ui-tests.ts
+++ b/types/usercentrics-browser-ui/usercentrics-browser-ui-tests.ts
@@ -16,4 +16,18 @@ async function getConsentSettingsFromUsercentrics() {
 
     // $ExpectType boolean
     await window._ucCmp.isConsentRequired();
+
+    /*
+      Adding serviceConsents example data from the docs and one with id of type number
+      Note: Different pages in the Usercentrics docs disagree on the type, so both are allowed:
+      https://usercentrics.com/docs/web/implementation/ui/interfaces/#basetcfuserdecision (number)
+      https://usercentrics.com/docs/web/features/api/control-functionality/#updatecategoriesconsents (string)
+     */
+    const serviceConsents = [
+        { id: "HkocEodjb7", consent: true },
+        { id: "S1_9Vsuj-Q", consent: false },
+        { id: 12345567, consent: false },
+    ];
+
+    await window._ucCmp.updateServicesConsents(serviceConsents);
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

### Reason
In the docs of Usercentrics Browser UI Functions, they are using `string` only. See [here](https://usercentrics.com/docs/web/features/api/control-functionality/#updatecategoriesconsents). I run into it, when I added the types into our project.