### PR TITLE
feat(youtube): add onYouTubeIframeAPIReady

### DIFF
--- a/types/youtube/index.d.ts
+++ b/types/youtube/index.d.ts
@@ -1006,3 +1006,11 @@ declare namespace YT {
         destroy(): void;
     }
 }
+
+interface Window {
+    /**
+     * The function that will be called by the IFrame API
+     * when the page has finished downloading the JavaScript for the player API.
+     */
+    onYouTubeIframeAPIReady?(): void;
+}

--- a/types/youtube/youtube-tests.ts
+++ b/types/youtube/youtube-tests.ts
@@ -291,3 +291,6 @@ const sphericalProperties: YT.SphericalProperties = player.getSphericalPropertie
 player.setSphericalProperties({ yaw: 1, pitch: 2, roll: 3, fov: 50, enableOrientationSensor: true });
 
 player.destroy();
+
+// $ExpectType (() => void) | undefined
+window.onYouTubeIframeAPIReady;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/youtube/iframe_api_reference#Requirements
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

For the IFrame API, `onYouTubeIframeAPIReady` must be implemented by users.