### PR TITLE
Relay: replace kind: string with kind: 'ConcreteString'

### DIFF
--- a/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
+++ b/types/relay-runtime/lib/store/RelayStoreTypes.d.ts
@@ -62,7 +62,7 @@ export interface SelectorData {
 }
 
 export interface SingularReaderSelector {
-    readonly kind: string;
+    readonly kind: "SingularReaderSelector";
     readonly dataID: DataID;
     readonly isWithinUnmatchedTypeRefinement: boolean;
     readonly node: ReaderFragment;
@@ -73,7 +73,7 @@ export interface SingularReaderSelector {
 export type ReaderSelector = SingularReaderSelector | PluralReaderSelector;
 
 export interface PluralReaderSelector {
-    readonly kind: string;
+    readonly kind: "PluralReaderSelector";
     readonly selectors: readonly SingularReaderSelector[];
 }
 

--- a/types/relay-runtime/lib/util/NormalizationNode.d.ts
+++ b/types/relay-runtime/lib/util/NormalizationNode.d.ts
@@ -6,7 +6,7 @@ import type { ConcreteRequest } from "./RelayConcreteNode";
  * request results.
  */
 export interface NormalizationOperation {
-    readonly kind: string; // "Operation";
+    readonly kind: "Operation";
     readonly name: string;
     readonly argumentDefinitions: readonly NormalizationLocalArgumentDefinition[];
     readonly selections: readonly NormalizationSelection[];
@@ -18,7 +18,7 @@ export interface NormalizationOperation {
 export type NormalizationHandle = NormalizationScalarHandle | NormalizationLinkedHandle;
 
 export interface NormalizationLinkedHandle {
-    readonly kind: string; // "LinkedHandle";
+    readonly kind: "LinkedHandle";
     readonly alias?: string | null | undefined;
     readonly name: string;
     readonly args?: readonly NormalizationArgument[] | null | undefined;
@@ -31,7 +31,7 @@ export interface NormalizationLinkedHandle {
 }
 
 export interface NormalizationScalarHandle {
-    readonly kind: string; // "ScalarHandle";
+    readonly kind: "ScalarHandle";
     readonly alias?: string | null | undefined;
     readonly name: string;
     readonly args?: readonly NormalizationArgument[] | null | undefined;
@@ -50,34 +50,34 @@ export type NormalizationArgument =
     | NormalizationVariableArgument;
 
 export interface NormalizationCondition {
-    readonly kind: string; // "Condition";
+    readonly kind: "Condition";
     readonly passingValue: boolean;
     readonly condition: string;
     readonly selections: readonly NormalizationSelection[];
 }
 
 export interface NormalizationClientExtension {
-    readonly kind: string; // "ClientExtension";
+    readonly kind: "ClientExtension";
     readonly selections: readonly NormalizationSelection[];
 }
 
 export type NormalizationField = NormalizationFlightField | NormalizationScalarField | NormalizationLinkedField;
 
 export interface NormalizationInlineFragment {
-    readonly kind: string; // "InlineFragment";
+    readonly kind: "InlineFragment";
     readonly selections: readonly NormalizationSelection[];
     readonly type: string;
     readonly abstractKey?: string | null | undefined;
 }
 
 export interface NormalizationFragmentSpread {
-    readonly kind: string; // "FragmentSpread";
+    readonly kind: "FragmentSpread";
     readonly fragment: NormalizationSplitOperation;
     readonly args?: readonly NormalizationArgument[] | null | undefined;
 }
 
 export interface NormalizationLinkedField {
-    readonly kind: string; // "LinkedField";
+    readonly kind: "LinkedField";
     readonly alias?: string | null | undefined;
     readonly name: string;
     readonly storageKey?: string | null | undefined;
@@ -88,13 +88,13 @@ export interface NormalizationLinkedField {
 }
 
 export interface NormalizationActorChange {
-    readonly kind: string; // "ActorChange";
+    readonly kind: "ActorChange";
     readonly linkedField: NormalizationLinkedField;
 }
 
 export interface NormalizationModuleImport {
     readonly args?: readonly NormalizationArgument[] | null | undefined;
-    readonly kind: string; // "ModuleImport";
+    readonly kind: "ModuleImport";
     readonly documentName: string;
     readonly fragmentPropName: string;
     readonly fragmentName: string;
@@ -106,20 +106,20 @@ export interface NormalizationModuleImport {
 }
 
 export interface NormalizationListValueArgument {
-    readonly kind: string; // "ListValue";
+    readonly kind: "ListValue";
     readonly name: string;
     readonly items: ReadonlyArray<NormalizationArgument | null>;
 }
 
 export interface NormalizationLiteralArgument {
-    readonly kind: string; // "Literal";
+    readonly kind: "Literal";
     readonly name: string;
     readonly type?: string | null | undefined;
     readonly value: any;
 }
 
 export interface NormalizationLocalArgumentDefinition {
-    readonly kind: string; // "LocalArgument";
+    readonly kind: "LocalArgument";
     readonly name: string;
     readonly defaultValue: any;
 }
@@ -135,7 +135,7 @@ export type NormalizationNode =
     | NormalizationStream;
 
 export interface NormalizationScalarField {
-    readonly kind: string; // "ScalarField";
+    readonly kind: "ScalarField";
     readonly alias?: string | null | undefined;
     readonly name: string;
     readonly args?: readonly NormalizationArgument[] | null | undefined;
@@ -143,7 +143,7 @@ export interface NormalizationScalarField {
 }
 
 export interface NormalizationFlightField {
-    readonly kind: string; // "FlightField";
+    readonly kind: "FlightField";
     readonly alias?: string | null | undefined;
     readonly name: string;
     readonly args?: readonly NormalizationArgument[] | null | undefined;
@@ -152,12 +152,12 @@ export interface NormalizationFlightField {
 
 export interface NormalizationClientComponent {
     readonly args?: readonly NormalizationArgument[] | null | undefined;
-    readonly kind: string; // "ClientComponent";
+    readonly kind: "ClientComponent";
     readonly fragment: NormalizationNode;
 }
 
 export interface NormalizationTypeDiscriminator {
-    readonly kind: string; // "TypeDiscriminator";
+    readonly kind: "TypeDiscriminator";
     readonly abstractKey: string;
 }
 
@@ -178,7 +178,7 @@ export type NormalizationSelection =
 
 export interface NormalizationSplitOperation {
     readonly argumentDefinitions?: readonly NormalizationLocalArgumentDefinition[];
-    readonly kind: string; // "SplitOperation";
+    readonly kind: "SplitOperation";
     readonly name: string;
     readonly metadata: { readonly [key: string]: unknown } | null | undefined;
     readonly selections: readonly NormalizationSelection[];
@@ -186,27 +186,27 @@ export interface NormalizationSplitOperation {
 
 export interface NormalizationStream {
     readonly if: string | null;
-    readonly kind: string; // "Stream";
+    readonly kind: "Stream";
     readonly label: string;
     readonly selections: readonly NormalizationSelection[];
 }
 
 export interface NormalizationDefer {
     readonly if: string | null;
-    readonly kind: string; // "Defer";
+    readonly kind: "Defer";
     readonly label: string;
     readonly selections: readonly NormalizationSelection[];
 }
 
 export interface NormalizationVariableArgument {
-    readonly kind: string; // "Variable";
+    readonly kind: "Variable";
     readonly name: string;
     readonly type?: string | null | undefined;
     readonly variableName: string;
 }
 
 export interface NormalizationObjectValueArgument {
-    readonly kind: string; // "ObjectValue";
+    readonly kind: "ObjectValue";
     readonly name: string;
     readonly fields: readonly NormalizationArgument[];
 }

--- a/types/relay-runtime/lib/util/ReaderNode.d.ts
+++ b/types/relay-runtime/lib/util/ReaderNode.d.ts
@@ -2,19 +2,19 @@ import type { ConnectionMetadata } from "../handlers/connection/ConnectionHandle
 import type { ConcreteRequest } from "./RelayConcreteNode";
 
 export interface ReaderFragmentSpread {
-    readonly kind: string; // 'FragmentSpread';
+    readonly kind: "FragmentSpread";
     readonly name: string;
     readonly args?: readonly ReaderArgument[] | null | undefined;
 }
 
 export interface ReaderInlineDataFragmentSpread {
-    readonly kind: string; // 'InlineDataFragmentSpread';
+    readonly kind: "InlineDataFragmentSpread";
     readonly name: string;
     readonly selections: readonly ReaderSelection[];
 }
 
 export interface ReaderLinkedField {
-    readonly kind: string; // 'LinkedField';
+    readonly kind: "LinkedField";
     readonly alias?: string | null | undefined;
     readonly name: string;
     readonly storageKey?: string | null | undefined;
@@ -25,7 +25,7 @@ export interface ReaderLinkedField {
 }
 
 export interface ReaderFragment {
-    readonly kind: string; // 'Fragment';
+    readonly kind: "Fragment";
     readonly name: string;
     readonly type: string;
     readonly abstractKey?: string | null | undefined;
@@ -86,7 +86,7 @@ export interface ReaderPaginationMetadata {
 }
 
 export interface ReaderInlineDataFragment {
-    readonly kind: string; // 'InlineDataFragment';
+    readonly kind: "InlineDataFragment";
     readonly name: string;
 }
 
@@ -99,33 +99,33 @@ export type ReaderArgument =
 export type ReaderArgumentDefinition = ReaderLocalArgument | ReaderRootArgument;
 
 export interface ReaderCondition {
-    readonly kind: string; // 'Condition';
+    readonly kind: "Condition";
     readonly passingValue: boolean;
     readonly condition: string;
     readonly selections: readonly ReaderSelection[];
 }
 
 export interface ReaderClientExtension {
-    readonly kind: string; // 'ClientExtension';
+    readonly kind: "ClientExtension";
     readonly selections: readonly ReaderSelection[];
 }
 
 export type ReaderField = ReaderScalarField | ReaderLinkedField | ReaderRelayResolver;
 
 export interface ReaderRootArgument {
-    readonly kind: string; // 'RootArgument';
+    readonly kind: "RootArgument";
     readonly name: string;
 }
 
 export interface ReaderInlineFragment {
-    readonly kind: string; // 'InlineFragment';
+    readonly kind: "InlineFragment";
     readonly selections: readonly ReaderSelection[];
     readonly type: string;
     readonly abstractKey?: string | null | undefined;
 }
 
 export interface ReaderLinkedField {
-    readonly kind: string; // 'LinkedField';
+    readonly kind: "LinkedField";
     readonly alias?: string | null | undefined;
     readonly name: string;
     readonly storageKey?: string | null | undefined;
@@ -136,7 +136,7 @@ export interface ReaderLinkedField {
 }
 
 export interface ReaderActorChange {
-    readonly kind: string; // 'ActorChange';
+    readonly kind: "ActorChange";
     readonly alias?: string | null | undefined;
     readonly name: string;
     readonly storageKey?: string | null | undefined;
@@ -146,33 +146,33 @@ export interface ReaderActorChange {
 
 export interface ReaderModuleImport {
     readonly args?: readonly ReaderArgument[] | null | undefined;
-    readonly kind: string; // 'ModuleImport';
+    readonly kind: "ModuleImport";
     readonly documentName: string;
     readonly fragmentPropName: string;
     readonly fragmentName: string;
 }
 
 export interface ReaderListValueArgument {
-    readonly kind: string; // 'ListValue';
+    readonly kind: "ListValue";
     readonly name: string;
     readonly items: ReadonlyArray<ReaderArgument | null>;
 }
 
 export interface ReaderLiteralArgument {
-    readonly kind: string; // 'Literal';
+    readonly kind: "Literal";
     readonly name: string;
     readonly type?: string | null | undefined;
     readonly value: any;
 }
 
 export interface ReaderLocalArgument {
-    readonly kind: string; // 'LocalArgument';
+    readonly kind: "LocalArgument";
     readonly name: string;
     readonly defaultValue: any;
 }
 
 export interface ReaderObjectValueArgument {
-    readonly kind: string; // 'ObjectValue';
+    readonly kind: "ObjectValue";
     readonly name: string;
     readonly fields: readonly ReaderArgument[];
 }
@@ -180,7 +180,7 @@ export interface ReaderObjectValueArgument {
 export type ReaderNode = ReaderCondition | ReaderLinkedField | ReaderFragment | ReaderInlineFragment;
 
 export interface ReaderScalarField {
-    readonly kind: string; // 'ScalarField';
+    readonly kind: "ScalarField";
     readonly alias?: string | null | undefined;
     readonly name: string;
     readonly args?: readonly ReaderArgument[] | null | undefined;
@@ -188,7 +188,7 @@ export interface ReaderScalarField {
 }
 
 export interface ReaderFlightField {
-    readonly kind: string; // 'FlightField';
+    readonly kind: "FlightField";
     readonly alias?: string | null | undefined;
     readonly name: string;
     readonly args?: readonly ReaderArgument[] | null | undefined;
@@ -196,26 +196,26 @@ export interface ReaderFlightField {
 }
 
 export interface ReaderDefer {
-    readonly kind: string; // 'Defer';
+    readonly kind: "Defer";
     readonly selections: readonly ReaderSelection[];
 }
 
 export interface ReaderStream {
-    readonly kind: string; // 'Stream';
+    readonly kind: "Stream";
     readonly selections: readonly ReaderSelection[];
 }
 
 export type RequiredFieldAction = "NONE" | "LOG" | "THROW";
 
 export interface ReaderRequiredField {
-    readonly kind: string; // 'RequiredField';
+    readonly kind: "RequiredField";
     readonly field: ReaderField;
     readonly action: RequiredFieldAction;
     readonly path: string;
 }
 
 export interface ReaderRelayResolver {
-    readonly kind: string; // 'RelayResolver';
+    readonly kind: "RelayResolver";
     readonly alias?: string | null | undefined;
     readonly name: string;
     readonly fragment: ReaderFragmentSpread;
@@ -227,7 +227,7 @@ export interface ReaderRelayResolver {
 }
 
 export interface ReaderClientEdge {
-    readonly kind: string; // 'ClientEdge';
+    readonly kind: "ClientEdge";
     readonly linkedField: ReaderLinkedField;
     readonly operation: ConcreteRequest;
     readonly backingField: ReaderRelayResolver | ReaderClientExtension;
@@ -250,7 +250,7 @@ export type ReaderSelection =
     | ReaderRelayResolver;
 
 export interface ReaderVariableArgument {
-    readonly kind: string; // 'Variable';
+    readonly kind: "Variable";
     readonly name: string;
     readonly type?: string | null | undefined;
     readonly variableName: string;

--- a/types/relay-runtime/lib/util/RelayConcreteNode.d.ts
+++ b/types/relay-runtime/lib/util/RelayConcreteNode.d.ts
@@ -9,7 +9,7 @@ import { OperationType } from "./RelayRuntimeTypes";
  * fragments).
  */
 export interface ConcreteRequest {
-    readonly kind: string; // 'Request';
+    readonly kind: "Request";
     readonly fragment: ReaderFragment;
     readonly operation: NormalizationOperation;
     readonly params: RequestParameters;
@@ -22,12 +22,12 @@ export interface ConcreteRequest {
 // Note: the phantom type parameter here helps ensures that the
 // $Parameters.js value matches the type param provided to preloadQuery.
 export interface PreloadableConcreteRequest<TQuery extends OperationType> {
-    readonly kind: string; // 'PreloadableConcreteRequest';
+    readonly kind: "PreloadableConcreteRequest";
     readonly params: RequestParameters;
 }
 
 export interface ConcreteUpdatableQuery {
-    readonly kind: string; // 'UpdatableQuery';
+    readonly kind: "UpdatableQuery";
     readonly fragment: ReaderFragment;
 }
 
@@ -43,7 +43,7 @@ export type RequestParameters =
         readonly text: null;
         // common fields
         readonly name: string;
-        readonly operationKind: string; // 'mutation' | 'query' | 'subscription';
+        readonly operationKind: "mutation" | "query" | "subscription";
         readonly providedVariables?: ProvidedVariablesType;
         readonly metadata: { [key: string]: unknown };
     }
@@ -53,7 +53,7 @@ export type RequestParameters =
         readonly text: string | null;
         // common fields
         readonly name: string;
-        readonly operationKind: string; // 'mutation' | 'query' | 'subscription';
+        readonly operationKind: "mutation" | "query" | "subscription";
         readonly providedVariables?: ProvidedVariablesType;
         readonly metadata: { [key: string]: unknown };
     };

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -438,7 +438,7 @@ const node: ConcreteRequest = (function() {
                 },
             ],
         },
-    ];
+    ] as const;
     return {
         kind: "Request",
         fragment: {
@@ -463,7 +463,7 @@ const node: ConcreteRequest = (function() {
             text: "query FooQuery {\n  __typename\n}\n",
             metadata: {},
         },
-    };
+    } as const;
 })();
 /* tslint:enable:only-arrow-functions no-var-keyword prefer-const */
 

--- a/types/relay-test-utils/test/index.tsx
+++ b/types/relay-test-utils/test/index.tsx
@@ -1,4 +1,4 @@
-import { FragmentRefs, graphql } from "relay-runtime";
+import { ConcreteRequest, FragmentRefs, graphql } from "relay-runtime";
 import { readFragment } from "relay-runtime/lib/store/ResolverFragments";
 import { createMockEnvironment, MockPayloadGenerator, testResolver } from "relay-test-utils";
 
@@ -111,7 +111,9 @@ function environmentTests() {
         <Modal queryRef={queryRef} />
     </RelayEnvironmentProvider>;
 
-    const operation = environment.mock.findOperation(operation => operation.root.node === userQuery);
+    const operation = environment.mock.findOperation(operation =>
+        operation.root.node === (userQuery as ConcreteRequest).operation
+    );
 
     environment.mock.complete(operation);
 


### PR DESCRIPTION
Replace `kind: string` with `kind: 'ConcreteString'` in relay-runtime. This allows for refinement in switch statements.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: e.g. https://github.com/facebook/relay/blob/98e39e09d90827289d6e27d47ecc4a9c08592476/packages/relay-runtime/util/RelayConcreteNode.js#L27 et al
