### PR TITLE
[rascal] Fix @typescript-eslint/no-misused-promises errors on subscription events

### DIFF
--- a/types/rascal/index.d.ts
+++ b/types/rascal/index.d.ts
@@ -437,16 +437,20 @@ declare const testConfig: {
 };
 
 type AckOrNack = (err?: Error, recovery?: Recovery | Recovery[]) => void;
+type CallbackReturn<T> = T | Promise<T>;
 
 export class SubscriberSessionAsPromised extends EventEmitter {
     name: string;
     cancel(): Promise<void>;
 
-    on(event: "message", listener: (message: Message, content: any, ackOrNackFn: AckOrNack) => void): this;
-    on(event: "error" | "cancelled", listener: (err: Error) => void): this;
+    on(
+        event: "message",
+        listener: (message: Message, content: any, ackOrNackFn: AckOrNack) => CallbackReturn<void>,
+    ): this;
+    on(event: "error" | "cancelled", listener: (err: Error) => CallbackReturn<void>): this;
     on(
         event: "invalid_content" | "redeliveries_exceeded" | "redeliveries_error",
-        listener: (err: Error, message: Message, ackOrNackFn: AckOrNack) => void,
+        listener: (err: Error, message: Message, ackOrNackFn: AckOrNack) => CallbackReturn<void>,
     ): this;
 }
 
@@ -472,11 +476,14 @@ export class SubscriptionSession extends EventEmitter {
     isCancelled(): boolean;
     cancel(next: ErrorCb): void;
 
-    on(event: "message", listener: (message: Message, content: any, ackOrNackFn: AckOrNack) => void): this;
-    on(event: "error" | "cancelled", listener: (err: Error) => void): this;
+    on(
+        event: "message",
+        listener: (message: Message, content: any, ackOrNackFn: AckOrNack) => CallbackReturn<void>,
+    ): this;
+    on(event: "error" | "cancelled", listener: (err: Error) => CallbackReturn<void>): this;
     on(
         event: "invalid_content" | "redeliveries_exceeded" | "redeliveries_error",
-        listener: (err: Error, message: Message, ackOrNackFn: AckOrNack) => void,
+        listener: (err: Error, message: Message, ackOrNackFn: AckOrNack) => CallbackReturn<void>,
     ): this;
 }
 


### PR DESCRIPTION
Make sure that callbacks on the subscription message listeners return `void | Promise<void>` instead of just `void` to avoid `@typescript-eslint/no-misused-promises` errors

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. - _couldn't figure out a way to test this_
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://typescript-eslint.io/rules/no-misused-promises/)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
