### PR TITLE
Fix typing of addKeyBinding() for reveal.js

### DIFF
--- a/types/reveal.js/index.d.ts
+++ b/types/reveal.js/index.d.ts
@@ -653,8 +653,8 @@ declare namespace Reveal {
          * @param callback
          */
         addKeyBinding(
-            binding: string | { keyCode: number; key: string; description: string },
-            callback: (event: KeyboardEvent) => void,
+            keyCode: number | { keyCode: number; key: string; description: string },
+            callback: string | ((event: KeyboardEvent) => void),
         ): void;
 
         /**

--- a/types/reveal.js/reveal.esm.js-tests.ts
+++ b/types/reveal.js/reveal.esm.js-tests.ts
@@ -794,7 +794,10 @@ deck.hasNavigatedVertically();
 // Adds/removes a custom key binding
 
 // $ExpectType void
-deck.addKeyBinding("enter", () => {});
+deck.addKeyBinding(82, () => {});
+
+// $ExpectType void
+deck.addKeyBinding(82, "next");
 
 // $ExpectType void
 deck.addKeyBinding({ keyCode: 1, key: "enter", description: "description" }, () => {});

--- a/types/reveal.js/reveal.js-tests.ts
+++ b/types/reveal.js/reveal.js-tests.ts
@@ -826,7 +826,10 @@ deck.hasNavigatedVertically();
 // Adds/removes a custom key binding
 
 // $ExpectType void
-deck.addKeyBinding("enter", () => {});
+deck.addKeyBinding(82, () => {});
+
+// $ExpectType void
+deck.addKeyBinding(82, "next");
 
 // $ExpectType void
 deck.addKeyBinding({ keyCode: 1, key: "enter", description: "description" }, () => {});


### PR DESCRIPTION
This PR changes the typing of addKeyBinding().

I have verified that the new signature matches the initial commit that added this function.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://revealjs.com/keyboard/