### PR TITLE
[node] buffer: allow `ArrayBuffer | string` to be passed to `Buffer.from`

### DIFF
--- a/types/node/buffer.buffer.d.ts
+++ b/types/node/buffer.buffer.d.ts
@@ -160,21 +160,6 @@ declare module "buffer" {
              * @param encoding The encoding of `string`. **Default:** `'utf8'`.
              */
             from(string: WithImplicitCoercion<string>, encoding?: BufferEncoding): Buffer<ArrayBuffer>;
-            /**
-             * Creates a view of the `ArrayBuffer` or a new `Buffer` containing `string`.
-             * The `encoding` parameter identifies the character encoding to be used when
-             * converting `string` into bytes.
-             *
-             * A `TypeError` will be thrown if `string` is not a string or another type
-             * appropriate for `Buffer.from()` variants.
-             *
-             * `Buffer.from(string)` may also use the internal `Buffer` pool like
-             * `Buffer.allocUnsafe()` does.
-             * @since v5.10.0
-             * @param arrayBufferOrString An array buffer or a string to encode.
-             * @param offsetOrEncoding A byte-offset or encoding.
-             * @param length A length.
-             */
             from(
                 arrayOrString: WithImplicitCoercion<ArrayLike<number> | string>,
             ): Buffer<ArrayBuffer>;

--- a/types/node/buffer.buffer.d.ts
+++ b/types/node/buffer.buffer.d.ts
@@ -176,9 +176,7 @@ declare module "buffer" {
              * @param length A length.
              */
             from(
-                arrayBufferOrString: WithImplicitCoercion<ArrayLike<number> | string>,
-                offsetOrEncoding?: number | BufferEncoding,
-                length?: number,
+                arrayOrString: WithImplicitCoercion<ArrayLike<number> | string>,
             ): Buffer<ArrayBuffer>;
             /**
              * Creates a new Buffer using the passed {data}

--- a/types/node/buffer.buffer.d.ts
+++ b/types/node/buffer.buffer.d.ts
@@ -175,7 +175,11 @@ declare module "buffer" {
              * @param offsetOrEncoding A byte-offset or encoding.
              * @param length A length.
              */
-            from(arrayBufferOrString: WithImplicitCoercion<string | ArrayBufferLike>, offsetOrEncoding?: number | BufferEncoding, length?: number): Buffer<ArrayBufferLike>;
+            from(
+                arrayBufferOrString: WithImplicitCoercion<string | ArrayBufferLike>,
+                offsetOrEncoding?: number | BufferEncoding,
+                length?: number,
+            ): Buffer<ArrayBufferLike>;
             /**
              * Creates a new Buffer using the passed {data}
              * @param values to create a new Buffer

--- a/types/node/buffer.buffer.d.ts
+++ b/types/node/buffer.buffer.d.ts
@@ -160,9 +160,7 @@ declare module "buffer" {
              * @param encoding The encoding of `string`. **Default:** `'utf8'`.
              */
             from(string: WithImplicitCoercion<string>, encoding?: BufferEncoding): Buffer<ArrayBuffer>;
-            from(
-                arrayOrString: WithImplicitCoercion<ArrayLike<number> | string>,
-            ): Buffer<ArrayBuffer>;
+            from(arrayOrString: WithImplicitCoercion<ArrayLike<number> | string>): Buffer<ArrayBuffer>;
             /**
              * Creates a new Buffer using the passed {data}
              * @param values to create a new Buffer

--- a/types/node/buffer.buffer.d.ts
+++ b/types/node/buffer.buffer.d.ts
@@ -176,10 +176,10 @@ declare module "buffer" {
              * @param length A length.
              */
             from(
-                arrayBufferOrString: WithImplicitCoercion<string | ArrayBufferLike>,
+                arrayBufferOrString: WithImplicitCoercion<ArrayLike<number> | string>,
                 offsetOrEncoding?: number | BufferEncoding,
                 length?: number,
-            ): Buffer<ArrayBufferLike>;
+            ): Buffer<ArrayBuffer>;
             /**
              * Creates a new Buffer using the passed {data}
              * @param values to create a new Buffer

--- a/types/node/buffer.buffer.d.ts
+++ b/types/node/buffer.buffer.d.ts
@@ -161,6 +161,22 @@ declare module "buffer" {
              */
             from(string: WithImplicitCoercion<string>, encoding?: BufferEncoding): Buffer<ArrayBuffer>;
             /**
+             * Creates a view of the `ArrayBuffer` or a new `Buffer` containing `string`.
+             * The `encoding` parameter identifies the character encoding to be used when
+             * converting `string` into bytes.
+             *
+             * A `TypeError` will be thrown if `string` is not a string or another type
+             * appropriate for `Buffer.from()` variants.
+             *
+             * `Buffer.from(string)` may also use the internal `Buffer` pool like
+             * `Buffer.allocUnsafe()` does.
+             * @since v5.10.0
+             * @param arrayBufferOrString An array buffer or a string to encode.
+             * @param offsetOrEncoding A byte-offset or encoding.
+             * @param length A length.
+             */
+            from(arrayBufferOrString: WithImplicitCoercion<string | ArrayBufferLike>, offsetOrEncoding?: number | BufferEncoding, length?: number): Buffer<ArrayBufferLike>;
+            /**
              * Creates a new Buffer using the passed {data}
              * @param values to create a new Buffer
              */

--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -149,6 +149,9 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as readonly Uint8Array[
         Buffer.from({} as { [Symbol.toPrimitive](): number });
     }
 
+    const arrayBufferOrString: ArrayBuffer | string = "foo";
+    Buffer.from(arrayBufferOrString);
+
     // @ts-expect-error
     Buffer.from({});
     // @ts-expect-error

--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -149,8 +149,16 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as readonly Uint8Array[
         Buffer.from({} as { [Symbol.toPrimitive](): number });
     }
 
-    const arrayBufferOrString: ArrayBuffer | string = "foo";
-    Buffer.from(arrayBufferOrString);
+    // ArrayLike or string
+    {
+        const arrayOrString = "foo" as number[] | string;
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from(arrayOrString);
+
+        const typedArrayOrString = "foo" as Uint8Array<ArrayBuffer> | string;
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from(typedArrayOrString);
+    }
 
     // @ts-expect-error
     Buffer.from({});

--- a/types/node/ts5.6/buffer.buffer.d.ts
+++ b/types/node/ts5.6/buffer.buffer.d.ts
@@ -158,9 +158,7 @@ declare module "buffer" {
              * @param encoding The encoding of `string`. **Default:** `'utf8'`.
              */
             from(string: WithImplicitCoercion<string>, encoding?: BufferEncoding): Buffer;
-            from(
-                arrayOrString: WithImplicitCoercion<ArrayLike<number> | string>,
-            ): Buffer;
+            from(arrayOrString: WithImplicitCoercion<ArrayLike<number> | string>): Buffer;
             /**
              * Creates a new Buffer using the passed {data}
              * @param values to create a new Buffer

--- a/types/node/ts5.6/buffer.buffer.d.ts
+++ b/types/node/ts5.6/buffer.buffer.d.ts
@@ -158,6 +158,9 @@ declare module "buffer" {
              * @param encoding The encoding of `string`. **Default:** `'utf8'`.
              */
             from(string: WithImplicitCoercion<string>, encoding?: BufferEncoding): Buffer;
+            from(
+                arrayOrString: WithImplicitCoercion<ArrayLike<number> | string>,
+            ): Buffer;
             /**
              * Creates a new Buffer using the passed {data}
              * @param values to create a new Buffer

--- a/types/node/v18/buffer.buffer.d.ts
+++ b/types/node/v18/buffer.buffer.d.ts
@@ -155,7 +155,6 @@ declare module "buffer" {
              * @param encoding The encoding of `string`. **Default:** `'utf8'`.
              */
             from(string: WithImplicitCoercion<string>, encoding?: BufferEncoding): Buffer<ArrayBuffer>;
-
             /**
              * Creates a view of the `ArrayBuffer` or a new `Buffer` containing `string`.
              * The `encoding` parameter identifies the character encoding to be used when
@@ -172,10 +171,10 @@ declare module "buffer" {
              * @param length A length.
              */
             from(
-                arrayBufferOrString: WithImplicitCoercion<string | ArrayBufferLike>,
+                arrayBufferOrString: WithImplicitCoercion<ArrayLike<number> | string>,
                 offsetOrEncoding?: number | BufferEncoding,
                 length?: number,
-            ): Buffer<ArrayBufferLike>;
+            ): Buffer<ArrayBuffer>;
             /**
              * Creates a new Buffer using the passed {data}
              * @param values to create a new Buffer

--- a/types/node/v18/buffer.buffer.d.ts
+++ b/types/node/v18/buffer.buffer.d.ts
@@ -171,9 +171,7 @@ declare module "buffer" {
              * @param length A length.
              */
             from(
-                arrayBufferOrString: WithImplicitCoercion<ArrayLike<number> | string>,
-                offsetOrEncoding?: number | BufferEncoding,
-                length?: number,
+                arrayOrString: WithImplicitCoercion<ArrayLike<number> | string>,
             ): Buffer<ArrayBuffer>;
             /**
              * Creates a new Buffer using the passed {data}

--- a/types/node/v18/buffer.buffer.d.ts
+++ b/types/node/v18/buffer.buffer.d.ts
@@ -155,6 +155,23 @@ declare module "buffer" {
              * @param encoding The encoding of `string`. **Default:** `'utf8'`.
              */
             from(string: WithImplicitCoercion<string>, encoding?: BufferEncoding): Buffer<ArrayBuffer>;
+
+            /**
+             * Creates a view of the `ArrayBuffer` or a new `Buffer` containing `string`.
+             * The `encoding` parameter identifies the character encoding to be used when
+             * converting `string` into bytes.
+             *
+             * A `TypeError` will be thrown if `string` is not a string or another type
+             * appropriate for `Buffer.from()` variants.
+             *
+             * `Buffer.from(string)` may also use the internal `Buffer` pool like
+             * `Buffer.allocUnsafe()` does.
+             * @since v5.10.0
+             * @param arrayBufferOrString An array buffer or a string to encode.
+             * @param offsetOrEncoding A byte-offset or encoding.
+             * @param length A length.
+             */
+            from(arrayBufferOrString: WithImplicitCoercion<string | ArrayBufferLike>, offsetOrEncoding?: number | BufferEncoding, length?: number): Buffer<ArrayBufferLike>;
             /**
              * Creates a new Buffer using the passed {data}
              * @param values to create a new Buffer

--- a/types/node/v18/buffer.buffer.d.ts
+++ b/types/node/v18/buffer.buffer.d.ts
@@ -155,9 +155,7 @@ declare module "buffer" {
              * @param encoding The encoding of `string`. **Default:** `'utf8'`.
              */
             from(string: WithImplicitCoercion<string>, encoding?: BufferEncoding): Buffer<ArrayBuffer>;
-            from(
-                arrayOrString: WithImplicitCoercion<ArrayLike<number> | string>,
-            ): Buffer<ArrayBuffer>;
+            from(arrayOrString: WithImplicitCoercion<ArrayLike<number> | string>): Buffer<ArrayBuffer>;
             /**
              * Creates a new Buffer using the passed {data}
              * @param values to create a new Buffer

--- a/types/node/v18/buffer.buffer.d.ts
+++ b/types/node/v18/buffer.buffer.d.ts
@@ -155,21 +155,6 @@ declare module "buffer" {
              * @param encoding The encoding of `string`. **Default:** `'utf8'`.
              */
             from(string: WithImplicitCoercion<string>, encoding?: BufferEncoding): Buffer<ArrayBuffer>;
-            /**
-             * Creates a view of the `ArrayBuffer` or a new `Buffer` containing `string`.
-             * The `encoding` parameter identifies the character encoding to be used when
-             * converting `string` into bytes.
-             *
-             * A `TypeError` will be thrown if `string` is not a string or another type
-             * appropriate for `Buffer.from()` variants.
-             *
-             * `Buffer.from(string)` may also use the internal `Buffer` pool like
-             * `Buffer.allocUnsafe()` does.
-             * @since v5.10.0
-             * @param arrayBufferOrString An array buffer or a string to encode.
-             * @param offsetOrEncoding A byte-offset or encoding.
-             * @param length A length.
-             */
             from(
                 arrayOrString: WithImplicitCoercion<ArrayLike<number> | string>,
             ): Buffer<ArrayBuffer>;

--- a/types/node/v18/buffer.buffer.d.ts
+++ b/types/node/v18/buffer.buffer.d.ts
@@ -171,7 +171,11 @@ declare module "buffer" {
              * @param offsetOrEncoding A byte-offset or encoding.
              * @param length A length.
              */
-            from(arrayBufferOrString: WithImplicitCoercion<string | ArrayBufferLike>, offsetOrEncoding?: number | BufferEncoding, length?: number): Buffer<ArrayBufferLike>;
+            from(
+                arrayBufferOrString: WithImplicitCoercion<string | ArrayBufferLike>,
+                offsetOrEncoding?: number | BufferEncoding,
+                length?: number,
+            ): Buffer<ArrayBufferLike>;
             /**
              * Creates a new Buffer using the passed {data}
              * @param values to create a new Buffer

--- a/types/node/v18/test/buffer.ts
+++ b/types/node/v18/test/buffer.ts
@@ -148,8 +148,16 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as readonly Uint8Array[
         Buffer.from({} as { [Symbol.toPrimitive](): number });
     }
 
-    const arrayBufferOrString: ArrayBuffer | string = "foo";
-    Buffer.from(arrayBufferOrString);
+    // ArrayLike or string
+    {
+        const arrayOrString = "foo" as number[] | string;
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from(arrayOrString);
+
+        const typedArrayOrString = "foo" as Uint8Array<ArrayBuffer> | string;
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from(typedArrayOrString);
+    }
 
     // @ts-expect-error
     Buffer.from({});

--- a/types/node/v18/test/buffer.ts
+++ b/types/node/v18/test/buffer.ts
@@ -148,6 +148,9 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as readonly Uint8Array[
         Buffer.from({} as { [Symbol.toPrimitive](): number });
     }
 
+    const arrayBufferOrString: ArrayBuffer | string = "foo";
+    Buffer.from(arrayBufferOrString);
+
     // @ts-expect-error
     Buffer.from({});
     // @ts-expect-error

--- a/types/node/v18/ts5.6/buffer.buffer.d.ts
+++ b/types/node/v18/ts5.6/buffer.buffer.d.ts
@@ -153,6 +153,9 @@ declare module "buffer" {
              * @param encoding The encoding of `string`. **Default:** `'utf8'`.
              */
             from(string: WithImplicitCoercion<string>, encoding?: BufferEncoding): Buffer;
+            from(
+                arrayOrString: WithImplicitCoercion<ArrayLike<number> | string>,
+            ): Buffer;
             /**
              * Creates a new Buffer using the passed {data}
              * @param values to create a new Buffer

--- a/types/node/v18/ts5.6/buffer.buffer.d.ts
+++ b/types/node/v18/ts5.6/buffer.buffer.d.ts
@@ -153,9 +153,7 @@ declare module "buffer" {
              * @param encoding The encoding of `string`. **Default:** `'utf8'`.
              */
             from(string: WithImplicitCoercion<string>, encoding?: BufferEncoding): Buffer;
-            from(
-                arrayOrString: WithImplicitCoercion<ArrayLike<number> | string>,
-            ): Buffer;
+            from(arrayOrString: WithImplicitCoercion<ArrayLike<number> | string>): Buffer;
             /**
              * Creates a new Buffer using the passed {data}
              * @param values to create a new Buffer

--- a/types/node/v20/buffer.buffer.d.ts
+++ b/types/node/v20/buffer.buffer.d.ts
@@ -160,21 +160,6 @@ declare module "buffer" {
              * @param encoding The encoding of `string`. **Default:** `'utf8'`.
              */
             from(string: WithImplicitCoercion<string>, encoding?: BufferEncoding): Buffer<ArrayBuffer>;
-            /**
-             * Creates a view of the `ArrayBuffer` or a new `Buffer` containing `string`.
-             * The `encoding` parameter identifies the character encoding to be used when
-             * converting `string` into bytes.
-             *
-             * A `TypeError` will be thrown if `string` is not a string or another type
-             * appropriate for `Buffer.from()` variants.
-             *
-             * `Buffer.from(string)` may also use the internal `Buffer` pool like
-             * `Buffer.allocUnsafe()` does.
-             * @since v5.10.0
-             * @param arrayBufferOrString An array buffer or a string to encode.
-             * @param offsetOrEncoding A byte-offset or encoding.
-             * @param length A length.
-             */
             from(
                 arrayOrString: WithImplicitCoercion<ArrayLike<number> | string>,
             ): Buffer<ArrayBuffer>;

--- a/types/node/v20/buffer.buffer.d.ts
+++ b/types/node/v20/buffer.buffer.d.ts
@@ -176,9 +176,7 @@ declare module "buffer" {
              * @param length A length.
              */
             from(
-                arrayBufferOrString: WithImplicitCoercion<ArrayLike<number> | string>,
-                offsetOrEncoding?: number | BufferEncoding,
-                length?: number,
+                arrayOrString: WithImplicitCoercion<ArrayLike<number> | string>,
             ): Buffer<ArrayBuffer>;
             /**
              * Creates a new Buffer using the passed {data}

--- a/types/node/v20/buffer.buffer.d.ts
+++ b/types/node/v20/buffer.buffer.d.ts
@@ -175,7 +175,11 @@ declare module "buffer" {
              * @param offsetOrEncoding A byte-offset or encoding.
              * @param length A length.
              */
-            from(arrayBufferOrString: WithImplicitCoercion<string | ArrayBufferLike>, offsetOrEncoding?: number | BufferEncoding, length?: number): Buffer<ArrayBufferLike>;
+            from(
+                arrayBufferOrString: WithImplicitCoercion<string | ArrayBufferLike>,
+                offsetOrEncoding?: number | BufferEncoding,
+                length?: number,
+            ): Buffer<ArrayBufferLike>;
             /**
              * Creates a new Buffer using the passed {data}
              * @param values to create a new Buffer

--- a/types/node/v20/buffer.buffer.d.ts
+++ b/types/node/v20/buffer.buffer.d.ts
@@ -160,9 +160,7 @@ declare module "buffer" {
              * @param encoding The encoding of `string`. **Default:** `'utf8'`.
              */
             from(string: WithImplicitCoercion<string>, encoding?: BufferEncoding): Buffer<ArrayBuffer>;
-            from(
-                arrayOrString: WithImplicitCoercion<ArrayLike<number> | string>,
-            ): Buffer<ArrayBuffer>;
+            from(arrayOrString: WithImplicitCoercion<ArrayLike<number> | string>): Buffer<ArrayBuffer>;
             /**
              * Creates a new Buffer using the passed {data}
              * @param values to create a new Buffer

--- a/types/node/v20/buffer.buffer.d.ts
+++ b/types/node/v20/buffer.buffer.d.ts
@@ -176,10 +176,10 @@ declare module "buffer" {
              * @param length A length.
              */
             from(
-                arrayBufferOrString: WithImplicitCoercion<string | ArrayBufferLike>,
+                arrayBufferOrString: WithImplicitCoercion<ArrayLike<number> | string>,
                 offsetOrEncoding?: number | BufferEncoding,
                 length?: number,
-            ): Buffer<ArrayBufferLike>;
+            ): Buffer<ArrayBuffer>;
             /**
              * Creates a new Buffer using the passed {data}
              * @param values to create a new Buffer

--- a/types/node/v20/buffer.buffer.d.ts
+++ b/types/node/v20/buffer.buffer.d.ts
@@ -161,6 +161,22 @@ declare module "buffer" {
              */
             from(string: WithImplicitCoercion<string>, encoding?: BufferEncoding): Buffer<ArrayBuffer>;
             /**
+             * Creates a view of the `ArrayBuffer` or a new `Buffer` containing `string`.
+             * The `encoding` parameter identifies the character encoding to be used when
+             * converting `string` into bytes.
+             *
+             * A `TypeError` will be thrown if `string` is not a string or another type
+             * appropriate for `Buffer.from()` variants.
+             *
+             * `Buffer.from(string)` may also use the internal `Buffer` pool like
+             * `Buffer.allocUnsafe()` does.
+             * @since v5.10.0
+             * @param arrayBufferOrString An array buffer or a string to encode.
+             * @param offsetOrEncoding A byte-offset or encoding.
+             * @param length A length.
+             */
+            from(arrayBufferOrString: WithImplicitCoercion<string | ArrayBufferLike>, offsetOrEncoding?: number | BufferEncoding, length?: number): Buffer<ArrayBufferLike>;
+            /**
              * Creates a new Buffer using the passed {data}
              * @param values to create a new Buffer
              */

--- a/types/node/v20/test/buffer.ts
+++ b/types/node/v20/test/buffer.ts
@@ -149,6 +149,9 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as readonly Uint8Array[
         Buffer.from({} as { [Symbol.toPrimitive](): number });
     }
 
+    const arrayBufferOrString: ArrayBuffer | string = "foo";
+    Buffer.from(arrayBufferOrString);
+
     // @ts-expect-error
     Buffer.from({});
     // @ts-expect-error

--- a/types/node/v20/test/buffer.ts
+++ b/types/node/v20/test/buffer.ts
@@ -149,8 +149,16 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as readonly Uint8Array[
         Buffer.from({} as { [Symbol.toPrimitive](): number });
     }
 
-    const arrayBufferOrString: ArrayBuffer | string = "foo";
-    Buffer.from(arrayBufferOrString);
+    // ArrayLike or string
+    {
+        const arrayOrString = "foo" as number[] | string;
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from(arrayOrString);
+
+        const typedArrayOrString = "foo" as Uint8Array<ArrayBuffer> | string;
+        // $ExpectType Buffer || Buffer<ArrayBuffer>
+        Buffer.from(typedArrayOrString);
+    }
 
     // @ts-expect-error
     Buffer.from({});

--- a/types/node/v20/ts5.6/buffer.buffer.d.ts
+++ b/types/node/v20/ts5.6/buffer.buffer.d.ts
@@ -158,9 +158,7 @@ declare module "buffer" {
              * @param encoding The encoding of `string`. **Default:** `'utf8'`.
              */
             from(string: WithImplicitCoercion<string>, encoding?: BufferEncoding): Buffer;
-            from(
-                arrayOrString: WithImplicitCoercion<ArrayLike<number> | string>,
-            ): Buffer;
+            from(arrayOrString: WithImplicitCoercion<ArrayLike<number> | string>): Buffer;
             /**
              * Creates a new Buffer using the passed {data}
              * @param values to create a new Buffer

--- a/types/node/v20/ts5.6/buffer.buffer.d.ts
+++ b/types/node/v20/ts5.6/buffer.buffer.d.ts
@@ -158,6 +158,9 @@ declare module "buffer" {
              * @param encoding The encoding of `string`. **Default:** `'utf8'`.
              */
             from(string: WithImplicitCoercion<string>, encoding?: BufferEncoding): Buffer;
+            from(
+                arrayOrString: WithImplicitCoercion<ArrayLike<number> | string>,
+            ): Buffer;
             /**
              * Creates a new Buffer using the passed {data}
              * @param values to create a new Buffer


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/buffer.html#class-buffer
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

I was passing `ArrayBuffer | string` to `Buffer.from`, but that started to error after #72056. This PR adds a signature for that case.
