### PR TITLE
CI: Pin @rdfjs/types for breaking packages

### DIFF
--- a/types/clownface/package.json
+++ b/types/clownface/package.json
@@ -7,7 +7,7 @@
     ],
     "type": "module",
     "dependencies": {
-        "@rdfjs/types": ">=1.0.0",
+        "@rdfjs/types": "^1",
         "@types/rdfjs__environment": "*"
     },
     "devDependencies": {

--- a/types/rdf-ext/package.json
+++ b/types/rdf-ext/package.json
@@ -7,7 +7,7 @@
     ],
     "type": "module",
     "dependencies": {
-        "@rdfjs/types": "*",
+        "@rdfjs/types": "^1",
         "@types/rdfjs__data-model": "*",
         "@types/rdfjs__dataset": "*",
         "@types/rdfjs__environment": "*",

--- a/types/rdf-store-fs/package.json
+++ b/types/rdf-store-fs/package.json
@@ -6,7 +6,7 @@
         "https://github.com/rdf-ext/rdf-store-fs"
     ],
     "dependencies": {
-        "@rdfjs/types": ">=1",
+        "@rdfjs/types": "^1",
         "@types/node": "*"
     },
     "devDependencies": {

--- a/types/rdf-validate-shacl/package.json
+++ b/types/rdf-validate-shacl/package.json
@@ -6,7 +6,7 @@
         "https://github.com/zazuko/rdf-validate-shacl#readme"
     ],
     "dependencies": {
-        "@rdfjs/types": "*",
+        "@rdfjs/types": "^1",
         "@types/clownface": "*",
         "@types/node": "*"
     },


### PR DESCRIPTION
A new major version release of @rdfjs/types contains breaking changes to certain data interfaces, which has caused [a few test complaints](https://github.com/DefinitelyTyped/DefinitelyTyped/actions/runs/12746848464) for the last week. This is a sticking plaster to unbreak CI for upstream DT packages.