### PR TITLE
Jest: objectContaining and toMatchObject parameters should be partials

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1073,7 +1073,7 @@ declare namespace jest {
          * expect(desiredHouse).toMatchObject<House>({...standardHouse, kitchen: {area: 20}}) // wherein standardHouse is some base object of type House
          */
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        toMatchObject<E extends {} | any[]>(expected: Partia;<E>): R;
+        toMatchObject<E extends {} | any[]>(expected: E extends any[] ? Partial<E[number]> : Partial<E>): R;    
         /**
          * This ensures that a value matches the most recent snapshot with property matchers.
          * Check out [the Snapshot Testing guide](http://facebook.github.io/jest/docs/snapshot-testing.html) for more information.

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -661,7 +661,7 @@ declare namespace jest {
          * This ensures that the object contains the desired structure.
          */
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        objectContaining<E = {}>(obj: E): any;
+        objectContaining<E = {}>(obj: Partial<E>): any;
         /**
          * `expect.not.stringMatching(string | regexp)` matches the received
          * string that does not match the expected regexp. It is the inverse of
@@ -763,7 +763,7 @@ declare namespace jest {
          * This ensures that the object contains the desired structure.
          */
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        objectContaining<E = {}>(obj: E): any;
+        objectContaining<E = {}>(obj: Partial<E>): any;
         /**
          * Matches any string that contains the exact provided string
          */
@@ -1073,7 +1073,7 @@ declare namespace jest {
          * expect(desiredHouse).toMatchObject<House>({...standardHouse, kitchen: {area: 20}}) // wherein standardHouse is some base object of type House
          */
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        toMatchObject<E extends {} | any[]>(expected: E): R;
+        toMatchObject<E extends {} | any[]>(expected: Partia;<E>): R;
         /**
          * This ensures that a value matches the most recent snapshot with property matchers.
          * Check out [the Snapshot Testing guide](http://facebook.github.io/jest/docs/snapshot-testing.html) for more information.

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1073,7 +1073,7 @@ declare namespace jest {
          * expect(desiredHouse).toMatchObject<House>({...standardHouse, kitchen: {area: 20}}) // wherein standardHouse is some base object of type House
          */
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        toMatchObject<E extends {} | any[]>(expected: E extends any[] ? Partial<E[number]> : Partial<E>): R;    
+        toMatchObject<E extends {} | any[]>(expected: E extends any[] ? E : Partial<E>): R;    
         /**
          * This ensures that a value matches the most recent snapshot with property matchers.
          * Check out [the Snapshot Testing guide](http://facebook.github.io/jest/docs/snapshot-testing.html) for more information.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  https://jestjs.io/docs/expect#tomatchobjectobject & https://jestjs.io/docs/expect#expectobjectcontainingobject
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.