### PR TITLE
[node] Addenda to v22.10.0 typings

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -249,19 +249,21 @@ declare global {
         };
 
     /**
-     * A browser-compatible implementation of [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage).
-     * Data is stored unencrypted in the file specified by the `--localstorage-file` CLI flag.
+     * A browser-compatible implementation of [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage). Data is stored
+     * unencrypted in the file specified by the `--localstorage-file` CLI flag.
+     * The maximum amount of data that can be stored is 10 MB.
      * Any modification of this data outside of the Web Storage API is not supported.
      * Enable this API with the `--experimental-webstorage` CLI flag.
+     * `localStorage` data is not stored per user or per request when used in the context
+     * of a server, it is shared across all users and requests.
      * @since v22.4.0
      */
     var localStorage: Storage;
 
     /**
-     * A browser-compatible implementation of [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage).
-     * Data is stored in memory, with a storage quota of 10 MB.
-     * Any modification of this data outside of the Web Storage API is not supported.
-     * Enable this API with the `--experimental-webstorage` CLI flag.
+     * A browser-compatible implementation of [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage). Data is stored in
+     * memory, with a storage quota of 10 MB. `sessionStorage` data persists only within
+     * the currently running process, and is not shared between workers.
      * @since v22.4.0
      */
     var sessionStorage: Storage;

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -896,6 +896,9 @@ declare module "net" {
     function getDefaultAutoSelectFamily(): boolean;
     /**
      * Sets the default value of the `autoSelectFamily` option of `socket.connect(options)`.
+     * @param value The new default value.
+     * The initial default value is `true`, unless the command line option
+     * `--no-network-family-autoselection` is provided.
      * @since v19.4.0
      */
     function setDefaultAutoSelectFamily(value: boolean): void;

--- a/types/node/sqlite.d.ts
+++ b/types/node/sqlite.d.ts
@@ -61,6 +61,15 @@ declare module "node:sqlite" {
          * @default true
          */
         enableForeignKeyConstraints?: boolean | undefined;
+        /**
+         * If `true`, SQLite will accept
+         * [double-quoted string literals](https://www.sqlite.org/quirks.html#dblquote).
+         * This is not recommended but can be
+         * enabled for compatibility with legacy database schemas.
+         * @since v22.10.0
+         * @default false
+         */
+        enableDoubleQuotedStringLiterals?: boolean | undefined;
     }
     /**
      * This class represents a single [connection](https://www.sqlite.org/c3ref/sqlite3.html) to a SQLite database. All APIs

--- a/types/node/sqlite.d.ts
+++ b/types/node/sqlite.d.ts
@@ -45,10 +45,22 @@
 declare module "node:sqlite" {
     interface DatabaseSyncOptions {
         /**
-         * If `true`, the database is opened by the constructor.
-         * When this value is `false`, the database must be opened via the `open()` method.
+         * If `true`, the database is opened by the constructor. When
+         * this value is `false`, the database must be opened via the `open()` method.
+         * @since v22.5.0
+         * @default true
          */
         open?: boolean | undefined;
+        /**
+         * If `true`, foreign key constraints
+         * are enabled. This is recommended but can be disabled for compatibility with
+         * legacy database schemas. The enforcement of foreign key constraints can be
+         * enabled and disabled after opening the database using
+         * [`PRAGMA foreign_keys`](https://www.sqlite.org/pragma.html#pragma_foreign_keys).
+         * @since v22.10.0
+         * @default true
+         */
+        enableForeignKeyConstraints?: boolean | undefined;
     }
     /**
      * This class represents a single [connection](https://www.sqlite.org/c3ref/sqlite3.html) to a SQLite database. All APIs

--- a/types/node/sqlite.d.ts
+++ b/types/node/sqlite.d.ts
@@ -161,12 +161,13 @@ declare module "node:sqlite" {
             ...anonymousParameters: SupportedValueType[]
         ): unknown[];
         /**
-         * This method returns the source SQL of the prepared statement with parameter
-         * placeholders replaced by values. This method is a wrapper around [`sqlite3_expanded_sql()`](https://www.sqlite.org/c3ref/expanded_sql.html).
+         * The source SQL text of the prepared statement with parameter
+         * placeholders replaced by the values that were used during the most recent
+         * execution of this prepared statement. This property is a wrapper around
+         * [`sqlite3_expanded_sql()`](https://www.sqlite.org/c3ref/expanded_sql.html).
          * @since v22.5.0
-         * @return The source SQL expanded to include parameter values.
          */
-        expandedSQL(): string;
+        readonly expandedSQL: string;
         /**
          * This method executes a prepared statement and returns the first result as an
          * object. If the prepared statement does not return any results, this method
@@ -224,11 +225,10 @@ declare module "node:sqlite" {
          */
         setReadBigInts(enabled: boolean): void;
         /**
-         * This method returns the source SQL of the prepared statement. This method is a
+         * The source SQL text of the prepared statement. This property is a
          * wrapper around [`sqlite3_sql()`](https://www.sqlite.org/c3ref/expanded_sql.html).
          * @since v22.5.0
-         * @return The source SQL used to create this prepared statement.
          */
-        sourceSQL(): string;
+        readonly sourceSQL: string;
     }
 }

--- a/types/node/test/sqlite.ts
+++ b/types/node/test/sqlite.ts
@@ -1,4 +1,4 @@
-import { DatabaseSync } from "node:sqlite";
+import { DatabaseSync, StatementSync } from "node:sqlite";
 import { TextEncoder } from "node:util";
 
 {
@@ -31,4 +31,10 @@ import { TextEncoder } from "node:util";
     result.lastInsertRowid; // $ExpectType number | bigint
 
     database.close();
+}
+
+{
+    let statement!: StatementSync;
+    statement.expandedSQL; // $ExpectType string
+    statement.sourceSQL; // $ExpectType string
 }


### PR DESCRIPTION
Adds the following changes which were not flagged as semver-minor:

- doc: add more details for localStorage and sessionStorage
- doc: fix initial default value of autoSelectFamily
- sqlite: disable DQS misfeature by default
- sqlite: enable foreign key constraints by default
- sqlite: make sourceSQL and expandedSQL string-valued properties

Follow-up to #71005.