### PR TITLE
[serverless] - fix(serverless): update the type of apiKeys and usagePlans

### DIFF
--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -24,6 +24,10 @@ declare namespace Aws {
         app?: string | undefined;
         tenant?: string | undefined;
         custom?: Custom | undefined;
+        // https://github.com/serverless/serverless/blob/main/lib/config-schema.js#L154
+        stages?: Stages | undefined;
+        // https://github.com/serverless/serverless/blob/main/lib/config-schema.js#L83
+        build?: string | { [key: string]: any } | undefined;
     }
 
     interface Service {
@@ -65,11 +69,13 @@ declare namespace Aws {
         architecture?: "x86_64" | "arm64" | undefined;
         environment?: Environment | string | undefined;
         endpointType?: "regional" | "edge" | "private" | undefined;
-        apiKeys?: Array<ApiKey | string> | undefined;
+        // https://github.com/serverless/serverless/blob/main/lib/plugins/aws/provider.js#L294
+        apiKeys?: Array<ApiKey | ApiKeys | string> | undefined;
         apiGateway?: ApiGateway | undefined;
         alb?: Alb | undefined;
         httpApi?: HttpApi | undefined;
-        usagePlan?: UsagePlan | undefined;
+        // https://github.com/serverless/serverless/blob/main/lib/plugins/aws/provider.js#L957
+        usagePlan?: UsagePlan | Array<UsagePlans> | undefined;
         stackTags?: Tags | undefined;
         stackPolicy?: ResourcePolicy[] | undefined;
         vpc?: string | Vpc | undefined;
@@ -136,17 +142,23 @@ declare namespace Aws {
         binaryMediaTypes?: string[] | undefined;
         metrics?: boolean | undefined;
         shouldStartNameWithService?: boolean | undefined;
-        apiKeys?: Array<ApiKey | string> | undefined;
+        // https://github.com/serverless/serverless/blob/main/lib/plugins/aws/provider.js#L294
+        apiKeys?: Array<ApiKey | ApiKeys | string> | undefined;
         resourcePolicy?: ResourcePolicy[] | undefined;
-        usagePlan?: UsagePlan | undefined;
+        // https://github.com/serverless/serverless/blob/main/lib/plugins/aws/provider.js#L957
+        usagePlan?: UsagePlan | Array<UsagePlans> | undefined;
     }
 
     interface ApiKey {
-        name: string;
-        value: string;
+        name?: string;
+        value?: string;
         description?: string | undefined;
         customerId?: string | undefined;
         enabled?: boolean | undefined;
+    }
+
+    interface ApiKeys {
+        [k: string]: (string | ApiKey)[];
     }
 
     interface CognitoAuthorizer {
@@ -233,6 +245,10 @@ declare namespace Aws {
     interface UsagePlan {
         quota?: Quota | undefined;
         throttle?: Throttle | undefined;
+    }
+
+    interface UsagePlans {
+        [k: string]: UsagePlan;
     }
 
     interface IamRoleStatement {
@@ -332,8 +348,10 @@ declare namespace Aws {
         type?: string | undefined;
     }
 
+    // https://github.com/serverless/serverless/blob/main/lib/plugins/aws/package/compile/events/api-gateway/index.js#L99
     interface HttpCors {
-        origins?: string | string[] | undefined;
+        origin?: string | undefined;
+        origins?: string[] | undefined;
         headers?: string | string[] | undefined;
         allowCredentials?: boolean | undefined;
         maxAge?: number | undefined;
@@ -791,6 +809,56 @@ declare namespace Aws {
 
     interface Credentials {
         [key: string]: any;
+    }
+
+    interface Stages {
+        [key: string]: Stage | undefined;
+        default?: Stage | undefined;
+    }
+
+    interface Stage {
+        params?: { [key: string]: string } | undefined;
+        observability?: boolean | "axiom" | "dashboard" | ObservabilityProvider;
+        resolvers?: {
+            [key: string]:
+                | ({
+                    type: "terraform";
+                } & (S3BackendForTerraform | RemoteBackendForTerraform | HttpBackendForTerraform))
+                | {
+                    type: "vault";
+                    address?: string | undefined;
+                    token?: string | undefined;
+                    version?: string | undefined;
+                    path?: string | undefined;
+                }
+                | undefined;
+        };
+    }
+
+    interface ObservabilityProvider {
+        provider: "axiom" | "dashboard";
+        dataset?: string | undefined;
+    }
+
+    interface S3BackendForTerraform {
+        backend: "s3";
+        bucket: string;
+        key: string;
+        region?: string | undefined;
+    }
+    interface RemoteBackendForTerraform {
+        backend: "remote";
+        organization?: string | undefined;
+        workspace?: string | undefined;
+        workspaceId?: string | undefined;
+        token?: string | undefined;
+        hostname?: string | undefined;
+    }
+    interface HttpBackendForTerraform {
+        backend: "http";
+        address?: string | undefined;
+        username?: string | undefined;
+        password?: string | undefined;
     }
 }
 

--- a/types/serverless/serverless-tests.ts
+++ b/types/serverless/serverless-tests.ts
@@ -1070,6 +1070,83 @@ const bunchOfConfigs: Aws.Serverless[] = [
             },
         },
     },
+    {
+        service: "my-service",
+        provider: {
+            name: "aws",
+            apiGateway: {
+                apiKeys: [
+                    {
+                        free: [
+                            "myFreeKey",
+                            "${opt:stage}-myFreeKey",
+                        ],
+                        paid: [
+                            "myPaidKey",
+                            "${opt:stage}-myPaidKey",
+                        ],
+                    },
+                ],
+                usagePlan: [
+                    {
+                        free: {
+                            quota: {
+                                limit: 5000,
+                                offset: 2,
+                                period: "MONTH",
+                            },
+                            throttle: {
+                                burstLimit: 200,
+                                rateLimit: 100,
+                            },
+                        },
+                        paid: {
+                            quota: {
+                                limit: 50000,
+                                offset: 2,
+                                period: "MONTH",
+                            },
+                            throttle: {
+                                burstLimit: 2000,
+                                rateLimit: 1000,
+                            },
+                        },
+                    },
+                ],
+            },
+        },
+    },
+    {
+        service: "stages",
+        provider: {
+            name: "aws",
+        },
+        stages: {
+            default: {
+                params: {
+                    domain: "preview.myapp.com",
+                },
+                observability: true,
+            },
+            production: {
+                params: {
+                    domain: "myapp.com",
+                },
+                observability: {
+                    provider: "dashboard",
+                    dataset: "my-custom-dataset",
+                },
+                resolvers: {
+                    terraform: {
+                        type: "terraform",
+                        backend: "s3",
+                        bucket: "terraform-state",
+                        key: "users-table/terraform.tfstate",
+                    },
+                },
+            },
+        },
+    },
 ];
 
 // Test Aws Class


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://www.serverless.com/framework/docs/providers/aws/events/apigateway#setting-api-keys-for-your-rest-api)>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

### Additional details

The type of `apiKeys` and `usagePlans` in the `Aws.Provider` interface is updated to support the object type.

Here is the equivalent yaml configuration:

```yaml
service: my-service
provider:
  name: aws
  apiGateway:
    apiKeys:
      - free:
          - myFreeKey
          - ${opt:stage}-myFreeKey
      - paid:
          - myPaidKey
          - ${opt:stage}-myPaidKey
    usagePlan:
      - free:
          quota:
            limit: 5000
            offset: 2
            period: MONTH
          throttle:
            burstLimit: 200
            rateLimit: 100
      - paid:
          quota:
            limit: 50000
            offset: 1
            period: MONTH
          throttle:
            burstLimit: 2000
            rateLimit: 1000
...
```

The name and value is also not mandatory in aws cloudformation resource, thus made those as non mandatory fields.

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-apikey.html
