### PR TITLE
Fix dependabot scanning for composite action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,9 @@
 version: 2
 updates:
   - package-ecosystem: 'github-actions'
-    directory: '/'
+    directories:
+      - '/'
+      - '/.github/actions/setup-for-scripts'
     schedule:
       interval: 'weekly'
     groups:


### PR DESCRIPTION
These dirs are not scanned by dependabot by default.