### PR TITLE
[@types/node-telegram-bot-api] fix: Add missing method `createInvoiceLink` in types.

### DIFF
--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -1998,7 +1998,7 @@ declare class TelegramBot extends TelegramBotEventEmitter<TelegramBot.TelegramEv
         providerToken: string,
         currency: string,
         prices: readonly TelegramBot.LabeledPrice[],
-        options?: TelegramBot.CreateInvoiceLinkOptions
+        options?: TelegramBot.CreateInvoiceLinkOptions,
     ): Promise<string>;
 
     answerShippingQuery(

--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -304,6 +304,21 @@ declare namespace TelegramBot {
         is_flexible?: boolean | undefined;
     }
 
+    interface CreateInvoiceLinkOptions {
+        provider_data?: string | undefined;
+        photo_url?: string | undefined;
+        photo_size?: number | undefined;
+        photo_width?: number | undefined;
+        photo_height?: number | undefined;
+        need_name?: boolean | undefined;
+        need_phone_number?: boolean | undefined;
+        need_email?: boolean | undefined;
+        need_shipping_address?: boolean | undefined;
+        send_phone_number_to_provider?: boolean | undefined;
+        send_email_to_provider?: boolean | undefined;
+        is_flexible?: boolean | undefined;
+    }
+
     interface CopyMessageOptions extends SendBasicOptions {
         caption?: string | undefined;
         parse_mode?: ParseMode | undefined;
@@ -1975,6 +1990,16 @@ declare class TelegramBot extends TelegramBotEventEmitter<TelegramBot.TelegramEv
         prices: readonly TelegramBot.LabeledPrice[],
         options?: TelegramBot.SendInvoiceOptions,
     ): Promise<TelegramBot.Message>;
+
+    createInvoiceLink(
+        title: string,
+        description: string,
+        payload: string,
+        providerToken: string,
+        currency: string,
+        prices: readonly TelegramBot.LabeledPrice[],
+        options?: TelegramBot.CreateInvoiceLinkOptions
+    ): Promise<string>;
 
     answerShippingQuery(
         shippingQueryId: string,

--- a/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
+++ b/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
@@ -331,7 +331,7 @@ MyTelegramBot.createInvoiceLink(
             amount: 1200,
         },
     ],
-    { photo_url: "url", need_email: false, send_phone_number_to_provider: false, is_flexible: true }
+    { photo_url: "url", need_email: false, send_phone_number_to_provider: false, is_flexible: true },
 );
 MyTelegramBot.answerShippingQuery("shippingQueryId", true, {
     shipping_options: [

--- a/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
+++ b/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
@@ -319,6 +319,20 @@ MyTelegramBot.sendInvoice(
     ],
     { is_flexible: true, start_parameter: "start_parameter" },
 );
+MyTelegramBot.createInvoiceLink(
+    "Invoice Title",
+    "Invoice Description",
+    "Invoice Payload",
+    "Providertoken",
+    "Currency",
+    [
+        {
+            label: "$",
+            amount: 1200,
+        },
+    ],
+    { photo_url: "url", need_email: false, send_phone_number_to_provider: false, is_flexible: true }
+);
 MyTelegramBot.answerShippingQuery("shippingQueryId", true, {
     shipping_options: [
         {


### PR DESCRIPTION
Fixes #71737 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Made changes and ran test on local - 
<img width="715" alt="Screenshot 2025-02-17 at 6 03 39 PM" src="https://github.com/user-attachments/assets/fe9cf000-ba0e-4702-a779-7033796caa52" />

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
This PR addresses the issue #71737 . Currently the types files doesn't have the method `createInvoiceLink` as described in the documentation [here](https://github.com/yagop/node-telegram-bot-api/blob/master/doc/api.md#telegrambotcreateinvoicelinktitle-description-payload-providertoken-currency-prices-options--promise). I added the method as per the documentation in the types file and added supporting test.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.


