### PR TITLE
fix(node/v18): missing perf_hooks API

### DIFF
--- a/types/node/v18/perf_hooks.d.ts
+++ b/types/node/v18/perf_hooks.d.ts
@@ -26,7 +26,7 @@
  *   performance.measure('A to B', 'A', 'B');
  * });
  * ```
- * @see [source](https://github.com/nodejs/node/blob/v18.0.0/lib/perf_hooks.js)
+ * @see [source](https://github.com/nodejs/node/blob/v18.20.5/lib/perf_hooks.js)
  */
 declare module "perf_hooks" {
     import { AsyncResource } from "node:async_hooks";
@@ -149,6 +149,11 @@ declare module "perf_hooks" {
          */
         readonly loopStart: number;
         /**
+         * The high resolution millisecond timestamp at which the Node.js process was initialized.
+         * @since v8.5.0
+         */
+        readonly nodeStart: number;
+        /**
          * The high resolution millisecond timestamp at which the V8 platform was
          * initialized.
          * @since v8.5.0
@@ -161,12 +166,12 @@ declare module "perf_hooks" {
         utilization: number;
     }
     /**
-     * @param util1 The result of a previous call to eventLoopUtilization()
-     * @param util2 The result of a previous call to eventLoopUtilization() prior to util1
+     * @param utilization1 The result of a previous call to `eventLoopUtilization()`.
+     * @param utilization2 The result of a previous call to `eventLoopUtilization()` prior to `utilization1`.
      */
     type EventLoopUtilityFunction = (
-        util1?: EventLoopUtilization,
-        util2?: EventLoopUtilization,
+        utilization1?: EventLoopUtilization,
+        utilization2?: EventLoopUtilization,
     ) => EventLoopUtilization;
     interface MarkOptions {
         /**
@@ -175,7 +180,7 @@ declare module "perf_hooks" {
         detail?: unknown | undefined;
         /**
          * An optional timestamp to be used as the mark time.
-         * @default `performance.now()`.
+         * @default `performance.now()`
          */
         startTime?: number | undefined;
     }
@@ -199,26 +204,38 @@ declare module "perf_hooks" {
     }
     interface TimerifyOptions {
         /**
-         * A histogram object created using
-         * `perf_hooks.createHistogram()` that will record runtime durations in
-         * nanoseconds.
+         * A histogram object created using `perf_hooks.createHistogram()` that will record runtime
+         * durations in nanoseconds.
          */
         histogram?: RecordableHistogram | undefined;
     }
     interface Performance {
         /**
-         * If name is not provided, removes all PerformanceMark objects from the Performance Timeline.
-         * If name is provided, removes only the named mark.
+         * If `name` is not provided, removes all `PerformanceMark` objects from the Performance Timeline.
+         * If `name` is provided, removes only the named mark.
          * @param name
+         * @since v8.5.0
          */
         clearMarks(name?: string): void;
         /**
-         * If name is not provided, removes all PerformanceMeasure objects from the Performance Timeline.
-         * If name is provided, removes only the named measure.
+         * If `name` is not provided, removes all `PerformanceMeasure` objects from the Performance Timeline.
+         * If `name` is provided, removes only the named measure.
          * @param name
          * @since v16.7.0
          */
         clearMeasures(name?: string): void;
+        /**
+         * If `name` is not provided, removes all `PerformanceResourceTiming` objects from the Resource Timeline.
+         * If `name` is provided, removes only the named resource.
+         * @since v18.2.0, v16.17.0
+         */
+        clearResourceTimings(name?: string): void;
+        /**
+         * eventLoopUtilization is similar to CPU utilization except that it is calculated using high precision wall-clock time.
+         * It represents the percentage of time the event loop has spent outside the event loop's event provider (e.g. epoll_wait).
+         * No other CPU idle time is taken into consideration.
+         */
+        eventLoopUtilization: EventLoopUtilityFunction;
         /**
          * Returns a list of `PerformanceEntry` objects in chronological order with respect to `performanceEntry.startTime`.
          * If you are only interested in performance entries of certain types or that have certain names, see
@@ -242,14 +259,18 @@ declare module "perf_hooks" {
          */
         getEntriesByType(type: EntryType): PerformanceEntry[];
         /**
-         * Creates a new PerformanceMark entry in the Performance Timeline.
-         * A PerformanceMark is a subclass of PerformanceEntry whose performanceEntry.entryType is always 'mark',
-         * and whose performanceEntry.duration is always 0.
+         * Creates a new `PerformanceMark` entry in the Performance Timeline.
+         * A `PerformanceMark` is a subclass of `PerformanceEntry` whose `performanceEntry.entryType` is always `'mark'`,
+         * and whose `performanceEntry.duration` is always `0`.
          * Performance marks are used to mark specific significant moments in the Performance Timeline.
+         *
+         * The created `PerformanceMark` entry is put in the global Performance Timeline and can be queried with
+         * `performance.getEntries`, `performance.getEntriesByName`, and `performance.getEntriesByType`. When the observation is
+         * performed, the entries should be cleared from the global Performance Timeline manually with `performance.clearMarks`.
          * @param name
          * @return The PerformanceMark entry that was created
          */
-        mark(name?: string, options?: MarkOptions): PerformanceMark;
+        mark(name: string, options?: MarkOptions): PerformanceMark;
         /**
          * Creates a new `PerformanceResourceTiming` entry in the Resource Timeline.
          * A `PerformanceResourceTiming` is a subclass of `PerformanceEntry` whose `performanceEntry.entryType` is always `'resource'`.
@@ -287,31 +308,85 @@ declare module "perf_hooks" {
         measure(name: string, startMark?: string, endMark?: string): PerformanceMeasure;
         measure(name: string, options: MeasureOptions): PerformanceMeasure;
         /**
-         * An instance of the PerformanceNodeTiming class that provides performance metrics for specific Node.js operational milestones.
+         * _This property is an extension by Node.js. It is not available in Web browsers._
+         *
+         * An instance of the `PerformanceNodeTiming` class that provides performance metrics for specific Node.js operational milestones.
+         * @since v8.5.0
          */
         readonly nodeTiming: PerformanceNodeTiming;
         /**
-         * @return the current high resolution millisecond timestamp
+         * Returns the current high resolution millisecond timestamp, where 0 represents the start of the current `node` process.
+         * @since v8.5.0
          */
         now(): number;
         /**
-         * The timeOrigin specifies the high resolution millisecond timestamp from which all performance metric durations are measured.
+         * Sets the global performance resource timing buffer size to the specified number of "resource" type performance entry objects.
+         *
+         * By default the max buffer size is set to 250.
+         * @since v18.8.0
+         */
+        setResourceTimingBufferSize(maxSize: number): void;
+        /**
+         * The [`timeOrigin`](https://w3c.github.io/hr-time/#dom-performance-timeorigin) specifies the high resolution millisecond timestamp
+         * at which the current `node` process began, measured in Unix time.
+         * @since v8.5.0
+         * Sets the global performance resource timing buffer size to the specified number of "resource" type performance entry objects.
+         *
+         * By default the max buffer size is set to 250.
+         * @since v18.8.0
+         */
+        setResourceTimingBufferSize(maxSize: number): void;
+        /**
+         * The [`timeOrigin`](https://w3c.github.io/hr-time/#dom-performance-timeorigin) specifies the high resolution millisecond timestamp
+         * at which the current `node` process began, measured in Unix time.
+         * @since v8.5.0
+        /**
          */
         readonly timeOrigin: number;
         /**
+         * _This property is an extension by Node.js. It is not available in Web browsers._
+         *
          * Wraps a function within a new function that measures the running time of the wrapped function.
-         * A PerformanceObserver must be subscribed to the 'function' event type in order for the timing details to be accessed.
+         * A `PerformanceObserver` must be subscribed to the `'function'` event type in order for the timing details to be accessed.
+         *
+         * ```js
+         * const {
+         *   performance,
+         *   PerformanceObserver,
+         * } = require('node:perf_hooks');
+         *
+         * function someFunction() {
+         *   console.log('hello world');
+         * }
+         *
+         * const wrapped = performance.timerify(someFunction);
+         *
+         * const obs = new PerformanceObserver((list) => {
+         *   console.log(list.getEntries()[0].duration);
+         *
+         *   performance.clearMarks();
+         *   performance.clearMeasures();
+         *   obs.disconnect();
+         * });
+         * obs.observe({ entryTypes: ['function'] });
+         *
+         * // A performance timeline entry will be created
+         * wrapped();
+         * ```
+         *
+         * If the wrapped function returns a promise, a finally handler will be attached to the promise and the duration will be reported
+         * once the finally handler is invoked.
          * @param fn
          */
         timerify<T extends (...params: any[]) => any>(fn: T, options?: TimerifyOptions): T;
         /**
-         * eventLoopUtilization is similar to CPU utilization except that it is calculated using high precision wall-clock time.
-         * It represents the percentage of time the event loop has spent outside the event loop's event provider (e.g. epoll_wait).
-         * No other CPU idle time is taken into consideration.
+         * An object which is JSON representation of the performance object. It is similar to
+         * [`window.performance.toJSON`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/toJSON) in browsers.
+         * @since v16.1.0
          */
-        eventLoopUtilization: EventLoopUtilityFunction;
+        toJSON(): any;
     }
-    interface PerformanceObserverEntryList {
+    class PerformanceObserverEntryList {
         /**
          * Returns a list of `PerformanceEntry` objects in chronological order
          * with respect to `performanceEntry.startTime`.
@@ -489,7 +564,6 @@ declare module "perf_hooks" {
      * @since v18.2.0, v16.17.0
      */
     class PerformanceResourceTiming extends PerformanceEntry {
-        readonly entryType: "resource";
         protected constructor();
         /**
          * The high resolution millisecond timestamp at immediately before dispatching the `fetch`
@@ -580,7 +654,6 @@ declare module "perf_hooks" {
          */
         toJSON(): any;
     }
-
     namespace constants {
         const NODE_PERFORMANCE_GC_MAJOR: number;
         const NODE_PERFORMANCE_GC_MINOR: number;
@@ -605,10 +678,15 @@ declare module "perf_hooks" {
     }
     interface Histogram {
         /**
-         * Returns a `Map` object detailing the accumulated percentile distribution.
-         * @since v11.10.0
+         * The number of samples recorded by the histogram.
+         * @since v17.4.0, v16.14.0
          */
-        readonly percentiles: Map<number, number>;
+        readonly count: number;
+        /**
+         * The number of samples recorded by the histogram.
+         * v17.4.0, v16.14.0
+         */
+        readonly countBigInt: bigint;
         /**
          * The number of times the event loop delay exceeded the maximum 1 hour event
          * loop delay threshold.
@@ -616,36 +694,67 @@ declare module "perf_hooks" {
          */
         readonly exceeds: number;
         /**
-         * The minimum recorded event loop delay.
-         * @since v11.10.0
+         * The number of times the event loop delay exceeded the maximum 1 hour event loop delay threshold.
+         * @since v17.4.0, v16.14.0
          */
-        readonly min: number;
+        readonly exceedsBigInt: bigint;
         /**
          * The maximum recorded event loop delay.
          * @since v11.10.0
          */
         readonly max: number;
         /**
+         * The maximum recorded event loop delay.
+         * v17.4.0, v16.14.0
+         */
+        readonly maxBigInt: number;
+        /**
          * The mean of the recorded event loop delays.
          * @since v11.10.0
          */
         readonly mean: number;
         /**
-         * The standard deviation of the recorded event loop delays.
+         * The minimum recorded event loop delay.
          * @since v11.10.0
          */
-        readonly stddev: number;
+        readonly min: number;
         /**
-         * Resets the collected histogram data.
-         * @since v11.10.0
+         * The minimum recorded event loop delay.
+         * v17.4.0, v16.14.0
          */
-        reset(): void;
+        readonly minBigInt: bigint;
         /**
          * Returns the value at the given percentile.
          * @since v11.10.0
          * @param percentile A percentile value in the range (0, 100].
          */
         percentile(percentile: number): number;
+        /**
+         * Returns the value at the given percentile.
+         * @since v17.4.0, v16.14.0
+         * @param percentile A percentile value in the range (0, 100].
+         */
+        percentileBigInt(percentile: number): bigint;
+        /**
+         * Returns a `Map` object detailing the accumulated percentile distribution.
+         * @since v11.10.0
+         */
+        readonly percentiles: Map<number, number>;
+        /**
+         * Returns a `Map` object detailing the accumulated percentile distribution.
+         * @since v17.4.0, v16.14.0
+         */
+        readonly percentilesBigInt: Map<bigint, bigint>;
+        /**
+         * Resets the collected histogram data.
+         * @since v11.10.0
+         */
+        reset(): void;
+        /**
+         * The standard deviation of the recorded event loop delays.
+         * @since v11.10.0
+         */
+        readonly stddev: number;
     }
     interface IntervalHistogram extends Histogram {
         /**
@@ -670,8 +779,6 @@ declare module "perf_hooks" {
         /**
          * Calculates the amount of time (in nanoseconds) that has passed since the
          * previous call to `recordDelta()` and records that amount in the histogram.
-         *
-         * ## Examples
          * @since v15.9.0, v14.18.0
          */
         recordDelta(): void;
@@ -738,7 +845,7 @@ declare module "perf_hooks" {
     global {
         /**
          * `performance` is a global reference for `import { performance } from 'node:perf_hooks'`
-         * https://nodejs.org/api/globals.html#performance
+         * @see https://nodejs.org/docs/latest-v18.x/api/globals.html#performance
          * @since v16.0.0
          */
         var performance: typeof globalThis extends {


### PR DESCRIPTION
Partial backport of the `perf_hooks` bits of #69718. No tests were included for this change, so there was nothing to backport.

I don't believe I need to update the types package version since it's at `18.19.9999` and no types are introduced from a later major version.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://nodejs.org/download/release/v18.0.0/docs/api/perf_hooks.html)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
