### PR TITLE
package-env, webpack-env: conditional global interface merges

### DIFF
--- a/types/parcel-env/index.d.ts
+++ b/types/parcel-env/index.d.ts
@@ -54,6 +54,11 @@ declare namespace __ParcelModuleApi {
     type __Require1 = (id: string) => any;
     type __Require2 = <T>(id: string) => T;
     type RequireLambda = __Require1 & __Require2;
+
+    namespace __NodeGlobalInterfacePolyfill {
+        type Module = NodeJS.Process extends { version: string } ? {} : NodeJS.Module;
+        type Require = NodeJS.Process extends { version: string } ? {} : NodeJS.Require;
+    }
 }
 
 /**
@@ -65,8 +70,8 @@ declare namespace NodeJS {
     interface Require extends __ParcelModuleApi.RequireFunction {}
 }
 
-interface NodeModule extends NodeJS.Module {}
-interface NodeRequire extends NodeJS.Require {}
+interface NodeModule extends __ParcelModuleApi.__NodeGlobalInterfacePolyfill.Module {}
+interface NodeRequire extends __ParcelModuleApi.__NodeGlobalInterfacePolyfill.Require {}
 
 declare var module: NodeJS.Module;
 declare var process: NodeJS.Process;

--- a/types/webpack-env/index.d.ts
+++ b/types/webpack-env/index.d.ts
@@ -270,6 +270,11 @@ declare namespace __WebpackModuleApi {
     type __Require1 = (id: string) => any;
     type __Require2 = <T>(id: string) => T;
     type RequireLambda = __Require1 & __Require2;
+
+    namespace __NodeGlobalInterfacePolyfill {
+        type Module = NodeJS.Process extends { version: string } ? {} : NodeJS.Module;
+        type Require = NodeJS.Process extends { version: string } ? {} : NodeJS.Require;
+    }
 }
 
 /**
@@ -364,14 +369,14 @@ interface ImportMeta {
 }
 
 declare namespace NodeJS {
-    interface Process extends __WebpackModuleApi.NodeProcess {}
-    interface RequireResolve extends __WebpackModuleApi.RequireResolve {}
     interface Module extends __WebpackModuleApi.Module {}
     interface Require extends __WebpackModuleApi.RequireFunction {}
+    interface RequireResolve extends __WebpackModuleApi.RequireResolve {}
+    interface Process extends __WebpackModuleApi.NodeProcess {}
 }
 
-interface NodeModule extends NodeJS.Module {}
-interface NodeRequire extends NodeJS.Require {}
+interface NodeModule extends __WebpackModuleApi.__NodeGlobalInterfacePolyfill.Module {}
+interface NodeRequire extends __WebpackModuleApi.__NodeGlobalInterfacePolyfill.Require {}
 
 declare var module: NodeJS.Module;
 declare var process: NodeJS.Process;


### PR DESCRIPTION
#71739, but correctly backwards-compatible. (Testing previous @types/node versions on dtslint wasn't enough, by the looks of things – these errors only materialise when testing manually with tsc with `skipLibCheck` off.)

Ensures that the (re-)declarations for `NodeModule` and `NodeRequire` only have any effect when @types/node is not loaded, to avoid mutating those interfaces and causing type mismatches.

Addresses https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71739#issuecomment-2619344347.