### PR TITLE
[d3-scale] Fix `range()` return type for sequential and diverging scales

### DIFF
--- a/types/d3-scale/d3-scale-tests.ts
+++ b/types/d3-scale/d3-scale-tests.ts
@@ -649,7 +649,7 @@ sequentialInterpolator = sequentialScaleColorString.interpolator();
 
 // range(...) ----------------------------------------------------------------
 
-const rangeSequential: [string, string] = sequentialScaleColorString.range()();
+const rangeSequential: [string, string] = sequentialScaleColorString.range();
 sequentialScaleColorString = sequentialScaleColorString.range(["#000000", "#ffffff"]);
 
 // rangeRound(...) ----------------------------------------------------------------
@@ -730,7 +730,7 @@ divergingScaleString = divergingScaleString.interpolator(sequentialInterpolator)
 
 // range(...) ----------------------------------------------------------------
 
-domainDivergingScale = divergingScaleNumber.range()();
+domainDivergingScale = divergingScaleNumber.range();
 divergingScaleNumber = divergingScaleNumber.range([0, 0.5, 1]);
 
 // rangeRound(...) ----------------------------------------------------------------

--- a/types/d3-scale/index.d.ts
+++ b/types/d3-scale/index.d.ts
@@ -1348,7 +1348,7 @@ export interface ScaleSequentialBase<Output, Unknown = never> {
     /**
      * See continuous.range.
      */
-    range(): () => [Output, Output];
+    range(): [Output, Output];
     /**
      * See continuous.range.
      * The given two-element array is converted to an interpolator function using d3.interpolate.
@@ -1676,7 +1676,7 @@ export interface ScaleDiverging<Output, Unknown = never> {
     /**
      * See continuous.range.
      */
-    range(): () => [Output, Output, Output];
+    range(): [Output, Output, Output];
     /**
      * See continuous.range.
      * The given two-element array is converted to an interpolator function using d3.interpolate and d3.piecewise.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://d3js.org/d3-scale/linear#linear_range
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
