### PR TITLE
fix: update ComponentRef comment

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1508,13 +1508,13 @@ declare namespace React {
      * @example
      *
      * ```tsx
-     * type MyComponentRef = React.ElementRef<typeof MyComponent>;
+     * type MyComponentRef = React.ComponentRef<typeof MyComponent>;
      * ```
      *
      * @example
      *
      * ```tsx
-     * type DivRef = React.ElementRef<'div'>;
+     * type DivRef = React.ComponentRef<'div'>;
      * ```
      */
     type ComponentRef<T extends ElementType> = ComponentPropsWithRef<T> extends RefAttributes<infer Method> ? Method

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -1507,13 +1507,13 @@ declare namespace React {
      * @example
      *
      * ```tsx
-     * type MyComponentRef = React.ElementRef<typeof MyComponent>;
+     * type MyComponentRef = React.ComponentRef<typeof MyComponent>;
      * ```
      *
      * @example
      *
      * ```tsx
-     * type DivRef = React.ElementRef<'div'>;
+     * type DivRef = React.ComponentRef<'div'>;
      * ```
      */
     type ComponentRef<T extends ElementType> = ComponentPropsWithRef<T> extends RefAttributes<infer Method> ? Method


### PR DESCRIPTION
ComponentRef's example still explain about ElementRef, even if it refers to ComponentRef. this makes me confused.
no code changed. just comment.