### PR TITLE
feat!(gettext-parser): update types for v8.0.0

### DIFF
--- a/types/gettext-parser/gettext-parser-tests.ts
+++ b/types/gettext-parser/gettext-parser-tests.ts
@@ -1,16 +1,31 @@
 import { mo, po } from "gettext-parser";
+import { createReadStream } from "node:fs";
 
-let parsed = po.parse("foo", "utf-8");
-let compiled = po.compile(parsed, {});
+let parsed = po.parse("foo", { defaultCharset: "utf-8", validation: true });
+parsed = po.parse("foo", { defaultCharset: "utf-8" });
+parsed = po.parse("foo", { validation: true });
+parsed = po.parse("foo", { validation: false });
 parsed = po.parse(Buffer.from("bar"));
-compiled = po.compile(parsed, { anyOption: false });
-const stream = po.createParseStream(Buffer.from("bar"));
-stream.on("data", (data) => {
-    console.log(data);
+
+let compiled = po.compile(parsed, {});
+compiled = po.compile(parsed);
+compiled = po.compile(parsed, { foldLength: 80 });
+compiled = po.compile(parsed, { escapeCharacters: true });
+compiled = po.compile(parsed, { escapeCharacters: false });
+compiled = po.compile(parsed, { sort: true });
+compiled = po.compile(parsed, { sort: false });
+compiled = po.compile(parsed, { eol: "\n" });
+compiled = po.compile(parsed, { sort: (a, b) => a.msgid.length > b.msgid.length ? 1 : -1 });
+
+const poParseStream = po.createParseStream();
+const input = createReadStream("bar");
+input.pipe(poParseStream);
+poParseStream.on("data", (data) => {
+    console.log(data.translations[""]);
 });
 
+parsed = mo.parse(Buffer.from("bar"), "wrong-charset");
 parsed = mo.parse(compiled, "wrong-charset");
-compiled = mo.compile(parsed, { noOption: 3 });
 
 const charset: string = parsed.charset;
 

--- a/types/gettext-parser/index.d.ts
+++ b/types/gettext-parser/index.d.ts
@@ -1,38 +1,58 @@
 /// <reference types="node" />
 
-import { Transform } from "readable-stream";
+import { Transform, TransformOptions } from "readable-stream";
 
 export interface GetTextComment {
-    translator: string;
-    reference: string;
-    extracted: string;
-    flag: string;
-    previous: string;
+    translator?: string;
+    reference?: string;
+    extracted?: string;
+    flag?: string;
+    previous?: string;
 }
 
 export interface GetTextTranslation {
-    msgctxt?: string | undefined;
+    msgctxt?: string;
     msgid: string;
-    msgid_plural?: any;
+    msgid_plural?: string;
     msgstr: string[];
-    comments?: GetTextComment | undefined;
+    comments?: GetTextComment;
+    obsolete?: boolean;
+}
+
+export interface GetTextTranslationRecord {
+    [msgctxt: string]: {
+        [msgId: string]: GetTextTranslation;
+    };
 }
 
 export interface GetTextTranslations {
     charset: string;
     headers: { [headerName: string]: string };
-    translations: { [msgctxt: string]: { [msgId: string]: GetTextTranslation } };
+    translations: GetTextTranslationRecord;
+    obsolete?: GetTextTranslationRecord;
+}
+
+export interface GetTextPoParserOptions {
+    defaultCharset?: string;
+    validation?: boolean;
+}
+
+export interface GetTextPoCompilerOptions {
+    foldLength?: number;
+    escapeCharacters?: boolean;
+    sort?: boolean | ((a: GetTextTranslation, b: GetTextTranslation) => number);
+    eol?: string;
 }
 
 export interface PoParser {
-    parse: (buffer: Buffer | string, defaultCharset?: string) => GetTextTranslations;
-    compile: (table: GetTextTranslations, options?: any) => Buffer;
-    createParseStream: (buffer: any, defaultCharset?: string) => Transform;
+    parse: (buffer: Buffer | string, options?: GetTextPoParserOptions) => GetTextTranslations;
+    compile: (table: GetTextTranslations, options?: GetTextPoCompilerOptions) => Buffer;
+    createParseStream: (options?: GetTextPoParserOptions, transformOptions?: TransformOptions) => Transform;
 }
 
 export interface MoParser {
     parse: (buffer: Buffer | string, defaultCharset?: string) => GetTextTranslations;
-    compile: (table: GetTextTranslations, options?: any) => Buffer;
+    compile: (table: GetTextTranslations) => Buffer;
 }
 
 export const po: PoParser;

--- a/types/gettext-parser/package.json
+++ b/types/gettext-parser/package.json
@@ -1,7 +1,8 @@
 {
     "private": true,
     "name": "@types/gettext-parser",
-    "version": "4.0.9999",
+    "version": "8.0.9999",
+    "type": "module",
     "projects": [
         "https://github.com/smhg/gettext-parser"
     ],


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - The signatures of the `po.parse` and `po.stream` changed in [v7.0.0](https://github.com/smhg/gettext-parser/releases/tag/v7.0.0)
    - `po.parse` signature: https://github.com/smhg/gettext-parser/blob/master/lib/poparser.js#L13
    - `po.stream` (createParseStream) signature: https://github.com/smhg/gettext-parser/blob/master/lib/poparser.js#L26
    - `po.compile` possible options: https://github.com/smhg/gettext-parser/blob/master/lib/pocompiler.js#L47-L61
    - `mo.compile` does not accept options: https://github.com/smhg/gettext-parser/blob/master/lib/mocompiler.js#L13
    - The library switched to pure ESM in [v8.0.0](https://github.com/smhg/gettext-parser/releases/tag/v8.0.0)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
