### PR TITLE
[reflect.ownkeys] remove esm from types

### DIFF
--- a/types/reflect.ownkeys/index.d.mts
+++ b/types/reflect.ownkeys/index.d.mts
@@ -1,8 +1,0 @@
-import index = require("./index");
-import implementation = require("./implementation");
-import polyfill = require("./polyfill");
-import shim = require("./shim");
-
-export default index;
-
-export { implementation, polyfill, shim };

--- a/types/reflect.ownkeys/package.json
+++ b/types/reflect.ownkeys/package.json
@@ -4,10 +4,7 @@
     "version": "1.1.9999",
     "exports": {
         ".": {
-            "types": {
-                "import": "./index.d.mts",
-                "default": "./index.d.ts"
-            }
+            "types": "./index.d.ts"
         },
         "./auto": {
             "types": "./auto.d.ts"

--- a/types/reflect.ownkeys/tsconfig.json
+++ b/types/reflect.ownkeys/tsconfig.json
@@ -14,7 +14,6 @@
     },
     "files": [
         "index.d.ts",
-        "index.d.mts",
         "auto.d.ts",
         "polyfill.d.ts",
         "implementation.d.ts",


### PR DESCRIPTION
Implementation removed ESM, so this PR updates the types to match that.

Changelog: https://github.com/es-shims/Reflect.ownKeys/blob/main/CHANGELOG.md#v115---2024-12-29
Change commit: https://github.com/es-shims/Reflect.ownKeys/commit/409aed33bb39e20eaa3ebfe0843850107789c864

