### PR TITLE
Update webextension-polyfill browser.runtime.OnMessage listener for all calling patterns

### DIFF
--- a/types/webextension-polyfill/namespaces/runtime.d.ts
+++ b/types/webextension-polyfill/namespaces/runtime.d.ts
@@ -262,6 +262,7 @@ export namespace Runtime {
      */
     type OnPerformanceWarningSeverity = "low" | "medium" | "high";
 
+    type SendResponse<TResponse = unknown> = (response: TResponse) => void;
     /**
      * The third parameter is a function to call (at most once) when you have a response.
      * The argument should be any JSON-ifiable object. If you have more than one <code>onMessage</code>
@@ -270,21 +271,12 @@ export namespace Runtime {
      * send a response asynchronously (this will keep the message channel open to the other end until <code>sendResponse</code>
      * is called).
      */
-    type OnMessageListenerCallback = (
-        message: unknown,
+    type OnMessageListener<TMessage = unknown, TResponse = unknown> = (
+        message: TMessage,
         sender: MessageSender,
-        sendResponse: (response: unknown) => void,
-    ) => true;
-
-    /**
-     * The return value should be a promise of any JSON-ifiable object. If you have more than one <code>onMessage</code>
-     * listener in the same document, then only one may send a response.
-     */
-    type OnMessageListenerAsync = (message: unknown, sender: MessageSender) => Promise<unknown>;
-
-    type OnMessageListenerNoResponse = (message: unknown, sender: MessageSender) => void;
-
-    type OnMessageListener = OnMessageListenerCallback | OnMessageListenerAsync | OnMessageListenerNoResponse;
+        sendResponse: SendResponse<TResponse>,
+        // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+    ) => Promise<TResponse> | boolean | undefined | void;
 
     /**
      * If an update is available, this contains more information about the available update.

--- a/types/webextension-polyfill/webextension-polyfill-tests.ts
+++ b/types/webextension-polyfill/webextension-polyfill-tests.ts
@@ -1,7 +1,52 @@
 import * as browser from "webextension-polyfill";
 // eslint-disable-next-line no-duplicate-imports
-import { Browser, Tabs } from "webextension-polyfill";
+import type { Browser, Tabs } from "webextension-polyfill";
 
 const x: Browser = browser;
 
 const promise: Promise<Tabs.Tab> = browser.tabs.create({});
+
+// Do not handle message
+browser.runtime.onMessage.addListener((message, sender) => false);
+
+// Handle message sync
+browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    sendResponse("ok");
+});
+
+// Handle message deferred
+browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    setTimeout(() => {
+        sendResponse("ok");
+    }, 100);
+    return true;
+});
+
+// Handle message async
+browser.runtime.onMessage.addListener(async (message, sender) => "ok");
+
+// Optionally handle message async
+browser.runtime.onMessage.addListener((message, sender) => Math.random() < 0.5 ? Promise.resolve("ok") : undefined);
+browser.runtime.onMessage.addListener((message, sender) => Math.random() < 0.5 ? Promise.resolve("ok") : false);
+
+// Conditionally handle via all possible methods.
+browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    const r = Math.random();
+
+    if (r < 0.1) {
+        // Ignore
+        return false;
+    }
+    if (r < 0.2) {
+        // Handle deferred
+        setTimeout(() => sendResponse("ok"), 100);
+        return true;
+    }
+    if (r < 0.3) {
+        // Handle sync
+        sendResponse("ok");
+        return;
+    }
+    // Handle async
+    return Promise.resolve("ok");
+});


### PR DESCRIPTION
See: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#parameters

This reverts(ish) some changes from #72037. See the added tests for valid uses that were being rejected.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#parameters
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
