### PR TITLE
[express-serve-static-core] Add error param to `app.listen` callback as changed in express v5

### DIFF
--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -13,6 +13,9 @@ app.listen(3000);
 app.listen(3000, () => {
     // no-op error callback
 });
+app.listen(3000, (error) => {
+    error; // $ExpectType Error | undefined
+});
 
 app.get("/:foo", req => {
     req.params.foo; // $ExpectType string

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -1183,12 +1183,12 @@ export interface Application<
      *    http.createServer(app).listen(80);
      *    https.createServer({ ... }, app).listen(443);
      */
-    listen(port: number, hostname: string, backlog: number, callback?: () => void): http.Server;
-    listen(port: number, hostname: string, callback?: () => void): http.Server;
-    listen(port: number, callback?: () => void): http.Server;
-    listen(callback?: () => void): http.Server;
-    listen(path: string, callback?: () => void): http.Server;
-    listen(handle: any, listeningListener?: () => void): http.Server;
+    listen(port: number, hostname: string, backlog: number, callback?: (error?: Error) => void): http.Server;
+    listen(port: number, hostname: string, callback?: (error?: Error) => void): http.Server;
+    listen(port: number, callback?: (error?: Error) => void): http.Server;
+    listen(callback?: (error?: Error) => void): http.Server;
+    listen(path: string, callback?: (error?: Error) => void): http.Server;
+    listen(handle: any, listeningListener?: (error?: Error) => void): http.Server;
 
     router: string;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Original PR](https://github.com/expressjs/express/pull/3216) and [migration guide](https://expressjs.com/en/guide/migrating-5.html#app.listen) (main docs have not been updated yet)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. - not applicable

Although this change has been mentioned in multiple issues (e.g. expressjs/express/issues/6191), it seems like it has not yet made its way to the DT repo. It's my first PR here, so please do point out any mistakes I might have made 🙏 