### PR TITLE
Support State and Context augmentation in koa-websocket

### DIFF
--- a/types/koa-websocket/index.d.ts
+++ b/types/koa-websocket/index.d.ts
@@ -5,7 +5,7 @@ import * as https from "https";
 import * as ws from "ws";
 
 declare module "koa" {
-    interface Context {
+    interface BaseContext {
         websocket: ws;
         path: string;
     }
@@ -16,7 +16,7 @@ declare namespace KoaWebsocket {
         MiddlewareContext<StateT> & ContextT
     >;
 
-    interface MiddlewareContext<StateT> extends Koa.Context {
+    interface MiddlewareContext<StateT> extends Koa.BaseContext {
         // Limitation: Declaration merging cannot overwrap existing properties.
         // That's why this property is here, not in the merged declaration above.
         app: App;

--- a/types/koa-websocket/koa-websocket-tests.ts
+++ b/types/koa-websocket/koa-websocket-tests.ts
@@ -68,3 +68,29 @@ supportMulterApp.ws.use(async (ctx, next) => {
     ctx.websocket.send("Hello world");
     await next();
 });
+
+declare module "koa" {
+    interface DefaultState {
+        augmented: string;
+    }
+    interface DefaultContext {
+        augmented: string;
+    }
+}
+
+const supportAugmentation = websocket(new Koa());
+supportAugmentation.ws.use(async (ctx, next) => {
+    ctx.websocket.on("message", (message) => {
+        console.log(message + ctx.augmented + ctx.state.augmented);
+        const server = ctx.app.ws.server;
+        if (server) {
+            server.clients.forEach(client => {
+                if (client !== ctx.websocket) {
+                    client.send(message);
+                }
+            });
+        }
+    });
+    ctx.websocket.send("Hello world");
+    await next();
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Using augmentation to set DefaultState leads to compilation error. 
declare module 'koa' {
  interface DefaultState {
      some: string;
  }
}

../node_modules/@types/koa-websocket/index.d.ts:19:15 - error TS2430: Interface 'MiddlewareContext<StateT>' incorrectly extends interface 'Context'.
  Types of property 'state' are incompatible.
    Type 'StateT' is not assignable to type 'DefaultState'.
19     interface MiddlewareContext<StateT> extends Koa.Context {
                 ~~~~~~~~~~~~~~~~~
  ../node_modules/@types/koa-websocket/index.d.ts:19:33
    19     interface MiddlewareContext<StateT> extends Koa.Context {
                                       ~~~~~~
    This type parameter might need an `extends Koa.DefaultState` constraint.
Found 1 error in ../node_modules/@types/koa-websocket/index.d.ts:19