### PR TITLE
fix(@types/node): Remedy Compiler Crash Caused By `assert.strict.AssertionError`

### DIFF
--- a/types/node/assert.d.ts
+++ b/types/node/assert.d.ts
@@ -1068,6 +1068,7 @@ declare module "assert" {
                 | "deepStrictEqual"
                 | "ifError"
                 | "strict"
+                | "AssertionError"
             >
             & {
                 (value: unknown, message?: string | Error): asserts value;
@@ -1083,6 +1084,7 @@ declare module "assert" {
                 deepStrictEqual: typeof deepStrictEqual;
                 ifError: typeof ifError;
                 strict: typeof strict;
+                AssertionError: typeof AssertionError;
             };
     }
     export = assert;

--- a/types/node/test/assert.ts
+++ b/types/node/test/assert.ts
@@ -184,3 +184,9 @@ assert.partialDeepStrictEqual({ a: 1, b: 2, c: 3 }, { a: 1, b: 2 });
     assert.deepStrictEqual(a, { b: 2 });
     a; // $ExpectType { b: number; }
 }
+
+// This is a regression test for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71889.
+// Due to the nature of the bug this can't be switched to `import strict from "node:assert/strict";`
+// or to `import strict = require("node:assert/strict");`
+import { AssertionError } from "node:assert/strict";
+new AssertionError({ message: "some message" });

--- a/types/node/v20/assert.d.ts
+++ b/types/node/v20/assert.d.ts
@@ -1015,6 +1015,7 @@ declare module "assert" {
                 | "deepStrictEqual"
                 | "ifError"
                 | "strict"
+                | "AssertionError"
             >
             & {
                 (value: unknown, message?: string | Error): asserts value;
@@ -1030,6 +1031,7 @@ declare module "assert" {
                 deepStrictEqual: typeof deepStrictEqual;
                 ifError: typeof ifError;
                 strict: typeof strict;
+                AssertionError: typeof AssertionError;
             };
     }
     export = assert;

--- a/types/node/v20/test/assert.ts
+++ b/types/node/v20/test/assert.ts
@@ -182,3 +182,9 @@ assert["fail"](true, true, "works like a charm");
     assert.deepStrictEqual(a, { b: 2 });
     a; // $ExpectType { b: number; }
 }
+
+// This is a regression test for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71889.
+// Due to the nature of the bug this can't be switched to `import strict from "node:assert/strict";`
+// or to `import strict = require("node:assert/strict");`
+import { AssertionError } from "node:assert/strict";
+new AssertionError({ message: "some message" });


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

This is neither of these. However it is a vital fix for users of `AssertionError`. This snippet crashes the TypeScript compiler entirely:
```ts
import { AssertionError } from "node:assert/strict"
new AssertionError({ message: "assert" });
```
See https://github.com/microsoft/TypeScript/issues/61149 for more details.