### PR TITLE
fix(phoenix_live_view): LiveView SocketOptions extend Phoenix's socket connection options

### DIFF
--- a/types/phoenix_live_view/index.d.ts
+++ b/types/phoenix_live_view/index.d.ts
@@ -65,7 +65,6 @@ export class LiveSocket {
     // phxSocket should be the Socket class (LiveSocket will use the constructor)
     constructor(url: string, phxSocket: any, opts: Partial<SocketOptions>);
 
-
     // public
     connect(): void;
     disableDebug(): void;

--- a/types/phoenix_live_view/index.d.ts
+++ b/types/phoenix_live_view/index.d.ts
@@ -19,7 +19,7 @@
 // Version 0.17.0 added LiveSocket.execJS() method for executing JavaScript utility operations on the client
 // See: https://github.com/phoenixframework/phoenix_live_view/blob/master/CHANGELOG.md#enhancements-17
 
-import { Socket } from "phoenix";
+import { Socket, SocketConnectOption } from "phoenix";
 
 export interface Defaults {
     debounce?: number | undefined;
@@ -41,8 +41,7 @@ export interface DomOptions {
 
 export type ViewLogger = (view: View, kind: string, msg: any, obj: any) => void;
 
-export interface SocketOptions {
-    longPollFallbackMs?: number | undefined;
+export interface SocketOptions extends SocketConnectOption {
     bindingPrefix?: string | undefined;
     defaults?: Defaults | undefined;
     dom?: DomOptions | undefined;
@@ -65,7 +64,8 @@ export type BindCallback = (
 
 export class LiveSocket {
     // phxSocket should be the Socket class (LiveSocket will use the constructor)
-    constructor(url: string, phxSocket: any, opts: SocketOptions);
+    constructor(url: string, phxSocket: any, opts: Partial<SocketOptions>);
+
 
     // public
     connect(): void;

--- a/types/phoenix_live_view/index.d.ts
+++ b/types/phoenix_live_view/index.d.ts
@@ -41,13 +41,12 @@ export interface DomOptions {
 
 export type ViewLogger = (view: View, kind: string, msg: any, obj: any) => void;
 
-export interface SocketOptions extends SocketConnectOption {
+export interface SocketOptions extends Partial<SocketConnectOption> {
     bindingPrefix?: string | undefined;
     defaults?: Defaults | undefined;
     dom?: DomOptions | undefined;
     hooks?: HooksOptions | undefined;
     loaderTimeout?: number | undefined;
-    params?: object | undefined;
     uploaders?: object | undefined;
     viewLogger?: ViewLogger | undefined;
 }

--- a/types/phoenix_live_view/phoenix_live_view-tests.ts
+++ b/types/phoenix_live_view/phoenix_live_view-tests.ts
@@ -49,6 +49,9 @@ function test_socket() {
         },
         hooks: MyHooks,
         uploaders: MyUploaders,
+        // These come from the Phoenix SocketConnectOption
+        reconnectAfterMs: (tries: number) => tries * tries,
+        debug: true
     };
 
     const liveSocket = new LiveSocket("/live", Socket, opts);

--- a/types/phoenix_live_view/phoenix_live_view-tests.ts
+++ b/types/phoenix_live_view/phoenix_live_view-tests.ts
@@ -51,7 +51,7 @@ function test_socket() {
         uploaders: MyUploaders,
         // These come from the Phoenix SocketConnectOption
         reconnectAfterMs: (tries: number) => tries * tries,
-        debug: true
+        debug: true,
     };
 
     const liveSocket = new LiveSocket("/live", Socket, opts);


### PR DESCRIPTION
Per [the LiveSocket constructor documentation](https://github.com/phoenixframework/phoenix_live_view/blob/main/assets/js/phoenix_live_view/live_socket.js):

> Outside of keys listed below, all configuration is passed directly to the Phoenix Socket constructor.

Thus, the acceptable set of options is the union of those documented on the `LiveSocket` and the Phoenix `Socket`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
