### PR TITLE
Fix Typescript not recognising greasemonkey types as a module

### DIFF
--- a/types/greasemonkey/index.d.ts
+++ b/types/greasemonkey/index.d.ts
@@ -1,3 +1,4 @@
+export = GM;
 // This definition is based on the API reference of Greasemonkey
 // https://wiki.greasespot.net/Greasemonkey_Manual:API
 // TypeScript Version: 3.2


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [~] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [~] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [~] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).