### PR TITLE
dangerfile: use `@definitelytyped/utils` `mangleScopedPackage`

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -2,7 +2,7 @@ import fs = require("fs");
 import os = require("os");
 import path = require("path");
 import cp = require("child_process");
-import { suggestionsDir } from "@definitelytyped/utils";
+import { suggestionsDir, mangleScopedPackage } from "@definitelytyped/utils";
 import { danger, fail, markdown } from "danger";
 const lines: string[] = [];
 const missingProperty = /module exports a property named '(.+?)', which is missing/;
@@ -38,7 +38,7 @@ if (fs.existsSync(suggestionsDir)) {
             if (Object.keys(missingProperties).length > 1) {
                 const originalJS = fileName.replace(".d.ts", ".js");
                 const unpkgURL = `https://unpkg.com/browse/${packageName}@latest/${originalJS}`;
-                const dtsName = packageName.replace("@", "").replace("/", "__");
+                const dtsName = `@types/${mangleScopedPackage(packageName)}`;
                 const dtsURL =
                     `https://github.com/DefinitelyTyped/DefinitelyTyped/blob/${danger.github.pr.head.sha}/types/${dtsName}/${fileName}`;
 


### PR DESCRIPTION
This encourages a single source of truth for this logic. If https://github.com/microsoft/DefinitelyTyped-tools/issues/1125 is addressed, for example, that fix will flow here "for free".