### PR TITLE
[webpack-env] declare as non-npm

### DIFF
--- a/types/webpack-env/package.json
+++ b/types/webpack-env/package.json
@@ -2,6 +2,8 @@
     "private": true,
     "name": "@types/webpack-env",
     "version": "1.18.9999",
+    "nonNpm": "conflict",
+    "nonNpmDescription": "webpack-env",
     "projects": [
         "https://github.com/webpack/webpack"
     ],


### PR DESCRIPTION
dtslint is currently warning about mismatches with the unrelated "webpack-env" package.