### PR TITLE
NodeJS RegisterOptions.parentURL should be optional

### DIFF
--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -283,7 +283,7 @@ declare module "module" {
         }
     }
     interface RegisterOptions<Data> {
-        parentURL: string | URL;
+        parentURL?: string | URL;
         data?: Data | undefined;
         transferList?: any[] | undefined;
     }

--- a/types/node/test/module.ts
+++ b/types/node/test/module.ts
@@ -134,6 +134,11 @@ Module.findSourceMap("/path/to/file.js", new Error()); // $ExpectType SourceMap 
         transferList: [someArrayBuffer],
     });
 
+    Module.register(specifier, {
+        data: someArrayBuffer,
+        transferList: [someArrayBuffer],
+    });
+
     interface TransferableData {
         number: number;
     }

--- a/types/node/v18/module.d.ts
+++ b/types/node/v18/module.d.ts
@@ -252,7 +252,7 @@ declare module "module" {
         ) => LoadFnOutput | Promise<LoadFnOutput>;
     }
     interface RegisterOptions<Data> {
-        parentURL: string | URL;
+        parentURL?: string | URL;
         data?: Data | undefined;
         transferList?: any[] | undefined;
     }

--- a/types/node/v18/test/module.ts
+++ b/types/node/v18/test/module.ts
@@ -119,6 +119,11 @@ const entry: Module.SourceMapping = smap.findEntry(1, 1);
         transferList: [someArrayBuffer],
     });
 
+    Module.register(specifier, {
+        data: someArrayBuffer,
+        transferList: [someArrayBuffer],
+    });
+
     interface TransferableData {
         number: number;
     }

--- a/types/node/v20/module.d.ts
+++ b/types/node/v20/module.d.ts
@@ -254,7 +254,7 @@ declare module "module" {
         ) => LoadFnOutput | Promise<LoadFnOutput>;
     }
     interface RegisterOptions<Data> {
-        parentURL: string | URL;
+        parentURL?: string | URL;
         data?: Data | undefined;
         transferList?: any[] | undefined;
     }

--- a/types/node/v20/test/module.ts
+++ b/types/node/v20/test/module.ts
@@ -131,6 +131,11 @@ const entry: Module.SourceMapping = smap.findEntry(1, 1);
         transferList: [someArrayBuffer],
     });
 
+    Module.register(specifier, {
+        data: someArrayBuffer,
+        transferList: [someArrayBuffer],
+    });
+
     interface TransferableData {
         number: number;
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://nodejs.org/docs/latest-v20.x/api/module.html#moduleregisterspecifier-parenturl-options>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
