### PR TITLE
[three-nebula] Remove use of Renderer interface

### DIFF
--- a/types/three-nebula/src/core/System.d.ts
+++ b/types/three-nebula/src/core/System.d.ts
@@ -42,7 +42,7 @@ export default class System {
     /**
      * @description The renderers for the system.
      */
-    renderers: Array<THREE.Renderer | CustomRenderer | GPURenderer | MeshRenderer | SpriteRenderer>;
+    renderers: Array<THREE.WebGLRenderer | CustomRenderer | GPURenderer | MeshRenderer | SpriteRenderer>;
     /**
      * @description A pool used to manage the internal system cache of objects
      */
@@ -114,4 +114,4 @@ export default class System {
     destroy(): void;
 }
 
-export type RendererUnion = THREE.Renderer | GPURenderer | SpriteRenderer | CustomRenderer | MeshRenderer;
+export type RendererUnion = THREE.WebGLRenderer | GPURenderer | SpriteRenderer | CustomRenderer | MeshRenderer;


### PR DESCRIPTION
I'm planning to remove the `Renderer` interface from the three.js types because it's more confusing than useful. It defines a subset of the `WebGLRenderer` interface with no clear scope, and now is more confusing with the introduction of the `Renderer` class that supports both WebGPU and WebGL.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
