### PR TITLE
[chrome] Allow using strings in place of `chrome.enum.VALUE` in offscreen and onInstalled

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -6584,7 +6584,7 @@ declare namespace chrome {
         /** The parameters describing the offscreen document to create. */
         export interface CreateParameters {
             /** The reason(s) the extension is creating the offscreen document. */
-            reasons: Reason[];
+            reasons: `${Reason}`[];
             /** The (relative) URL to load in the document. */
             url: string;
             /** A developer-provided string that explains, in more detail, the need for the background context. The user agent _may_ use this in display to the user. */
@@ -8077,7 +8077,7 @@ declare namespace chrome {
             /**
              * The reason that this event is being dispatched.
              */
-            reason: OnInstalledReason;
+            reason: `${OnInstalledReason}`;
             /**
              * Optional.
              * Indicates the previous version of the extension, which has just been updated. This is present only if 'reason' is 'update'.

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -967,9 +967,11 @@ function testTtsEngine() {
 
 chrome.runtime.onInstalled.addListener((details) => {
     details; // $ExpectType InstalledDetails
-    details.reason; // $ExpectType OnInstalledReason
     details.previousVersion; // $ExpectType string | undefined
     details.id; // $ExpectType string | undefined
+    if (details.reason === "install") { // Accept string version of enum
+        details.reason; // $ExpectType OnInstalledReason
+    }
 
     // @ts-expect-error
     details.reason = "not-real-reason";
@@ -2903,7 +2905,10 @@ async function testTopSitesForPromise() {
 // https://developer.chrome.com/docs/extensions/reference/offscreen/
 async function testOffscreenDocument() {
     await chrome.offscreen.createDocument({
-        reasons: [chrome.offscreen.Reason.CLIPBOARD],
+        reasons: [
+            chrome.offscreen.Reason.CLIPBOARD,
+            "AUDIO_PLAYBACK", // Accept both enum values and strings
+        ],
         url: "https://example.com",
         justification: "Example",
     });

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -968,7 +968,7 @@ function testTtsEngine() {
 chrome.runtime.onInstalled.addListener((details) => {
     details; // $ExpectType InstalledDetails
     details.previousVersion; // $ExpectType string | undefined
-    details.reason; // $ExpectType OnInstalledReason
+    details.reason; // $ExpectType "install" | "update" | "chrome_update" | "shared_module_update"
     details.id; // $ExpectType string | undefined
     if (details.reason === "install") { // Accept string version of enum
         return;

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -968,9 +968,10 @@ function testTtsEngine() {
 chrome.runtime.onInstalled.addListener((details) => {
     details; // $ExpectType InstalledDetails
     details.previousVersion; // $ExpectType string | undefined
+    details.reason; // $ExpectType OnInstalledReason
     details.id; // $ExpectType string | undefined
     if (details.reason === "install") { // Accept string version of enum
-        details.reason; // $ExpectType OnInstalledReason
+        return;
     }
 
     // @ts-expect-error


### PR DESCRIPTION
Most enum usage follows this style, but these two don't. Particularly I'm making this change because switching from `webextension-polyfill` to `chrome` was forcing me to make this unnecessary change:

```diff
- if (reason === "install") {
+ if (reason === chrome.runtime.OnInstalledReason.INSTALL) {
```

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [ ] ~~Provide a URL to documentation or source code which provides context for the suggested changes:~~ _Not a change of types, just a UX improvement_