### PR TITLE
Fix @types/ws ESM exports

### DIFF
--- a/types/ws/index.d.mts
+++ b/types/ws/index.d.mts
@@ -1,22 +1,418 @@
-export {
-    AddressInfo,
-    CertMeta,
-    ClientOptions,
-    CloseEvent,
-    createWebSocketStream,
-    Data,
-    ErrorEvent,
-    Event,
-    EventListenerOptions,
-    FinishRequestCallback,
-    MessageEvent,
-    PerMessageDeflateOptions,
-    RawData,
-    ServerOptions,
-    VerifyClientCallbackAsync,
-    VerifyClientCallbackSync,
-    WebSocket,
-    WebSocketServer,
-} from "./index.js";
-import WebSocket = require("./index.js");
+/// <reference types="node" />
+
+import { EventEmitter } from "events";
+import {
+    Agent,
+    ClientRequest,
+    ClientRequestArgs,
+    IncomingMessage,
+    OutgoingHttpHeaders,
+    Server as HTTPServer,
+} from "http";
+import { Server as HTTPSServer } from "https";
+import { Duplex, DuplexOptions } from "stream";
+import { SecureContextOptions } from "tls";
+import { URL } from "url";
+import { ZlibOptions } from "zlib";
+
+// can not get all overload of BufferConstructor['from'], need to copy all it's first arguments here
+// https://github.com/microsoft/TypeScript/issues/32164
+type BufferLike =
+    | string
+    | Buffer
+    | DataView
+    | number
+    | ArrayBufferView
+    | Uint8Array
+    | ArrayBuffer
+    | SharedArrayBuffer
+    | readonly any[]
+    | readonly number[]
+    | { valueOf(): ArrayBuffer }
+    | { valueOf(): SharedArrayBuffer }
+    | { valueOf(): Uint8Array }
+    | { valueOf(): readonly number[] }
+    | { valueOf(): string }
+    | { [Symbol.toPrimitive](hint: string): string };
+
+// WebSocket socket.
+declare class WebSocket extends EventEmitter {
+    /** The connection is not yet open. */
+    static readonly CONNECTING: 0;
+    /** The connection is open and ready to communicate. */
+    static readonly OPEN: 1;
+    /** The connection is in the process of closing. */
+    static readonly CLOSING: 2;
+    /** The connection is closed. */
+    static readonly CLOSED: 3;
+
+    binaryType: "nodebuffer" | "arraybuffer" | "fragments";
+    readonly bufferedAmount: number;
+    readonly extensions: string;
+    /** Indicates whether the websocket is paused */
+    readonly isPaused: boolean;
+    readonly protocol: string;
+    /** The current state of the connection */
+    readonly readyState:
+        | typeof WebSocket.CONNECTING
+        | typeof WebSocket.OPEN
+        | typeof WebSocket.CLOSING
+        | typeof WebSocket.CLOSED;
+    readonly url: string;
+
+    /** The connection is not yet open. */
+    readonly CONNECTING: 0;
+    /** The connection is open and ready to communicate. */
+    readonly OPEN: 1;
+    /** The connection is in the process of closing. */
+    readonly CLOSING: 2;
+    /** The connection is closed. */
+    readonly CLOSED: 3;
+
+    onopen: ((event: WebSocket.Event) => void) | null;
+    onerror: ((event: WebSocket.ErrorEvent) => void) | null;
+    onclose: ((event: WebSocket.CloseEvent) => void) | null;
+    onmessage: ((event: WebSocket.MessageEvent) => void) | null;
+
+    constructor(address: null);
+    constructor(address: string | URL, options?: WebSocket.ClientOptions | ClientRequestArgs);
+    constructor(
+        address: string | URL,
+        protocols?: string | string[],
+        options?: WebSocket.ClientOptions | ClientRequestArgs,
+    );
+
+    close(code?: number, data?: string | Buffer): void;
+    ping(data?: any, mask?: boolean, cb?: (err: Error) => void): void;
+    pong(data?: any, mask?: boolean, cb?: (err: Error) => void): void;
+    // https://github.com/websockets/ws/issues/2076#issuecomment-1250354722
+    send(data: BufferLike, cb?: (err?: Error) => void): void;
+    send(
+        data: BufferLike,
+        options: {
+            mask?: boolean | undefined;
+            binary?: boolean | undefined;
+            compress?: boolean | undefined;
+            fin?: boolean | undefined;
+        },
+        cb?: (err?: Error) => void,
+    ): void;
+    terminate(): void;
+
+    /**
+     * Pause the websocket causing it to stop emitting events. Some events can still be
+     * emitted after this is called, until all buffered data is consumed. This method
+     * is a noop if the ready state is `CONNECTING` or `CLOSED`.
+     */
+    pause(): void;
+    /**
+     * Make a paused socket resume emitting events. This method is a noop if the ready
+     * state is `CONNECTING` or `CLOSED`.
+     */
+    resume(): void;
+
+    // HTML5 WebSocket events
+    addEventListener<K extends keyof WebSocket.WebSocketEventMap>(
+        type: K,
+        listener: (event: WebSocket.WebSocketEventMap[K]) => void,
+        options?: WebSocket.EventListenerOptions,
+    ): void;
+    removeEventListener<K extends keyof WebSocket.WebSocketEventMap>(
+        type: K,
+        listener: (event: WebSocket.WebSocketEventMap[K]) => void,
+    ): void;
+
+    // Events
+    on(event: "close", listener: (this: WebSocket, code: number, reason: Buffer) => void): this;
+    on(event: "error", listener: (this: WebSocket, err: Error) => void): this;
+    on(event: "upgrade", listener: (this: WebSocket, request: IncomingMessage) => void): this;
+    on(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary: boolean) => void): this;
+    on(event: "open", listener: (this: WebSocket) => void): this;
+    on(event: "ping" | "pong", listener: (this: WebSocket, data: Buffer) => void): this;
+    on(
+        event: "unexpected-response",
+        listener: (this: WebSocket, request: ClientRequest, response: IncomingMessage) => void,
+    ): this;
+    on(event: string | symbol, listener: (this: WebSocket, ...args: any[]) => void): this;
+
+    once(event: "close", listener: (this: WebSocket, code: number, reason: Buffer) => void): this;
+    once(event: "error", listener: (this: WebSocket, err: Error) => void): this;
+    once(event: "upgrade", listener: (this: WebSocket, request: IncomingMessage) => void): this;
+    once(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary: boolean) => void): this;
+    once(event: "open", listener: (this: WebSocket) => void): this;
+    once(event: "ping" | "pong", listener: (this: WebSocket, data: Buffer) => void): this;
+    once(
+        event: "unexpected-response",
+        listener: (this: WebSocket, request: ClientRequest, response: IncomingMessage) => void,
+    ): this;
+    once(event: string | symbol, listener: (this: WebSocket, ...args: any[]) => void): this;
+
+    off(event: "close", listener: (this: WebSocket, code: number, reason: Buffer) => void): this;
+    off(event: "error", listener: (this: WebSocket, err: Error) => void): this;
+    off(event: "upgrade", listener: (this: WebSocket, request: IncomingMessage) => void): this;
+    off(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary: boolean) => void): this;
+    off(event: "open", listener: (this: WebSocket) => void): this;
+    off(event: "ping" | "pong", listener: (this: WebSocket, data: Buffer) => void): this;
+    off(
+        event: "unexpected-response",
+        listener: (this: WebSocket, request: ClientRequest, response: IncomingMessage) => void,
+    ): this;
+    off(event: string | symbol, listener: (this: WebSocket, ...args: any[]) => void): this;
+
+    addListener(event: "close", listener: (code: number, reason: Buffer) => void): this;
+    addListener(event: "error", listener: (err: Error) => void): this;
+    addListener(event: "upgrade", listener: (request: IncomingMessage) => void): this;
+    addListener(event: "message", listener: (data: WebSocket.RawData, isBinary: boolean) => void): this;
+    addListener(event: "open", listener: () => void): this;
+    addListener(event: "ping" | "pong", listener: (data: Buffer) => void): this;
+    addListener(
+        event: "unexpected-response",
+        listener: (request: ClientRequest, response: IncomingMessage) => void,
+    ): this;
+    addListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+    removeListener(event: "close", listener: (code: number, reason: Buffer) => void): this;
+    removeListener(event: "error", listener: (err: Error) => void): this;
+    removeListener(event: "upgrade", listener: (request: IncomingMessage) => void): this;
+    removeListener(event: "message", listener: (data: WebSocket.RawData, isBinary: boolean) => void): this;
+    removeListener(event: "open", listener: () => void): this;
+    removeListener(event: "ping" | "pong", listener: (data: Buffer) => void): this;
+    removeListener(
+        event: "unexpected-response",
+        listener: (request: ClientRequest, response: IncomingMessage) => void,
+    ): this;
+    removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+}
+
+declare namespace WebSocket {
+    /**
+     * Data represents the raw message payload received over the WebSocket.
+     */
+    type RawData = Buffer | ArrayBuffer | Buffer[];
+
+    /**
+     * Data represents the message payload received over the WebSocket.
+     */
+    type Data = string | Buffer | ArrayBuffer | Buffer[];
+
+    /**
+     * CertMeta represents the accepted types for certificate & key data.
+     */
+    type CertMeta = string | string[] | Buffer | Buffer[];
+
+    /**
+     * VerifyClientCallbackSync is a synchronous callback used to inspect the
+     * incoming message. The return value (boolean) of the function determines
+     * whether or not to accept the handshake.
+     */
+    type VerifyClientCallbackSync<Request extends IncomingMessage = IncomingMessage> = (info: {
+        origin: string;
+        secure: boolean;
+        req: Request;
+    }) => boolean;
+
+    /**
+     * VerifyClientCallbackAsync is an asynchronous callback used to inspect the
+     * incoming message. The return value (boolean) of the function determines
+     * whether or not to accept the handshake.
+     */
+    type VerifyClientCallbackAsync<Request extends IncomingMessage = IncomingMessage> = (
+        info: { origin: string; secure: boolean; req: Request },
+        callback: (res: boolean, code?: number, message?: string, headers?: OutgoingHttpHeaders) => void,
+    ) => void;
+
+    /**
+     * FinishRequestCallback is a callback for last minute customization of the
+     * headers. If finishRequest is set, then it has the responsibility to call
+     * request.end() once it is done setting request headers.
+     */
+    type FinishRequestCallback = (request: IncomingMessage, websocket: WebSocket) => void;
+
+    interface ClientOptions extends SecureContextOptions {
+        protocol?: string | undefined;
+        followRedirects?: boolean | undefined;
+        generateMask?(mask: Buffer): void;
+        handshakeTimeout?: number | undefined;
+        maxRedirects?: number | undefined;
+        perMessageDeflate?: boolean | PerMessageDeflateOptions | undefined;
+        localAddress?: string | undefined;
+        protocolVersion?: number | undefined;
+        headers?: { [key: string]: string } | undefined;
+        origin?: string | undefined;
+        agent?: Agent | undefined;
+        host?: string | undefined;
+        family?: number | undefined;
+        checkServerIdentity?(servername: string, cert: CertMeta): boolean;
+        rejectUnauthorized?: boolean | undefined;
+        maxPayload?: number | undefined;
+        skipUTF8Validation?: boolean | undefined;
+        finishRequest?: FinishRequestCallback | undefined;
+    }
+
+    interface PerMessageDeflateOptions {
+        serverNoContextTakeover?: boolean | undefined;
+        clientNoContextTakeover?: boolean | undefined;
+        serverMaxWindowBits?: number | undefined;
+        clientMaxWindowBits?: number | undefined;
+        zlibDeflateOptions?:
+            | {
+                flush?: number | undefined;
+                finishFlush?: number | undefined;
+                chunkSize?: number | undefined;
+                windowBits?: number | undefined;
+                level?: number | undefined;
+                memLevel?: number | undefined;
+                strategy?: number | undefined;
+                dictionary?: Buffer | Buffer[] | DataView | undefined;
+                info?: boolean | undefined;
+            }
+            | undefined;
+        zlibInflateOptions?: ZlibOptions | undefined;
+        threshold?: number | undefined;
+        concurrencyLimit?: number | undefined;
+    }
+
+    interface Event {
+        type: string;
+        target: WebSocket;
+    }
+
+    interface ErrorEvent {
+        error: any;
+        message: string;
+        type: string;
+        target: WebSocket;
+    }
+
+    interface CloseEvent {
+        wasClean: boolean;
+        code: number;
+        reason: string;
+        type: string;
+        target: WebSocket;
+    }
+
+    interface MessageEvent {
+        data: Data;
+        type: string;
+        target: WebSocket;
+    }
+
+    interface WebSocketEventMap {
+        open: Event;
+        error: ErrorEvent;
+        close: CloseEvent;
+        message: MessageEvent;
+    }
+
+    interface EventListenerOptions {
+        once?: boolean | undefined;
+    }
+
+    interface ServerOptions<
+        U extends typeof WebSocket = typeof WebSocket,
+        V extends typeof IncomingMessage = typeof IncomingMessage,
+    > {
+        host?: string | undefined;
+        port?: number | undefined;
+        backlog?: number | undefined;
+        server?: HTTPServer<V> | HTTPSServer<V> | undefined;
+        verifyClient?:
+            | VerifyClientCallbackAsync<InstanceType<V>>
+            | VerifyClientCallbackSync<InstanceType<V>>
+            | undefined;
+        handleProtocols?: (protocols: Set<string>, request: InstanceType<V>) => string | false;
+        path?: string | undefined;
+        noServer?: boolean | undefined;
+        clientTracking?: boolean | undefined;
+        perMessageDeflate?: boolean | PerMessageDeflateOptions | undefined;
+        maxPayload?: number | undefined;
+        skipUTF8Validation?: boolean | undefined;
+        WebSocket?: U | undefined;
+    }
+
+    interface AddressInfo {
+        address: string;
+        family: string;
+        port: number;
+    }
+}
+
+export import AddressInfo = WebSocket.AddressInfo;
+export import CertMeta = WebSocket.CertMeta;
+export import ClientOptions = WebSocket.ClientOptions;
+export import CloseEvent = WebSocket.CloseEvent;
+export import Data = WebSocket.Data;
+export import ErrorEvent = WebSocket.ErrorEvent;
+export import Event = WebSocket.Event;
+export import EventListenerOptions = WebSocket.EventListenerOptions;
+export import FinishRequestCallback = WebSocket.FinishRequestCallback;
+export import MessageEvent = WebSocket.MessageEvent;
+export import PerMessageDeflateOptions = WebSocket.PerMessageDeflateOptions;
+export import RawData = WebSocket.RawData;
+export import ServerOptions = WebSocket.ServerOptions;
+export import VerifyClientCallbackAsync = WebSocket.VerifyClientCallbackAsync;
+export import VerifyClientCallbackSync = WebSocket.VerifyClientCallbackSync;
+
+// WebSocket Server
+declare class Server<
+    T extends typeof WebSocket = typeof WebSocket,
+    U extends typeof IncomingMessage = typeof IncomingMessage,
+> extends EventEmitter {
+    options: WebSocket.ServerOptions<T, U>;
+    path: string;
+    clients: Set<InstanceType<T>>;
+
+    constructor(options?: WebSocket.ServerOptions<T, U>, callback?: () => void);
+
+    address(): WebSocket.AddressInfo | string | null;
+    close(cb?: (err?: Error) => void): void;
+    handleUpgrade(
+        request: InstanceType<U>,
+        socket: Duplex,
+        upgradeHead: Buffer,
+        callback: (client: InstanceType<T>, request: InstanceType<U>) => void,
+    ): void;
+    shouldHandle(request: InstanceType<U>): boolean | Promise<boolean>;
+
+    // Events
+    on(event: "connection", cb: (this: Server<T>, socket: InstanceType<T>, request: InstanceType<U>) => void): this;
+    on(event: "error", cb: (this: Server<T>, error: Error) => void): this;
+    on(event: "headers", cb: (this: Server<T>, headers: string[], request: InstanceType<U>) => void): this;
+    on(event: "close" | "listening", cb: (this: Server<T>) => void): this;
+    on(event: string | symbol, listener: (this: Server<T>, ...args: any[]) => void): this;
+
+    once(event: "connection", cb: (this: Server<T>, socket: InstanceType<T>, request: InstanceType<U>) => void): this;
+    once(event: "error", cb: (this: Server<T>, error: Error) => void): this;
+    once(event: "headers", cb: (this: Server<T>, headers: string[], request: InstanceType<U>) => void): this;
+    once(event: "close" | "listening", cb: (this: Server<T>) => void): this;
+    once(event: string | symbol, listener: (this: Server<T>, ...args: any[]) => void): this;
+
+    off(event: "connection", cb: (this: Server<T>, socket: InstanceType<T>, request: InstanceType<U>) => void): this;
+    off(event: "error", cb: (this: Server<T>, error: Error) => void): this;
+    off(event: "headers", cb: (this: Server<T>, headers: string[], request: InstanceType<U>) => void): this;
+    off(event: "close" | "listening", cb: (this: Server<T>) => void): this;
+    off(event: string | symbol, listener: (this: Server<T>, ...args: any[]) => void): this;
+
+    addListener(event: "connection", cb: (client: InstanceType<T>, request: InstanceType<U>) => void): this;
+    addListener(event: "error", cb: (err: Error) => void): this;
+    addListener(event: "headers", cb: (headers: string[], request: InstanceType<U>) => void): this;
+    addListener(event: "close" | "listening", cb: () => void): this;
+    addListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+    removeListener(event: "connection", cb: (client: InstanceType<T>, request: InstanceType<U>) => void): this;
+    removeListener(event: "error", cb: (err: Error) => void): this;
+    removeListener(event: "headers", cb: (headers: string[], request: InstanceType<U>) => void): this;
+    removeListener(event: "close" | "listening", cb: () => void): this;
+    removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+}
+export { type Server };
+
+export const WebSocketServer: typeof Server;
+export interface WebSocketServer extends Server {} // eslint-disable-line @typescript-eslint/no-empty-interface
+
+// WebSocket stream
+export function createWebSocketStream(websocket: WebSocket, options?: DuplexOptions): Duplex;
+
 export default WebSocket;
+export { WebSocket };

--- a/types/ws/tsconfig.json
+++ b/types/ws/tsconfig.json
@@ -14,6 +14,8 @@
     },
     "files": [
         "index.d.ts",
-        "ws-tests.ts"
+        "index.d.mts",
+        "ws-tests.ts",
+        "ws-tests.mts"
     ]
 }

--- a/types/ws/ws-tests.mts
+++ b/types/ws/ws-tests.mts
@@ -1,0 +1,498 @@
+import * as http from "http";
+import * as https from "https";
+import * as url from "url";
+import WebSocket from "ws";
+// eslint-disable-next-line no-duplicate-imports
+import * as wslib from "ws";
+
+{
+    // @ts-expect-error does not work with ES module
+    new WebSocket.WebSocket("ws://www.host.com/path");
+    // @ts-expect-error does not work with ES module
+    new WebSocket.WebSocketServer();
+}
+
+{
+    const ws = new WebSocket("ws://www.host.com/path");
+    ws.on("open", () => ws.send("something"));
+    ws.on("message", data => {});
+    // @ts-expect-error
+    ws.send({ hello: "world" });
+
+    ws.send(new Uint8Array([]));
+
+    const Any = null as any;
+
+    ws.send(Any as number);
+    ws.send(Any as ArrayBufferView);
+    ws.send(Any as { valueOf(): ArrayBuffer });
+    ws.send(Any as Uint8Array);
+    ws.send(Any as { valueOf(): Uint8Array });
+    ws.send(Any as { valueOf(): string });
+}
+
+{
+    const addr = new url.URL("ws://www.host.com/path");
+    const ws = new WebSocket(addr);
+    ws.on("open", () => {
+        const array = new Float32Array(5);
+        for (let i = 0; i < array.length; ++i) array[i] = i / 2;
+        ws.send(array, { binary: true, mask: true });
+    });
+}
+
+{
+    const ws: wslib.WebSocket = new wslib.WebSocket("ws://www.host.com/path");
+}
+
+{
+    const wss: wslib.WebSocketServer = new wslib.WebSocketServer({ port: 8081 });
+}
+
+{
+    const wss = new wslib.WebSocketServer({ port: 8081 });
+    wss.on("connection", (ws, req) => {
+        ws.on("message", message => console.log("received: %s", message));
+        ws.send("something");
+        ws.send("something", (error?: Error) => {});
+        ws.send("something", {}, (error?: Error) => {});
+    });
+    wss.once("connection", (ws, req) => {
+        ws.send("something");
+    });
+    wss.off("connection", (ws, req) => {
+        ws.send("something");
+    });
+}
+
+{
+    const wss = new wslib.WebSocketServer({ port: 8082 });
+
+    const broadcast = (data: string) => {
+        wss.clients.forEach(ws => ws.send(data));
+    };
+}
+
+{
+    const wsc = new WebSocket("ws://echo.websocket.org/");
+
+    wsc.on("open", () => wsc.send(Date.now().toString(), { mask: true }));
+    wsc.on("close", () => console.log("disconnected"));
+    wsc.on("error", error => {
+        console.log(`unexpected response: ${error}`);
+    });
+
+    wsc.on("message", (data) => {
+        console.log(`Roundtrip time: ${Date.now() - parseInt(data.toString(), 10)} ms`);
+        setTimeout(() => {
+            wsc.send(Date.now().toString(), { mask: true });
+        }, 500);
+    });
+}
+
+{
+    new wslib.WebSocketServer({ server: https.createServer({}) });
+    new wslib.WebSocketServer({ server: http.createServer() });
+}
+
+{
+    const verifyClient = (
+        info: { origin: string; secure: boolean; req: http.IncomingMessage },
+        callback: (res: boolean) => void,
+    ): void => {
+        callback(true);
+    };
+
+    const wsv = new wslib.WebSocketServer({
+        server: http.createServer(),
+        clientTracking: true,
+        perMessageDeflate: true,
+    });
+
+    wsv.on("connection", function connection(ws) {
+        console.log(ws.protocol);
+    });
+}
+
+{
+    const wss = new wslib.WebSocketServer();
+
+    wss.addListener("connection", (client, request) => {
+        request.socket.remoteAddress;
+
+        // @ts-expect-error
+        request.aborted === 10;
+
+        client.terminate();
+        request.destroy();
+    });
+
+    wss.close();
+
+    const addr = wss.address();
+
+    if (addr === null) {
+        // $ExpectType null
+        addr;
+    }
+}
+
+{
+    new wslib.WebSocketServer({ noServer: true, perMessageDeflate: false });
+    new wslib.WebSocketServer({ noServer: true, perMessageDeflate: {} });
+    new wslib.WebSocketServer({
+        noServer: true,
+        perMessageDeflate: {
+            serverNoContextTakeover: true,
+            clientNoContextTakeover: true,
+            serverMaxWindowBits: 0,
+            clientMaxWindowBits: 0,
+            zlibDeflateOptions: {
+                flush: 0,
+                finishFlush: 0,
+                chunkSize: 0,
+                windowBits: 0,
+                level: 0,
+                memLevel: 0,
+                strategy: 0,
+                dictionary: new Buffer("test"),
+                info: false,
+            },
+            zlibInflateOptions: {
+                chunkSize: 0,
+            },
+        },
+        verifyClient: (info: any, cb: any) => {
+            cb(true, 123, "message", { Upgrade: "websocket" });
+        },
+    });
+}
+
+{
+    const ws = new WebSocket("ws://www.host.com/path", {
+        timeout: 5000,
+        maxPayload: 10 * 1024 * 1024,
+    });
+    ws.on("open", () => ws.send("something assume to be really long"));
+}
+
+{
+    const ws = new WebSocket("ws://www.host.com/path");
+    ws.onopen = (event: WebSocket.Event) => {
+        console.log(event.target, event.type);
+    };
+    ws.onerror = (event: WebSocket.ErrorEvent) => {
+        console.log(event.error, event.message, event.target, event.type);
+    };
+    ws.onclose = (event: WebSocket.CloseEvent) => {
+        console.log(event.code, event.reason, event.target, event.wasClean, event.type);
+    };
+    ws.onmessage = (event: WebSocket.MessageEvent) => {
+        console.log(event.data, event.target, event.type);
+    };
+}
+
+{
+    const ws = new WebSocket("ws://www.host.com/path");
+
+    const duplex = wslib.createWebSocketStream(ws, {
+        allowHalfOpen: true,
+    });
+
+    duplex.pipe(process.stdout);
+    process.stdin.pipe(duplex);
+}
+
+{
+    const ws = new WebSocket("ws://www.host.com/path");
+
+    const duplex = wslib.createWebSocketStream(ws);
+
+    duplex.pipe(process.stdout);
+    process.stdin.pipe(duplex);
+}
+
+{
+    const ws = new WebSocket("ws://www.host.com/path");
+    // @ts-expect-error
+    ws.addEventListener("other", () => {});
+    // @ts-expect-error
+    ws.removeEventListener("other", () => {});
+}
+
+{
+    const ws = new WebSocket("ws://www.host.com/path");
+    const listener = (event: WebSocket.MessageEvent) => console.log(event.data, event.target, event.type);
+    ws.addEventListener("message", listener, { once: true });
+    ws.removeEventListener("message", listener);
+
+    ws.addEventListener("open" as "open" | "close" | "error" | "message", console.log);
+    ws.removeEventListener("open" as "open" | "close" | "error" | "message", console.log);
+}
+
+{
+    const ws = new WebSocket("ws://www.host.com/path");
+    const eventHandler: Parameters<typeof ws.once>[1] = () => {};
+    const event = "";
+    const errorHandler = (err: Error) => {
+        ws.off(event, eventHandler);
+    };
+    ws.once("error", errorHandler);
+}
+
+function f() {
+    const ws = new WebSocket("ws://www.host.com/path");
+
+    // @ts-expect-error
+    const a: 5 = ws.readyState;
+
+    // @ts-expect-error
+    ws.readyState = ws.OPEN;
+
+    // @ts-expect-error
+    ws.readyState = !ws.OPEN;
+
+    if (ws.readyState === ws.OPEN) {
+        // @ts-expect-error
+        const a: 2 = ws.readyState;
+        const x: 1 = ws.readyState;
+        return;
+    }
+    if (ws.readyState === ws.CONNECTING) {
+        const x: 0 = ws.readyState;
+        return;
+    }
+    if (ws.readyState === ws.CLOSING) {
+        const x: 2 = ws.readyState;
+        return;
+    }
+    if (ws.readyState === ws.CLOSED) {
+        const x: 3 = ws.readyState;
+        return;
+    }
+
+    // $ExpectType never
+    const x: never = ws.readyState;
+}
+
+{
+    const ws = new WebSocket("ws://www.host.com/path");
+
+    // @ts-expect-error
+    ws.CONNECTING = 123;
+
+    // @ts-expect-error
+    ws.OPEN = 123;
+
+    // @ts-expect-error
+    ws.CLOSING = 123;
+
+    // @ts-expect-error
+    ws.CLOSED = 123;
+}
+
+{
+    const ws = new WebSocket("ws://www.host.com/path");
+
+    ws.binaryType = "arraybuffer";
+    ws.binaryType = "fragments";
+    ws.binaryType = "nodebuffer";
+
+    // @ts-expect-error
+    ws.binaryType = "";
+    // @ts-expect-error
+    ws.binaryType = true;
+    // @ts-expect-error
+    ws.binaryType = "invalid-value";
+}
+
+{
+    const ws = new WebSocket("ws://www.host.com/path");
+
+    // $ExpectType number
+    ws.bufferedAmount;
+    // $ExpectType string
+    ws.extensions;
+    // $ExpectType string
+    ws.protocol;
+
+    // @ts-expect-error
+    ws.bufferedAmount = 1;
+    // @ts-expect-error
+    ws.bufferedAmount = true;
+
+    // @ts-expect-error
+    ws.extensions = "a-value";
+    // @ts-expect-error
+    ws.extensions = true;
+
+    // @ts-expect-error
+    ws.protocol = "a-value";
+    // @ts-expect-error
+    ws.protocol = true;
+}
+
+{
+    const webSocketServer = new wslib.WebSocketServer();
+    const server = new http.Server();
+    server.on("upgrade", (request, socket, head) => {
+        if (request.url === "/path") {
+            webSocketServer.handleUpgrade(request, socket, head, (ws) => {
+                webSocketServer.emit("connection", ws, request);
+            });
+        }
+    });
+}
+
+declare module "ws" {
+    interface Server {
+        getWebSocketId(): string;
+    }
+}
+
+{
+    class MyWebSocket extends WebSocket {
+        id?: string;
+    }
+    const server = new wslib.WebSocketServer({ WebSocket: MyWebSocket });
+
+    server.on("connection", (ws) => {
+        // $ExpectType string | undefined
+        ws.id;
+
+        ws.id = server.getWebSocketId();
+    });
+}
+
+{
+    const ws = new WebSocket("ws://www.host.com/path", {
+        generateMask: (mask) => {},
+        skipUTF8Validation: true,
+    });
+}
+
+{
+    class CustomWebSocket extends WebSocket {
+        foo(): "foo" {
+            return "foo";
+        }
+    }
+    const server = new http.Server();
+    const webSocketServer = new wslib.WebSocketServer({ WebSocket: CustomWebSocket, noServer: true });
+    webSocketServer.on("connection", (ws) => {
+        // $ExpectType CustomWebSocket
+        ws;
+        // $ExpectType "foo"
+        ws.foo();
+    });
+    Array.from(webSocketServer.clients).forEach((ws) => {
+        // $ExpectType CustomWebSocket
+        ws;
+        // $ExpectType "foo"
+        ws.foo();
+    });
+    server.on("upgrade", (request, socket, head) => {
+        if (request.url === "/path") {
+            webSocketServer.handleUpgrade(request, socket, head, (ws) => {
+                // $ExpectType CustomWebSocket
+                ws;
+                // $ExpectType "foo"
+                ws.foo();
+            });
+        }
+    });
+}
+
+{
+    const ws = new WebSocket("ws://www.host.com/path");
+
+    if (ws.isPaused) {
+        ws.resume();
+    } else {
+        ws.pause();
+    }
+
+    // @ts-expect-error
+    ws.isPaused = true;
+
+    ws.onopen = null;
+    ws.onerror = null;
+    ws.onclose = null;
+    ws.onmessage = null;
+}
+
+{
+    class Request extends http.IncomingMessage {}
+    class MyWebsocket extends WebSocket {}
+    const server = http.createServer({ IncomingMessage: Request });
+    const wss = new wslib.WebSocketServer({ WebSocket: MyWebsocket, server });
+
+    wss.on("connection", (ws, req) => {
+        // $ExpectType MyWebsocket
+        ws;
+        // $ExpectType Request
+        req;
+    });
+    wss.once("connection", (ws, req) => {
+        // $ExpectType MyWebsocket
+        ws;
+        // $ExpectType Request
+        req;
+    });
+    wss.off("connection", (ws, req) => {
+        // $ExpectType MyWebsocket
+        ws;
+        // $ExpectType Request
+        req;
+    });
+    wss.addListener("connection", (ws, req) => {
+        // $ExpectType MyWebsocket
+        ws;
+        // $ExpectType Request
+        req;
+    });
+    wss.removeListener("connection", (ws, req) => {
+        // $ExpectType MyWebsocket
+        ws;
+        // $ExpectType Request
+        req;
+    });
+
+    wss.on("headers", (_headers, req) => {
+        // $ExpectType Request
+        req;
+    });
+    wss.once("headers", (_headers, req) => {
+        // $ExpectType Request
+        req;
+    });
+    wss.off("headers", (_headers, req) => {
+        // $ExpectType Request
+        req;
+    });
+    wss.addListener("headers", (_headers, req) => {
+        // $ExpectType Request
+        req;
+    });
+    wss.removeListener("headers", (_headers, req) => {
+        // $ExpectType Request
+        req;
+    });
+
+    Array.from(wss.clients).forEach(client => {
+        // $ExpectType MyWebsocket
+        client;
+    });
+}
+
+{
+    const ws = new WebSocket("ws://www.host.com/path", {
+        finishRequest: (req, socket) => {
+            // $ExpectType IncomingMessage
+            req;
+
+            // $ExpectType WebSocket
+            socket;
+        },
+    });
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Unlike the [CommonJS exports](https://github.com/websockets/ws/blob/b9ca55b0aa8c72b39a778542bd0fa9b6c455d4c4/index.js#L5-L13), the [ESM exports](https://github.com/websockets/ws/blob/b9ca55b0aa8c72b39a778542bd0fa9b6c455d4c4/wrapper.mjs#L7-L8) do not expose the named exports as properties of the default export. This means you can incorrectly `import WS from "ws"; new WS.WebSocket()` from ESM and it will only fail at runtime.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
