### PR TITLE
[@types/express-serve-static-core] app.router is Router from express v5

### DIFF
--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -348,5 +348,4 @@ app.get("/:readonly", req => {
 app.get("/async", Promise.resolve);
 
 // Starting with Express 5, app.router is the app's in-built instance of router
-app.router.stack
-
+app.router.stack;

--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -346,3 +346,7 @@ app.get("/:readonly", req => {
 
 // Starting with Express 5 RequestHandler can be async
 app.get("/async", Promise.resolve);
+
+// Starting with Express 5, app.router is the app's in-built instance of router
+app.router.stack
+

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -1194,7 +1194,7 @@ export interface Application<
     listen(path: string, callback?: (error?: Error) => void): http.Server;
     listen(handle: any, listeningListener?: (error?: Error) => void): http.Server;
 
-    router: string;
+    router: Router;
 
     settings: any;
 


### PR DESCRIPTION
Starting from express v5, `app.router` is a reference to the app's built in router and not a string.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://expressjs.com/en/5x/api.html#app.router>>
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`~~.
