### PR TITLE
Fix TS2395 for Glide.js types

### DIFF
--- a/types/glidejs__glide/dist/glide.modular.esm.d.ts
+++ b/types/glidejs__glide/dist/glide.modular.esm.d.ts
@@ -2,24 +2,24 @@
 
 import Glide = require("../index");
 import ComponentFunction from "../components";
-import { Anchors } from "../components/anchors";
-import { Autoplay } from "../components/autoplay";
-import { Breakpoints } from "../components/breakpoints";
-import { Clones } from "../components/clones";
-import { Controls } from "../components/controls";
-import { Direction } from "../components/direction";
-import { Gaps } from "../components/gaps";
-import { Html } from "../components/html";
-import { Images } from "../components/images";
-import { Keyboard } from "../components/keyboard";
-import { Move } from "../components/move";
-import { Peek } from "../components/peek";
-import { Resize } from "../components/resize";
-import { Run } from "../components/run";
-import { Sizes } from "../components/sizes";
-import { Swipe } from "../components/swipe";
-import { Transition } from "../components/transition";
-import { Translate } from "../components/translate";
+import { Anchors as AnchorsComponent } from "../components/anchors";
+import { Autoplay as AutoplayComponent } from "../components/autoplay";
+import { Breakpoints as BreakpointsComponent } from "../components/breakpoints";
+import { Clones as ClonesComponent } from "../components/clones";
+import { Controls as ControlsComponent } from "../components/controls";
+import { Direction as DirectionComponent } from "../components/direction";
+import { Gaps as GapsComponent } from "../components/gaps";
+import { Html as HtmlComponent } from "../components/html";
+import { Images as ImagesComponent } from "../components/images";
+import { Keyboard as KeyboardComponent } from "../components/keyboard";
+import { Move as MoveComponent } from "../components/move";
+import { Peek as PeekComponent } from "../components/peek";
+import { Resize as ResizeComponent } from "../components/resize";
+import { Run as RunComponent } from "../components/run";
+import { Sizes as SizesComponent } from "../components/sizes";
+import { Swipe as SwipeComponent } from "../components/swipe";
+import { Transition as TransitionComponent } from "../components/transition";
+import { Translate as TranslateComponent } from "../components/translate";
 import TransformerFunction from "../mutator/transformers";
 
 export { ComponentFunction, TransformerFunction };
@@ -28,59 +28,59 @@ export { ComponentFunction, TransformerFunction };
  * Handles clicking and dragging events of the internal `<a>` HTML elements,
  * so they won't interfere while interacting with an instance.
  */
-export const Anchors: ComponentFunction<Anchors>;
+export const Anchors: ComponentFunction<AnchorsComponent>;
 
 /**
  * Manages auto-changing of slides after a defined time interval.
  */
-export const Autoplay: ComponentFunction<Autoplay>;
+export const Autoplay: ComponentFunction<AutoplayComponent>;
 
 /**
  * Reconfigures instance and its options based on currently matched `@media` breakpoint.
  */
-export const Breakpoints: ComponentFunction<Breakpoints>;
+export const Breakpoints: ComponentFunction<BreakpointsComponent>;
 
-export const Clones: ComponentFunction<Clones>;
+export const Clones: ComponentFunction<ClonesComponent>;
 
 /**
  * Manages creating a buttons that allows user to control movement of the instance.
  */
-export const Controls: ComponentFunction<Controls>;
+export const Controls: ComponentFunction<ControlsComponent>;
 
-export const Direction: ComponentFunction<Direction>;
+export const Direction: ComponentFunction<DirectionComponent>;
 
-export const Gaps: ComponentFunction<Gaps>;
+export const Gaps: ComponentFunction<GapsComponent>;
 
-export const Html: ComponentFunction<Html>;
+export const Html: ComponentFunction<HtmlComponent>;
 
 /**
  * Handles dragging events of the internal `<img>` HTML elements,
  * so they won't interfere while interacting with an instance.
  */
-export const Images: ComponentFunction<Images>;
+export const Images: ComponentFunction<ImagesComponent>;
 
 /**
  * Allows for controlling movement of the instance with keyboard's arrow keys.
  */
-export const Keyboard: ComponentFunction<Keyboard>;
+export const Keyboard: ComponentFunction<KeyboardComponent>;
 
-export const Move: ComponentFunction<Move>;
+export const Move: ComponentFunction<MoveComponent>;
 
-export const Peek: ComponentFunction<Peek>;
+export const Peek: ComponentFunction<PeekComponent>;
 
-export const Resize: ComponentFunction<Resize>;
+export const Resize: ComponentFunction<ResizeComponent>;
 
-export const Run: ComponentFunction<Run>;
+export const Run: ComponentFunction<RunComponent>;
 
-export const Sizes: ComponentFunction<Sizes>;
+export const Sizes: ComponentFunction<SizesComponent>;
 
 /**
  * Allows for controlling movement of the instance using finger swipe gestures.
  */
-export const Swipe: ComponentFunction<Swipe>;
+export const Swipe: ComponentFunction<SwipeComponent>;
 
-export const Transition: ComponentFunction<Transition>;
+export const Transition: ComponentFunction<TransitionComponent>;
 
-export const Translate: ComponentFunction<Translate>;
+export const Translate: ComponentFunction<TranslateComponent>;
 
 export default Glide;

--- a/types/glidejs__glide/tsconfig.json
+++ b/types/glidejs__glide/tsconfig.json
@@ -15,6 +15,7 @@
     },
     "files": [
         "index.d.ts",
-        "glidejs__glide-tests.ts"
+        "glidejs__glide-tests.ts",
+        "glidejs__glide-modular-tests.ts"
     ]
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
   - Works when fixing it in the [minimal reproduction] repository   
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
   - Didn't manage to reproduce the issue with tests in here :S 
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- **N/A** Provide a URL to documentation or source code which provides context for the suggested changes
- **N/A** If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Glide.js modular types definition file have an error about merged declarations. For more details, check out the [minimal reproduction] repository. Essentially the issue is that imported names are then duplicated when exporting them. Tested locally the changes with the minimal reproduction repo and the issue was gone. Not sure how to reproduce the issue as tests in here. When using WebStorm IDE to edit the file, the error appears too.


[minimal reproduction]: https://github.com/davidlj95/glidejs-types-minimal-repro
