### PR TITLE
@types/ssh2 fix session env event field name value->val

### DIFF
--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -1631,7 +1631,7 @@ export interface SetEnvInfo {
     /** The environment variable's name. */
     key: string;
     /** The environment variable's value. */
-    value: string;
+    val: string;
 }
 
 export interface SignalInfo {

--- a/types/ssh2/package.json
+++ b/types/ssh2/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/ssh2",
-    "version": "1.15.99991",
+    "version": "1.15.9999",
     "projects": [
         "https://github.com/mscdex/ssh2"
     ],

--- a/types/ssh2/package.json
+++ b/types/ssh2/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/ssh2",
-    "version": "1.15.9999",
+    "version": "1.15.99991",
     "projects": [
         "https://github.com/mscdex/ssh2"
     ],


### PR DESCRIPTION
The correct field name is 'val' not 'value' for the session's 'env' event. Can be seen as 'val' in the original code here:

https://github.com/mscdex/ssh2/blob/08c5dd884b7bba75f779e2455c25820c1b352691/lib/server.js#L873-L875

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mscdex/ssh2/blob/08c5dd884b7bba75f779e2455c25820c1b352691/lib/server.js#L873-L875

- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
