### PR TITLE
fix(node): Socket send accepts Buffer, TypedArray and DataView as input

### DIFF
--- a/types/node/dgram.d.ts
+++ b/types/node/dgram.d.ts
@@ -352,22 +352,22 @@ declare module "dgram" {
          * @param callback Called when the message has been sent.
          */
         send(
-            msg: string | Uint8Array | readonly any[],
+            msg: string | NodeJS.ArrayBufferView | readonly any[],
             port?: number,
             address?: string,
             callback?: (error: Error | null, bytes: number) => void,
         ): void;
         send(
-            msg: string | Uint8Array | readonly any[],
+            msg: string | NodeJS.ArrayBufferView | readonly any[],
             port?: number,
             callback?: (error: Error | null, bytes: number) => void,
         ): void;
         send(
-            msg: string | Uint8Array | readonly any[],
+            msg: string | NodeJS.ArrayBufferView | readonly any[],
             callback?: (error: Error | null, bytes: number) => void,
         ): void;
         send(
-            msg: string | Uint8Array,
+            msg: string | NodeJS.ArrayBufferView,
             offset: number,
             length: number,
             port?: number,
@@ -375,14 +375,14 @@ declare module "dgram" {
             callback?: (error: Error | null, bytes: number) => void,
         ): void;
         send(
-            msg: string | Uint8Array,
+            msg: string | NodeJS.ArrayBufferView,
             offset: number,
             length: number,
             port?: number,
             callback?: (error: Error | null, bytes: number) => void,
         ): void;
         send(
-            msg: string | Uint8Array,
+            msg: string | NodeJS.ArrayBufferView,
             offset: number,
             length: number,
             callback?: (error: Error | null, bytes: number) => void,

--- a/types/node/test/dgram.ts
+++ b/types/node/test/dgram.ts
@@ -15,6 +15,8 @@ import * as net from "node:net";
     ds.send(new Buffer("hello"), 0, 5, 5000, "127.0.0.1", (error: Error | null, bytes: number): void => {
     });
     ds.send(new Buffer("hello"), 5000, "127.0.0.1");
+    ds.send(new DataView(new ArrayBuffer(0)), 5000, "127.0.0.1");
+    ds.send([], 5000, "127.0.0.1");
     ds = ds.close();
     ds.setMulticastInterface("127.0.0.1");
     ds = dgram.createSocket({

--- a/types/node/v16/dgram.d.ts
+++ b/types/node/v16/dgram.d.ts
@@ -352,22 +352,22 @@ declare module "dgram" {
          * @param callback Called when the message has been sent.
          */
         send(
-            msg: string | Uint8Array | readonly any[],
+            msg: string | NodeJS.ArrayBufferView | readonly any[],
             port?: number,
             address?: string,
             callback?: (error: Error | null, bytes: number) => void,
         ): void;
         send(
-            msg: string | Uint8Array | readonly any[],
+            msg: string | NodeJS.ArrayBufferView | readonly any[],
             port?: number,
             callback?: (error: Error | null, bytes: number) => void,
         ): void;
         send(
-            msg: string | Uint8Array | readonly any[],
+            msg: string | NodeJS.ArrayBufferView | readonly any[],
             callback?: (error: Error | null, bytes: number) => void,
         ): void;
         send(
-            msg: string | Uint8Array,
+            msg: string | NodeJS.ArrayBufferView,
             offset: number,
             length: number,
             port?: number,
@@ -375,14 +375,14 @@ declare module "dgram" {
             callback?: (error: Error | null, bytes: number) => void,
         ): void;
         send(
-            msg: string | Uint8Array,
+            msg: string | NodeJS.ArrayBufferView,
             offset: number,
             length: number,
             port?: number,
             callback?: (error: Error | null, bytes: number) => void,
         ): void;
         send(
-            msg: string | Uint8Array,
+            msg: string | NodeJS.ArrayBufferView,
             offset: number,
             length: number,
             callback?: (error: Error | null, bytes: number) => void,

--- a/types/node/v16/test/dgram.ts
+++ b/types/node/v16/test/dgram.ts
@@ -15,6 +15,9 @@ import * as net from "node:net";
     ds.send(new Buffer("hello"), 0, 5, 5000, "127.0.0.1", (error: Error | null, bytes: number): void => {
     });
     ds.send(new Buffer("hello"), 5000, "127.0.0.1");
+    ds.send(new DataView(new ArrayBuffer(0)), 5000, "127.0.0.1");
+    ds.send(new Uint8Array(), 5000, "127.0.0.1");
+    ds.send([], 5000, "127.0.0.1");
     ds = ds.close();
     ds.setMulticastInterface("127.0.0.1");
     ds = dgram.createSocket({

--- a/types/node/v18/dgram.d.ts
+++ b/types/node/v18/dgram.d.ts
@@ -352,22 +352,22 @@ declare module "dgram" {
          * @param callback Called when the message has been sent.
          */
         send(
-            msg: string | Uint8Array | readonly any[],
+            msg: string | NodeJS.ArrayBufferView | readonly any[],
             port?: number,
             address?: string,
             callback?: (error: Error | null, bytes: number) => void,
         ): void;
         send(
-            msg: string | Uint8Array | readonly any[],
+            msg: string | NodeJS.ArrayBufferView | readonly any[],
             port?: number,
             callback?: (error: Error | null, bytes: number) => void,
         ): void;
         send(
-            msg: string | Uint8Array | readonly any[],
+            msg: string | NodeJS.ArrayBufferView | readonly any[],
             callback?: (error: Error | null, bytes: number) => void,
         ): void;
         send(
-            msg: string | Uint8Array,
+            msg: string | NodeJS.ArrayBufferView,
             offset: number,
             length: number,
             port?: number,
@@ -375,14 +375,14 @@ declare module "dgram" {
             callback?: (error: Error | null, bytes: number) => void,
         ): void;
         send(
-            msg: string | Uint8Array,
+            msg: string | NodeJS.ArrayBufferView,
             offset: number,
             length: number,
             port?: number,
             callback?: (error: Error | null, bytes: number) => void,
         ): void;
         send(
-            msg: string | Uint8Array,
+            msg: string | NodeJS.ArrayBufferView,
             offset: number,
             length: number,
             callback?: (error: Error | null, bytes: number) => void,

--- a/types/node/v18/test/dgram.ts
+++ b/types/node/v18/test/dgram.ts
@@ -15,6 +15,9 @@ import * as net from "node:net";
     ds.send(new Buffer("hello"), 0, 5, 5000, "127.0.0.1", (error: Error | null, bytes: number): void => {
     });
     ds.send(new Buffer("hello"), 5000, "127.0.0.1");
+    ds.send(new DataView(new ArrayBuffer(0)), 5000, "127.0.0.1");
+    ds.send(new Uint8Array(), 5000, "127.0.0.1");
+    ds.send([], 5000, "127.0.0.1");
     ds = ds.close();
     ds.setMulticastInterface("127.0.0.1");
     ds = dgram.createSocket({

--- a/types/node/v20/dgram.d.ts
+++ b/types/node/v20/dgram.d.ts
@@ -352,22 +352,22 @@ declare module "dgram" {
          * @param callback Called when the message has been sent.
          */
         send(
-            msg: string | Uint8Array | readonly any[],
+            msg: string | NodeJS.ArrayBufferView | readonly any[],
             port?: number,
             address?: string,
             callback?: (error: Error | null, bytes: number) => void,
         ): void;
         send(
-            msg: string | Uint8Array | readonly any[],
+            msg: string | NodeJS.ArrayBufferView | readonly any[],
             port?: number,
             callback?: (error: Error | null, bytes: number) => void,
         ): void;
         send(
-            msg: string | Uint8Array | readonly any[],
+            msg: string | NodeJS.ArrayBufferView | readonly any[],
             callback?: (error: Error | null, bytes: number) => void,
         ): void;
         send(
-            msg: string | Uint8Array,
+            msg: string | NodeJS.ArrayBufferView,
             offset: number,
             length: number,
             port?: number,
@@ -375,14 +375,14 @@ declare module "dgram" {
             callback?: (error: Error | null, bytes: number) => void,
         ): void;
         send(
-            msg: string | Uint8Array,
+            msg: string | NodeJS.ArrayBufferView,
             offset: number,
             length: number,
             port?: number,
             callback?: (error: Error | null, bytes: number) => void,
         ): void;
         send(
-            msg: string | Uint8Array,
+            msg: string | NodeJS.ArrayBufferView,
             offset: number,
             length: number,
             callback?: (error: Error | null, bytes: number) => void,

--- a/types/node/v20/test/dgram.ts
+++ b/types/node/v20/test/dgram.ts
@@ -15,6 +15,9 @@ import * as net from "node:net";
     ds.send(new Buffer("hello"), 0, 5, 5000, "127.0.0.1", (error: Error | null, bytes: number): void => {
     });
     ds.send(new Buffer("hello"), 5000, "127.0.0.1");
+    ds.send(new DataView(new ArrayBuffer(0)), 5000, "127.0.0.1");
+    ds.send(new Uint8Array(), 5000, "127.0.0.1");
+    ds.send([], 5000, "127.0.0.1");
     ds = ds.close();
     ds.setMulticastInterface("127.0.0.1");
     ds = dgram.createSocket({


### PR DESCRIPTION
The `Socket.send` method in node `dgram` supports `Buffer`, `TypedArray` and `DataView` not just `Uint8Array`

Doc links for versions going back to v16 that this repo covers
- [latest](https://nodejs.org/docs/latest-v23.x/api/dgram.html#socketsendmsg-offset-length-port-address-callback)
- [v20](https://nodejs.org/docs/latest-v20.x/api/dgram.html#socketsendmsg-offset-length-port-address-callback)
- [v18](https://nodejs.org/docs/latest-v18.x/api/dgram.html#socketsendmsg-offset-length-port-address-callback)
- [v16](https://nodejs.org/docs/latest-v16.x/api/dgram.html#socketsendmsg-offset-length-port-address-callback)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
