### PR TITLE
[pg] Add missing lock_timeout client configuration option

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -21,6 +21,7 @@ export interface ClientConfig {
     statement_timeout?: false | number | undefined;
     ssl?: boolean | ConnectionOptions | undefined;
     query_timeout?: number | undefined;
+    lock_timeout?: number | undefined;
     keepAliveInitialDelayMillis?: number | undefined;
     idle_in_transaction_session_timeout?: number | undefined;
     application_name?: string | undefined;

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -233,6 +233,7 @@ const pool = new Pool({
     idleTimeoutMillis: 30000,
     connectionTimeoutMillis: 2000,
     keepAlive: false,
+    lock_timeout: 5000,
     log: (...args) => {
         console.log.apply(console, args);
     },
@@ -242,6 +243,7 @@ console.log(pool.totalCount);
 console.log(pool.idleCount);
 console.log(pool.waitingCount);
 console.log(pool.expiredCount);
+console.log(pool.options.lock_timeout);
 pool.connect((err, client, done) => {
     if (err) {
         console.error("error fetching client from pool", err);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/brianc/node-postgres/blob/master/packages/pg/lib/client.js#L437-L439
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. - the `lock_timeout` was introduced via https://github.com/brianc/node-postgres/pull/2779, which was published approx 2 years ago in version [8.8.0](https://github.com/brianc/node-postgres/blob/master/CHANGELOG.md#pg880)

