### PR TITLE
MailParser: fix stream subtype of Source

### DIFF
--- a/types/mailparser/index.d.ts
+++ b/types/mailparser/index.d.ts
@@ -296,7 +296,7 @@ export class MailParser extends StreamModule.Transform {
 /**
  * A message source.
  */
-export type Source = Buffer | Stream | string;
+export type Source = Buffer | NodeJS.ReadableStream | string;
 
 /**
  * Options object for MailParser.

--- a/types/mailparser/mailparser-tests.ts
+++ b/types/mailparser/mailparser-tests.ts
@@ -44,7 +44,7 @@ fs.createReadStream("email.eml").pipe(mailparser);
 // check different sources and promise/callback api for simpleParser
 const sourceString = "";
 const sourceBuffer = new Buffer("");
-const sourceStream = fs.createReadStream("foo.eml");
+const sourceStream = fs.createReadStream("foo.eml") as NodeJS.ReadableStream;
 
 simpleParser(sourceString, (err, mail) => err ? err : mail.html);
 simpleParser(sourceBuffer, (err, mail) => err ? err : mail.html);


### PR DESCRIPTION
This PR fixes an incorrect type definition for `Source`.  

The type `Stream` is incorrect for two reasons:  

1. It is too restrictive, as it excludes streams that implement `ReadableStream` but not `ReadStream`.  
2. It is too permissive, as it allows writable streams, which can cause runtime errors such as `ERR_STREAM_CANNOT_PIPE`.  

The correct type to use is `NodeJS.ReadableStream`.
