### PR TITLE
fix(oidc-provider): resolve mismatch for base class used by Grant type

### DIFF
--- a/types/oidc-provider/index.d.ts
+++ b/types/oidc-provider/index.d.ts
@@ -250,7 +250,7 @@ declare class Session extends BaseModel {
     static get(ctx: Koa.Context): Promise<Session>;
 }
 
-declare class Grant extends BaseModel {
+declare class Grant extends BaseToken {
     constructor(properties?: { clientId?: string | undefined; accountId?: string | undefined });
 
     accountId?: string | undefined;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)

I tested my modifying the base class locally to get past type errors related to accessing fields such as `isExpired`.

- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

In `oidc-provider` v8.8.0, the Grant model extends BaseToken and then BaseModel. This PR addresses this discrepancy so that fields like "isExpired" are accessible in the type definition: https://github.com/panva/node-oidc-provider/blob/4ea264ebd28d9d2df25f0bf200033c1e3928b31c/lib/models/grant.js#L9-L11

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
