### PR TITLE
[serverless] - fix(serverless): add custom authorizers to httpApi provider definitions

### DIFF
--- a/types/serverless/plugins/aws/provider/awsProvider.d.ts
+++ b/types/serverless/plugins/aws/provider/awsProvider.d.ts
@@ -189,8 +189,20 @@ declare namespace Aws {
         audience: string[];
     }
 
+    interface CustomAuthorizer {
+        type: "request";
+        functionName?: string;
+        functionArn?: string;
+        name?: string;
+        resultTtlInSeconds?: number;
+        enableSimpleResponses?: boolean;
+        payloadVersion?: string;
+        identitySource?: string[];
+        managedExternally?: boolean;
+    }
+
     interface Authorizers {
-        [key: string]: CognitoAuthorizer | OidcAuthorizer | JwtAuthorizer;
+        [key: string]: CognitoAuthorizer | OidcAuthorizer | JwtAuthorizer | CustomAuthorizer;
     }
 
     interface Alb {

--- a/types/serverless/serverless-tests.ts
+++ b/types/serverless/serverless-tests.ts
@@ -392,6 +392,10 @@ const awsServerless: Aws.Serverless = {
                     issuerUrl: "testissuerUrl",
                     audience: ["testaudience"],
                 },
+                testCustomAuthorizer: {
+                    type: "request",
+                    functionName: "testCustomAuthorizer"
+                }
             },
             useProviderTags: true,
             metrics: true,
@@ -953,6 +957,9 @@ const awsServerless: Aws.Serverless = {
                 authorizer: "aws_iam",
             },
         },
+        testCustomAuthorizer: {
+            handler: "testauthorizer",
+        }
     },
     layers: {
         testLayer: {


### PR DESCRIPTION
This is a supported type based off this documentation and code
* https://github.com/serverless/serverless/blob/main/lib/plugins/aws/package/compile/events/http-api.js#L254
* https://www.serverless.com/framework/docs/providers/aws/guide/serverless.yml#api-gateway-v2-http-api

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [code](https://github.com/serverless/serverless/blob/main/lib/plugins/aws/package/compile/events/http-api.js#L254), [docs](https://www.serverless.com/framework/docs/providers/aws/guide/serverless.yml#api-gateway-v2-http-api)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
