### PR TITLE
fix(react): add 'slot' attribute to SVGAttributes

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3645,6 +3645,7 @@ declare namespace React {
         seed?: number | string | undefined;
         shapeRendering?: number | string | undefined;
         slope?: number | string | undefined;
+        slot?: string | undefined;
         spacing?: number | string | undefined;
         specularConstant?: number | string | undefined;
         specularExponent?: number | string | undefined;

--- a/types/react/test/elementAttributes.tsx
+++ b/types/react/test/elementAttributes.tsx
@@ -38,6 +38,9 @@ const testCases = [
     <svg>
         <image crossOrigin="anonymous" />
     </svg>,
+    <svg slot="start">
+        <path d="M50 10 L90 90 H10 Z" />
+    </svg>,
     <details open={true} onToggle={() => {}} name="foo" />,
     <input value={["one", "two"] as readonly string[]} />,
     <input value={["one", "two"] as string[]} />,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [facebook/react#32406](https://github.com/facebook/react/issues/32406)

## What this PR does
This PR adds the `slot` attribute to `SVGAttributes<T>`, which is valid in the DOM but missing in React’s TypeScript types.

## Why this is needed
- The `slot` attribute exists on `<svg>` elements in the DOM.
- Currently, using `slot` attribute on `<svg>` in JSX results in a TypeScript error.
- This fix allows `React.SVGProps` to accept the `slot` attribute.

## Tests added
- A test has been added in `test/elementAttributes.tsx` to ensure `slot` works correctly on `<svg>`.
