### PR TITLE
Fix Meteor `Mongo.Cursor` iterator return type

### DIFF
--- a/types/meteor/mongo.d.ts
+++ b/types/meteor/mongo.d.ts
@@ -479,8 +479,8 @@ declare module 'meteor/mongo' {
                 callbacks: ObserveChangesCallbacks<T>,
                 options?: { nonMutatingCallbacks?: boolean | undefined },
             ): Meteor.LiveQueryHandle;
-            [Symbol.iterator](): Iterator<T>;
-            [Symbol.asyncIterator](): AsyncIterator<T>;
+            [Symbol.iterator](): Iterator<U>;
+            [Symbol.asyncIterator](): AsyncIterator<U>;
         }
 
         var ObjectID: ObjectIDStatic;


### PR DESCRIPTION
This fixes wrong types defined for the `Mongo.Cursor` return value, which affectes the following use case example:

```js
import { Mongo } from 'meteor/mongo';

export class FooData {
  /** @type {string} */
  name;
}

export class Foo extends FooData {
  echo() {
    console.log(this.name);
  }
}

/**
 * @extends {Collection<FooData, Foo>}
 */
export const CollFoo = new Mongo.Collection('collFoo', {
  transform: (doc) => Object.assign(new Foo(), doc),
});

// All of the following use cases are valid
CollFoo.findOne().echo();
CollFoo.find().fetch()[0].echo();
// But this is highlighted in IDE as wrong because `Mong.Cursor[Symbol.iterator]()` return type is set to `FooData` not `Foo`
CollFoo.find()[Symbol.iterator]().next().value.echo();
```