### PR TITLE
[react-reconciler] Add missing NoEventPriority constant

### DIFF
--- a/types/react-reconciler/constants.d.ts
+++ b/types/react-reconciler/constants.d.ts
@@ -4,3 +4,4 @@ export const DefaultEventPriority = 0b0000000000000000000000000010000;
 export const IdleEventPriority = 0b0100000000000000000000000000000;
 export const LegacyRoot = 0;
 export const ConcurrentRoot = 1;
+export const NoEventPriority = 0;

--- a/types/react-reconciler/package.json
+++ b/types/react-reconciler/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/react-reconciler",
-    "version": "0.28.9999",
+    "version": "0.31.9999",
     "projects": [
         "https://reactjs.org/"
     ],

--- a/types/react-reconciler/test/ReactReconcilerPriorityConstant.ts
+++ b/types/react-reconciler/test/ReactReconcilerPriorityConstant.ts
@@ -4,3 +4,4 @@ export const DEFAULT_EVENT_PRIORITY = 16;
 export const IDLE_EVENT_PRIORITY = 536870912;
 export const LEGACY_ROOT = 0;
 export const CONCURRENT_ROOT = 1;
+export const NO_EVENT_PRIORITY = 0;

--- a/types/react-reconciler/test/react-reconciler-tests.ts
+++ b/types/react-reconciler/test/react-reconciler-tests.ts
@@ -41,3 +41,6 @@ isEqual(Constants.LEGACY_ROOT, ReactReconcilerConstants.LegacyRoot);
 
 // $ExpectType boolean
 isEqual(Constants.CONCURRENT_ROOT, ReactReconcilerConstants.ConcurrentRoot);
+
+// $ExpectType boolean
+isEqual(Constants.NO_EVENT_PRIORITY, ReactReconcilerConstants.NoEventPriority);


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

This adds the `NoEventPriority` constant from https://github.com/facebook/react/commit/8e1462e8c471fbec98aac2b3e1326498d0ff7139. I'm not sure which release of `react-reconciler` first included this constant, but it is present in `react-reconciler@v0.31.0`.

There are still issues with the types in this package. For example, `shouldAttemptEagerTransition` is missing (added in https://github.com/facebook/react/commit/d121c67004a2e6b0bb5d341843663ef213f64863). I haven't yet figured out what needs to be updated in this repo to include that. If I do, I'll create a separate pull request for that.
