### PR TITLE
fix(dockerode): add missing keys in ContainerInspectInfo Mounts

### DIFF
--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -567,9 +567,11 @@ declare namespace Dockerode {
             };
         };
         Mounts: Array<{
+            Type: string;
             Name?: string | undefined;
             Source: string;
             Destination: string;
+            Driver?: string | undefined;
             Mode: string;
             RW: boolean;
             Propagation: string;

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -567,7 +567,7 @@ declare namespace Dockerode {
             };
         };
         Mounts: Array<{
-            Type: string;
+            Type: "bind" | "volume" | "image" | "tmpfs" | "npipe" | "cluster";
             Name?: string | undefined;
             Source: string;
             Destination: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. (no change)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - `dockerode`
    - `Container.inspect()` dials docker engine `GET /containers/{id}/json` https://github.com/apocas/dockerode/blob/7c3d517e9ca468aa1794f2b825a5b5533300c49d/lib/container.js#L52
  - `moby` docker engine API
    -  `GET /containers/{id}/json` result key `Mount` is `MountPoint` https://github.com/moby/moby/blob/28dc5a82b3dfc331b6021c5cc25583b4a480bdc7/api/swagger.yaml#L7907-L7997
    - `MountPoint` definition includes `Type` and optional `Driver` https://github.com/moby/moby/blob/28dc5a82b3dfc331b6021c5cc25583b4a480bdc7/api/swagger.yaml#L203-L274
    - Opened issue referring missing key `Type` in example https://github.com/moby/moby/issues/49476
