### PR TITLE
Adds missing multiple-property to WidgetTypedInputTypeDefinition of node-red editor ui.

### DIFF
--- a/types/node-red__editor-client/index.d.ts
+++ b/types/node-red__editor-client/index.d.ts
@@ -1685,6 +1685,8 @@ declare namespace editorClient {
         hasValue?: boolean | undefined;
         /** A function to validate the value for the type. */
         validate?: ((v: string) => boolean) | RegExp | undefined;
+        /** If options is set, this can enable multiple selection of them. */
+        multiple?: boolean | undefined;
     }
 
     interface WidgetTypedInput extends JQuery {


### PR DESCRIPTION
Adds missing multiple-property to WidgetTypedInputTypeDefinition

Please fill in this template.

- [ x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [x ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [ x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

https://nodered.org/docs/api/ui/typedInput/
