### PR TITLE
[@types/oojs-ui] Refine return type of getRange() in MultilineTextInputWidget

### DIFF
--- a/types/oojs-ui/MultilineTextInputWidget.d.ts
+++ b/types/oojs-ui/MultilineTextInputWidget.d.ts
@@ -22,6 +22,11 @@ declare namespace OO.ui {
     interface MultilineTextInputWidget extends MultilineTextInputWidget.Props, MultilineTextInputWidget.Prototype {}
 
     namespace MultilineTextInputWidget {
+        interface NonNullRange {
+            from: number;
+            to: number;
+        }
+
         interface EventMap extends TextInputWidget.EventMap {
             resize: [];
         }
@@ -67,6 +72,13 @@ declare namespace OO.ui {
              * @return
              */
             isAutosizing(): boolean;
+
+            /**
+             * Get an object describing the current selection range in a directional manner
+             *
+             * @return Object containing 'from' and 'to' offsets
+             */
+            getRange(): NonNullRange;
 
             // #region EventEmitter overloads
             on<K extends keyof EventMap, A extends ArgTuple = [], C = null>(

--- a/types/oojs-ui/oojs-ui-tests.ts
+++ b/types/oojs-ui/oojs-ui-tests.ts
@@ -2401,6 +2401,9 @@
 
     instance.isAutosizing(); // $ExpectType boolean
 
+    // $ExpectType NonNullRange
+    instance.getRange();
+
     instance.on("resize", () => {});
 }
 // #endregion


### PR DESCRIPTION
According to the specs (https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-selectionstart, https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement/selectionStart), `selectionStart` and `selectionEnd` properties used in the return value of `TextInputWidget.prototype.getRange` can be `null` only for the `<input>` element, but not `<textarea>`. So, we may safely remove `null`s from `from` and `to` properties:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/683ec4a2b420ff6bd3873a7338416ad3ec0b6595/types/oojs-ui/TextInputWidget.d.ts#L26-L29
to simplify type checking.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://doc.wikimedia.org/oojs-ui/master/js/widgets_TextInputWidget.js.html#line368, https://doc.wikimedia.org/oojs-ui/master/js/widgets_MultilineTextInputWidget.js.html#line257
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.