### PR TITLE
fix(selenium-webdriver): revert return type of `until.elementsLocated` to `Promise<WebElement[]>`

### DIFF
--- a/types/selenium-webdriver/lib/until.d.ts
+++ b/types/selenium-webdriver/lib/until.d.ts
@@ -139,7 +139,7 @@ export function elementTextMatches(element: WebElement, regex: RegExp): WebEleme
  * @return {!Condition.<!Array.<!WebElement>>} The new
  *     condition.
  */
-export function elementsLocated(locator: Locator): Condition<WebElement[]>;
+export function elementsLocated(locator: Locator): Promise<WebElement[]>;
 
 /**
  * Creates a condition that will wait for the given element to become stale.

--- a/types/selenium-webdriver/test/index.ts
+++ b/types/selenium-webdriver/test/index.ts
@@ -573,7 +573,7 @@ function TestUntilModule() {
     );
     let conditionBBase: webdriver.Condition<boolean> = conditionB;
     let conditionWebElement: webdriver.WebElementCondition;
-    let conditionWebElements: webdriver.Condition<webdriver.WebElement[]>;
+    let conditionWebElements: Promise<webdriver.WebElement[]>;
 
     conditionB = webdriver.until.ableToSwitchToFrame(5);
     let conditionAlert: webdriver.Condition<webdriver.Alert> = webdriver.until.alertIsPresent();


### PR DESCRIPTION
The recent commit b0f70c1ea223dc166a34a5fab06f350a2f87c96e introduced a new `Condition` class and changed the return type of `until.elementsLocated` to `Condition<WebElement[]>`. This change caused type incompatibility issues for existing code that relied on the previous return type of `Promise<WebElement[]>`.

This commit reverts the return type of `until.elementsLocated` back to `Promise<WebElement[]>` to restore compatibility with existing code.

Fixes #71955

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/SeleniumHQ/selenium/issues/14239
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
