### PR TITLE
[@types/node] add `registerHooks` to `node:module`

### DIFF
--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -175,6 +175,25 @@ declare module "module" {
             options?: RegisterOptions<Data>,
         ): void;
         function register<Data = any>(specifier: string | URL, options?: RegisterOptions<Data>): void;
+        /**
+         * Register synchronous customization hooks. See
+         * [`module.registerHooks`](https://nodejs.org/api/module.html#moduleregisterhooksoptions)
+         * @since v23.5.0, v22.15
+         * @param hooks The synchronous customization hooks to be registered. This should be an object with
+         * key names matching the hooks.
+         */
+        function registerHooks(hooks: {
+			resolve?: ResolveHook,
+			load?: LoadHook,
+		}): ModuleHooks;
+
+		class ModuleHooks {
+			constructor(resolve?: ResolveHook, load?: LoadHook);
+            /**
+             * Remove this set of hooks.
+             */
+			deregister(): void;
+		}
         interface StripTypeScriptTypesOptions {
             /**
              * Possible values are:

--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -183,17 +183,17 @@ declare module "module" {
          * key names matching the hooks.
          */
         function registerHooks(hooks: {
-			resolve?: ResolveHook,
-			load?: LoadHook,
-		}): ModuleHooks;
+            resolve?: ResolveHook,
+            load?: LoadHook,
+        }): ModuleHooks;
 
-		class ModuleHooks {
-			constructor(resolve?: ResolveHook, load?: LoadHook);
+        class ModuleHooks {
+            constructor(resolve?: ResolveHook, load?: LoadHook);
             /**
              * Remove this set of hooks.
              */
-			deregister(): void;
-		}
+            deregister(): void;
+        }
         interface StripTypeScriptTypesOptions {
             /**
              * Possible values are:


### PR DESCRIPTION
This should be backported to node 22.x (likely 22.15.0) in the near future.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/module.html#moduleregisterhooksoptions