### PR TITLE
feat: add more precise types to static methods once and on in node event emitter

### DIFF
--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -100,13 +100,12 @@ declare module "events" {
         lowWaterMark?: number | undefined;
     }
     interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
-    type EventMap<T> = RecordOf<T> | DefaultEventMap;
+    type EventMap<T> = Record<keyof T, any> | DefaultEventMap;
     type DefaultEventMap = [never];
     type AnyRest = [...args: any[]];
     type Args<K, T> = T extends DefaultEventMap ? AnyRest : (
         K extends keyof T ? T[K] : never
     );
-    type RecordOf<T> = [T] extends [Record<infer K, [infer V]>] ? Record<K, [V]> : [T] extends [Record<infer K, Array<infer V>>] ? Record<K, Array<V>> : never;
     type EventMapKey<T> = T extends DefaultEventMap ? string | symbol : keyof T
     type Key<K, T> = T extends DefaultEventMap ? string | symbol : K | keyof T;
     type Key2<K, T> = T extends DefaultEventMap ? string | symbol : K & keyof T;
@@ -120,9 +119,7 @@ declare module "events" {
     type Listener2<K, T> = Listener<K, T, Function>;
     type EventMapValue<T extends EventMap<T>, K> =
         T extends DefaultEventMap ? any[] :
-            K extends keyof T ? T[K] : never
-    type EventEmitterLike<T extends EventMap<T>> = T extends EventEmitter<T> ? EventEmitter<T> : NodeJS.EventEmitter<T>;
-
+            K extends keyof T ? T[K] : never;
 
     /**
      * The `EventEmitter` class is defined and exposed by the `node:events` module:
@@ -313,9 +310,14 @@ declare module "events" {
          * @since v13.6.0, v12.16.0
          * @return An `AsyncIterator` that iterates `eventName` events emitted by the `emitter`
          */
-        static on(
-            emitter: NodeJS.EventEmitter,
-            eventName: string | symbol,
+        static on<T extends EventMap<T> = DefaultEventMap, K extends EventMapKey<T> = any>(
+            emitter: EventEmitter<T>,
+            eventName: K,
+            options?: StaticEventEmitterIteratorOptions,
+        ): NodeJS.AsyncIterator<EventMapValue<T, K>, EventMapValue<T, K>>;
+        static on<T extends EventMap<T> = DefaultEventMap, K extends EventMapKey<T> = any>(
+            emitter: NodeJS.EventEmitter<T>,
+            eventName: K,
             options?: StaticEventEmitterIteratorOptions,
         ): NodeJS.AsyncIterator<any[]>;
         static on(

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -135,6 +135,7 @@ declare module "events" {
      * @since v0.1.26
      */
     class EventEmitter<T extends EventMap<T> = DefaultEventMap> {
+        declare private _type?: T;
         constructor(options?: EventEmitterOptions);
 
         [EventEmitter.captureRejectionSymbol]?<K>(error: Error, event: Key<K, T>, ...args: Args<K, T>): void;

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -106,7 +106,7 @@ declare module "events" {
     type Args<K, T> = T extends DefaultEventMap ? AnyRest : (
         K extends keyof T ? T[K] : never
     );
-    type EventMapKey<T> = T extends DefaultEventMap ? string | symbol : keyof T
+    type EventMapKey<T> = T extends DefaultEventMap ? string | symbol : keyof T;
     type Key<K, T> = T extends DefaultEventMap ? string | symbol : K | keyof T;
     type Key2<K, T> = T extends DefaultEventMap ? string | symbol : K & keyof T;
     type Listener<K, T, F> = T extends DefaultEventMap ? F : (
@@ -117,9 +117,9 @@ declare module "events" {
     );
     type Listener1<K, T> = Listener<K, T, (...args: any[]) => void>;
     type Listener2<K, T> = Listener<K, T, Function>;
-    type EventMapValue<T extends EventMap<T>, K> =
-        T extends DefaultEventMap ? any[] :
-            K extends keyof T ? T[K] : never;
+    type EventMapValue<T extends EventMap<T>, K> = T extends DefaultEventMap ? any[]
+        : K extends keyof T ? T[K]
+        : never;
 
     /**
      * The `EventEmitter` class is defined and exposed by the `node:events` module:
@@ -224,11 +224,11 @@ declare module "events" {
             eventName: K,
             options?: StaticEventEmitterOptions,
         ): Promise<EventMapValue<T, K>>;
-       static once<T extends EventMap<T> = DefaultEventMap, K extends EventMapKey<T> = any>(
-           emitter: NodeJS.EventEmitter<T>,
-           eventName: K,
-           options?: StaticEventEmitterOptions,
-       ): Promise<any[]>;
+        static once<T extends EventMap<T> = DefaultEventMap, K extends EventMapKey<T> = any>(
+            emitter: NodeJS.EventEmitter<T>,
+            eventName: K,
+            options?: StaticEventEmitterOptions,
+        ): Promise<any[]>;
         static once(emitter: EventTarget, eventName: string, options?: StaticEventEmitterOptions): Promise<any[]>;
         /**
          * ```js

--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -100,7 +100,7 @@ declare module "events" {
         lowWaterMark?: number | undefined;
     }
     interface EventEmitter<T extends EventMap<T> = DefaultEventMap> extends NodeJS.EventEmitter<T> {}
-    type EventMap<T> = Record<keyof T, any> | DefaultEventMap;
+    type EventMap<T> = Record<keyof T, any[]> | DefaultEventMap;
     type DefaultEventMap = [never];
     type AnyRest = [...args: any[]];
     type Args<K, T> = T extends DefaultEventMap ? AnyRest : (

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "22.10.9999",
+    "version": "22.11.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [

--- a/types/node/test/events_generic.ts
+++ b/types/node/test/events_generic.ts
@@ -25,6 +25,8 @@ declare const event5: "event5";
 declare function expectNotAnyOrNeverArray<T extends unknown[]>(
     input: 0 extends T & 1 ? never : T extends (infer U)[] ? [U] extends [never] ? never : NotAny<U>[] : T,
 ): void;
+// eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+declare function expectNotAny<T>(input: NotAny<T>): void;
 
 {
     // @ts-expect-error
@@ -291,4 +293,63 @@ declare function expectNotAnyOrNeverArray<T extends unknown[]>(
 {
     const iter = events.on(new events.EventEmitter(), "error");
     const result: Promise<IteratorResult<number[], number[]>> = iter.next();
+}
+
+{
+    interface EventMap {
+        "no-parameters": [];
+        "with-parameters": [n: number, s: string];
+    }
+
+    class DerivedEmitter extends events.EventEmitter<EventMap> {}
+    const derivedEmitter = new DerivedEmitter();
+    const dA = events.on(derivedEmitter, "no-parameters");
+    dA.next().then(({ value }) => {
+        expectNotAny(value);
+        const result: [] = value;
+    });
+
+    const dB = events.on(derivedEmitter, "with-parameters");
+    dB.next().then(({ value }) => {
+        expectNotAny(value);
+        const result: [n: number, s: string] = value;
+    });
+
+    events.once(derivedEmitter, "no-parameters").then((result) => {
+        expectNotAny(result);
+        const typedResult: [] = result;
+    });
+    events.once(derivedEmitter, "with-parameters").then((result) => {
+        expectNotAny(result);
+        const typedResult: [n: number, s: string] = result;
+    });
+}
+
+{
+    interface EventMap {
+        "no-parameters": [];
+        "with-parameters": [n: number, s: string];
+    }
+    class DerivedEmitterGeneric<Events extends Record<keyof Events, unknown[]>> extends events.EventEmitter<Events> {}
+    const derivedEmitter = new DerivedEmitterGeneric<EventMap>();
+    const dA = events.on(derivedEmitter, "no-parameters");
+    dA.next().then(({ value }) => {
+        expectNotAny(value);
+        const result: [] = value;
+    });
+
+    const dB = events.on(derivedEmitter, "with-parameters");
+    dB.next().then(({ value }) => {
+        expectNotAny(value);
+        const result: [n: number, s: string] = value;
+    });
+
+    events.once(derivedEmitter, "no-parameters").then((result) => {
+        expectNotAny(result);
+        const typedResult: [] = result;
+    });
+    events.once(derivedEmitter, "with-parameters").then((result) => {
+        expectNotAny(result);
+        const typedResult: [n: number, s: string] = result;
+    });
 }

--- a/types/node/test/events_generic.ts
+++ b/types/node/test/events_generic.ts
@@ -93,6 +93,7 @@ declare const event5: "event5";
 
     result = events.EventEmitter.defaultMaxListeners;
 
+    // @ts-expect-error
     const promise: Promise<any[]> = events.once(new events.EventEmitter<T>(), "error");
 
     result = emitter.getMaxListeners();
@@ -112,10 +113,15 @@ declare const event5: "event5";
 {
     let result: Promise<number[]>;
 
+    // @ts-expect-error
     result = events.once(emitter, event1);
+    // @ts-expect-error
     result = events.once(emitter, event2);
+    // this is still valid, because event3 args are typed as `any`
     result = events.once(emitter, event3);
+    // @ts-expect-error
     result = events.once(emitter, event4);
+    // @ts-expect-error
     result = events.once(emitter, event5);
 
     emitter.emit("event1", "hello", 42);
@@ -246,4 +252,12 @@ declare const event5: "event5";
     emitter.emit(s1, "hello", false);
     // @ts-expect-error
     emitter.emit(s2, "hello", false);
+}
+
+{
+    const result1: Promise<[string, number]> = events.once(emitter, event1);
+    const result2: Promise<[boolean]> = events.once(emitter, event2);
+    const result3: Promise<[]> = events.once(emitter, event3);
+    const result4: Promise<string[]> = events.once(emitter, event4);
+    const result5: Promise<unknown[]> = events.once(emitter, event5);
 }

--- a/types/node/test/events_generic.ts
+++ b/types/node/test/events_generic.ts
@@ -8,7 +8,7 @@ interface T {
     event5: unknown[];
 }
 
-type NotAny<T> = 0 extends T&1 ? never : T;
+type NotAny<T> = 0 extends T & 1 ? never : T;
 
 const emitter = new events.EventEmitter<T>();
 declare const listener1: (...args: T["event1"]) => void;
@@ -22,7 +22,9 @@ declare const event3: "event3";
 declare const event4: "event4";
 declare const event5: "event5";
 // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-declare function expectNotAnyOrNeverArray<T extends unknown[]>(input: 0 extends T&1 ? never : T extends (infer U)[] ? [U] extends [never] ? never : NotAny<U>[] : T): void;
+declare function expectNotAnyOrNeverArray<T extends unknown[]>(
+    input: 0 extends T & 1 ? never : T extends (infer U)[] ? [U] extends [never] ? never : NotAny<U>[] : T,
+): void;
 
 {
     // @ts-expect-error
@@ -277,7 +279,7 @@ declare function expectNotAnyOrNeverArray<T extends unknown[]>(input: 0 extends 
 
 {
     const iter = events.on(emitter, event1);
-    iter.next().then(({value}) => {
+    iter.next().then(({ value }) => {
         expectNotAnyOrNeverArray(value);
         const result: [string, number] = value;
         // @ts-expect-error


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

## Justification

For a typed event emitter, it's desirable to have more precise types for `once` and `on`, when available. Currently, the methods are loosely typed. When an `EventEmitter` is passed in, we can infer the types and return strictly typed values.

### Note

This is technically a breaking change, as reflected in the test updates. Will defer to the owners to decide what to do with it, I'm not familiar with the how the team manages these kinds of changes with the release cadence of the upstream library.

These changes are _more correct_, and it would be nice to have them in.