### PR TITLE
parcel-env, webpack-env: use namespaced interfaces for declarations

### DIFF
--- a/types/parcel-env/index.d.ts
+++ b/types/parcel-env/index.d.ts
@@ -56,18 +56,18 @@ declare namespace __ParcelModuleApi {
     type RequireLambda = __Require1 & __Require2;
 }
 
-interface NodeRequire extends __ParcelModuleApi.RequireFunction {}
-
-declare var require: NodeRequire;
-
-interface NodeModule extends __ParcelModuleApi.Module {}
-
-declare var module: NodeModule;
-
 /**
  * Declare process variable
  */
 declare namespace NodeJS {
+    interface Module extends __ParcelModuleApi.Module {}
     interface Process extends __ParcelModuleApi.NodeProcess {}
+    interface Require extends __ParcelModuleApi.RequireFunction {}
 }
+
+interface NodeModule extends NodeJS.Module {}
+interface NodeRequire extends NodeJS.Require {}
+
+declare var module: NodeJS.Module;
 declare var process: NodeJS.Process;
+declare var require: NodeJS.Require;

--- a/types/parcel-env/package.json
+++ b/types/parcel-env/package.json
@@ -8,6 +8,7 @@
         "https://github.com/parcel/parcel-bundler"
     ],
     "devDependencies": {
+        "@types/node": "*",
         "@types/parcel-env": "workspace:."
     },
     "owners": [

--- a/types/parcel-env/parcel-env-tests.ts
+++ b/types/parcel-env/parcel-env-tests.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 interface SomeModule {
     someMethod(): void;
 }

--- a/types/webpack-env/index.d.ts
+++ b/types/webpack-env/index.d.ts
@@ -33,10 +33,10 @@ declare namespace __WebpackModuleApi {
          *
          * This creates a chunk. The chunk can be named. If a chunk with this name already exists, the dependencies are merged into that chunk and that chunk is used.
          */
-        ensure(paths: string[], callback: (require: NodeRequire) => void, chunkName?: string): void;
+        ensure(paths: string[], callback: (require: NodeJS.Require) => void, chunkName?: string): void;
         ensure(
             paths: string[],
-            callback: (require: NodeRequire) => void,
+            callback: (require: NodeJS.Require) => void,
             errorCallback?: (error: any) => void,
             chunkName?: string,
         ): void;
@@ -64,7 +64,7 @@ declare namespace __WebpackModuleApi {
          * Multiple requires to the same module result in only one module execution and only one export. Therefore a cache in the runtime exists. Removing values from this cache cause new module execution and a new export. This is only needed in rare cases (for compatibility!).
          */
         cache: {
-            [id: string]: NodeModule | undefined;
+            [id: string]: NodeJS.Module | undefined;
         };
     }
 
@@ -73,8 +73,8 @@ declare namespace __WebpackModuleApi {
         id: ModuleId;
         filename: string;
         loaded: boolean;
-        parent: NodeModule | null | undefined;
-        children: NodeModule[];
+        parent: NodeJS.Module | null | undefined;
+        children: NodeJS.Module[];
         hot?: Hot | undefined;
     }
 
@@ -272,10 +272,6 @@ declare namespace __WebpackModuleApi {
     type RequireLambda = __Require1 & __Require2;
 }
 
-interface NodeRequire extends NodeJS.Require {}
-
-declare var require: NodeRequire;
-
 /**
  * The resource query of the current module.
  *
@@ -367,17 +363,16 @@ interface ImportMeta {
     ) => __WebpackModuleApi.RequireContext;
 }
 
-interface NodeModule extends NodeJS.Module {}
-
-declare var module: NodeModule;
-
-/**
- * Declare process variable
- */
 declare namespace NodeJS {
     interface Process extends __WebpackModuleApi.NodeProcess {}
     interface RequireResolve extends __WebpackModuleApi.RequireResolve {}
     interface Module extends __WebpackModuleApi.Module {}
     interface Require extends __WebpackModuleApi.RequireFunction {}
 }
+
+interface NodeModule extends NodeJS.Module {}
+interface NodeRequire extends NodeJS.Require {}
+
+declare var module: NodeJS.Module;
 declare var process: NodeJS.Process;
+declare var require: NodeJS.Require;


### PR DESCRIPTION
Follow-up to #71303.

Fixes "env" packages that re-declare @types/node globals, which was causing compilation errors without `skipLibCheck` due to the `NodeRequire` "alias" interface being non-identical to its canonical `NodeJS.Require` counterpart if both @types/node and the affected package are loaded simultaneously (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71303#issuecomment-2611403687)