### PR TITLE
Omit injected props from WithSizes return type

### DIFF
--- a/types/react-sizes/index.d.ts
+++ b/types/react-sizes/index.d.ts
@@ -5,6 +5,6 @@ export interface Sizes {
 
 export function WithSizes<SP extends object, P extends SP>(
     mapSizesToProps: (sizes: Sizes) => SP,
-): (component: React.ComponentType<P>) => React.ComponentType<P>;
+): (component: React.ComponentType<P>) => React.ComponentType<Omit<P, keyof SP>>;
 
 export default WithSizes;

--- a/types/react-sizes/react-sizes-tests.tsx
+++ b/types/react-sizes/react-sizes-tests.tsx
@@ -7,8 +7,7 @@ interface TestProps {
     height: number;
 }
 
-const mapSizesToProps = ({ width, height }: Sizes): TestProps => ({
-    foo: "foo",
+const mapSizesToProps = ({ width, height }: Sizes) => ({
     width,
     height,
 });
@@ -26,4 +25,4 @@ const TestComponent: React.ComponentType<TestProps> = ({ foo, width, height }) =
     );
 };
 
-WithSizes(mapSizesToProps)(TestComponent); // $ExpectType ComponentType<TestProps>
+WithSizes<ReturnType<typeof mapSizesToProps>, TestProps>(mapSizesToProps)(TestComponent); // $ExpectType ComponentType<Omit<TestProps, "width" | "height">>


### PR DESCRIPTION
The output component after the HOC has been applied should not support the same props that are injected by it. Even if it did support them, they would be overwritten by the HOC.

More details on this can be found in the original draft for these types: https://github.com/renatorib/react-sizes/issues/13#issuecomment-483725124

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/renatorib/react-sizes/issues/13#issuecomment-483725124
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

This is a copy of the abandoned PR #51460.
