### PR TITLE
[@types/oojs-ui] Add `selected` configuration option to OptionWidget

### DIFF
--- a/types/oojs-ui/OptionWidget.d.ts
+++ b/types/oojs-ui/OptionWidget.d.ts
@@ -21,7 +21,10 @@ declare namespace OO.ui {
                 mixin.FlaggedElement.ConfigOptions,
                 mixin.AccessKeyedElement.ConfigOptions,
                 mixin.TitledElement.ConfigOptions
-        {}
+        {
+            /** Whether this option should be selected initially. */
+            selected?: boolean;
+        }
 
         interface Static
             extends

--- a/types/oojs-ui/oojs-ui-tests.ts
+++ b/types/oojs-ui/oojs-ui-tests.ts
@@ -2606,7 +2606,9 @@
     // $ExpectType boolean
     OO.ui.OptionWidget.static.scrollIntoViewOnSelect;
 
-    const instance = new OO.ui.OptionWidget();
+    const instance = new OO.ui.OptionWidget({
+        selected: true,
+    });
 
     // $ExpectType boolean
     instance.isSelectable();


### PR DESCRIPTION
Why is there no `selected` configuration option in OptionWidget? [It's documented](https://doc.wikimedia.org/oojs-ui/master/js/OO.ui.OptionWidget.html#OptionWidget)... I added it.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://doc.wikimedia.org/oojs-ui/master/js/OO.ui.OptionWidget.html#OptionWidget
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
