### PR TITLE
[Chrome] Enterprise.platformKeys methods can be a promises since Chrome 131

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -3602,7 +3602,7 @@ declare namespace chrome {
         /**
          * Returns the available Tokens. In a regular user's session the list will always contain the user's token with id "user". If a system-wide TPM token is available, the returned list will also contain the system-wide token with id "system". The system-wide token will be the same for all sessions on this device (device in the sense of e.g. a Chromebook).
          *
-         * Can return its result via Promise in Manifest V3 or later since Chrome 131.
+         * Can return its result via Promise since Chrome 131.
          */
         export function getTokens(): Promise<Token[]>;
         export function getTokens(callback: (tokens: Token[]) => void): void;
@@ -3611,7 +3611,7 @@ declare namespace chrome {
          * Returns the list of all client certificates available from the given token. Can be used to check for the existence and expiration of client certificates that are usable for a certain authentication.
          * @param tokenId The id of a Token returned by getTokens.
          *
-         * Can return its result via Promise in Manifest V3 or later since Chrome 131.
+         * Can return its result via Promise since Chrome 131.
          */
         export function getCertificates(tokenId: string): Promise<ArrayBuffer[]>;
         export function getCertificates(tokenId: string, callback: (certificates: ArrayBuffer[]) => void): void;
@@ -3621,7 +3621,7 @@ declare namespace chrome {
          * @param tokenId The id of a Token returned by getTokens.
          * @param certificate The DER encoding of a X.509 certificate.
          *
-         * Can return its result via Promise in Manifest V3 or later since Chrome 131.
+         * Can return its result via Promise since Chrome 131.
          */
         export function importCertificate(tokenId: string, certificate: ArrayBuffer): Promise<void>;
         export function importCertificate(tokenId: string, certificate: ArrayBuffer, callback: () => void): void;
@@ -3631,7 +3631,7 @@ declare namespace chrome {
          * @param tokenId The id of a Token returned by getTokens.
          * @param certificate The DER encoding of a X.509 certificate.
          *
-         * Can return its result via Promise in Manifest V3 or later since Chrome 131.
+         * Can return its result via Promise since Chrome 131.
          */
         export function removeCertificate(tokenId: string, certificate: ArrayBuffer): Promise<void>;
         export function removeCertificate(tokenId: string, certificate: ArrayBuffer, callback: () => void): void;
@@ -3645,7 +3645,7 @@ declare namespace chrome {
          *
          * @param options Object containing the fields defined in {@link ChallengeKeyOptions}.
          *
-         * Can return its result via Promise in Manifest V3 or later since Chrome 131.
+         * Can return its result via Promise since Chrome 131.
          * @since Chrome 110
          */
         export function challengeKey(options: ChallengeKeyOptions): Promise<ArrayBuffer>;
@@ -3666,7 +3666,7 @@ declare namespace chrome {
          * @param challenge A challenge as emitted by the Verified Access Web API.
          * @param registerKey If set, the current Enterprise Machine Key is registered with the `system` token and relinquishes the Enterprise Machine Key role. The key can then be associated with a certificate and used like any other signing key. This key is 2048-bit RSA. Subsequent calls to this function will then generate a new Enterprise Machine Key. Since Chrome 59.
          *
-         * Can return its result via Promise in Manifest V3 or later since Chrome 131.
+         * Can return its result via Promise since Chrome 131.
          * @since Chrome 50
          */
         export function challengeMachineKey(challenge: ArrayBuffer): Promise<ArrayBuffer>;

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -3601,94 +3601,101 @@ declare namespace chrome {
 
         /**
          * Returns the available Tokens. In a regular user's session the list will always contain the user's token with id "user". If a system-wide TPM token is available, the returned list will also contain the system-wide token with id "system". The system-wide token will be the same for all sessions on this device (device in the sense of e.g. a Chromebook).
-         * @param callback Invoked by getTokens with the list of available Tokens.
-         * Parameter tokens: The list of available tokens.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 131.
          */
+        export function getTokens(): Promise<Token[]>;
         export function getTokens(callback: (tokens: Token[]) => void): void;
 
         /**
          * Returns the list of all client certificates available from the given token. Can be used to check for the existence and expiration of client certificates that are usable for a certain authentication.
          * @param tokenId The id of a Token returned by getTokens.
-         * @param callback Called back with the list of the available certificates.
-         * Parameter certificates: The list of certificates, each in DER encoding of a X.509 certificate.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 131.
          */
+        export function getCertificates(tokenId: string): Promise<ArrayBuffer[]>;
         export function getCertificates(tokenId: string, callback: (certificates: ArrayBuffer[]) => void): void;
 
         /**
-         * Imports certificate to the given token if the certified key is already stored in this token. After a successful certification request, this function should be used to store the obtained certificate and to make it available to the operating system and browser for authentication.
+         * Imports `certificate` to the given token if the certified key is already stored in this token. After a successful certification request, this function should be used to store the obtained certificate and to make it available to the operating system and browser for authentication.
          * @param tokenId The id of a Token returned by getTokens.
          * @param certificate The DER encoding of a X.509 certificate.
-         * @param callback Called back when this operation is finished.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 131.
          */
-        export function importCertificate(tokenId: string, certificate: ArrayBuffer, callback?: () => void): void;
+        export function importCertificate(tokenId: string, certificate: ArrayBuffer): Promise<void>;
+        export function importCertificate(tokenId: string, certificate: ArrayBuffer, callback: () => void): void;
 
         /**
-         * Removes certificate from the given token if present. Should be used to remove obsolete certificates so that they are not considered during authentication and do not clutter the certificate choice. Should be used to free storage in the certificate store.
+         * Removes `certificate` from the given token if present. Should be used to remove obsolete certificates so that they are not considered during authentication and do not clutter the certificate choice. Should be used to free storage in the certificate store.
          * @param tokenId The id of a Token returned by getTokens.
          * @param certificate The DER encoding of a X.509 certificate.
-         * @param callback Called back when this operation is finished.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 131.
          */
-        export function removeCertificate(tokenId: string, certificate: ArrayBuffer, callback?: () => void): void;
+        export function removeCertificate(tokenId: string, certificate: ArrayBuffer): Promise<void>;
+        export function removeCertificate(tokenId: string, certificate: ArrayBuffer, callback: () => void): void;
 
         /**
-         * Challenges a hardware-backed Enterprise Machine Key and emits the response as part of a remote attestation protocol. Only useful on Chrome OS and in conjunction with the Verified Access Web API which both issues challenges and verifies responses. A successful verification by the Verified Access Web API is a strong signal of all of the following:
+         * Similar to `challengeMachineKey` and `challengeUserKey`, but allows specifying the algorithm of a registered key. Challenges a hardware-backed Enterprise Machine Key and emits the response as part of a remote attestation protocol. Only useful on ChromeOS and in conjunction with the Verified Access Web API which both issues challenges and verifies responses.
          *
-         * * The current device is a legitimate Chrome OS device.
-         * * The current device is managed by the domain specified during verification.
-         * * The current signed-in user is managed by the domain specified during verification.
-         * * The current device state complies with enterprise device policy. For example, a policy may specify that the device must not be in developer mode.
-         * * Any device identity emitted by the verification is tightly bound to the hardware of the current device.
+         * A successful verification by the Verified Access Web API is a strong signal that the current device is a legitimate ChromeOS device, the current device is managed by the domain specified during verification, the current signed-in user is managed by the domain specified during verification, and the current device state complies with enterprise device policy. For example, a policy may specify that the device must not be in developer mode. Any device identity emitted by the verification is tightly bound to the hardware of the current device. If `user` Scope is specified, the identity is also tightly bound to the current signed-in user.
          *
-         * This function is highly restricted and will fail if the current device is not managed, the current user is not managed, or if this operation has not explicitly been enabled for the caller by enterprise device policy. The Enterprise Machine Key does not reside in the "system" token and is not accessible by any other API.
-         * @param options Object containing the fields defined in ChallengeKeyOptions.
-         * @param callback Called back with the challenge response.
+         * This function is highly restricted and will fail if the current device is not managed, the current user is not managed, or if this operation has not explicitly been enabled for the caller by enterprise device policy. The challenged key does not reside in the `system` or `user` token and is not accessible by any other API.
+         *
+         * @param options Object containing the fields defined in {@link ChallengeKeyOptions}.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 131.
          * @since Chrome 110
          */
+        export function challengeKey(options: ChallengeKeyOptions): Promise<ArrayBuffer>;
         export function challengeKey(options: ChallengeKeyOptions, callback: (response: ArrayBuffer) => void): void;
 
         /**
-         * @deprecated Deprecated since Chrome 110, use enterprise.platformKeys.challengeKey instead.
+         * @deprecated Deprecated since Chrome 110, use {@link challengeKey} instead.
          *
          * Challenges a hardware-backed Enterprise Machine Key and emits the response as part of a remote attestation protocol. Only useful on Chrome OS and in conjunction with the Verified Access Web API which both issues challenges and verifies responses. A successful verification by the Verified Access Web API is a strong signal of all of the following:
          *
-         * * The current device is a legitimate Chrome OS device.
+         * * The current device is a legitimate ChromeOS device.
          * * The current device is managed by the domain specified during verification.
          * * The current signed-in user is managed by the domain specified during verification.
          * * The current device state complies with enterprise device policy. For example, a policy may specify that the device must not be in developer mode.
          * * Any device identity emitted by the verification is tightly bound to the hardware of the current device.
          *
-         * This function is highly restricted and will fail if the current device is not managed, the current user is not managed, or if this operation has not explicitly been enabled for the caller by enterprise device policy. The Enterprise Machine Key does not reside in the "system" token and is not accessible by any other API.
+         * This function is highly restricted and will fail if the current device is not managed, the current user is not managed, or if this operation has not explicitly been enabled for the caller by enterprise device policy. The Enterprise Machine Key does not reside in the `system` token and is not accessible by any other API.
          * @param challenge A challenge as emitted by the Verified Access Web API.
-         * @param registerKey If set, the current Enterprise Machine Key is registered with the "system" token and relinquishes the Enterprise Machine Key role. The key can then be associated with a certificate and used like any other signing key. This key is 2048-bit RSA. Subsequent calls to this function will then generate a new Enterprise Machine Key. Since Chrome 59.
-         * @param callback Called back with the challenge response.
+         * @param registerKey If set, the current Enterprise Machine Key is registered with the `system` token and relinquishes the Enterprise Machine Key role. The key can then be associated with a certificate and used like any other signing key. This key is 2048-bit RSA. Subsequent calls to this function will then generate a new Enterprise Machine Key. Since Chrome 59.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 131.
          * @since Chrome 50
          */
-
+        export function challengeMachineKey(challenge: ArrayBuffer): Promise<ArrayBuffer>;
+        export function challengeMachineKey(challenge: ArrayBuffer, registerKey: boolean): Promise<ArrayBuffer>;
+        export function challengeMachineKey(challenge: ArrayBuffer, callback: (response: ArrayBuffer) => void): void;
         export function challengeMachineKey(
             challenge: ArrayBuffer,
             registerKey: boolean,
             callback: (response: ArrayBuffer) => void,
         ): void;
 
-        export function challengeMachineKey(challenge: ArrayBuffer, callback: (response: ArrayBuffer) => void): void;
         /**
-         * @deprecated Deprecated since Chrome 110, use enterprise.platformKeys.challengeKey instead.
+         * @deprecated Deprecated since Chrome 110, use {@link challengeKey} instead.
          *
-         * Challenges a hardware-backed Enterprise User Key and emits the response as part of a remote attestation protocol. Only useful on Chrome OS and in conjunction with the Verified Access Web API which both issues challenges and verifies responses. A successful verification by the Verified Access Web API is a strong signal of all of the following:
+         * Challenges a hardware-backed Enterprise User Key and emits the response as part of a remote attestation protocol. Only useful on ChromeOS and in conjunction with the Verified Access Web API which both issues challenges and verifies responses. A successful verification by the Verified Access Web API is a strong signal of all of the following:
          *
-         * * The current device is a legitimate Chrome OS device.
+         * * The current device is a legitimate ChromeOS device.
          * * The current device is managed by the domain specified during verification.
          * * The current signed-in user is managed by the domain specified during verification.
          * * The current device state complies with enterprise user policy. For example, a policy may specify that the device must not be in developer mode.
          * * The public key emitted by the verification is tightly bound to the hardware of the current device and to the current signed-in user.
          *
-         * This function is highly restricted and will fail if the current device is not managed, the current user is not managed, or if this operation has not explicitly been enabled for the caller by enterprise user policy. The Enterprise User Key does not reside in the "user" token and is not accessible by any other API.
+         * This function is highly restricted and will fail if the current device is not managed, the current user is not managed, or if this operation has not explicitly been enabled for the caller by enterprise user policy. The Enterprise User Key does not reside in the `user` token and is not accessible by any other API.
          * @param challenge A challenge as emitted by the Verified Access Web API.
-         * @param registerKey If set, the current Enterprise User Key is registered with the "user" token and relinquishes the Enterprise User Key role. The key can then be associated with a certificate and used like any other signing key. This key is 2048-bit RSA. Subsequent calls to this function will then generate a new Enterprise User Key.
+         * @param registerKey If set, the current Enterprise User Key is registered with the `user` token and relinquishes the Enterprise User Key role. The key can then be associated with a certificate and used like any other signing key. This key is 2048-bit RSA. Subsequent calls to this function will then generate a new Enterprise User Key.
          * @param callback Called back with the challenge response.
          * @since Chrome 50
          */
-
+        export function challengeUserKey(challenge: ArrayBuffer, registerKey: boolean): Promise<ArrayBuffer>;
         export function challengeUserKey(
             challenge: ArrayBuffer,
             registerKey: boolean,

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -3169,6 +3169,8 @@ function testUserScripts() {
 
 // https://developer.chrome.com/docs/extensions/reference/api/enterprise/platformKeys
 function testEnterPrisePlatformKeys() {
+    const tokenId = "tokenId";
+
     chrome.enterprise.platformKeys.Scope.MACHINE === "MACHINE";
     chrome.enterprise.platformKeys.Scope.USER === "USER";
 
@@ -3181,18 +3183,47 @@ function testEnterPrisePlatformKeys() {
         registerKey: { algorithm: "ECDSA" },
     }, () => {});
 
-    chrome.enterprise.platformKeys.challengeMachineKey(new ArrayBuffer(0), true, response => {}); // $ExpectType void
-    chrome.enterprise.platformKeys.challengeMachineKey(new ArrayBuffer(0), response => {}); // $ExpectType void
+    chrome.enterprise.platformKeys.challengeMachineKey(new ArrayBuffer(0)); // $ExpectType Promise<ArrayBuffer>
+    chrome.enterprise.platformKeys.challengeMachineKey(new ArrayBuffer(0), true); // $ExpectType Promise<ArrayBuffer>
+    chrome.enterprise.platformKeys.challengeMachineKey(new ArrayBuffer(0), response => { // $ExpectType void
+        response; // $ExpectType ArrayBuffer
+    });
+    chrome.enterprise.platformKeys.challengeMachineKey(new ArrayBuffer(0), true, response => { // $ExpectType void
+        response; // $ExpectType ArrayBuffer
+    });
+    // @ts-expect-error
+    chrome.enterprise.platformKeys.challengeMachineKey(new ArrayBuffer(0), () => {}).then(() => {});
 
-    chrome.enterprise.platformKeys.challengeUserKey(new ArrayBuffer(0), true, response => {}); // $ExpectType void
+    chrome.enterprise.platformKeys.challengeUserKey(new ArrayBuffer(0), true); // $ExpectType Promise<ArrayBuffer>
+    chrome.enterprise.platformKeys.challengeUserKey(new ArrayBuffer(0), true, response => { // $ExpectType void
+        response; // $ExpectType ArrayBuffer
+    });
+    // @ts-expect-error
+    chrome.enterprise.platformKeys.challengeUserKey(new ArrayBuffer(0), true, () => {}).then(() => {});
 
-    chrome.enterprise.platformKeys.getCertificates("tokenId", certificates => {}); // $ExpectType void
+    chrome.enterprise.platformKeys.getCertificates(tokenId); // $ExpectType Promise<ArrayBuffer[]>
+    chrome.enterprise.platformKeys.getCertificates(tokenId, certificates => { // $ExpectType void
+        certificates; // $ExpectType ArrayBuffer[]
+    });
+    // @ts-expect-error
+    chrome.enterprise.platformKeys.getCertificates(tokenId, () => {}).then(() => {});
 
-    chrome.enterprise.platformKeys.getTokens(tokens => {}); // $ExpectType void
+    chrome.enterprise.platformKeys.getTokens(); // $ExpectType Promise<Token[]>
+    chrome.enterprise.platformKeys.getTokens(tokens => { // $ExpectType void
+        tokens; // $ExpectType Token[]
+    });
+    // @ts-expect-error
+    chrome.enterprise.platformKeys.getTokens(() => {}).then(() => {});
 
-    chrome.enterprise.platformKeys.importCertificate("tokenId", new ArrayBuffer(0), () => {}); // $ExpectType void
+    chrome.enterprise.platformKeys.importCertificate(tokenId, new ArrayBuffer(0)); // $ExpectType Promise<void>
+    chrome.enterprise.platformKeys.importCertificate(tokenId, new ArrayBuffer(0), () => {}); // $ExpectType void
+    // @ts-expect-error
+    chrome.enterprise.platformKeys.importCertificate(tokenId, new ArrayBuffer(0), () => {}).then(() => {});
 
-    chrome.enterprise.platformKeys.removeCertificate("tokenId", new ArrayBuffer(0), () => {}); // $ExpectType void
+    chrome.enterprise.platformKeys.removeCertificate(tokenId, new ArrayBuffer(0)); // $ExpectType Promise<void>
+    chrome.enterprise.platformKeys.removeCertificate(tokenId, new ArrayBuffer(0), () => {}); // $ExpectType void
+    // @ts-expect-error
+    chrome.enterprise.platformKeys.removeCertificate(tokenId, new ArrayBuffer(0), () => {}).then(() => {});
 }
 
 // https://developer.chrome.com/docs/extensions/reference/api/power


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/enterprise/platformKeys
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes :
- Fix `challengeKey` JSDoc
- Add support `promise` for all methods
