### PR TITLE
feat(jquery.cookie): fix `JQueryCookieOptions.expires` type

### DIFF
--- a/types/jquery.cookie/index.d.ts
+++ b/types/jquery.cookie/index.d.ts
@@ -4,7 +4,7 @@ interface JQueryCookieOptions {
     /**
      * Define lifetime of the cookie. Value can be a Number which will be interpreted as days from time of creation or a Date object. If omitted, the cookie becomes a session cookie.
      */
-    expires?: any;
+    expires?: number | Date;
     /**
      * Define the path where the cookie is valid. By default the path of the cookie is the path of the page where the cookie was created (standard browser behavior). If you want to make it available for instance across the entire domain use path: '/'. Default: path of page where the cookie was created.
      */

--- a/types/jquery.cookie/jquery.cookie-tests.ts
+++ b/types/jquery.cookie/jquery.cookie-tests.ts
@@ -17,6 +17,13 @@ class CookieOptions implements JQueryCookieOptions {
 
 $.cookie("the_cookie", "the_value");
 
+$.cookie("the_cookie", "the_value", { expires: 7 });
+
+$.cookie("the_cookie", "the_value", { expires: new Date() });
+
+// @ts-expect-error
+$.cookie("the_cookie", "the_value", { expires: "tomorrow" });
+
 console.log($.cookie("the_cookie"));
 
 var testObject = new TestObject("Hello World", 5);


### PR DESCRIPTION
Looking at the source code: https://github.com/carhartl/jquery-cookie/blob/master/src/jquery.cookie.js#L62-L69,  
the `expires` property can't be `any`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).