### PR TITLE
[@types/oojs-ui] Add CopyLinkLayout

### DIFF
--- a/types/oojs-ui/CopyTextLayout.d.ts
+++ b/types/oojs-ui/CopyTextLayout.d.ts
@@ -50,7 +50,8 @@ declare namespace OO.ui {
             T extends TextInputWidget | MultilineTextInputWidget =
                 | TextInputWidget
                 | MultilineTextInputWidget
-        > extends FieldLayout.Prototype<T> {
+        > extends FieldLayout.Prototype<T>
+        {
             /**
              * Handle button click events.
              *

--- a/types/oojs-ui/CopyTextLayout.d.ts
+++ b/types/oojs-ui/CopyTextLayout.d.ts
@@ -1,147 +1,147 @@
 declare namespace OO.ui {
-	/**
-	 * CopyTextLayout is an action field layout containing some readonly text
-	 * and a button to copy it to the clipboard.
-	 *
-	 * ResourceLoader module: `oojs-ui-widgets`
-	 *
-	 * @see https://doc.wikimedia.org/oojs-ui/master/js/#!/api/OO.ui.CopyTextLayout
-	 */
-	interface CopyTextLayout<
-		T extends TextInputWidget | MultilineTextInputWidget =
-			| TextInputWidget
-			| MultilineTextInputWidget
-	> extends CopyTextLayout.Props, CopyTextLayout.Prototype<T>
-	{}
+    /**
+     * CopyTextLayout is an action field layout containing some readonly text
+     * and a button to copy it to the clipboard.
+     *
+     * ResourceLoader module: `oojs-ui-widgets`
+     *
+     * @see https://doc.wikimedia.org/oojs-ui/master/js/#!/api/OO.ui.CopyTextLayout
+     */
+    interface CopyTextLayout<
+        T extends TextInputWidget | MultilineTextInputWidget =
+            | TextInputWidget
+            | MultilineTextInputWidget
+    > extends CopyTextLayout.Props, CopyTextLayout.Prototype<T>
+    {}
 
-	namespace CopyTextLayout {
-		interface EventMap extends mixin.LabelElement.EventMap {
-			/**
-			 * When the user has executed a copy command.
-			 *
-			 * @param success Whether the copy command succeeded
-			 */
-			copy: [success: boolean];
-		}
+    namespace CopyTextLayout {
+        interface EventMap extends mixin.LabelElement.EventMap {
+            /**
+             * When the user has executed a copy command.
+             *
+             * @param success Whether the copy command succeeded
+             */
+            copy: [success: boolean];
+        }
 
-		interface ConfigOptions<M extends boolean | undefined> extends ActionFieldLayout.ConfigOptions {
-			/** Text to copy, can also be provided as `textInput.value` */
-			copyText?: string;
-			/** Config for the text input widget */
-			textInput?: M extends true
-				? MultilineTextInputWidget.ConfigOptions
-				: TextInputWidget.ConfigOptions;
-			/** Config for the button widget */
-			button?: ButtonWidget.ConfigOptions;
-			/** Whether to use a multiline text input */
-			multiline?: M;
-		}
+        interface ConfigOptions<M extends boolean | undefined> extends ActionFieldLayout.ConfigOptions {
+            /** Text to copy, can also be provided as `textInput.value` */
+            copyText?: string;
+            /** Config for the text input widget */
+            textInput?: M extends true
+                ? MultilineTextInputWidget.ConfigOptions
+                : TextInputWidget.ConfigOptions;
+            /** Config for the button widget */
+            button?: ButtonWidget.ConfigOptions;
+            /** Whether to use a multiline text input */
+            multiline?: M;
+        }
 
-		type Static = ActionFieldLayout.Static;
+        type Static = ActionFieldLayout.Static;
 
-		interface Props extends ActionFieldLayout.Props {
-			/** Text input widget used in the layout */
-			textInput: TextInputWidget | MultilineTextInputWidget;
-			/** Button widget used in the layout */
-			button: ButtonWidget;
-		}
+        interface Props extends ActionFieldLayout.Props {
+            /** Text input widget used in the layout */
+            textInput: TextInputWidget | MultilineTextInputWidget;
+            /** Button widget used in the layout */
+            button: ButtonWidget;
+        }
 
-		interface Prototype<
-			T extends TextInputWidget | MultilineTextInputWidget =
-				| TextInputWidget
-				| MultilineTextInputWidget
-		> extends FieldLayout.Prototype<T> {
-			/**
-			 * Handle button click events.
-			 *
-			 * @fires copy
-			 */
-			onButtonClick(): void;
+        interface Prototype<
+            T extends TextInputWidget | MultilineTextInputWidget =
+                | TextInputWidget
+                | MultilineTextInputWidget
+        > extends FieldLayout.Prototype<T> {
+            /**
+             * Handle button click events.
+             *
+             * @fires copy
+             */
+            onButtonClick(): void;
 
-			/**
-			 * Handle text widget focus events.
-			 */
-			onInputFocus(): void;
+            /**
+             * Handle text widget focus events.
+             */
+            onInputFocus(): void;
 
-			/**
-			 * Select the text to copy.
-			 */
-			selectText(): void;
+            /**
+             * Select the text to copy.
+             */
+            selectText(): void;
 
-			/**
-			 * Get the widget contained by the field.
-			 *
-			 * @return Field widget
-			 */
-			getField(): T;
+            /**
+             * Get the widget contained by the field.
+             *
+             * @return Field widget
+             */
+            getField(): T;
 
-			// #region EventEmitter overloads
-			on<K extends keyof EventMap, A extends ArgTuple = [], C = null>(
-				event: K,
-				method: EventHandler<C, (this: C, ...args: [...A, ...EventMap[K]]) => void>,
-				args?: A,
-				context?: C
-			): this;
-			on<K extends string, C = null>(
-				event: K extends keyof EventMap ? never : K,
-				method: EventHandler<C>,
-				args?: any[],
-				context?: C
-			): this;
+            // #region EventEmitter overloads
+            on<K extends keyof EventMap, A extends ArgTuple = [], C = null>(
+                event: K,
+                method: EventHandler<C, (this: C, ...args: [...A, ...EventMap[K]]) => void>,
+                args?: A,
+                context?: C
+            ): this;
+            on<K extends string, C = null>(
+                event: K extends keyof EventMap ? never : K,
+                method: EventHandler<C>,
+                args?: any[],
+                context?: C
+            ): this;
 
-			once<K extends keyof EventMap>(
-				event: K,
-				listener: (this: null, ...args: EventMap[K]) => void
-			): this;
-			once<K extends string>(
-				event: K extends keyof EventMap ? never : K,
-				listener: (this: null, ...args: any[]) => void
-			): this;
+            once<K extends keyof EventMap>(
+                event: K,
+                listener: (this: null, ...args: EventMap[K]) => void
+            ): this;
+            once<K extends string>(
+                event: K extends keyof EventMap ? never : K,
+                listener: (this: null, ...args: any[]) => void
+            ): this;
 
-			off<K extends keyof EventMap, C = null>(
-				event: K,
-				method?: EventHandler<C, (this: C, ...args: EventMap[K]) => void>,
-				context?: C
-			): this;
-			off<K extends string, C = null>(
-				event: K extends keyof EventMap ? never : K,
-				method?: EventHandler<C>,
-				context?: C
-			): this;
+            off<K extends keyof EventMap, C = null>(
+                event: K,
+                method?: EventHandler<C, (this: C, ...args: EventMap[K]) => void>,
+                context?: C
+            ): this;
+            off<K extends string, C = null>(
+                event: K extends keyof EventMap ? never : K,
+                method?: EventHandler<C>,
+                context?: C
+            ): this;
 
-			emit<K extends keyof EventMap>(event: K, ...args: EventMap[K]): boolean;
-			emit<K extends string>(event: K extends keyof EventMap ? never : K, ...args: any[]): boolean;
+            emit<K extends keyof EventMap>(event: K, ...args: EventMap[K]): boolean;
+            emit<K extends string>(event: K extends keyof EventMap ? never : K, ...args: any[]): boolean;
 
-			emitThrow<K extends keyof EventMap>(event: K, ...args: EventMap[K]): boolean;
-			emitThrow<K extends string>(
-				event: K extends keyof EventMap ? never : K,
-				...args: any[]
-			): boolean;
+            emitThrow<K extends keyof EventMap>(event: K, ...args: EventMap[K]): boolean;
+            emitThrow<K extends string>(
+                event: K extends keyof EventMap ? never : K,
+                ...args: any[]
+            ): boolean;
 
-			connect<T extends Partial<Record<keyof EventMap, any>>, C>( // eslint-disable-line @definitelytyped/no-unnecessary-generics
-				context: C,
-				methods: EventConnectionMap<T, C, EventMap>
-			): this;
+            connect<T extends Partial<Record<keyof EventMap, any>>, C>( // eslint-disable-line @definitelytyped/no-unnecessary-generics
+                context: C,
+                methods: EventConnectionMap<T, C, EventMap>
+            ): this;
 
-			disconnect<T extends Partial<Record<keyof EventMap, any>>, C>( // eslint-disable-line @definitelytyped/no-unnecessary-generics
-				context: C,
-				methods?: EventConnectionMap<T, C, EventMap>
-			): this;
-			// #endregion
-		}
+            disconnect<T extends Partial<Record<keyof EventMap, any>>, C>( // eslint-disable-line @definitelytyped/no-unnecessary-generics
+                context: C,
+                methods?: EventConnectionMap<T, C, EventMap>
+            ): this;
+            // #endregion
+        }
 
-		interface Constructor {
-			/** @param config Configuration options */
-			new <M extends boolean | undefined = undefined>(config: ConfigOptions<M>): CopyTextLayout<
-				M extends true ? MultilineTextInputWidget : TextInputWidget
-			>;
-			prototype: Prototype;
-			static: Static;
-			super: ActionFieldLayout.Constructor;
-			/** @deprecated Use `super` instead */
-			parent: ActionFieldLayout.Constructor;
-		}
-	}
+        interface Constructor {
+            /** @param config Configuration options */
+            new <M extends boolean | undefined = undefined>(config: ConfigOptions<M>): CopyTextLayout<
+                M extends true ? MultilineTextInputWidget : TextInputWidget
+            >;
+            prototype: Prototype;
+            static: Static;
+            super: ActionFieldLayout.Constructor;
+            /** @deprecated Use `super` instead */
+            parent: ActionFieldLayout.Constructor;
+        }
+    }
 
-	const CopyTextLayout: CopyTextLayout.Constructor;
+    const CopyTextLayout: CopyTextLayout.Constructor;
 }

--- a/types/oojs-ui/CopyTextLayout.d.ts
+++ b/types/oojs-ui/CopyTextLayout.d.ts
@@ -10,9 +10,8 @@ declare namespace OO.ui {
     interface CopyTextLayout<
         T extends TextInputWidget | MultilineTextInputWidget =
             | TextInputWidget
-            | MultilineTextInputWidget
-    > extends CopyTextLayout.Props, CopyTextLayout.Prototype<T>
-    {}
+            | MultilineTextInputWidget,
+    > extends CopyTextLayout.Props, CopyTextLayout.Prototype<T> {}
 
     namespace CopyTextLayout {
         interface EventMap extends mixin.LabelElement.EventMap {
@@ -28,8 +27,7 @@ declare namespace OO.ui {
             /** Text to copy, can also be provided as `textInput.value` */
             copyText?: string;
             /** Config for the text input widget */
-            textInput?: M extends true
-                ? MultilineTextInputWidget.ConfigOptions
+            textInput?: M extends true ? MultilineTextInputWidget.ConfigOptions
                 : TextInputWidget.ConfigOptions;
             /** Config for the button widget */
             button?: ButtonWidget.ConfigOptions;
@@ -49,9 +47,8 @@ declare namespace OO.ui {
         interface Prototype<
             T extends TextInputWidget | MultilineTextInputWidget =
                 | TextInputWidget
-                | MultilineTextInputWidget
-        > extends FieldLayout.Prototype<T>
-        {
+                | MultilineTextInputWidget,
+        > extends FieldLayout.Prototype<T> {
             /**
              * Handle button click events.
              *
@@ -81,33 +78,33 @@ declare namespace OO.ui {
                 event: K,
                 method: EventHandler<C, (this: C, ...args: [...A, ...EventMap[K]]) => void>,
                 args?: A,
-                context?: C
+                context?: C,
             ): this;
             on<K extends string, C = null>(
                 event: K extends keyof EventMap ? never : K,
                 method: EventHandler<C>,
                 args?: any[],
-                context?: C
+                context?: C,
             ): this;
 
             once<K extends keyof EventMap>(
                 event: K,
-                listener: (this: null, ...args: EventMap[K]) => void
+                listener: (this: null, ...args: EventMap[K]) => void,
             ): this;
             once<K extends string>(
                 event: K extends keyof EventMap ? never : K,
-                listener: (this: null, ...args: any[]) => void
+                listener: (this: null, ...args: any[]) => void,
             ): this;
 
             off<K extends keyof EventMap, C = null>(
                 event: K,
                 method?: EventHandler<C, (this: C, ...args: EventMap[K]) => void>,
-                context?: C
+                context?: C,
             ): this;
             off<K extends string, C = null>(
                 event: K extends keyof EventMap ? never : K,
                 method?: EventHandler<C>,
-                context?: C
+                context?: C,
             ): this;
 
             emit<K extends keyof EventMap>(event: K, ...args: EventMap[K]): boolean;
@@ -121,19 +118,19 @@ declare namespace OO.ui {
 
             connect<T extends Partial<Record<keyof EventMap, any>>, C>( // eslint-disable-line @definitelytyped/no-unnecessary-generics
                 context: C,
-                methods: EventConnectionMap<T, C, EventMap>
+                methods: EventConnectionMap<T, C, EventMap>,
             ): this;
 
             disconnect<T extends Partial<Record<keyof EventMap, any>>, C>( // eslint-disable-line @definitelytyped/no-unnecessary-generics
                 context: C,
-                methods?: EventConnectionMap<T, C, EventMap>
+                methods?: EventConnectionMap<T, C, EventMap>,
             ): this;
             // #endregion
         }
 
         interface Constructor {
             /** @param config Configuration options */
-            new <M extends boolean | undefined = undefined>(config: ConfigOptions<M>): CopyTextLayout<
+            new<M extends boolean | undefined = undefined>(config: ConfigOptions<M>): CopyTextLayout<
                 M extends true ? MultilineTextInputWidget : TextInputWidget
             >;
             prototype: Prototype;

--- a/types/oojs-ui/CopyTextLayout.d.ts
+++ b/types/oojs-ui/CopyTextLayout.d.ts
@@ -1,0 +1,147 @@
+declare namespace OO.ui {
+	/**
+	 * CopyTextLayout is an action field layout containing some readonly text
+	 * and a button to copy it to the clipboard.
+	 *
+	 * ResourceLoader module: `oojs-ui-widgets`
+	 *
+	 * @see https://doc.wikimedia.org/oojs-ui/master/js/#!/api/OO.ui.CopyTextLayout
+	 */
+	interface CopyTextLayout<
+		T extends TextInputWidget | MultilineTextInputWidget =
+			| TextInputWidget
+			| MultilineTextInputWidget
+	> extends CopyTextLayout.Props, CopyTextLayout.Prototype<T>
+	{}
+
+	namespace CopyTextLayout {
+		interface EventMap extends mixin.LabelElement.EventMap {
+			/**
+			 * When the user has executed a copy command.
+			 *
+			 * @param success Whether the copy command succeeded
+			 */
+			copy: [success: boolean];
+		}
+
+		interface ConfigOptions<M extends boolean | undefined> extends ActionFieldLayout.ConfigOptions {
+			/** Text to copy, can also be provided as `textInput.value` */
+			copyText?: string;
+			/** Config for the text input widget */
+			textInput?: M extends true
+				? MultilineTextInputWidget.ConfigOptions
+				: TextInputWidget.ConfigOptions;
+			/** Config for the button widget */
+			button?: ButtonWidget.ConfigOptions;
+			/** Whether to use a multiline text input */
+			multiline?: M;
+		}
+
+		type Static = ActionFieldLayout.Static;
+
+		interface Props extends ActionFieldLayout.Props {
+			/** Text input widget used in the layout */
+			textInput: TextInputWidget | MultilineTextInputWidget;
+			/** Button widget used in the layout */
+			button: ButtonWidget;
+		}
+
+		interface Prototype<
+			T extends TextInputWidget | MultilineTextInputWidget =
+				| TextInputWidget
+				| MultilineTextInputWidget
+		> extends FieldLayout.Prototype<T> {
+			/**
+			 * Handle button click events.
+			 *
+			 * @fires copy
+			 */
+			onButtonClick(): void;
+
+			/**
+			 * Handle text widget focus events.
+			 */
+			onInputFocus(): void;
+
+			/**
+			 * Select the text to copy.
+			 */
+			selectText(): void;
+
+			/**
+			 * Get the widget contained by the field.
+			 *
+			 * @return Field widget
+			 */
+			getField(): T;
+
+			// #region EventEmitter overloads
+			on<K extends keyof EventMap, A extends ArgTuple = [], C = null>(
+				event: K,
+				method: EventHandler<C, (this: C, ...args: [...A, ...EventMap[K]]) => void>,
+				args?: A,
+				context?: C
+			): this;
+			on<K extends string, C = null>(
+				event: K extends keyof EventMap ? never : K,
+				method: EventHandler<C>,
+				args?: any[],
+				context?: C
+			): this;
+
+			once<K extends keyof EventMap>(
+				event: K,
+				listener: (this: null, ...args: EventMap[K]) => void
+			): this;
+			once<K extends string>(
+				event: K extends keyof EventMap ? never : K,
+				listener: (this: null, ...args: any[]) => void
+			): this;
+
+			off<K extends keyof EventMap, C = null>(
+				event: K,
+				method?: EventHandler<C, (this: C, ...args: EventMap[K]) => void>,
+				context?: C
+			): this;
+			off<K extends string, C = null>(
+				event: K extends keyof EventMap ? never : K,
+				method?: EventHandler<C>,
+				context?: C
+			): this;
+
+			emit<K extends keyof EventMap>(event: K, ...args: EventMap[K]): boolean;
+			emit<K extends string>(event: K extends keyof EventMap ? never : K, ...args: any[]): boolean;
+
+			emitThrow<K extends keyof EventMap>(event: K, ...args: EventMap[K]): boolean;
+			emitThrow<K extends string>(
+				event: K extends keyof EventMap ? never : K,
+				...args: any[]
+			): boolean;
+
+			connect<T extends Partial<Record<keyof EventMap, any>>, C>( // eslint-disable-line @definitelytyped/no-unnecessary-generics
+				context: C,
+				methods: EventConnectionMap<T, C, EventMap>
+			): this;
+
+			disconnect<T extends Partial<Record<keyof EventMap, any>>, C>( // eslint-disable-line @definitelytyped/no-unnecessary-generics
+				context: C,
+				methods?: EventConnectionMap<T, C, EventMap>
+			): this;
+			// #endregion
+		}
+
+		interface Constructor {
+			/** @param config Configuration options */
+			new <M extends boolean | undefined = undefined>(config: ConfigOptions<M>): CopyTextLayout<
+				M extends true ? MultilineTextInputWidget : TextInputWidget
+			>;
+			prototype: Prototype;
+			static: Static;
+			super: ActionFieldLayout.Constructor;
+			/** @deprecated Use `super` instead */
+			parent: ActionFieldLayout.Constructor;
+		}
+	}
+
+	const CopyTextLayout: CopyTextLayout.Constructor;
+}

--- a/types/oojs-ui/index.d.ts
+++ b/types/oojs-ui/index.d.ts
@@ -20,6 +20,7 @@
 /// <reference path="CheckboxMultiselectInputWidget.d.ts" />
 /// <reference path="CheckboxMultiselectWidget.d.ts" />
 /// <reference path="ComboBoxInputWidget.d.ts" />
+/// <reference path="CopyTextLayout.d.ts" />
 /// <reference path="DecoratedOptionWidget.d.ts" />
 /// <reference path="Dialog.d.ts" />
 /// <reference path="DropdownInputWidget.d.ts" />

--- a/types/oojs-ui/oojs-ui-tests.ts
+++ b/types/oojs-ui/oojs-ui-tests.ts
@@ -1325,6 +1325,68 @@
 }
 // #endregion
 
+// #region OO.ui.CopyTextLayout
+{
+    // $ExpectType ActionFieldLayout<TextInputWidget>
+    new OO.ui.CopyTextLayout.super(new OO.ui.TextInputWidget(), new OO.ui.ButtonWidget());
+
+    const instance = new OO.ui.CopyTextLayout({
+        copyText: "Text to copy",
+        textInput: {
+            placeholder: "Placeholder"
+        },
+        button: {
+            flags: ["progressive"]
+        }
+    });
+
+    // $ExpectType TextInputWidget
+    instance.getField();
+
+    // $ExpectType void
+    instance.onButtonClick();
+
+    // $ExpectType void
+    instance.onInputFocus();
+
+    // $ExpectType void
+    instance.selectText();
+
+    instance.on("copy", success => {
+        success; // $ExpectType boolean
+    })
+
+    const instanceMultilineFalse = new OO.ui.CopyTextLayout({
+        copyText: "Text to copy",
+        textInput: {
+            placeholder: "Placeholder"
+        },
+        button: {
+            flags: ["progressive"]
+        },
+        multiline: false
+    });
+
+    // $ExpectType TextInputWidget
+    instanceMultilineFalse.getField();
+
+    const instanceMultilineTrue = new OO.ui.CopyTextLayout({
+        copyText: "Text to copy",
+        textInput: {
+            placeholder: "Placeholder",
+            rows: 3
+        },
+        button: {
+            flags: ["progressive"]
+        },
+        multiline: true
+    });
+
+    // $ExpectType MultilineTextInputWidget
+    instanceMultilineTrue.getField();
+}
+// #endregion
+
 // #region OO.ui.DecoratedOptionWidget
 {
     // $ExpectType OptionWidget

--- a/types/oojs-ui/oojs-ui-tests.ts
+++ b/types/oojs-ui/oojs-ui-tests.ts
@@ -1333,11 +1333,11 @@
     const instance = new OO.ui.CopyTextLayout({
         copyText: "Text to copy",
         textInput: {
-            placeholder: "Placeholder"
+            placeholder: "Placeholder",
         },
         button: {
-            flags: ["progressive"]
-        }
+            flags: ["progressive"],
+        },
     });
 
     // $ExpectType TextInputWidget
@@ -1354,17 +1354,17 @@
 
     instance.on("copy", success => {
         success; // $ExpectType boolean
-    })
+    });
 
     const instanceMultilineFalse = new OO.ui.CopyTextLayout({
         copyText: "Text to copy",
         textInput: {
-            placeholder: "Placeholder"
+            placeholder: "Placeholder",
         },
         button: {
-            flags: ["progressive"]
+            flags: ["progressive"],
         },
-        multiline: false
+        multiline: false,
     });
 
     // $ExpectType TextInputWidget
@@ -1374,12 +1374,12 @@
         copyText: "Text to copy",
         textInput: {
             placeholder: "Placeholder",
-            rows: 3
+            rows: 3,
         },
         button: {
-            flags: ["progressive"]
+            flags: ["progressive"],
         },
-        multiline: true
+        multiline: true,
     });
 
     // $ExpectType MultilineTextInputWidget


### PR DESCRIPTION
Generics is used to choose between `OO.ui.TextInputWidget` and `OO.ui.MultilineTextInputWidget` as widget depending on the `multiline` config option.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://doc.wikimedia.org/oojs-ui/master/js/#!/api/OO.ui.CopyTextLayout
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
