### PR TITLE
Plotlyjs add support for maxdepth (sunburst, treemap, icicle)

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1313,7 +1313,6 @@ export type ColorScale = string | string[] | Array<[number, string]>;
 export type DataTransform = Partial<Transform>;
 export type ScatterData = PlotData;
 
-// Bar Scatter
 export interface PlotData {
     type: PlotType;
     x: Datum[] | Datum[][] | TypedArray;
@@ -1539,6 +1538,7 @@ export interface PlotData {
     }>;
     autocontour: boolean;
     ncontours: number;
+    maxdepth: number;
     uirevision: string | number;
     uid: string;
 }

--- a/types/plotly.js/test/core-tests.ts
+++ b/types/plotly.js/test/core-tests.ts
@@ -492,6 +492,24 @@ const layout = {
 
     Plotly.newPlot("myDiv", data, layout);
 })();
+
+(() => {
+    const data: Array<Partial<PlotData>> = [
+        {
+            type: "treemap",
+            labels: ["Eve", "Cain", "Seth", "Enos", "Noam", "Abel", "Awan", "Enoch", "Azura"],
+            parents: ["", "Eve", "Eve", "Seth", "Seth", "Eve", "Eve", "Awan", "Eve" ],
+            maxdepth: 1,
+        },
+    ];
+
+    const layout = {
+        height: 700,
+        width: 700,
+    };
+
+    Plotly.newPlot("myDiv", data, layout);
+})();
 //////////////////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////////////////

--- a/types/plotly.js/test/core-tests.ts
+++ b/types/plotly.js/test/core-tests.ts
@@ -498,7 +498,7 @@ const layout = {
         {
             type: "treemap",
             labels: ["Eve", "Cain", "Seth", "Enos", "Noam", "Abel", "Awan", "Enoch", "Azura"],
-            parents: ["", "Eve", "Eve", "Seth", "Seth", "Eve", "Eve", "Awan", "Eve" ],
+            parents: ["", "Eve", "Eve", "Seth", "Seth", "Eve", "Eve", "Awan", "Eve"],
             maxdepth: 1,
         },
     ];


### PR DESCRIPTION
Fixes https://github.com/plotly/plotly.js/issues/6015

Adds `maxdepth`, which is supported by plots `sunburst`, `treemap` and `icicle`. Ideally the types would enforce _only_ those plots can use the field, but that's a more invasive PR I might do later if I make more substantial changes.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/plotly/plotly.js/blob/bd35269acea8a50a5973656849279f2775dd8ea8/src/traces/sunburst/attributes.js#L80-L88
  - https://github.com/plotly/plotly.js/blob/bd35269acea8a50a5973656849279f2775dd8ea8/src/traces/treemap/attributes.js#L23
  - https://github.com/plotly/plotly.js/blob/bd35269acea8a50a5973656849279f2775dd8ea8/src/traces/icicle/attributes.js#L24
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
