### PR TITLE
[diff] add stripTrailingCr to LinesOptions

### DIFF
--- a/types/diff/diff-tests.ts
+++ b/types/diff/diff-tests.ts
@@ -24,6 +24,7 @@ Diff.diffLines(
     "line\nold value\nline",
     "line\nnew value\nline",
     {
+        stripTrailingCr: true,
         ignoreNewlineAtEof: true,
         maxEditLength: 1,
         oneChangePerToken: true,
@@ -93,6 +94,7 @@ function verifyPatchMethods(oldStr: string, newStr: string, uniDiff: Diff.Parsed
     const verifyPatch = Diff.parsePatch(
         Diff.createTwoFilesPatch("oldFile.ts", "newFile.ts", oldStr, newStr, "old", "new", {
             context: 1,
+            stripTrailingCr: true,
         }),
     );
 

--- a/types/diff/index.d.ts
+++ b/types/diff/index.d.ts
@@ -61,6 +61,11 @@ export interface LinesOptions extends BaseOptions {
      * friendly output.
      */
     newlineIsToken?: boolean | undefined;
+
+    /**
+     * `true` to remove all trailing CR (`\r`) characters before performing the diff. Defaults to false. This helps to get a useful diff when diffing UNIX text files against Windows text files.
+     */
+    stripTrailingCr?: boolean | undefined;
 }
 
 export interface JsonOptions extends LinesOptions {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/kpdecker/jsdiff/blob/5aa838309b6829e767e47e4fa16d8fd09c3336a0/README.md?plain=1#L55

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

### Notes
This PR Adds `stripTrailingCr` option to `LinesOptions` interface used in `diffLines`, `createTwoFilesPatch`, and other patch-creation methods.

This option was introduced in [v5.2.0](https://github.com/kpdecker/jsdiff/blob/master/release-notes.md#v520) of the `diff` package, but is currently missing in the definitions.