### PR TITLE
fix(dockerode): fix wrong type in ImageBuildOptions

### DIFF
--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -327,7 +327,7 @@ docker.buildImage(
     },
 );
 
-docker.buildImage(".", { nocache: true, version: "2" }, (err, response) => {
+docker.buildImage(".", { nocache: true, version: "2", pull: true }, (err, response) => {
     // NOOP
 });
 

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -956,7 +956,7 @@ declare namespace Dockerode {
         remote?: string | undefined;
         q?: boolean | undefined;
         cachefrom?: string | undefined;
-        pull?: string | undefined;
+        pull?: boolean | undefined;
         rm?: boolean | undefined;
         forcerm?: boolean | undefined;
         memory?: number | undefined;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - `dockerode`
    - `docker.buildImage()` uses the docker engine API `POST /build` https://github.com/apocas/dockerode/blob/7c3d517e9ca468aa1794f2b825a5b5533300c49d/lib/docker.js#L266-L267
  - docker engine API `moby`
    - the `pull` parameter in `POST /build` route is a boolean https://github.com/moby/moby/blob/62bc5979908f152a8929ce44927cbdd929bf53ea/api/server/router/build/build_routes.go#L45C3-L45C50
