### PR TITLE
[node] Harden TestContext's `assert` against missing methods, add missing v22 method

### DIFF
--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -564,6 +564,23 @@ declare module "node:test" {
         /**
          * An object containing assertion methods bound to the test context.
          * The top-level functions from the `node:assert` module are exposed here for the purpose of creating test plans.
+         *
+         * **Note:** Some of the functions from `node:assert` contain type assertions. If these are called via the
+         * TestContext `assert` object, then the context parameter in the test's function signature **must be explicitly typed**
+         * (ie. the parameter must have a type annotation), otherwise an error will be raised by the TypeScript compiler:
+         * ```ts
+         * import { test, type TestContext } from 'node:test';
+         *
+         * // The test function's context parameter must have a type annotation.
+         * test('example', (t: TestContext) => {
+         *   t.assert.deepStrictEqual(actual, expected);
+         * });
+         *
+         * // Omitting the type annotation will result in a compilation error.
+         * test('example', t => {
+         *   t.assert.deepStrictEqual(actual, expected); // Error: 't' needs an explicit type annotation.
+         * });
+         * ```
          * @since v22.2.0, v20.15.0
          */
         readonly assert: TestContextAssert;
@@ -741,139 +758,28 @@ declare module "node:test" {
          */
         readonly mock: MockTracker;
     }
-    interface TestContextAssert {
-        /**
-         * Identical to the `deepEqual` function from the `node:assert` module, but bound to the test context.
-         */
-        deepEqual: typeof import("node:assert").deepEqual;
-        /**
-         * Identical to the `deepStrictEqual` function from the `node:assert` module, but bound to the test context.
-         *
-         * **Note:** as this method returns a type assertion, the context parameter in the callback signature must have a
-         * type annotation, otherwise an error will be raised by the TypeScript compiler:
-         * ```ts
-         * import { test, type TestContext } from 'node:test';
-         *
-         * // The test function's context parameter must have a type annotation.
-         * test('example', (t: TestContext) => {
-         *   t.assert.deepStrictEqual(actual, expected);
-         * });
-         *
-         * // Omitting the type annotation will result in a compilation error.
-         * test('example', t => {
-         *   t.assert.deepStrictEqual(actual, expected); // Error: 't' needs an explicit type annotation.
-         * });
-         * ```
-         */
-        deepStrictEqual: typeof import("node:assert").deepStrictEqual;
-        /**
-         * Identical to the `doesNotMatch` function from the `node:assert` module, but bound to the test context.
-         */
-        doesNotMatch: typeof import("node:assert").doesNotMatch;
-        /**
-         * Identical to the `doesNotReject` function from the `node:assert` module, but bound to the test context.
-         */
-        doesNotReject: typeof import("node:assert").doesNotReject;
-        /**
-         * Identical to the `doesNotThrow` function from the `node:assert` module, but bound to the test context.
-         */
-        doesNotThrow: typeof import("node:assert").doesNotThrow;
-        /**
-         * Identical to the `equal` function from the `node:assert` module, but bound to the test context.
-         */
-        equal: typeof import("node:assert").equal;
-        /**
-         * Identical to the `fail` function from the `node:assert` module, but bound to the test context.
-         */
-        fail: typeof import("node:assert").fail;
-        /**
-         * Identical to the `ifError` function from the `node:assert` module, but bound to the test context.
-         *
-         * **Note:** as this method returns a type assertion, the context parameter in the callback signature must have a
-         * type annotation, otherwise an error will be raised by the TypeScript compiler:
-         * ```ts
-         * import { test, type TestContext } from 'node:test';
-         *
-         * // The test function's context parameter must have a type annotation.
-         * test('example', (t: TestContext) => {
-         *   t.assert.ifError(err);
-         * });
-         *
-         * // Omitting the type annotation will result in a compilation error.
-         * test('example', t => {
-         *   t.assert.ifError(err); // Error: 't' needs an explicit type annotation.
-         * });
-         * ```
-         */
-        ifError: typeof import("node:assert").ifError;
-        /**
-         * Identical to the `match` function from the `node:assert` module, but bound to the test context.
-         */
-        match: typeof import("node:assert").match;
-        /**
-         * Identical to the `notDeepEqual` function from the `node:assert` module, but bound to the test context.
-         */
-        notDeepEqual: typeof import("node:assert").notDeepEqual;
-        /**
-         * Identical to the `notDeepStrictEqual` function from the `node:assert` module, but bound to the test context.
-         */
-        notDeepStrictEqual: typeof import("node:assert").notDeepStrictEqual;
-        /**
-         * Identical to the `notEqual` function from the `node:assert` module, but bound to the test context.
-         */
-        notEqual: typeof import("node:assert").notEqual;
-        /**
-         * Identical to the `notStrictEqual` function from the `node:assert` module, but bound to the test context.
-         */
-        notStrictEqual: typeof import("node:assert").notStrictEqual;
-        /**
-         * Identical to the `ok` function from the `node:assert` module, but bound to the test context.
-         *
-         * **Note:** as this method returns a type assertion, the context parameter in the callback signature must have a
-         * type annotation, otherwise an error will be raised by the TypeScript compiler:
-         * ```ts
-         * import { test, type TestContext } from 'node:test';
-         *
-         * // The test function's context parameter must have a type annotation.
-         * test('example', (t: TestContext) => {
-         *   t.assert.ok(condition);
-         * });
-         *
-         * // Omitting the type annotation will result in a compilation error.
-         * test('example', t => {
-         *   t.assert.ok(condition)); // Error: 't' needs an explicit type annotation.
-         * });
-         * ```
-         */
-        ok: typeof import("node:assert").ok;
-        /**
-         * Identical to the `rejects` function from the `node:assert` module, but bound to the test context.
-         */
-        rejects: typeof import("node:assert").rejects;
-        /**
-         * Identical to the `strictEqual` function from the `node:assert` module, but bound to the test context.
-         *
-         * **Note:** as this method returns a type assertion, the context parameter in the callback signature must have a
-         * type annotation, otherwise an error will be raised by the TypeScript compiler:
-         * ```ts
-         * import { test, type TestContext } from 'node:test';
-         *
-         * // The test function's context parameter must have a type annotation.
-         * test('example', (t: TestContext) => {
-         *   t.assert.strictEqual(actual, expected);
-         * });
-         *
-         * // Omitting the type annotation will result in a compilation error.
-         * test('example', t => {
-         *   t.assert.strictEqual(actual, expected); // Error: 't' needs an explicit type annotation.
-         * });
-         * ```
-         */
-        strictEqual: typeof import("node:assert").strictEqual;
-        /**
-         * Identical to the `throws` function from the `node:assert` module, but bound to the test context.
-         */
-        throws: typeof import("node:assert").throws;
+    interface TestContextAssert extends
+        Pick<
+            typeof import("assert"),
+            | "deepEqual"
+            | "deepStrictEqual"
+            | "doesNotMatch"
+            | "doesNotReject"
+            | "doesNotThrow"
+            | "equal"
+            | "fail"
+            | "ifError"
+            | "match"
+            | "notDeepEqual"
+            | "notDeepStrictEqual"
+            | "notEqual"
+            | "notStrictEqual"
+            | "ok"
+            | "rejects"
+            | "strictEqual"
+            | "throws"
+        >
+    {
         /**
          * This function implements assertions for snapshot testing.
          * ```js

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -775,6 +775,7 @@ declare module "node:test" {
             | "notEqual"
             | "notStrictEqual"
             | "ok"
+            | "partialDeepStrictEqual"
             | "rejects"
             | "strictEqual"
             | "throws"

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -998,6 +998,12 @@ const invalidTestContext = new TestContext();
 // @ts-expect-error Should not be able to instantiate a SuiteContext
 const invalidSuiteContext = new SuiteContext();
 
+test("check all assertion functions are re-exported", t => {
+    type AssertModuleExports = keyof typeof import("assert");
+    const keys: keyof { [K in keyof typeof t.assert as K extends AssertModuleExports ? K : never]: any } =
+        {} as Exclude<AssertModuleExports, "AssertionError" | "CallTracker" | "strict">;
+});
+
 test("planning with streams", (t: TestContext, done) => {
     function* generate() {
         yield "a";

--- a/types/node/v20/test.d.ts
+++ b/types/node/v20/test.d.ts
@@ -455,6 +455,23 @@ declare module "node:test" {
         /**
          * An object containing assertion methods bound to the test context.
          * The top-level functions from the `node:assert` module are exposed here for the purpose of creating test plans.
+         *
+         * **Note:** Some of the functions from `node:assert` contain type assertions. If these are called via the
+         * TestContext `assert` object, then the context parameter in the test's function signature **must be explicitly typed**
+         * (ie. the parameter must have a type annotation), otherwise an error will be raised by the TypeScript compiler:
+         * ```ts
+         * import { test, type TestContext } from 'node:test';
+         *
+         * // The test function's context parameter must have a type annotation.
+         * test('example', (t: TestContext) => {
+         *   t.assert.deepStrictEqual(actual, expected);
+         * });
+         *
+         * // Omitting the type annotation will result in a compilation error.
+         * test('example', t => {
+         *   t.assert.deepStrictEqual(actual, expected); // Error: 't' needs an explicit type annotation.
+         * });
+         * ```
          * @since v20.15.0
          */
         readonly assert: TestContextAssert;
@@ -626,140 +643,28 @@ declare module "node:test" {
          */
         readonly mock: MockTracker;
     }
-    interface TestContextAssert {
-        /**
-         * Identical to the `deepEqual` function from the `node:assert` module, but bound to the test context.
-         */
-        deepEqual: typeof import("node:assert").deepEqual;
-        /**
-         * Identical to the `deepStrictEqual` function from the `node:assert` module, but bound to the test context.
-         *
-         * **Note:** as this method returns a type assertion, the context parameter in the callback signature must have a
-         * type annotation, otherwise an error will be raised by the TypeScript compiler:
-         * ```ts
-         * import { test, type TestContext } from 'node:test';
-         *
-         * // The test function's context parameter must have a type annotation.
-         * test('example', (t: TestContext) => {
-         *   t.assert.deepStrictEqual(actual, expected);
-         * });
-         *
-         * // Omitting the type annotation will result in a compilation error.
-         * test('example', t => {
-         *   t.assert.deepStrictEqual(actual, expected); // Error: 't' needs an explicit type annotation.
-         * });
-         * ```
-         */
-        deepStrictEqual: typeof import("node:assert").deepStrictEqual;
-        /**
-         * Identical to the `doesNotMatch` function from the `node:assert` module, but bound to the test context.
-         */
-        doesNotMatch: typeof import("node:assert").doesNotMatch;
-        /**
-         * Identical to the `doesNotReject` function from the `node:assert` module, but bound to the test context.
-         */
-        doesNotReject: typeof import("node:assert").doesNotReject;
-        /**
-         * Identical to the `doesNotThrow` function from the `node:assert` module, but bound to the test context.
-         */
-        doesNotThrow: typeof import("node:assert").doesNotThrow;
-        /**
-         * Identical to the `equal` function from the `node:assert` module, but bound to the test context.
-         */
-        equal: typeof import("node:assert").equal;
-        /**
-         * Identical to the `fail` function from the `node:assert` module, but bound to the test context.
-         */
-        fail: typeof import("node:assert").fail;
-        /**
-         * Identical to the `ifError` function from the `node:assert` module, but bound to the test context.
-         *
-         * **Note:** as this method returns a type assertion, the context parameter in the callback signature must have a
-         * type annotation, otherwise an error will be raised by the TypeScript compiler:
-         * ```ts
-         * import { test, type TestContext } from 'node:test';
-         *
-         * // The test function's context parameter must have a type annotation.
-         * test('example', (t: TestContext) => {
-         *   t.assert.ifError(err);
-         * });
-         *
-         * // Omitting the type annotation will result in a compilation error.
-         * test('example', t => {
-         *   t.assert.ifError(err); // Error: 't' needs an explicit type annotation.
-         * });
-         * ```
-         */
-        ifError: typeof import("node:assert").ifError;
-        /**
-         * Identical to the `match` function from the `node:assert` module, but bound to the test context.
-         */
-        match: typeof import("node:assert").match;
-        /**
-         * Identical to the `notDeepEqual` function from the `node:assert` module, but bound to the test context.
-         */
-        notDeepEqual: typeof import("node:assert").notDeepEqual;
-        /**
-         * Identical to the `notDeepStrictEqual` function from the `node:assert` module, but bound to the test context.
-         */
-        notDeepStrictEqual: typeof import("node:assert").notDeepStrictEqual;
-        /**
-         * Identical to the `notEqual` function from the `node:assert` module, but bound to the test context.
-         */
-        notEqual: typeof import("node:assert").notEqual;
-        /**
-         * Identical to the `notStrictEqual` function from the `node:assert` module, but bound to the test context.
-         */
-        notStrictEqual: typeof import("node:assert").notStrictEqual;
-        /**
-         * Identical to the `ok` function from the `node:assert` module, but bound to the test context.
-         *
-         * **Note:** as this method returns a type assertion, the context parameter in the callback signature must have a
-         * type annotation, otherwise an error will be raised by the TypeScript compiler:
-         * ```ts
-         * import { test, type TestContext } from 'node:test';
-         *
-         * // The test function's context parameter must have a type annotation.
-         * test('example', (t: TestContext) => {
-         *   t.assert.ok(condition);
-         * });
-         *
-         * // Omitting the type annotation will result in a compilation error.
-         * test('example', t => {
-         *   t.assert.ok(condition)); // Error: 't' needs an explicit type annotation.
-         * });
-         * ```
-         */
-        ok: typeof import("node:assert").ok;
-        /**
-         * Identical to the `rejects` function from the `node:assert` module, but bound to the test context.
-         */
-        rejects: typeof import("node:assert").rejects;
-        /**
-         * Identical to the `strictEqual` function from the `node:assert` module, but bound to the test context.
-         *
-         * **Note:** as this method returns a type assertion, the context parameter in the callback signature must have a
-         * type annotation, otherwise an error will be raised by the TypeScript compiler:
-         * ```ts
-         * import { test, type TestContext } from 'node:test';
-         *
-         * // The test function's context parameter must have a type annotation.
-         * test('example', (t: TestContext) => {
-         *   t.assert.strictEqual(actual, expected);
-         * });
-         *
-         * // Omitting the type annotation will result in a compilation error.
-         * test('example', t => {
-         *   t.assert.strictEqual(actual, expected); // Error: 't' needs an explicit type annotation.
-         * });
-         * ```
-         */
-        strictEqual: typeof import("node:assert").strictEqual;
-        /**
-         * Identical to the `throws` function from the `node:assert` module, but bound to the test context.
-         */
-        throws: typeof import("node:assert").throws;
-    }
+    interface TestContextAssert extends
+        Pick<
+            typeof import("assert"),
+            | "deepEqual"
+            | "deepStrictEqual"
+            | "doesNotMatch"
+            | "doesNotReject"
+            | "doesNotThrow"
+            | "equal"
+            | "fail"
+            | "ifError"
+            | "match"
+            | "notDeepEqual"
+            | "notDeepStrictEqual"
+            | "notEqual"
+            | "notStrictEqual"
+            | "ok"
+            | "rejects"
+            | "strictEqual"
+            | "throws"
+        >
+    {}
 
     /**
      * An instance of `SuiteContext` is passed to each suite function in order to

--- a/types/node/v20/test/test.ts
+++ b/types/node/v20/test/test.ts
@@ -952,6 +952,12 @@ const invalidTestContext = new TestContext();
 // @ts-expect-error Should not be able to instantiate a SuiteContext
 const invalidSuiteContext = new SuiteContext();
 
+test("check all assertion functions are re-exported", t => {
+    type AssertModuleExports = keyof typeof import("assert");
+    const keys: keyof { [K in keyof typeof t.assert as K extends AssertModuleExports ? K : never]: any } =
+        {} as Exclude<AssertModuleExports, "AssertionError" | "CallTracker" | "strict">;
+});
+
 test("planning with streams", (t: TestContext, done) => {
     function* generate() {
         yield "a";


### PR DESCRIPTION
Previously, the test module had no CI checks for whether or not the correct functions from the assert module were re-exported as methods in TestContext's `assert`. Changes that add top-level functions in the assert module are easily missed from the test module – for example when #71663 added `partialDeepStrictEqual()`, which didn't make it into TestContext.

This edit simplifies the re-export behaviour, and adds tests that will flag if top-level assertion functions get added from the assert module and aren't mirrored in the test module, using similar checks to those used upstream. CI results are available for both commits for demonstration purposes, both before and after adding the function that was missing in the v22 branch.

The docblocks for the `assert` properties in test.d.ts weren't exposed by tsserver when annotating method calls anyway, so removing these isn't really an issue.