### PR TITLE
[type-is] Fix match function name

### DIFF
--- a/types/type-is/index.d.ts
+++ b/types/type-is/index.d.ts
@@ -11,5 +11,5 @@ declare namespace typeIs {
     function hasBody(request: IncomingMessage): boolean;
     function is(mediaType: string, types: string[]): string | false;
     function is(mediaType: string, ...types: string[]): string | false;
-    function mimeMatch(expected: false | string, actual: string): boolean;
+    function match(expected: false | string, actual: string): boolean;
 }

--- a/types/type-is/type-is-tests.ts
+++ b/types/type-is/type-is-tests.ts
@@ -54,3 +54,10 @@ app.use((req, res, next) => {
             break;
     }
 });
+
+// typeis.match(expected, actual)
+typeis.match("text/html", "text/html"); // => true
+typeis.match("*/html", "text/html"); // => true
+typeis.match("text/*", "text/html"); // => true
+typeis.match("*/*", "text/html"); // => true
+typeis.match("*/*+json", "application/x-custom+json"); // => true


### PR DESCRIPTION
Internally, the function is called `mimeMatch`, but it's exposed as `match`. This changes the declaration to use the right name. [Reference](https://github.com/jshttp/type-is/blob/1.6.18/index.js#L27)

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jshttp/type-is/blob/1.6.18/index.js#L27
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.