### PR TITLE
[node] stream/consumers: cleanup, correct references to ReadableStream

### DIFF
--- a/types/node/stream/consumers.d.ts
+++ b/types/node/stream/consumers.d.ts
@@ -1,11 +1,37 @@
+/**
+ * The utility consumer functions provide common options for consuming
+ * streams.
+ * @since v16.7.0
+ */
 declare module "stream/consumers" {
     import { Blob as NodeBlob } from "node:buffer";
-    import { Readable } from "node:stream";
-    function buffer(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<Buffer>;
-    function text(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<string>;
-    function arrayBuffer(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<ArrayBuffer>;
-    function blob(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<NodeBlob>;
-    function json(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<unknown>;
+    import { ReadableStream as WebReadableStream } from "node:stream/web";
+    /**
+     * @since v16.7.0
+     * @returns Fulfills with an `ArrayBuffer` containing the full contents of the stream.
+     */
+    function arrayBuffer(stream: WebReadableStream | NodeJS.ReadableStream | AsyncIterable<any>): Promise<ArrayBuffer>;
+    /**
+     * @since v16.7.0
+     * @returns Fulfills with a `Blob` containing the full contents of the stream.
+     */
+    function blob(stream: WebReadableStream | NodeJS.ReadableStream | AsyncIterable<any>): Promise<NodeBlob>;
+    /**
+     * @since v16.7.0
+     * @returns Fulfills with a `Buffer` containing the full contents of the stream.
+     */
+    function buffer(stream: WebReadableStream | NodeJS.ReadableStream | AsyncIterable<any>): Promise<Buffer>;
+    /**
+     * @since v16.7.0
+     * @returns Fulfills with the contents of the stream parsed as a
+     * UTF-8 encoded string that is then passed through `JSON.parse()`.
+     */
+    function json(stream: WebReadableStream | NodeJS.ReadableStream | AsyncIterable<any>): Promise<unknown>;
+    /**
+     * @since v16.7.0
+     * @returns Fulfills with the contents of the stream parsed as a UTF-8 encoded string.
+     */
+    function text(stream: WebReadableStream | NodeJS.ReadableStream | AsyncIterable<any>): Promise<string>;
 }
 declare module "node:stream/consumers" {
     export * from "stream/consumers";

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -18,7 +18,7 @@ import { Blob } from "node:buffer";
 import { Http2ServerResponse } from "node:http2";
 import { performance } from "node:perf_hooks";
 import { stdout } from "node:process";
-import { arrayBuffer, blob, buffer, json, text } from "node:stream/consumers";
+import * as consumers from "node:stream/consumers";
 import { finished as finishedPromise, pipeline as pipelinePromise } from "node:stream/promises";
 import { ReadableStream, TransformStream, WritableStream } from "node:stream/web";
 import { setInterval as every, setTimeout as wait } from "node:timers/promises";
@@ -501,25 +501,18 @@ async function streamPipelineAsyncPromiseOptions() {
 }
 
 async function testConsumers() {
-    const r = createReadStream("file.txt");
+    let consumable!: ReadableStream | Readable | AsyncGenerator<any>;
 
-    // $ExpectType string
-    await text(r);
-    // $ExpectType unknown
-    await json(r);
-    // $ExpectType Buffer || Buffer<ArrayBufferLike>
-    await buffer(r);
     // $ExpectType ArrayBuffer
-    await arrayBuffer(r);
+    await consumers.arrayBuffer(consumable);
     // $ExpectType Blob
-    await blob(r);
-
-    const iterable: AsyncGenerator<Buffer> = async function*() {}();
-    await buffer(iterable);
-
-    const iterator: AsyncIterator<Buffer> = { next: () => iterable.next() };
-    // @ts-expect-error
-    await buffer(iterator);
+    await consumers.blob(consumable);
+    // $ExpectType Buffer || Buffer<ArrayBufferLike>
+    await consumers.buffer(consumable);
+    // $ExpectType unknown
+    await consumers.json(consumable);
+    // $ExpectType string
+    await consumers.text(consumable);
 }
 
 // https://nodejs.org/api/stream.html#stream_readable_pipe_destination_options

--- a/types/node/v18/stream/consumers.d.ts
+++ b/types/node/v18/stream/consumers.d.ts
@@ -1,11 +1,37 @@
+/**
+ * The utility consumer functions provide common options for consuming
+ * streams.
+ * @since v16.7.0
+ */
 declare module "stream/consumers" {
     import { Blob as NodeBlob } from "node:buffer";
-    import { Readable } from "node:stream";
-    function buffer(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<Buffer>;
-    function text(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<string>;
-    function arrayBuffer(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<ArrayBuffer>;
-    function blob(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<NodeBlob>;
-    function json(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<unknown>;
+    import { ReadableStream as WebReadableStream } from "node:stream/web";
+    /**
+     * @since v16.7.0
+     * @returns Fulfills with an `ArrayBuffer` containing the full contents of the stream.
+     */
+    function arrayBuffer(stream: WebReadableStream | NodeJS.ReadableStream | AsyncIterable<any>): Promise<ArrayBuffer>;
+    /**
+     * @since v16.7.0
+     * @returns Fulfills with a `Blob` containing the full contents of the stream.
+     */
+    function blob(stream: WebReadableStream | NodeJS.ReadableStream | AsyncIterable<any>): Promise<NodeBlob>;
+    /**
+     * @since v16.7.0
+     * @returns Fulfills with a `Buffer` containing the full contents of the stream.
+     */
+    function buffer(stream: WebReadableStream | NodeJS.ReadableStream | AsyncIterable<any>): Promise<Buffer>;
+    /**
+     * @since v16.7.0
+     * @returns Fulfills with the contents of the stream parsed as a
+     * UTF-8 encoded string that is then passed through `JSON.parse()`.
+     */
+    function json(stream: WebReadableStream | NodeJS.ReadableStream | AsyncIterable<any>): Promise<unknown>;
+    /**
+     * @since v16.7.0
+     * @returns Fulfills with the contents of the stream parsed as a UTF-8 encoded string.
+     */
+    function text(stream: WebReadableStream | NodeJS.ReadableStream | AsyncIterable<any>): Promise<string>;
 }
 declare module "node:stream/consumers" {
     export * from "stream/consumers";

--- a/types/node/v18/test/stream.ts
+++ b/types/node/v18/test/stream.ts
@@ -16,7 +16,7 @@ import assert = require("node:assert");
 import { Http2ServerResponse } from "node:http2";
 import { performance } from "node:perf_hooks";
 import { stdout } from "node:process";
-import { arrayBuffer, blob, buffer, json, text } from "node:stream/consumers";
+import * as consumers from "node:stream/consumers";
 import { finished as finishedPromise, pipeline as pipelinePromise } from "node:stream/promises";
 import { ReadableStream, TransformStream, WritableStream } from "node:stream/web";
 import { setInterval as every } from "node:timers/promises";
@@ -495,18 +495,18 @@ async function streamPipelineAsyncPromiseOptions() {
 }
 
 async function testConsumers() {
-    const r = createReadStream("file.txt");
+    let consumable!: ReadableStream | Readable | AsyncGenerator<any>;
 
-    // $ExpectType string
-    await text(r);
-    // $ExpectType unknown
-    await json(r);
-    // $ExpectType Buffer || Buffer<ArrayBufferLike>
-    await buffer(r);
     // $ExpectType ArrayBuffer
-    await arrayBuffer(r);
+    await consumers.arrayBuffer(consumable);
     // $ExpectType Blob
-    await blob(r);
+    await consumers.blob(consumable);
+    // $ExpectType Buffer || Buffer<ArrayBufferLike>
+    await consumers.buffer(consumable);
+    // $ExpectType unknown
+    await consumers.json(consumable);
+    // $ExpectType string
+    await consumers.text(consumable);
 }
 
 // https://nodejs.org/api/stream.html#stream_readable_pipe_destination_options

--- a/types/node/v20/stream/consumers.d.ts
+++ b/types/node/v20/stream/consumers.d.ts
@@ -1,11 +1,37 @@
+/**
+ * The utility consumer functions provide common options for consuming
+ * streams.
+ * @since v16.7.0
+ */
 declare module "stream/consumers" {
     import { Blob as NodeBlob } from "node:buffer";
-    import { Readable } from "node:stream";
-    function buffer(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<Buffer>;
-    function text(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<string>;
-    function arrayBuffer(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<ArrayBuffer>;
-    function blob(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<NodeBlob>;
-    function json(stream: NodeJS.ReadableStream | Readable | AsyncIterable<any>): Promise<unknown>;
+    import { ReadableStream as WebReadableStream } from "node:stream/web";
+    /**
+     * @since v16.7.0
+     * @returns Fulfills with an `ArrayBuffer` containing the full contents of the stream.
+     */
+    function arrayBuffer(stream: WebReadableStream | NodeJS.ReadableStream | AsyncIterable<any>): Promise<ArrayBuffer>;
+    /**
+     * @since v16.7.0
+     * @returns Fulfills with a `Blob` containing the full contents of the stream.
+     */
+    function blob(stream: WebReadableStream | NodeJS.ReadableStream | AsyncIterable<any>): Promise<NodeBlob>;
+    /**
+     * @since v16.7.0
+     * @returns Fulfills with a `Buffer` containing the full contents of the stream.
+     */
+    function buffer(stream: WebReadableStream | NodeJS.ReadableStream | AsyncIterable<any>): Promise<Buffer>;
+    /**
+     * @since v16.7.0
+     * @returns Fulfills with the contents of the stream parsed as a
+     * UTF-8 encoded string that is then passed through `JSON.parse()`.
+     */
+    function json(stream: WebReadableStream | NodeJS.ReadableStream | AsyncIterable<any>): Promise<unknown>;
+    /**
+     * @since v16.7.0
+     * @returns Fulfills with the contents of the stream parsed as a UTF-8 encoded string.
+     */
+    function text(stream: WebReadableStream | NodeJS.ReadableStream | AsyncIterable<any>): Promise<string>;
 }
 declare module "node:stream/consumers" {
     export * from "stream/consumers";

--- a/types/node/v20/test/stream.ts
+++ b/types/node/v20/test/stream.ts
@@ -18,7 +18,7 @@ import { Blob } from "node:buffer";
 import { Http2ServerResponse } from "node:http2";
 import { performance } from "node:perf_hooks";
 import { stdout } from "node:process";
-import { arrayBuffer, blob, buffer, json, text } from "node:stream/consumers";
+import * as consumers from "node:stream/consumers";
 import { finished as finishedPromise, pipeline as pipelinePromise } from "node:stream/promises";
 import { ReadableStream, TransformStream, WritableStream } from "node:stream/web";
 import { setInterval as every, setTimeout as wait } from "node:timers/promises";
@@ -501,25 +501,18 @@ async function streamPipelineAsyncPromiseOptions() {
 }
 
 async function testConsumers() {
-    const r = createReadStream("file.txt");
+    let consumable!: ReadableStream | Readable | AsyncGenerator<any>;
 
-    // $ExpectType string
-    await text(r);
-    // $ExpectType unknown
-    await json(r);
-    // $ExpectType Buffer || Buffer<ArrayBufferLike>
-    await buffer(r);
     // $ExpectType ArrayBuffer
-    await arrayBuffer(r);
+    await consumers.arrayBuffer(consumable);
     // $ExpectType Blob
-    await blob(r);
-
-    const iterable: AsyncGenerator<Buffer> = async function*() {}();
-    await buffer(iterable);
-
-    const iterator: AsyncIterator<Buffer> = { next: () => iterable.next() };
-    // @ts-expect-error
-    await buffer(iterator);
+    await consumers.blob(consumable);
+    // $ExpectType Buffer || Buffer<ArrayBufferLike>
+    await consumers.buffer(consumable);
+    // $ExpectType unknown
+    await consumers.json(consumable);
+    // $ExpectType string
+    await consumers.text(consumable);
 }
 
 // https://nodejs.org/api/stream.html#stream_readable_pipe_destination_options


### PR DESCRIPTION
These consumers are primarily designed to consume web `ReadableStream`s, but when these types were added, there appears to have been some confusion between this interface and the unrelated, but unhelpfully named, `NodeJS.ReadableStream`.

Since `ReadableStream`s are also assignable to `AsyncIterable`, this never really caused any problems, but the signatures could do with being corrected.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest/api/webstreams.html#utility-consumers
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
