### PR TITLE
@rdfjs/data-model, rdf-ext: @rdfjs/types v2 compatibility

### DIFF
--- a/types/clownface/package.json
+++ b/types/clownface/package.json
@@ -7,7 +7,7 @@
     ],
     "type": "module",
     "dependencies": {
-        "@rdfjs/types": "^1",
+        "@rdfjs/types": ">=1",
         "@types/rdfjs__environment": "*"
     },
     "devDependencies": {

--- a/types/rdf-ext/DataFactory.d.ts
+++ b/types/rdf-ext/DataFactory.d.ts
@@ -1,4 +1,3 @@
-import { FromTerm } from "@rdfjs/data-model/lib/fromTerm.js";
 import * as RDF from "@rdfjs/types";
 import { BlankNodeExt } from "./lib/BlankNode.js";
 import { DefaultGraphExt } from "./lib/DefaultGraph.js";
@@ -27,9 +26,14 @@ export interface DataFactoryExt extends RDF.DataFactory<QuadExt, RDF.Quad> {
         graph?: RDF.Quad_Graph,
     ): QuadExt;
 
-    fromTerm: <T extends RDF.Term>(original: T) => ReturnType<FromTerm<T, this>>;
+    fromTerm(original: RDF.NamedNode): NamedNodeExt;
+    fromTerm(original: RDF.BlankNode): BlankNodeExt;
+    fromTerm(original: RDF.Literal): LiteralExt;
+    fromTerm(original: RDF.Variable): VariableExt;
+    fromTerm(original: RDF.DefaultGraph): DefaultGraphExt;
+    fromTerm(original: RDF.BaseQuad): QuadExt;
 
-    fromQuad: (original: RDF.Quad) => ReturnType<FromTerm<RDF.Quad, this>>;
+    fromQuad(original: RDF.Quad): QuadExt;
 }
 
 interface DataFactoryExtCtor {

--- a/types/rdf-ext/package.json
+++ b/types/rdf-ext/package.json
@@ -7,7 +7,7 @@
     ],
     "type": "module",
     "dependencies": {
-        "@rdfjs/types": "^1",
+        "@rdfjs/types": "*",
         "@types/rdfjs__data-model": "*",
         "@types/rdfjs__dataset": "*",
         "@types/rdfjs__environment": "*",

--- a/types/rdf-store-fs/package.json
+++ b/types/rdf-store-fs/package.json
@@ -6,7 +6,7 @@
         "https://github.com/rdf-ext/rdf-store-fs"
     ],
     "dependencies": {
-        "@rdfjs/types": "^1",
+        "@rdfjs/types": ">=1",
         "@types/node": "*"
     },
     "devDependencies": {

--- a/types/rdf-validate-shacl/package.json
+++ b/types/rdf-validate-shacl/package.json
@@ -6,7 +6,7 @@
         "https://github.com/zazuko/rdf-validate-shacl#readme"
     ],
     "dependencies": {
-        "@rdfjs/types": "^1",
+        "@rdfjs/types": "*",
         "@types/clownface": "*",
         "@types/node": "*"
     },

--- a/types/rdfjs__data-model/Factory.d.ts
+++ b/types/rdfjs__data-model/Factory.d.ts
@@ -1,15 +1,21 @@
 import * as RDF from "@rdfjs/types";
-import { FromTerm } from "./lib/fromTerm.js";
 
-interface DataFactory extends Required<RDF.DataFactory<RDF.BaseQuad>> {
+interface DataFactory extends Required<RDF.DataFactory<RDF.Quad, RDF.BaseQuad>> {
     quad<Q extends RDF.BaseQuad = RDF.Quad>(
         subject: Q["subject"],
         predicate: Q["predicate"],
         object: Q["object"],
         graph?: Q["graph"],
     ): Q;
-    fromTerm<T extends RDF.Term>(value: T): ReturnType<FromTerm<T, this>>;
-    fromQuad<T extends RDF.BaseQuad = RDF.Quad>(value: T): ReturnType<FromTerm<T, this>>;
+
+    fromTerm(original: RDF.NamedNode): RDF.NamedNode;
+    fromTerm(original: RDF.BlankNode): RDF.BlankNode;
+    fromTerm(original: RDF.Literal): RDF.Literal;
+    fromTerm(original: RDF.Variable): RDF.Variable;
+    fromTerm(original: RDF.DefaultGraph): RDF.DefaultGraph;
+    fromTerm(original: RDF.BaseQuad): RDF.Quad;
+
+    fromQuad(original: RDF.BaseQuad): RDF.Quad;
 }
 
 declare class DataFactory {

--- a/types/rdfjs__data-model/package.json
+++ b/types/rdfjs__data-model/package.json
@@ -7,7 +7,7 @@
     ],
     "type": "module",
     "dependencies": {
-        "@rdfjs/types": "^1.0.1"
+        "@rdfjs/types": "*"
     },
     "devDependencies": {
         "@types/rdfjs__data-model": "workspace:.",

--- a/types/rdfjs__data-model/rdfjs__data-model-tests.ts
+++ b/types/rdfjs__data-model/rdfjs__data-model-tests.ts
@@ -78,9 +78,9 @@ const myBaseQuadBad = factory.quad(
     factory.namedNode("http://example.org/object"),
 );
 
-// $ExpectType BaseQuad
+// $ExpectType Quad
 const fromQuadValue = factory.fromQuad(myQuad);
-// $ExpectType BaseQuad
+// $ExpectType Quad
 const fromBaseQuadValue = factory.fromQuad(myBaseQuad);
 
 // @ts-expect-error
@@ -90,5 +90,5 @@ factory.fromQuad(factory.variable("?o"));
 const fromTermValue = factory.fromTerm(factory.variable("?o"));
 
 const baseQuad: RDF.BaseQuad = <any> {};
-// $ExpectType BaseQuad
+// $ExpectType Quad
 const fromTermBaseQuad = factory.fromTerm(baseQuad);


### PR DESCRIPTION
ref: rdfjs/types#46

The DT packages for @rdfjs/data-model and rdf-ext had definitions for `DataFactory#fromTerm()` and `DataFactory#fromQuad()` which were type-incompatible with the methods added in @rdfjs/types v2.

This brings those definitions in line with @rdfjs/types, and reverts #71645.

cc @tpluscode