### PR TITLE
[node] `node:timers` cleanup, restore `NodeJS` namespace to ambient-only

### DIFF
--- a/types/node/test/globals.ts
+++ b/types/node/test/globals.ts
@@ -61,3 +61,8 @@ declare var RANDOM_GLOBAL_VARIABLE: true;
     e.message; // $ExpectType string
     e.name; // $ExpectType string
 }
+
+{
+    // @ts-expect-error The pseudoglobal `NodeJS` namespace should not be addressable outside ambient contexts
+    NodeJS;
+}

--- a/types/node/test/timers_promises.ts
+++ b/types/node/test/timers_promises.ts
@@ -1,27 +1,42 @@
 import { TimerOptions } from "node:timers";
 import { scheduler, setImmediate, setInterval, setTimeout } from "node:timers/promises";
+
 const opts: TimerOptions = {
     ref: false,
     signal: new AbortController().signal,
 };
 
-const res: Promise<number> = setImmediate(123, opts);
-setImmediate(); // $ExpectType Promise<void>
+// $ExpectType Promise<number>
+setImmediate(123, opts);
+// $ExpectType Promise<number>
+setImmediate(123);
+// $ExpectType Promise<void>
+setImmediate();
 
-const res2: Promise<string> = setTimeout(123, "asd", opts);
-setTimeout(); // $ExpectType Promise<void>
+// $ExpectType Promise<string>
+setTimeout(123, "asd", opts);
+// $ExpectType Promise<string>
+setTimeout(123, "asd");
+// $ExpectType Promise<void>
+setTimeout(123);
+// $ExpectType Promise<void>
+setTimeout();
 
-const res3: AsyncIterable<string> = setInterval(123, "asd", opts);
-setInterval(); // $ExpectType AsyncIterable<void>
+// $ExpectType AsyncIterator<string, any, any>
+setInterval(123, "asd", opts);
+// $ExpectType AsyncIterator<string, any, any>
+setInterval(123, "asd");
+// $ExpectType AsyncIterator<void, any, any>
+setInterval(123);
+// $ExpectType AsyncIterator<void, any, any>
+setInterval();
 
-const res4: Promise<void> = scheduler.yield();
-scheduler.yield(); // $ExpectType Promise<void>
+// $ExpectType Promise<void>
+scheduler.wait(123, { signal: new AbortController().signal });
+// $ExpectType Promise<void>
+scheduler.wait(123);
+// @ts-expect-error
+scheduler.wait();
 
-const res5: Promise<void> = scheduler.wait(123, opts);
-scheduler.wait(); // $ExpectType Promise<void>
-
-(async () => {
-    for await (const test of setInterval(123, 1)) {
-        test; // $ExpectType number
-    }
-});
+// $ExpectType Promise<void>
+scheduler.yield();

--- a/types/node/timers.d.ts
+++ b/types/node/timers.d.ts
@@ -10,12 +10,8 @@
  */
 declare module "timers" {
     import { Abortable } from "node:events";
-    import {
-        setImmediate as setImmediatePromise,
-        setInterval as setIntervalPromise,
-        setTimeout as setTimeoutPromise,
-    } from "node:timers/promises";
-    interface TimerOptions extends Abortable {
+    import * as promises from "node:timers/promises";
+    export interface TimerOptions extends Abortable {
         /**
          * Set to `false` to indicate that the scheduled `Timeout`
          * should not require the Node.js event loop to remain active.
@@ -23,38 +19,33 @@ declare module "timers" {
          */
         ref?: boolean | undefined;
     }
-    let setTimeout: typeof global.setTimeout;
-    let clearTimeout: typeof global.clearTimeout;
-    let setInterval: typeof global.setInterval;
-    let clearInterval: typeof global.clearInterval;
-    let setImmediate: typeof global.setImmediate;
-    let clearImmediate: typeof global.clearImmediate;
     global {
         namespace NodeJS {
-            // compatibility with older typings
-            interface Timer extends RefCounted {
-                hasRef(): boolean;
-                refresh(): this;
-                [Symbol.toPrimitive](): number;
-            }
             /**
              * This object is created internally and is returned from `setImmediate()`. It
              * can be passed to `clearImmediate()` in order to cancel the scheduled
              * actions.
              *
              * By default, when an immediate is scheduled, the Node.js event loop will continue
-             * running as long as the immediate is active. The `Immediate` object returned by `setImmediate()` exports both `immediate.ref()` and `immediate.unref()` functions that can be used to
-             * control this default behavior.
+             * running as long as the immediate is active. The `Immediate` object returned by
+             * `setImmediate()` exports both `immediate.ref()` and `immediate.unref()`
+             * functions that can be used to control this default behavior.
              */
-            class Immediate implements RefCounted {
+            interface Immediate extends RefCounted, Disposable {
                 /**
-                 * When called, requests that the Node.js event loop _not_ exit so long as the `Immediate` is active. Calling `immediate.ref()` multiple times will have no
+                 * If true, the `Immediate` object will keep the Node.js event loop active.
+                 * @since v11.0.0
+                 */
+                hasRef(): boolean;
+                /**
+                 * When called, requests that the Node.js event loop _not_ exit so long as the
+                 * `Immediate` is active. Calling `immediate.ref()` multiple times will have no
                  * effect.
                  *
                  * By default, all `Immediate` objects are "ref'ed", making it normally unnecessary
                  * to call `immediate.ref()` unless `immediate.unref()` had been called previously.
                  * @since v9.7.0
-                 * @return a reference to `immediate`
+                 * @returns a reference to `immediate`
                  */
                 ref(): this;
                 /**
@@ -63,53 +54,59 @@ declare module "timers" {
                  * running, the process may exit before the `Immediate` object's callback is
                  * invoked. Calling `immediate.unref()` multiple times will have no effect.
                  * @since v9.7.0
-                 * @return a reference to `immediate`
+                 * @returns a reference to `immediate`
                  */
                 unref(): this;
                 /**
-                 * If true, the `Immediate` object will keep the Node.js event loop active.
-                 * @since v11.0.0
-                 */
-                hasRef(): boolean;
-                _onImmediate: Function; // to distinguish it from the Timeout class
-                /**
                  * Cancels the immediate. This is similar to calling `clearImmediate()`.
-                 * @since v20.5.0
+                 * @since v20.5.0, v18.18.0
+                 * @experimental
                  */
                 [Symbol.dispose](): void;
+                _onImmediate(...args: any[]): void;
+            }
+            // Legacy interface used in Node.js v9 and prior
+            // TODO: remove in a future major version bump
+            /** @deprecated Use `NodeJS.Timeout` instead. */
+            interface Timer extends RefCounted {
+                hasRef(): boolean;
+                refresh(): this;
+                [Symbol.toPrimitive](): number;
             }
             /**
-             * This object is created internally and is returned from `setTimeout()` and `setInterval()`. It can be passed to either `clearTimeout()` or `clearInterval()` in order to cancel the
-             * scheduled actions.
+             * This object is created internally and is returned from `setTimeout()` and
+             * `setInterval()`. It can be passed to either `clearTimeout()` or
+             * `clearInterval()` in order to cancel the scheduled actions.
              *
-             * By default, when a timer is scheduled using either `setTimeout()` or `setInterval()`, the Node.js event loop will continue running as long as the
+             * By default, when a timer is scheduled using either `setTimeout()` or
+             * `setInterval()`, the Node.js event loop will continue running as long as the
              * timer is active. Each of the `Timeout` objects returned by these functions
              * export both `timeout.ref()` and `timeout.unref()` functions that can be used to
              * control this default behavior.
              */
-            class Timeout implements Timer {
+            interface Timeout extends RefCounted, Disposable, Timer {
                 /**
-                 * When called, requests that the Node.js event loop _not_ exit so long as the`Timeout` is active. Calling `timeout.ref()` multiple times will have no effect.
-                 *
-                 * By default, all `Timeout` objects are "ref'ed", making it normally unnecessary
-                 * to call `timeout.ref()` unless `timeout.unref()` had been called previously.
+                 * Cancels the timeout.
                  * @since v0.9.1
-                 * @return a reference to `timeout`
+                 * @legacy Use `clearTimeout()` instead.
+                 * @returns a reference to `timeout`
                  */
-                ref(): this;
-                /**
-                 * When called, the active `Timeout` object will not require the Node.js event loop
-                 * to remain active. If there is no other activity keeping the event loop running,
-                 * the process may exit before the `Timeout` object's callback is invoked. Calling `timeout.unref()` multiple times will have no effect.
-                 * @since v0.9.1
-                 * @return a reference to `timeout`
-                 */
-                unref(): this;
+                close(): this;
                 /**
                  * If true, the `Timeout` object will keep the Node.js event loop active.
                  * @since v11.0.0
                  */
                 hasRef(): boolean;
+                /**
+                 * When called, requests that the Node.js event loop _not_ exit so long as the
+                 * `Timeout` is active. Calling `timeout.ref()` multiple times will have no effect.
+                 *
+                 * By default, all `Timeout` objects are "ref'ed", making it normally unnecessary
+                 * to call `timeout.ref()` unless `timeout.unref()` had been called previously.
+                 * @since v0.9.1
+                 * @returns a reference to `timeout`
+                 */
+                ref(): this;
                 /**
                  * Sets the timer's start time to the current time, and reschedules the timer to
                  * call its callback at the previously specified duration adjusted to the current
@@ -119,85 +116,37 @@ declare module "timers" {
                  * Using this on a timer that has already called its callback will reactivate the
                  * timer.
                  * @since v10.2.0
-                 * @return a reference to `timeout`
+                 * @returns a reference to `timeout`
                  */
                 refresh(): this;
+                /**
+                 * When called, the active `Timeout` object will not require the Node.js event loop
+                 * to remain active. If there is no other activity keeping the event loop running,
+                 * the process may exit before the `Timeout` object's callback is invoked. Calling
+                 * `timeout.unref()` multiple times will have no effect.
+                 * @since v0.9.1
+                 * @returns a reference to `timeout`
+                 */
+                unref(): this;
+                /**
+                 * Coerce a `Timeout` to a primitive. The primitive can be used to
+                 * clear the `Timeout`. The primitive can only be used in the
+                 * same thread where the timeout was created. Therefore, to use it
+                 * across `worker_threads` it must first be passed to the correct
+                 * thread. This allows enhanced compatibility with browser
+                 * `setTimeout()` and `setInterval()` implementations.
+                 * @since v14.9.0, v12.19.0
+                 */
                 [Symbol.toPrimitive](): number;
                 /**
                  * Cancels the timeout.
-                 * @since v20.5.0
+                 * @since v20.5.0, v18.18.0
+                 * @experimental
                  */
                 [Symbol.dispose](): void;
+                _onTimeout(...args: any[]): void;
             }
         }
-        /**
-         * Schedules execution of a one-time `callback` after `delay` milliseconds.
-         *
-         * The `callback` will likely not be invoked in precisely `delay` milliseconds.
-         * Node.js makes no guarantees about the exact timing of when callbacks will fire,
-         * nor of their ordering. The callback will be called as close as possible to the
-         * time specified.
-         *
-         * When `delay` is larger than `2147483647` or less than `1`, the `delay` will be set to `1`. Non-integer delays are truncated to an integer.
-         *
-         * If `callback` is not a function, a `TypeError` will be thrown.
-         *
-         * This method has a custom variant for promises that is available using `timersPromises.setTimeout()`.
-         * @since v0.0.1
-         * @param callback The function to call when the timer elapses.
-         * @param [delay=1] The number of milliseconds to wait before calling the `callback`.
-         * @param args Optional arguments to pass when the `callback` is called.
-         * @return for use with {@link clearTimeout}
-         */
-        function setTimeout<TArgs extends any[]>(
-            callback: (...args: TArgs) => void,
-            ms?: number,
-            ...args: TArgs
-        ): NodeJS.Timeout;
-        // util.promisify no rest args compability
-        // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-        function setTimeout(callback: (args: void) => void, ms?: number): NodeJS.Timeout;
-        namespace setTimeout {
-            const __promisify__: typeof setTimeoutPromise;
-        }
-        /**
-         * Cancels a `Timeout` object created by `setTimeout()`.
-         * @since v0.0.1
-         * @param timeout A `Timeout` object as returned by {@link setTimeout} or the `primitive` of the `Timeout` object as a string or a number.
-         */
-        function clearTimeout(timeoutId: NodeJS.Timeout | string | number | undefined): void;
-        /**
-         * Schedules repeated execution of `callback` every `delay` milliseconds.
-         *
-         * When `delay` is larger than `2147483647` or less than `1`, the `delay` will be
-         * set to `1`. Non-integer delays are truncated to an integer.
-         *
-         * If `callback` is not a function, a `TypeError` will be thrown.
-         *
-         * This method has a custom variant for promises that is available using `timersPromises.setInterval()`.
-         * @since v0.0.1
-         * @param callback The function to call when the timer elapses.
-         * @param [delay=1] The number of milliseconds to wait before calling the `callback`.
-         * @param args Optional arguments to pass when the `callback` is called.
-         * @return for use with {@link clearInterval}
-         */
-        function setInterval<TArgs extends any[]>(
-            callback: (...args: TArgs) => void,
-            ms?: number,
-            ...args: TArgs
-        ): NodeJS.Timeout;
-        // util.promisify no rest args compability
-        // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-        function setInterval(callback: (args: void) => void, ms?: number): NodeJS.Timeout;
-        namespace setInterval {
-            const __promisify__: typeof setIntervalPromise;
-        }
-        /**
-         * Cancels a `Timeout` object created by `setInterval()`.
-         * @since v0.0.1
-         * @param timeout A `Timeout` object as returned by {@link setInterval} or the `primitive` of the `Timeout` object as a string or a number.
-         */
-        function clearInterval(intervalId: NodeJS.Timeout | string | number | undefined): void;
         /**
          * Schedules the "immediate" execution of the `callback` after I/O events'
          * callbacks.
@@ -210,30 +159,128 @@ declare module "timers" {
          *
          * If `callback` is not a function, a `TypeError` will be thrown.
          *
-         * This method has a custom variant for promises that is available using `timersPromises.setImmediate()`.
+         * This method has a custom variant for promises that is available using
+         * `timersPromises.setImmediate()`.
          * @since v0.9.1
-         * @param callback The function to call at the end of this turn of the Node.js `Event Loop`
+         * @param callback The function to call at the end of this turn of
+         * the Node.js [Event Loop](https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/#setimmediate-vs-settimeout)
          * @param args Optional arguments to pass when the `callback` is called.
-         * @return for use with {@link clearImmediate}
+         * @returns for use with `clearImmediate()`
          */
         function setImmediate<TArgs extends any[]>(
             callback: (...args: TArgs) => void,
             ...args: TArgs
         ): NodeJS.Immediate;
-        // util.promisify no rest args compability
+        // Allow a single void-accepting argument to be optional in arguments lists.
+        // Allows usage such as `new Promise(resolve => setTimeout(resolve, ms))` (#54258)
         // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-        function setImmediate(callback: (args: void) => void): NodeJS.Immediate;
+        function setImmediate(callback: (_: void) => void): NodeJS.Immediate;
         namespace setImmediate {
-            const __promisify__: typeof setImmediatePromise;
+            import __promisify__ = promises.setImmediate;
+            export { __promisify__ };
+        }
+        /**
+         * Schedules repeated execution of `callback` every `delay` milliseconds.
+         *
+         * When `delay` is larger than `2147483647` or less than `1` or `NaN`, the `delay`
+         * will be set to `1`. Non-integer delays are truncated to an integer.
+         *
+         * If `callback` is not a function, a `TypeError` will be thrown.
+         *
+         * This method has a custom variant for promises that is available using
+         * `timersPromises.setInterval()`.
+         * @since v0.0.1
+         * @param callback The function to call when the timer elapses.
+         * @param delay The number of milliseconds to wait before calling the
+         * `callback`. **Default:** `1`.
+         * @param args Optional arguments to pass when the `callback` is called.
+         * @returns for use with `clearInterval()`
+         */
+        function setInterval<TArgs extends any[]>(
+            callback: (...args: TArgs) => void,
+            delay?: number,
+            ...args: TArgs
+        ): NodeJS.Timeout;
+        // Allow a single void-accepting argument to be optional in arguments lists.
+        // Allows usage such as `new Promise(resolve => setTimeout(resolve, ms))` (#54258)
+        // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+        function setInterval(callback: (_: void) => void, delay?: number): NodeJS.Timeout;
+        /**
+         * Schedules execution of a one-time `callback` after `delay` milliseconds.
+         *
+         * The `callback` will likely not be invoked in precisely `delay` milliseconds.
+         * Node.js makes no guarantees about the exact timing of when callbacks will fire,
+         * nor of their ordering. The callback will be called as close as possible to the
+         * time specified.
+         *
+         * When `delay` is larger than `2147483647` or less than `1` or `NaN`, the `delay`
+         * will be set to `1`. Non-integer delays are truncated to an integer.
+         *
+         * If `callback` is not a function, a `TypeError` will be thrown.
+         *
+         * This method has a custom variant for promises that is available using
+         * `timersPromises.setTimeout()`.
+         * @since v0.0.1
+         * @param callback The function to call when the timer elapses.
+         * @param delay The number of milliseconds to wait before calling the
+         * `callback`. **Default:** `1`.
+         * @param args Optional arguments to pass when the `callback` is called.
+         * @returns for use with `clearTimeout()`
+         */
+        function setTimeout<TArgs extends any[]>(
+            callback: (...args: TArgs) => void,
+            delay?: number,
+            ...args: TArgs
+        ): NodeJS.Timeout;
+        // Allow a single void-accepting argument to be optional in arguments lists.
+        // Allows usage such as `new Promise(resolve => setTimeout(resolve, ms))` (#54258)
+        // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+        function setTimeout(callback: (_: void) => void, delay?: number): NodeJS.Timeout;
+        namespace setTimeout {
+            import __promisify__ = promises.setTimeout;
+            export { __promisify__ };
         }
         /**
          * Cancels an `Immediate` object created by `setImmediate()`.
          * @since v0.9.1
-         * @param immediate An `Immediate` object as returned by {@link setImmediate}.
+         * @param immediate An `Immediate` object as returned by `setImmediate()`.
          */
-        function clearImmediate(immediateId: NodeJS.Immediate | undefined): void;
+        function clearImmediate(immediate: NodeJS.Immediate | undefined): void;
+        /**
+         * Cancels a `Timeout` object created by `setInterval()`.
+         * @since v0.0.1
+         * @param timeout A `Timeout` object as returned by `setInterval()`
+         * or the primitive of the `Timeout` object as a string or a number.
+         */
+        function clearInterval(timeout: NodeJS.Timeout | string | number | undefined): void;
+        /**
+         * Cancels a `Timeout` object created by `setTimeout()`.
+         * @since v0.0.1
+         * @param timeout A `Timeout` object as returned by `setTimeout()`
+         * or the primitive of the `Timeout` object as a string or a number.
+         */
+        function clearTimeout(timeout: NodeJS.Timeout | string | number | undefined): void;
+        /**
+         * The `queueMicrotask()` method queues a microtask to invoke `callback`. If
+         * `callback` throws an exception, the `process` object `'uncaughtException'`
+         * event will be emitted.
+         *
+         * The microtask queue is managed by V8 and may be used in a similar manner to
+         * the `process.nextTick()` queue, which is managed by Node.js. The
+         * `process.nextTick()` queue is always processed before the microtask queue
+         * within each turn of the Node.js event loop.
+         * @since v11.0.0
+         * @param callback Function to be queued.
+         */
         function queueMicrotask(callback: () => void): void;
     }
+    import clearImmediate = globalThis.clearImmediate;
+    import clearInterval = globalThis.clearInterval;
+    import clearTimeout = globalThis.clearTimeout;
+    import setImmediate = globalThis.setImmediate;
+    import setInterval = globalThis.setInterval;
+    import setTimeout = globalThis.setTimeout;
+    export { clearImmediate, clearInterval, clearTimeout, promises, setImmediate, setInterval, setTimeout };
 }
 declare module "node:timers" {
     export * from "timers";

--- a/types/node/timers/promises.d.ts
+++ b/types/node/timers/promises.d.ts
@@ -1,6 +1,7 @@
 /**
  * The `timers/promises` API provides an alternative set of timer functions
- * that return `Promise` objects. The API is accessible via `import timersPromises from 'node:timers/promises'`.
+ * that return `Promise` objects. The API is accessible via
+ * `require('node:timers/promises')`.
  *
  * ```js
  * import {
@@ -10,6 +11,7 @@
  * } from 'node:timers/promises';
  * ```
  * @since v15.0.0
+ * @see [source](https://github.com/nodejs/node/blob/v22.x/lib/timers/promises.js)
  */
 declare module "timers/promises" {
     import { TimerOptions } from "node:timers";
@@ -24,7 +26,8 @@ declare module "timers/promises" {
      * console.log(res);  // Prints 'result'
      * ```
      * @since v15.0.0
-     * @param [delay=1] The number of milliseconds to wait before fulfilling the promise.
+     * @param delay The number of milliseconds to wait before fulfilling the
+     * promise. **Default:** `1`.
      * @param value A value with which the promise is fulfilled.
      */
     function setTimeout<T = void>(delay?: number, value?: T, options?: TimerOptions): Promise<T>;
@@ -62,33 +65,41 @@ declare module "timers/promises" {
      * console.log(Date.now());
      * ```
      * @since v15.9.0
+     * @param delay The number of milliseconds to wait between iterations.
+     * **Default:** `1`.
+     * @param value A value with which the iterator returns.
      */
-    function setInterval<T = void>(delay?: number, value?: T, options?: TimerOptions): AsyncIterable<T>;
+    function setInterval<T = void>(delay?: number, value?: T, options?: TimerOptions): NodeJS.AsyncIterator<T>;
     interface Scheduler {
         /**
-         * An experimental API defined by the [Scheduling APIs](https://github.com/WICG/scheduling-apis) draft specification being developed as a standard Web Platform API.
+         * An experimental API defined by the [Scheduling APIs](https://github.com/WICG/scheduling-apis) draft specification
+         * being developed as a standard Web Platform API.
          *
-         * Calling `timersPromises.scheduler.wait(delay, options)` is roughly equivalent to calling `timersPromises.setTimeout(delay, undefined, options)` except that the `ref`
-         * option is not supported.
+         * Calling `timersPromises.scheduler.wait(delay, options)` is roughly equivalent
+         * to calling `timersPromises.setTimeout(delay, undefined, options)` except that
+         * the `ref` option is not supported.
          *
          * ```js
          * import { scheduler } from 'node:timers/promises';
          *
          * await scheduler.wait(1000); // Wait one second before continuing
          * ```
-         * @since v16.14.0
+         * @since v17.3.0, v16.14.0
          * @experimental
-         * @param [delay=1] The number of milliseconds to wait before fulfilling the promise.
+         * @param delay The number of milliseconds to wait before resolving the
+         * promise.
          */
-        wait: (delay?: number, options?: TimerOptions) => Promise<void>;
+        wait(delay: number, options?: { signal?: AbortSignal }): Promise<void>;
         /**
-         * An experimental API defined by the [Scheduling APIs](https://nodejs.org/docs/latest-v20.x/api/async_hooks.html#promise-execution-tracking) draft specification
+         * An experimental API defined by the [Scheduling APIs](https://github.com/WICG/scheduling-apis) draft specification
          * being developed as a standard Web Platform API.
-         * Calling `timersPromises.scheduler.yield()` is equivalent to calling `timersPromises.setImmediate()` with no arguments.
-         * @since v16.14.0
+         *
+         * Calling `timersPromises.scheduler.yield()` is equivalent to calling
+         * `timersPromises.setImmediate()` with no arguments.
+         * @since v17.3.0, v16.14.0
          * @experimental
          */
-        yield: () => Promise<void>;
+        yield(): Promise<void>;
     }
     const scheduler: Scheduler;
 }

--- a/types/node/v18/test/globals.ts
+++ b/types/node/v18/test/globals.ts
@@ -41,3 +41,8 @@ declare var RANDOM_GLOBAL_VARIABLE: true;
     x.reason; // $ExpectType any
     x.throwIfAborted(); // $ExpectType void
 }
+
+{
+    // @ts-expect-error The pseudoglobal `NodeJS` namespace should not be addressable outside ambient contexts
+    NodeJS;
+}

--- a/types/node/v18/test/timers.ts
+++ b/types/node/v18/test/timers.ts
@@ -1,108 +1,84 @@
 import * as timers from "node:timers";
 import { promisify } from "node:util";
+
 {
-    {
-        const immediate = timers
-            .setImmediate(() => {
-                console.log("immediate");
-            })
-            .unref()
-            .ref();
-        const b: boolean = immediate.hasRef();
-        timers.clearImmediate(immediate);
-    }
-    {
-        const timeout = timers
-            .setInterval(() => {
-                console.log("interval");
-            }, 20)
-            .unref()
-            .ref()
-            .refresh();
-        const b: boolean = timeout.hasRef();
-        timers.clearInterval(timeout);
-        timers.clearInterval(timeout[Symbol.toPrimitive]());
-    }
-    {
-        const timeout = timers
-            .setTimeout(() => {
-                console.log("timeout");
-            }, 20)
-            .unref()
-            .ref()
-            .refresh();
-        const b: boolean = timeout.hasRef();
-        timers.clearTimeout(timeout);
-        timers.clearTimeout(timeout[Symbol.toPrimitive]());
-    }
-    async function testPromisify(doSomething: {
-        (foo: any, onSuccessCallback: (result: string) => void, onErrorCallback: (reason: any) => void): void;
-        [promisify.custom](foo: any): Promise<string>;
-    }) {
-        const setTimeout = promisify(timers.setTimeout);
-        // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-        let v: void = await setTimeout(100);
-        let s: string = await setTimeout(100, "");
+    // $ExpectType Immediate
+    const immediate = timers.setImmediate(() => {});
+    // $ExpectType boolean
+    immediate.hasRef();
+    // $ExpectType Immediate
+    immediate.ref();
+    // $ExpectType Immediate
+    immediate.unref();
 
-        const setImmediate = promisify(timers.setImmediate);
-        v = await setImmediate();
-        s = await setImmediate("");
-
-        // $ExpectType (foo: any) => Promise<string>
-        const doSomethingPromise = promisify(doSomething);
-
-        // $ExpectType string
-        s = await doSomethingPromise("foo");
-    }
+    timers.clearImmediate(immediate);
+    immediate[Symbol.dispose]();
 }
 
 {
-    const setTimeout = promisify(timers.setTimeout);
+    // $ExpectType Timeout
+    const interval = timers.setInterval(() => {}, 100);
+    // $ExpectType Timeout
+    interval.close();
+    // $ExpectType boolean
+    interval.hasRef();
+    // $ExpectType Timeout
+    interval.ref();
+    // $ExpectType Timeout
+    interval.refresh();
+    // $ExpectType Timeout
+    interval.unref();
 
-    const ac = new AbortController();
-
-    const signal = ac.signal;
-    setTimeout(10, undefined, { signal });
-    ac.abort();
+    timers.clearInterval(interval);
+    timers.clearInterval(interval[Symbol.toPrimitive]());
+    interval[Symbol.dispose]();
 }
 
 {
-    const setImmediate = promisify(timers.setImmediate);
+    // $ExpectType Timeout
+    const timeout = timers.setTimeout(() => {}, 100);
+    // $ExpectType Timeout
+    timeout.close();
+    // $ExpectType boolean
+    timeout.hasRef();
+    // $ExpectType Timeout
+    timeout.ref();
+    // $ExpectType Timeout
+    timeout.refresh();
+    // $ExpectType Timeout
+    timeout.unref();
 
-    const ac = new AbortController();
-
-    const signal = ac.signal;
-    setImmediate(10, { signal });
-    ac.abort();
+    timers.clearTimeout(timeout);
+    timers.clearTimeout(timeout[Symbol.toPrimitive]());
+    timeout[Symbol.dispose]();
 }
 
-// unresolved callback argument types
+// Test custom promisifiers
+{
+    const setImmediate: typeof import("node:timers/promises").setImmediate = promisify(timers.setImmediate);
+    const setTimeout: typeof import("node:timers/promises").setTimeout = promisify(timers.setTimeout);
+    // @ts-expect-error setInterval is not promisifiable
+    const setInterval: typeof import("node:timers/promises").setInterval = promisify(timers.setInterval);
+}
+
+// Allow single callback parameter of type `unknown` to be omitted from passed arguments
 {
     // `NodeJS.*` is present to make sure we're not using `dom` types
     new Promise((resolve): NodeJS.Timeout => timers.setTimeout(resolve, 100));
-    new Promise((resolve): NodeJS.Timer => timers.setInterval(resolve, 100));
-    // tslint:disable-next-line no-unnecessary-callback-wrapper
+    new Promise((resolve): NodeJS.Timeout => timers.setInterval(resolve, 100));
     new Promise((resolve): NodeJS.Immediate => timers.setImmediate(resolve));
+    // @ts-expect-error single argument should not be optional if not of type `unknown`
+    const timeout: NodeJS.Timeout = timers.setTimeout((s: string) => {}, 100);
 }
 
 // globals
 {
-    setTimeout((a: number, b: string) => {}, 12, 1, "test");
-    setInterval((a: number, b: string) => {}, 12, 1, "test");
-    setImmediate((a: number, b: string) => {}, 1, "test");
-    queueMicrotask(() => {
-        // cool
-    });
+    const setImmediate: typeof timers.setImmediate = globalThis.setImmediate;
+    const setInterval: typeof timers.setInterval = globalThis.setInterval;
+    const setTimeout: typeof timers.setTimeout = globalThis.setTimeout;
+    const clearImmediate: typeof timers.clearImmediate = globalThis.clearImmediate;
+    const clearInterval: typeof timers.clearInterval = globalThis.clearInterval;
+    const clearTimeout: typeof timers.clearTimeout = globalThis.clearTimeout;
 
-    function waitFor(options?: { timeout: number }) {
-        const timerId = options && setTimeout(() => {}, options.timeout);
-        clearTimeout(timerId);
-        timerId?.[Symbol.dispose]();
-        const intervalId = options && setTimeout(() => {}, options.timeout);
-        clearInterval(intervalId);
-        intervalId?.[Symbol.dispose]();
-        const immediateId = options && setImmediate(() => {});
-        clearImmediate(immediateId);
-        immediateId?.[Symbol.dispose]();
-    }
+    queueMicrotask(() => {});
 }

--- a/types/node/v18/test/timers_promises.ts
+++ b/types/node/v18/test/timers_promises.ts
@@ -1,27 +1,42 @@
 import { TimerOptions } from "node:timers";
 import { scheduler, setImmediate, setInterval, setTimeout } from "node:timers/promises";
+
 const opts: TimerOptions = {
     ref: false,
     signal: new AbortController().signal,
 };
 
-const res: Promise<number> = setImmediate(123, opts);
-setImmediate(); // $ExpectType Promise<void>
+// $ExpectType Promise<number>
+setImmediate(123, opts);
+// $ExpectType Promise<number>
+setImmediate(123);
+// $ExpectType Promise<void>
+setImmediate();
 
-const res2: Promise<string> = setTimeout(123, "asd", opts);
-setTimeout(); // $ExpectType Promise<void>
+// $ExpectType Promise<string>
+setTimeout(123, "asd", opts);
+// $ExpectType Promise<string>
+setTimeout(123, "asd");
+// $ExpectType Promise<void>
+setTimeout(123);
+// $ExpectType Promise<void>
+setTimeout();
 
-const res3: AsyncIterable<string> = setInterval(123, "asd", opts);
-setInterval(); // $ExpectType AsyncIterable<void>
+// $ExpectType AsyncIterator<string, any, any>
+setInterval(123, "asd", opts);
+// $ExpectType AsyncIterator<string, any, any>
+setInterval(123, "asd");
+// $ExpectType AsyncIterator<void, any, any>
+setInterval(123);
+// $ExpectType AsyncIterator<void, any, any>
+setInterval();
 
-const res4: Promise<void> = scheduler.yield();
-scheduler.yield(); // $ExpectType Promise<void>
+// $ExpectType Promise<void>
+scheduler.wait(123, { signal: new AbortController().signal });
+// $ExpectType Promise<void>
+scheduler.wait(123);
+// @ts-expect-error
+scheduler.wait();
 
-const res5: Promise<void> = scheduler.wait(123);
-scheduler.wait(); // $ExpectType Promise<void>
-
-(async () => {
-    for await (const test of setInterval(123, 1)) {
-        test; // $ExpectType number
-    }
-});
+// $ExpectType Promise<void>
+scheduler.yield();

--- a/types/node/v18/timers.d.ts
+++ b/types/node/v18/timers.d.ts
@@ -6,16 +6,12 @@
  * The timer functions within Node.js implement a similar API as the timers API
  * provided by Web Browsers but use a different internal implementation that is
  * built around the Node.js [Event Loop](https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/#setimmediate-vs-settimeout).
- * @see [source](https://github.com/nodejs/node/blob/v18.0.0/lib/timers.js)
+ * @see [source](https://github.com/nodejs/node/blob/v18.x/lib/timers.js)
  */
 declare module "timers" {
     import { Abortable } from "node:events";
-    import {
-        setImmediate as setImmediatePromise,
-        setInterval as setIntervalPromise,
-        setTimeout as setTimeoutPromise,
-    } from "node:timers/promises";
-    interface TimerOptions extends Abortable {
+    import * as promises from "node:timers/promises";
+    export interface TimerOptions extends Abortable {
         /**
          * Set to `false` to indicate that the scheduled `Timeout`
          * should not require the Node.js event loop to remain active.
@@ -23,39 +19,93 @@ declare module "timers" {
          */
         ref?: boolean | undefined;
     }
-    let setTimeout: typeof global.setTimeout;
-    let clearTimeout: typeof global.clearTimeout;
-    let setInterval: typeof global.setInterval;
-    let clearInterval: typeof global.clearInterval;
-    let setImmediate: typeof global.setImmediate;
-    let clearImmediate: typeof global.clearImmediate;
     global {
         namespace NodeJS {
-            // compatibility with older typings
-            interface Timer extends RefCounted {
-                hasRef(): boolean;
-                refresh(): this;
-                [Symbol.toPrimitive](): number;
-            }
-            interface Immediate extends RefCounted {
+            /**
+             * This object is created internally and is returned from `setImmediate()`. It
+             * can be passed to `clearImmediate()` in order to cancel the scheduled
+             * actions.
+             *
+             * By default, when an immediate is scheduled, the Node.js event loop will continue
+             * running as long as the immediate is active. The `Immediate` object returned by
+             * `setImmediate()` exports both `immediate.ref()` and `immediate.unref()`
+             * functions that can be used to control this default behavior.
+             */
+            interface Immediate extends RefCounted, Disposable {
                 /**
                  * If true, the `Immediate` object will keep the Node.js event loop active.
                  * @since v11.0.0
                  */
                 hasRef(): boolean;
-                _onImmediate: Function; // to distinguish it from the Timeout class
+                /**
+                 * When called, requests that the Node.js event loop _not_ exit so long as the
+                 * `Immediate` is active. Calling `immediate.ref()` multiple times will have no
+                 * effect.
+                 *
+                 * By default, all `Immediate` objects are "ref'ed", making it normally unnecessary
+                 * to call `immediate.ref()` unless `immediate.unref()` had been called previously.
+                 * @since v9.7.0
+                 * @returns a reference to `immediate`
+                 */
+                ref(): this;
+                /**
+                 * When called, the active `Immediate` object will not require the Node.js event
+                 * loop to remain active. If there is no other activity keeping the event loop
+                 * running, the process may exit before the `Immediate` object's callback is
+                 * invoked. Calling `immediate.unref()` multiple times will have no effect.
+                 * @since v9.7.0
+                 * @returns a reference to `immediate`
+                 */
+                unref(): this;
                 /**
                  * Cancels the immediate. This is similar to calling `clearImmediate()`.
                  * @since v18.18.0
+                 * @experimental
                  */
                 [Symbol.dispose](): void;
+                _onImmediate(...args: any[]): void;
             }
-            interface Timeout extends Timer {
+            // Legacy interface used in Node.js v9 and prior
+            /** @deprecated Use `NodeJS.Timeout` instead. */
+            interface Timer extends RefCounted {
+                hasRef(): boolean;
+                refresh(): this;
+                [Symbol.toPrimitive](): number;
+            }
+            /**
+             * This object is created internally and is returned from `setTimeout()` and
+             * `setInterval()`. It can be passed to either `clearTimeout()` or
+             * `clearInterval()` in order to cancel the scheduled actions.
+             *
+             * By default, when a timer is scheduled using either `setTimeout()` or
+             * `setInterval()`, the Node.js event loop will continue running as long as the
+             * timer is active. Each of the `Timeout` objects returned by these functions
+             * export both `timeout.ref()` and `timeout.unref()` functions that can be used to
+             * control this default behavior.
+             */
+            interface Timeout extends RefCounted, Disposable, Timer {
+                /**
+                 * Cancels the timeout.
+                 * @since v0.9.1
+                 * @legacy Use `clearTimeout()` instead.
+                 * @returns a reference to `timeout`
+                 */
+                close(): this;
                 /**
                  * If true, the `Timeout` object will keep the Node.js event loop active.
                  * @since v11.0.0
                  */
                 hasRef(): boolean;
+                /**
+                 * When called, requests that the Node.js event loop _not_ exit so long as the
+                 * `Timeout` is active. Calling `timeout.ref()` multiple times will have no effect.
+                 *
+                 * By default, all `Timeout` objects are "ref'ed", making it normally unnecessary
+                 * to call `timeout.ref()` unless `timeout.unref()` had been called previously.
+                 * @since v0.9.1
+                 * @returns a reference to `timeout`
+                 */
+                ref(): this;
                 /**
                  * Sets the timer's start time to the current time, and reschedules the timer to
                  * call its callback at the previously specified duration adjusted to the current
@@ -65,61 +115,171 @@ declare module "timers" {
                  * Using this on a timer that has already called its callback will reactivate the
                  * timer.
                  * @since v10.2.0
-                 * @return a reference to `timeout`
+                 * @returns a reference to `timeout`
                  */
                 refresh(): this;
+                /**
+                 * When called, the active `Timeout` object will not require the Node.js event loop
+                 * to remain active. If there is no other activity keeping the event loop running,
+                 * the process may exit before the `Timeout` object's callback is invoked. Calling
+                 * `timeout.unref()` multiple times will have no effect.
+                 * @since v0.9.1
+                 * @returns a reference to `timeout`
+                 */
+                unref(): this;
+                /**
+                 * Coerce a `Timeout` to a primitive. The primitive can be used to
+                 * clear the `Timeout`. The primitive can only be used in the
+                 * same thread where the timeout was created. Therefore, to use it
+                 * across `worker_threads` it must first be passed to the correct
+                 * thread. This allows enhanced compatibility with browser
+                 * `setTimeout()` and `setInterval()` implementations.
+                 * @since v14.9.0, v12.19.0
+                 */
                 [Symbol.toPrimitive](): number;
                 /**
                  * Cancels the timeout.
                  * @since v18.18.0
+                 * @experimental
                  */
                 [Symbol.dispose](): void;
+                _onTimeout(...args: any[]): void;
             }
         }
         /**
-         * Schedules execution of a one-time `callback` after `delay` milliseconds. The `callback` will likely not be invoked in precisely `delay` milliseconds.
-         * Node.js makes no guarantees about the exact timing of when callbacks will fire, nor of their ordering. The callback will be called as close as possible to the time specified.
-         * When `delay` is larger than `2147483647` or less than `1`, the `delay` will be set to `1`. Non-integer delays are truncated to an integer.
-         * If `callback` is not a function, a [TypeError](https://nodejs.org/api/errors.html#class-typeerror) will be thrown.
+         * Schedules the "immediate" execution of the `callback` after I/O events'
+         * callbacks.
+         *
+         * When multiple calls to `setImmediate()` are made, the `callback` functions are
+         * queued for execution in the order in which they are created. The entire callback
+         * queue is processed every event loop iteration. If an immediate timer is queued
+         * from inside an executing callback, that timer will not be triggered until the
+         * next event loop iteration.
+         *
+         * If `callback` is not a function, a `TypeError` will be thrown.
+         *
+         * This method has a custom variant for promises that is available using
+         * `timersPromises.setImmediate()`.
+         * @since v0.9.1
+         * @param callback The function to call at the end of this turn of
+         * the Node.js [Event Loop](https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/#setimmediate-vs-settimeout)
+         * @param args Optional arguments to pass when the `callback` is called.
+         * @returns for use with `clearImmediate()`
+         */
+        function setImmediate<TArgs extends any[]>(
+            callback: (...args: TArgs) => void,
+            ...args: TArgs
+        ): NodeJS.Immediate;
+        // Allow a single void-accepting argument to be optional in arguments lists.
+        // Allows usage such as `new Promise(resolve => setTimeout(resolve, ms))` (#54258)
+        // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+        function setImmediate(callback: (_: void) => void): NodeJS.Immediate;
+        namespace setImmediate {
+            import __promisify__ = promises.setImmediate;
+            export { __promisify__ };
+        }
+        /**
+         * Schedules repeated execution of `callback` every `delay` milliseconds.
+         *
+         * When `delay` is larger than `2147483647` or less than `1`, the `delay` will be
+         * set to `1`. Non-integer delays are truncated to an integer.
+         *
+         * If `callback` is not a function, a `TypeError` will be thrown.
+         *
+         * This method has a custom variant for promises that is available using
+         * `timersPromises.setInterval()`.
          * @since v0.0.1
+         * @param callback The function to call when the timer elapses.
+         * @param delay The number of milliseconds to wait before calling the
+         * `callback`. **Default:** `1`.
+         * @param args Optional arguments to pass when the `callback` is called.
+         * @returns for use with `clearInterval()`
+         */
+        function setInterval<TArgs extends any[]>(
+            callback: (...args: TArgs) => void,
+            delay?: number,
+            ...args: TArgs
+        ): NodeJS.Timeout;
+        // Allow a single void-accepting argument to be optional in arguments lists.
+        // Allows usage such as `new Promise(resolve => setTimeout(resolve, ms))` (#54258)
+        // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+        function setInterval(callback: (_: void) => void, delay?: number): NodeJS.Timeout;
+        /**
+         * Schedules execution of a one-time `callback` after `delay` milliseconds.
+         *
+         * The `callback` will likely not be invoked in precisely `delay` milliseconds.
+         * Node.js makes no guarantees about the exact timing of when callbacks will fire,
+         * nor of their ordering. The callback will be called as close as possible to the
+         * time specified.
+         *
+         * When `delay` is larger than `2147483647` or less than `1` or `NaN`, the `delay`
+         * will be set to `1`. Non-integer delays are truncated to an integer.
+         *
+         * If `callback` is not a function, a `TypeError` will be thrown.
+         *
+         * This method has a custom variant for promises that is available using
+         * `timersPromises.setTimeout()`.
+         * @since v0.0.1
+         * @param callback The function to call when the timer elapses.
+         * @param delay The number of milliseconds to wait before calling the
+         * `callback`. **Default:** `1`.
+         * @param args Optional arguments to pass when the `callback` is called.
+         * @returns for use with `clearTimeout()`
          */
         function setTimeout<TArgs extends any[]>(
             callback: (...args: TArgs) => void,
             delay?: number,
             ...args: TArgs
         ): NodeJS.Timeout;
-        // util.promisify no rest args compability
+        // Allow a single void-accepting argument to be optional in arguments lists.
+        // Allows usage such as `new Promise(resolve => setTimeout(resolve, ms))` (#54258)
         // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-        function setTimeout(callback: (args: void) => void, delay?: number): NodeJS.Timeout;
+        function setTimeout(callback: (_: void) => void, delay?: number): NodeJS.Timeout;
         namespace setTimeout {
-            const __promisify__: typeof setTimeoutPromise;
+            import __promisify__ = promises.setTimeout;
+            export { __promisify__ };
         }
-        function clearTimeout(timeoutId: NodeJS.Timeout | string | number | undefined): void;
-        function setInterval<TArgs extends any[]>(
-            callback: (...args: TArgs) => void,
-            delay?: number,
-            ...args: TArgs
-        ): NodeJS.Timeout;
-        // util.promisify no rest args compability
-        // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-        function setInterval(callback: (args: void) => void, delay?: number): NodeJS.Timeout;
-        namespace setInterval {
-            const __promisify__: typeof setIntervalPromise;
-        }
-        function clearInterval(intervalId: NodeJS.Timeout | string | number | undefined): void;
-        function setImmediate<TArgs extends any[]>(
-            callback: (...args: TArgs) => void,
-            ...args: TArgs
-        ): NodeJS.Immediate;
-        // util.promisify no rest args compability
-        // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-        function setImmediate(callback: (args: void) => void): NodeJS.Immediate;
-        namespace setImmediate {
-            const __promisify__: typeof setImmediatePromise;
-        }
-        function clearImmediate(immediateId: NodeJS.Immediate | undefined): void;
+        /**
+         * Cancels an `Immediate` object created by `setImmediate()`.
+         * @since v0.9.1
+         * @param immediate An `Immediate` object as returned by `setImmediate()`.
+         */
+        function clearImmediate(immediate: NodeJS.Immediate | undefined): void;
+        /**
+         * Cancels a `Timeout` object created by `setInterval()`.
+         * @since v0.0.1
+         * @param timeout A `Timeout` object as returned by `setInterval()`
+         * or the primitive of the `Timeout` object as a string or a number.
+         */
+        function clearInterval(timeout: NodeJS.Timeout | string | number | undefined): void;
+        /**
+         * Cancels a `Timeout` object created by `setTimeout()`.
+         * @since v0.0.1
+         * @param timeout A `Timeout` object as returned by `setTimeout()`
+         * or the primitive of the `Timeout` object as a string or a number.
+         */
+        function clearTimeout(timeout: NodeJS.Timeout | string | number | undefined): void;
+        /**
+         * The `queueMicrotask()` method queues a microtask to invoke `callback`. If
+         * `callback` throws an exception, the `process` object `'uncaughtException'`
+         * event will be emitted.
+         *
+         * The microtask queue is managed by V8 and may be used in a similar manner to
+         * the `process.nextTick()` queue, which is managed by Node.js. The
+         * `process.nextTick()` queue is always processed before the microtask queue
+         * within each turn of the Node.js event loop.
+         * @since v11.0.0
+         * @param callback Function to be queued.
+         */
         function queueMicrotask(callback: () => void): void;
     }
+    import clearImmediate = globalThis.clearImmediate;
+    import clearInterval = globalThis.clearInterval;
+    import clearTimeout = globalThis.clearTimeout;
+    import setImmediate = globalThis.setImmediate;
+    import setInterval = globalThis.setInterval;
+    import setTimeout = globalThis.setTimeout;
+    export { clearImmediate, clearInterval, clearTimeout, setImmediate, setInterval, setTimeout };
 }
 declare module "node:timers" {
     export * from "timers";

--- a/types/node/v18/timers/promises.d.ts
+++ b/types/node/v18/timers/promises.d.ts
@@ -1,6 +1,7 @@
 /**
  * The `timers/promises` API provides an alternative set of timer functions
- * that return `Promise` objects. The API is accessible via `import timersPromises from 'node:timers/promises'`.
+ * that return `Promise` objects. The API is accessible via
+ * `require('node:timers/promises')`.
  *
  * ```js
  * import {
@@ -10,6 +11,7 @@
  * } from 'timers/promises';
  * ```
  * @since v15.0.0
+ * @see [source](https://github.com/nodejs/node/blob/v18.x/lib/timers/promises.js)
  */
 declare module "timers/promises" {
     import { TimerOptions } from "node:timers";
@@ -17,14 +19,15 @@ declare module "timers/promises" {
      * ```js
      * import {
      *   setTimeout,
-     * } from 'timers/promises';
+     * } from 'node:timers/promises';
      *
      * const res = await setTimeout(100, 'result');
      *
      * console.log(res);  // Prints 'result'
      * ```
      * @since v15.0.0
-     * @param [delay=1] The number of milliseconds to wait before fulfilling the promise.
+     * @param delay The number of milliseconds to wait before fulfilling the
+     * promise. **Default:** `1`.
      * @param value A value with which the promise is fulfilled.
      */
     function setTimeout<T = void>(delay?: number, value?: T, options?: TimerOptions): Promise<T>;
@@ -32,7 +35,7 @@ declare module "timers/promises" {
      * ```js
      * import {
      *   setImmediate,
-     * } from 'timers/promises';
+     * } from 'node:timers/promises';
      *
      * const res = await setImmediate('result');
      *
@@ -44,11 +47,13 @@ declare module "timers/promises" {
     function setImmediate<T = void>(value?: T, options?: TimerOptions): Promise<T>;
     /**
      * Returns an async iterator that generates values in an interval of `delay` ms.
+     * If `ref` is `true`, you need to call `next()` of async iterator explicitly
+     * or implicitly to keep the event loop alive.
      *
      * ```js
      * import {
      *   setInterval,
-     * } from 'timers/promises';
+     * } from 'node:timers/promises';
      *
      * const interval = 100;
      * for await (const startTime of setInterval(interval, Date.now())) {
@@ -60,32 +65,42 @@ declare module "timers/promises" {
      * console.log(Date.now());
      * ```
      * @since v15.9.0
+     * @param delay The number of milliseconds to wait between iterations.
+     * **Default:** `1`.
+     * @param value A value with which the iterator returns.
      */
-    function setInterval<T = void>(delay?: number, value?: T, options?: TimerOptions): AsyncIterable<T>;
-
+    function setInterval<T = void>(delay?: number, value?: T, options?: TimerOptions): NodeJS.AsyncIterator<T>;
     interface Scheduler {
         /**
+         * An experimental API defined by the [Scheduling APIs](https://github.com/WICG/scheduling-apis) draft specification
+         * being developed as a standard Web Platform API.
+         *
+         * Calling `timersPromises.scheduler.wait(delay, options)` is roughly equivalent
+         * to calling `timersPromises.setTimeout(delay, undefined, options)` except that
+         * the `ref` option is not supported.
+         *
          * ```js
          * import { scheduler } from 'node:timers/promises';
          *
          * await scheduler.wait(1000); // Wait one second before continuing
          * ```
-         * An experimental API defined by the Scheduling APIs draft specification being developed as a standard Web Platform API.
-         * Calling timersPromises.scheduler.wait(delay, options) is roughly equivalent to calling timersPromises.setTimeout(delay, undefined, options) except that the ref option is not supported.
-         * @since v16.14.0
+         * @since v17.3.0, v16.14.0
          * @experimental
-         * @param [delay=1] The number of milliseconds to wait before fulfilling the promise.
+         * @param delay The number of milliseconds to wait before resolving the
+         * promise.
          */
-        wait: (delay?: number, options?: TimerOptions) => Promise<void>;
+        wait(delay: number, options?: { signal?: AbortSignal }): Promise<void>;
         /**
-         * An experimental API defined by the Scheduling APIs draft specification being developed as a standard Web Platform API.
-         * Calling timersPromises.scheduler.yield() is equivalent to calling timersPromises.setImmediate() with no arguments.
-         * @since v16.14.0
+         * An experimental API defined by the [Scheduling APIs](https://github.com/WICG/scheduling-apis) draft specification
+         * being developed as a standard Web Platform API.
+         *
+         * Calling `timersPromises.scheduler.yield()` is equivalent to calling
+         * `timersPromises.setImmediate()` with no arguments.
+         * @since v17.3.0, v16.14.0
          * @experimental
          */
-        yield: () => Promise<void>;
+        yield(): Promise<void>;
     }
-
     const scheduler: Scheduler;
 }
 declare module "node:timers/promises" {

--- a/types/node/v20/test/globals.ts
+++ b/types/node/v20/test/globals.ts
@@ -41,3 +41,8 @@ declare var RANDOM_GLOBAL_VARIABLE: true;
     x.reason; // $ExpectType any
     x.throwIfAborted(); // $ExpectType void
 }
+
+{
+    // @ts-expect-error The pseudoglobal `NodeJS` namespace should not be addressable outside ambient contexts
+    NodeJS;
+}

--- a/types/node/v20/test/timers_promises.ts
+++ b/types/node/v20/test/timers_promises.ts
@@ -1,27 +1,42 @@
 import { TimerOptions } from "node:timers";
 import { scheduler, setImmediate, setInterval, setTimeout } from "node:timers/promises";
+
 const opts: TimerOptions = {
     ref: false,
     signal: new AbortController().signal,
 };
 
-const res: Promise<number> = setImmediate(123, opts);
-setImmediate(); // $ExpectType Promise<void>
+// $ExpectType Promise<number>
+setImmediate(123, opts);
+// $ExpectType Promise<number>
+setImmediate(123);
+// $ExpectType Promise<void>
+setImmediate();
 
-const res2: Promise<string> = setTimeout(123, "asd", opts);
-setTimeout(); // $ExpectType Promise<void>
+// $ExpectType Promise<string>
+setTimeout(123, "asd", opts);
+// $ExpectType Promise<string>
+setTimeout(123, "asd");
+// $ExpectType Promise<void>
+setTimeout(123);
+// $ExpectType Promise<void>
+setTimeout();
 
-const res3: AsyncIterable<string> = setInterval(123, "asd", opts);
-setInterval(); // $ExpectType AsyncIterable<void>
+// $ExpectType AsyncIterator<string, any, any>
+setInterval(123, "asd", opts);
+// $ExpectType AsyncIterator<string, any, any>
+setInterval(123, "asd");
+// $ExpectType AsyncIterator<void, any, any>
+setInterval(123);
+// $ExpectType AsyncIterator<void, any, any>
+setInterval();
 
-const res4: Promise<void> = scheduler.yield();
-scheduler.yield(); // $ExpectType Promise<void>
+// $ExpectType Promise<void>
+scheduler.wait(123, { signal: new AbortController().signal });
+// $ExpectType Promise<void>
+scheduler.wait(123);
+// @ts-expect-error
+scheduler.wait();
 
-const res5: Promise<void> = scheduler.wait(123);
-scheduler.wait(); // $ExpectType Promise<void>
-
-(async () => {
-    for await (const test of setInterval(123, 1)) {
-        test; // $ExpectType number
-    }
-});
+// $ExpectType Promise<void>
+scheduler.yield();

--- a/types/node/v20/timers.d.ts
+++ b/types/node/v20/timers.d.ts
@@ -6,16 +6,12 @@
  * The timer functions within Node.js implement a similar API as the timers API
  * provided by Web Browsers but use a different internal implementation that is
  * built around the Node.js [Event Loop](https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/#setimmediate-vs-settimeout).
- * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/timers.js)
+ * @see [source](https://github.com/nodejs/node/blob/v20.x/lib/timers.js)
  */
 declare module "timers" {
     import { Abortable } from "node:events";
-    import {
-        setImmediate as setImmediatePromise,
-        setInterval as setIntervalPromise,
-        setTimeout as setTimeoutPromise,
-    } from "node:timers/promises";
-    interface TimerOptions extends Abortable {
+    import * as promises from "node:timers/promises";
+    export interface TimerOptions extends Abortable {
         /**
          * Set to `false` to indicate that the scheduled `Timeout`
          * should not require the Node.js event loop to remain active.
@@ -23,38 +19,33 @@ declare module "timers" {
          */
         ref?: boolean | undefined;
     }
-    let setTimeout: typeof global.setTimeout;
-    let clearTimeout: typeof global.clearTimeout;
-    let setInterval: typeof global.setInterval;
-    let clearInterval: typeof global.clearInterval;
-    let setImmediate: typeof global.setImmediate;
-    let clearImmediate: typeof global.clearImmediate;
     global {
         namespace NodeJS {
-            // compatibility with older typings
-            interface Timer extends RefCounted {
-                hasRef(): boolean;
-                refresh(): this;
-                [Symbol.toPrimitive](): number;
-            }
             /**
              * This object is created internally and is returned from `setImmediate()`. It
              * can be passed to `clearImmediate()` in order to cancel the scheduled
              * actions.
              *
              * By default, when an immediate is scheduled, the Node.js event loop will continue
-             * running as long as the immediate is active. The `Immediate` object returned by `setImmediate()` exports both `immediate.ref()` and `immediate.unref()` functions that can be used to
-             * control this default behavior.
+             * running as long as the immediate is active. The `Immediate` object returned by
+             * `setImmediate()` exports both `immediate.ref()` and `immediate.unref()`
+             * functions that can be used to control this default behavior.
              */
-            class Immediate implements RefCounted {
+            interface Immediate extends RefCounted, Disposable {
                 /**
-                 * When called, requests that the Node.js event loop _not_ exit so long as the `Immediate` is active. Calling `immediate.ref()` multiple times will have no
+                 * If true, the `Immediate` object will keep the Node.js event loop active.
+                 * @since v11.0.0
+                 */
+                hasRef(): boolean;
+                /**
+                 * When called, requests that the Node.js event loop _not_ exit so long as the
+                 * `Immediate` is active. Calling `immediate.ref()` multiple times will have no
                  * effect.
                  *
                  * By default, all `Immediate` objects are "ref'ed", making it normally unnecessary
                  * to call `immediate.ref()` unless `immediate.unref()` had been called previously.
                  * @since v9.7.0
-                 * @return a reference to `immediate`
+                 * @returns a reference to `immediate`
                  */
                 ref(): this;
                 /**
@@ -63,53 +54,58 @@ declare module "timers" {
                  * running, the process may exit before the `Immediate` object's callback is
                  * invoked. Calling `immediate.unref()` multiple times will have no effect.
                  * @since v9.7.0
-                 * @return a reference to `immediate`
+                 * @returns a reference to `immediate`
                  */
                 unref(): this;
                 /**
-                 * If true, the `Immediate` object will keep the Node.js event loop active.
-                 * @since v11.0.0
-                 */
-                hasRef(): boolean;
-                _onImmediate: Function; // to distinguish it from the Timeout class
-                /**
                  * Cancels the immediate. This is similar to calling `clearImmediate()`.
-                 * @since v20.5.0
+                 * @since v20.5.0, v18.18.0
+                 * @experimental
                  */
                 [Symbol.dispose](): void;
+                _onImmediate(...args: any[]): void;
+            }
+            // Legacy interface used in Node.js v9 and prior
+            /** @deprecated Use `NodeJS.Timeout` instead. */
+            interface Timer extends RefCounted {
+                hasRef(): boolean;
+                refresh(): this;
+                [Symbol.toPrimitive](): number;
             }
             /**
-             * This object is created internally and is returned from `setTimeout()` and `setInterval()`. It can be passed to either `clearTimeout()` or `clearInterval()` in order to cancel the
-             * scheduled actions.
+             * This object is created internally and is returned from `setTimeout()` and
+             * `setInterval()`. It can be passed to either `clearTimeout()` or
+             * `clearInterval()` in order to cancel the scheduled actions.
              *
-             * By default, when a timer is scheduled using either `setTimeout()` or `setInterval()`, the Node.js event loop will continue running as long as the
+             * By default, when a timer is scheduled using either `setTimeout()` or
+             * `setInterval()`, the Node.js event loop will continue running as long as the
              * timer is active. Each of the `Timeout` objects returned by these functions
              * export both `timeout.ref()` and `timeout.unref()` functions that can be used to
              * control this default behavior.
              */
-            class Timeout implements Timer {
+            interface Timeout extends RefCounted, Disposable, Timer {
                 /**
-                 * When called, requests that the Node.js event loop _not_ exit so long as the`Timeout` is active. Calling `timeout.ref()` multiple times will have no effect.
-                 *
-                 * By default, all `Timeout` objects are "ref'ed", making it normally unnecessary
-                 * to call `timeout.ref()` unless `timeout.unref()` had been called previously.
+                 * Cancels the timeout.
                  * @since v0.9.1
-                 * @return a reference to `timeout`
+                 * @legacy Use `clearTimeout()` instead.
+                 * @returns a reference to `timeout`
                  */
-                ref(): this;
-                /**
-                 * When called, the active `Timeout` object will not require the Node.js event loop
-                 * to remain active. If there is no other activity keeping the event loop running,
-                 * the process may exit before the `Timeout` object's callback is invoked. Calling `timeout.unref()` multiple times will have no effect.
-                 * @since v0.9.1
-                 * @return a reference to `timeout`
-                 */
-                unref(): this;
+                close(): this;
                 /**
                  * If true, the `Timeout` object will keep the Node.js event loop active.
                  * @since v11.0.0
                  */
                 hasRef(): boolean;
+                /**
+                 * When called, requests that the Node.js event loop _not_ exit so long as the
+                 * `Timeout` is active. Calling `timeout.ref()` multiple times will have no effect.
+                 *
+                 * By default, all `Timeout` objects are "ref'ed", making it normally unnecessary
+                 * to call `timeout.ref()` unless `timeout.unref()` had been called previously.
+                 * @since v0.9.1
+                 * @returns a reference to `timeout`
+                 */
+                ref(): this;
                 /**
                  * Sets the timer's start time to the current time, and reschedules the timer to
                  * call its callback at the previously specified duration adjusted to the current
@@ -119,85 +115,37 @@ declare module "timers" {
                  * Using this on a timer that has already called its callback will reactivate the
                  * timer.
                  * @since v10.2.0
-                 * @return a reference to `timeout`
+                 * @returns a reference to `timeout`
                  */
                 refresh(): this;
+                /**
+                 * When called, the active `Timeout` object will not require the Node.js event loop
+                 * to remain active. If there is no other activity keeping the event loop running,
+                 * the process may exit before the `Timeout` object's callback is invoked. Calling
+                 * `timeout.unref()` multiple times will have no effect.
+                 * @since v0.9.1
+                 * @returns a reference to `timeout`
+                 */
+                unref(): this;
+                /**
+                 * Coerce a `Timeout` to a primitive. The primitive can be used to
+                 * clear the `Timeout`. The primitive can only be used in the
+                 * same thread where the timeout was created. Therefore, to use it
+                 * across `worker_threads` it must first be passed to the correct
+                 * thread. This allows enhanced compatibility with browser
+                 * `setTimeout()` and `setInterval()` implementations.
+                 * @since v14.9.0, v12.19.0
+                 */
                 [Symbol.toPrimitive](): number;
                 /**
                  * Cancels the timeout.
-                 * @since v20.5.0
+                 * @since v20.5.0, v18.18.0
+                 * @experimental
                  */
                 [Symbol.dispose](): void;
+                _onTimeout(...args: any[]): void;
             }
         }
-        /**
-         * Schedules execution of a one-time `callback` after `delay` milliseconds.
-         *
-         * The `callback` will likely not be invoked in precisely `delay` milliseconds.
-         * Node.js makes no guarantees about the exact timing of when callbacks will fire,
-         * nor of their ordering. The callback will be called as close as possible to the
-         * time specified.
-         *
-         * When `delay` is larger than `2147483647` or less than `1`, the `delay` will be set to `1`. Non-integer delays are truncated to an integer.
-         *
-         * If `callback` is not a function, a `TypeError` will be thrown.
-         *
-         * This method has a custom variant for promises that is available using `timersPromises.setTimeout()`.
-         * @since v0.0.1
-         * @param callback The function to call when the timer elapses.
-         * @param [delay=1] The number of milliseconds to wait before calling the `callback`.
-         * @param args Optional arguments to pass when the `callback` is called.
-         * @return for use with {@link clearTimeout}
-         */
-        function setTimeout<TArgs extends any[]>(
-            callback: (...args: TArgs) => void,
-            delay?: number,
-            ...args: TArgs
-        ): NodeJS.Timeout;
-        // util.promisify no rest args compability
-        // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-        function setTimeout(callback: (args: void) => void, delay?: number): NodeJS.Timeout;
-        namespace setTimeout {
-            const __promisify__: typeof setTimeoutPromise;
-        }
-        /**
-         * Cancels a `Timeout` object created by `setTimeout()`.
-         * @since v0.0.1
-         * @param timeout A `Timeout` object as returned by {@link setTimeout} or the `primitive` of the `Timeout` object as a string or a number.
-         */
-        function clearTimeout(timeoutId: NodeJS.Timeout | string | number | undefined): void;
-        /**
-         * Schedules repeated execution of `callback` every `delay` milliseconds.
-         *
-         * When `delay` is larger than `2147483647` or less than `1`, the `delay` will be
-         * set to `1`. Non-integer delays are truncated to an integer.
-         *
-         * If `callback` is not a function, a `TypeError` will be thrown.
-         *
-         * This method has a custom variant for promises that is available using `timersPromises.setInterval()`.
-         * @since v0.0.1
-         * @param callback The function to call when the timer elapses.
-         * @param [delay=1] The number of milliseconds to wait before calling the `callback`.
-         * @param args Optional arguments to pass when the `callback` is called.
-         * @return for use with {@link clearInterval}
-         */
-        function setInterval<TArgs extends any[]>(
-            callback: (...args: TArgs) => void,
-            delay?: number,
-            ...args: TArgs
-        ): NodeJS.Timeout;
-        // util.promisify no rest args compability
-        // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-        function setInterval(callback: (args: void) => void, delay?: number): NodeJS.Timeout;
-        namespace setInterval {
-            const __promisify__: typeof setIntervalPromise;
-        }
-        /**
-         * Cancels a `Timeout` object created by `setInterval()`.
-         * @since v0.0.1
-         * @param timeout A `Timeout` object as returned by {@link setInterval} or the `primitive` of the `Timeout` object as a string or a number.
-         */
-        function clearInterval(intervalId: NodeJS.Timeout | string | number | undefined): void;
         /**
          * Schedules the "immediate" execution of the `callback` after I/O events'
          * callbacks.
@@ -210,30 +158,128 @@ declare module "timers" {
          *
          * If `callback` is not a function, a `TypeError` will be thrown.
          *
-         * This method has a custom variant for promises that is available using `timersPromises.setImmediate()`.
+         * This method has a custom variant for promises that is available using
+         * `timersPromises.setImmediate()`.
          * @since v0.9.1
-         * @param callback The function to call at the end of this turn of the Node.js `Event Loop`
+         * @param callback The function to call at the end of this turn of
+         * the Node.js [Event Loop](https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/#setimmediate-vs-settimeout)
          * @param args Optional arguments to pass when the `callback` is called.
-         * @return for use with {@link clearImmediate}
+         * @returns for use with `clearImmediate()`
          */
         function setImmediate<TArgs extends any[]>(
             callback: (...args: TArgs) => void,
             ...args: TArgs
         ): NodeJS.Immediate;
-        // util.promisify no rest args compability
+        // Allow a single void-accepting argument to be optional in arguments lists.
+        // Allows usage such as `new Promise(resolve => setTimeout(resolve, ms))` (#54258)
         // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-        function setImmediate(callback: (args: void) => void): NodeJS.Immediate;
+        function setImmediate(callback: (_: void) => void): NodeJS.Immediate;
         namespace setImmediate {
-            const __promisify__: typeof setImmediatePromise;
+            import __promisify__ = promises.setImmediate;
+            export { __promisify__ };
+        }
+        /**
+         * Schedules repeated execution of `callback` every `delay` milliseconds.
+         *
+         * When `delay` is larger than `2147483647` or less than `1`, the `delay` will be
+         * set to `1`. Non-integer delays are truncated to an integer.
+         *
+         * If `callback` is not a function, a `TypeError` will be thrown.
+         *
+         * This method has a custom variant for promises that is available using
+         * `timersPromises.setInterval()`.
+         * @since v0.0.1
+         * @param callback The function to call when the timer elapses.
+         * @param delay The number of milliseconds to wait before calling the
+         * `callback`. **Default:** `1`.
+         * @param args Optional arguments to pass when the `callback` is called.
+         * @returns for use with `clearInterval()`
+         */
+        function setInterval<TArgs extends any[]>(
+            callback: (...args: TArgs) => void,
+            delay?: number,
+            ...args: TArgs
+        ): NodeJS.Timeout;
+        // Allow a single void-accepting argument to be optional in arguments lists.
+        // Allows usage such as `new Promise(resolve => setTimeout(resolve, ms))` (#54258)
+        // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+        function setInterval(callback: (_: void) => void, delay?: number): NodeJS.Timeout;
+        /**
+         * Schedules execution of a one-time `callback` after `delay` milliseconds.
+         *
+         * The `callback` will likely not be invoked in precisely `delay` milliseconds.
+         * Node.js makes no guarantees about the exact timing of when callbacks will fire,
+         * nor of their ordering. The callback will be called as close as possible to the
+         * time specified.
+         *
+         * When `delay` is larger than `2147483647` or less than `1` or `NaN`, the `delay`
+         * will be set to `1`. Non-integer delays are truncated to an integer.
+         *
+         * If `callback` is not a function, a `TypeError` will be thrown.
+         *
+         * This method has a custom variant for promises that is available using
+         * `timersPromises.setTimeout()`.
+         * @since v0.0.1
+         * @param callback The function to call when the timer elapses.
+         * @param delay The number of milliseconds to wait before calling the
+         * `callback`. **Default:** `1`.
+         * @param args Optional arguments to pass when the `callback` is called.
+         * @returns for use with `clearTimeout()`
+         */
+        function setTimeout<TArgs extends any[]>(
+            callback: (...args: TArgs) => void,
+            delay?: number,
+            ...args: TArgs
+        ): NodeJS.Timeout;
+        // Allow a single void-accepting argument to be optional in arguments lists.
+        // Allows usage such as `new Promise(resolve => setTimeout(resolve, ms))` (#54258)
+        // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+        function setTimeout(callback: (_: void) => void, delay?: number): NodeJS.Timeout;
+        namespace setTimeout {
+            import __promisify__ = promises.setTimeout;
+            export { __promisify__ };
         }
         /**
          * Cancels an `Immediate` object created by `setImmediate()`.
          * @since v0.9.1
-         * @param immediate An `Immediate` object as returned by {@link setImmediate}.
+         * @param immediate An `Immediate` object as returned by `setImmediate()`.
          */
-        function clearImmediate(immediateId: NodeJS.Immediate | undefined): void;
+        function clearImmediate(immediate: NodeJS.Immediate | undefined): void;
+        /**
+         * Cancels a `Timeout` object created by `setInterval()`.
+         * @since v0.0.1
+         * @param timeout A `Timeout` object as returned by `setInterval()`
+         * or the primitive of the `Timeout` object as a string or a number.
+         */
+        function clearInterval(timeout: NodeJS.Timeout | string | number | undefined): void;
+        /**
+         * Cancels a `Timeout` object created by `setTimeout()`.
+         * @since v0.0.1
+         * @param timeout A `Timeout` object as returned by `setTimeout()`
+         * or the primitive of the `Timeout` object as a string or a number.
+         */
+        function clearTimeout(timeout: NodeJS.Timeout | string | number | undefined): void;
+        /**
+         * The `queueMicrotask()` method queues a microtask to invoke `callback`. If
+         * `callback` throws an exception, the `process` object `'uncaughtException'`
+         * event will be emitted.
+         *
+         * The microtask queue is managed by V8 and may be used in a similar manner to
+         * the `process.nextTick()` queue, which is managed by Node.js. The
+         * `process.nextTick()` queue is always processed before the microtask queue
+         * within each turn of the Node.js event loop.
+         * @since v11.0.0
+         * @param callback Function to be queued.
+         */
         function queueMicrotask(callback: () => void): void;
     }
+    import clearImmediate = globalThis.clearImmediate;
+    import clearInterval = globalThis.clearInterval;
+    import clearTimeout = globalThis.clearTimeout;
+    import setImmediate = globalThis.setImmediate;
+    import setInterval = globalThis.setInterval;
+    import setTimeout = globalThis.setTimeout;
+    export { clearImmediate, clearInterval, clearTimeout, promises, setImmediate, setInterval, setTimeout };
 }
 declare module "node:timers" {
     export * from "timers";

--- a/types/node/v20/timers/promises.d.ts
+++ b/types/node/v20/timers/promises.d.ts
@@ -1,15 +1,17 @@
 /**
  * The `timers/promises` API provides an alternative set of timer functions
- * that return `Promise` objects. The API is accessible via `import timersPromises from 'node:timers/promises'`.
+ * that return `Promise` objects. The API is accessible via
+ * `require('node:timers/promises')`.
  *
  * ```js
  * import {
  *   setTimeout,
  *   setImmediate,
  *   setInterval,
- * } from 'timers/promises';
+ * } from 'node:timers/promises';
  * ```
  * @since v15.0.0
+ * @see [source](https://github.com/nodejs/node/blob/v20.x/lib/timers/promises.js)
  */
 declare module "timers/promises" {
     import { TimerOptions } from "node:timers";
@@ -17,14 +19,15 @@ declare module "timers/promises" {
      * ```js
      * import {
      *   setTimeout,
-     * } from 'timers/promises';
+     * } from 'node:timers/promises';
      *
      * const res = await setTimeout(100, 'result');
      *
      * console.log(res);  // Prints 'result'
      * ```
      * @since v15.0.0
-     * @param [delay=1] The number of milliseconds to wait before fulfilling the promise.
+     * @param delay The number of milliseconds to wait before fulfilling the
+     * promise. **Default:** `1`.
      * @param value A value with which the promise is fulfilled.
      */
     function setTimeout<T = void>(delay?: number, value?: T, options?: TimerOptions): Promise<T>;
@@ -32,7 +35,7 @@ declare module "timers/promises" {
      * ```js
      * import {
      *   setImmediate,
-     * } from 'timers/promises';
+     * } from 'node:timers/promises';
      *
      * const res = await setImmediate('result');
      *
@@ -50,7 +53,7 @@ declare module "timers/promises" {
      * ```js
      * import {
      *   setInterval,
-     * } from 'timers/promises';
+     * } from 'node:timers/promises';
      *
      * const interval = 100;
      * for await (const startTime of setInterval(interval, Date.now())) {
@@ -62,33 +65,41 @@ declare module "timers/promises" {
      * console.log(Date.now());
      * ```
      * @since v15.9.0
+     * @param delay The number of milliseconds to wait between iterations.
+     * **Default:** `1`.
+     * @param value A value with which the iterator returns.
      */
-    function setInterval<T = void>(delay?: number, value?: T, options?: TimerOptions): AsyncIterable<T>;
+    function setInterval<T = void>(delay?: number, value?: T, options?: TimerOptions): NodeJS.AsyncIterator<T>;
     interface Scheduler {
         /**
-         * An experimental API defined by the [Scheduling APIs](https://github.com/WICG/scheduling-apis) draft specification being developed as a standard Web Platform API.
+         * An experimental API defined by the [Scheduling APIs](https://github.com/WICG/scheduling-apis) draft specification
+         * being developed as a standard Web Platform API.
          *
-         * Calling `timersPromises.scheduler.wait(delay, options)` is roughly equivalent to calling `timersPromises.setTimeout(delay, undefined, options)` except that the `ref`
-         * option is not supported.
+         * Calling `timersPromises.scheduler.wait(delay, options)` is roughly equivalent
+         * to calling `timersPromises.setTimeout(delay, undefined, options)` except that
+         * the `ref` option is not supported.
          *
          * ```js
          * import { scheduler } from 'node:timers/promises';
          *
          * await scheduler.wait(1000); // Wait one second before continuing
          * ```
-         * @since v16.14.0
+         * @since v17.3.0, v16.14.0
          * @experimental
-         * @param [delay=1] The number of milliseconds to wait before fulfilling the promise.
+         * @param delay The number of milliseconds to wait before resolving the
+         * promise.
          */
-        wait: (delay?: number, options?: Pick<TimerOptions, "signal">) => Promise<void>;
+        wait(delay: number, options?: { signal?: AbortSignal }): Promise<void>;
         /**
-         * An experimental API defined by the [Scheduling APIs](https://nodejs.org/docs/latest-v20.x/api/async_hooks.html#promise-execution-tracking) draft specification
+         * An experimental API defined by the [Scheduling APIs](https://github.com/WICG/scheduling-apis) draft specification
          * being developed as a standard Web Platform API.
-         * Calling `timersPromises.scheduler.yield()` is equivalent to calling `timersPromises.setImmediate()` with no arguments.
-         * @since v16.14.0
+         *
+         * Calling `timersPromises.scheduler.yield()` is equivalent to calling
+         * `timersPromises.setImmediate()` with no arguments.
+         * @since v17.3.0, v16.14.0
          * @experimental
          */
-        yield: () => Promise<void>;
+        yield(): Promise<void>;
     }
     const scheduler: Scheduler;
 }


### PR DESCRIPTION
Addresses the following issues:
- `NodeJS.Immediate` and `NodeJS.Timeout` were changed previously from interfaces to classes, which drew the `NodeJS` namespace out of ambient-only space and made it an addressable global variable. These classes' constructors aren't accessible, so they can just be kept as interface declarations.
- Adds the missing `promises` export from `node:timers` in v20 and v22.
- Removes the custom promisifier brand for `setInterval`, which isn't promisifiable.
- Updates `promises.setInterval()` to use `NodeJS.AsyncIterator`.
- Prefers exported aliases over declaring `typeof` variables.
- Marks the legacy `NodeJS.Timer` as deprecated for future removal.

Also syncs docblocks and re-orders definitions to match the API docs for easier maintenance.

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v18.x/api/timers.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
