### PR TITLE
CI: Constrain dependency in mertasan__tailwindcss-variables

### DIFF
--- a/types/mertasan__tailwindcss-variables/package.json
+++ b/types/mertasan__tailwindcss-variables/package.json
@@ -6,7 +6,7 @@
         "https://github.com/mertasan/tailwindcss-variables#readme"
     ],
     "dependencies": {
-        "tailwindcss": ">=3.2.0"
+        "tailwindcss": "^3.2.0"
     },
     "devDependencies": {
         "@types/mertasan__tailwindcss-variables": "workspace:."


### PR DESCRIPTION
@mertasan/tailwindcss-variables has a tailwindcss dependency which is constrained in the actual package, but is currently open-ended in DT. Incompatiblity with the newly-released tailwindcss v4 is causing CI complaints.