### PR TITLE
[n3]: bump rdfjs types

### DIFF
--- a/types/n3/package.json
+++ b/types/n3/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/n3",
-    "version": "1.21.9999",
+    "version": "1.24.9999",
     "projects": [
         "https://github.com/rdfjs/n3.js"
     ],

--- a/types/n3/package.json
+++ b/types/n3/package.json
@@ -6,7 +6,7 @@
         "https://github.com/rdfjs/n3.js"
     ],
     "dependencies": {
-        "@rdfjs/types": "^1.1.0",
+        "@rdfjs/types": "^2.0.1",
         "@types/node": "*"
     },
     "devDependencies": {

--- a/types/n3/package.json
+++ b/types/n3/package.json
@@ -6,7 +6,7 @@
         "https://github.com/rdfjs/n3.js"
     ],
     "dependencies": {
-        "@rdfjs/types": "^2.0.1",
+        "@rdfjs/types": "*",
         "@types/node": "*"
     },
     "devDependencies": {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [NA] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

The breaking change to the types package is [the addition of `fromQuad` and `fromTerm` to the `DataFactory`](https://github.com/rdfjs/types/pull/46) which n3 implements in https://github.com/rdfjs/N3.js/pull/449 and released in v1.22.0 of the package.

@rubensworks it is unclear to me whether we should be:
 - bumping the types package to v2, or
 - allowing any version with `"*"`
 
 I suspect we may want the latter ... 