### PR TITLE
Update uswds/uswds tests for TS 5.8

### DIFF
--- a/types/uswds__uswds/uswds__uswds-tests.ts
+++ b/types/uswds__uswds/uswds__uswds-tests.ts
@@ -341,7 +341,7 @@ import("@uswds/uswds").then((imports) => {
         component.off(element); // $ExpectType void
     });
 });
-import("@uswds/uswds/src/js/components").then((imports) => {
+import("@uswds/uswds/src/js/components/index.js").then((imports) => {
     Object.keys(components).forEach((key) => {
         const component = imports[key as ComponentKey];
         component.on(); // $ExpectType void


### PR DESCRIPTION
Dynamic import uses ES module resolution so needs to write /index.js -- implicit resolution of index.d.ts no longer works.
