### PR TITLE
Fix return type of compareBegin and compareEnd methods of strange ranges

### DIFF
--- a/types/strange/index.d.ts
+++ b/types/strange/index.d.ts
@@ -163,7 +163,7 @@ interface Range<T extends Range.Endpoint> {
      * new Range(5, 10).compareBegin(0) // => 1
      * new Range(5, 10).compareBegin(null) // => 1
      */
-    compareBegin(begin: T | null): -1 | 0 | 0;
+    compareBegin(begin: T | null): -1 | 0 | 1;
 
     /**
      * Compares this range's end with the given value.
@@ -179,7 +179,7 @@ interface Range<T extends Range.Endpoint> {
      * new Range(0, 5).compareEnd(10) // => 1
      * new Range(0, 5).compareEnd(null) // => -1
      */
-    compareEnd(end: T | null): -1 | 0 | 0;
+    compareEnd(end: T | null): -1 | 0 | 1;
 
     /**
      * Check whether the range is empty.


### PR DESCRIPTION
Fix compare* methods' return type

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
