### PR TITLE
[Chrome] Add HeaderInfo for declarativeNetRequest since Chrome 128

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -13329,6 +13329,18 @@ declare namespace chrome {
              * Note: this must be specified for allowAllRequests rules and may only include the sub_frame and main_frame resource types.
              */
             resourceTypes?: ResourceType[] | undefined;
+
+            /**
+             * Rule does not match if the request matches any response header condition in this list (if specified). If both `excludedResponseHeaders` and `responseHeaders` are specified, then the `excludedResponseHeaders` property takes precedence.
+             * @since Chrome 128
+             */
+            excludedResponseHeaders?: HeaderInfo[];
+
+            /**
+             * Rule matches if the request matches any response header condition in this list (if specified).
+             * @since Chrome 128
+             */
+            responseHeaders?: HeaderInfo[];
         }
 
         export interface MatchedRule {
@@ -13361,6 +13373,24 @@ declare namespace chrome {
              * Matches rules not associated with any active tab if set to -1.
              */
             tabId?: number | undefined;
+        }
+
+        /** @since Chrome 128 */
+        export interface HeaderInfo {
+            /** If specified, this condition is not matched if the header exists but its value contains at least one element in this list. This uses the same match pattern syntax as `values`. */
+            excludedValues?: string[];
+            /** The name of the header. This condition matches on the name only if both `values` and `excludedValues` are not specified. */
+            header: string;
+            /**
+             * If specified, this condition matches if the header's value matches at least one pattern in this list. This supports case-insensitive header value matching plus the following constructs:
+             *
+             * **'\*'** : Matches any number of characters.
+             *
+             * **'?'** : Matches zero or one character(s).
+             *
+             * **'\*'** and **'?'** can be escaped with a backslash, e.g. **'\\\*'** and **'\\?'**
+             */
+            values?: string[];
         }
 
         export interface ModifyHeaderInfo {

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1765,6 +1765,8 @@ async function testDeclarativeNetRequest() {
         rule.condition; // $ExpectType RuleCondition
         rule.id; // $ExpectType number
         rule.priority; // $ExpectType number | undefined
+        rule.condition.excludedResponseHeaders; // $ExpectType HeaderInfo[] | undefined
+        rule.condition.responseHeaders; // $ExpectType HeaderInfo[] | undefined
     });
 
     await chrome.declarativeNetRequest.getEnabledRulesets();


### PR DESCRIPTION
Add `HeaderInfo` interface

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest?hl=en#type-HeaderInfo
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Note :
- Add `HeaderInfo` interface
- Update `RuleCondition` interface
