### PR TITLE
[web-bluetooth] Fix `addEventListener()` options parameters

### DIFF
--- a/types/web-bluetooth/index.d.ts
+++ b/types/web-bluetooth/index.d.ts
@@ -82,6 +82,10 @@ interface CharacteristicEventHandlers {
     oncharacteristicvaluechanged: (this: this, ev: Event) => any;
 }
 
+interface BluetoothRemoteGATTCharacteristicEventMap {
+    "characteristicvaluechanged": Event;
+}
+
 interface BluetoothRemoteGATTCharacteristic extends EventTarget, CharacteristicEventHandlers {
     readonly service: BluetoothRemoteGATTService;
     readonly uuid: string;
@@ -95,18 +99,22 @@ interface BluetoothRemoteGATTCharacteristic extends EventTarget, CharacteristicE
     writeValueWithoutResponse(value: BufferSource): Promise<void>;
     startNotifications(): Promise<BluetoothRemoteGATTCharacteristic>;
     stopNotifications(): Promise<BluetoothRemoteGATTCharacteristic>;
-    addEventListener(
-        type: "characteristicvaluechanged",
-        listener: (this: this, ev: Event) => any,
-        useCapture?: boolean,
-    ): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
+    addEventListener<K extends keyof BluetoothRemoteGATTCharacteristicEventMap>(type: K, listener: (this: BluetoothRemoteGATTCharacteristic, ev: BluetoothRemoteGATTCharacteristicEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof BluetoothRemoteGATTCharacteristicEventMap>(type: K, listener: (this: BluetoothRemoteGATTCharacteristic, ev: BluetoothRemoteGATTCharacteristicEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }
 
 interface ServiceEventHandlers {
     onserviceadded: (this: this, ev: Event) => any;
     onservicechanged: (this: this, ev: Event) => any;
     onserviceremoved: (this: this, ev: Event) => any;
+}
+
+interface BluetoothRemoteGATTServiceEventMap {
+    "serviceadded": Event;
+    "servicechanged": Event;
+    "serviceremoved": Event;
 }
 
 interface BluetoothRemoteGATTService extends EventTarget, CharacteristicEventHandlers, ServiceEventHandlers {
@@ -117,10 +125,10 @@ interface BluetoothRemoteGATTService extends EventTarget, CharacteristicEventHan
     getCharacteristics(characteristic?: BluetoothCharacteristicUUID): Promise<BluetoothRemoteGATTCharacteristic[]>;
     getIncludedService(service: BluetoothServiceUUID): Promise<BluetoothRemoteGATTService>;
     getIncludedServices(service?: BluetoothServiceUUID): Promise<BluetoothRemoteGATTService[]>;
-    addEventListener(type: "serviceadded", listener: (this: this, ev: Event) => any, useCapture?: boolean): void;
-    addEventListener(type: "servicechanged", listener: (this: this, ev: Event) => any, useCapture?: boolean): void;
-    addEventListener(type: "serviceremoved", listener: (this: this, ev: Event) => any, useCapture?: boolean): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
+    addEventListener<K extends keyof BluetoothRemoteGATTServiceEventMap>(type: K, listener: (this: BluetoothRemoteGATTService, ev: BluetoothRemoteGATTServiceEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof BluetoothRemoteGATTServiceEventMap>(type: K, listener: (this: BluetoothRemoteGATTService, ev: BluetoothRemoteGATTServiceEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }
 
 interface BluetoothRemoteGATTServer {
@@ -141,6 +149,11 @@ interface WatchAdvertisementsOptions {
     signal?: AbortSignal;
 }
 
+interface BluetoothDeviceEventMap {
+    "advertisementreceived": BluetoothAdvertisingEvent;
+    "gattserverdisconnected": Event;
+}
+
 interface BluetoothDevice
     extends EventTarget, BluetoothDeviceEventHandlers, CharacteristicEventHandlers, ServiceEventHandlers
 {
@@ -150,17 +163,15 @@ interface BluetoothDevice
     forget(): Promise<void>;
     watchAdvertisements(options?: WatchAdvertisementsOptions): Promise<void>;
     readonly watchingAdvertisements: boolean;
-    addEventListener(
-        type: "gattserverdisconnected",
-        listener: (this: this, ev: Event) => any,
-        useCapture?: boolean,
-    ): void;
-    addEventListener(
-        type: "advertisementreceived",
-        listener: (this: this, ev: BluetoothAdvertisingEvent) => any,
-        useCapture?: boolean,
-    ): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
+    addEventListener<K extends keyof BluetoothDeviceEventMap>(type: K, listener: (this: BluetoothDevice, ev: BluetoothDeviceEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof BluetoothDeviceEventMap>(type: K, listener: (this: BluetoothDevice, ev: BluetoothDeviceEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+}
+
+interface BluetoothEventMap {
+    "availabilitychanged": Event;
+    "advertisementreceived": BluetoothAdvertisingEvent;
 }
 
 interface Bluetooth
@@ -172,13 +183,10 @@ interface Bluetooth
     readonly referringDevice?: BluetoothDevice | undefined;
     requestDevice(options?: RequestDeviceOptions): Promise<BluetoothDevice>;
     requestLEScan(options?: BluetoothLEScanOptions): Promise<BluetoothLEScan>;
-    addEventListener(type: "availabilitychanged", listener: (this: this, ev: Event) => any, useCapture?: boolean): void;
-    addEventListener(
-        type: "advertisementreceived",
-        listener: (this: this, ev: BluetoothAdvertisingEvent) => any,
-        useCapture?: boolean,
-    ): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
+    addEventListener<K extends keyof BluetoothEventMap>(type: K, listener: (this: Bluetooth, ev: BluetoothEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof BluetoothEventMap>(type: K, listener: (this: Bluetooth, ev: BluetoothEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }
 
 declare namespace BluetoothUUID {

--- a/types/web-bluetooth/index.d.ts
+++ b/types/web-bluetooth/index.d.ts
@@ -99,10 +99,26 @@ interface BluetoothRemoteGATTCharacteristic extends EventTarget, CharacteristicE
     writeValueWithoutResponse(value: BufferSource): Promise<void>;
     startNotifications(): Promise<BluetoothRemoteGATTCharacteristic>;
     stopNotifications(): Promise<BluetoothRemoteGATTCharacteristic>;
-    addEventListener<K extends keyof BluetoothRemoteGATTCharacteristicEventMap>(type: K, listener: (this: BluetoothRemoteGATTCharacteristic, ev: BluetoothRemoteGATTCharacteristicEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener<K extends keyof BluetoothRemoteGATTCharacteristicEventMap>(type: K, listener: (this: BluetoothRemoteGATTCharacteristic, ev: BluetoothRemoteGATTCharacteristicEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    addEventListener<K extends keyof BluetoothRemoteGATTCharacteristicEventMap>(
+        type: K,
+        listener: (this: BluetoothRemoteGATTCharacteristic, ev: BluetoothRemoteGATTCharacteristicEventMap[K]) => any,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    addEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    removeEventListener<K extends keyof BluetoothRemoteGATTCharacteristicEventMap>(
+        type: K,
+        listener: (this: BluetoothRemoteGATTCharacteristic, ev: BluetoothRemoteGATTCharacteristicEventMap[K]) => any,
+        options?: boolean | EventListenerOptions,
+    ): void;
+    removeEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | EventListenerOptions,
+    ): void;
 }
 
 interface ServiceEventHandlers {
@@ -125,10 +141,26 @@ interface BluetoothRemoteGATTService extends EventTarget, CharacteristicEventHan
     getCharacteristics(characteristic?: BluetoothCharacteristicUUID): Promise<BluetoothRemoteGATTCharacteristic[]>;
     getIncludedService(service: BluetoothServiceUUID): Promise<BluetoothRemoteGATTService>;
     getIncludedServices(service?: BluetoothServiceUUID): Promise<BluetoothRemoteGATTService[]>;
-    addEventListener<K extends keyof BluetoothRemoteGATTServiceEventMap>(type: K, listener: (this: BluetoothRemoteGATTService, ev: BluetoothRemoteGATTServiceEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener<K extends keyof BluetoothRemoteGATTServiceEventMap>(type: K, listener: (this: BluetoothRemoteGATTService, ev: BluetoothRemoteGATTServiceEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    addEventListener<K extends keyof BluetoothRemoteGATTServiceEventMap>(
+        type: K,
+        listener: (this: BluetoothRemoteGATTService, ev: BluetoothRemoteGATTServiceEventMap[K]) => any,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    addEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    removeEventListener<K extends keyof BluetoothRemoteGATTServiceEventMap>(
+        type: K,
+        listener: (this: BluetoothRemoteGATTService, ev: BluetoothRemoteGATTServiceEventMap[K]) => any,
+        options?: boolean | EventListenerOptions,
+    ): void;
+    removeEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | EventListenerOptions,
+    ): void;
 }
 
 interface BluetoothRemoteGATTServer {
@@ -163,10 +195,26 @@ interface BluetoothDevice
     forget(): Promise<void>;
     watchAdvertisements(options?: WatchAdvertisementsOptions): Promise<void>;
     readonly watchingAdvertisements: boolean;
-    addEventListener<K extends keyof BluetoothDeviceEventMap>(type: K, listener: (this: BluetoothDevice, ev: BluetoothDeviceEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener<K extends keyof BluetoothDeviceEventMap>(type: K, listener: (this: BluetoothDevice, ev: BluetoothDeviceEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    addEventListener<K extends keyof BluetoothDeviceEventMap>(
+        type: K,
+        listener: (this: BluetoothDevice, ev: BluetoothDeviceEventMap[K]) => any,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    addEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    removeEventListener<K extends keyof BluetoothDeviceEventMap>(
+        type: K,
+        listener: (this: BluetoothDevice, ev: BluetoothDeviceEventMap[K]) => any,
+        options?: boolean | EventListenerOptions,
+    ): void;
+    removeEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | EventListenerOptions,
+    ): void;
 }
 
 interface BluetoothEventMap {
@@ -183,10 +231,26 @@ interface Bluetooth
     readonly referringDevice?: BluetoothDevice | undefined;
     requestDevice(options?: RequestDeviceOptions): Promise<BluetoothDevice>;
     requestLEScan(options?: BluetoothLEScanOptions): Promise<BluetoothLEScan>;
-    addEventListener<K extends keyof BluetoothEventMap>(type: K, listener: (this: Bluetooth, ev: BluetoothEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener<K extends keyof BluetoothEventMap>(type: K, listener: (this: Bluetooth, ev: BluetoothEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    addEventListener<K extends keyof BluetoothEventMap>(
+        type: K,
+        listener: (this: Bluetooth, ev: BluetoothEventMap[K]) => any,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    addEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    removeEventListener<K extends keyof BluetoothEventMap>(
+        type: K,
+        listener: (this: Bluetooth, ev: BluetoothEventMap[K]) => any,
+        options?: boolean | EventListenerOptions,
+    ): void;
+    removeEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | EventListenerOptions,
+    ): void;
 }
 
 declare namespace BluetoothUUID {

--- a/types/web-bluetooth/package.json
+++ b/types/web-bluetooth/package.json
@@ -24,6 +24,10 @@
         {
             "name": "David Bjerremose",
             "githubUsername": "DaBs"
+        },
+        {
+            "name": "Nathan Rajlich",
+            "githubUsername": "TooTallNate"
         }
     ]
 }

--- a/types/web-bluetooth/web-bluetooth-tests.ts
+++ b/types/web-bluetooth/web-bluetooth-tests.ts
@@ -25,6 +25,10 @@ navigator.bluetooth.addEventListener("advertisementreceived", event => {
     event; // $ExpectType BluetoothAdvertisingEvent
 });
 
+navigator.bluetooth.addEventListener("advertisementreceived", event => {
+    event; // $ExpectType BluetoothAdvertisingEvent
+}, { once: true, signal: AbortSignal.timeout(1000) });
+
 BluetoothUUID.getService(0x180D); // $ExpectType string
 
 BluetoothUUID.getCharacteristic(0x2A37); // $ExpectType string
@@ -92,6 +96,7 @@ function handleHeartRateMeasurementCharacteristic(characteristic: BluetoothRemot
     return characteristic.startNotifications()
         .then(char => {
             characteristic.addEventListener("characteristicvaluechanged", onHeartRateChanged);
+            characteristic.addEventListener("characteristicvaluechanged", onHeartRateChanged, { once: true, signal: AbortSignal.timeout(1000) });
         });
 }
 

--- a/types/web-bluetooth/web-bluetooth-tests.ts
+++ b/types/web-bluetooth/web-bluetooth-tests.ts
@@ -96,7 +96,10 @@ function handleHeartRateMeasurementCharacteristic(characteristic: BluetoothRemot
     return characteristic.startNotifications()
         .then(char => {
             characteristic.addEventListener("characteristicvaluechanged", onHeartRateChanged);
-            characteristic.addEventListener("characteristicvaluechanged", onHeartRateChanged, { once: true, signal: AbortSignal.timeout(1000) });
+            characteristic.addEventListener("characteristicvaluechanged", onHeartRateChanged, {
+                once: true,
+                signal: AbortSignal.timeout(1000),
+            });
         });
 }
 


### PR DESCRIPTION
Allows for an `EventListenerOptions` object to be passed to `addEventListener()` and `removeEventListener()` overloads to the Web Bluetooth classes that extend `EventTarget`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#options