### PR TITLE
Make EventEmitterAsyncResource Generic like EventEmitter

### DIFF
--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -559,7 +559,7 @@ declare module "events" {
          * same options as `EventEmitter` and `AsyncResource` themselves.
          * @since v17.4.0, v16.14.0
          */
-        export class EventEmitterAsyncResource extends EventEmitter {
+        export class EventEmitterAsyncResource<T extends EventMap<T> = DefaultEventMap> extends EventEmitter<T> {
             /**
              * @param options Only optional in child class.
              */

--- a/types/node/v16/events.d.ts
+++ b/types/node/v16/events.d.ts
@@ -359,7 +359,7 @@ declare module "events" {
          * @throws if `options.name` is not provided when instantiated directly.
          * @since v17.4.0, v16.14.0
          */
-        export class EventEmitterAsyncResource extends EventEmitter {
+        export class EventEmitterAsyncResource<T extends EventMap<T> = DefaultEventMap>  extends EventEmitter<T> {
             /**
              * @param options Only optional in child class.
              */

--- a/types/node/v18/events.d.ts
+++ b/types/node/v18/events.d.ts
@@ -460,7 +460,7 @@ declare module "events" {
          * @throws if `options.name` is not provided when instantiated directly.
          * @since v17.4.0, v16.14.0
          */
-        export class EventEmitterAsyncResource extends EventEmitter {
+        export class EventEmitterAsyncResource<T extends EventMap<T> = DefaultEventMap> extends EventEmitter<T> {
             /**
              * @param options Only optional in child class.
              */

--- a/types/node/v20/events.d.ts
+++ b/types/node/v20/events.d.ts
@@ -559,7 +559,7 @@ declare module "events" {
          * same options as `EventEmitter` and `AsyncResource` themselves.
          * @since v17.4.0, v16.14.0
          */
-        export class EventEmitterAsyncResource extends EventEmitter {
+        export class EventEmitterAsyncResource<T extends EventMap<T> = DefaultEventMap>  extends EventEmitter<T> {
             /**
              * @param options Only optional in child class.
              */


### PR DESCRIPTION
I should be able to specify the event types the same on the sub class. Would be really nice to be able to make a PR to [piscina](https://github.com/piscinajs/piscina) to strictly type events. 

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).





