### PR TITLE
[@types/diff] `patched()` callback can return false

### DIFF
--- a/types/diff/diff-tests.ts
+++ b/types/diff/diff-tests.ts
@@ -115,7 +115,9 @@ function verifyApplyMethods(oldStr: string, newStr: string, uniDiffStr: string) 
         },
         patched(index, content) {
             index; // $ExpectType ParsedDiff
-            verifyApply.push(content);
+            if (content !== false) {
+                verifyApply.push(content);
+            }
         },
         complete(err) {
             if (err) {

--- a/types/diff/index.d.ts
+++ b/types/diff/index.d.ts
@@ -127,7 +127,7 @@ export interface ApplyPatchOptions {
 
 export interface ApplyPatchesOptions extends ApplyPatchOptions {
     loadFile(index: ParsedDiff, callback: (err: any, data: string) => void): void;
-    patched(index: ParsedDiff, content: string, callback: (err: any) => void): void;
+    patched(index: ParsedDiff, content: string | false, callback: (err: any) => void): void;
     complete(err: any): void;
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:


If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [see this sentance in the README](https://www.npmjs.com/package/diff#:~:text=content%20will%20be%20the%20return%20value%20from%20applyPatch) and [the c](https://github.com/kpdecker/jsdiff/blob/36d9a0e4529cbc3b76e27f33111ce45dcdb76131/src/patch/apply.js#L280-L281)[ode](https://github.com/kpdecker/jsdiff/blob/36d9a0e4529cbc3b76e27f33111ce45dcdb76131/src/patch/apply.js#L80)
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.~~
