### PR TITLE
[node] buffer: improve constructor signatures, fix CI for TS 5.9

### DIFF
--- a/types/asn1/asn1-tests.ts
+++ b/types/asn1/asn1-tests.ts
@@ -1,6 +1,6 @@
 import { Ber, BerReader, BerWriter } from "asn1";
 
-let buf = Buffer.alloc(0);
+let buf: Buffer = Buffer.alloc(0);
 let bufferOrNull: Buffer | null = Buffer.alloc(0);
 const bool = false;
 let boolOrNull: boolean | null = false;

--- a/types/b4a/b4a-tests.ts
+++ b/types/b4a/b4a-tests.ts
@@ -54,7 +54,7 @@ u8a = b4a.fill(buf, 1, 2, 3, "utf8");
 u8a = b4a.from(sb);
 u8a = b4a.from(buf);
 u8a = b4a.from("this is a tést");
-u8a = b4a.from(buf, 1, 2);
+u8a = b4a.from(buf.buffer, 1, 2);
 u8a = b4a.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72] as readonly number[]);
 // @ts-expect-error
 b4a.from({});

--- a/types/b4a/index.d.ts
+++ b/types/b4a/index.d.ts
@@ -66,29 +66,21 @@ export function fill(
     encoding?: BufferEncoding,
 ): Buffer | Uint8Array;
 /**
+ * See https://nodejs.org/api/buffer.html#static-method-bufferfromarray
+ */
+export function from(array: Uint8Array | readonly number[]): Buffer | Uint8Array;
+/**
  * See https://nodejs.org/api/buffer.html#static-method-bufferfromarraybuffer-byteoffset-length
  */
 export function from(
-    arrayBuffer: WithImplicitCoercion<ArrayBuffer | SharedArrayBuffer>,
+    arrayBuffer: ArrayBuffer | SharedArrayBuffer,
     byteOffset?: number,
     length?: number,
 ): Buffer | Uint8Array;
 /**
- * See https://nodejs.org/api/buffer.html#static-method-bufferfrombuffer
- */
-export function from(data: Uint8Array | readonly number[]): Buffer | Uint8Array;
-/**
- * See https://nodejs.org/api/buffer.html#static-method-bufferfromarray
- */
-// tslint:disable-next-line unified-signatures
-export function from(data: WithImplicitCoercion<Uint8Array | readonly number[] | string>): Buffer | Uint8Array;
-/**
  * See https://nodejs.org/api/buffer.html#static-method-bufferfromstring-encoding
  */
-export function from(
-    str: WithImplicitCoercion<string> | { [Symbol.toPrimitive](hint: "string"): string },
-    encoding?: BufferEncoding,
-): Buffer | Uint8Array;
+export function from(string: string, encoding?: BufferEncoding): Buffer | Uint8Array;
 /**
  * See https://nodejs.org/api/buffer.html#bufincludesvalue-byteoffset-encoding
  * @param buffer

--- a/types/buffers/buffers-tests.ts
+++ b/types/buffers/buffers-tests.ts
@@ -3,7 +3,7 @@ import Buffers = require("buffers");
 var any: any;
 var num: number;
 var str: string;
-var buf = new Buffer([1, 2, 3]);
+var buf: Buffer = new Buffer([1, 2, 3]);
 var bufs: Buffers = new Buffers(); // with new, as type
 
 bufs = Buffers(); // no new

--- a/types/ecurve/ecurve-tests.ts
+++ b/types/ecurve/ecurve-tests.ts
@@ -19,7 +19,7 @@ const curvePt = ecparams.G.multiply(BigInteger.fromBuffer(privateKey));
 const x = curvePt.affineX.toBuffer(32);
 const y = curvePt.affineY.toBuffer(32);
 
-let publicKey = Buffer.concat([new Buffer([0x04]), x, y]);
+let publicKey: Buffer = Buffer.concat([new Buffer([0x04]), x, y]);
 console.log(publicKey.toString("hex"));
 // => 04d0988bfa799f7d7ef9ab3de97ef481cd0f75d2367ad456607647edde665d6f6fbdd594388756a7beaf73b4822bc22d36e9bda7db82df2b8b623673eefc0b7495
 

--- a/types/hexo-util/hexo-util-tests.ts
+++ b/types/hexo-util/hexo-util-tests.ts
@@ -23,7 +23,7 @@ import { createHash } from "crypto";
 import { join } from "path";
 import { Readable } from "stream";
 
-let buffer = Buffer.alloc(0);
+let buffer: Buffer = Buffer.alloc(0);
 let directory: { [x: string]: any } = {};
 let string = "";
 

--- a/types/node/buffer.buffer.d.ts
+++ b/types/node/buffer.buffer.d.ts
@@ -451,4 +451,10 @@ declare module "buffer" {
             subarray(start?: number, end?: number): Buffer<TArrayBuffer>;
         }
     }
+    /** @deprecated Use `Buffer.allocUnsafeSlow()` instead. */
+    var SlowBuffer: {
+        /** @deprecated Use `Buffer.allocUnsafeSlow()` instead. */
+        new(size: number): Buffer<ArrayBuffer>;
+        prototype: Buffer;
+    };
 }

--- a/types/node/buffer.buffer.d.ts
+++ b/types/node/buffer.buffer.d.ts
@@ -1,4 +1,6 @@
 declare module "buffer" {
+    type ImplicitArrayBuffer<T extends WithImplicitCoercion<ArrayBufferLike>> = T extends
+        { valueOf(): infer V extends ArrayBufferLike } ? V : T;
     global {
         interface BufferConstructor {
             // see buffer.d.ts for implementation shared with all TypeScript versions
@@ -24,7 +26,7 @@ declare module "buffer" {
              * @param array The octets to store.
              * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
              */
-            new(array: Uint8Array): Buffer<ArrayBuffer>;
+            new(array: ArrayLike<number>): Buffer<ArrayBuffer>;
             /**
              * Produces a Buffer backed by the same allocated memory as
              * the given {ArrayBuffer}/{SharedArrayBuffer}.
@@ -33,20 +35,6 @@ declare module "buffer" {
              * @deprecated since v10.0.0 - Use `Buffer.from(arrayBuffer[, byteOffset[, length]])` instead.
              */
             new<TArrayBuffer extends ArrayBufferLike = ArrayBuffer>(arrayBuffer: TArrayBuffer): Buffer<TArrayBuffer>;
-            /**
-             * Allocates a new buffer containing the given {array} of octets.
-             *
-             * @param array The octets to store.
-             * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
-             */
-            new(array: readonly any[]): Buffer<ArrayBuffer>;
-            /**
-             * Copies the passed {buffer} data onto a new {Buffer} instance.
-             *
-             * @param buffer The buffer to copy.
-             * @deprecated since v10.0.0 - Use `Buffer.from(buffer)` instead.
-             */
-            new(buffer: Buffer): Buffer<ArrayBuffer>;
             /**
              * Allocates a new `Buffer` using an `array` of bytes in the range `0` – `255`.
              * Array entries outside that range will be truncated to fit into it.
@@ -58,40 +46,120 @@ declare module "buffer" {
              * const buf = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
              * ```
              *
-             * If `array` is an `Array`\-like object (that is, one with a `length` property of
+             * If `array` is an `Array`-like object (that is, one with a `length` property of
              * type `number`), it is treated as if it is an array, unless it is a `Buffer` or
-             * a `Uint8Array`. This means all other `TypedArray` variants get treated as an `Array`. To create a `Buffer` from the bytes backing a `TypedArray`, use `Buffer.copyBytesFrom()`.
+             * a `Uint8Array`. This means all other `TypedArray` variants get treated as an
+             * `Array`. To create a `Buffer` from the bytes backing a `TypedArray`, use
+             * `Buffer.copyBytesFrom()`.
              *
              * A `TypeError` will be thrown if `array` is not an `Array` or another type
              * appropriate for `Buffer.from()` variants.
              *
-             * `Buffer.from(array)` and `Buffer.from(string)` may also use the internal `Buffer` pool like `Buffer.allocUnsafe()` does.
+             * `Buffer.from(array)` and `Buffer.from(string)` may also use the internal
+             * `Buffer` pool like `Buffer.allocUnsafe()` does.
              * @since v5.10.0
              */
-            from<TArrayBuffer extends ArrayBufferLike>(
-                arrayBuffer: WithImplicitCoercion<TArrayBuffer>,
+            from(array: WithImplicitCoercion<ArrayLike<number>>): Buffer<ArrayBuffer>;
+            /**
+             * This creates a view of the `ArrayBuffer` without copying the underlying
+             * memory. For example, when passed a reference to the `.buffer` property of a
+             * `TypedArray` instance, the newly created `Buffer` will share the same
+             * allocated memory as the `TypedArray`'s underlying `ArrayBuffer`.
+             *
+             * ```js
+             * import { Buffer } from 'node:buffer';
+             *
+             * const arr = new Uint16Array(2);
+             *
+             * arr[0] = 5000;
+             * arr[1] = 4000;
+             *
+             * // Shares memory with `arr`.
+             * const buf = Buffer.from(arr.buffer);
+             *
+             * console.log(buf);
+             * // Prints: <Buffer 88 13 a0 0f>
+             *
+             * // Changing the original Uint16Array changes the Buffer also.
+             * arr[1] = 6000;
+             *
+             * console.log(buf);
+             * // Prints: <Buffer 88 13 70 17>
+             * ```
+             *
+             * The optional `byteOffset` and `length` arguments specify a memory range within
+             * the `arrayBuffer` that will be shared by the `Buffer`.
+             *
+             * ```js
+             * import { Buffer } from 'node:buffer';
+             *
+             * const ab = new ArrayBuffer(10);
+             * const buf = Buffer.from(ab, 0, 2);
+             *
+             * console.log(buf.length);
+             * // Prints: 2
+             * ```
+             *
+             * A `TypeError` will be thrown if `arrayBuffer` is not an `ArrayBuffer` or a
+             * `SharedArrayBuffer` or another type appropriate for `Buffer.from()`
+             * variants.
+             *
+             * It is important to remember that a backing `ArrayBuffer` can cover a range
+             * of memory that extends beyond the bounds of a `TypedArray` view. A new
+             * `Buffer` created using the `buffer` property of a `TypedArray` may extend
+             * beyond the range of the `TypedArray`:
+             *
+             * ```js
+             * import { Buffer } from 'node:buffer';
+             *
+             * const arrA = Uint8Array.from([0x63, 0x64, 0x65, 0x66]); // 4 elements
+             * const arrB = new Uint8Array(arrA.buffer, 1, 2); // 2 elements
+             * console.log(arrA.buffer === arrB.buffer); // true
+             *
+             * const buf = Buffer.from(arrB.buffer);
+             * console.log(buf);
+             * // Prints: <Buffer 63 64 65 66>
+             * ```
+             * @since v5.10.0
+             * @param arrayBuffer An `ArrayBuffer`, `SharedArrayBuffer`, for example the
+             * `.buffer` property of a `TypedArray`.
+             * @param byteOffset Index of first byte to expose. **Default:** `0`.
+             * @param length Number of bytes to expose. **Default:**
+             * `arrayBuffer.byteLength - byteOffset`.
+             */
+            from<TArrayBuffer extends WithImplicitCoercion<ArrayBufferLike>>(
+                arrayBuffer: TArrayBuffer,
                 byteOffset?: number,
                 length?: number,
-            ): Buffer<TArrayBuffer>;
+            ): Buffer<ImplicitArrayBuffer<TArrayBuffer>>;
             /**
-             * Creates a new Buffer using the passed {data}
-             * @param data data to create a new Buffer
+             * Creates a new `Buffer` containing `string`. The `encoding` parameter identifies
+             * the character encoding to be used when converting `string` into bytes.
+             *
+             * ```js
+             * import { Buffer } from 'node:buffer';
+             *
+             * const buf1 = Buffer.from('this is a tést');
+             * const buf2 = Buffer.from('7468697320697320612074c3a97374', 'hex');
+             *
+             * console.log(buf1.toString());
+             * // Prints: this is a tést
+             * console.log(buf2.toString());
+             * // Prints: this is a tést
+             * console.log(buf1.toString('latin1'));
+             * // Prints: this is a tÃ©st
+             * ```
+             *
+             * A `TypeError` will be thrown if `string` is not a string or another type
+             * appropriate for `Buffer.from()` variants.
+             *
+             * `Buffer.from(string)` may also use the internal `Buffer` pool like
+             * `Buffer.allocUnsafe()` does.
+             * @since v5.10.0
+             * @param string A string to encode.
+             * @param encoding The encoding of `string`. **Default:** `'utf8'`.
              */
-            from(data: Uint8Array | readonly number[]): Buffer<ArrayBuffer>;
-            from(data: WithImplicitCoercion<Uint8Array | readonly number[] | string>): Buffer<ArrayBuffer>;
-            /**
-             * Creates a new Buffer containing the given JavaScript string {str}.
-             * If provided, the {encoding} parameter identifies the character encoding.
-             * If not provided, {encoding} defaults to 'utf8'.
-             */
-            from(
-                str:
-                    | WithImplicitCoercion<string>
-                    | {
-                        [Symbol.toPrimitive](hint: "string"): string;
-                    },
-                encoding?: BufferEncoding,
-            ): Buffer<ArrayBuffer>;
+            from(string: WithImplicitCoercion<string>, encoding?: BufferEncoding): Buffer<ArrayBuffer>;
             /**
              * Creates a new Buffer using the passed {data}
              * @param values to create a new Buffer

--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -237,7 +237,10 @@ declare module "buffer" {
     }
     export import atob = globalThis.atob;
     export import btoa = globalThis.btoa;
-
+    export type WithImplicitCoercion<T> =
+        | T
+        | { valueOf(): T }
+        | (T extends string ? { [Symbol.toPrimitive](hint: "string"): T } : never);
     global {
         namespace NodeJS {
             export { BufferEncoding };
@@ -256,11 +259,6 @@ declare module "buffer" {
             | "latin1"
             | "binary"
             | "hex";
-        type WithImplicitCoercion<T> =
-            | T
-            | {
-                valueOf(): T;
-            };
         /**
          * Raw data is stored in instances of the Buffer class.
          * A Buffer is similar to an array of integers but corresponds to a raw memory allocation outside the V8 heap.  A Buffer cannot be resized.

--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -114,11 +114,6 @@ declare module "buffer" {
      * @param toEnc To target encoding.
      */
     export function transcode(source: Uint8Array, fromEnc: TranscodeEncoding, toEnc: TranscodeEncoding): Buffer;
-    export const SlowBuffer: {
-        /** @deprecated since v6.0.0, use `Buffer.allocUnsafeSlow()` */
-        new(size: number): Buffer;
-        prototype: Buffer;
-    };
     /**
      * Resolves a `'blob:nodedata:...'` an associated `Blob` object registered using
      * a prior call to `URL.createObjectURL()`.

--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -1,7 +1,7 @@
 // Specifically test buffer module regression.
 import {
     Blob as NodeBlob,
-    Buffer as ImportedBuffer,
+    Buffer,
     constants,
     File,
     isAscii,
@@ -9,7 +9,7 @@ import {
     kMaxLength,
     kStringMaxLength,
     resolveObjectURL,
-    SlowBuffer as ImportedSlowBuffer,
+    SlowBuffer,
     transcode,
     TranscodeEncoding,
 } from "node:buffer";
@@ -29,6 +29,11 @@ console.log(Buffer.byteLength("xyz123"));
 console.log(Buffer.byteLength("xyz123", "ascii"));
 const result1 = Buffer.concat([utf8Buffer, base64Buffer] as readonly Uint8Array[]);
 const result2 = Buffer.concat([utf8Buffer, base64Buffer] as readonly Uint8Array[], 9999999);
+
+// Globals
+{
+    const globalBuffer: typeof Buffer = globalThis.Buffer;
+}
 
 // Module constants
 {
@@ -58,76 +63,96 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as readonly Uint8Array[
     buf.swap64();
 }
 
-// Class Method: Buffer.from(data)
+// Class Method: Buffer.from()
 {
-    // Array
-    const buf1: Buffer = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72] as readonly number[]);
+    // Array-like
+    {
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72] as const);
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from(new Uint8Array());
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from(Uint8ClampedArray.of(1024));
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from({ length: 6, 0: 0x62, 1: 0x75, 2: 0x66, 3: 0x66, 4: 0x65, 5: 0x72 });
+    }
+
     // Buffer
-    const buf2: Buffer = Buffer.from(buf1, 1, 2);
-    // String
-    const buf3: Buffer = Buffer.from("this is a tést");
+    {
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from(Buffer.alloc(0));
+    }
+
     // ArrayBuffer
-    const arrUint16: Uint16Array = new Uint16Array(2);
-    arrUint16[0] = 5000;
-    arrUint16[1] = 4000;
-    const buf4: Buffer = Buffer.from(arrUint16.buffer);
-    const arrUint8: Uint8Array = new Uint8Array(2);
-    const buf5: Buffer = Buffer.from(arrUint8);
-    const buf6: Buffer = Buffer.from(buf1);
-    const sb: SharedArrayBuffer = {} as any;
-    const buf7: Buffer = Buffer.from(sb);
+    {
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from(new ArrayBuffer(0));
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from(new ArrayBuffer(32), 16, 16);
+        // $ExpectType Buffer || Buffer<SharedArrayBuffer>
+        Buffer.from(new SharedArrayBuffer(0));
+        // $ExpectType Buffer || Buffer<SharedArrayBuffer>
+        Buffer.from(new SharedArrayBuffer(32), 16, 16);
+        // $ExpectType Buffer || Buffer<ArrayBuffer | SharedArrayBuffer>
+        Buffer.from({} as ArrayBuffer | SharedArrayBuffer);
+    }
+
+    // String
+    {
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from("buffer");
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from("buffer", "latin1");
+    }
+
+    // implicit coercion
+    {
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from({
+            valueOf() {
+                return [] as const;
+            },
+        });
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from({
+            valueOf() {
+                return Buffer.alloc(0);
+            },
+        });
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from({
+            valueOf() {
+                return "buffer";
+            },
+        }, "utf-8");
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from({
+            valueOf() {
+                return new ArrayBuffer(0);
+            },
+        });
+        // $ExpectType Buffer || Buffer<SharedArrayBuffer>
+        Buffer.from({
+            valueOf() {
+                return new SharedArrayBuffer(0);
+            },
+        });
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from({
+            [Symbol.toPrimitive]() {
+                return "buffer";
+            },
+        }, "latin1");
+        // @ts-expect-error
+        Buffer.from({} as { valueOf(): {} });
+        // @ts-expect-error
+        Buffer.from({} as { [Symbol.toPrimitive](): number });
+    }
+
     // @ts-expect-error
     Buffer.from({});
-}
-
-// Class Method: Buffer.from(arrayBuffer[, byteOffset[, length]])
-{
-    const arr: Uint16Array = new Uint16Array(2);
-    arr[0] = 5000;
-    arr[1] = 4000;
-
-    let buf: Buffer;
-    buf = Buffer.from(arr.buffer, 1);
-    buf = Buffer.from(arr.buffer, 0, 1);
-
     // @ts-expect-error
-    Buffer.from("this is a test", 1, 1);
-    // Ideally passing a normal Buffer would be a type error too, but it's not
-    //  since Buffer is assignable to ArrayBuffer currently
-}
-
-// Class Method: Buffer.from(str[, encoding])
-{
-    const buf2: Buffer = Buffer.from("7468697320697320612074c3a97374", "hex");
-    /* tslint:disable-next-line no-construct */
-    Buffer.from(new String("DEADBEEF"), "hex");
-    // @ts-expect-error
-    Buffer.from(buf2, "hex");
-}
-
-// Class Method: Buffer.from(object, [, byteOffset[, length]])  (Implicit coercion)
-{
-    const pseudoBuf = {
-        valueOf() {
-            return Buffer.from([1, 2, 3]);
-        },
-    };
-    let buf: Buffer = Buffer.from(pseudoBuf);
-    const pseudoString = {
-        valueOf() {
-            return "Hello";
-        },
-    };
-    buf = Buffer.from(pseudoString);
-    buf = Buffer.from(pseudoString, "utf-8");
-    // @ts-expect-error
-    Buffer.from(pseudoString, 1, 2);
-    const pseudoArrayBuf = {
-        valueOf() {
-            return new Uint16Array(2);
-        },
-    };
-    buf = Buffer.from(pseudoArrayBuf, 1, 1);
+    Buffer.from(0);
 }
 
 // Class Method: Buffer.alloc(size[, fill[, encoding]])
@@ -263,18 +288,18 @@ b.fill("a").fill("b");
     */
 }
 
-// Imported Buffer from buffer module works properly
+// SlowBuffer
 {
-    const b = new ImportedBuffer("123");
-    b.writeUInt8(0, 6);
-    const sb = new ImportedSlowBuffer(43);
-    b.writeUInt8(0, 6);
+    // $ExpectType Buffer || Buffer<ArrayBuffer>
+    new SlowBuffer(256);
+    // @ts-expect-error
+    SlowBuffer(256);
 }
 
 // NodeJS.BufferEncoding works properly
 {
     const encoding: NodeJS.BufferEncoding = "ascii";
-    const b = new ImportedBuffer("123", encoding);
+    const b = new Buffer("123", encoding);
     b.writeUInt8(0, 6);
 }
 
@@ -390,15 +415,6 @@ const c: NodeJS.TypedArray = new Buffer(123);
     readable.pipe(writable);
     writableFinished = writable.writableFinished;
     writable.destroyed;
-}
-
-{
-    const obj = {
-        valueOf() {
-            return "hello";
-        },
-    };
-    Buffer.from(obj);
 }
 
 const buff = Buffer.from("Hello World!");

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -509,7 +509,7 @@ import * as url from "node:url";
     let _req = new http.IncomingMessage(new net.Socket());
     let _res = new http.ServerResponse(_req);
     let _err = new Error();
-    let _head = Buffer.from("");
+    let _head: Buffer = Buffer.from("");
     let _bool = true;
 
     server = server.addListener("checkContinue", (req, res) => {

--- a/types/node/test/https.ts
+++ b/types/node/test/https.ts
@@ -299,7 +299,7 @@ import * as url from "node:url";
 {
     let server = new https.Server();
     let _socket = new tls.TLSSocket(new net.Socket());
-    let _buffer = Buffer.from("");
+    let _buffer: Buffer = Buffer.from("");
     let _err = new Error();
     let _boolean = true;
     let sessionCallback = (err: Error, resp: Buffer) => {};
@@ -450,7 +450,7 @@ import * as url from "node:url";
     let _req = new http.IncomingMessage(new net.Socket());
     let _res = new http.ServerResponse(_req);
     let _err = new Error();
-    let _head = Buffer.from("");
+    let _head: Buffer = Buffer.from("");
     let _bool = true;
 
     server = server.addListener("checkContinue", (req, res) => {

--- a/types/node/test/net.ts
+++ b/types/node/test/net.ts
@@ -128,7 +128,7 @@ import * as net from "node:net";
     let _socket: net.Socket = new net.Socket(constructorOpts);
 
     let bool = true;
-    let buffer = Buffer.from("123");
+    let buffer: Buffer = Buffer.from("123");
     let error = new Error("asd");
     let str = "123";
     let num = 123;

--- a/types/node/ts5.6/buffer.buffer.d.ts
+++ b/types/node/ts5.6/buffer.buffer.d.ts
@@ -24,7 +24,7 @@ declare module "buffer" {
              * @param array The octets to store.
              * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
              */
-            new(array: Uint8Array): Buffer;
+            new(array: ArrayLike<number>): Buffer;
             /**
              * Produces a Buffer backed by the same allocated memory as
              * the given {ArrayBuffer}/{SharedArrayBuffer}.
@@ -33,20 +33,6 @@ declare module "buffer" {
              * @deprecated since v10.0.0 - Use `Buffer.from(arrayBuffer[, byteOffset[, length]])` instead.
              */
             new(arrayBuffer: ArrayBuffer | SharedArrayBuffer): Buffer;
-            /**
-             * Allocates a new buffer containing the given {array} of octets.
-             *
-             * @param array The octets to store.
-             * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
-             */
-            new(array: readonly any[]): Buffer;
-            /**
-             * Copies the passed {buffer} data onto a new {Buffer} instance.
-             *
-             * @param buffer The buffer to copy.
-             * @deprecated since v10.0.0 - Use `Buffer.from(buffer)` instead.
-             */
-            new(buffer: Buffer): Buffer;
             /**
              * Allocates a new `Buffer` using an `array` of bytes in the range `0` – `255`.
              * Array entries outside that range will be truncated to fit into it.
@@ -58,15 +44,86 @@ declare module "buffer" {
              * const buf = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
              * ```
              *
-             * If `array` is an `Array`\-like object (that is, one with a `length` property of
+             * If `array` is an `Array`-like object (that is, one with a `length` property of
              * type `number`), it is treated as if it is an array, unless it is a `Buffer` or
-             * a `Uint8Array`. This means all other `TypedArray` variants get treated as an `Array`. To create a `Buffer` from the bytes backing a `TypedArray`, use `Buffer.copyBytesFrom()`.
+             * a `Uint8Array`. This means all other `TypedArray` variants get treated as an
+             * `Array`. To create a `Buffer` from the bytes backing a `TypedArray`, use
+             * `Buffer.copyBytesFrom()`.
              *
              * A `TypeError` will be thrown if `array` is not an `Array` or another type
              * appropriate for `Buffer.from()` variants.
              *
-             * `Buffer.from(array)` and `Buffer.from(string)` may also use the internal `Buffer` pool like `Buffer.allocUnsafe()` does.
+             * `Buffer.from(array)` and `Buffer.from(string)` may also use the internal
+             * `Buffer` pool like `Buffer.allocUnsafe()` does.
              * @since v5.10.0
+             */
+            from(array: WithImplicitCoercion<ArrayLike<number>>): Buffer;
+            /**
+             * This creates a view of the `ArrayBuffer` without copying the underlying
+             * memory. For example, when passed a reference to the `.buffer` property of a
+             * `TypedArray` instance, the newly created `Buffer` will share the same
+             * allocated memory as the `TypedArray`'s underlying `ArrayBuffer`.
+             *
+             * ```js
+             * import { Buffer } from 'node:buffer';
+             *
+             * const arr = new Uint16Array(2);
+             *
+             * arr[0] = 5000;
+             * arr[1] = 4000;
+             *
+             * // Shares memory with `arr`.
+             * const buf = Buffer.from(arr.buffer);
+             *
+             * console.log(buf);
+             * // Prints: <Buffer 88 13 a0 0f>
+             *
+             * // Changing the original Uint16Array changes the Buffer also.
+             * arr[1] = 6000;
+             *
+             * console.log(buf);
+             * // Prints: <Buffer 88 13 70 17>
+             * ```
+             *
+             * The optional `byteOffset` and `length` arguments specify a memory range within
+             * the `arrayBuffer` that will be shared by the `Buffer`.
+             *
+             * ```js
+             * import { Buffer } from 'node:buffer';
+             *
+             * const ab = new ArrayBuffer(10);
+             * const buf = Buffer.from(ab, 0, 2);
+             *
+             * console.log(buf.length);
+             * // Prints: 2
+             * ```
+             *
+             * A `TypeError` will be thrown if `arrayBuffer` is not an `ArrayBuffer` or a
+             * `SharedArrayBuffer` or another type appropriate for `Buffer.from()`
+             * variants.
+             *
+             * It is important to remember that a backing `ArrayBuffer` can cover a range
+             * of memory that extends beyond the bounds of a `TypedArray` view. A new
+             * `Buffer` created using the `buffer` property of a `TypedArray` may extend
+             * beyond the range of the `TypedArray`:
+             *
+             * ```js
+             * import { Buffer } from 'node:buffer';
+             *
+             * const arrA = Uint8Array.from([0x63, 0x64, 0x65, 0x66]); // 4 elements
+             * const arrB = new Uint8Array(arrA.buffer, 1, 2); // 2 elements
+             * console.log(arrA.buffer === arrB.buffer); // true
+             *
+             * const buf = Buffer.from(arrB.buffer);
+             * console.log(buf);
+             * // Prints: <Buffer 63 64 65 66>
+             * ```
+             * @since v5.10.0
+             * @param arrayBuffer An `ArrayBuffer`, `SharedArrayBuffer`, for example the
+             * `.buffer` property of a `TypedArray`.
+             * @param byteOffset Index of first byte to expose. **Default:** `0`.
+             * @param length Number of bytes to expose. **Default:**
+             * `arrayBuffer.byteLength - byteOffset`.
              */
             from(
                 arrayBuffer: WithImplicitCoercion<ArrayBuffer | SharedArrayBuffer>,
@@ -74,24 +131,33 @@ declare module "buffer" {
                 length?: number,
             ): Buffer;
             /**
-             * Creates a new Buffer using the passed {data}
-             * @param data data to create a new Buffer
+             * Creates a new `Buffer` containing `string`. The `encoding` parameter identifies
+             * the character encoding to be used when converting `string` into bytes.
+             *
+             * ```js
+             * import { Buffer } from 'node:buffer';
+             *
+             * const buf1 = Buffer.from('this is a tést');
+             * const buf2 = Buffer.from('7468697320697320612074c3a97374', 'hex');
+             *
+             * console.log(buf1.toString());
+             * // Prints: this is a tést
+             * console.log(buf2.toString());
+             * // Prints: this is a tést
+             * console.log(buf1.toString('latin1'));
+             * // Prints: this is a tÃ©st
+             * ```
+             *
+             * A `TypeError` will be thrown if `string` is not a string or another type
+             * appropriate for `Buffer.from()` variants.
+             *
+             * `Buffer.from(string)` may also use the internal `Buffer` pool like
+             * `Buffer.allocUnsafe()` does.
+             * @since v5.10.0
+             * @param string A string to encode.
+             * @param encoding The encoding of `string`. **Default:** `'utf8'`.
              */
-            from(data: Uint8Array | readonly number[]): Buffer;
-            from(data: WithImplicitCoercion<Uint8Array | readonly number[] | string>): Buffer;
-            /**
-             * Creates a new Buffer containing the given JavaScript string {str}.
-             * If provided, the {encoding} parameter identifies the character encoding.
-             * If not provided, {encoding} defaults to 'utf8'.
-             */
-            from(
-                str:
-                    | WithImplicitCoercion<string>
-                    | {
-                        [Symbol.toPrimitive](hint: "string"): string;
-                    },
-                encoding?: BufferEncoding,
-            ): Buffer;
+            from(string: WithImplicitCoercion<string>, encoding?: BufferEncoding): Buffer;
             /**
              * Creates a new Buffer using the passed {data}
              * @param values to create a new Buffer

--- a/types/node/ts5.6/buffer.buffer.d.ts
+++ b/types/node/ts5.6/buffer.buffer.d.ts
@@ -448,4 +448,10 @@ declare module "buffer" {
             subarray(start?: number, end?: number): Buffer;
         }
     }
+    /** @deprecated Use `Buffer.allocUnsafeSlow()` instead. */
+    var SlowBuffer: {
+        /** @deprecated Use `Buffer.allocUnsafeSlow()` instead. */
+        new(size: number): Buffer;
+        prototype: Buffer;
+    };
 }

--- a/types/node/v18/buffer.buffer.d.ts
+++ b/types/node/v18/buffer.buffer.d.ts
@@ -445,4 +445,10 @@ declare module "buffer" {
             subarray(start?: number, end?: number): Buffer<TArrayBuffer>;
         }
     }
+    /** @deprecated Use `Buffer.allocUnsafeSlow()` instead. */
+    var SlowBuffer: {
+        /** @deprecated Use `Buffer.allocUnsafeSlow()` instead. */
+        new(size: number): Buffer<ArrayBuffer>;
+        prototype: Buffer;
+    };
 }

--- a/types/node/v18/buffer.buffer.d.ts
+++ b/types/node/v18/buffer.buffer.d.ts
@@ -1,4 +1,6 @@
 declare module "buffer" {
+    type ImplicitArrayBuffer<T extends WithImplicitCoercion<ArrayBufferLike>> = T extends
+        { valueOf(): infer V extends ArrayBufferLike } ? V : T;
     global {
         interface BufferConstructor {
             // see buffer.d.ts for implementation shared with all TypeScript versions
@@ -24,7 +26,7 @@ declare module "buffer" {
              * @param array The octets to store.
              * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
              */
-            new(array: Uint8Array): Buffer<ArrayBuffer>;
+            new(array: ArrayLike<number>): Buffer<ArrayBuffer>;
             /**
              * Produces a Buffer backed by the same allocated memory as
              * the given {ArrayBuffer}/{SharedArrayBuffer}.
@@ -33,20 +35,6 @@ declare module "buffer" {
              * @deprecated since v10.0.0 - Use `Buffer.from(arrayBuffer[, byteOffset[, length]])` instead.
              */
             new<TArrayBuffer extends ArrayBufferLike = ArrayBuffer>(arrayBuffer: TArrayBuffer): Buffer<TArrayBuffer>;
-            /**
-             * Allocates a new buffer containing the given {array} of octets.
-             *
-             * @param array The octets to store.
-             * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
-             */
-            new(array: readonly any[]): Buffer<ArrayBuffer>;
-            /**
-             * Copies the passed {buffer} data onto a new {Buffer} instance.
-             *
-             * @param buffer The buffer to copy.
-             * @deprecated since v10.0.0 - Use `Buffer.from(buffer)` instead.
-             */
-            new(buffer: Buffer): Buffer<ArrayBuffer>;
             /**
              * Allocates a new `Buffer` using an `array` of bytes in the range `0` – `255`.
              * Array entries outside that range will be truncated to fit into it.
@@ -57,41 +45,116 @@ declare module "buffer" {
              * // Creates a new Buffer containing the UTF-8 bytes of the string 'buffer'.
              * const buf = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
              * ```
-             *
-             * If `array` is an `Array`\-like object (that is, one with a `length` property of
+             * If `array` is an `Array`-like object (that is, one with a `length` property of
              * type `number`), it is treated as if it is an array, unless it is a `Buffer` or
-             * a `Uint8Array`. This means all other `TypedArray` variants get treated as an`Array`. To create a `Buffer` from the bytes backing a `TypedArray`, use `Buffer.copyBytesFrom()`.
+             * a `Uint8Array`. This means all other `TypedArray` variants get treated as an
+             * `Array`. To create a `Buffer` from the bytes backing a `TypedArray`, use
+             * `Buffer.copyBytesFrom()`.
              *
              * A `TypeError` will be thrown if `array` is not an `Array` or another type
              * appropriate for `Buffer.from()` variants.
              *
-             * `Buffer.from(array)` and `Buffer.from(string)` may also use the internal`Buffer` pool like `Buffer.allocUnsafe()` does.
+             * `Buffer.from(array)` and `Buffer.from(string)` may also use the internal
+             * `Buffer` pool like `Buffer.allocUnsafe()` does.
              * @since v5.10.0
              */
-            from<TArrayBuffer extends ArrayBufferLike>(
-                arrayBuffer: WithImplicitCoercion<TArrayBuffer>,
+            from(array: WithImplicitCoercion<ArrayLike<number>>): Buffer<ArrayBuffer>;
+            /**
+             * This creates a view of the `ArrayBuffer` without copying the underlying
+             * memory. For example, when passed a reference to the `.buffer` property of a
+             * `TypedArray` instance, the newly created `Buffer` will share the same
+             * allocated memory as the `TypedArray`'s underlying `ArrayBuffer`.
+             *
+             * ```js
+             * import { Buffer } from 'node:buffer';
+             *
+             * const arr = new Uint16Array(2);
+             *
+             * arr[0] = 5000;
+             * arr[1] = 4000;
+             *
+             * // Shares memory with `arr`.
+             * const buf = Buffer.from(arr.buffer);
+             *
+             * console.log(buf);
+             * // Prints: <Buffer 88 13 a0 0f>
+             *
+             * // Changing the original Uint16Array changes the Buffer also.
+             * arr[1] = 6000;
+             *
+             * console.log(buf);
+             * // Prints: <Buffer 88 13 70 17>
+             * ```
+             * The optional `byteOffset` and `length` arguments specify a memory range within
+             * the `arrayBuffer` that will be shared by the `Buffer`.
+             *
+             * ```js
+             * import { Buffer } from 'node:buffer';
+             *
+             * const ab = new ArrayBuffer(10);
+             * const buf = Buffer.from(ab, 0, 2);
+             *
+             * console.log(buf.length);
+             * // Prints: 2
+             * ```
+             *
+             * A `TypeError` will be thrown if `arrayBuffer` is not an `ArrayBuffer` or a
+             * `SharedArrayBuffer` or another type appropriate for `Buffer.from()`
+             * variants.
+             *
+             * It is important to remember that a backing `ArrayBuffer` can cover a range
+             * of memory that extends beyond the bounds of a `TypedArray` view. A new
+             * `Buffer` created using the `buffer` property of a `TypedArray` may extend
+             * beyond the range of the `TypedArray`:
+             *
+             * ```js
+             * import { Buffer } from 'node:buffer';
+             *
+             * const arrA = Uint8Array.from([0x63, 0x64, 0x65, 0x66]); // 4 elements
+             * const arrB = new Uint8Array(arrA.buffer, 1, 2); // 2 elements
+             * console.log(arrA.buffer === arrB.buffer); // true
+             *
+             * const buf = Buffer.from(arrB.buffer);
+             * console.log(buf);
+             * // Prints: <Buffer 63 64 65 66>
+             * ```
+             * @since v5.10.0
+             * @param arrayBuffer An `ArrayBuffer`, `SharedArrayBuffer`, for example the
+             * `.buffer` property of a `TypedArray`.
+             * @param byteOffset Index of first byte to expose. **Default:** `0`.
+             * @param length Number of bytes to expose. **Default:**
+             * `arrayBuffer.byteLength - byteOffset`.
+             */
+            from<TArrayBuffer extends WithImplicitCoercion<ArrayBufferLike>>(
+                arrayBuffer: TArrayBuffer,
                 byteOffset?: number,
                 length?: number,
-            ): Buffer<TArrayBuffer>;
+            ): Buffer<ImplicitArrayBuffer<TArrayBuffer>>;
             /**
-             * Creates a new Buffer using the passed {data}
-             * @param data data to create a new Buffer
+             * Creates a new `Buffer` containing `string`. The `encoding` parameter identifies
+             * the character encoding to be used when converting `string` into bytes.
+             *
+             * ```js
+             * import { Buffer } from 'node:buffer';
+             *
+             * const buf1 = Buffer.from('this is a tést');
+             * const buf2 = Buffer.from('7468697320697320612074c3a97374', 'hex');
+             *
+             * console.log(buf1.toString());
+             * // Prints: this is a tést
+             * console.log(buf2.toString());
+             * // Prints: this is a tést
+             * console.log(buf1.toString('latin1'));
+             * // Prints: this is a tÃ©st
+             * ```
+             *
+             * A `TypeError` will be thrown if `string` is not a string or another type
+             * appropriate for `Buffer.from()` variants.
+             * @since v5.10.0
+             * @param string A string to encode.
+             * @param encoding The encoding of `string`. **Default:** `'utf8'`.
              */
-            from(data: Uint8Array | readonly number[]): Buffer<ArrayBuffer>;
-            from(data: WithImplicitCoercion<Uint8Array | readonly number[] | string>): Buffer<ArrayBuffer>;
-            /**
-             * Creates a new Buffer containing the given JavaScript string {str}.
-             * If provided, the {encoding} parameter identifies the character encoding.
-             * If not provided, {encoding} defaults to 'utf8'.
-             */
-            from(
-                str:
-                    | WithImplicitCoercion<string>
-                    | {
-                        [Symbol.toPrimitive](hint: "string"): string;
-                    },
-                encoding?: BufferEncoding,
-            ): Buffer<ArrayBuffer>;
+            from(string: WithImplicitCoercion<string>, encoding?: BufferEncoding): Buffer<ArrayBuffer>;
             /**
              * Creates a new Buffer using the passed {data}
              * @param values to create a new Buffer

--- a/types/node/v18/buffer.d.ts
+++ b/types/node/v18/buffer.d.ts
@@ -104,11 +104,6 @@ declare module "buffer" {
      * @param toEnc To target encoding.
      */
     export function transcode(source: Uint8Array, fromEnc: TranscodeEncoding, toEnc: TranscodeEncoding): Buffer;
-    export const SlowBuffer: {
-        /** @deprecated since v6.0.0, use `Buffer.allocUnsafeSlow()` */
-        new(size: number): Buffer;
-        prototype: Buffer;
-    };
     /**
      * Resolves a `'blob:nodedata:...'` an associated `Blob` object registered using
      * a prior call to `URL.createObjectURL()`.

--- a/types/node/v18/buffer.d.ts
+++ b/types/node/v18/buffer.d.ts
@@ -216,7 +216,10 @@ declare module "buffer" {
     }
     export import atob = globalThis.atob;
     export import btoa = globalThis.btoa;
-
+    export type WithImplicitCoercion<T> =
+        | T
+        | { valueOf(): T }
+        | (T extends string ? { [Symbol.toPrimitive](hint: "string"): T } : never);
     global {
         namespace NodeJS {
             export { BufferEncoding };
@@ -234,11 +237,6 @@ declare module "buffer" {
             | "latin1"
             | "binary"
             | "hex";
-        type WithImplicitCoercion<T> =
-            | T
-            | {
-                valueOf(): T;
-            };
         /**
          * Raw data is stored in instances of the Buffer class.
          * A Buffer is similar to an array of integers but corresponds to a raw memory allocation outside the V8 heap.  A Buffer cannot be resized.

--- a/types/node/v18/test/http.ts
+++ b/types/node/v18/test/http.ts
@@ -504,7 +504,7 @@ import * as url from "node:url";
     let _req = new http.IncomingMessage(new net.Socket());
     let _res = new http.ServerResponse(_req);
     let _err = new Error();
-    let _head = Buffer.from("");
+    let _head: Buffer = Buffer.from("");
     let _bool = true;
 
     server = server.addListener("checkContinue", (req, res) => {

--- a/types/node/v18/test/https.ts
+++ b/types/node/v18/test/https.ts
@@ -299,7 +299,7 @@ import * as url from "node:url";
 {
     let server = new https.Server();
     let _socket = new tls.TLSSocket(new net.Socket());
-    let _buffer = Buffer.from("");
+    let _buffer: Buffer = Buffer.from("");
     let _err = new Error();
     let _boolean = true;
     let sessionCallback = (err: Error, resp: Buffer) => {};
@@ -450,7 +450,7 @@ import * as url from "node:url";
     let _req = new http.IncomingMessage(new net.Socket());
     let _res = new http.ServerResponse(_req);
     let _err = new Error();
-    let _head = Buffer.from("");
+    let _head: Buffer = Buffer.from("");
     let _bool = true;
 
     server = server.addListener("checkContinue", (req, res) => {

--- a/types/node/v18/test/net.ts
+++ b/types/node/v18/test/net.ts
@@ -118,7 +118,7 @@ import * as net from "node:net";
     let _socket: net.Socket = new net.Socket(constructorOpts);
 
     let bool = true;
-    let buffer = Buffer.from("123");
+    let buffer: Buffer = Buffer.from("123");
     let error = new Error("asd");
     let str = "123";
     let num = 123;

--- a/types/node/v18/ts5.6/buffer.buffer.d.ts
+++ b/types/node/v18/ts5.6/buffer.buffer.d.ts
@@ -24,7 +24,7 @@ declare module "buffer" {
              * @param array The octets to store.
              * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
              */
-            new(array: Uint8Array): Buffer;
+            new(array: ArrayLike<number>): Buffer;
             /**
              * Produces a Buffer backed by the same allocated memory as
              * the given {ArrayBuffer}/{SharedArrayBuffer}.
@@ -33,20 +33,6 @@ declare module "buffer" {
              * @deprecated since v10.0.0 - Use `Buffer.from(arrayBuffer[, byteOffset[, length]])` instead.
              */
             new(arrayBuffer: ArrayBuffer | SharedArrayBuffer): Buffer;
-            /**
-             * Allocates a new buffer containing the given {array} of octets.
-             *
-             * @param array The octets to store.
-             * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
-             */
-            new(array: readonly any[]): Buffer;
-            /**
-             * Copies the passed {buffer} data onto a new {Buffer} instance.
-             *
-             * @param buffer The buffer to copy.
-             * @deprecated since v10.0.0 - Use `Buffer.from(buffer)` instead.
-             */
-            new(buffer: Buffer): Buffer;
             /**
              * Allocates a new `Buffer` using an `array` of bytes in the range `0` – `255`.
              * Array entries outside that range will be truncated to fit into it.
@@ -57,16 +43,85 @@ declare module "buffer" {
              * // Creates a new Buffer containing the UTF-8 bytes of the string 'buffer'.
              * const buf = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
              * ```
-             *
-             * If `array` is an `Array`\-like object (that is, one with a `length` property of
+             * If `array` is an `Array`-like object (that is, one with a `length` property of
              * type `number`), it is treated as if it is an array, unless it is a `Buffer` or
-             * a `Uint8Array`. This means all other `TypedArray` variants get treated as an`Array`. To create a `Buffer` from the bytes backing a `TypedArray`, use `Buffer.copyBytesFrom()`.
+             * a `Uint8Array`. This means all other `TypedArray` variants get treated as an
+             * `Array`. To create a `Buffer` from the bytes backing a `TypedArray`, use
+             * `Buffer.copyBytesFrom()`.
              *
              * A `TypeError` will be thrown if `array` is not an `Array` or another type
              * appropriate for `Buffer.from()` variants.
              *
-             * `Buffer.from(array)` and `Buffer.from(string)` may also use the internal`Buffer` pool like `Buffer.allocUnsafe()` does.
+             * `Buffer.from(array)` and `Buffer.from(string)` may also use the internal
+             * `Buffer` pool like `Buffer.allocUnsafe()` does.
              * @since v5.10.0
+             */
+            from(array: WithImplicitCoercion<ArrayLike<number>>): Buffer;
+            /**
+             * This creates a view of the `ArrayBuffer` without copying the underlying
+             * memory. For example, when passed a reference to the `.buffer` property of a
+             * `TypedArray` instance, the newly created `Buffer` will share the same
+             * allocated memory as the `TypedArray`'s underlying `ArrayBuffer`.
+             *
+             * ```js
+             * import { Buffer } from 'node:buffer';
+             *
+             * const arr = new Uint16Array(2);
+             *
+             * arr[0] = 5000;
+             * arr[1] = 4000;
+             *
+             * // Shares memory with `arr`.
+             * const buf = Buffer.from(arr.buffer);
+             *
+             * console.log(buf);
+             * // Prints: <Buffer 88 13 a0 0f>
+             *
+             * // Changing the original Uint16Array changes the Buffer also.
+             * arr[1] = 6000;
+             *
+             * console.log(buf);
+             * // Prints: <Buffer 88 13 70 17>
+             * ```
+             * The optional `byteOffset` and `length` arguments specify a memory range within
+             * the `arrayBuffer` that will be shared by the `Buffer`.
+             *
+             * ```js
+             * import { Buffer } from 'node:buffer';
+             *
+             * const ab = new ArrayBuffer(10);
+             * const buf = Buffer.from(ab, 0, 2);
+             *
+             * console.log(buf.length);
+             * // Prints: 2
+             * ```
+             *
+             * A `TypeError` will be thrown if `arrayBuffer` is not an `ArrayBuffer` or a
+             * `SharedArrayBuffer` or another type appropriate for `Buffer.from()`
+             * variants.
+             *
+             * It is important to remember that a backing `ArrayBuffer` can cover a range
+             * of memory that extends beyond the bounds of a `TypedArray` view. A new
+             * `Buffer` created using the `buffer` property of a `TypedArray` may extend
+             * beyond the range of the `TypedArray`:
+             *
+             * ```js
+             * import { Buffer } from 'node:buffer';
+             *
+             * const arrA = Uint8Array.from([0x63, 0x64, 0x65, 0x66]); // 4 elements
+             * const arrB = new Uint8Array(arrA.buffer, 1, 2); // 2 elements
+             * console.log(arrA.buffer === arrB.buffer); // true
+             *
+             * const buf = Buffer.from(arrB.buffer);
+             * console.log(buf);
+             * // Prints: <Buffer 63 64 65 66>
+             * ```
+             * @since v5.10.0
+             * @param arrayBuffer An `ArrayBuffer`, `SharedArrayBuffer`, for example the
+             * `.buffer` property of a `TypedArray`.
+             * @param byteOffset Index of first byte to expose. **Default:** `0`.
+             * @param length Number of bytes to expose. **Default:**
+             * `arrayBuffer.byteLength - byteOffset`.
              */
             from(
                 arrayBuffer: WithImplicitCoercion<ArrayBuffer | SharedArrayBuffer>,
@@ -74,24 +129,30 @@ declare module "buffer" {
                 length?: number,
             ): Buffer;
             /**
-             * Creates a new Buffer using the passed {data}
-             * @param data data to create a new Buffer
+             * Creates a new `Buffer` containing `string`. The `encoding` parameter identifies
+             * the character encoding to be used when converting `string` into bytes.
+             *
+             * ```js
+             * import { Buffer } from 'node:buffer';
+             *
+             * const buf1 = Buffer.from('this is a tést');
+             * const buf2 = Buffer.from('7468697320697320612074c3a97374', 'hex');
+             *
+             * console.log(buf1.toString());
+             * // Prints: this is a tést
+             * console.log(buf2.toString());
+             * // Prints: this is a tést
+             * console.log(buf1.toString('latin1'));
+             * // Prints: this is a tÃ©st
+             * ```
+             *
+             * A `TypeError` will be thrown if `string` is not a string or another type
+             * appropriate for `Buffer.from()` variants.
+             * @since v5.10.0
+             * @param string A string to encode.
+             * @param encoding The encoding of `string`. **Default:** `'utf8'`.
              */
-            from(data: Uint8Array | readonly number[]): Buffer;
-            from(data: WithImplicitCoercion<Uint8Array | readonly number[] | string>): Buffer;
-            /**
-             * Creates a new Buffer containing the given JavaScript string {str}.
-             * If provided, the {encoding} parameter identifies the character encoding.
-             * If not provided, {encoding} defaults to 'utf8'.
-             */
-            from(
-                str:
-                    | WithImplicitCoercion<string>
-                    | {
-                        [Symbol.toPrimitive](hint: "string"): string;
-                    },
-                encoding?: BufferEncoding,
-            ): Buffer;
+            from(string: WithImplicitCoercion<string>, encoding?: BufferEncoding): Buffer;
             /**
              * Creates a new Buffer using the passed {data}
              * @param values to create a new Buffer

--- a/types/node/v18/ts5.6/buffer.buffer.d.ts
+++ b/types/node/v18/ts5.6/buffer.buffer.d.ts
@@ -443,4 +443,10 @@ declare module "buffer" {
             subarray(start?: number, end?: number): Buffer;
         }
     }
+    /** @deprecated Use `Buffer.allocUnsafeSlow()` instead. */
+    var SlowBuffer: {
+        /** @deprecated Use `Buffer.allocUnsafeSlow()` instead. */
+        new(size: number): Buffer;
+        prototype: Buffer;
+    };
 }

--- a/types/node/v20/buffer.buffer.d.ts
+++ b/types/node/v20/buffer.buffer.d.ts
@@ -450,4 +450,10 @@ declare module "buffer" {
             subarray(start?: number, end?: number): Buffer<TArrayBuffer>;
         }
     }
+    /** @deprecated Use `Buffer.allocUnsafeSlow()` instead. */
+    var SlowBuffer: {
+        /** @deprecated Use `Buffer.allocUnsafeSlow()` instead. */
+        new(size: number): Buffer<ArrayBuffer>;
+        prototype: Buffer;
+    };
 }

--- a/types/node/v20/buffer.buffer.d.ts
+++ b/types/node/v20/buffer.buffer.d.ts
@@ -1,4 +1,6 @@
 declare module "buffer" {
+    type ImplicitArrayBuffer<T extends WithImplicitCoercion<ArrayBufferLike>> = T extends
+        { valueOf(): infer V extends ArrayBufferLike } ? V : T;
     global {
         interface BufferConstructor {
             // see buffer.d.ts for implementation shared with all TypeScript versions
@@ -24,7 +26,7 @@ declare module "buffer" {
              * @param array The octets to store.
              * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
              */
-            new(array: Uint8Array): Buffer<ArrayBuffer>;
+            new(array: ArrayLike<number>): Buffer<ArrayBuffer>;
             /**
              * Produces a Buffer backed by the same allocated memory as
              * the given {ArrayBuffer}/{SharedArrayBuffer}.
@@ -33,20 +35,6 @@ declare module "buffer" {
              * @deprecated since v10.0.0 - Use `Buffer.from(arrayBuffer[, byteOffset[, length]])` instead.
              */
             new<TArrayBuffer extends ArrayBufferLike = ArrayBuffer>(arrayBuffer: TArrayBuffer): Buffer<TArrayBuffer>;
-            /**
-             * Allocates a new buffer containing the given {array} of octets.
-             *
-             * @param array The octets to store.
-             * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
-             */
-            new(array: readonly any[]): Buffer<ArrayBuffer>;
-            /**
-             * Copies the passed {buffer} data onto a new {Buffer} instance.
-             *
-             * @param buffer The buffer to copy.
-             * @deprecated since v10.0.0 - Use `Buffer.from(buffer)` instead.
-             */
-            new(buffer: Buffer): Buffer<ArrayBuffer>;
             /**
              * Allocates a new `Buffer` using an `array` of bytes in the range `0` – `255`.
              * Array entries outside that range will be truncated to fit into it.
@@ -58,40 +46,120 @@ declare module "buffer" {
              * const buf = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
              * ```
              *
-             * If `array` is an `Array`\-like object (that is, one with a `length` property of
+             * If `array` is an `Array`-like object (that is, one with a `length` property of
              * type `number`), it is treated as if it is an array, unless it is a `Buffer` or
-             * a `Uint8Array`. This means all other `TypedArray` variants get treated as an `Array`. To create a `Buffer` from the bytes backing a `TypedArray`, use `Buffer.copyBytesFrom()`.
+             * a `Uint8Array`. This means all other `TypedArray` variants get treated as an
+             * `Array`. To create a `Buffer` from the bytes backing a `TypedArray`, use
+             * `Buffer.copyBytesFrom()`.
              *
              * A `TypeError` will be thrown if `array` is not an `Array` or another type
              * appropriate for `Buffer.from()` variants.
              *
-             * `Buffer.from(array)` and `Buffer.from(string)` may also use the internal `Buffer` pool like `Buffer.allocUnsafe()` does.
+             * `Buffer.from(array)` and `Buffer.from(string)` may also use the internal
+             * `Buffer` pool like `Buffer.allocUnsafe()` does.
              * @since v5.10.0
              */
-            from<TArrayBuffer extends ArrayBufferLike>(
-                arrayBuffer: WithImplicitCoercion<TArrayBuffer>,
+            from(array: WithImplicitCoercion<ArrayLike<number>>): Buffer<ArrayBuffer>;
+            /**
+             * This creates a view of the `ArrayBuffer` without copying the underlying
+             * memory. For example, when passed a reference to the `.buffer` property of a
+             * `TypedArray` instance, the newly created `Buffer` will share the same
+             * allocated memory as the `TypedArray`'s underlying `ArrayBuffer`.
+             *
+             * ```js
+             * import { Buffer } from 'node:buffer';
+             *
+             * const arr = new Uint16Array(2);
+             *
+             * arr[0] = 5000;
+             * arr[1] = 4000;
+             *
+             * // Shares memory with `arr`.
+             * const buf = Buffer.from(arr.buffer);
+             *
+             * console.log(buf);
+             * // Prints: <Buffer 88 13 a0 0f>
+             *
+             * // Changing the original Uint16Array changes the Buffer also.
+             * arr[1] = 6000;
+             *
+             * console.log(buf);
+             * // Prints: <Buffer 88 13 70 17>
+             * ```
+             *
+             * The optional `byteOffset` and `length` arguments specify a memory range within
+             * the `arrayBuffer` that will be shared by the `Buffer`.
+             *
+             * ```js
+             * import { Buffer } from 'node:buffer';
+             *
+             * const ab = new ArrayBuffer(10);
+             * const buf = Buffer.from(ab, 0, 2);
+             *
+             * console.log(buf.length);
+             * // Prints: 2
+             * ```
+             *
+             * A `TypeError` will be thrown if `arrayBuffer` is not an `ArrayBuffer` or a
+             * `SharedArrayBuffer` or another type appropriate for `Buffer.from()`
+             * variants.
+             *
+             * It is important to remember that a backing `ArrayBuffer` can cover a range
+             * of memory that extends beyond the bounds of a `TypedArray` view. A new
+             * `Buffer` created using the `buffer` property of a `TypedArray` may extend
+             * beyond the range of the `TypedArray`:
+             *
+             * ```js
+             * import { Buffer } from 'node:buffer';
+             *
+             * const arrA = Uint8Array.from([0x63, 0x64, 0x65, 0x66]); // 4 elements
+             * const arrB = new Uint8Array(arrA.buffer, 1, 2); // 2 elements
+             * console.log(arrA.buffer === arrB.buffer); // true
+             *
+             * const buf = Buffer.from(arrB.buffer);
+             * console.log(buf);
+             * // Prints: <Buffer 63 64 65 66>
+             * ```
+             * @since v5.10.0
+             * @param arrayBuffer An `ArrayBuffer`, `SharedArrayBuffer`, for example the
+             * `.buffer` property of a `TypedArray`.
+             * @param byteOffset Index of first byte to expose. **Default:** `0`.
+             * @param length Number of bytes to expose. **Default:**
+             * `arrayBuffer.byteLength - byteOffset`.
+             */
+            from<TArrayBuffer extends WithImplicitCoercion<ArrayBufferLike>>(
+                arrayBuffer: TArrayBuffer,
                 byteOffset?: number,
                 length?: number,
-            ): Buffer<TArrayBuffer>;
+            ): Buffer<ImplicitArrayBuffer<TArrayBuffer>>;
             /**
-             * Creates a new Buffer using the passed {data}
-             * @param data data to create a new Buffer
+             * Creates a new `Buffer` containing `string`. The `encoding` parameter identifies
+             * the character encoding to be used when converting `string` into bytes.
+             *
+             * ```js
+             * import { Buffer } from 'node:buffer';
+             *
+             * const buf1 = Buffer.from('this is a tést');
+             * const buf2 = Buffer.from('7468697320697320612074c3a97374', 'hex');
+             *
+             * console.log(buf1.toString());
+             * // Prints: this is a tést
+             * console.log(buf2.toString());
+             * // Prints: this is a tést
+             * console.log(buf1.toString('latin1'));
+             * // Prints: this is a tÃ©st
+             * ```
+             *
+             * A `TypeError` will be thrown if `string` is not a string or another type
+             * appropriate for `Buffer.from()` variants.
+             *
+             * `Buffer.from(string)` may also use the internal `Buffer` pool like
+             * `Buffer.allocUnsafe()` does.
+             * @since v5.10.0
+             * @param string A string to encode.
+             * @param encoding The encoding of `string`. **Default:** `'utf8'`.
              */
-            from(data: Uint8Array | readonly number[]): Buffer<ArrayBuffer>;
-            from(data: WithImplicitCoercion<Uint8Array | readonly number[] | string>): Buffer<ArrayBuffer>;
-            /**
-             * Creates a new Buffer containing the given JavaScript string {str}.
-             * If provided, the {encoding} parameter identifies the character encoding.
-             * If not provided, {encoding} defaults to 'utf8'.
-             */
-            from(
-                str:
-                    | WithImplicitCoercion<string>
-                    | {
-                        [Symbol.toPrimitive](hint: "string"): string;
-                    },
-                encoding?: BufferEncoding,
-            ): Buffer<ArrayBuffer>;
+            from(string: WithImplicitCoercion<string>, encoding?: BufferEncoding): Buffer<ArrayBuffer>;
             /**
              * Creates a new Buffer using the passed {data}
              * @param values to create a new Buffer

--- a/types/node/v20/buffer.d.ts
+++ b/types/node/v20/buffer.d.ts
@@ -238,7 +238,10 @@ declare module "buffer" {
     }
     export import atob = globalThis.atob;
     export import btoa = globalThis.btoa;
-
+    export type WithImplicitCoercion<T> =
+        | T
+        | { valueOf(): T }
+        | (T extends string ? { [Symbol.toPrimitive](hint: "string"): T } : never);
     global {
         namespace NodeJS {
             export { BufferEncoding };
@@ -257,11 +260,6 @@ declare module "buffer" {
             | "latin1"
             | "binary"
             | "hex";
-        type WithImplicitCoercion<T> =
-            | T
-            | {
-                valueOf(): T;
-            };
         /**
          * Raw data is stored in instances of the Buffer class.
          * A Buffer is similar to an array of integers but corresponds to a raw memory allocation outside the V8 heap.  A Buffer cannot be resized.

--- a/types/node/v20/buffer.d.ts
+++ b/types/node/v20/buffer.d.ts
@@ -114,11 +114,6 @@ declare module "buffer" {
      * @param toEnc To target encoding.
      */
     export function transcode(source: Uint8Array, fromEnc: TranscodeEncoding, toEnc: TranscodeEncoding): Buffer;
-    export const SlowBuffer: {
-        /** @deprecated since v6.0.0, use `Buffer.allocUnsafeSlow()` */
-        new(size: number): Buffer;
-        prototype: Buffer;
-    };
     /**
      * Resolves a `'blob:nodedata:...'` an associated `Blob` object registered using
      * a prior call to `URL.createObjectURL()`.

--- a/types/node/v20/test/buffer.ts
+++ b/types/node/v20/test/buffer.ts
@@ -1,7 +1,7 @@
 // Specifically test buffer module regression.
 import {
     Blob as NodeBlob,
-    Buffer as ImportedBuffer,
+    Buffer,
     constants,
     File,
     isAscii,
@@ -9,7 +9,7 @@ import {
     kMaxLength,
     kStringMaxLength,
     resolveObjectURL,
-    SlowBuffer as ImportedSlowBuffer,
+    SlowBuffer,
     transcode,
     TranscodeEncoding,
 } from "node:buffer";
@@ -29,6 +29,11 @@ console.log(Buffer.byteLength("xyz123"));
 console.log(Buffer.byteLength("xyz123", "ascii"));
 const result1 = Buffer.concat([utf8Buffer, base64Buffer] as readonly Uint8Array[]);
 const result2 = Buffer.concat([utf8Buffer, base64Buffer] as readonly Uint8Array[], 9999999);
+
+// Globals
+{
+    const globalBuffer: typeof Buffer = globalThis.Buffer;
+}
 
 // Module constants
 {
@@ -58,76 +63,96 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as readonly Uint8Array[
     buf.swap64();
 }
 
-// Class Method: Buffer.from(data)
+// Class Method: Buffer.from()
 {
-    // Array
-    const buf1: Buffer = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72] as readonly number[]);
+    // Array-like
+    {
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72] as const);
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from(new Uint8Array());
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from(Uint8ClampedArray.of(1024));
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from({ length: 6, 0: 0x62, 1: 0x75, 2: 0x66, 3: 0x66, 4: 0x65, 5: 0x72 });
+    }
+
     // Buffer
-    const buf2: Buffer = Buffer.from(buf1, 1, 2);
-    // String
-    const buf3: Buffer = Buffer.from("this is a tést");
+    {
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from(Buffer.alloc(0));
+    }
+
     // ArrayBuffer
-    const arrUint16: Uint16Array = new Uint16Array(2);
-    arrUint16[0] = 5000;
-    arrUint16[1] = 4000;
-    const buf4: Buffer = Buffer.from(arrUint16.buffer);
-    const arrUint8: Uint8Array = new Uint8Array(2);
-    const buf5: Buffer = Buffer.from(arrUint8);
-    const buf6: Buffer = Buffer.from(buf1);
-    const sb: SharedArrayBuffer = {} as any;
-    const buf7: Buffer = Buffer.from(sb);
+    {
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from(new ArrayBuffer(0));
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from(new ArrayBuffer(32), 16, 16);
+        // $ExpectType Buffer || Buffer<SharedArrayBuffer>
+        Buffer.from(new SharedArrayBuffer(0));
+        // $ExpectType Buffer || Buffer<SharedArrayBuffer>
+        Buffer.from(new SharedArrayBuffer(32), 16, 16);
+        // $ExpectType Buffer || Buffer<ArrayBuffer | SharedArrayBuffer>
+        Buffer.from({} as ArrayBuffer | SharedArrayBuffer);
+    }
+
+    // String
+    {
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from("buffer");
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from("buffer", "latin1");
+    }
+
+    // implicit coercion
+    {
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from({
+            valueOf() {
+                return [] as const;
+            },
+        });
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from({
+            valueOf() {
+                return Buffer.alloc(0);
+            },
+        });
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from({
+            valueOf() {
+                return "buffer";
+            },
+        }, "utf-8");
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from({
+            valueOf() {
+                return new ArrayBuffer(0);
+            },
+        });
+        // $ExpectType Buffer || Buffer<SharedArrayBuffer>
+        Buffer.from({
+            valueOf() {
+                return new SharedArrayBuffer(0);
+            },
+        });
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from({
+            [Symbol.toPrimitive]() {
+                return "buffer";
+            },
+        }, "latin1");
+        // @ts-expect-error
+        Buffer.from({} as { valueOf(): {} });
+        // @ts-expect-error
+        Buffer.from({} as { [Symbol.toPrimitive](): number });
+    }
+
     // @ts-expect-error
     Buffer.from({});
-}
-
-// Class Method: Buffer.from(arrayBuffer[, byteOffset[, length]])
-{
-    const arr: Uint16Array = new Uint16Array(2);
-    arr[0] = 5000;
-    arr[1] = 4000;
-
-    let buf: Buffer;
-    buf = Buffer.from(arr.buffer, 1);
-    buf = Buffer.from(arr.buffer, 0, 1);
-
     // @ts-expect-error
-    Buffer.from("this is a test", 1, 1);
-    // Ideally passing a normal Buffer would be a type error too, but it's not
-    //  since Buffer is assignable to ArrayBuffer currently
-}
-
-// Class Method: Buffer.from(str[, encoding])
-{
-    const buf2: Buffer = Buffer.from("7468697320697320612074c3a97374", "hex");
-    /* tslint:disable-next-line no-construct */
-    Buffer.from(new String("DEADBEEF"), "hex");
-    // @ts-expect-error
-    Buffer.from(buf2, "hex");
-}
-
-// Class Method: Buffer.from(object, [, byteOffset[, length]])  (Implicit coercion)
-{
-    const pseudoBuf = {
-        valueOf() {
-            return Buffer.from([1, 2, 3]);
-        },
-    };
-    let buf: Buffer = Buffer.from(pseudoBuf);
-    const pseudoString = {
-        valueOf() {
-            return "Hello";
-        },
-    };
-    buf = Buffer.from(pseudoString);
-    buf = Buffer.from(pseudoString, "utf-8");
-    // @ts-expect-error
-    Buffer.from(pseudoString, 1, 2);
-    const pseudoArrayBuf = {
-        valueOf() {
-            return new Uint16Array(2);
-        },
-    };
-    buf = Buffer.from(pseudoArrayBuf, 1, 1);
+    Buffer.from(0);
 }
 
 // Class Method: Buffer.alloc(size[, fill[, encoding]])
@@ -263,18 +288,18 @@ b.fill("a").fill("b");
     */
 }
 
-// Imported Buffer from buffer module works properly
+// SlowBuffer
 {
-    const b = new ImportedBuffer("123");
-    b.writeUInt8(0, 6);
-    const sb = new ImportedSlowBuffer(43);
-    b.writeUInt8(0, 6);
+    // $ExpectType Buffer || Buffer<ArrayBuffer>
+    new SlowBuffer(256);
+    // @ts-expect-error
+    SlowBuffer(256);
 }
 
 // NodeJS.BufferEncoding works properly
 {
     const encoding: NodeJS.BufferEncoding = "ascii";
-    const b = new ImportedBuffer("123", encoding);
+    const b = new Buffer("123", encoding);
     b.writeUInt8(0, 6);
 }
 
@@ -390,15 +415,6 @@ const c: NodeJS.TypedArray = new Buffer(123);
     readable.pipe(writable);
     writableFinished = writable.writableFinished;
     writable.destroyed;
-}
-
-{
-    const obj = {
-        valueOf() {
-            return "hello";
-        },
-    };
-    Buffer.from(obj);
 }
 
 const buff = Buffer.from("Hello World!");

--- a/types/node/v20/test/http.ts
+++ b/types/node/v20/test/http.ts
@@ -504,7 +504,7 @@ import * as url from "node:url";
     let _req = new http.IncomingMessage(new net.Socket());
     let _res = new http.ServerResponse(_req);
     let _err = new Error();
-    let _head = Buffer.from("");
+    let _head: Buffer = Buffer.from("");
     let _bool = true;
 
     server = server.addListener("checkContinue", (req, res) => {

--- a/types/node/v20/test/https.ts
+++ b/types/node/v20/test/https.ts
@@ -299,7 +299,7 @@ import * as url from "node:url";
 {
     let server = new https.Server();
     let _socket = new tls.TLSSocket(new net.Socket());
-    let _buffer = Buffer.from("");
+    let _buffer: Buffer = Buffer.from("");
     let _err = new Error();
     let _boolean = true;
     let sessionCallback = (err: Error, resp: Buffer) => {};
@@ -450,7 +450,7 @@ import * as url from "node:url";
     let _req = new http.IncomingMessage(new net.Socket());
     let _res = new http.ServerResponse(_req);
     let _err = new Error();
-    let _head = Buffer.from("");
+    let _head: Buffer = Buffer.from("");
     let _bool = true;
 
     server = server.addListener("checkContinue", (req, res) => {

--- a/types/node/v20/test/net.ts
+++ b/types/node/v20/test/net.ts
@@ -118,7 +118,7 @@ import * as net from "node:net";
     let _socket: net.Socket = new net.Socket(constructorOpts);
 
     let bool = true;
-    let buffer = Buffer.from("123");
+    let buffer: Buffer = Buffer.from("123");
     let error = new Error("asd");
     let str = "123";
     let num = 123;

--- a/types/node/v20/ts5.6/buffer.buffer.d.ts
+++ b/types/node/v20/ts5.6/buffer.buffer.d.ts
@@ -24,7 +24,7 @@ declare module "buffer" {
              * @param array The octets to store.
              * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
              */
-            new(array: Uint8Array): Buffer;
+            new(array: ArrayLike<number>): Buffer;
             /**
              * Produces a Buffer backed by the same allocated memory as
              * the given {ArrayBuffer}/{SharedArrayBuffer}.
@@ -33,20 +33,6 @@ declare module "buffer" {
              * @deprecated since v10.0.0 - Use `Buffer.from(arrayBuffer[, byteOffset[, length]])` instead.
              */
             new(arrayBuffer: ArrayBuffer | SharedArrayBuffer): Buffer;
-            /**
-             * Allocates a new buffer containing the given {array} of octets.
-             *
-             * @param array The octets to store.
-             * @deprecated since v10.0.0 - Use `Buffer.from(array)` instead.
-             */
-            new(array: readonly any[]): Buffer;
-            /**
-             * Copies the passed {buffer} data onto a new {Buffer} instance.
-             *
-             * @param buffer The buffer to copy.
-             * @deprecated since v10.0.0 - Use `Buffer.from(buffer)` instead.
-             */
-            new(buffer: Buffer): Buffer;
             /**
              * Allocates a new `Buffer` using an `array` of bytes in the range `0` – `255`.
              * Array entries outside that range will be truncated to fit into it.
@@ -58,15 +44,86 @@ declare module "buffer" {
              * const buf = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
              * ```
              *
-             * If `array` is an `Array`\-like object (that is, one with a `length` property of
+             * If `array` is an `Array`-like object (that is, one with a `length` property of
              * type `number`), it is treated as if it is an array, unless it is a `Buffer` or
-             * a `Uint8Array`. This means all other `TypedArray` variants get treated as an `Array`. To create a `Buffer` from the bytes backing a `TypedArray`, use `Buffer.copyBytesFrom()`.
+             * a `Uint8Array`. This means all other `TypedArray` variants get treated as an
+             * `Array`. To create a `Buffer` from the bytes backing a `TypedArray`, use
+             * `Buffer.copyBytesFrom()`.
              *
              * A `TypeError` will be thrown if `array` is not an `Array` or another type
              * appropriate for `Buffer.from()` variants.
              *
-             * `Buffer.from(array)` and `Buffer.from(string)` may also use the internal `Buffer` pool like `Buffer.allocUnsafe()` does.
+             * `Buffer.from(array)` and `Buffer.from(string)` may also use the internal
+             * `Buffer` pool like `Buffer.allocUnsafe()` does.
              * @since v5.10.0
+             */
+            from(array: WithImplicitCoercion<ArrayLike<number>>): Buffer;
+            /**
+             * This creates a view of the `ArrayBuffer` without copying the underlying
+             * memory. For example, when passed a reference to the `.buffer` property of a
+             * `TypedArray` instance, the newly created `Buffer` will share the same
+             * allocated memory as the `TypedArray`'s underlying `ArrayBuffer`.
+             *
+             * ```js
+             * import { Buffer } from 'node:buffer';
+             *
+             * const arr = new Uint16Array(2);
+             *
+             * arr[0] = 5000;
+             * arr[1] = 4000;
+             *
+             * // Shares memory with `arr`.
+             * const buf = Buffer.from(arr.buffer);
+             *
+             * console.log(buf);
+             * // Prints: <Buffer 88 13 a0 0f>
+             *
+             * // Changing the original Uint16Array changes the Buffer also.
+             * arr[1] = 6000;
+             *
+             * console.log(buf);
+             * // Prints: <Buffer 88 13 70 17>
+             * ```
+             *
+             * The optional `byteOffset` and `length` arguments specify a memory range within
+             * the `arrayBuffer` that will be shared by the `Buffer`.
+             *
+             * ```js
+             * import { Buffer } from 'node:buffer';
+             *
+             * const ab = new ArrayBuffer(10);
+             * const buf = Buffer.from(ab, 0, 2);
+             *
+             * console.log(buf.length);
+             * // Prints: 2
+             * ```
+             *
+             * A `TypeError` will be thrown if `arrayBuffer` is not an `ArrayBuffer` or a
+             * `SharedArrayBuffer` or another type appropriate for `Buffer.from()`
+             * variants.
+             *
+             * It is important to remember that a backing `ArrayBuffer` can cover a range
+             * of memory that extends beyond the bounds of a `TypedArray` view. A new
+             * `Buffer` created using the `buffer` property of a `TypedArray` may extend
+             * beyond the range of the `TypedArray`:
+             *
+             * ```js
+             * import { Buffer } from 'node:buffer';
+             *
+             * const arrA = Uint8Array.from([0x63, 0x64, 0x65, 0x66]); // 4 elements
+             * const arrB = new Uint8Array(arrA.buffer, 1, 2); // 2 elements
+             * console.log(arrA.buffer === arrB.buffer); // true
+             *
+             * const buf = Buffer.from(arrB.buffer);
+             * console.log(buf);
+             * // Prints: <Buffer 63 64 65 66>
+             * ```
+             * @since v5.10.0
+             * @param arrayBuffer An `ArrayBuffer`, `SharedArrayBuffer`, for example the
+             * `.buffer` property of a `TypedArray`.
+             * @param byteOffset Index of first byte to expose. **Default:** `0`.
+             * @param length Number of bytes to expose. **Default:**
+             * `arrayBuffer.byteLength - byteOffset`.
              */
             from(
                 arrayBuffer: WithImplicitCoercion<ArrayBuffer | SharedArrayBuffer>,
@@ -74,24 +131,33 @@ declare module "buffer" {
                 length?: number,
             ): Buffer;
             /**
-             * Creates a new Buffer using the passed {data}
-             * @param data data to create a new Buffer
+             * Creates a new `Buffer` containing `string`. The `encoding` parameter identifies
+             * the character encoding to be used when converting `string` into bytes.
+             *
+             * ```js
+             * import { Buffer } from 'node:buffer';
+             *
+             * const buf1 = Buffer.from('this is a tést');
+             * const buf2 = Buffer.from('7468697320697320612074c3a97374', 'hex');
+             *
+             * console.log(buf1.toString());
+             * // Prints: this is a tést
+             * console.log(buf2.toString());
+             * // Prints: this is a tést
+             * console.log(buf1.toString('latin1'));
+             * // Prints: this is a tÃ©st
+             * ```
+             *
+             * A `TypeError` will be thrown if `string` is not a string or another type
+             * appropriate for `Buffer.from()` variants.
+             *
+             * `Buffer.from(string)` may also use the internal `Buffer` pool like
+             * `Buffer.allocUnsafe()` does.
+             * @since v5.10.0
+             * @param string A string to encode.
+             * @param encoding The encoding of `string`. **Default:** `'utf8'`.
              */
-            from(data: Uint8Array | readonly number[]): Buffer;
-            from(data: WithImplicitCoercion<Uint8Array | readonly number[] | string>): Buffer;
-            /**
-             * Creates a new Buffer containing the given JavaScript string {str}.
-             * If provided, the {encoding} parameter identifies the character encoding.
-             * If not provided, {encoding} defaults to 'utf8'.
-             */
-            from(
-                str:
-                    | WithImplicitCoercion<string>
-                    | {
-                        [Symbol.toPrimitive](hint: "string"): string;
-                    },
-                encoding?: BufferEncoding,
-            ): Buffer;
+            from(string: WithImplicitCoercion<string>, encoding?: BufferEncoding): Buffer;
             /**
              * Creates a new Buffer using the passed {data}
              * @param values to create a new Buffer

--- a/types/node/v20/ts5.6/buffer.buffer.d.ts
+++ b/types/node/v20/ts5.6/buffer.buffer.d.ts
@@ -448,4 +448,10 @@ declare module "buffer" {
             subarray(start?: number, end?: number): Buffer;
         }
     }
+    /** @deprecated Use `Buffer.allocUnsafeSlow()` instead. */
+    var SlowBuffer: {
+        /** @deprecated Use `Buffer.allocUnsafeSlow()` instead. */
+        new(size: number): Buffer;
+        prototype: Buffer;
+    };
 }

--- a/types/typedarray-to-buffer/typedarray-to-buffer-tests.ts
+++ b/types/typedarray-to-buffer/typedarray-to-buffer-tests.ts
@@ -1,4 +1,4 @@
 import toBuffer = require("typedarray-to-buffer");
 
 let arr = new Uint8Array([1, 2, 3]);
-arr = toBuffer(arr); // $ExpectType Buffer || Buffer<ArrayBufferLike>
+toBuffer(arr); // $ExpectType Buffer || Buffer<ArrayBufferLike>

--- a/types/uuid/v2/uuid-tests.ts
+++ b/types/uuid/v2/uuid-tests.ts
@@ -40,6 +40,6 @@ let bufferv4: number[] = new Array(32);
 bufferv4 = uuid(null, bufferv4);
 bufferv4 = uuid(null, bufferv4, 16);
 
-let nodeBufferv4 = Buffer.alloc(32);
+let nodeBufferv4: Buffer = Buffer.alloc(32);
 nodeBufferv4 = uuid.v4(null, nodeBufferv4);
 nodeBufferv4 = uuid.v4(null, nodeBufferv4, 16);

--- a/types/varstruct/varstruct-tests.ts
+++ b/types/varstruct/varstruct-tests.ts
@@ -61,7 +61,7 @@ vstruct.DoubleLE; // $ExpectType Codec<number>
 
 vstruct.Array(1, vstruct.String(10)); // $ExpectType Codec<string[]>
 vstruct.VarArray(vstruct.Int16BE, vstruct.Buffer(10)); // $ExpectType Codec<Buffer[]> || Codec<Buffer<ArrayBufferLike>[]>
-// $ExpectType Codec<CodecTypes<readonly [Codec<number>, Codec<Buffer | undefined>]>> || Codec<CodecTypes<readonly [Codec<number>, Codec<Buffer<ArrayBuffer> | undefined>]>>
+// $ExpectType Codec<CodecTypes<readonly [Codec<number>, Codec<Buffer | undefined>]>> || Codec<CodecTypes<readonly [Codec<number>, Codec<Buffer<ArrayBuffer> | undefined>]>> || Codec<CodecTypes<readonly [Codec<number>, Codec<Buffer<ArrayBufferLike> | undefined>]>>
 const seq = vstruct.Sequence([vstruct.UInt32LE, vstruct.Value(vstruct.Buffer(1), Buffer.alloc(1))] as const);
 seq.encode([1, Buffer.alloc(10)]);
 seq.encode([1, undefined]);


### PR DESCRIPTION
microsoft/TypeScript#60150 caused breakage.

Two main themes:
- `Buffer` is no longer assignable to `ArrayBuffer`.
  - This was always an unintentional quirk of the shape of the ArrayBuffer prototype, and the change has revealed that several of the DT tests were mistaking Buffers for ArrayBuffers.
  - This is simply a case of fixing the bad tests, although this also flagged some inconsistencies with the `Buffer.from()` overloads, which have been addressed.
- `Buffer<ArrayBufferLike>` is no longer assignable to `Buffer<ArrayBuffer>`.
  - This is more of a problem, since there is a divergence between the Buffer constructor methods in `node:buffer`, which return `Buffer<ArrayBuffer>` etc., and the remainder of the library, where the APIs ubiquitously use the default `Buffer<ArrayBufferLike>`.
  - These were previously mutually assignable, as `ArrayBufferLike` was previously (unintentionally) assignable to `ArrayBuffer`.
  - There are plenty of examples in the tests of cases like the following:
    ```ts
    let buffer = Buffer.from("test"); // Buffer<ArrayBuffer>
    buffer = someNodeAPI.returnsBuffer(); // Buffer<ArrayBufferLike>
    ```
    which now raises an error.
  - This affects not only the @types/node tests, but several other DT packages with similar usage in their tests, and undoubtedly countless more in the wild.

In theory, this issue could be eliminated at source by removing the `TArrayBuffer`-narrowing behaviour of the Buffer constructor methods. However, this would create divergence between the constructor behaviours of Buffer and Uint8Array, and if everyone is going to have to update their affected usage of every other typed array anyway, then there isn't a compelling motive to hack this away for Buffer specifically.