### PR TITLE
[Fix] Argument of type 'RequestHandler<ParamsDictionary, any, any, Pars…

### DIFF
--- a/types/multer/index.d.ts
+++ b/types/multer/index.d.ts
@@ -1,4 +1,4 @@
-import { Request, RequestHandler } from "express";
+import { Request, RequestHandlerParams } from "express";
 import { Readable } from "stream";
 
 declare global {
@@ -83,7 +83,7 @@ declare namespace multer {
          *
          * @param fieldName Name of the multipart form field to process.
          */
-        single(fieldName: string): RequestHandler;
+        single(fieldName: string): RequestHandlerParams;
         /**
          * Returns middleware that processes multiple files sharing the same field
          * name.
@@ -95,7 +95,7 @@ declare namespace multer {
          * @param maxCount Optional. Maximum number of files to process. (default: Infinity)
          * @throws `MulterError('LIMIT_UNEXPECTED_FILE')` if more than `maxCount` files are associated with `fieldName`
          */
-        array(fieldName: string, maxCount?: number): RequestHandler;
+        array(fieldName: string, maxCount?: number): RequestHandlerParams;
         /**
          * Returns middleware that processes multiple files associated with the
          * given form fields.
@@ -107,7 +107,7 @@ declare namespace multer {
          * @param fields Array of `Field` objects describing multipart form fields to process.
          * @throws `MulterError('LIMIT_UNEXPECTED_FILE')` if more than `maxCount` files are associated with `fieldName` for any field.
          */
-        fields(fields: readonly Field[]): RequestHandler;
+        fields(fields: readonly Field[]): RequestHandlerParams;
         /**
          * Returns middleware that processes all files contained in the multipart
          * request.
@@ -115,13 +115,13 @@ declare namespace multer {
          * The `Request` object will be populated with a `files` array containing
          * an information object for each processed file.
          */
-        any(): RequestHandler;
+        any(): RequestHandlerParams;
         /**
          * Returns middleware that accepts only non-file multipart form fields.
          *
          * @throws `MulterError('LIMIT_UNEXPECTED_FILE')` if any file is encountered.
          */
-        none(): RequestHandler;
+        none(): RequestHandlerParams;
     }
 
     /**


### PR DESCRIPTION
After bumping both express and multer packages and definitely typed to latest 

```
  "express": "5.0.1",
  "multer": "^1.4.5-lts.1",
  "@types/express": "^5.0.0",
  "@types/multer": "^1.4.12",
```

I got this error on every single multer middleare:
![image](https://github.com/user-attachments/assets/0f8dfb26-60c9-4718-a3b4-e346572fdbde)

```
Argument of type 
'RequestHandler<ParamsDictionary, any, any, ParsedQs, Record<string, any>>' 
is not assignable to parameter of type 
'RequestHandlerParams<ParamsDictionary, any, any, ParsedQs, Record<string, any>>'.
``` 

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/commits/cef18c51191fd279ef99f49a7d085b11cb3d8d18/types/express-serve-static-core/index.d.ts
