### PR TITLE
[Chrome] Add getWorldConfigurations and resetWorldConfiguration for userScripts since Chrome 133

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -14236,26 +14236,22 @@ declare namespace chrome {
          */
         export type ExecutionWorld = "MAIN" | "USER_SCRIPT";
 
-        /**
-         * Properties for configuring the user script world.
-         */
         export interface WorldProperties {
             /** Specifies the world csp. The default is the `ISOLATED` world csp. */
             csp?: string;
             /** Specifies whether messaging APIs are exposed. The default is false.*/
             messaging?: boolean;
+            /**
+             * Specifies the ID of the specific user script world to update. If not provided, updates the properties of the default user script world. Values with leading underscores (`_`) are reserved.
+             * @since Chrome 133
+             */
+            worldId?: string;
         }
 
-        /**
-         * Properties for filtering user scripts.
-         */
         export interface UserScriptFilter {
             ids?: string[];
         }
 
-        /**
-         * Properties for a registered user script.
-         */
         export interface RegisteredUserScript {
             /** If true, it will inject into all frames, even if the frame is not the top-most frame in the tab. Each frame is checked independently for URL requirements; it will not inject into child frames if the URL requirements are not met. Defaults to false, meaning that only the top frame is matched. */
             allFrames?: boolean;
@@ -14275,6 +14271,11 @@ declare namespace chrome {
             runAt?: RunAt;
             /** The JavaScript execution environment to run the script in. The default is `USER_SCRIPT` */
             world?: ExecutionWorld;
+            /**
+             * Specifies the user script world ID to execute in. If omitted, the script will execute in the default user script world. Only valid if `world` is omitted or is `USER_SCRIPT`. Values with leading underscores (`_`) are reserved.
+             * @since Chrome 133
+             */
+            worldId?: string;
         }
 
         /**
@@ -14323,6 +14324,13 @@ declare namespace chrome {
         export function getScripts(filter: UserScriptFilter, callback: (scripts: RegisteredUserScript[]) => void): void;
 
         /**
+         * Retrieves all registered world configurations.
+         * @since Chrome 133
+         */
+        export function getWorldConfigurations(): Promise<WorldProperties[]>;
+        export function getWorldConfigurations(callback: (worlds: WorldProperties[]) => void): void;
+
+        /**
          * Registers one or more user scripts for this extension.
          *
          * @param scripts - Contains a list of user scripts to be registered.
@@ -14336,6 +14344,14 @@ declare namespace chrome {
          * @param callback - Callback function to be executed after registering user scripts.
          */
         export function register(scripts: RegisteredUserScript[], callback: () => void): void;
+
+        /**
+         * Resets the configuration for a user script world. Any scripts that inject into the world with the specified ID will use the default world configuration.
+         * @param worldId The ID of the user script world to reset. If omitted, resets the default world's configuration.
+         */
+        export function resetWorldConfiguration(worldId?: string): Promise<void>;
+        export function resetWorldConfiguration(worldId: string, callback: () => void): void;
+        export function resetWorldConfiguration(callback: () => void): void;
 
         /**
          * Unregisters all dynamically-registered user scripts for this extension.

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -3134,7 +3134,11 @@ function testInstanceID() {
 }
 
 function testUserScripts() {
-    const worldProperties = { csp: "script-src 'self'", messaging: true };
+    const worldProperties: chrome.userScripts.WorldProperties = {
+        csp: "script-src 'self'",
+        messaging: true,
+        worldId: "customId",
+    };
     chrome.userScripts.configureWorld(worldProperties); // $ExpectType Promise<void>
     chrome.userScripts.configureWorld(worldProperties, () => void 0); // $ExpectType void
 
@@ -3162,10 +3166,26 @@ function testUserScripts() {
         },
     ];
 
+    chrome.userScripts.getWorldConfigurations(); // $ExpectType Promise<WorldProperties[]>
+    chrome.userScripts.getWorldConfigurations(([world]) => { // $ExpectType void
+        world.csp; // $ExpectType string | undefined
+        world.messaging; // $ExpectType boolean | undefined
+        world.worldId; // $ExpectType string | undefined
+    });
+    // @ts-expect-error
+    chrome.userScripts.getWorldConfigurations(() => {}).then(() => {});
+
     chrome.userScripts.register(scripts); // $ExpectType Promise<void>
     chrome.userScripts.register(scripts, () => void 0); // $ExpectType void
     // @ts-expect-error Missing required property 'js'.
     chrome.userScripts.register(badScripts);
+
+    chrome.userScripts.resetWorldConfiguration(); // $ExpectType Promise<void>
+    chrome.userScripts.resetWorldConfiguration("scriptId1"); // $ExpectType Promise<void>
+    chrome.userScripts.resetWorldConfiguration(() => {}); // $ExpectType void
+    chrome.userScripts.resetWorldConfiguration("scriptId1", () => {}); // $ExpectType void
+    // @ts-expect-error
+    chrome.userScripts.resetWorldConfiguration(() => {}).then(() => {});
 
     chrome.userScripts.unregister(userScriptFilter); // $ExpectType Promise<void>
     chrome.userScripts.unregister(userScriptFilter, () => void 0); // $ExpectType void


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/userScripts#method-getWorldConfigurations
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
