### PR TITLE
Narrow types in w3c-web-serial

### DIFF
--- a/types/w3c-web-serial/index.d.ts
+++ b/types/w3c-web-serial/index.d.ts
@@ -40,8 +40,8 @@ interface SerialPortInfo {
 
 /*~ https://wicg.github.io/serial/#dom-serialport */
 declare class SerialPort extends EventTarget {
-    onconnect: ((this: this, ev: Event) => any) | null;
-    ondisconnect: ((this: this, ev: Event) => any) | null;
+    onconnect: ((this: this, ev: Event) => void) | null;
+    ondisconnect: ((this: this, ev: Event) => void) | null;
     /** A flag indicating the logical connection state of serial port */
     readonly connected: boolean;
     readonly readable: ReadableStream<Uint8Array> | null;
@@ -56,7 +56,7 @@ declare class SerialPort extends EventTarget {
 
     addEventListener(
         type: "connect" | "disconnect",
-        listener: (this: this, ev: Event) => any,
+        listener: (this: this, ev: Event) => void,
         useCapture?: boolean,
     ): void;
     addEventListener(
@@ -66,7 +66,7 @@ declare class SerialPort extends EventTarget {
     ): void;
     removeEventListener(
         type: "connect" | "disconnect",
-        callback: (this: this, ev: Event) => any,
+        callback: (this: this, ev: Event) => void,
         useCapture?: boolean,
     ): void;
     removeEventListener(
@@ -96,14 +96,14 @@ interface SerialPortRequestOptions {
 
 /*~ https://wicg.github.io/serial/#dom-serial */
 declare class Serial extends EventTarget {
-    onconnect: ((this: this, ev: Event) => any) | null;
-    ondisconnect: ((this: this, ev: Event) => any) | null;
+    onconnect: ((this: this, ev: Event) => void) | null;
+    ondisconnect: ((this: this, ev: Event) => void) | null;
 
     getPorts(): Promise<SerialPort[]>;
     requestPort(options?: SerialPortRequestOptions): Promise<SerialPort>;
     addEventListener(
         type: "connect" | "disconnect",
-        listener: (this: this, ev: Event) => any,
+        listener: (this: this, ev: Event) => void,
         useCapture?: boolean,
     ): void;
     addEventListener(
@@ -113,7 +113,7 @@ declare class Serial extends EventTarget {
     ): void;
     removeEventListener(
         type: "connect" | "disconnect",
-        callback: (this: this, ev: Event) => any,
+        callback: (this: this, ev: Event) => void,
         useCapture?: boolean,
     ): void;
     removeEventListener(

--- a/types/w3c-web-serial/index.d.ts
+++ b/types/w3c-web-serial/index.d.ts
@@ -7,8 +7,8 @@ type FlowControlType = "none" | "hardware";
 /*~ https://wicg.github.io/serial/#dom-serialoptions */
 interface SerialOptions {
     baudRate: number;
-    dataBits?: number | undefined;
-    stopBits?: number | undefined;
+    dataBits?: 7 | 8 | undefined;
+    stopBits?: 1 | 2 | undefined;
     parity?: ParityType | undefined;
     bufferSize?: number | undefined;
     flowControl?: FlowControlType | undefined;


### PR DESCRIPTION
`number` is too broad for `dataBits` and `stopBits`.  Additionally, both `addEventListener()` and `listener` should not have return values.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] ~~[Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.~~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
-- https://wicg.github.io/serial/#dom-serialoptions
-- https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#the_event_listener_callback

- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.~~