### PR TITLE
[@types/docusign-esign] fix: add method `getEnvelopeDocGenFormFields` to types file.

### DIFF
--- a/types/docusign-esign/docusign-esign-tests.ts
+++ b/types/docusign-esign/docusign-esign-tests.ts
@@ -40,6 +40,15 @@ const getEnvelope = async (
     return results;
 };
 
+const getEnvelopeDocGenFormFields = async (envelopeId: string) => {
+    const params = await getDsRequestParams();
+    const client = await getClient(params.token);
+    const envelopesApi = new docusign.EnvelopesApi(client);
+
+    const results = await envelopesApi.getEnvelopeDocGenFormFields(params.accountId, envelopeId);
+    return results;
+};
+
 const getEnvelopeWithStoredConfiguredClient = async (
     envelopeId: string,
     options: { advancedUpdate?: string | undefined; include?: string | undefined },

--- a/types/docusign-esign/index.d.ts
+++ b/types/docusign-esign/index.d.ts
@@ -1332,6 +1332,12 @@ export class EnvelopesApi {
         callback?: (() => void) | ((error: any, data: any, response: any) => void),
     ): Promise<Envelope>;
 
+    getEnvelopeDocGenFormFields(
+        accountId: string,
+        envelopeId: string,
+        callback?: (() => void) | ((error: any, data: any, response: any) => void),
+    ): Promise<DocGenFormFieldResponse>;
+
     getEnvelopeDocumentHtmlDefinitions(
         accountId: string,
         envelopeId: string,
@@ -17754,6 +17760,53 @@ export interface DocumentFieldsInformation {
     documentFields?:
         | /* A name-value pair that describes an item and provides a value for the item. */ NameValue[]
         | undefined;
+}
+
+export interface DocGenFormFieldOption {
+    description?: string | undefined;
+    label?: string | undefined;
+    selected?: string | undefined;
+    value?: string | undefined;
+}
+
+export interface DocGenFormFieldRowValue {
+    docGenFormFieldList?: DocGenFormField[] | undefined;
+}
+
+export interface DocGenFormFieldValidation {
+    errorMessage?: string | undefined;
+    expression?: string | undefined;
+}
+
+export interface DocGenSytaxError {
+    errorCode?: string | undefined;
+    message?: string | undefined;
+    tagIdentifier?: string | undefined;
+}
+
+export interface DocGenFormField {
+    description?: string | undefined;
+    label?: string | undefined;
+    name?: string | undefined;
+    options?: DocGenFormFieldOption[] | undefined;
+    predefinedValidation?: string | undefined;
+    required?: string | undefined;
+    rowValues?: DocGenFormFieldRowValue[] | undefined;
+    type?: string | undefined;
+    validation?: DocGenFormFieldValidation[] | undefined;
+    value?: string | undefined;
+}
+
+export interface DocGenFormFields {
+    docGenDocumentStatus?: string | undefined;
+    docGenErrors?: DocGenSytaxError[] | undefined;
+    docGenFormFieldList?: DocGenFormField[] | undefined;
+    documentId?: string | undefined;
+}
+
+export interface DocGenFormFieldResponse {
+    docGenFormFields?: DocGenFormFields[] | undefined;
+    errorDetails?: ErrorDetails | undefined;
 }
 
 export interface DocumentHtmlCollapsibleDisplaySettings {


### PR DESCRIPTION
Fixes #70160 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Ran test on local after making the changes - 
<img width="717" alt="Screenshot 2025-02-23 at 7 22 13 PM" src="https://github.com/user-attachments/assets/4dbc79f5-3ab8-43ca-a4c9-71f314d542b7" />

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
This PR adds the missing method `getEnvelopeDocGenFormFields` in the `EnvelopesApi` class. This issues was raised in #70160 . I referred to code documentation for the library [here](https://github.com/docusign/docusign-esign-node-client/blob/16f04f2cd473afa17bfc4e1148ff81c8c40a591d/src/api/EnvelopesApi.js#L4683) to add the method and respective interfaces.

Please review and let me know if you have any suggestions or feedback. 
Looking forward to your review!

