### PR TITLE
Shard out to 16 jobs on runs of all tests

### DIFF
--- a/scripts/get-ci-matrix.js
+++ b/scripts/get-ci-matrix.js
@@ -1,11 +1,12 @@
 const arg = process.argv[2];
 
+const maxAllJobs = 16;
 const maxJobs = 12;
 
 let shardCount;
 
 if (arg === "all") {
-    shardCount = maxJobs;
+    shardCount = maxAllJobs;
 } else {
     const testCount = Number.parseInt(arg);
     const testsPerJob = 100;


### PR DESCRIPTION
The default max this script will generate is 12 jobs; when running the entire repo, this takes roughly 30 minutes.

Merging a Node PR takes <20 minutes; I feel like we could expand our job count for full runs to try and get it closer. It's often useful to manually run the whole thing to double check that it's clean.