### PR TITLE
[sinon] add SinonStubbedFunction<T> type

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -675,11 +675,7 @@ declare namespace Sinon {
          * An exception is thrown if the property is not already a function.
          * The original function can be restored by calling object.method.restore(); (or stub.restore();).
          */
-        <T, K extends keyof T>(
-            obj: T,
-            method: K,
-        ): T[K] extends (...args: infer TArgs) => infer TReturnValue ? SinonStub<TArgs, TReturnValue>
-            : SinonStub;
+        <T, K extends keyof T>(obj: T, method: K): SinonStubbedFunction<T[K]>;
     }
 
     interface SinonExpectation extends SinonStub {
@@ -1481,6 +1477,13 @@ declare namespace Sinon {
      */
     type SinonStubbedMember<T> = T extends (...args: infer TArgs) => infer TReturnValue ? SinonStub<TArgs, TReturnValue>
         : T;
+
+    /**
+     * Replaces a function type with a Sinon stub.
+     */
+    type SinonStubbedFunction<T> = T extends (...args: infer TArgs) => infer TReturnValue
+        ? SinonStub<TArgs, TReturnValue>
+        : SinonStub;
 
     interface SinonFake {
         /**

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -882,16 +882,18 @@ function testTypedStub() {
     }
     let stub: sinon.SinonStub<[number, string], boolean> = sinon.stub();
     let stub2 = sinon.stub<[number, string], boolean>();
+    let stub3: sinon.SinonStubbedFunction<Foo["bar"]>;
     const foo = new Foo();
     stub = sinon.stub(foo, "bar");
     stub2 = sinon.stub(foo, "bar");
+    stub3 = sinon.stub(foo, "bar");
     const result: boolean = stub(42, "qux");
     const fooStub: sinon.SinonStubbedInstance<Foo> = {
         bar: sinon.stub(),
     };
 
-    const stub3 = sinon.stub<readonly [number, string], boolean>();
-    stub3.firstCall.args; // $ExpectType readonly [number, string]
+    const stub4 = sinon.stub<readonly [number, string], boolean>();
+    stub4.firstCall.args; // $ExpectType readonly [number, string]
 }
 
 function testMock() {


### PR DESCRIPTION
I was using my own version of `SinonStubbedMember` because I was not aware there was one built-in. Using it in the `stub` signature should make it more discoverable.