### PR TITLE
[@types/tabulator-tables]: Fix typo in method `getRangeData()`

### DIFF
--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -3339,7 +3339,7 @@ declare class Tabulator {
      * ]
      * ```
      */
-    getRangeData: () => unknown[][];
+    getRangesData: () => unknown[][];
 
     setSheets: (data: SpreadsheetSheet[]) => void;
     addSheet: (data: SpreadsheetSheet) => void;

--- a/types/tabulator-tables/tabulator-tables-tests.ts
+++ b/types/tabulator-tables/tabulator-tables-tests.ts
@@ -1545,7 +1545,7 @@ const range1 = table.addRange(cell, cell);
 range1.clearValues();
 table.getRanges().forEach(range => range.remove());
 
-const data1 = table.getRangeData();
+const data1 = table.getRangesData();
 data1[0][0] = { name: "steve" };
 
 // Testing 6.0 features


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
Test results:
<img width="979" alt="Screenshot 2025-02-13 at 6 56 47 PM" src="https://github.com/user-attachments/assets/699fd83e-c954-4708-81d2-765b25c6fe22" />


If changing an existing definition:

- [x] **Provide a URL to documentation or source code which provides context for the suggested changes:** 
This PR Fixes #71822 
The [library](https://tabulator.info/docs/6.3/range#manage-data) exposes a method `getRangesData()` but the type definition had a method `getRangeData()` instead. 

- [x] **If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.**
I also checked an older major version [5.6](https://tabulator.info/docs/5.6/range#manage-data) of the library and it also had `getRangesData()` instead of `getRangeData()`. The type definition already seems to be up to date with the latest library version except that it had this typo, which this PR fixes.

Fix:
1. Updated the method name in type definition file to match the method name expose by the library. 
2. Did corresponding change in the test file. 
3. Ran test and checked that it passes.
