### PR TITLE
fix(maxmsp): correct Buffer methods channelcount, framecount and length to be function calls

### DIFF
--- a/types/maxmsp/index.d.ts
+++ b/types/maxmsp/index.d.ts
@@ -137,17 +137,17 @@ declare class Buffer {
     /**
      * Return the number of channels in the buffer~ object.
      */
-    channelcount: number;
+    channelcount(): number;
 
     /**
      * Return the number of frames (samples in a single channel) in the buffer~ object.
      */
-    framecount: number;
+    framecount(): number;
 
     /**
      * Return the length of the buffer~ object in milliseconds.
      */
-    length: number;
+    length(): number;
 
     /**
      * Return an array with count samples from channel (1-based counting) starting at frame (zero-based counting).

--- a/types/maxmsp/maxmsp-tests.ts
+++ b/types/maxmsp/maxmsp-tests.ts
@@ -22,6 +22,9 @@ const myBuffer = new Buffer("audio_buffer");
 myBuffer.peek(1, 5, 10);
 myBuffer.poke(1, 5, [0.1, 0.2, 0.3]);
 myBuffer.send("sizeinsamps", 44100);
+post(myBuffer.channelcount());
+post(myBuffer.framecount());
+post(myBuffer.length());
 
 // Dict usage example
 const d = new Dict("test_dict");


### PR DESCRIPTION
Changed Buffer class methods from properties to function calls to match Max/MSP runtime behavior:
- channelcount: number -> channelcount(): number
- framecount: number -> framecount(): number
- length: number -> length(): number

...and updated tests!