### PR TITLE
@types/react-speech-recognition: Add missing`browserSupportsContinuousListening` type

### DIFF
--- a/types/react-speech-recognition/index.d.ts
+++ b/types/react-speech-recognition/index.d.ts
@@ -37,6 +37,7 @@ export function useSpeechRecognition(options?: SpeechRecognitionOptions): {
     listening: boolean;
     resetTranscript: () => void;
     browserSupportsSpeechRecognition: boolean;
+    browserSupportsContinuousListening: boolean;
     isMicrophoneAvailable: boolean;
 };
 


### PR DESCRIPTION
Add missing variable type definition

Docs:
- https://github.com/JamesBrill/react-speech-recognition/issues/188