### PR TITLE
[google-apps-script] Added the `fields` argument to `Drive.Comments.create()` and `Drive.Replies.create()`

### DIFF
--- a/types/google-apps-script/apis/drive_v3.d.ts
+++ b/types/google-apps-script/apis/drive_v3.d.ts
@@ -1143,6 +1143,7 @@ declare namespace GoogleAppsScript {
                             resource: Drive.V3.Schema.Reply,
                             fileId: string,
                             commentId: string,
+                            optionalArgs: { fields: string },
                         ): Drive_v3.Drive.V3.Schema.Reply;
                         /**Gets a reply by ID.
                         @param fileId The ID of the file.
@@ -1486,6 +1487,7 @@ declare namespace GoogleAppsScript {
                         create(
                             resource: Drive.V3.Schema.Comment,
                             fileId: string,
+                            optionalArgs: { fields: string },
                         ): Drive_v3.Drive.V3.Schema.Comment;
                         /**Gets a comment by ID.
                         @param fileId The ID of the file.

--- a/types/google-apps-script/test/google-apps-script-tests.ts
+++ b/types/google-apps-script/test/google-apps-script-tests.ts
@@ -1179,6 +1179,13 @@ function listDrives() {
     }
 }
 
+// Example: Create a comment and a reply
+function commentAndReply() {
+    const comment = Drive.Comments.create({ content: "Comment text" }, "FileID", { fields: "id" });
+    const reply = Drive.Replies.create({ content: "Reply text" }, "FileID", comment.id, { fields: "id" });
+    console.log(reply.id);
+}
+
 // Example: List tabs (Google Docs)
 function listTabs() {
     const allTabs = DocumentApp.openById("FileID").getTabs();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/drive/api/reference/rest/v3/comments/create - see that the `fields` parameter is required. There is no better docs and even the Apps script editor autocomplete tooltip is incorrect. But I have tested that this works (and is, in fact, required)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Closes #71853