### PR TITLE
[node] Update typings to v22.13.0

### DIFF
--- a/types/node/assert.d.ts
+++ b/types/node/assert.d.ts
@@ -957,6 +957,59 @@ declare module "assert" {
          */
         function doesNotMatch(value: string, regExp: RegExp, message?: string | Error): void;
         /**
+         * `assert.partialDeepStrictEqual()` Asserts the equivalence between the `actual` and `expected` parameters through a
+         * deep comparison, ensuring that all properties in the `expected` parameter are
+         * present in the `actual` parameter with equivalent values, not allowing type coercion.
+         * The main difference with `assert.deepStrictEqual()` is that `assert.partialDeepStrictEqual()` does not require
+         * all properties in the `actual` parameter to be present in the `expected` parameter.
+         * This method should always pass the same test cases as `assert.deepStrictEqual()`, behaving as a super set of it.
+         *
+         * ```js
+         * import assert from 'node:assert';
+         *
+         * assert.partialDeepStrictEqual({ a: 1, b: 2 }, { a: 1, b: 2 });
+         * // OK
+         *
+         * assert.partialDeepStrictEqual({ a: { b: { c: 1 } } }, { a: { b: { c: 1 } } });
+         * // OK
+         *
+         * assert.partialDeepStrictEqual({ a: 1, b: 2, c: 3 }, { a: 1, b: 2 });
+         * // OK
+         *
+         * assert.partialDeepStrictEqual(new Set(['value1', 'value2']), new Set(['value1', 'value2']));
+         * // OK
+         *
+         * assert.partialDeepStrictEqual(new Map([['key1', 'value1']]), new Map([['key1', 'value1']]));
+         * // OK
+         *
+         * assert.partialDeepStrictEqual(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 3]));
+         * // OK
+         *
+         * assert.partialDeepStrictEqual(/abc/, /abc/);
+         * // OK
+         *
+         * assert.partialDeepStrictEqual([{ a: 5 }, { b: 5 }], [{ a: 5 }]);
+         * // OK
+         *
+         * assert.partialDeepStrictEqual(new Set([{ a: 1 }, { b: 1 }]), new Set([{ a: 1 }]));
+         * // OK
+         *
+         * assert.partialDeepStrictEqual(new Date(0), new Date(0));
+         * // OK
+         *
+         * assert.partialDeepStrictEqual({ a: 1 }, { a: 1, b: 2 });
+         * // AssertionError
+         *
+         * assert.partialDeepStrictEqual({ a: 1, b: '2' }, { a: 1, b: 2 });
+         * // AssertionError
+         *
+         * assert.partialDeepStrictEqual({ a: { b: 2 } }, { a: { b: '2' } });
+         * // AssertionError
+         * ```
+         * @since v22.13.0
+         */
+        function partialDeepStrictEqual(actual: unknown, expected: unknown, message?: string | Error): void;
+        /**
          * In strict assertion mode, non-strict methods behave like their corresponding strict methods. For example,
          * {@link deepEqual} will behave like {@link deepStrictEqual}.
          *

--- a/types/node/buffer.buffer.d.ts
+++ b/types/node/buffer.buffer.d.ts
@@ -107,7 +107,8 @@ declare module "buffer" {
              *
              * If `totalLength` is provided, it is coerced to an unsigned integer. If the
              * combined length of the `Buffer`s in `list` exceeds `totalLength`, the result is
-             * truncated to `totalLength`.
+             * truncated to `totalLength`. If the combined length of the `Buffer`s in `list` is
+             * less than `totalLength`, the remaining space is filled with zeros.
              *
              * ```js
              * import { Buffer } from 'node:buffer';

--- a/types/node/dgram.d.ts
+++ b/types/node/dgram.d.ts
@@ -26,7 +26,7 @@
  * @see [source](https://github.com/nodejs/node/blob/v22.x/lib/dgram.js)
  */
 declare module "dgram" {
-    import { AddressInfo } from "node:net";
+    import { AddressInfo, BlockList } from "node:net";
     import * as dns from "node:dns";
     import { Abortable, EventEmitter } from "node:events";
     interface RemoteInfo {
@@ -59,6 +59,8 @@ declare module "dgram" {
                 callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void,
             ) => void)
             | undefined;
+        receiveBlockList?: BlockList | undefined;
+        sendBlockList?: BlockList | undefined;
     }
     /**
      * Creates a `dgram.Socket` object. Once the socket is created, calling `socket.bind()` will instruct the socket to begin listening for datagram

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -223,6 +223,7 @@ declare module "http" {
         path?: string | null | undefined;
         port?: number | string | null | undefined;
         protocol?: string | null | undefined;
+        setDefaultHeaders?: boolean | undefined;
         setHost?: boolean | undefined;
         signal?: AbortSignal | undefined;
         socketPath?: string | undefined;

--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -168,6 +168,80 @@ declare module "module" {
             options?: RegisterOptions<Data>,
         ): void;
         function register<Data = any>(specifier: string | URL, options?: RegisterOptions<Data>): void;
+        interface StripTypeScriptTypesOptions {
+            /**
+             * Possible values are:
+             * * `'strip'` Only strip type annotations without performing the transformation of TypeScript features.
+             * * `'transform'` Strip type annotations and transform TypeScript features to JavaScript.
+             * @default 'strip'
+             */
+            mode?: "strip" | "transform" | undefined;
+            /**
+             * Only when `mode` is `'transform'`, if `true`, a source map
+             * will be generated for the transformed code.
+             * @default false
+             */
+            sourceMap?: boolean | undefined;
+            /**
+             * Specifies the source url used in the source map.
+             */
+            sourceUrl?: string | undefined;
+        }
+        /**
+         * `module.stripTypeScriptTypes()` removes type annotations from TypeScript code. It
+         * can be used to strip type annotations from TypeScript code before running it
+         * with `vm.runInContext()` or `vm.compileFunction()`.
+         * By default, it will throw an error if the code contains TypeScript features
+         * that require transformation such as `Enums`,
+         * see [type-stripping](https://nodejs.org/docs/latest-v22.x/api/typescript.md#type-stripping) for more information.
+         * When mode is `'transform'`, it also transforms TypeScript features to JavaScript,
+         * see [transform TypeScript features](https://nodejs.org/docs/latest-v22.x/api/typescript.md#typescript-features) for more information.
+         * When mode is `'strip'`, source maps are not generated, because locations are preserved.
+         * If `sourceMap` is provided, when mode is `'strip'`, an error will be thrown.
+         *
+         * _WARNING_: The output of this function should not be considered stable across Node.js versions,
+         * due to changes in the TypeScript parser.
+         *
+         * ```js
+         * import { stripTypeScriptTypes } from 'node:module';
+         * const code = 'const a: number = 1;';
+         * const strippedCode = stripTypeScriptTypes(code);
+         * console.log(strippedCode);
+         * // Prints: const a         = 1;
+         * ```
+         *
+         * If `sourceUrl` is provided, it will be used appended as a comment at the end of the output:
+         *
+         * ```js
+         * import { stripTypeScriptTypes } from 'node:module';
+         * const code = 'const a: number = 1;';
+         * const strippedCode = stripTypeScriptTypes(code, { mode: 'strip', sourceUrl: 'source.ts' });
+         * console.log(strippedCode);
+         * // Prints: const a         = 1\n\n//# sourceURL=source.ts;
+         * ```
+         *
+         * When `mode` is `'transform'`, the code is transformed to JavaScript:
+         *
+         * ```js
+         * import { stripTypeScriptTypes } from 'node:module';
+         * const code = `
+         *   namespace MathUtil {
+         *     export const add = (a: number, b: number) => a + b;
+         *   }`;
+         * const strippedCode = stripTypeScriptTypes(code, { mode: 'transform', sourceMap: true });
+         * console.log(strippedCode);
+         * // Prints:
+         * // var MathUtil;
+         * // (function(MathUtil) {
+         * //     MathUtil.add = (a, b)=>a + b;
+         * // })(MathUtil || (MathUtil = {}));
+         * // # sourceMappingURL=data:application/json;base64, ...
+         * ```
+         * @since v22.13.0
+         * @param code The code to strip type annotations from.
+         * @returns The code with type annotations stripped.
+         */
+        function stripTypeScriptTypes(code: string, options?: StripTypeScriptTypesOptions): string;
         /* eslint-enable @definitelytyped/no-unnecessary-generics */
         /**
          * The `module.syncBuiltinESMExports()` method updates all the live bindings for

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -1008,6 +1008,14 @@ declare module "net" {
          * @since v15.14.0, v14.18.0
          */
         readonly flowlabel: number;
+        /**
+         * @since v22.13.0
+         * @param input An input string containing an IP address and optional port,
+         * e.g. `123.1.2.3:1234` or `[1::1]:1234`.
+         * @returns Returns a `SocketAddress` if parsing was successful.
+         * Otherwise returns `undefined`.
+         */
+        static parse(input: string): SocketAddress | undefined;
     }
 }
 declare module "node:net" {

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -65,6 +65,7 @@ declare module "net" {
          * @since v18.13.0
          */
         autoSelectFamilyAttemptTimeout?: number | undefined;
+        blockList?: BlockList | undefined;
     }
     interface IpcSocketConnectOpts {
         path: string;

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -536,6 +536,15 @@ declare module "net" {
          * @since v18.17.0, v20.1.0
          */
         highWaterMark?: number | undefined;
+        /**
+         * `blockList` can be used for disabling inbound
+         * access to specific IP addresses, IP ranges, or IP subnets. This does not
+         * work if the server is behind a reverse proxy, NAT, etc. because the address
+         * checked against the block list is the address of the proxy, or the one
+         * specified by the NAT.
+         * @since v22.13.0
+         */
+        blockList?: BlockList | undefined;
     }
     interface DropArgument {
         localAddress?: string;

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -796,6 +796,12 @@ declare module "net" {
          * @since v15.0.0, v14.18.0
          */
         rules: readonly string[];
+        /**
+         * Returns `true` if the `value` is a `net.BlockList`.
+         * @since v22.13.0
+         * @param value Any JS value
+         */
+        static isBlockList(value: unknown): value is BlockList;
     }
     interface TcpNetConnectOpts extends TcpSocketConnectOpts, SocketConstructorOpts {
         timeout?: number | undefined;

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "22.12.9999",
+    "version": "22.13.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [

--- a/types/node/perf_hooks.d.ts
+++ b/types/node/perf_hooks.d.ts
@@ -594,6 +594,11 @@ declare module "perf_hooks" {
                     buffered?: boolean | undefined;
                 },
         ): void;
+        /**
+         * @since v16.0.0
+         * @returns Current list of entries stored in the performance observer, emptying it out.
+         */
+        takeRecords(): PerformanceEntry[];
     }
     /**
      * Provides detailed network timing data regarding the loading of an application's resources.

--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -1676,7 +1676,7 @@ declare module "process" {
                  */
                 nextTick(callback: Function, ...args: any[]): void;
                 /**
-                 * This API is available through the [--experimental-permission](https://nodejs.org/api/cli.html#--experimental-permission) flag.
+                 * This API is available through the [--permission](https://nodejs.org/api/cli.html#--permission) flag.
                  *
                  * `process.permission` is an object whose methods are used to manage permissions for the current process.
                  * Additional documentation is available in the [Permission Model](https://nodejs.org/api/permissions.html#permission-model).

--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -186,7 +186,10 @@ declare module "process" {
                 readonly inspector: boolean;
                 /**
                  * A boolean value that is `true` if the current Node.js build includes support for IPv6.
+                 *
+                 * Since all Node.js builds have IPv6 support, this value is always `true`.
                  * @since v0.5.3
+                 * @deprecated This property is always true, and any checks based on it are redundant.
                  */
                 readonly ipv6: boolean;
                 /**
@@ -202,17 +205,29 @@ declare module "process" {
                 readonly tls: boolean;
                 /**
                  * A boolean value that is `true` if the current Node.js build includes support for ALPN in TLS.
+                 *
+                 * In Node.js 11.0.0 and later versions, the OpenSSL dependencies feature unconditional ALPN support.
+                 * This value is therefore identical to that of `process.features.tls`.
                  * @since v4.8.0
+                 * @deprecated Use `process.features.tls` instead.
                  */
                 readonly tls_alpn: boolean;
                 /**
                  * A boolean value that is `true` if the current Node.js build includes support for OCSP in TLS.
+                 *
+                 * In Node.js 11.0.0 and later versions, the OpenSSL dependencies feature unconditional OCSP support.
+                 * This value is therefore identical to that of `process.features.tls`.
                  * @since v0.11.13
+                 * @deprecated Use `process.features.tls` instead.
                  */
                 readonly tls_ocsp: boolean;
                 /**
                  * A boolean value that is `true` if the current Node.js build includes support for SNI in TLS.
+                 *
+                 * In Node.js 11.0.0 and later versions, the OpenSSL dependencies feature unconditional SNI support.
+                 * This value is therefore identical to that of `process.features.tls`.
                  * @since v0.5.3
+                 * @deprecated Use `process.features.tls` instead.
                  */
                 readonly tls_sni: boolean;
                 /**
@@ -223,8 +238,10 @@ declare module "process" {
                 readonly typescript: "strip" | "transform" | false;
                 /**
                  * A boolean value that is `true` if the current Node.js build includes support for libuv.
-                 * Since it's currently not possible to build Node.js without libuv, this value is always `true`.
+                 *
+                 * Since it's not possible to build Node.js without libuv, this value is always `true`.
                  * @since v0.5.3
+                 * @deprecated This property is always true, and any checks based on it are redundant.
                  */
                 readonly uv: boolean;
             }

--- a/types/node/sea.d.ts
+++ b/types/node/sea.d.ts
@@ -149,5 +149,5 @@ declare module "node:sea" {
      * writes to the returned array buffer is likely to result in a crash.
      * @since v20.12.0
      */
-    function getRawAsset(key: AssetKey): string | ArrayBuffer;
+    function getRawAsset(key: AssetKey): ArrayBuffer;
 }

--- a/types/node/sqlite.d.ts
+++ b/types/node/sqlite.d.ts
@@ -332,18 +332,23 @@ declare module "node:sqlite" {
         readonly sourceSQL: string;
     }
     /**
-     * Conflicting changes are omitted.
-     * @since v22.12.0
+     * @since v22.13.0
      */
-    const SQLITE_CHANGESET_OMIT: number;
-    /**
-     * Conflicting changes replace existing values.
-     * @since v22.12.0
-     */
-    const SQLITE_CHANGESET_REPLACE: number;
-    /**
-     * Abort when a change encounters a conflict and roll back databsase.
-     * @since v22.12.0
-     */
-    const SQLITE_CHANGESET_ABORT: number;
+    namespace constants {
+        /**
+         * Conflicting changes are omitted.
+         * @since v22.12.0
+         */
+        const SQLITE_CHANGESET_OMIT: number;
+        /**
+         * Conflicting changes replace existing values.
+         * @since v22.12.0
+         */
+        const SQLITE_CHANGESET_REPLACE: number;
+        /**
+         * Abort when a change encounters a conflict and roll back database.
+         * @since v22.12.0
+         */
+        const SQLITE_CHANGESET_ABORT: number;
+    }
 }

--- a/types/node/sqlite.d.ts
+++ b/types/node/sqlite.d.ts
@@ -282,6 +282,24 @@ declare module "node:sqlite" {
         get(...anonymousParameters: SupportedValueType[]): unknown;
         get(namedParameters: Record<string, SupportedValueType>, ...anonymousParameters: SupportedValueType[]): unknown;
         /**
+         * This method executes a prepared statement and returns an iterator of
+         * objects. If the prepared statement does not return any results, this method
+         * returns an empty iterator. The prepared statement [parameters are bound](https://www.sqlite.org/c3ref/bind_blob.html) using
+         * the values in `namedParameters` and `anonymousParameters`.
+         * @since v22.13.0
+         * @param namedParameters An optional object used to bind named parameters.
+         * The keys of this object are used to configure the mapping.
+         * @param anonymousParameters Zero or more values to bind to anonymous parameters.
+         * @returns An iterable iterator of objects. Each object corresponds to a row
+         * returned by executing the prepared statement. The keys and values of each
+         * object correspond to the column names and values of the row.
+         */
+        iterate(...anonymousParameters: SupportedValueType[]): NodeJS.Iterator<unknown>;
+        iterate(
+            namedParameters: Record<string, SupportedValueType>,
+            ...anonymousParameters: SupportedValueType[]
+        ): NodeJS.Iterator<unknown>;
+        /**
          * This method executes a prepared statement and returns an object summarizing the
          * resulting changes. The prepared statement [parameters are bound](https://www.sqlite.org/c3ref/bind_blob.html) using the
          * values in `namedParameters` and `anonymousParameters`.

--- a/types/node/sqlite.d.ts
+++ b/types/node/sqlite.d.ts
@@ -78,6 +78,14 @@ declare module "node:sqlite" {
          * @default false
          */
         readOnly?: boolean | undefined;
+        /**
+         * If `true`, the `loadExtension` SQL function
+         * and the `loadExtension()` method are enabled.
+         * You can call `enableLoadExtension(false)` later to disable this feature.
+         * @since v22.13.0
+         * @default false
+         */
+        allowExtension?: boolean | undefined;
     }
     interface CreateSessionOptions {
         /**
@@ -155,6 +163,22 @@ declare module "node:sqlite" {
          * @since v22.5.0
          */
         close(): void;
+        /**
+         * Loads a shared library into the database connection. This method is a wrapper
+         * around [`sqlite3_load_extension()`](https://www.sqlite.org/c3ref/load_extension.html). It is required to enable the
+         * `allowExtension` option when constructing the `DatabaseSync` instance.
+         * @since v22.13.0
+         * @param path The path to the shared library to load.
+         */
+        loadExtension(path: string): void;
+        /**
+         * Enables or disables the `loadExtension` SQL function, and the `loadExtension()`
+         * method. When `allowExtension` is `false` when constructing, you cannot enable
+         * loading extensions for security reasons.
+         * @since v22.13.0
+         * @param allow Whether to allow loading extensions.
+         */
+        enableLoadExtension(allow: boolean): void;
         /**
          * This method allows one or more SQL statements to be executed without returning
          * any results. This method is useful when executing SQL statements read from a

--- a/types/node/sqlite.d.ts
+++ b/types/node/sqlite.d.ts
@@ -43,6 +43,7 @@
  * @see [source](https://github.com/nodejs/node/blob/v22.x/lib/sqlite.js)
  */
 declare module "node:sqlite" {
+    type SupportedValueType = null | number | bigint | string | Uint8Array;
     interface DatabaseSyncOptions {
         /**
          * If `true`, the database is opened by the constructor. When
@@ -105,6 +106,34 @@ declare module "node:sqlite" {
          */
         onConflict?: number | undefined;
     }
+    interface FunctionOptions {
+        /**
+         * If `true`, the [`SQLITE_DETERMINISTIC`](https://www.sqlite.org/c3ref/c_deterministic.html) flag is
+         * set on the created function.
+         * @default false
+         */
+        deterministic?: boolean | undefined;
+        /**
+         * If `true`, the [`SQLITE_DIRECTONLY`](https://www.sqlite.org/c3ref/c_directonly.html) flag is set on
+         * the created function.
+         * @default false
+         */
+        directOnly?: boolean | undefined;
+        /**
+         * If `true`, integer arguments to `function`
+         * are converted to `BigInt`s. If `false`, integer arguments are passed as
+         * JavaScript numbers.
+         * @default false
+         */
+        useBigIntArguments?: boolean | undefined;
+        /**
+         * If `true`, `function` can accept a variable number of
+         * arguments. If `false`, `function` must be invoked with exactly
+         * `function.length` arguments.
+         * @default false
+         */
+        varargs?: boolean | undefined;
+    }
     /**
      * This class represents a single [connection](https://www.sqlite.org/c3ref/sqlite3.html) to a SQLite database. All APIs
      * exposed by this class execute synchronously.
@@ -134,6 +163,21 @@ declare module "node:sqlite" {
          * @param sql A SQL string to execute.
          */
         exec(sql: string): void;
+        /**
+         * This method is used to create SQLite user-defined functions. This method is a
+         * wrapper around [`sqlite3_create_function_v2()`](https://www.sqlite.org/c3ref/create_function.html).
+         * @since v22.13.0
+         * @param name The name of the SQLite function to create.
+         * @param options Optional configuration settings for the function.
+         * @param func The JavaScript function to call when the SQLite
+         * function is invoked.
+         */
+        function(
+            name: string,
+            options: FunctionOptions,
+            func: (...args: SupportedValueType[]) => SupportedValueType,
+        ): void;
+        function(name: string, func: (...args: SupportedValueType[]) => SupportedValueType): void;
         /**
          * Opens the database specified in the `location` argument of the `DatabaseSync`constructor. This method should only be used when the database is not opened via
          * the constructor. An exception is thrown if the database is already open.
@@ -215,7 +259,6 @@ declare module "node:sqlite" {
          */
         close(): void;
     }
-    type SupportedValueType = null | number | bigint | string | Uint8Array;
     interface StatementResultingChanges {
         /**
          * The number of rows modified, inserted, or deleted by the most recently completed `INSERT`, `UPDATE`, or `DELETE` statement.

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -887,10 +887,7 @@ declare module "node:test" {
          *   });
          * });
          * ```
-         *
-         * Only available through the [--experimental-test-snapshots](https://nodejs.org/api/cli.html#--experimental-test-snapshots) flag.
          * @since v22.3.0
-         * @experimental
          */
         snapshot(value: any, options?: AssertSnapshotOptions): void;
     }
@@ -1691,9 +1688,7 @@ declare module "node:test" {
         [Symbol.dispose](): void;
     }
     /**
-     * Only available through the [--experimental-test-snapshots](https://nodejs.org/api/cli.html#--experimental-test-snapshots) flag.
      * @since v22.3.0
-     * @experimental
      */
     namespace snapshot {
         /**

--- a/types/node/test/assert.ts
+++ b/types/node/test/assert.ts
@@ -141,6 +141,8 @@ assert.throws(
 
 assert["fail"](true, true, "works like a charm");
 
+assert.partialDeepStrictEqual({ a: 1, b: 2, c: 3 }, { a: 1, b: 2 });
+
 {
     const a = null as any;
     assert.ifError(a);

--- a/types/node/test/dgram.ts
+++ b/types/node/test/dgram.ts
@@ -26,6 +26,8 @@ import * as net from "node:net";
         recvBufferSize: 1000,
         sendBufferSize: 1000,
         lookup: dns.lookup,
+        receiveBlockList: new net.BlockList(),
+        sendBlockList: new net.BlockList(),
     });
     ds[Symbol.asyncDispose]();
 }

--- a/types/node/test/module.ts
+++ b/types/node/test/module.ts
@@ -222,3 +222,17 @@ Module.Module === Module;
 
     Module.flushCompileCache();
 }
+
+{
+    const code = "const a: number = 1;";
+    const strippedCode = Module.stripTypeScriptTypes(code);
+    console.log(strippedCode);
+    // Prints: const a         = 1;
+}
+
+{
+    const code = "const a: number = 1;";
+    const strippedCode = Module.stripTypeScriptTypes(code, { mode: "strip", sourceUrl: "source.ts" });
+    console.log(strippedCode);
+    // Prints: const a         = 1\n\n//# sourceURL=source.ts;
+}

--- a/types/node/test/net.ts
+++ b/types/node/test/net.ts
@@ -416,4 +416,5 @@ import * as net from "node:net";
     bl.addSubnet(sockAddr, 12);
     const res: boolean = bl.check("127.0.0.1", "ipv4") || bl.check(sockAddr);
     bl.rules; // $ExpectType readonly string[]
+    net.BlockList.isBlockList(bl); // $ExpectType boolean
 }

--- a/types/node/test/net.ts
+++ b/types/node/test/net.ts
@@ -405,6 +405,7 @@ import * as net from "node:net";
     sockAddr.family; // $ExpectType IPVersion
     sockAddr.flowlabel; // $ExpectType number
     sockAddr.port; // $ExpectType number
+    net.SocketAddress.parse("[1::1]:1234"); // $ExpectType SocketAddress | undefined
 
     const bl = new net.BlockList();
     bl.addAddress("127.0.0.1", "ipv4");

--- a/types/node/test/net.ts
+++ b/types/node/test/net.ts
@@ -23,6 +23,7 @@ import * as net from "node:net";
         keepAlive: true,
         keepAliveInitialDelay: 1000,
         highWaterMark: 16384,
+        blockList: new net.BlockList(),
     });
     // Check methods which return server instances by chaining calls
     server = server.listen(0)

--- a/types/node/test/net.ts
+++ b/types/node/test/net.ts
@@ -11,6 +11,7 @@ import * as net from "node:net";
         port: 443,
         signal: abort.signal,
         timeout: 10E3,
+        blockList: new net.BlockList(),
     };
     const socket: net.Socket = net.createConnection(connectOpts, (): void => {
         // nothing

--- a/types/node/test/sea.ts
+++ b/types/node/test/sea.ts
@@ -1,4 +1,4 @@
-import { getAsset, getAssetAsBlob, isSea } from "node:sea";
+import { getAsset, getAssetAsBlob, getRawAsset, isSea } from "node:sea";
 
 {
     // $ExpectType boolean
@@ -11,4 +11,7 @@ import { getAsset, getAssetAsBlob, isSea } from "node:sea";
 
     // $ExpectType Blob
     getAssetAsBlob("c.png");
+
+    // $ExpectType ArrayBuffer
+    getRawAsset("d.webm");
 }

--- a/types/node/test/sqlite.ts
+++ b/types/node/test/sqlite.ts
@@ -43,6 +43,12 @@ import { TextEncoder } from "node:util";
 }
 
 {
+    const database = new DatabaseSync(":memory:", { allowExtension: true });
+    database.loadExtension("/path/to/extension.so");
+    database.enableLoadExtension(false);
+}
+
+{
     let statement!: StatementSync;
     statement.expandedSQL; // $ExpectType string
     statement.sourceSQL; // $ExpectType string

--- a/types/node/test/sqlite.ts
+++ b/types/node/test/sqlite.ts
@@ -23,6 +23,7 @@ import { TextEncoder } from "node:util";
 
     const query = database.prepare("SELECT * FROM data ORDER BY key");
     query.all(); // $ExpectType unknown[]
+    query.iterate(); // $ExpectType Iterator<unknown, any, any>
 
     const sql = "INSERT INTO types (key, val) VALUES ($k, ?)";
     const stmt = database.prepare(sql);

--- a/types/node/test/sqlite.ts
+++ b/types/node/test/sqlite.ts
@@ -12,6 +12,14 @@ import { TextEncoder } from "node:util";
     ) STRICT
     `);
 
+    database.function(
+        "COUNT_ARGS",
+        { deterministic: true, varargs: true },
+        function() {
+            return arguments.length;
+        },
+    );
+
     const insert = database.prepare("INSERT INTO types (key, int, double, text, buf) VALUES (?, ?, ?, ?, ?)");
     insert.setReadBigInts(true);
     insert.setAllowBareNamedParameters(true);

--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -451,7 +451,7 @@ const errorMap: Map<number, [string, string]> = util.getSystemErrorMap();
     // $ExpectType CallSiteObject[]
     util.getCallSites(100);
 
-    const callSites = util.getCallSites();
+    const callSites = util.getCallSites({ sourceMap: true });
 
     console.log("Call Sites:");
     callSites.forEach((callSite, index) => {

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -1321,8 +1321,6 @@ declare module "util" {
         | "strikethrough"
         | "underline";
     /**
-     * Stability: 1.1 - Active development
-     *
      * This function returns a formatted text considering the `format` passed.
      *
      * ```js

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -185,6 +185,13 @@ declare module "util" {
      * @since v10.0.0
      */
     export function formatWithOptions(inspectOptions: InspectOptions, format?: any, ...param: any[]): string;
+    interface GetCallSitesOptions {
+        /**
+         * Reconstruct the original location in the stacktrace from the source-map.
+         * Enabled by default with the flag `--enable-source-maps`.
+         */
+        sourceMap?: boolean | undefined;
+    }
     /**
      * Returns an array of call site objects containing the stack of
      * the caller function.
@@ -225,12 +232,40 @@ declare module "util" {
      *
      * anotherFunction();
      * ```
+     *
+     * It is possible to reconstruct the original locations by setting the option `sourceMap` to `true`.
+     * If the source map is not available, the original location will be the same as the current location.
+     * When the `--enable-source-maps` flag is enabled, for example when using `--experimental-transform-types`,
+     * `sourceMap` will be true by default.
+     *
+     * ```ts
+     * import util from 'node:util';
+     *
+     * interface Foo {
+     *   foo: string;
+     * }
+     *
+     * const callSites = util.getCallSites({ sourceMap: true });
+     *
+     * // With sourceMap:
+     * // Function Name: ''
+     * // Script Name: example.js
+     * // Line Number: 7
+     * // Column Number: 26
+     *
+     * // Without sourceMap:
+     * // Function Name: ''
+     * // Script Name: example.js
+     * // Line Number: 2
+     * // Column Number: 26
+     * ```
      * @param frameCount Number of frames to capture as call site objects.
      * **Default:** `10`. Allowable range is between 1 and 200.
      * @return An array of call site objects
      * @since v22.9.0
      */
-    export function getCallSites(frameCount?: number): CallSiteObject[];
+    export function getCallSites(frameCount?: number, options?: GetCallSitesOptions): CallSiteObject[];
+    export function getCallSites(options: GetCallSitesOptions): CallSiteObject[];
     /**
      * Returns the string name for a numeric error code that comes from a Node.js API.
      * The mapping between error codes and error names is platform-dependent.

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -352,27 +352,36 @@ declare module "util" {
      */
     export function transferableAbortSignal(signal: AbortSignal): AbortSignal;
     /**
-     * Listens to abort event on the provided `signal` and
-     * returns a promise that is fulfilled when the `signal` is
-     * aborted. If the passed `resource` is garbage collected before the `signal` is
-     * aborted, the returned promise shall remain pending indefinitely.
+     * Listens to abort event on the provided `signal` and returns a promise that resolves when the `signal` is aborted.
+     * If `resource` is provided, it weakly references the operation's associated object,
+     * so if `resource` is garbage collected before the `signal` aborts,
+     * then returned promise shall remain pending.
+     * This prevents memory leaks in long-running or non-cancelable operations.
      *
      * ```js
      * import { aborted } from 'node:util';
      *
+     * // Obtain an object with an abortable signal, like a custom resource or operation.
      * const dependent = obtainSomethingAbortable();
      *
+     * // Pass `dependent` as the resource, indicating the promise should only resolve
+     * // if `dependent` is still in memory when the signal is aborted.
      * aborted(dependent.signal, dependent).then(() => {
-     *   // Do something when dependent is aborted.
+     *   // This code runs when `dependent` is aborted.
+     *   console.log('Dependent resource was aborted.');
      * });
      *
+     * // Simulate an event that triggers the abort.
      * dependent.on('event', () => {
-     *   dependent.abort();
+     *   dependent.abort(); // This will cause the `aborted` promise to resolve.
      * });
      * ```
      * @since v19.7.0
      * @experimental
-     * @param resource Any non-null entity, reference to which is held weakly.
+     * @param resource Any non-null object tied to the abortable operation and held weakly.
+     * If `resource` is garbage collected before the `signal` aborts, the promise remains pending,
+     * allowing Node.js to stop tracking it.
+     * This helps prevent memory leaks in long-running or non-cancelable operations.
      */
     export function aborted(signal: AbortSignal, resource: any): Promise<void>;
     /**


### PR DESCRIPTION
- assert: add partialDeepStrictEqual
- buffer: document concat zero-fill
- dgram: support blocklist in udp
- doc: add doc for PerformanceObserver.takeRecords()
- doc: clarify util.aborted resource usage
- doc: `sea.getRawAsset(key)` always returns an ArrayBuffer
- doc: stabilize util.styleText
- http: add setDefaultHeaders option to http.request
- module: add module.stripTypeScriptTypes
- net: support blocklist in net.connect
- net: support blocklist for net.Server
- net: add SocketAddress.parse
- net: add net.BlockList.isBlockList(value)
- process: deprecate `features.{ipv6,uv}` and `features.tls_*`
- sqlite: add `StatementSync.prototype.iterate` method
- sqlite: add support for custom functions
- sqlite: aggregate constants in a single property
- sqlite: support `db.loadExtension`
- src,lib: stabilize permission model
- test_runner: mark snapshot testing as stable
- util: add sourcemap support to getCallSites

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V22.md#22.13.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
