### PR TITLE
[chromecast-caf-receiver] Allow passing null to setActiveByIds

### DIFF
--- a/types/chromecast-caf-receiver/cast.framework.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.d.ts
@@ -96,7 +96,7 @@ export class TextTracksManager {
      * Sets text tracks to be active by id.
      * @throws Error If id is invalid.
      */
-    setActiveByIds(newIds: number[]): void;
+    setActiveByIds(newIds: number[] | null): void;
 
     /**
      * Sets text tracks to be active by language.

--- a/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
+++ b/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
@@ -51,6 +51,9 @@ pManager.addEventListener(
 );
 
 const ttManager = new cast.framework.TextTracksManager();
+ttManager.setActiveByIds(null);
+ttManager.setActiveByIds([2, 3]);
+
 const qManager = new cast.framework.QueueManager();
 const qBase = new cast.framework.QueueBase();
 const items = qBase.fetchItems(1, 3, 4);


### PR DESCRIPTION
Documentation says "Value may be null":
https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.TextTracksManager#setActiveByIds

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.TextTracksManager#setActiveByIds
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.