### PR TITLE
fix(@types/react): add missing `onScrollEnd` event

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2333,6 +2333,7 @@ declare namespace React {
 
         // UI Events
         onScroll?: UIEventHandler<T> | undefined;
+        onScrollEnd?: UIEventHandler<T> | undefined;
         onScrollCapture?: UIEventHandler<T> | undefined;
 
         // Wheel Events

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2333,8 +2333,9 @@ declare namespace React {
 
         // UI Events
         onScroll?: UIEventHandler<T> | undefined;
-        onScrollEnd?: UIEventHandler<T> | undefined;
         onScrollCapture?: UIEventHandler<T> | undefined;
+        onScrollEnd?: UIEventHandler<T> | undefined;
+        onScrollEndCapture?: UIEventHandler<T> | undefined;
 
         // Wheel Events
         onWheel?: WheelEventHandler<T> | undefined;

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -2333,6 +2333,8 @@ declare namespace React {
         // UI Events
         onScroll?: UIEventHandler<T> | undefined;
         onScrollCapture?: UIEventHandler<T> | undefined;
+        onScrollEnd?: UIEventHandler<T> | undefined;
+        onScrollEndCapture?: UIEventHandler<T> | undefined;
 
         // Wheel Events
         onWheel?: WheelEventHandler<T> | undefined;


### PR DESCRIPTION
Types for https://github.com/facebook/react/pull/26789

I thought `scrollend` event is accessible only via `el.addEventListener("scrollend", cb)` but I can confirm on my side callback in `onScrollEnd` is successfully called :) 
![image](https://github.com/user-attachments/assets/3b8afcb1-aad8-4185-8275-0171f6ecaae7)

