### PR TITLE
feat: Fix typings for @types/skmeans

### DIFF
--- a/types/skmeans/index.d.ts
+++ b/types/skmeans/index.d.ts
@@ -1,11 +1,16 @@
 type CentroidValues<TPoint extends number | number[]> = TPoint[] | "kmrand" | "kmpp";
 
+interface TestResult<TPoint> {
+    idx: number
+    centroid: TPoint
+}
+
 interface DataResult<TPoint extends number | number[]> {
     it: number;
     k: number;
     centroids: TPoint[];
     idxs: number[];
-    test: (x: TPoint, distance?: (x: TPoint, y: TPoint) => number) => void;
+    test: (x: TPoint, distance?: (x: TPoint, y: TPoint) => number) => TestResult<TPoint>;
 }
 
 /**


### PR DESCRIPTION
`DataResult`'s `test` function had a return type of `void` which is incorrect. I've created a `TestResult` type to represent this type and updated the return type of `test`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/solzimer/skmeans/blob/master/main.js](https://github.com/solzimer/skmeans/blob/master/main.js)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
