### PR TITLE
[@types/dbus] fix: fix incorrect callback parameter name and type

### DIFF
--- a/types/dbus/dbus-tests.ts
+++ b/types/dbus/dbus-tests.ts
@@ -15,6 +15,8 @@ dbus.getInterface<Adapter>("org.bluez", "/org/bluez/hci0", "org.bluez.Adapter1",
                 iface.StartDiscovery(() => {});
             }
         });
+
+        iface.getProperty("Powered", () => {});
     }
 });
 

--- a/types/dbus/dbus-tests.ts
+++ b/types/dbus/dbus-tests.ts
@@ -16,7 +16,14 @@ dbus.getInterface<Adapter>("org.bluez", "/org/bluez/hci0", "org.bluez.Adapter1",
             }
         });
 
-        iface.getProperty("Powered", () => {});
+        iface.setProperty("System", 32, err => {
+            if (!err) {
+                iface.StartDiscovery(() => {});
+            }
+        })
+
+        iface.getProperty("Powered", (err: Error | null, value: boolean): void => {});
+        iface.getProperty("System", (err: Error | null, value: number): void => {});
     }
 });
 

--- a/types/dbus/index.d.ts
+++ b/types/dbus/index.d.ts
@@ -27,7 +27,7 @@ declare namespace DBus {
         objectPath: string;
         interfaceName: string;
 
-        getProperty(name: string, callback: (err: Error | null, name: string) => void): void;
+        getProperty(name: string, callback: (err: Error | null, value: any) => void): void;
         setProperty(name: string, value: any, callback: (err: Error | null) => void): void;
         getProperties(callback: (err: Error | null, properties: { [name: string]: any }) => void): void;
         /**


### PR DESCRIPTION
Fixes #71006 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Made the change and ran the tests. Screenshot below - 
<img width="695" alt="Screenshot 2025-02-16 at 6 04 44 PM" src="https://github.com/user-attachments/assets/e8f93324-8bf0-4a0a-88e2-33c9e0db15b4" />



- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
As indicated in issue - #71006 , as per the [documentation](https://github.com/Shouqun/node-dbus/blob/master/README.md#interfaceprototypegetpropertypropertyname-callback) the second argument of the callback will be value of the property (not the name). Therefore, I changed the parameter to `value`. Also, since the property can be set to `any` type of value ([see](https://github.com/Shouqun/node-dbus/blob/master/README.md#interfaceprototypesetpropertypropertyname-value-callback)), I updated the type to `any`.

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
