### PR TITLE
[@types/openseadragon] Add drawer to Options

### DIFF
--- a/types/openseadragon/index.d.ts
+++ b/types/openseadragon/index.d.ts
@@ -230,6 +230,7 @@ declare namespace OpenSeadragon {
     interface Options {
         id?: string | undefined;
         element?: HTMLElement | undefined;
+        drawer?: 'webgl' | 'canvas' | 'html';
         tileSources?:
             | string
             | TileSourceOptions

--- a/types/openseadragon/openseadragon-tests.ts
+++ b/types/openseadragon/openseadragon-tests.ts
@@ -53,6 +53,7 @@ const viewer3 = OpenSeadragon({
     id: "openseadragon",
     prefixUrl: "openseadragon/images/",
     showNavigator: false,
+    drawer: 'canvas',
     tileSources: {
         type: "legacy-image-pyramid",
         levels: [


### PR DESCRIPTION
In the implementation of OpenSeadragon, a drawer option can be specified. This type definition is missing that option.
