### PR TITLE
CI: fix TypedArray/ArrayBuffer errors for TS 5.9

### DIFF
--- a/types/akamai-edgeworkers/test/crypto.ts
+++ b/types/akamai-edgeworkers/test/crypto.ts
@@ -159,8 +159,8 @@ crypto.subtle
                 hash: "SHA-256",
             },
             imported_key,
-            signature,
-            data,
+            signature.buffer,
+            data.buffer,
         );
     });
 crypto.subtle.importKey(
@@ -209,7 +209,7 @@ crypto.subtle.importKey(
 ).then((imported_key) => {
     const data = Uint8Array.from([97, 110, 103, 117, 115, 32, 97, 110, 100, 32, 111, 119, 101, 110]);
     crypto.subtle.sign("HMAC", imported_key, data).then((sig) => {
-        crypto.subtle.verify("HMAC", imported_key, sig, data);
+        crypto.subtle.verify("HMAC", imported_key, sig, data.buffer);
     });
 });
 

--- a/types/akamai-edgeworkers/test/scenario-crypto.ts
+++ b/types/akamai-edgeworkers/test/scenario-crypto.ts
@@ -248,8 +248,8 @@ KlSNHLY0ZX554kjI8DknO3x8J5z+H31OX7spkrI6xdqj9Q0Ouoy6UmjJ3w==
             hash: "SHA-256",
         },
         cryptoKey,
-        signature,
-        data2,
+        signature.buffer,
+        data2.buffer,
     );
 
     /**
@@ -314,7 +314,7 @@ KlSNHLY0ZX554kjI8DknO3x8J5z+H31OX7spkrI6xdqj9Q0Ouoy6UmjJ3w==
      *
      * @returns A promise that fulfills with a boolean value: true if the signature is valid, false otherwise
      */
-    await crypto.subtle.verify("HMAC", hmac_imported_key, sig, data).then((isVerified) => {
+    await crypto.subtle.verify("HMAC", hmac_imported_key, sig, data.buffer).then((isVerified) => {
         request.respondWith(200, {}, "Verified: " + isVerified);
     }).catch(e => {
         request.respondWith(501, {}, "failure: " + e);

--- a/types/chrome-apps/test/index.ts
+++ b/types/chrome-apps/test/index.ts
@@ -945,7 +945,7 @@ chrome.enterprise.platformKeys.getTokens((tokens) => {
 });
 
 chrome.enterprise.platformKeys.challengeKey(
-    { scope: "MACHINE", challenge: new Uint8Array(), registerKey: { algorithm: "ECDSA" } },
+    { scope: "MACHINE", challenge: new Uint8Array().buffer, registerKey: { algorithm: "ECDSA" } },
     () => {},
 );
 

--- a/types/node-forge/node-forge-tests.ts
+++ b/types/node-forge/node-forge-tests.ts
@@ -213,7 +213,7 @@ if (forge.util.fillString("1", 5) !== "11111") throw Error("forge.util.fillStrin
 }
 
 {
-    let src: Uint8Array;
+    let src = new Uint8Array(2); // indirectly resolve type to ensure assignability to forge.util.ArrayBufferView in TS 5.9+
     let encode: string;
     let decode: Uint8Array;
 

--- a/types/node-wav/index.d.ts
+++ b/types/node-wav/index.d.ts
@@ -26,7 +26,7 @@ export function decode(buffer: Buffer): {
  * @return The encoded {@link Buffer}.
  */
 export function encode(
-    channelData: readonly ArrayBuffer[],
+    channelData: readonly ArrayLike<number>[],
     opts: {
         /**
          * The sample rate of the given {@link channelData}.


### PR DESCRIPTION
A specific changeset for breakage related to microsoft/TypeScript#60150 and unrelated to @types/node's `Buffer`.

Test-only changes:
- `akamai-edgeworkers`: erroneous use of TypedArray where ArrayBuffer expected
- `chrome-apps`: erroneous use of TypedArray where ArrayBuffer expected
- `node-forge`: implementation specifically only accepts views on `ArrayBuffer` rather than `ArrayBufferLike`, so a test variable type needs to be `Uint8Array<ArrayBuffer>` rather than `Uint8Array`

Definition changes:
- `node-wav`: use of ArrayBuffer where TypedArray was intended; in fact, the implementation just requires an array-like object here
