### PR TITLE
fix(react-icofont): fix FalseExportDefault, fix prop types, add jsdoc

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -1441,7 +1441,6 @@
         "react-holder",
         "react-howler",
         "react-html5-camera-photo",
-        "react-icofont",
         "react-icon-base",
         "react-image-gallery",
         "react-imgpro",

--- a/types/react-icofont/index.d.ts
+++ b/types/react-icofont/index.d.ts
@@ -1,12 +1,38 @@
 import * as React from "react";
 
-export interface IcofontProps {
-    icon: string;
-    spin?: boolean | undefined;
-    flip?: "h" | "v" | undefined;
-    rotate?: "90" | "180" | "270" | undefined;
-    size?: "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | undefined;
-    className?: string | undefined;
+declare namespace Icofont {
+    interface IcofontProps extends Partial<React.JSX.IntrinsicElements["i"]> {
+        /**
+         * Any valid icon name from the icofont website (https://icofont.com/icons).
+         * Guess what, if you copy the class name that includes the prefix (icofont-), it will also work fine.
+         */
+        icon: string;
+
+        /**
+         * Currently rotate angles `90`, `180`, `270` values are supported.
+         * The rotate angle values are in degree.
+         */
+        rotate?: "90" | "180" | "270" | undefined;
+
+        /**
+         * `horizontal` or `h` and `vertical` or `v`.
+         * You can also do, flip="h v" or flip="horizontal vertical" for flipping both horizontally and vertically.
+         */
+        flip?: "h" | "horizontal" | "v" | "vertical" | "h v" | "horizontal vertical" | undefined;
+
+        /**
+         * Size can have value from 1 to 10.
+         * For example, setting size="2" will make the icon twice as big.
+         */
+        size?: "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | undefined;
+
+        /**
+         * In the case of true value, the icon will spin endlessly. You can spin any icon.
+         */
+        spin?: boolean | undefined;
+    }
 }
 
-export default class Icofont extends React.Component<IcofontProps> {}
+declare class Icofont extends React.Component<Icofont.IcofontProps> {}
+
+export = Icofont;

--- a/types/react-icofont/react-icofont-tests.tsx
+++ b/types/react-icofont/react-icofont-tests.tsx
@@ -1,8 +1,18 @@
 import * as React from "react";
-import Icofont from "react-icofont";
+import Icofont, { IcofontProps } from "react-icofont";
 
-class Test extends React.Component<any> {
-    render() {
-        return <Icofont icon="spinner-alt-4" size="3" spin={true} />;
-    }
-}
+// @ts-expect-error -- props.icon is required.
+<Icofont />;
+
+// Required props.
+<Icofont icon="spinner-alt-4" />;
+
+// Optional props.
+<Icofont
+    icon="spinner-alt-4"
+    rotate="180"
+    flip="horizontal"
+    size="7"
+    spin={true}
+    className="ico-font"
+/>;


### PR DESCRIPTION
- Prop types are added / updated and reordered according to [npm page](https://www.npmjs.com/package/react-icofont#how-to-use).
- `extends Partial<React.JSX.IntrinsicElements["i"]>` is done due to [component implementation](https://github.com/theanam/react-icofont/blob/master/src/index.js#L35).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
