### PR TITLE
fix export map for packages

### DIFF
--- a/types/html-escaper/package.json
+++ b/types/html-escaper/package.json
@@ -4,8 +4,10 @@
     "version": "3.0.9999",
     "type": "module",
     "exports": {
-        "import": "./index.d.ts",
-        "default": "./index.d.cts"
+        ".": {
+            "import": "./index.d.ts",
+            "default": "./index.d.cts"
+        }
     },
     "projects": [
         "https://github.com/WebReflection/html-escaper"

--- a/types/wordwrapjs/package.json
+++ b/types/wordwrapjs/package.json
@@ -4,8 +4,10 @@
     "version": "5.1.9999",
     "type": "module",
     "exports": {
-        "import": "./index.d.ts",
-        "require": "./index.d.cts"
+        ".": {
+            "import": "./index.d.ts",
+            "require": "./index.d.cts"
+        }
     },
     "projects": [
         "https://github.com/75lb/wordwrapjs#readme"


### PR DESCRIPTION
- **feat(html-escaper): fix export map**
- **feat(wordwrapjs): fix export map**

From [attw doc](https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseCJS.md), it seems `"."` is needed for export map. Seems most other package types are doing this, so it should be the correct fix.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
