### PR TITLE
updated types for webextension-polyfill

### DIFF
--- a/types/webextension-polyfill/namespaces/activityLog.d.ts
+++ b/types/webextension-polyfill/namespaces/activityLog.d.ts
@@ -88,7 +88,7 @@ export namespace ActivityLog {
     /**
      * Receives an activityItem for each logging event.
      */
-    interface onExtensionActivityEvent extends Events.Event<(details: OnExtensionActivityDetailsType) => void> {
+    interface OnExtensionActivityEvent extends Events.Event<(details: OnExtensionActivityDetailsType) => void> {
         /**
          * Registers an event listener <em>callback</em> to an event.
          *
@@ -101,6 +101,6 @@ export namespace ActivityLog {
         /**
          * Receives an activityItem for each logging event.
          */
-        onExtensionActivity: onExtensionActivityEvent;
+        onExtensionActivity: OnExtensionActivityEvent;
     }
 }

--- a/types/webextension-polyfill/namespaces/proxy.d.ts
+++ b/types/webextension-polyfill/namespaces/proxy.d.ts
@@ -184,7 +184,7 @@ export namespace Proxy {
     /**
      * Fired when proxy data is needed for a request.
      */
-    interface onRequestEvent extends Events.Event<(details: OnRequestDetailsType) => void> {
+    interface OnRequestEvent extends Events.Event<(details: OnRequestDetailsType) => void> {
         /**
          * Registers an event listener <em>callback</em> to an event.
          *
@@ -203,7 +203,7 @@ export namespace Proxy {
         /**
          * Fired when proxy data is needed for a request.
          */
-        onRequest: onRequestEvent;
+        onRequest: OnRequestEvent;
 
         /**
          * Notifies about errors caused by the invalid use of the proxy API.

--- a/types/webextension-polyfill/namespaces/runtime.d.ts
+++ b/types/webextension-polyfill/namespaces/runtime.d.ts
@@ -263,6 +263,30 @@ export namespace Runtime {
     type OnPerformanceWarningSeverity = "low" | "medium" | "high";
 
     /**
+     * The third parameter is a function to call (at most once) when you have a response.
+     * The argument should be any JSON-ifiable object. If you have more than one <code>onMessage</code>
+     * listener in the same document, then only one may send a response. <code>sendResponse</code>
+     * becomes invalid when the event listener returns, unless you return true from the event listener to indicate you wish to
+     * send a response asynchronously (this will keep the message channel open to the other end until <code>sendResponse</code>
+     * is called).
+     */
+    type OnMessageListenerCallback = (
+        message: unknown,
+        sender: MessageSender,
+        sendResponse: (response: unknown) => void,
+    ) => true;
+
+    /**
+     * The return value should be a promise of any JSON-ifiable object. If you have more than one <code>onMessage</code>
+     * listener in the same document, then only one may send a response.
+     */
+    type OnMessageListenerAsync = (message: unknown, sender: MessageSender) => Promise<unknown>;
+
+    type OnMessageListenerNoResponse = (message: unknown, sender: MessageSender) => void;
+
+    type OnMessageListener = OnMessageListenerCallback | OnMessageListenerAsync | OnMessageListenerNoResponse;
+
+    /**
      * If an update is available, this contains more information about the available update.
      */
     interface RequestUpdateCheckCallbackDetailsType {
@@ -579,53 +603,18 @@ export namespace Runtime {
 
         /**
          * Fired when a message is sent from either an extension process or a content script.
-         *
-         * @param message Optional. The message sent by the calling script.
-         * @param sendResponse Function to call (at most once) when you have a response. This is an alternative to returning a
-         * Promise. The argument should be any JSON-ifiable object. If you have more than one <code>onMessage</code>
-         * listener in the same document, then only one may send a response. This function becomes invalid when the event listener
-         * returns, unless you return true from the event listener to indicate you wish to send a response asynchronously (this
-         * will keep the message channel open to the other end until <code>sendResponse</code> is called).
          */
-        onMessage: Events.Event<
-            (
-                message: unknown,
-                sender: MessageSender,
-                sendResponse: (message: unknown) => void,
-            ) => Promise<unknown> | true | undefined
-        >;
+        onMessage: Events.Event<OnMessageListener>;
 
         /**
          * Fired when a message is sent from another extension/app. Cannot be used in a content script.
-         *
-         * @param message Optional. The message sent by the calling script.
-         * @param sendResponse Function to call (at most once) when you have a response. This is an alternative to returning a
-         * Promise. The argument should be any JSON-ifiable object. If you have more than one <code>onMessage</code>
-         * listener in the same document, then only one may send a response. This function becomes invalid when the event listener
-         * returns, unless you return true from the event listener to indicate you wish to send a response asynchronously (this
-         * will keep the message channel open to the other end until <code>sendResponse</code> is called).
          */
-        onMessageExternal: Events.Event<
-            (
-                message: unknown,
-                sender: MessageSender,
-                sendResponse: (message: unknown) => void,
-            ) => Promise<unknown> | true | undefined
-        >;
+        onMessageExternal: Events.Event<OnMessageListener>;
 
         /**
          * Fired when a message is sent from a USER_SCRIPT world registered through the userScripts API.
-         *
-         * @param message Optional. The message sent by the calling script.
-         * @param sendResponse Function to call (at most once) when you have a response. The argument should be any JSON-ifiable
-         * object. If you have more than one <code>onMessage</code> listener in the same document,
-         * then only one may send a response. This function becomes invalid when the event listener returns,
-         * unless you return true from the event listener to indicate you wish to send a response asynchronously (this will keep
-         * the message channel open to the other end until <code>sendResponse</code> is called).
          */
-        onUserScriptMessage: Events.Event<
-            (message: unknown, sender: MessageSender, sendResponse: () => void) => boolean | undefined
-        >;
+        onUserScriptMessage: Events.Event<OnMessageListener>;
 
         /**
          * Fired when a runtime performance issue is detected with the extension. Observe this event to be proactively notified of

--- a/types/webextension-polyfill/namespaces/tabs.d.ts
+++ b/types/webextension-polyfill/namespaces/tabs.d.ts
@@ -1052,7 +1052,7 @@ export namespace Tabs {
     /**
      * Fired when a tab is updated.
      */
-    interface onUpdatedEvent
+    interface OnUpdatedEvent
         extends Events.Event<(tabId: number, changeInfo: OnUpdatedChangeInfoType, tab: Tab) => void>
     {
         /**
@@ -1406,7 +1406,7 @@ export namespace Tabs {
         /**
          * Fired when a tab is updated.
          */
-        onUpdated: onUpdatedEvent;
+        onUpdated: OnUpdatedEvent;
 
         /**
          * Fired when a tab is moved within a window. Only one move event is fired, representing the tab the user directly moved.

--- a/types/webextension-polyfill/namespaces/webNavigation.d.ts
+++ b/types/webextension-polyfill/namespaces/webNavigation.d.ts
@@ -350,7 +350,7 @@ export namespace WebNavigation {
     /**
      * Fired when a navigation is about to occur.
      */
-    interface onBeforeNavigateEvent extends Events.Event<(details: OnBeforeNavigateDetailsType) => void> {
+    interface OnBeforeNavigateEvent extends Events.Event<(details: OnBeforeNavigateDetailsType) => void> {
         /**
          * Registers an event listener <em>callback</em> to an event.
          *
@@ -366,7 +366,7 @@ export namespace WebNavigation {
      * might still be downloading, but at least part of the document has been received from the server and the browser has
      * decided to switch to the new document.
      */
-    interface onCommittedEvent extends Events.Event<(details: OnCommittedDetailsType) => void> {
+    interface OnCommittedEvent extends Events.Event<(details: OnCommittedDetailsType) => void> {
         /**
          * Registers an event listener <em>callback</em> to an event.
          *
@@ -380,7 +380,7 @@ export namespace WebNavigation {
     /**
      * Fired when the page's DOM is fully constructed, but the referenced resources may not finish loading.
      */
-    interface onDOMContentLoadedEvent extends Events.Event<(details: OnDOMContentLoadedDetailsType) => void> {
+    interface OnDOMContentLoadedEvent extends Events.Event<(details: OnDOMContentLoadedDetailsType) => void> {
         /**
          * Registers an event listener <em>callback</em> to an event.
          *
@@ -394,7 +394,7 @@ export namespace WebNavigation {
     /**
      * Fired when a document, including the resources it refers to, is completely loaded and initialized.
      */
-    interface onCompletedEvent extends Events.Event<(details: OnCompletedDetailsType) => void> {
+    interface OnCompletedEvent extends Events.Event<(details: OnCompletedDetailsType) => void> {
         /**
          * Registers an event listener <em>callback</em> to an event.
          *
@@ -409,7 +409,7 @@ export namespace WebNavigation {
      * Fired when an error occurs and the navigation is aborted. This can happen if either a network error occurred,
      * or the user aborted the navigation.
      */
-    interface onErrorOccurredEvent extends Events.Event<(details: OnErrorOccurredDetailsType) => void> {
+    interface OnErrorOccurredEvent extends Events.Event<(details: OnErrorOccurredDetailsType) => void> {
         /**
          * Registers an event listener <em>callback</em> to an event.
          *
@@ -423,7 +423,7 @@ export namespace WebNavigation {
     /**
      * Fired when a new window, or a new tab in an existing window, is created to host a navigation.
      */
-    interface onCreatedNavigationTargetEvent
+    interface OnCreatedNavigationTargetEvent
         extends Events.Event<(details: OnCreatedNavigationTargetDetailsType) => void>
     {
         /**
@@ -439,7 +439,7 @@ export namespace WebNavigation {
     /**
      * Fired when the reference fragment of a frame was updated. All future events for that frame will use the updated URL.
      */
-    interface onReferenceFragmentUpdatedEvent
+    interface OnReferenceFragmentUpdatedEvent
         extends Events.Event<(details: OnReferenceFragmentUpdatedDetailsType) => void>
     {
         /**
@@ -458,7 +458,7 @@ export namespace WebNavigation {
     /**
      * Fired when the frame's history was updated to a new URL. All future events for that frame will use the updated URL.
      */
-    interface onHistoryStateUpdatedEvent extends Events.Event<(details: OnHistoryStateUpdatedDetailsType) => void> {
+    interface OnHistoryStateUpdatedEvent extends Events.Event<(details: OnHistoryStateUpdatedDetailsType) => void> {
         /**
          * Registers an event listener <em>callback</em> to an event.
          *
@@ -488,40 +488,40 @@ export namespace WebNavigation {
         /**
          * Fired when a navigation is about to occur.
          */
-        onBeforeNavigate: onBeforeNavigateEvent;
+        onBeforeNavigate: OnBeforeNavigateEvent;
 
         /**
          * Fired when a navigation is committed. The document (and the resources it refers to, such as images and subframes)
          * might still be downloading, but at least part of the document has been received from the server and the browser has
          * decided to switch to the new document.
          */
-        onCommitted: onCommittedEvent;
+        onCommitted: OnCommittedEvent;
 
         /**
          * Fired when the page's DOM is fully constructed, but the referenced resources may not finish loading.
          */
-        onDOMContentLoaded: onDOMContentLoadedEvent;
+        onDOMContentLoaded: OnDOMContentLoadedEvent;
 
         /**
          * Fired when a document, including the resources it refers to, is completely loaded and initialized.
          */
-        onCompleted: onCompletedEvent;
+        onCompleted: OnCompletedEvent;
 
         /**
          * Fired when an error occurs and the navigation is aborted. This can happen if either a network error occurred,
          * or the user aborted the navigation.
          */
-        onErrorOccurred: onErrorOccurredEvent;
+        onErrorOccurred: OnErrorOccurredEvent;
 
         /**
          * Fired when a new window, or a new tab in an existing window, is created to host a navigation.
          */
-        onCreatedNavigationTarget: onCreatedNavigationTargetEvent;
+        onCreatedNavigationTarget: OnCreatedNavigationTargetEvent;
 
         /**
          * Fired when the reference fragment of a frame was updated. All future events for that frame will use the updated URL.
          */
-        onReferenceFragmentUpdated: onReferenceFragmentUpdatedEvent;
+        onReferenceFragmentUpdated: OnReferenceFragmentUpdatedEvent;
 
         /**
          * Fired when the contents of the tab is replaced by a different (usually previously pre-rendered) tab.
@@ -531,6 +531,6 @@ export namespace WebNavigation {
         /**
          * Fired when the frame's history was updated to a new URL. All future events for that frame will use the updated URL.
          */
-        onHistoryStateUpdated: onHistoryStateUpdatedEvent;
+        onHistoryStateUpdated: OnHistoryStateUpdatedEvent;
     }
 }

--- a/types/webextension-polyfill/namespaces/webRequest.d.ts
+++ b/types/webextension-polyfill/namespaces/webRequest.d.ts
@@ -337,7 +337,8 @@ export namespace WebRequest {
     /**
      * A BlockingResponse or a Promise<BlockingResponse>
      */
-    type BlockingResponseOrPromise = BlockingResponse | Promise<BlockingResponse>;
+    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+    type BlockingResponseOrPromiseOrVoid = BlockingResponse | Promise<BlockingResponse> | void;
 
     /**
      * "uninitialized": The StreamFilter is not fully initialized. No methods may be called until a "start" event has been
@@ -1496,8 +1497,8 @@ export namespace WebRequest {
     /**
      * Fired when a request is about to occur.
      */
-    interface onBeforeRequestEvent
-        extends Events.Event<(details: OnBeforeRequestDetailsType) => BlockingResponseOrPromise | undefined>
+    interface OnBeforeRequestEvent
+        extends Events.Event<(details: OnBeforeRequestDetailsType) => BlockingResponseOrPromiseOrVoid>
     {
         /**
          * Registers an event listener <em>callback</em> to an event.
@@ -1507,7 +1508,7 @@ export namespace WebRequest {
          * @param extraInfoSpec Optional. Array of extra information that should be passed to the listener function.
          */
         addListener(
-            callback: (details: OnBeforeRequestDetailsType) => BlockingResponseOrPromise | undefined,
+            callback: (details: OnBeforeRequestDetailsType) => BlockingResponseOrPromiseOrVoid,
             filter: RequestFilter,
             extraInfoSpec?: OnBeforeRequestOptions[],
         ): void;
@@ -1517,8 +1518,8 @@ export namespace WebRequest {
      * Fired before sending an HTTP request, once the request headers are available. This may occur after a TCP connection is
      * made to the server, but before any HTTP data is sent.
      */
-    interface onBeforeSendHeadersEvent
-        extends Events.Event<(details: OnBeforeSendHeadersDetailsType) => BlockingResponseOrPromise | undefined>
+    interface OnBeforeSendHeadersEvent
+        extends Events.Event<(details: OnBeforeSendHeadersDetailsType) => BlockingResponseOrPromiseOrVoid>
     {
         /**
          * Registers an event listener <em>callback</em> to an event.
@@ -1528,7 +1529,7 @@ export namespace WebRequest {
          * @param extraInfoSpec Optional. Array of extra information that should be passed to the listener function.
          */
         addListener(
-            callback: (details: OnBeforeSendHeadersDetailsType) => BlockingResponseOrPromise | undefined,
+            callback: (details: OnBeforeSendHeadersDetailsType) => BlockingResponseOrPromiseOrVoid,
             filter: RequestFilter,
             extraInfoSpec?: OnBeforeSendHeadersOptions[],
         ): void;
@@ -1538,7 +1539,7 @@ export namespace WebRequest {
      * Fired just before a request is going to be sent to the server (modifications of previous onBeforeSendHeaders callbacks
      * are visible by the time onSendHeaders is fired).
      */
-    interface onSendHeadersEvent extends Events.Event<(details: OnSendHeadersDetailsType) => void> {
+    interface OnSendHeadersEvent extends Events.Event<(details: OnSendHeadersDetailsType) => void> {
         /**
          * Registers an event listener <em>callback</em> to an event.
          *
@@ -1556,8 +1557,8 @@ export namespace WebRequest {
     /**
      * Fired when HTTP response headers of a request have been received.
      */
-    interface onHeadersReceivedEvent
-        extends Events.Event<(details: OnHeadersReceivedDetailsType) => BlockingResponseOrPromise | undefined>
+    interface OnHeadersReceivedEvent
+        extends Events.Event<(details: OnHeadersReceivedDetailsType) => BlockingResponseOrPromiseOrVoid>
     {
         /**
          * Registers an event listener <em>callback</em> to an event.
@@ -1567,7 +1568,7 @@ export namespace WebRequest {
          * @param extraInfoSpec Optional. Array of extra information that should be passed to the listener function.
          */
         addListener(
-            callback: (details: OnHeadersReceivedDetailsType) => BlockingResponseOrPromise | undefined,
+            callback: (details: OnHeadersReceivedDetailsType) => BlockingResponseOrPromiseOrVoid,
             filter: RequestFilter,
             extraInfoSpec?: OnHeadersReceivedOptions[],
         ): void;
@@ -1578,8 +1579,8 @@ export namespace WebRequest {
      * credentials, it can cancel the request and display the error page, or it can take no action on the challenge.
      * If bad user credentials are provided, this may be called multiple times for the same request.
      */
-    interface onAuthRequiredEvent
-        extends Events.Event<(details: OnAuthRequiredDetailsType) => BlockingResponseOrPromise | undefined>
+    interface OnAuthRequiredEvent
+        extends Events.Event<(details: OnAuthRequiredDetailsType) => BlockingResponseOrPromiseOrVoid>
     {
         /**
          * Registers an event listener <em>callback</em> to an event.
@@ -1589,7 +1590,7 @@ export namespace WebRequest {
          * @param extraInfoSpec Optional. Array of extra information that should be passed to the listener function.
          */
         addListener(
-            callback: (details: OnAuthRequiredDetailsType) => BlockingResponseOrPromise | undefined,
+            callback: (details: OnAuthRequiredDetailsType) => BlockingResponseOrPromiseOrVoid,
             filter: RequestFilter,
             extraInfoSpec?: OnAuthRequiredOptions[],
         ): void;
@@ -1599,7 +1600,7 @@ export namespace WebRequest {
      * Fired when the first byte of the response body is received. For HTTP requests, this means that the status line and
      * response headers are available.
      */
-    interface onResponseStartedEvent extends Events.Event<(details: OnResponseStartedDetailsType) => void> {
+    interface OnResponseStartedEvent extends Events.Event<(details: OnResponseStartedDetailsType) => void> {
         /**
          * Registers an event listener <em>callback</em> to an event.
          *
@@ -1617,7 +1618,7 @@ export namespace WebRequest {
     /**
      * Fired when a server-initiated redirect is about to occur.
      */
-    interface onBeforeRedirectEvent extends Events.Event<(details: OnBeforeRedirectDetailsType) => void> {
+    interface OnBeforeRedirectEvent extends Events.Event<(details: OnBeforeRedirectDetailsType) => void> {
         /**
          * Registers an event listener <em>callback</em> to an event.
          *
@@ -1635,7 +1636,7 @@ export namespace WebRequest {
     /**
      * Fired when a request is completed.
      */
-    interface onCompletedEvent extends Events.Event<(details: OnCompletedDetailsType) => void> {
+    interface OnCompletedEvent extends Events.Event<(details: OnCompletedDetailsType) => void> {
         /**
          * Registers an event listener <em>callback</em> to an event.
          *
@@ -1653,7 +1654,7 @@ export namespace WebRequest {
     /**
      * Fired when an error occurs.
      */
-    interface onErrorOccurredEvent extends Events.Event<(details: OnErrorOccurredDetailsType) => void> {
+    interface OnErrorOccurredEvent extends Events.Event<(details: OnErrorOccurredDetailsType) => void> {
         /**
          * Registers an event listener <em>callback</em> to an event.
          *
@@ -1690,52 +1691,52 @@ export namespace WebRequest {
         /**
          * Fired when a request is about to occur.
          */
-        onBeforeRequest: onBeforeRequestEvent;
+        onBeforeRequest: OnBeforeRequestEvent;
 
         /**
          * Fired before sending an HTTP request, once the request headers are available. This may occur after a TCP connection is
          * made to the server, but before any HTTP data is sent.
          */
-        onBeforeSendHeaders: onBeforeSendHeadersEvent;
+        onBeforeSendHeaders: OnBeforeSendHeadersEvent;
 
         /**
          * Fired just before a request is going to be sent to the server (modifications of previous onBeforeSendHeaders callbacks
          * are visible by the time onSendHeaders is fired).
          */
-        onSendHeaders: onSendHeadersEvent;
+        onSendHeaders: OnSendHeadersEvent;
 
         /**
          * Fired when HTTP response headers of a request have been received.
          */
-        onHeadersReceived: onHeadersReceivedEvent;
+        onHeadersReceived: OnHeadersReceivedEvent;
 
         /**
          * Fired when an authentication failure is received. The listener has three options: it can provide authentication
          * credentials, it can cancel the request and display the error page, or it can take no action on the challenge.
          * If bad user credentials are provided, this may be called multiple times for the same request.
          */
-        onAuthRequired: onAuthRequiredEvent;
+        onAuthRequired: OnAuthRequiredEvent;
 
         /**
          * Fired when the first byte of the response body is received. For HTTP requests, this means that the status line and
          * response headers are available.
          */
-        onResponseStarted: onResponseStartedEvent;
+        onResponseStarted: OnResponseStartedEvent;
 
         /**
          * Fired when a server-initiated redirect is about to occur.
          */
-        onBeforeRedirect: onBeforeRedirectEvent;
+        onBeforeRedirect: OnBeforeRedirectEvent;
 
         /**
          * Fired when a request is completed.
          */
-        onCompleted: onCompletedEvent;
+        onCompleted: OnCompletedEvent;
 
         /**
          * Fired when an error occurs.
          */
-        onErrorOccurred: onErrorOccurredEvent;
+        onErrorOccurred: OnErrorOccurredEvent;
 
         /**
          * The maximum number of times that <code>handlerBehaviorChanged</code> can be called per 10 minute sustained interval.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Lusito/webextension-polyfill-ts/issues/109

Changes:
- Made certain listeners allow void return type, as that is how they are specified by the webextension definition.
- onMessage Listeners now differ between 3 types of listeners, so that one can only use the sendResponse parameter if the listener returns true.
- Fixed some interfaces not being CamelCase.
- Fixed onUserScriptMessage not having a response parameter.