### PR TITLE
Rearranged StorageArea interface in types/chrome/index.d.ts to assume Promise when null passed

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -8969,12 +8969,6 @@ declare namespace chrome {
         export interface StorageArea {
             /**
              * Gets the amount of space (in bytes) being used by one or more items.
-             * @param callback Callback with the amount of space being used by storage, or on failure (in which case runtime.lastError will be set).
-             * Parameter bytesInUse: Amount of space being used in storage, in bytes.
-             */
-            getBytesInUse(callback: (bytesInUse: number) => void): void;
-            /**
-             * Gets the amount of space (in bytes) being used by one or more items.
              * @param keys Optional. A single key or list of keys to get the total usage for. An empty list will return 0. Pass in null to get the total usage of all of storage.
              * @return A Promise that resolves with a number
              * @since MV3
@@ -8990,6 +8984,12 @@ declare namespace chrome {
                 keys: keyof T | Array<keyof T> | null,
                 callback: (bytesInUse: number) => void,
             ): void;
+            /**
+             * Gets the amount of space (in bytes) being used by one or more items.
+             * @param callback Callback with the amount of space being used by storage, or on failure (in which case runtime.lastError will be set).
+             * Parameter bytesInUse: Amount of space being used in storage, in bytes.
+             */
+            getBytesInUse(callback: (bytesInUse: number) => void): void;
             /**
              * Removes all items from storage.
              * @return A void Promise
@@ -9034,12 +9034,6 @@ declare namespace chrome {
              */
             remove<T = { [key: string]: any }>(keys: keyof T | Array<keyof T>, callback: () => void): void;
             /**
-             * Gets the entire contents of storage.
-             * @param callback Callback with storage items, or on failure (in which case runtime.lastError will be set).
-             * Parameter items: Object with items in their key-value mappings.
-             */
-            get<T = { [key: string]: any }>(callback: (items: T) => void): void;
-            /**
              * Gets one or more items from storage.
              * @param keys A single key to get, list of keys to get, or a dictionary specifying default values.
              * An empty list or object will return an empty result object. Pass in null to get the entire contents of storage.
@@ -9060,6 +9054,12 @@ declare namespace chrome {
                 keys: NoInferX<keyof T> | Array<NoInferX<keyof T>> | Partial<NoInferX<T>> | null,
                 callback: (items: T) => void,
             ): void;
+            /**
+             * Gets the entire contents of storage.
+             * @param callback Callback with storage items, or on failure (in which case runtime.lastError will be set).
+             * Parameter items: Object with items in their key-value mappings.
+             */
+            get<T = { [key: string]: any }>(callback: (items: T) => void): void;
             /**
              * Sets the desired access level for the storage area. The default will be only trusted contexts.
              * @param accessOptions An object containing an accessLevel key which contains the access level of the storage area.


### PR DESCRIPTION
Currently, chrome.storage.<StorageArea>.get(null) will be typed as a synchronous operation with a callback function instead of a Promise. Rearranging the order assumes it will return a Promise unless a callback function is provided in line with current specs

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [chrome.storage API: StorageArea](https://developer.chrome.com/docs/extensions/reference/api/storage#type-StorageArea)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
