### PR TITLE
imagemin: fix Buffer -> Uint8Array

### DIFF
--- a/types/imagemin/imagemin-tests.ts
+++ b/types/imagemin/imagemin-tests.ts
@@ -6,20 +6,20 @@ imagemin(["*.png"], { destination: "dist", plugins: [] }).then((results: Result[
 
 imagemin
     .buffer(
-        Buffer.from([
+        Uint8Array.from([
             /* ... */
         ]),
     )
-    .then((result: Buffer) => {
+    .then((result: Uint8Array) => {
         /* ... */
     });
 imagemin
     .buffer(
-        Buffer.from([
+        Uint8Array.from([
             /* ... */
         ]),
         { plugins: [] },
     )
-    .then((result: Buffer) => {
+    .then((result: Uint8Array) => {
         /* ... */
     });

--- a/types/imagemin/index.d.ts
+++ b/types/imagemin/index.d.ts
@@ -9,7 +9,7 @@ declare namespace imagemin {
     /**
      * @async
      */
-    function buffer(input: Buffer, options?: BufferOptions): Promise<Buffer>;
+    function buffer(data: Uint8Array, options?: BufferOptions): Promise<Uint8Array>;
 }
 
 export type Plugin = (input: Uint8Array) => Promise<Uint8Array>;
@@ -21,7 +21,7 @@ export interface Options {
 }
 
 export interface Result {
-    data: Buffer;
+    data: Uint8Array;
     sourcePath: string;
     destinationPath: string;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/imagemin/imagemin - see input types defined there as Uint8Array. Also see Uint8Array hard coded in https://github.com/imagemin/imagemin/blob/main/index.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. (N/A - not a new version)