### PR TITLE
[lodash] Use unknown for noop args

### DIFF
--- a/types/lodash/common/util.d.ts
+++ b/types/lodash/common/util.d.ts
@@ -673,19 +673,19 @@ declare module "../index" {
          *
          * @return undefined
          */
-        noop(...args: any[]): void;
+        noop(...args: unknown[]): void;
     }
     interface LoDashImplicitWrapper<TValue> {
         /**
          * @see _.noop
          */
-        noop(...args: any[]): void;
+        noop(...args: unknown[]): void;
     }
     interface LoDashExplicitWrapper<TValue> {
         /**
          * @see _.noop
          */
-        noop(...args: any[]): PrimitiveChain<undefined>;
+        noop(...args: unknown[]): PrimitiveChain<undefined>;
     }
 
     interface LoDashStatic {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [codesandbox](https://codesandbox.io/p/sandbox/react-typescript-lodash-forked-3txlws?file=%2Fsrc%2FApp.tsx%3A3%2C1-4%2C1)

This addresses an issue where a function's type will be overwritten when using `noop` as a default value when destructured from an object inside a function body.

