### PR TITLE
Teach TS `turbo-frame`, `turbo-stream` tags

### DIFF
--- a/types/hotwired__turbo/hotwired__turbo-tests.ts
+++ b/types/hotwired__turbo/hotwired__turbo-tests.ts
@@ -1,6 +1,9 @@
-import { FrameElement, StreamActions, StreamElement, visit } from "@hotwired/turbo";
+import { StreamActions, visit } from "@hotwired/turbo";
 
-const turboFrame = document.querySelector<FrameElement>("turbo-frame")!;
+const turboFrame = document.querySelector("turbo-frame")!;
+
+// $ExpectType FrameElement
+turboFrame;
 
 // @ts-expect-error
 turboFrame.complete = true;
@@ -16,7 +19,10 @@ turboFrame.loading = "slow";
 
 turboFrame.reload().catch(console.error);
 
-const turboStream = document.querySelector<StreamElement>("turbo-stream")!;
+const turboStream = document.querySelector("turbo-stream")!;
+
+// $ExpectType StreamElement
+turboStream;
 
 // @ts-expect-error
 turboStream.action = "123";

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -218,6 +218,11 @@ export type TurboFetchRequestErrorEvent = CustomEvent<{
     error: Error;
 }>;
 
+export interface TurboElementTagNameMap {
+    "turbo-frame": FrameElement;
+    "turbo-stream": StreamElement;
+}
+
 export interface TurboElementEventMap {
     "turbo:before-frame-render": TurboBeforeFrameRenderEvent;
     "turbo:before-fetch-request": TurboBeforeFetchRequestEvent;
@@ -245,6 +250,7 @@ export interface TurboGlobalEventHandlersEventMap extends TurboElementEventMap {
 
 declare global {
     /* eslint-disable @typescript-eslint/no-empty-interface */
+    interface HTMLElementTagNameMap extends TurboElementTagNameMap {}
     interface ElementEventMap extends TurboElementEventMap {}
     interface GlobalEventHandlersEventMap extends TurboGlobalEventHandlersEventMap {}
     /* eslint-enable @typescript-eslint/no-empty-interface */


### PR DESCRIPTION
This allows TypeScript to infer the correct return type for methods that accept a selector string argument, such as `document.querySelector` and `Element.closest`.

N.B. this patch does not add support for `turbo-stream-element` as typings for `StreamSourceElement` and related types are currently missing.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (See https://github.com/opf/openproject/pull/17654)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.~~

Here is an example of a web component adding itself to `HTMLElementTagNameMap`:

https://github.com/github/clipboard-copy-element/blob/main/src/clipboard-copy-element-define.ts#L22-L24
