### PR TITLE
toastify-js, add the ESM module

### DIFF
--- a/types/toastify-js/src/toastify-es.d.ts
+++ b/types/toastify-js/src/toastify-es.d.ts
@@ -1,2 +1,2 @@
-import Toastify = require('../index')
+import Toastify = require("../index");
 export default Toastify;

--- a/types/toastify-js/src/toastify-es.d.ts
+++ b/types/toastify-js/src/toastify-es.d.ts
@@ -1,2 +1,2 @@
-import Toastify from "../index";
+import Toastify = require('../index')
 export default Toastify;

--- a/types/toastify-js/src/toastify-es.d.ts
+++ b/types/toastify-js/src/toastify-es.d.ts
@@ -1,2 +1,2 @@
-import Toastify from '../index'
-export default Toastify
+import Toastify from "../index";
+export default Toastify;

--- a/types/toastify-js/src/toastify-es.d.ts
+++ b/types/toastify-js/src/toastify-es.d.ts
@@ -1,0 +1,2 @@
+import Toastify from '../index'
+export default Toastify

--- a/types/toastify-js/toastify-js-tests.ts
+++ b/types/toastify-js/toastify-js-tests.ts
@@ -1,5 +1,5 @@
 import { Options } from "toastify-js";
-import ToastifyEsm from "toastify-js/src/toastify-es"
+import ToastifyEsm from "toastify-js/src/toastify-es";
 import Toastify = require("toastify-js");
 
 Toastify({

--- a/types/toastify-js/toastify-js-tests.ts
+++ b/types/toastify-js/toastify-js-tests.ts
@@ -1,4 +1,5 @@
 import { Options } from "toastify-js";
+import ToastifyEsm from "toastify-js/src/toastify-es"
 import Toastify = require("toastify-js");
 
 Toastify({
@@ -50,6 +51,8 @@ const options: Options = {
 };
 
 Toastify(options);
+
+ToastifyEsm(); // $ExpectType Toastify
 
 // #60413
 const toast = Toastify({

--- a/types/toastify-js/tsconfig.json
+++ b/types/toastify-js/tsconfig.json
@@ -15,6 +15,7 @@
     },
     "files": [
         "index.d.ts",
-        "toastify-js-tests.ts"
+        "toastify-js-tests.ts",
+        "src/toastify-es.d.ts"
     ]
 }


### PR DESCRIPTION
Toastify-js also has an exported `src/toastify-es.js` file (which is not just the same as the default, it is a mini-rewrite, although the types are the same). Not sure if this is the correct way of doing this, but as the es export is *functionally* different from the base one, it is relevant which you use.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.