### PR TITLE
fix(loadable__webpack-plugin): fix MissingExportEquals, add jsdoc & test

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -193,7 +193,6 @@
         "kss",
         "leveldown",
         "lint-staged",
-        "loadable__webpack-plugin",
         "locutus",
         "luxon",
         "mapbox__mapbox-sdk",

--- a/types/loadable__webpack-plugin/index.d.ts
+++ b/types/loadable__webpack-plugin/index.d.ts
@@ -1,28 +1,38 @@
 import * as webpack from "webpack";
 
-interface PluginOptions {
-    /**
-     * The stats filename.
-     *
-     * @default loadable-stats.json
-     */
-    filename?: string | undefined;
+declare namespace LoadablePlugin {
+    interface PluginOptions {
+        /**
+         * The stats filename.
+         *
+         * @default loadable-stats.json
+         */
+        filename?: string | undefined;
 
-    /**
-     * Always write stats file to disk.
-     *
-     * @default false
-     */
-    writeToDisk?: boolean | { filename: string } | undefined;
+        /**
+         * Always write stats file to disk.
+         *
+         * @default false
+         */
+        writeToDisk?:
+            | boolean
+            | {
+                /** Write assets to disk at given `filename` location */
+                filename: string;
+            }
+            | undefined;
 
-    /**
-     * @default true
-     */
-    outputAsset?: boolean | undefined;
+        /**
+         * Always write stats file to the `output.path` directory.
+         *
+         * @default true
+         */
+        outputAsset?: boolean | undefined;
+    }
 }
 
 declare class LoadablePlugin extends webpack.Plugin {
-    constructor(options?: PluginOptions);
+    constructor(options?: LoadablePlugin.PluginOptions);
 }
 
-export default LoadablePlugin;
+export = LoadablePlugin;

--- a/types/loadable__webpack-plugin/loadable__webpack-plugin-tests.ts
+++ b/types/loadable__webpack-plugin/loadable__webpack-plugin-tests.ts
@@ -1,10 +1,19 @@
 import LoadablePlugin from "@loadable/webpack-plugin";
 import { Configuration } from "webpack";
 
-let config: Configuration = {
+let config: Configuration;
+
+// With no argument.
+config = {
     plugins: [new LoadablePlugin()],
 };
 
+// With no required properties.
+config = {
+    plugins: [new LoadablePlugin({})],
+};
+
+// With optional properties.
 config = {
     plugins: [
         new LoadablePlugin({
@@ -15,6 +24,13 @@ config = {
     ],
 };
 
+// arg.writeToDisk can be an object.
 config = {
-    plugins: [new LoadablePlugin({ writeToDisk: { filename: "stats.json" } })],
+    plugins: [
+        new LoadablePlugin({
+            writeToDisk: {
+                filename: "stats.json",
+            },
+        }),
+    ],
 };

--- a/types/loadable__webpack-plugin/package.json
+++ b/types/loadable__webpack-plugin/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/loadable__webpack-plugin",
-    "version": "5.7.9999",
+    "version": "5.15.9999",
     "projects": [
         "https://github.com/smooth-code/loadable-components"
     ],


### PR DESCRIPTION
The added jsdoc can be found in the [project documentation site](https://loadable-components.com/docs/api-loadable-webpack-plugin/).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
