### PR TITLE
fix(targz): add missing @types/node, fix option type for exported fn

### DIFF
--- a/types/targz/index.d.ts
+++ b/types/targz/index.d.ts
@@ -1,12 +1,28 @@
+/// <reference types="node" />
+
 import * as tar from "tar-fs";
 import * as zlib from "zlib";
 
-export interface options {
+export interface CompressOptions {
+    src: string;
+    dest: string;
+    tar?: tar.PackOptions | undefined;
+    gz?: zlib.ZlibOptions | undefined;
+}
+
+export interface DecompressOptions {
     src: string;
     dest: string;
     tar?: tar.ExtractOptions | undefined;
     gz?: zlib.ZlibOptions | undefined;
 }
 
-export function compress(opts?: options, callback?: (error: Error | string | null) => void): void;
-export function decompress(opts?: options, callback?: (error: Error | string | null) => void): void;
+export function compress(
+    opts?: CompressOptions,
+    callback?: (error?: Error | string | null | undefined) => void,
+): void;
+
+export function decompress(
+    opts?: DecompressOptions,
+    callback?: (error?: Error | string | null | undefined) => void,
+): void;

--- a/types/targz/package.json
+++ b/types/targz/package.json
@@ -6,6 +6,7 @@
         "https://github.com/miskun/targz#readme"
     ],
     "dependencies": {
+        "@types/node": "*",
         "@types/tar-fs": "*"
     },
     "devDependencies": {

--- a/types/targz/targz-tests.ts
+++ b/types/targz/targz-tests.ts
@@ -6,7 +6,42 @@ targz.compress(
         src: "srcPath",
         dest: "destPath",
     },
-    (err: Error | string | null) => {},
+    (err) => {
+        // $ExpectType Error | string | null | undefined
+        err;
+    },
+);
+
+// $ExpectType void
+targz.compress(
+    {
+        src: "srcPath",
+        dest: "destPath",
+        tar: {},
+        gz: {},
+    },
+    (err) => {
+        // $ExpectType Error | string | null | undefined
+        err;
+    },
+);
+
+targz.compress(
+    {
+        src: "srcPath",
+        dest: "destPath",
+        tar: {
+            entries: ["file.txt"],
+            dereference: true,
+            finalize: true,
+            finish: () => {},
+        },
+        gz: {},
+    },
+    (err) => {
+        // $ExpectType Error | string | null | undefined
+        err;
+    },
 );
 
 // $ExpectType void
@@ -15,5 +50,40 @@ targz.decompress(
         src: "srcPath",
         dest: "destPath",
     },
-    (err: Error | string | null) => {},
+    (err) => {
+        // $ExpectType Error | string | null | undefined
+        err;
+    },
+);
+
+// $ExpectType void
+targz.decompress(
+    {
+        src: "srcPath",
+        dest: "destPath",
+        tar: {},
+        gz: {},
+    },
+    (err) => {
+        // $ExpectType Error | string | null | undefined
+        err;
+    },
+);
+
+// $ExpectType void
+targz.decompress(
+    {
+        src: "srcPath",
+        dest: "destPath",
+        tar: {
+            ignore: () => true,
+            filter: () => true,
+            strip: 3,
+        },
+        gz: {},
+    },
+    (err) => {
+        // $ExpectType Error | string | null | undefined
+        err;
+    },
 );


### PR DESCRIPTION
From source code, 
- `module.exports.compress()` calls `tar.pack()` with `opts.tar`. See [here](https://github.com/miskun/targz/blob/master/lib/targz.js#L37).
- `module.exports.decompress()` calls `tar.extract()` with `opts.tar`. See [here](https://github.com/miskun/targz/blob/master/lib/targz.js#L72).

Hence the option types need to be fixed.

And `@types/node` is added, coz this is needed for providing type to `zlib` import.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
