### PR TITLE
[react-virtualized] fix WindowScrollerChildProps['registerChild'] type

### DIFF
--- a/types/react-virtualized/dist/es/WindowScroller.d.ts
+++ b/types/react-virtualized/dist/es/WindowScroller.d.ts
@@ -13,7 +13,7 @@ export type WindowScrollerChildProps = {
     scrollTop: number;
     scrollLeft: number;
     onChildScroll: (params: { scrollTop: number }) => void;
-    registerChild: (element?: React.ReactNode) => void;
+    registerChild: (element?: Element | null) => void;
 };
 
 export type WindowScrollerProps = {

--- a/types/react-virtualized/react-virtualized-tests.tsx
+++ b/types/react-virtualized/react-virtualized-tests.tsx
@@ -1668,28 +1668,30 @@ export class WindowScrollerExample extends PureComponent<{}, any> {
         return (
             <div className={"styles.WindowScrollerWrapper"}>
                 <WindowScroller ref={this._setRef} scrollElement={isScrollingCustomElement ? customElement : null}>
-                    {({ height, isScrolling, scrollTop, onChildScroll }) => (
-                        <AutoSizer disableHeight>
-                            {({ width }) => (
-                                <List
-                                    onScroll={onChildScroll}
-                                    autoHeight
-                                    className={"styles.List"}
-                                    height={height}
-                                    isScrolling={isScrolling}
-                                    overscanRowCount={2}
-                                    rowCount={list.size}
-                                    rowHeight={30}
-                                    rowRenderer={params =>
-                                        this._rowRenderer({
-                                            ...params,
-                                            isScrolling,
-                                        })}
-                                    scrollTop={scrollTop}
-                                    width={width}
-                                />
-                            )}
-                        </AutoSizer>
+                    {({ height, isScrolling, scrollTop, onChildScroll, registerChild }) => (
+                        <div ref={registerChild}>
+                            <AutoSizer disableHeight>
+                                {({ width }) => (
+                                    <List
+                                        onScroll={onChildScroll}
+                                        autoHeight
+                                        className={"styles.List"}
+                                        height={height}
+                                        isScrolling={isScrolling}
+                                        overscanRowCount={2}
+                                        rowCount={list.size}
+                                        rowHeight={30}
+                                        rowRenderer={params =>
+                                            this._rowRenderer({
+                                                ...params,
+                                                isScrolling,
+                                            })}
+                                        scrollTop={scrollTop}
+                                        width={width}
+                                    />
+                                )}
+                            </AutoSizer>
+                        </div>
                     )}
                 </WindowScroller>
             </div>


### PR DESCRIPTION
The `WindowScrollerChildProps['registerChild']` callback should not accept a `ReactNode` as it expects a DOM node and the [code even warns](https://github.com/bvaughn/react-virtualized/blob/c737715486f724586aee8870ebea1e9efb7b0bfe/source/WindowScroller/WindowScroller.js#L197-L201) if you don't provide one. This PR updates the type and similarly to #71206 updates the type so it can be passed in a a ref callback (i.e `<div ref={registerChild} />`)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bvaughn/react-virtualized/blob/c737715486f724586aee8870ebea1e9efb7b0bfe/source/WindowScroller/WindowScroller.js#L23
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
