### PR TITLE
Define `ContentType` union type for HTTP content negotiation and add `HeaderContent` type for header specification. Update `setHeader` method to enforce content-type validation.

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -111,6 +111,69 @@ declare module "http" {
         warning?: string | undefined;
         "www-authenticate"?: string | undefined;
     }
+
+    // A union type representing various MIME types for HTTP content negotiation.
+    // Used to specify or check the content type of HTTP requests and responses.
+    type ContentTypeValues =
+        | "text/plain"
+        | "text/html"
+        | "text/css"
+        | "text/javascript"
+        | "text/csv"
+        | "text/xml"
+        | "text/json"
+        | "text/markdown"
+        | "text/calendar"
+        | "text/event-stream"
+        | "application/json"
+        | "application/xml"
+        | "application/javascript"
+        | "application/ld+json"
+        | "application/xhtml+xml"
+        | "application/atom+xml"
+        | "application/rss+xml"
+        | "application/zip"
+        | "application/gzip"
+        | "application/pdf"
+        | "application/msword"
+        | "application/vnd.ms-excel"
+        | "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        | "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        | "application/rtf"
+        | "application/octet-stream"
+        | "image/jpeg"
+        | "image/png"
+        | "image/gif"
+        | "image/webp"
+        | "image/svg+xml"
+        | "image/bmp"
+        | "audio/mpeg"
+        | "audio/ogg"
+        | "audio/wav"
+        | "video/mp4"
+        | "video/webm"
+        | "video/ogg"
+        | "video/x-matroska"
+        | "font/woff"
+        | "font/woff2"
+        | "font/otf"
+        | "font/ttf"
+        | "multipart/form-data"
+        | "multipart/byteranges"
+        | "multipart/mixed"
+        | "application/x-7z-compressed"
+        | "application/x-rar-compressed"
+        | "application/x-tar"
+        | "application/epub+zip"
+        | "application/vnd.api+json";
+
+    // Define the `HeaderContent` type which specifies headers and their corresponding values.
+    // Each header is an object with a `name` and a `value` property.
+    interface HeaderContent {
+        name: "Content-Type";
+        value: `${ContentTypeValues}${string}`;
+    }
+
     // outgoing headers allows numbers (as they are converted internally to strings)
     type OutgoingHttpHeader = number | string | string[];
     interface OutgoingHttpHeaders extends NodeJS.Dict<OutgoingHttpHeader> {
@@ -588,7 +651,11 @@ declare module "http" {
          * @param name Header name
          * @param value Header value
          */
-        setHeader(name: string, value: number | string | readonly string[]): this;
+        setHeader<T extends string>(
+            name: T,
+            value: Extract<HeaderContent, { name: T }> extends { name: T; value: infer R } ? R
+                : number | string | readonly string[],
+        ): this;
         /**
          * Sets multiple header values for implicit headers. headers must be an instance of
          * `Headers` or `Map`, if a header already exists in the to-be-sent headers, its

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -4,6 +4,28 @@ import * as net from "node:net";
 import * as stream from "node:stream";
 import * as url from "node:url";
 
+// http Server (with ContentType and HeaderContent tests)
+{
+    // Test ContentType Union type
+    let contentType: http.ContentTypeValues;
+
+    // Valid cases
+    contentType = "text/plain"; // should work
+    contentType = "application/json"; // should work
+    contentType = "image/jpeg"; // should work
+
+    // Invalid case - TypeScript should flag this
+    // @ts-expect-error
+    contentType = "invalid/type"; // Error: Type '"invalid/type"' is not assignable to type 'ContentType'
+
+    // Test HeaderContent type
+    const header: http.HeaderContent = { name: "Content-Type", value: "application/json" }; // should work
+
+    // Invalid case - TypeScript should flag this
+    // @ts-expect-error
+    const invalidHeader: http.HeaderContent = { name: "Content-Type", value: "invalid/type" }; // Error: Type '"invalid/type"' is not assignable to type 'ContentType'
+}
+
 // http Server
 {
     function reqListener(req: http.IncomingMessage, res: http.ServerResponse): void {}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changes:
 - Added a new ContentType union type to represent various MIME types for HTTP content negotiation.
 - Introduced HeaderContent type to specify the headers with a name ("Content-Type") and its corresponding value (ContentType).
 - Updated setHeader method to enforce content-type validation, ensuring only valid MIME types are set.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type>>
