### PR TITLE
[pdfmake] Add SVG link and PDF/A document definition properties

### DIFF
--- a/types/pdfmake/interfaces.d.ts
+++ b/types/pdfmake/interfaces.d.ts
@@ -1864,6 +1864,21 @@ export interface StyleDictionary {
 export type PDFVersion = "1.3" | "1.4" | "1.5" | "1.6" | "1.7" | "1.7ext3";
 
 /**
+ * Supported PDF subsets.
+ */
+export type PDFSubset =
+    | "PDF/A-1"
+    | "PDF/A-1a"
+    | "PDF/A-1b"
+    | "PDF/A-2"
+    | "PDF/A-2a"
+    | "PDF/A-2b"
+    | "PDF/A-3"
+    | "PDF/A-3a"
+    | "PDF/A-3b"
+    | "PDF/UA";
+
+/**
  * Watermark that is rendered on top of each page.
  */
 export interface Watermark {
@@ -2142,6 +2157,25 @@ export interface TDocumentDefinitions {
      * Defaults to `1.3`.
      */
     version?: PDFVersion | undefined;
+
+    /**
+     * Subset of the PDF specification the document is created with.
+     */
+    subset?: PDFSubset | undefined;
+
+    /**
+     * Controls whether the document is marked as a tagged PDF.
+     *
+     * Defaults to `false`.
+     */
+    tagged?: boolean | undefined;
+
+    /**
+     * Controls whether the document title should be displayed in the window title of the PDF viewer.
+     *
+     * Defaults to `false`.
+     */
+    displayTitle?: boolean | undefined;
 
     /**
      * Watermark that is rendered on top of each page.

--- a/types/pdfmake/interfaces.d.ts
+++ b/types/pdfmake/interfaces.d.ts
@@ -1041,7 +1041,7 @@ export interface ContentCanvas extends ContentBase, ForbidOtherElementProperties
  *
  * For images other than SVG, use a {@link ContentImage} instead.
  */
-export interface ContentSvg extends ContentBase, ForbidOtherElementProperties<"svg"> {
+export interface ContentSvg extends ContentBase, ContentLink, ForbidOtherElementProperties<"svg"> {
     /**
      * Renders the given SVG content string as an image.
      *

--- a/types/pdfmake/test/pdfmake-examples-tests.ts
+++ b/types/pdfmake/test/pdfmake-examples-tests.ts
@@ -2534,3 +2534,16 @@ const watermark2: TDocumentDefinitions = {
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec id semper massa, nec dapibus mauris. Mauris in mattis nibh. Aenean feugiat volutpat aliquam. Donec sed tellus feugiat, dignissim lectus id, eleifend tortor. Ut at mauris vel dui euismod accumsan. Cras sodales, ante sit amet varius dapibus, dolor neque finibus justo, vel ornare arcu dolor vitae tellus. Aenean faucibus egestas urna in interdum. Mauris convallis dolor a condimentum sagittis. Suspendisse non laoreet nisl. Curabitur sed pharetra ipsum. Curabitur aliquet purus vitae pharetra tincidunt. Cras aliquam tempor justo sit amet euismod. Praesent risus magna, lobortis eget dictum sit amet, tristique vel enim. Duis aliquet, urna maximus sollicitudin lobortis, mi nunc dignissim ligula, et lacinia magna leo non sem.",
     ],
 };
+
+const pdfa: TDocumentDefinitions = {
+    version: "1.5",
+    subset: "PDF/A-3a",
+    tagged: true,
+    displayTitle: true,
+    info: {
+        title: "Awesome PDF document from pdfmake",
+    },
+    content: [
+        "PDF/A document for archive",
+    ],
+};

--- a/types/pdfmake/test/pdfmake-interfaces-tests.ts
+++ b/types/pdfmake/test/pdfmake-interfaces-tests.ts
@@ -385,3 +385,10 @@ const decorations: Content = [
     { text: "Single decoration", decoration: "underline" },
     { text: "Multiple decorations", decoration: ["underline", "lineThrough", "overline"] },
 ];
+
+const svgWithLink: Content = [
+    {
+        svg: "<svg height=\"100\" width=\"100\"><circle cx=\"50\" cy=\"50\" r=\"40\" stroke=\"black\" stroke-width=\"3\" fill=\"red\" /></svg>",
+        link: "http://foo.bar",
+    },
+];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/bpampuch/pdfmake/commit/40fb9d0641df07fb6ab1502de11393bfbfcf45aa
  - https://github.com/bpampuch/pdfmake/commit/ca6f874dc1c9c66146f7ce56352291b76482e12b
  - https://github.com/bpampuch/pdfmake/commit/4e87757a28ba78a6002b0ddf3aa8225acc703579
  - https://pdfmake.github.io/docs/0.1/document-definition-object/pdfa/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
