### PR TITLE
CI: Mark nw.gui as `nonNpm: "conflict"`

### DIFF
--- a/types/nw.gui/package.json
+++ b/types/nw.gui/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "@types/nw.gui",
     "version": "0.0.9999",
-    "nonNpm": true,
+    "nonNpm": "conflict",
     "nonNpmDescription": "nw.gui",
     "projects": [
         "https://github.com/rogerwang/node-webkit"


### PR DESCRIPTION
Doesn't look like the dodgy npm package is going away any time soon, and this is needed to unblock upstream CI.