### PR TITLE
feat(swagger-react-ui): Support ESM and update package version 

### DIFF
--- a/types/swagger-ui-react/index.d.mts
+++ b/types/swagger-ui-react/index.d.mts
@@ -1,5 +1,5 @@
-import * as React from 'react'
-import {SwaggerUIProps} from "./swagger-ui-react.js";
+import * as React from "react";
+import { SwaggerUIProps } from "./swagger-ui-react.js";
 
 declare const SwaggerUI: React.FunctionComponent<SwaggerUIProps>;
 export default SwaggerUI;

--- a/types/swagger-ui-react/index.d.mts
+++ b/types/swagger-ui-react/index.d.mts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {SwaggerUIProps} from "./swagger-ui-react";
+import {SwaggerUIProps} from "./swagger-ui-react.js";
 
 declare const SwaggerUI: React.FunctionComponent<SwaggerUIProps>;
-export = SwaggerUI
+export default SwaggerUI;

--- a/types/swagger-ui-react/index.d.ts
+++ b/types/swagger-ui-react/index.d.ts
@@ -1,5 +1,5 @@
-import * as React from 'react'
-import {SwaggerUIProps} from "./swagger-ui-react";
+import * as React from "react";
+import { SwaggerUIProps } from "./swagger-ui-react";
 
 declare const SwaggerUI: React.FunctionComponent<SwaggerUIProps>;
-export = SwaggerUI
+export = SwaggerUI;

--- a/types/swagger-ui-react/package.json
+++ b/types/swagger-ui-react/package.json
@@ -5,6 +5,12 @@
     "projects": [
         "https://github.com/swagger-api/swagger-ui#readme"
     ],
+    "exports": {
+        ".": {
+            "import": "./index.d.mts",
+            "require": "./index.d.ts"
+        }
+    },
     "dependencies": {
         "@types/react": "*"
     },

--- a/types/swagger-ui-react/package.json
+++ b/types/swagger-ui-react/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/swagger-ui-react",
-    "version": "4.19.9999",
+    "version": "5.18.9999",
     "projects": [
         "https://github.com/swagger-api/swagger-ui#readme"
     ],

--- a/types/swagger-ui-react/swagger-ui-react-tests.tsx
+++ b/types/swagger-ui-react/swagger-ui-react-tests.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import SwaggerUI from "swagger-ui-react";
 
 <div>

--- a/types/swagger-ui-react/swagger-ui-react.d.ts
+++ b/types/swagger-ui-react/swagger-ui-react.d.ts
@@ -1,0 +1,45 @@
+interface Request {
+  [k: string]: any;
+}
+interface Response {
+  [k: string]: any;
+}
+type System = any;
+
+type PluginGenerator = (system: System) => object;
+
+type Plugin = object | PluginGenerator;
+
+type Preset = () => unknown;
+
+export interface SwaggerUIProps {
+  spec?: object | string;
+  url?: string;
+  layout?: string;
+  onComplete?: (system: System) => void;
+  requestInterceptor?: (req: Request) => Request | Promise<Request>;
+  responseInterceptor?: (res: Response) => Response | Promise<Response>;
+  docExpansion?: "list" | "full" | "none";
+  defaultModelExpandDepth?: number;
+  defaultModelsExpandDepth?: number;
+  defaultModelRendering?: "example" | "model";
+  queryConfigEnabled?: boolean;
+  plugins?: Plugin[];
+  supportedSubmitMethods?: Array<"get" | "put" | "post" | "delete" | "options" | "head" | "patch" | "trace">;
+  deepLinking?: boolean;
+  showMutatedRequest?: boolean;
+  showExtensions?: boolean;
+  showCommonExtensions?: boolean;
+  presets?: Preset[];
+  filter?: string | boolean;
+  requestSnippetsEnabled?: boolean;
+  requestSnippets?: object;
+  displayOperationId?: boolean;
+  tryItOutEnabled?: boolean;
+  displayRequestDuration?: boolean;
+  persistAuthorization?: boolean;
+  withCredentials?: boolean;
+  oauth2RedirectUrl?: string;
+}
+
+export default SwaggerUIProps;

--- a/types/swagger-ui-react/swagger-ui-react.d.ts
+++ b/types/swagger-ui-react/swagger-ui-react.d.ts
@@ -1,8 +1,8 @@
 interface Request {
-  [k: string]: any;
+    [k: string]: any;
 }
 interface Response {
-  [k: string]: any;
+    [k: string]: any;
 }
 type System = any;
 
@@ -13,33 +13,33 @@ type Plugin = object | PluginGenerator;
 type Preset = () => unknown;
 
 export interface SwaggerUIProps {
-  spec?: object | string;
-  url?: string;
-  layout?: string;
-  onComplete?: (system: System) => void;
-  requestInterceptor?: (req: Request) => Request | Promise<Request>;
-  responseInterceptor?: (res: Response) => Response | Promise<Response>;
-  docExpansion?: "list" | "full" | "none";
-  defaultModelExpandDepth?: number;
-  defaultModelsExpandDepth?: number;
-  defaultModelRendering?: "example" | "model";
-  queryConfigEnabled?: boolean;
-  plugins?: Plugin[];
-  supportedSubmitMethods?: Array<"get" | "put" | "post" | "delete" | "options" | "head" | "patch" | "trace">;
-  deepLinking?: boolean;
-  showMutatedRequest?: boolean;
-  showExtensions?: boolean;
-  showCommonExtensions?: boolean;
-  presets?: Preset[];
-  filter?: string | boolean;
-  requestSnippetsEnabled?: boolean;
-  requestSnippets?: object;
-  displayOperationId?: boolean;
-  tryItOutEnabled?: boolean;
-  displayRequestDuration?: boolean;
-  persistAuthorization?: boolean;
-  withCredentials?: boolean;
-  oauth2RedirectUrl?: string;
+    spec?: object | string;
+    url?: string;
+    layout?: string;
+    onComplete?: (system: System) => void;
+    requestInterceptor?: (req: Request) => Request | Promise<Request>;
+    responseInterceptor?: (res: Response) => Response | Promise<Response>;
+    docExpansion?: "list" | "full" | "none";
+    defaultModelExpandDepth?: number;
+    defaultModelsExpandDepth?: number;
+    defaultModelRendering?: "example" | "model";
+    queryConfigEnabled?: boolean;
+    plugins?: Plugin[];
+    supportedSubmitMethods?: Array<"get" | "put" | "post" | "delete" | "options" | "head" | "patch" | "trace">;
+    deepLinking?: boolean;
+    showMutatedRequest?: boolean;
+    showExtensions?: boolean;
+    showCommonExtensions?: boolean;
+    presets?: Preset[];
+    filter?: string | boolean;
+    requestSnippetsEnabled?: boolean;
+    requestSnippets?: object;
+    displayOperationId?: boolean;
+    tryItOutEnabled?: boolean;
+    displayRequestDuration?: boolean;
+    persistAuthorization?: boolean;
+    withCredentials?: boolean;
+    oauth2RedirectUrl?: string;
 }
 
 export default SwaggerUIProps;

--- a/types/swagger-ui-react/tsconfig.json
+++ b/types/swagger-ui-react/tsconfig.json
@@ -16,6 +16,8 @@
     },
     "files": [
         "index.d.ts",
+        "index.d.mts",
+        "swagger-ui-react.d.ts",
         "swagger-ui-react-tests.tsx"
     ]
 }


### PR DESCRIPTION
In the previous PR https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71747 where I updated librarytypes I incorectly increment the package version according to the docs.

I set the version according to the latest original packager version. https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71747

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/swagger-api/swagger-ui/pull/9855
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

