### PR TITLE
fix(swagger-ui-express): allow null as swaggerDoc parameter

### DIFF
--- a/types/swagger-ui-express/index.d.ts
+++ b/types/swagger-ui-express/index.d.ts
@@ -35,7 +35,7 @@ export interface SwaggerUiOptions {
  * @returns an express middleware function that returns the generated HTML page.
  */
 export function setup(
-    swaggerDoc?: JsonObject,
+    swaggerDoc?: JsonObject | null,
     opts?: SwaggerUiOptions,
     options?: SwaggerOptions,
     customCss?: string,

--- a/types/swagger-ui-express/swagger-ui-express-tests.ts
+++ b/types/swagger-ui-express/swagger-ui-express-tests.ts
@@ -105,3 +105,6 @@ const uiOptsWithSwaggerOpts = {
 };
 
 swaggerUi.setup(swaggerDocument, uiOptsWithSwaggerOpts);
+
+app.get("/api-docs-with-null-doc", swaggerUi.serve);
+app.get("/api-docs-with-null-doc", swaggerUi.setup(null, swaggerUiOpts));


### PR DESCRIPTION
The current type definitions for swagger-ui-express don't allow passing `null` as the `swaggerDoc` parameter when using the URL-based configuration, despite this being a documented feature in the library's README.

> To load your swagger from a url instead of injecting the document, pass null as the first parameter, and pass the relative or absolute URL as the 'url' property to 'swaggerOptions'

This PR fixes the type definitions by:

1. Adding `null` as a valid type for the `swaggerDoc` parameter

2. Adding test cases that verify URL-based configuration works with explicit `null`

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/scottie1984/swagger-ui-express?tab=readme-ov-file#load-swagger-from-url
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.