### PR TITLE
fix(leaflet.vectorgrid): add possible function type to vectorTileLayerStyles property in VectorGridOptions

### DIFF
--- a/types/leaflet.vectorgrid/index.d.ts
+++ b/types/leaflet.vectorgrid/index.d.ts
@@ -73,7 +73,7 @@ declare module "leaflet" {
         /** A factory method which will be used to instantiate the per-tile renderers. */
         rendererFactory?: TileFactoryFunction<T>;
         /** A data structure holding initial symbolizer definitions for the vector features. */
-        vectorTileLayerStyles?: Record<string, PathOptions>;
+        vectorTileLayerStyles?: (Record<string, PathOptions> | ((properties:Record<string,string>, zoom:number) => L.Path));
         /** Whether this VectorGrid fires Interactive Layer events. */
         interactive?: boolean;
         /**

--- a/types/leaflet.vectorgrid/index.d.ts
+++ b/types/leaflet.vectorgrid/index.d.ts
@@ -75,7 +75,7 @@ declare module "leaflet" {
         /** A data structure holding initial symbolizer definitions for the vector features. */
         vectorTileLayerStyles?:
             | Record<string, PathOptions>
-            | ((properties: Record<string, string>, zoom: number) => L.Path);
+            | ((properties: Record<string, string>, zoom: number) => PathOptions);
         /** Whether this VectorGrid fires Interactive Layer events. */
         interactive?: boolean;
         /**

--- a/types/leaflet.vectorgrid/index.d.ts
+++ b/types/leaflet.vectorgrid/index.d.ts
@@ -73,7 +73,9 @@ declare module "leaflet" {
         /** A factory method which will be used to instantiate the per-tile renderers. */
         rendererFactory?: TileFactoryFunction<T>;
         /** A data structure holding initial symbolizer definitions for the vector features. */
-        vectorTileLayerStyles?: (Record<string, PathOptions> | ((properties:Record<string,string>, zoom:number) => L.Path));
+        vectorTileLayerStyles?:
+            | Record<string, PathOptions>
+            | ((properties: Record<string, string>, zoom: number) => L.Path);
         /** Whether this VectorGrid fires Interactive Layer events. */
         interactive?: boolean;
         /**

--- a/types/leaflet.vectorgrid/leaflet.vectorgrid-tests.ts
+++ b/types/leaflet.vectorgrid/leaflet.vectorgrid-tests.ts
@@ -93,7 +93,8 @@ vectorgridOptions = {
 
 // $ExpectType VectorGrid<HTMLCanvasElement | SVGViewElement>
 new L.VectorGrid({
-    ...vectorgridOptions, vectorTileLayerStyles: (_properties, _zoom) => {
-        return {}
+    ...vectorgridOptions,
+    vectorTileLayerStyles: (_properties, _zoom) => {
+        return {};
     },
-}) 
+});

--- a/types/leaflet.vectorgrid/leaflet.vectorgrid-tests.ts
+++ b/types/leaflet.vectorgrid/leaflet.vectorgrid-tests.ts
@@ -90,3 +90,10 @@ vectorgridOptions = {
     getFeatureId: undefined,
     filter: undefined,
 };
+
+// $ExpectType VectorGrid<HTMLCanvasElement | SVGViewElement>
+new L.VectorGrid({
+    ...vectorgridOptions, vectorTileLayerStyles: (_properties, _zoom) => {
+        return {}
+    },
+}) 


### PR DESCRIPTION
add function to vectorTileLayerStyles property in VectorGridOptions

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/Leaflet/Leaflet.VectorGrid/blob/master/src/Leaflet.VectorGrid.js#L114>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
