### PR TITLE
[ws] Sync to v8.18

### DIFF
--- a/types/ws/index.d.mts
+++ b/types/ws/index.d.mts
@@ -129,6 +129,7 @@ declare class WebSocket extends EventEmitter {
     on(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary: boolean) => void): this;
     on(event: "open", listener: (this: WebSocket) => void): this;
     on(event: "ping" | "pong", listener: (this: WebSocket, data: Buffer) => void): this;
+    on(event: "redirect", listener: (this: WebSocket, url: string, request: ClientRequest) => void): this;
     on(
         event: "unexpected-response",
         listener: (this: WebSocket, request: ClientRequest, response: IncomingMessage) => void,
@@ -141,6 +142,7 @@ declare class WebSocket extends EventEmitter {
     once(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary: boolean) => void): this;
     once(event: "open", listener: (this: WebSocket) => void): this;
     once(event: "ping" | "pong", listener: (this: WebSocket, data: Buffer) => void): this;
+    once(event: "redirect", listener: (this: WebSocket, url: string, request: ClientRequest) => void): this;
     once(
         event: "unexpected-response",
         listener: (this: WebSocket, request: ClientRequest, response: IncomingMessage) => void,
@@ -153,6 +155,7 @@ declare class WebSocket extends EventEmitter {
     off(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary: boolean) => void): this;
     off(event: "open", listener: (this: WebSocket) => void): this;
     off(event: "ping" | "pong", listener: (this: WebSocket, data: Buffer) => void): this;
+    off(event: "redirect", listener: (this: WebSocket, url: string, request: ClientRequest) => void): this;
     off(
         event: "unexpected-response",
         listener: (this: WebSocket, request: ClientRequest, response: IncomingMessage) => void,
@@ -165,6 +168,7 @@ declare class WebSocket extends EventEmitter {
     addListener(event: "message", listener: (data: WebSocket.RawData, isBinary: boolean) => void): this;
     addListener(event: "open", listener: () => void): this;
     addListener(event: "ping" | "pong", listener: (data: Buffer) => void): this;
+    addListener(event: "redirect", listener: (url: string, request: ClientRequest) => void): this;
     addListener(
         event: "unexpected-response",
         listener: (request: ClientRequest, response: IncomingMessage) => void,
@@ -177,6 +181,7 @@ declare class WebSocket extends EventEmitter {
     removeListener(event: "message", listener: (data: WebSocket.RawData, isBinary: boolean) => void): this;
     removeListener(event: "open", listener: () => void): this;
     removeListener(event: "ping" | "pong", listener: (data: Buffer) => void): this;
+    removeListener(event: "redirect", listener: (url: string, request: ClientRequest) => void): this;
     removeListener(
         event: "unexpected-response",
         listener: (request: ClientRequest, response: IncomingMessage) => void,

--- a/types/ws/index.d.mts
+++ b/types/ws/index.d.mts
@@ -253,6 +253,7 @@ declare namespace WebSocket {
         family?: number | undefined;
         checkServerIdentity?(servername: string, cert: CertMeta): boolean;
         rejectUnauthorized?: boolean | undefined;
+        allowSynchronousEvents?: boolean | undefined;
         maxPayload?: number | undefined;
         skipUTF8Validation?: boolean | undefined;
         finishRequest?: FinishRequestCallback | undefined;
@@ -333,6 +334,7 @@ declare namespace WebSocket {
         handleProtocols?: (protocols: Set<string>, request: InstanceType<V>) => string | false;
         path?: string | undefined;
         noServer?: boolean | undefined;
+        allowSynchronousEvents?: boolean | undefined;
         clientTracking?: boolean | undefined;
         perMessageDeflate?: boolean | PerMessageDeflateOptions | undefined;
         maxPayload?: number | undefined;

--- a/types/ws/index.d.mts
+++ b/types/ws/index.d.mts
@@ -385,30 +385,44 @@ declare class Server<
     on(event: "error", cb: (this: Server<T>, error: Error) => void): this;
     on(event: "headers", cb: (this: Server<T>, headers: string[], request: InstanceType<U>) => void): this;
     on(event: "close" | "listening", cb: (this: Server<T>) => void): this;
+    on(
+        event: "wsClientError",
+        cb: (this: Server<T>, error: Error, socket: Duplex, request: InstanceType<U>) => void,
+    ): this;
     on(event: string | symbol, listener: (this: Server<T>, ...args: any[]) => void): this;
 
     once(event: "connection", cb: (this: Server<T>, socket: InstanceType<T>, request: InstanceType<U>) => void): this;
     once(event: "error", cb: (this: Server<T>, error: Error) => void): this;
     once(event: "headers", cb: (this: Server<T>, headers: string[], request: InstanceType<U>) => void): this;
     once(event: "close" | "listening", cb: (this: Server<T>) => void): this;
+    once(
+        event: "wsClientError",
+        cb: (this: Server<T>, error: Error, socket: Duplex, request: InstanceType<U>) => void,
+    ): this;
     once(event: string | symbol, listener: (this: Server<T>, ...args: any[]) => void): this;
 
     off(event: "connection", cb: (this: Server<T>, socket: InstanceType<T>, request: InstanceType<U>) => void): this;
     off(event: "error", cb: (this: Server<T>, error: Error) => void): this;
     off(event: "headers", cb: (this: Server<T>, headers: string[], request: InstanceType<U>) => void): this;
     off(event: "close" | "listening", cb: (this: Server<T>) => void): this;
+    off(
+        event: "wsClientError",
+        cb: (this: Server<T>, error: Error, socket: Duplex, request: InstanceType<U>) => void,
+    ): this;
     off(event: string | symbol, listener: (this: Server<T>, ...args: any[]) => void): this;
 
     addListener(event: "connection", cb: (client: InstanceType<T>, request: InstanceType<U>) => void): this;
     addListener(event: "error", cb: (err: Error) => void): this;
     addListener(event: "headers", cb: (headers: string[], request: InstanceType<U>) => void): this;
     addListener(event: "close" | "listening", cb: () => void): this;
+    addListener(event: "wsClientError", cb: (error: Error, socket: Duplex, request: InstanceType<U>) => void): this;
     addListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
     removeListener(event: "connection", cb: (client: InstanceType<T>, request: InstanceType<U>) => void): this;
     removeListener(event: "error", cb: (err: Error) => void): this;
     removeListener(event: "headers", cb: (headers: string[], request: InstanceType<U>) => void): this;
     removeListener(event: "close" | "listening", cb: () => void): this;
+    removeListener(event: "wsClientError", cb: (error: Error, socket: Duplex, request: InstanceType<U>) => void): this;
     removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
 }
 export { type Server };

--- a/types/ws/index.d.mts
+++ b/types/ws/index.d.mts
@@ -27,6 +27,7 @@ type BufferLike =
     | Uint8Array
     | ArrayBuffer
     | SharedArrayBuffer
+    | Blob
     | readonly any[]
     | readonly number[]
     | { valueOf(): ArrayBuffer }

--- a/types/ws/index.d.mts
+++ b/types/ws/index.d.mts
@@ -114,12 +114,16 @@ declare class WebSocket extends EventEmitter {
     // HTML5 WebSocket events
     addEventListener<K extends keyof WebSocket.WebSocketEventMap>(
         type: K,
-        listener: (event: WebSocket.WebSocketEventMap[K]) => void,
+        listener:
+            | ((event: WebSocket.WebSocketEventMap[K]) => void)
+            | { handleEvent(event: WebSocket.WebSocketEventMap[K]): void },
         options?: WebSocket.EventListenerOptions,
     ): void;
     removeEventListener<K extends keyof WebSocket.WebSocketEventMap>(
         type: K,
-        listener: (event: WebSocket.WebSocketEventMap[K]) => void,
+        listener:
+            | ((event: WebSocket.WebSocketEventMap[K]) => void)
+            | { handleEvent(event: WebSocket.WebSocketEventMap[K]): void },
     ): void;
 
     // Events

--- a/types/ws/index.d.mts
+++ b/types/ws/index.d.mts
@@ -254,6 +254,7 @@ declare namespace WebSocket {
         checkServerIdentity?(servername: string, cert: CertMeta): boolean;
         rejectUnauthorized?: boolean | undefined;
         allowSynchronousEvents?: boolean | undefined;
+        autoPong?: boolean | undefined;
         maxPayload?: number | undefined;
         skipUTF8Validation?: boolean | undefined;
         finishRequest?: FinishRequestCallback | undefined;
@@ -335,6 +336,7 @@ declare namespace WebSocket {
         path?: string | undefined;
         noServer?: boolean | undefined;
         allowSynchronousEvents?: boolean | undefined;
+        autoPong?: boolean | undefined;
         clientTracking?: boolean | undefined;
         perMessageDeflate?: boolean | PerMessageDeflateOptions | undefined;
         maxPayload?: number | undefined;

--- a/types/ws/index.d.mts
+++ b/types/ws/index.d.mts
@@ -130,7 +130,7 @@ declare class WebSocket extends EventEmitter {
 
     // Events
     on(event: "close", listener: (this: WebSocket, code: number, reason: Buffer) => void): this;
-    on(event: "error", listener: (this: WebSocket, err: Error) => void): this;
+    on(event: "error", listener: (this: WebSocket, error: Error) => void): this;
     on(event: "upgrade", listener: (this: WebSocket, request: IncomingMessage) => void): this;
     on(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary: boolean) => void): this;
     on(event: "open", listener: (this: WebSocket) => void): this;
@@ -143,7 +143,7 @@ declare class WebSocket extends EventEmitter {
     on(event: string | symbol, listener: (this: WebSocket, ...args: any[]) => void): this;
 
     once(event: "close", listener: (this: WebSocket, code: number, reason: Buffer) => void): this;
-    once(event: "error", listener: (this: WebSocket, err: Error) => void): this;
+    once(event: "error", listener: (this: WebSocket, error: Error) => void): this;
     once(event: "upgrade", listener: (this: WebSocket, request: IncomingMessage) => void): this;
     once(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary: boolean) => void): this;
     once(event: "open", listener: (this: WebSocket) => void): this;
@@ -156,7 +156,7 @@ declare class WebSocket extends EventEmitter {
     once(event: string | symbol, listener: (this: WebSocket, ...args: any[]) => void): this;
 
     off(event: "close", listener: (this: WebSocket, code: number, reason: Buffer) => void): this;
-    off(event: "error", listener: (this: WebSocket, err: Error) => void): this;
+    off(event: "error", listener: (this: WebSocket, error: Error) => void): this;
     off(event: "upgrade", listener: (this: WebSocket, request: IncomingMessage) => void): this;
     off(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary: boolean) => void): this;
     off(event: "open", listener: (this: WebSocket) => void): this;
@@ -169,7 +169,7 @@ declare class WebSocket extends EventEmitter {
     off(event: string | symbol, listener: (this: WebSocket, ...args: any[]) => void): this;
 
     addListener(event: "close", listener: (code: number, reason: Buffer) => void): this;
-    addListener(event: "error", listener: (err: Error) => void): this;
+    addListener(event: "error", listener: (error: Error) => void): this;
     addListener(event: "upgrade", listener: (request: IncomingMessage) => void): this;
     addListener(event: "message", listener: (data: WebSocket.RawData, isBinary: boolean) => void): this;
     addListener(event: "open", listener: () => void): this;
@@ -182,7 +182,7 @@ declare class WebSocket extends EventEmitter {
     addListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
     removeListener(event: "close", listener: (code: number, reason: Buffer) => void): this;
-    removeListener(event: "error", listener: (err: Error) => void): this;
+    removeListener(event: "error", listener: (error: Error) => void): this;
     removeListener(event: "upgrade", listener: (request: IncomingMessage) => void): this;
     removeListener(event: "message", listener: (data: WebSocket.RawData, isBinary: boolean) => void): this;
     removeListener(event: "open", listener: () => void): this;
@@ -392,7 +392,7 @@ declare class Server<
     shouldHandle(request: InstanceType<U>): boolean | Promise<boolean>;
 
     // Events
-    on(event: "connection", cb: (this: Server<T>, socket: InstanceType<T>, request: InstanceType<U>) => void): this;
+    on(event: "connection", cb: (this: Server<T>, websocket: InstanceType<T>, request: InstanceType<U>) => void): this;
     on(event: "error", cb: (this: Server<T>, error: Error) => void): this;
     on(event: "headers", cb: (this: Server<T>, headers: string[], request: InstanceType<U>) => void): this;
     on(event: "close" | "listening", cb: (this: Server<T>) => void): this;
@@ -402,7 +402,10 @@ declare class Server<
     ): this;
     on(event: string | symbol, listener: (this: Server<T>, ...args: any[]) => void): this;
 
-    once(event: "connection", cb: (this: Server<T>, socket: InstanceType<T>, request: InstanceType<U>) => void): this;
+    once(
+        event: "connection",
+        cb: (this: Server<T>, websocket: InstanceType<T>, request: InstanceType<U>) => void,
+    ): this;
     once(event: "error", cb: (this: Server<T>, error: Error) => void): this;
     once(event: "headers", cb: (this: Server<T>, headers: string[], request: InstanceType<U>) => void): this;
     once(event: "close" | "listening", cb: (this: Server<T>) => void): this;
@@ -412,7 +415,7 @@ declare class Server<
     ): this;
     once(event: string | symbol, listener: (this: Server<T>, ...args: any[]) => void): this;
 
-    off(event: "connection", cb: (this: Server<T>, socket: InstanceType<T>, request: InstanceType<U>) => void): this;
+    off(event: "connection", cb: (this: Server<T>, websocket: InstanceType<T>, request: InstanceType<U>) => void): this;
     off(event: "error", cb: (this: Server<T>, error: Error) => void): this;
     off(event: "headers", cb: (this: Server<T>, headers: string[], request: InstanceType<U>) => void): this;
     off(event: "close" | "listening", cb: (this: Server<T>) => void): this;
@@ -422,15 +425,15 @@ declare class Server<
     ): this;
     off(event: string | symbol, listener: (this: Server<T>, ...args: any[]) => void): this;
 
-    addListener(event: "connection", cb: (client: InstanceType<T>, request: InstanceType<U>) => void): this;
-    addListener(event: "error", cb: (err: Error) => void): this;
+    addListener(event: "connection", cb: (websocket: InstanceType<T>, request: InstanceType<U>) => void): this;
+    addListener(event: "error", cb: (error: Error) => void): this;
     addListener(event: "headers", cb: (headers: string[], request: InstanceType<U>) => void): this;
     addListener(event: "close" | "listening", cb: () => void): this;
     addListener(event: "wsClientError", cb: (error: Error, socket: Duplex, request: InstanceType<U>) => void): this;
     addListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
-    removeListener(event: "connection", cb: (client: InstanceType<T>, request: InstanceType<U>) => void): this;
-    removeListener(event: "error", cb: (err: Error) => void): this;
+    removeListener(event: "connection", cb: (websocket: InstanceType<T>, request: InstanceType<U>) => void): this;
+    removeListener(event: "error", cb: (error: Error) => void): this;
     removeListener(event: "headers", cb: (headers: string[], request: InstanceType<U>) => void): this;
     removeListener(event: "close" | "listening", cb: () => void): this;
     removeListener(event: "wsClientError", cb: (error: Error, socket: Duplex, request: InstanceType<U>) => void): this;

--- a/types/ws/index.d.mts
+++ b/types/ws/index.d.mts
@@ -10,6 +10,7 @@ import {
     Server as HTTPServer,
 } from "http";
 import { Server as HTTPSServer } from "https";
+import { createConnection } from "net";
 import { Duplex, DuplexOptions } from "stream";
 import { SecureContextOptions } from "tls";
 import { URL } from "url";
@@ -257,6 +258,7 @@ declare namespace WebSocket {
         autoPong?: boolean | undefined;
         maxPayload?: number | undefined;
         skipUTF8Validation?: boolean | undefined;
+        createConnection?: typeof createConnection | undefined;
         finishRequest?: FinishRequestCallback | undefined;
     }
 

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -256,6 +256,7 @@ declare namespace WebSocket {
         family?: number | undefined;
         checkServerIdentity?(servername: string, cert: CertMeta): boolean;
         rejectUnauthorized?: boolean | undefined;
+        allowSynchronousEvents?: boolean | undefined;
         maxPayload?: number | undefined;
         skipUTF8Validation?: boolean | undefined;
         finishRequest?: FinishRequestCallback | undefined;
@@ -334,6 +335,7 @@ declare namespace WebSocket {
         handleProtocols?: (protocols: Set<string>, request: InstanceType<V>) => string | false;
         path?: string | undefined;
         noServer?: boolean | undefined;
+        allowSynchronousEvents?: boolean | undefined;
         clientTracking?: boolean | undefined;
         perMessageDeflate?: boolean | PerMessageDeflateOptions | undefined;
         maxPayload?: number | undefined;

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -129,6 +129,7 @@ declare class WebSocket extends EventEmitter {
     on(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary: boolean) => void): this;
     on(event: "open", listener: (this: WebSocket) => void): this;
     on(event: "ping" | "pong", listener: (this: WebSocket, data: Buffer) => void): this;
+    on(event: "redirect", listener: (this: WebSocket, url: string, request: ClientRequest) => void): this;
     on(
         event: "unexpected-response",
         listener: (this: WebSocket, request: ClientRequest, response: IncomingMessage) => void,
@@ -141,6 +142,7 @@ declare class WebSocket extends EventEmitter {
     once(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary: boolean) => void): this;
     once(event: "open", listener: (this: WebSocket) => void): this;
     once(event: "ping" | "pong", listener: (this: WebSocket, data: Buffer) => void): this;
+    once(event: "redirect", listener: (this: WebSocket, url: string, request: ClientRequest) => void): this;
     once(
         event: "unexpected-response",
         listener: (this: WebSocket, request: ClientRequest, response: IncomingMessage) => void,
@@ -153,6 +155,7 @@ declare class WebSocket extends EventEmitter {
     off(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary: boolean) => void): this;
     off(event: "open", listener: (this: WebSocket) => void): this;
     off(event: "ping" | "pong", listener: (this: WebSocket, data: Buffer) => void): this;
+    off(event: "redirect", listener: (this: WebSocket, url: string, request: ClientRequest) => void): this;
     off(
         event: "unexpected-response",
         listener: (this: WebSocket, request: ClientRequest, response: IncomingMessage) => void,
@@ -165,6 +168,7 @@ declare class WebSocket extends EventEmitter {
     addListener(event: "message", listener: (data: WebSocket.RawData, isBinary: boolean) => void): this;
     addListener(event: "open", listener: () => void): this;
     addListener(event: "ping" | "pong", listener: (data: Buffer) => void): this;
+    addListener(event: "redirect", listener: (url: string, request: ClientRequest) => void): this;
     addListener(
         event: "unexpected-response",
         listener: (request: ClientRequest, response: IncomingMessage) => void,
@@ -177,6 +181,7 @@ declare class WebSocket extends EventEmitter {
     removeListener(event: "message", listener: (data: WebSocket.RawData, isBinary: boolean) => void): this;
     removeListener(event: "open", listener: () => void): this;
     removeListener(event: "ping" | "pong", listener: (data: Buffer) => void): this;
+    removeListener(event: "redirect", listener: (url: string, request: ClientRequest) => void): this;
     removeListener(
         event: "unexpected-response",
         listener: (request: ClientRequest, response: IncomingMessage) => void,

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -27,6 +27,7 @@ type BufferLike =
     | Uint8Array
     | ArrayBuffer
     | SharedArrayBuffer
+    | Blob
     | readonly any[]
     | readonly number[]
     | { valueOf(): ArrayBuffer }

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -114,12 +114,16 @@ declare class WebSocket extends EventEmitter {
     // HTML5 WebSocket events
     addEventListener<K extends keyof WebSocket.WebSocketEventMap>(
         type: K,
-        listener: (event: WebSocket.WebSocketEventMap[K]) => void,
+        listener:
+            | ((event: WebSocket.WebSocketEventMap[K]) => void)
+            | { handleEvent(event: WebSocket.WebSocketEventMap[K]): void },
         options?: WebSocket.EventListenerOptions,
     ): void;
     removeEventListener<K extends keyof WebSocket.WebSocketEventMap>(
         type: K,
-        listener: (event: WebSocket.WebSocketEventMap[K]) => void,
+        listener:
+            | ((event: WebSocket.WebSocketEventMap[K]) => void)
+            | { handleEvent(event: WebSocket.WebSocketEventMap[K]): void },
     ): void;
 
     // Events

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -257,6 +257,7 @@ declare namespace WebSocket {
         checkServerIdentity?(servername: string, cert: CertMeta): boolean;
         rejectUnauthorized?: boolean | undefined;
         allowSynchronousEvents?: boolean | undefined;
+        autoPong?: boolean | undefined;
         maxPayload?: number | undefined;
         skipUTF8Validation?: boolean | undefined;
         finishRequest?: FinishRequestCallback | undefined;
@@ -336,6 +337,7 @@ declare namespace WebSocket {
         path?: string | undefined;
         noServer?: boolean | undefined;
         allowSynchronousEvents?: boolean | undefined;
+        autoPong?: boolean | undefined;
         clientTracking?: boolean | undefined;
         perMessageDeflate?: boolean | PerMessageDeflateOptions | undefined;
         maxPayload?: number | undefined;

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -130,7 +130,7 @@ declare class WebSocket extends EventEmitter {
 
     // Events
     on(event: "close", listener: (this: WebSocket, code: number, reason: Buffer) => void): this;
-    on(event: "error", listener: (this: WebSocket, err: Error) => void): this;
+    on(event: "error", listener: (this: WebSocket, error: Error) => void): this;
     on(event: "upgrade", listener: (this: WebSocket, request: IncomingMessage) => void): this;
     on(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary: boolean) => void): this;
     on(event: "open", listener: (this: WebSocket) => void): this;
@@ -143,7 +143,7 @@ declare class WebSocket extends EventEmitter {
     on(event: string | symbol, listener: (this: WebSocket, ...args: any[]) => void): this;
 
     once(event: "close", listener: (this: WebSocket, code: number, reason: Buffer) => void): this;
-    once(event: "error", listener: (this: WebSocket, err: Error) => void): this;
+    once(event: "error", listener: (this: WebSocket, error: Error) => void): this;
     once(event: "upgrade", listener: (this: WebSocket, request: IncomingMessage) => void): this;
     once(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary: boolean) => void): this;
     once(event: "open", listener: (this: WebSocket) => void): this;
@@ -156,7 +156,7 @@ declare class WebSocket extends EventEmitter {
     once(event: string | symbol, listener: (this: WebSocket, ...args: any[]) => void): this;
 
     off(event: "close", listener: (this: WebSocket, code: number, reason: Buffer) => void): this;
-    off(event: "error", listener: (this: WebSocket, err: Error) => void): this;
+    off(event: "error", listener: (this: WebSocket, error: Error) => void): this;
     off(event: "upgrade", listener: (this: WebSocket, request: IncomingMessage) => void): this;
     off(event: "message", listener: (this: WebSocket, data: WebSocket.RawData, isBinary: boolean) => void): this;
     off(event: "open", listener: (this: WebSocket) => void): this;
@@ -169,7 +169,7 @@ declare class WebSocket extends EventEmitter {
     off(event: string | symbol, listener: (this: WebSocket, ...args: any[]) => void): this;
 
     addListener(event: "close", listener: (code: number, reason: Buffer) => void): this;
-    addListener(event: "error", listener: (err: Error) => void): this;
+    addListener(event: "error", listener: (error: Error) => void): this;
     addListener(event: "upgrade", listener: (request: IncomingMessage) => void): this;
     addListener(event: "message", listener: (data: WebSocket.RawData, isBinary: boolean) => void): this;
     addListener(event: "open", listener: () => void): this;
@@ -182,7 +182,7 @@ declare class WebSocket extends EventEmitter {
     addListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
     removeListener(event: "close", listener: (code: number, reason: Buffer) => void): this;
-    removeListener(event: "error", listener: (err: Error) => void): this;
+    removeListener(event: "error", listener: (error: Error) => void): this;
     removeListener(event: "upgrade", listener: (request: IncomingMessage) => void): this;
     removeListener(event: "message", listener: (data: WebSocket.RawData, isBinary: boolean) => void): this;
     removeListener(event: "open", listener: () => void): this;
@@ -376,7 +376,10 @@ declare namespace WebSocket {
         shouldHandle(request: InstanceType<U>): boolean | Promise<boolean>;
 
         // Events
-        on(event: "connection", cb: (this: Server<T>, socket: InstanceType<T>, request: InstanceType<U>) => void): this;
+        on(
+            event: "connection",
+            cb: (this: Server<T>, websocket: InstanceType<T>, request: InstanceType<U>) => void,
+        ): this;
         on(event: "error", cb: (this: Server<T>, error: Error) => void): this;
         on(event: "headers", cb: (this: Server<T>, headers: string[], request: InstanceType<U>) => void): this;
         on(event: "close" | "listening", cb: (this: Server<T>) => void): this;
@@ -388,7 +391,7 @@ declare namespace WebSocket {
 
         once(
             event: "connection",
-            cb: (this: Server<T>, socket: InstanceType<T>, request: InstanceType<U>) => void,
+            cb: (this: Server<T>, websocket: InstanceType<T>, request: InstanceType<U>) => void,
         ): this;
         once(event: "error", cb: (this: Server<T>, error: Error) => void): this;
         once(event: "headers", cb: (this: Server<T>, headers: string[], request: InstanceType<U>) => void): this;
@@ -412,15 +415,15 @@ declare namespace WebSocket {
         ): this;
         off(event: string | symbol, listener: (this: Server<T>, ...args: any[]) => void): this;
 
-        addListener(event: "connection", cb: (client: InstanceType<T>, request: InstanceType<U>) => void): this;
-        addListener(event: "error", cb: (err: Error) => void): this;
+        addListener(event: "connection", cb: (websocket: InstanceType<T>, request: InstanceType<U>) => void): this;
+        addListener(event: "error", cb: (error: Error) => void): this;
         addListener(event: "headers", cb: (headers: string[], request: InstanceType<U>) => void): this;
         addListener(event: "close" | "listening", cb: () => void): this;
         addListener(event: "wsClientError", cb: (error: Error, socket: Duplex, request: InstanceType<U>) => void): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
-        removeListener(event: "connection", cb: (client: InstanceType<T>, request: InstanceType<U>) => void): this;
-        removeListener(event: "error", cb: (err: Error) => void): this;
+        removeListener(event: "connection", cb: (websocket: InstanceType<T>, request: InstanceType<U>) => void): this;
+        removeListener(event: "error", cb: (error: Error) => void): this;
         removeListener(event: "headers", cb: (headers: string[], request: InstanceType<U>) => void): this;
         removeListener(event: "close" | "listening", cb: () => void): this;
         removeListener(

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -10,6 +10,7 @@ import {
     Server as HTTPServer,
 } from "http";
 import { Server as HTTPSServer } from "https";
+import { createConnection } from "net";
 import { Duplex, DuplexOptions } from "stream";
 import { SecureContextOptions } from "tls";
 import { URL } from "url";
@@ -260,6 +261,7 @@ declare namespace WebSocket {
         autoPong?: boolean | undefined;
         maxPayload?: number | undefined;
         skipUTF8Validation?: boolean | undefined;
+        createConnection?: typeof createConnection | undefined;
         finishRequest?: FinishRequestCallback | undefined;
     }
 

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -369,6 +369,10 @@ declare namespace WebSocket {
         on(event: "error", cb: (this: Server<T>, error: Error) => void): this;
         on(event: "headers", cb: (this: Server<T>, headers: string[], request: InstanceType<U>) => void): this;
         on(event: "close" | "listening", cb: (this: Server<T>) => void): this;
+        on(
+            event: "wsClientError",
+            cb: (this: Server<T>, error: Error, socket: Duplex, request: InstanceType<U>) => void,
+        ): this;
         on(event: string | symbol, listener: (this: Server<T>, ...args: any[]) => void): this;
 
         once(
@@ -378,6 +382,10 @@ declare namespace WebSocket {
         once(event: "error", cb: (this: Server<T>, error: Error) => void): this;
         once(event: "headers", cb: (this: Server<T>, headers: string[], request: InstanceType<U>) => void): this;
         once(event: "close" | "listening", cb: (this: Server<T>) => void): this;
+        once(
+            event: "wsClientError",
+            cb: (this: Server<T>, error: Error, socket: Duplex, request: InstanceType<U>) => void,
+        ): this;
         once(event: string | symbol, listener: (this: Server<T>, ...args: any[]) => void): this;
 
         off(
@@ -387,18 +395,27 @@ declare namespace WebSocket {
         off(event: "error", cb: (this: Server<T>, error: Error) => void): this;
         off(event: "headers", cb: (this: Server<T>, headers: string[], request: InstanceType<U>) => void): this;
         off(event: "close" | "listening", cb: (this: Server<T>) => void): this;
+        off(
+            event: "wsClientError",
+            cb: (this: Server<T>, error: Error, socket: Duplex, request: InstanceType<U>) => void,
+        ): this;
         off(event: string | symbol, listener: (this: Server<T>, ...args: any[]) => void): this;
 
         addListener(event: "connection", cb: (client: InstanceType<T>, request: InstanceType<U>) => void): this;
         addListener(event: "error", cb: (err: Error) => void): this;
         addListener(event: "headers", cb: (headers: string[], request: InstanceType<U>) => void): this;
         addListener(event: "close" | "listening", cb: () => void): this;
+        addListener(event: "wsClientError", cb: (error: Error, socket: Duplex, request: InstanceType<U>) => void): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
 
         removeListener(event: "connection", cb: (client: InstanceType<T>, request: InstanceType<U>) => void): this;
         removeListener(event: "error", cb: (err: Error) => void): this;
         removeListener(event: "headers", cb: (headers: string[], request: InstanceType<U>) => void): this;
         removeListener(event: "close" | "listening", cb: () => void): this;
+        removeListener(
+            event: "wsClientError",
+            cb: (error: Error, socket: Duplex, request: InstanceType<U>) => void,
+        ): this;
         removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
     }
 

--- a/types/ws/package.json
+++ b/types/ws/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/ws",
-    "version": "8.5.9999",
+    "version": "8.18.9999",
     "projects": [
         "https://github.com/websockets/ws"
     ],

--- a/types/ws/ws-tests.mts
+++ b/types/ws/ws-tests.mts
@@ -222,9 +222,18 @@ import * as wslib from "ws";
 
 {
     const ws = new WebSocket("ws://www.host.com/path");
-    const listener = (event: WebSocket.MessageEvent) => console.log(event.data, event.target, event.type);
-    ws.addEventListener("message", listener, { once: true });
-    ws.removeEventListener("message", listener);
+
+    const listenerFn = (event: WebSocket.MessageEvent) => console.log(event.data, event.target, event.type);
+    ws.addEventListener("message", listenerFn, { once: true });
+    ws.removeEventListener("message", listenerFn);
+
+    const listenerObj = {
+        handleEvent(event: WebSocket.MessageEvent) {
+            console.log(this, event);
+        },
+    };
+    ws.addEventListener("message", listenerObj);
+    ws.removeEventListener("message", listenerObj);
 
     ws.addEventListener("open" as "open" | "close" | "error" | "message", console.log);
     ws.removeEventListener("open" as "open" | "close" | "error" | "message", console.log);

--- a/types/ws/ws-tests.mts
+++ b/types/ws/ws-tests.mts
@@ -166,6 +166,7 @@ import * as wslib from "ws";
             cb(true, 123, "message", { Upgrade: "websocket" });
         },
         allowSynchronousEvents: false,
+        autoPong: false,
     });
 }
 
@@ -526,6 +527,7 @@ declare module "ws" {
 {
     const ws = new WebSocket("ws://www.host.com/path", {
         allowSynchronousEvents: false,
+        autoPong: false,
         finishRequest: (req, socket) => {
             // $ExpectType IncomingMessage
             req;

--- a/types/ws/ws-tests.mts
+++ b/types/ws/ws-tests.mts
@@ -28,6 +28,7 @@ import * as wslib from "ws";
     ws.send(Any as ArrayBufferView);
     ws.send(Any as { valueOf(): ArrayBuffer });
     ws.send(Any as Uint8Array);
+    ws.send(new Blob([]));
     ws.send(Any as { valueOf(): Uint8Array });
     ws.send(Any as { valueOf(): string });
 }

--- a/types/ws/ws-tests.mts
+++ b/types/ws/ws-tests.mts
@@ -98,13 +98,6 @@ import * as wslib from "ws";
 }
 
 {
-    const verifyClient = (
-        info: { origin: string; secure: boolean; req: http.IncomingMessage },
-        callback: (res: boolean) => void,
-    ): void => {
-        callback(true);
-    };
-
     const wsv = new wslib.WebSocketServer({
         server: http.createServer(),
         clientTracking: true,

--- a/types/ws/ws-tests.mts
+++ b/types/ws/ws-tests.mts
@@ -165,6 +165,7 @@ import * as wslib from "ws";
         verifyClient: (info: any, cb: any) => {
             cb(true, 123, "message", { Upgrade: "websocket" });
         },
+        allowSynchronousEvents: false,
     });
 }
 
@@ -524,6 +525,7 @@ declare module "ws" {
 
 {
     const ws = new WebSocket("ws://www.host.com/path", {
+        allowSynchronousEvents: false,
         finishRequest: (req, socket) => {
             // $ExpectType IncomingMessage
             req;

--- a/types/ws/ws-tests.mts
+++ b/types/ws/ws-tests.mts
@@ -1,5 +1,6 @@
 import * as http from "http";
 import * as https from "https";
+import * as net from "net";
 import * as url from "url";
 import WebSocket from "ws";
 // eslint-disable-next-line no-duplicate-imports
@@ -528,6 +529,7 @@ declare module "ws" {
     const ws = new WebSocket("ws://www.host.com/path", {
         allowSynchronousEvents: false,
         autoPong: false,
+        createConnection: net.createConnection,
         finishRequest: (req, socket) => {
             // $ExpectType IncomingMessage
             req;

--- a/types/ws/ws-tests.mts
+++ b/types/ws/ws-tests.mts
@@ -232,6 +232,17 @@ import * as wslib from "ws";
 
 {
     const ws = new WebSocket("ws://www.host.com/path");
+
+    ws.addListener("redirect", (url, request) => {
+        // $ExpectType string
+        url;
+        // $ExpectType ClientRequest
+        request;
+    });
+}
+
+{
+    const ws = new WebSocket("ws://www.host.com/path");
     const eventHandler: Parameters<typeof ws.once>[1] = () => {};
     const event = "";
     const errorHandler = (err: Error) => {

--- a/types/ws/ws-tests.mts
+++ b/types/ws/ws-tests.mts
@@ -490,6 +490,23 @@ declare module "ws" {
         req;
     });
 
+    wss.on("wsClientError", (error, socket, req) => {
+        // $ExpectType Error
+        error;
+        // $ExpectType Duplex
+        socket;
+        // $ExpectType Request
+        req;
+    });
+    wss.off("wsClientError", (error, socket, req) => {
+        // $ExpectType Error
+        error;
+        // $ExpectType Duplex
+        socket;
+        // $ExpectType Request
+        req;
+    });
+
     Array.from(wss.clients).forEach(client => {
         // $ExpectType MyWebsocket
         client;

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -158,6 +158,7 @@ import * as wslib from "ws";
             cb(true, 123, "message", { Upgrade: "websocket" });
         },
         allowSynchronousEvents: false,
+        autoPong: false,
     });
 }
 
@@ -518,6 +519,7 @@ declare module "ws" {
 {
     const ws = new WebSocket("ws://www.host.com/path", {
         allowSynchronousEvents: false,
+        autoPong: false,
         finishRequest: (req, socket) => {
             // $ExpectType IncomingMessage
             req;

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -224,6 +224,17 @@ import * as wslib from "ws";
 
 {
     const ws = new WebSocket("ws://www.host.com/path");
+
+    ws.addListener("redirect", (url, request) => {
+        // $ExpectType string
+        url;
+        // $ExpectType ClientRequest
+        request;
+    });
+}
+
+{
+    const ws = new WebSocket("ws://www.host.com/path");
     const eventHandler: Parameters<typeof ws.once>[1] = () => {};
     const event = "";
     const errorHandler = (err: Error) => {

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -18,6 +18,7 @@ import * as wslib from "ws";
 
     ws.send(Any as number);
     ws.send(Any as ArrayBufferView);
+    ws.send(new Blob([]));
     ws.send(Any as { valueOf(): ArrayBuffer });
     ws.send(Any as Uint8Array);
     ws.send(Any as { valueOf(): Uint8Array });

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -214,12 +214,21 @@ import * as wslib from "ws";
 
 {
     const ws = new WebSocket("ws://www.host.com/path");
-    const listener = (event: WebSocket.MessageEvent) => console.log(event.data, event.target, event.type);
-    ws.addEventListener("message", listener, { once: true });
-    ws.removeEventListener("message", listener);
+
+    const listenerFn = (event: WebSocket.MessageEvent) => console.log(event.data, event.target, event.type);
+    ws.addEventListener("message", listenerFn, { once: true });
+    ws.removeEventListener("message", listenerFn);
 
     ws.addEventListener("open" as "open" | "close" | "error" | "message", console.log);
     ws.removeEventListener("open" as "open" | "close" | "error" | "message", console.log);
+
+    const listenerObj = {
+        handleEvent(event: WebSocket.MessageEvent) {
+            console.log(this, event);
+        },
+    };
+    ws.addEventListener("message", listenerObj);
+    ws.removeEventListener("message", listenerObj);
 }
 
 {

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -1,6 +1,7 @@
 import WebSocket = require("ws");
 import * as http from "http";
 import * as https from "https";
+import * as net from "net";
 import * as url from "url";
 import * as wslib from "ws";
 
@@ -520,6 +521,7 @@ declare module "ws" {
     const ws = new WebSocket("ws://www.host.com/path", {
         allowSynchronousEvents: false,
         autoPong: false,
+        createConnection: net.createConnection,
         finishRequest: (req, socket) => {
             // $ExpectType IncomingMessage
             req;

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -157,6 +157,7 @@ import * as wslib from "ws";
         verifyClient: (info: any, cb: any) => {
             cb(true, 123, "message", { Upgrade: "websocket" });
         },
+        allowSynchronousEvents: false,
     });
 }
 
@@ -516,6 +517,7 @@ declare module "ws" {
 
 {
     const ws = new WebSocket("ws://www.host.com/path", {
+        allowSynchronousEvents: false,
         finishRequest: (req, socket) => {
             // $ExpectType IncomingMessage
             req;

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -90,13 +90,6 @@ import * as wslib from "ws";
 }
 
 {
-    const verifyClient = (
-        info: { origin: string; secure: boolean; req: http.IncomingMessage },
-        callback: (res: boolean) => void,
-    ): void => {
-        callback(true);
-    };
-
     const wsv = new WebSocket.Server({
         server: http.createServer(),
         clientTracking: true,

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -482,6 +482,23 @@ declare module "ws" {
         req;
     });
 
+    wss.on("wsClientError", (error, socket, req) => {
+        // $ExpectType Error
+        error;
+        // $ExpectType Duplex
+        socket;
+        // $ExpectType Request
+        req;
+    });
+    wss.off("wsClientError", (error, socket, req) => {
+        // $ExpectType Error
+        error;
+        // $ExpectType Duplex
+        socket;
+        // $ExpectType Request
+        req;
+    });
+
     Array.from(wss.clients).forEach(client => {
         // $ExpectType MyWebsocket
         client;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changing existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - **Add `Blob` to data type**
    Introduced in v8.18.0 via https://github.com/websockets/ws/pull/2229
  -  **Add `createConnection` client option**
    Introduced in v8.17.0 via https://github.com/websockets/ws/pull/2219
  - **Add `autoPong` option**
    Introduced in v8.16.0 via https://github.com/websockets/ws/commit/01ba54edaeff0f3a58abd7cb9f8e1f3bf134d0fc
  - **Add `allowSynchronousEvents`option**
    Introduced in v8.15.0 via https://github.com/websockets/ws/commit/93e3552e95ba5ad656c30b94f6be96afe22d4805
    Renamed in v8.15.1 via https://github.com/websockets/ws/commit/4ed7fe58b42a87d06452b6bc19028d167262c30b
  - **Support object with `handleEvent` function as event listener**
    Introduced in v8.11.0 via https://github.com/websockets/ws/commit/9ab743aa706be653e3b3c94d07960fe4342f9da5
  - **Add `wsClientError` server event**
    Introduced in v8.7.0 via https://github.com/websockets/ws/commit/6e5a5ce341ffab5ea48542f0aa82c7f4eae80df9
  - **Add `redirect` client event**
    Introduced in v8.6.0 via https://github.com/websockets/ws/pull/2030
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Additional notes:
- List of changes checked via release notes: https://github.com/websockets/ws/releases
- `finishRequest` option introduced in v8.13.0 has already been added via #70991