### PR TITLE
express-useragent - changed Details interface property "isBot" becouse it's not a boolean but string | boolean

### DIFF
--- a/types/express-useragent/index.d.ts
+++ b/types/express-useragent/index.d.ts
@@ -41,7 +41,7 @@ export interface Details {
     isBada: boolean;
     isSamsung: boolean;
     isRaspberry: boolean;
-    isBot: boolean;
+    isBot: string | boolean;
     isCurl: boolean;
     isAndroidTablet: boolean;
     isWinJs: boolean;


### PR DESCRIPTION
Changed isBot from boolean to string | boolean becouse, when I try to get data when fetching with postman. isBot variable is 'postman' and not a boolean value.

Please fill in this template.

- express-useragent - changed Details interface property "isBot" becouse it's not a boolean but string | boolean- [ ] Test the change in your own code. (Compile and run.)
- the code works normally and without any errors
(https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).

Select one of these and delete the others:
If changing an existing definition:

```js
{
  isYaBrowser: false,
  isAuthoritative: false,
  isMobile: false,
  isMobileNative: false,
  isTablet: false,
  isiPad: false,
  isiPod: false,
  isiPhone: false,
  isiPhoneNative: false,
  isAndroid: false,
  isAndroidNative: false,
  isBlackberry: false,
  isOpera: false,
  isIE: false,
  isEdge: false,
  isIECompatibilityMode: false,
  isSafari: false,
  isFirefox: false,
  isWebkit: false,
  isChrome: false,
  isKonqueror: false,
  isOmniWeb: false,
  isSeaMonkey: false,
  isFlock: false,
  isAmaya: false,
  isPhantomJS: false,
  isEpiphany: false,
  isDesktop: false,
  isWindows: false,
  isLinux: false,
  isLinux64: false,
  isMac: false,
  isChromeOS: false,
  isBada: false,
  isSamsung: false,
  isRaspberry: false,
  isBot: 'postman',
  isCurl: false,
  isAndroidTablet: false,
  isWinJs: false,
  isKindleFire: false,
  isSilk: false,
  isCaptive: false,
  isSmartTV: false,
  isUC: false,
  isFacebook: false,
  isAlamoFire: false,
  isElectron: false,
  silkAccelerated: false,
  browser: 'PostmanRuntime',
  version: '7.43.0',
  os: 'unknown',
  platform: 'unknown',
  geoIp: {},
  source: 'PostmanRuntime/7.43.0',
  isWechat: false
}
```
```js
export interface Details {
    isMobile: boolean;
    isMobileNative: boolean;
    isTablet: boolean;
    isiPad: boolean;
    isiPod: boolean;
    isiPhone: boolean;
    isAndroid: boolean;
    isBlackberry: boolean;
    isOpera: boolean;
    isIE: boolean;
    isEdge: boolean;
    isIECompatibilityMode: boolean;
    isSafari: boolean;
    isFirefox: boolean;
    isWebkit: boolean;
    isChrome: boolean;
    isKonqueror: boolean;
    isOmniWeb: boolean;
    isSeaMonkey: boolean;
    isFlock: boolean;
    isAmaya: boolean;
    isEpiphany: boolean;
    isDesktop: boolean;
    isWindows: boolean;
    isWindowsPhone: boolean;
    isLinux: boolean;
    isLinux64: boolean;
    isMac: boolean;
    isChromeOS: boolean;
    isBada: boolean;
    isSamsung: boolean;
    isRaspberry: boolean;
    isBot: boolean;
    isCurl: boolean;
    isAndroidTablet: boolean;
    isWinJs: boolean;
    isKindleFire: boolean;
    isSilk: boolean;
    isCaptive: boolean;
    isSmartTV: boolean;
    silkAccelerated: boolean;
    browser: string;
    version: string;
    os: string;
    platform: string;
    geoIp: { [key: string]: any };
    source: string;
}
```

so as we can see the definiton is wrong


