### PR TITLE
[chrome] update fileSystemProvider namespace

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -4540,134 +4540,423 @@ declare namespace chrome {
      * @platform ChromeOS only
      */
     export namespace fileSystemProvider {
-        export interface OpenedFileInfo {
-            /** A request ID to be be used by consecutive read/write and close requests. */
-            openRequestId: number;
-            /** The path of the opened file. */
-            filePath: string;
-            /** Whether the file was opened for reading or writing. */
-            mode: string;
-        }
-
-        export interface FileWatchersInfo {
-            /** The path of the entry being observed. */
-            entryPath: string;
-            /** Whether watching should include all child entries recursively. It can be true for directories only. */
-            recursive: boolean;
-            /** Optional. Tag used by the last notification for the watcher.  */
-            lastTag?: string | undefined;
-        }
-
-        export interface CloudIdentifier {
-            /** Identifier for the cloud storage provider (e.g. 'drive.google.com'). */
-            providerName: string;
-            /** The provider's identifier for the given file/directory. */
-            id: string;
-        }
-
-        export interface CloudFileInfo {
-            /** A tag that represents the version of the file. */
-            versionTag?: string | undefined;
-        }
-
-        export interface EntryMetadata {
-            /** True if it is a directory. Must be provided if requested in `options`. */
-            isDirectory?: boolean;
-            /** Name of this entry (not full path name). Must not contain '/'. For root it must be empty. Must be provided if requested in `options`. */
-            name?: string;
-            /** File size in bytes. Must be provided if requested in `options`. */
-            size?: number;
-            /** The last modified time of this entry. Must be provided if requested in `options`. */
-            modificationTime?: Date;
-            /** Optional. Mime type for the entry. Always optional, but should provided if requested in `options`. */
-            mimeType?: string | undefined;
-            /** Optional. Thumbnail image as a data URI in either PNG, JPEG or WEBP format, at most 32 KB in size. Optional, but can be provided only when explicitly requested by the onGetMetadataRequested event. */
-            thumbnail?: string | undefined;
-            /** Optional. Cloud storage representation of this entry. Must be provided if requested in `options` and the file is backed by cloud storage. For local files not backed by cloud storage, it should be undefined when requested. */
-            cloudIdentifier?: CloudIdentifier | undefined;
-            /** Optional. Information that identifies a specific file in the underlying cloud file system. Must be provided if requested in `options` and the file is backed by cloud storage. */
-            cloudFileInfo?: CloudFileInfo | undefined;
-        }
-
-        export interface FileSystemInfo {
-            /** The identifier of the file system. */
-            fileSystemId: string;
-            /** A human-readable name for the file system. */
-            displayName: string;
-            /** Whether the file system supports operations which may change contents of the file system (such as creating, deleting or writing to files). */
-            writable: boolean;
-            /**
-             * The maximum number of files that can be opened at once. If 0, then not limited.
-             * @since Chrome 42
-             */
-            openedFilesLimit: number;
-            /**
-             * List of currently opened files.
-             * @since Chrome 42
-             */
-            openedFiles: OpenedFileInfo[];
-            /**
-             * Optional.
-             * Whether the file system supports the tag field for observing directories.
-             * @since Chrome 45
-             */
-            supportsNotifyTag?: boolean | undefined;
-            /**
-             * List of watchers.
-             * @since Chrome 45
-             */
-            watchers: FileWatchersInfo[];
-        }
-
-        /** @since Chrome 45 */
-        export interface GetActionsRequestedOptions {
+        export interface AbortRequestedOptions {
             /** The identifier of the file system related to this operation. */
             fileSystemId: string;
+            /** An ID of the request to be aborted. */
+            operationRequestId: number;
             /** The unique identifier of this request. */
             requestId: number;
-            /** List of paths of entries for the list of actions. */
-            entryPaths: string[];
         }
 
         /** @since Chrome 45 */
         export interface Action {
-            /** The identifier of the action. Any string or CommonActionId for common actions. */
+            /** The identifier of the action. Any string or {@link CommonActionId} for common actions. */
             id: string;
-            /** Optional. The title of the action. It may be ignored for common actions.  */
-            title?: string | undefined;
+            /** The title of the action. It may be ignored for common actions. */
+            title?: string;
         }
 
-        /** @since Chrome 45 */
-        export interface ExecuteActionRequestedOptions {
+        export interface AddWatcherRequestedOptions {
+            /** The path of the entry to be observed. */
+            entryPath: string;
+            /** The identifier of the file system related to this operation. */
+            fileSystemId: string;
+            /** Whether observing should include all child entries recursively. It can be true for directories only. */
+            recursive: boolean;
+            /** The unique identifier of this request. */
+            requestId: number;
+        }
+
+        export interface Change {
+            /** The type of the change which happened to the entry. */
+            changeType: `${ChangeType}`;
+            /**
+             * Information relating to the file if backed by a cloud file system.
+             * @since Chrome 125
+             */
+            cloudFileInfo?: CloudFileInfo;
+            /** The path of the changed entry. */
+            entryPath: string;
+        }
+
+        /** Type of a change detected on the observed directory. */
+        export enum ChangeType {
+            CHANGED = "CHANGED",
+            DELETED = "DELETED",
+        }
+
+        export interface CloseFileRequestedOptions {
+            /** The identifier of the file system related to this operation. */
+            fileSystemId: string;
+            /** A request ID used to open the file. */
+            openRequestId: number;
+            /** The unique identifier of this request. */
+            requestId: number;
+        }
+
+        /** @since Chrome 125 */
+        export interface CloudFileInfo {
+            /** A tag that represents the version of the file. */
+            versionTag?: string;
+        }
+
+        /** @since Chrome 117 */
+        export interface CloudIdentifier {
+            /** The provider's identifier for the given file/directory. */
+            id: string;
+            /** Identifier for the cloud storage provider (e.g. 'drive.google.com'). */
+            providerName: string;
+        }
+
+        /**
+         * List of common actions. `"SHARE"` is for sharing files with others. `"SAVE_FOR_OFFLINE"` for pinning (saving for offline access). `"OFFLINE_NOT_NECESSARY"` for notifying that the file doesn't need to be stored for offline access anymore. Used by {@link onGetActionsRequested} and {@link onExecuteActionRequested}.
+         * @since Chrome 45
+         */
+        export enum CommonActionId {
+            SAVE_FOR_OFFLINE = "SAVE_FOR_OFFLINE",
+            OFFLINE_NOT_NECESSARY = "OFFLINE_NOT_NECESSARY",
+            SHARE = "SHARE",
+        }
+
+        /** @since Chrome 44 */
+        export interface ConfigureRequestedOptions {
+            /** The identifier of the file system to be configured. */
+            fileSystemId: string;
+            /** The unique identifier of this request. */
+            requestId: number;
+        }
+
+        export interface CopyEntryRequestedOptions {
             /** The identifier of the file system related to this operation. */
             fileSystemId: string;
             /** The unique identifier of this request. */
             requestId: number;
-            /** The set of paths of the entries to be used for the action. */
-            entryPaths: string[];
+            /** The source path of the entry to be copied. */
+            sourcePath: string;
+            /** The destination path for the copy operation. */
+            targetPath: string;
+        }
+
+        export interface CreateDirectoryRequestedOptions {
+            /** The path of the directory to be created. */
+            directoryPath: string;
+            /** The identifier of the file system related to this operation. */
+            fileSystemId: string;
+            /** Whether the operation is recursive (for directories only). */
+            recursive: boolean;
+            /** The unique identifier of this request. */
+            requestId: number;
+        }
+
+        export interface CreateFileRequestedOptions {
+            /** The path of the file to be created. */
+            filePath: string;
+            /** The identifier of the file system related to this operation. */
+            fileSystemId: string;
+            /** The unique identifier of this request. */
+            requestId: number;
+        }
+
+        export interface DeleteEntryRequestedOptions {
+            /** The path of the entry to be deleted. */
+            entryPath: string;
+            /** The identifier of the file system related to this operation. */
+            fileSystemId: string;
+            /** Whether the operation is recursive (for directories only). */
+            recursive: boolean;
+            /** The unique identifier of this request. */
+            requestId: number;
+        }
+
+        export interface EntryMetadata {
+            /**
+             * Information that identifies a specific file in the underlying cloud file system. Must be provided if requested in `options` and the file is backed by cloud storage.
+             * @since Chrome 125
+             */
+            cloudFileInfo?: CloudFileInfo;
+            /**
+             * Cloud storage representation of this entry. Must be provided if requested in `options` and the file is backed by cloud storage. For local files not backed by cloud storage, it should be undefined when requested.
+             * @since Chrome 117
+             */
+            cloudIdentifier?: CloudIdentifier;
+            /** True if it is a directory. Must be provided if requested in `options`. */
+            isDirectory?: boolean;
+            /** Mime type for the entry. Always optional, but should be provided if requested in `options`. */
+            mimeType?: string;
+            /** The last modified time of this entry. Must be provided if requested in `options`. */
+            modificationTime?: Date;
+            /** Name of this entry (not full path name). Must not contain '/'. For root it must be empty. Must be provided if requested in `options`. */
+            name?: string;
+            /** File size in bytes. Must be provided if requested in `options`. */
+            size?: number;
+            /** Thumbnail image as a data URI in either PNG, JPEG or WEBP format, at most 32 KB in size. Optional, but can be provided only when explicitly requested by the {@link onGetMetadataRequested} event. */
+            thumbnail?: string;
+        }
+
+        /** @since Chrome 45 */
+        export interface ExecuteActionRequestedOptions {
             /** The identifier of the action to be executed. */
             actionId: string;
+            /**
+             * The set of paths of the entries to be used for the action.
+             * @since Chrome 47
+             */
+            entryPaths: string[];
+            /** The identifier of the file system related to this operation. */
+            fileSystemId: string;
+            /** The unique identifier of this request. */
+            requestId: number;
+        }
+
+        export interface FileSystemInfo {
+            /** A human-readable name for the file system. */
+            displayName: string;
+            /** The identifier of the file system. */
+            fileSystemId: string;
+            /** List of currently opened files. */
+            openedFiles: OpenedFile[];
+            /** The maximum number of files that can be opened at once. If 0, then not limited. */
+            openedFilesLimit: number;
+            /**
+             * Whether the file system supports the `tag` field for observing directories.
+             * @since Chrome 45
+             */
+            supportsNotifyTag?: boolean;
+            /**
+             * List of watchers.
+             * @since Chrome 45
+             */
+            watchers: Watcher[];
+            /** Whether the file system supports operations which may change contents of the file system (such as creating, deleting or writing to files). */
+            writable: boolean;
+        }
+
+        /** @since Chrome 45 */
+        export interface GetActionsRequestedOptions {
+            /**
+             * List of paths of entries for the list of actions.
+             * @since Chrome 47
+             */
+            entryPaths: string[];
+            /** The identifier of the file system related to this operation. */
+            fileSystemId: string;
+            /** The unique identifier of this request. */
+            requestId: number;
+        }
+
+        export interface GetMetadataRequestedOptions {
+            /**
+             * Set to `true` if `cloudFileInfo` value is requested.
+             * @since Chrome 125
+             */
+            cloudFileInfo: boolean;
+            /**
+             * Set to `true` if `cloudIdentifier` value is requested.
+             * @since Chrome 117
+             */
+            cloudIdentifier: boolean;
+            /** The path of the entry to fetch metadata about. */
+            entryPath: string;
+            /** The identifier of the file system related to this operation. */
+            fileSystemId: string;
+            /**
+             * Set to `true` if `is_directory` value is requested.
+             * @since Chrome 49
+             */
+            isDirectory: boolean;
+            /**
+             * Set to `true` if `mimeType` value is requested.
+             * @since Chrome 49
+             */
+            mimeType: boolean;
+            /**
+             * Set to `true` if `modificationTime` value is requested.
+             * @since Chrome 49
+             */
+            modificationTime: boolean;
+            /**
+             * Set to `true` if `name` value is requested.
+             * @since Chrome 49
+             */
+            name: boolean;
+            /** The unique identifier of this request. */
+            requestId: number;
+            /**
+             * Set to `true` if `size` value is requested.
+             * @since Chrome 49
+             */
+            size: boolean;
+            /** Set to `true` if `thumbnail` value is requested. */
+            thumbnail: boolean;
         }
 
         export interface MountOptions {
-            /** The string identifier of the file system. Must be unique per each extension. */
-            fileSystemId: string;
             /** A human-readable name for the file system. */
             displayName: string;
-            /** Optional. Whether the file system supports operations which may change contents of the file system (such as creating, deleting or writing to files).  */
-            writable?: boolean | undefined;
+            /** The string identifier of the file system. Must be unique per each extension. */
+            fileSystemId: string;
+            /** The maximum number of files that can be opened at once. If not specified, or 0, then not limited. */
+            openedFilesLimit?: number;
             /**
-             * Optional.
-             * The maximum number of files that can be opened at once. If not specified, or 0, then not limited.
-             * @since Chrome 41
+             * Whether the framework should resume the file system at the next sign-in session. True by default.
+             * @since Chrome 64
              */
-            openedFilesLimit?: number | undefined;
+            persistent?: boolean;
             /**
-             * Optional.
-             * Whether the file system supports the tag field for observed directories.
+             * Whether the file system supports the `tag` field for observed directories.
              * @since Chrome 45
              */
-            supportsNotifyTag?: boolean | undefined;
+            supportsNotifyTag?: boolean;
+            /** Whether the file system supports operations which may change contents of the file system (such as creating, deleting or writing to files). */
+            writable?: boolean;
+        }
+
+        export interface MoveEntryRequestedOptions {
+            /** The identifier of the file system related to this operation. */
+            fileSystemId: string;
+            /** The unique identifier of this request. */
+            requestId: number;
+            /** The source path of the entry to be moved into a new place. */
+            sourcePath: string;
+            /** The destination path for the copy operation. */
+            targetPath: string;
+        }
+
+        export interface NotifyOptions {
+            /** The type of the change which happened to the observed entry. If it is DELETED, then the observed entry will be automatically removed from the list of observed entries. */
+            changeType: `${ChangeType}`;
+            /** List of changes to entries within the observed directory (including the entry itself) */
+            changes?: Change[];
+            /** The identifier of the file system related to this change. */
+            fileSystemId: string;
+            /** The path of the observed entry. */
+            observedPath: string;
+            /** Mode of the observed entry. */
+            recursive: boolean;
+            /** Tag for the notification. Required if the file system was mounted with the `supportsNotifyTag` option. Note, that this flag is necessary to provide notifications about changes which changed even when the system was shutdown. */
+            tag?: string;
+        }
+
+        export interface OpenedFile {
+            /** The path of the opened file. */
+            filePath: string;
+            /** Whether the file was opened for reading or writing. */
+            mode: `${OpenFileMode}`;
+            /** A request ID to be be used by consecutive read/write and close requests. */
+            openRequestId: number;
+        }
+
+        /** Mode of opening a file. Used by {@link onOpenFileRequested}. */
+        export enum OpenFileMode {
+            READ = "READ",
+            WRITE = "WRITE",
+        }
+
+        export interface OpenFileRequestedOptions {
+            /** The path of the file to be opened. */
+            filePath: string;
+            /** The identifier of the file system related to this operation. */
+            fileSystemId: string;
+            /** Whether the file will be used for reading or writing. */
+            mode: `${OpenFileMode}`;
+            /** A request ID which will be used by consecutive read/write and close requests. */
+            requestId: number;
+        }
+
+        /** Error codes used by providing extensions in response to requests as well as in case of errors when calling methods of the API. For success, `"OK"` must be used.*/
+        export enum ProviderError {
+            OK = "OK",
+            FAILED = "FAILED",
+            IN_USE = "IN_USE",
+            EXISTS = "EXISTS",
+            NOT_FOUND = "NOT_FOUND",
+            ACCESS_DENIED = "ACCESS_DENIED",
+            TOO_MANY_OPENED = "TOO_MANY_OPENED",
+            NO_MEMORY = "NO_MEMORY",
+            NO_SPACE = "NO_SPACE",
+            NOT_A_DIRECTORY = "NOT_A_DIRECTORY",
+            INVALID_OPERATION = "INVALID_OPERATION",
+            SECURITY = "SECURITY",
+            ABORT = "ABORT",
+            NOT_A_FILE = "NOT_A_FILE",
+            NOT_EMPTY = "NOT_EMPTY",
+            INVALID_URL = "INVALID_URL",
+            IO = "IO",
+        }
+
+        export interface ReadDirectoryRequestedOptions {
+            /** The path of the directory which contents are requested. */
+            directoryPath: string;
+            /** The identifier of the file system related to this operation. */
+            fileSystemId: string;
+            /**
+             * Set to `true` if `is_directory` value is requested.
+             * @since Chrome 49
+             */
+            isDirectory: boolean;
+            /**
+             * Set to `true` if `mimeType` value is requested.
+             * @since Chrome 49
+             */
+            mimeType: boolean;
+            /**
+             * Set to `true` if `modificationTime` value is requested.
+             * @since Chrome 49
+             */
+            modificationTime: boolean;
+            /**
+             * Set to `true` if `name` value is requested.
+             * @since Chrome 49
+             */
+            name: boolean;
+            /** The unique identifier of this request. */
+            requestId: number;
+            /**
+             * Set to `true` if `size` value is requested.
+             * @since Chrome 49
+             */
+            size: boolean;
+            /**
+             * Set to `true` if `thumbnail` value is requested.
+             * @since Chrome 49
+             */
+            thumbnail: boolean;
+        }
+
+        export interface ReadFileRequestedOptions {
+            /** The identifier of the file system related to this operation. */
+            fileSystemId: string;
+            /** Number of bytes to be returned. */
+            length: number;
+            /** Position in the file (in bytes) to start reading from. */
+            offset: number;
+            /** A request ID used to open the file. */
+            openRequestId: number;
+            /** The unique identifier of this request. */
+            requestId: number;
+        }
+
+        export interface RemoveWatcherRequestedOptions {
+            /** The path of the watched entry. */
+            entryPath: string;
+            /** The identifier of the file system related to this operation. */
+            fileSystemId: string;
+            /** Mode of the watcher. */
+            recursive: boolean;
+            /** The unique identifier of this request. */
+            requestId: number;
+        }
+
+        export interface TruncateRequestedOptions {
+            /** The path of the file to be truncated. */
+            filePath: string;
+            /** The identifier of the file system related to this operation. */
+            fileSystemId: string;
+            /** Number of bytes to be retained after the operation completes. */
+            length: number;
+            /** The unique identifier of this request. */
+            requestId: number;
         }
 
         export interface UnmountOptions {
@@ -4675,391 +4964,333 @@ declare namespace chrome {
             fileSystemId: string;
         }
 
-        export interface NotificationChange {
-            /** The path of the changed entry. */
-            entryPath: string;
-            /** The type of the change which happened to the entry. */
-            changeType: string;
-            /** Information relating to the file if backed by a cloud file system. */
-            cloudFileInfo?: CloudFileInfo | undefined;
-        }
-
-        export interface NotificationOptions {
-            /** The identifier of the file system related to this change. */
-            fileSystemId: string;
-            /** The path of the observed entry. */
-            observedPath: string;
-            /** Mode of the observed entry. */
-            recursive: boolean;
-            /** The type of the change which happened to the observed entry. If it is DELETED, then the observed entry will be automatically removed from the list of observed entries. */
-            changeType: string;
-            /** Optional. List of changes to entries within the observed directory (including the entry itself)  */
-            changes?: NotificationChange[] | undefined;
-            /** Optional. Tag for the notification. Required if the file system was mounted with the supportsNotifyTag option. Note, that this flag is necessary to provide notifications about changes which changed even when the system was shutdown.  */
-            tag?: string | undefined;
-        }
-
-        export interface RequestedEventOptions {
-            /** The identifier of the file system related to this operation. */
+        export interface UnmountRequestedOptions {
+            /** The identifier of the file system to be unmounted. */
             fileSystemId: string;
             /** The unique identifier of this request. */
             requestId: number;
         }
 
-        export interface EntryPathRequestedEventOptions extends RequestedEventOptions {
-            /** The path of the entry to which this operation is related to. */
+        export interface Watcher {
+            /** The path of the entry being observed. */
             entryPath: string;
+            /** Tag used by the last notification for the watcher. */
+            lastTag?: string;
+            /** Whether watching should include all child entries recursively. It can be true for directories only. */
+            recursive: boolean;
         }
 
-        export interface MetadataRequestedEventOptions extends EntryPathRequestedEventOptions {
-            /** Set to true if `is_directory` value is requested. */
-            isDirectory: boolean;
-            /** Set to true if `name` value is requested. */
-            name: boolean;
-            /** Set to true if `size` value is requested. */
-            size: boolean;
-            /** Set to true if `modificationTime` value is requested. */
-            modificationTime: boolean;
-            /** Set to true if `mimeType` value is requested. */
-            mimeType: boolean;
-            /** Set to true if `thumbnail` is requested. */
-            thumbnail: boolean;
-            /** Set to true if `cloudIdentifier` is requested. */
-            cloudIdentifier: boolean;
-            /** Set to true if `cloudFileInfo` is requested. */
-            cloudFileInfo: boolean;
-        }
-
-        export interface DirectoryPathRequestedEventOptions extends RequestedEventOptions {
-            /** The path of the directory which is to be operated on. */
-            directoryPath: string;
-            /** Set to true if `is_directory` value is requested. */
-            isDirectory: boolean;
-            /** Set to true if `name` value is requested. */
-            name: boolean;
-            /** Set to true if `size` value is requested. */
-            size: boolean;
-            /** Set to true if `modificationTime` value is requested. */
-            modificationTime: boolean;
-            /** Set to true if `mimeType` value is requested. */
-            mimeType: boolean;
-            /** Set to true if `thumbnail` is requested. */
-            thumbnail: boolean;
-        }
-
-        export interface FilePathRequestedEventOptions extends RequestedEventOptions {
-            /** The path of the entry for the operation */
-            filePath: string;
-        }
-
-        export interface OpenFileRequestedEventOptions extends FilePathRequestedEventOptions {
-            /** Whether the file will be used for reading or writing. */
-            mode: string;
-        }
-
-        export interface OpenedFileRequestedEventOptions extends RequestedEventOptions {
+        export interface WriteFileRequestedOptions {
+            /** Buffer of bytes to be written to the file. */
+            data: ArrayBuffer;
+            /** The identifier of the file system related to this operation. */
+            fileSystemId: string;
+            /** Position in the file (in bytes) to start writing the bytes from. */
+            offset: number;
             /** A request ID used to open the file. */
             openRequestId: number;
+            /** The unique identifier of this request. */
+            requestId: number;
         }
-
-        export interface OpenedFileOffsetRequestedEventOptions extends OpenedFileRequestedEventOptions {
-            /** Position in the file (in bytes) to start reading from. */
-            offset: number;
-            /** Number of bytes to be returned. */
-            length: number;
-        }
-
-        export interface CreateDirectoryRequestedEventOptions extends RequestedEventOptions {
-            /** The path of the directory to be created. */
-            directoryPath: string;
-
-            /** Whether the operation is recursive (for directories only). */
-            recursive: boolean;
-        }
-
-        export interface EntryPathRecursiveRequestedEventOptions extends EntryPathRequestedEventOptions {
-            /** Whether the operation is recursive (for directories only). */
-            recursive: boolean;
-        }
-
-        export interface SourceTargetPathRequestedEventOptions extends RequestedEventOptions {
-            /** The source path for the operation. */
-            sourcePath: string;
-            /** The destination path for the operation. */
-            targetPath: string;
-        }
-
-        export interface FilePathLengthRequestedEventOptions extends FilePathRequestedEventOptions {
-            /** Number of bytes to be retained after the operation completes. */
-            length: number;
-        }
-
-        export interface OpenedFileIoRequestedEventOptions extends OpenedFileRequestedEventOptions {
-            /** Position in the file (in bytes) to start operating from. */
-            offset: number;
-            /** Buffer of bytes to be operated on the file. */
-            data: ArrayBuffer;
-        }
-
-        export interface OperationRequestedEventOptions extends RequestedEventOptions {
-            /** An ID of the request to which this operation is related. */
-            operationRequestId: number;
-        }
-
-        export interface RequestedEvent extends
-            chrome.events.Event<
-                (
-                    options: RequestedEventOptions,
-                    successCallback: Function,
-                    errorCallback: (error: string) => void,
-                ) => void
-            >
-        {}
-
-        export interface MetadataRequestedEvent extends
-            chrome.events.Event<
-                (
-                    options: MetadataRequestedEventOptions,
-                    successCallback: (metadata: EntryMetadata) => void,
-                    errorCallback: (error: string) => void,
-                ) => void
-            >
-        {}
-
-        export interface DirectoryPathRequestedEvent extends
-            chrome.events.Event<
-                (
-                    options: DirectoryPathRequestedEventOptions,
-                    successCallback: (entries: EntryMetadata[], hasMore: boolean) => void,
-                    errorCallback: (error: string) => void,
-                ) => void
-            >
-        {}
-
-        export interface OpenFileRequestedEvent extends
-            chrome.events.Event<
-                (
-                    options: OpenFileRequestedEventOptions,
-                    successCallback: (metadata?: EntryMetadata) => void,
-                    errorCallback: (error: string) => void,
-                ) => void
-            >
-        {}
-
-        export interface OpenedFileRequestedEvent extends
-            chrome.events.Event<
-                (
-                    options: OpenedFileRequestedEventOptions,
-                    successCallback: Function,
-                    errorCallback: (error: string) => void,
-                ) => void
-            >
-        {}
-
-        export interface OpenedFileOffsetRequestedEvent extends
-            chrome.events.Event<
-                (
-                    options: OpenedFileOffsetRequestedEventOptions,
-                    successCallback: (data: ArrayBuffer, hasMore: boolean) => void,
-                    errorCallback: (error: string) => void,
-                ) => void
-            >
-        {}
-
-        export interface CreateDirectoryRequestedEvent extends
-            chrome.events.Event<
-                (
-                    options: CreateDirectoryRequestedEventOptions,
-                    successCallback: Function,
-                    errorCallback: (error: string) => void,
-                ) => void
-            >
-        {}
-
-        export interface EntryPathRecursiveRequestedEvent extends
-            chrome.events.Event<
-                (
-                    options: EntryPathRecursiveRequestedEventOptions,
-                    successCallback: Function,
-                    errorCallback: (error: string) => void,
-                ) => void
-            >
-        {}
-
-        export interface FilePathRequestedEvent extends
-            chrome.events.Event<
-                (
-                    options: FilePathRequestedEventOptions,
-                    successCallback: Function,
-                    errorCallback: (error: string) => void,
-                ) => void
-            >
-        {}
-
-        export interface SourceTargetPathRequestedEvent extends
-            chrome.events.Event<
-                (
-                    options: SourceTargetPathRequestedEventOptions,
-                    successCallback: Function,
-                    errorCallback: (error: string) => void,
-                ) => void
-            >
-        {}
-
-        export interface FilePathLengthRequestedEvent extends
-            chrome.events.Event<
-                (
-                    options: FilePathLengthRequestedEventOptions,
-                    successCallback: Function,
-                    errorCallback: (error: string) => void,
-                ) => void
-            >
-        {}
-
-        export interface OpenedFileIoRequestedEvent extends
-            chrome.events.Event<
-                (
-                    options: OpenedFileIoRequestedEventOptions,
-                    successCallback: Function,
-                    errorCallback: (error: string) => void,
-                ) => void
-            >
-        {}
-
-        export interface OperationRequestedEvent extends
-            chrome.events.Event<
-                (
-                    options: OperationRequestedEventOptions,
-                    successCallback: Function,
-                    errorCallback: (error: string) => void,
-                ) => void
-            >
-        {}
-
-        export interface OptionlessRequestedEvent
-            extends chrome.events.Event<(successCallback: Function, errorCallback: (error: string) => void) => void>
-        {}
-
-        export interface GetActionsRequested extends
-            chrome.events.Event<
-                (
-                    options: GetActionsRequestedOptions,
-                    successCallback: (actions: Action[]) => void,
-                    errorCallback: (error: string) => void,
-                ) => void
-            >
-        {}
-
-        export interface ExecuteActionRequested extends
-            chrome.events.Event<
-                (
-                    options: ExecuteActionRequestedOptions,
-                    successCallback: () => void,
-                    errorCallback: (error: string) => void,
-                ) => void
-            >
-        {}
 
         /**
-         * Mounts a file system with the given fileSystemId and displayName. displayName will be shown in the left panel of Files.app. displayName can contain any characters including '/', but cannot be an empty string. displayName must be descriptive but doesn't have to be unique. The fileSystemId must not be an empty string.
-         * Depending on the type of the file system being mounted, the source option must be set appropriately.
-         * In case of an error, runtime.lastError will be set with a corresponding error code.
-         * @param callback A generic result callback to indicate success or failure.
+         * Returns information about a file system with the passed `fileSystemId`.
+         *
+         * Can return its result via Promise since Chrome 96.
          */
-        export function mount(options: MountOptions, callback?: () => void): void;
-        /**
-         * Unmounts a file system with the given fileSystemId. It must be called after onUnmountRequested is invoked. Also, the providing extension can decide to perform unmounting if not requested (eg. in case of lost connection, or a file error).
-         * In case of an error, runtime.lastError will be set with a corresponding error code.
-         * @param callback A generic result callback to indicate success or failure.
-         */
-        export function unmount(options: UnmountOptions, callback?: () => void): void;
+        export function get(fileSystemId: string): Promise<FileSystemInfo>;
+        export function get(fileSystemId: string, callback: (fileSystem: FileSystemInfo) => void): void;
+
         /**
          * Returns all file systems mounted by the extension.
-         * @param callback Callback to receive the result of getAll function.
+         *
+         * Can return its result via Promise since Chrome 96.
          */
+        export function getAll(): Promise<FileSystemInfo[]>;
         export function getAll(callback: (fileSystems: FileSystemInfo[]) => void): void;
+
         /**
-         * Returns information about a file system with the passed fileSystemId.
-         * @since Chrome 42
-         * @param callback Callback to receive the result of get function.
+         * Mounts a file system with the given `fileSystemId` and `displayName`. `displayName` will be shown in the left panel of the Files app. `displayName` can contain any characters including '/', but cannot be an empty string. `displayName` must be descriptive but doesn't have to be unique. The `fileSystemId` must not be an empty string.
+         *
+         * Depending on the type of the file system being mounted, the `source` option must be set appropriately.
+         *
+         * In case of an error, {@link runtime.lastError} will be set with a corresponding error code.
+         *
+         * Can return its result via Promise since Chrome 96.
          */
-        export function get(fileSystemId: string, callback: (fileSystem: FileSystemInfo) => void): void;
+        export function mount(options: MountOptions): Promise<void>;
+        export function mount(options: MountOptions, callback: () => void): void;
+
         /**
-         * Notifies about changes in the watched directory at observedPath in recursive mode. If the file system is mounted with supportsNofityTag, then tag must be provided, and all changes since the last notification always reported, even if the system was shutdown. The last tag can be obtained with getAll.
-         * To use, the file_system_provider.notify manifest option must be set to true.
-         * Value of tag can be any string which is unique per call, so it's possible to identify the last registered notification. Eg. if the providing extension starts after a reboot, and the last registered notification's tag is equal to "123", then it should call notify for all changes which happened since the change tagged as "123". It cannot be an empty string.
+         * Notifies about changes in the watched directory at `observedPath` in `recursive` mode. If the file system is mounted with `supportsNotifyTag`, then `tag` must be provided, and all changes since the last notification always reported, even if the system was shutdown. The last tag can be obtained with {@link getAll}.
+         *
+         * To use, the `file_system_provider.notify` manifest option must be set to true.
+         *
+         * Value of `tag` can be any string which is unique per call, so it's possible to identify the last registered notification. Eg. if the providing extension starts after a reboot, and the last registered notification's tag is equal to "123", then it should call {@link notify} for all changes which happened since the change tagged as "123". It cannot be an empty string.
+         *
          * Not all providers are able to provide a tag, but if the file system has a changelog, then the tag can be eg. a change number, or a revision number.
+         *
          * Note that if a parent directory is removed, then all descendant entries are also removed, and if they are watched, then the API must be notified about the fact. Also, if a directory is renamed, then all descendant entries are in fact removed, as there is no entry under their original paths anymore.
-         * In case of an error, runtime.lastError will be set will a corresponding error code.
-         * @param callback A generic result callback to indicate success or failure.
-         */
-        export function notify(options: NotificationOptions, callback: () => void): void;
-
-        /** Raised when unmounting for the file system with the fileSystemId identifier is requested. In the response, the unmount API method must be called together with successCallback. If unmounting is not possible (eg. due to a pending operation), then errorCallback must be called.  */
-        export var onUnmountRequested: RequestedEvent;
-        /** Raised when metadata of a file or a directory at entryPath is requested. The metadata must be returned with the successCallback call. In case of an error, errorCallback must be called. */
-        export var onGetMetadataRequested: MetadataRequestedEvent;
-        /** Raised when contents of a directory at directoryPath are requested. The results must be returned in chunks by calling the successCallback several times. In case of an error, errorCallback must be called. */
-        export var onReadDirectoryRequested: DirectoryPathRequestedEvent;
-        /** Raised when opening a file at filePath is requested. If the file does not exist, then the operation must fail. Maximum number of files opened at once can be specified with MountOptions. */
-        export var onOpenFileRequested: OpenFileRequestedEvent;
-        /** Raised when opening a file previously opened with openRequestId is requested to be closed. */
-        export var onCloseFileRequested: OpenedFileRequestedEvent;
-        /** Raised when reading contents of a file opened previously with openRequestId is requested. The results must be returned in chunks by calling successCallback several times. In case of an error, errorCallback must be called. */
-        export var onReadFileRequested: OpenedFileOffsetRequestedEvent;
-        /** Raised when creating a directory is requested. The operation must fail with the EXISTS error if the target directory already exists. If recursive is true, then all of the missing directories on the directory path must be created. */
-        export var onCreateDirectoryRequested: CreateDirectoryRequestedEvent;
-        /** Raised when deleting an entry is requested. If recursive is true, and the entry is a directory, then all of the entries inside must be recursively deleted as well. */
-        export var onDeleteEntryRequested: EntryPathRecursiveRequestedEvent;
-        /** Raised when creating a file is requested. If the file already exists, then errorCallback must be called with the "EXISTS" error code. */
-        export var onCreateFileRequested: FilePathRequestedEvent;
-        /** Raised when copying an entry (recursively if a directory) is requested. If an error occurs, then errorCallback must be called. */
-        export var onCopyEntryRequested: SourceTargetPathRequestedEvent;
-        /** Raised when moving an entry (recursively if a directory) is requested. If an error occurs, then errorCallback must be called. */
-        export var onMoveEntryRequested: SourceTargetPathRequestedEvent;
-        /** Raised when truncating a file to a desired length is requested. If an error occurs, then errorCallback must be called. */
-        export var onTruncateRequested: FilePathLengthRequestedEvent;
-        /** Raised when writing contents to a file opened previously with openRequestId is requested. */
-        export var onWriteFileRequested: OpenedFileIoRequestedEvent;
-        /** Raised when aborting an operation with operationRequestId is requested. The operation executed with operationRequestId must be immediately stopped and successCallback of this abort request executed. If aborting fails, then errorCallback must be called. Note, that callbacks of the aborted operation must not be called, as they will be ignored. Despite calling errorCallback, the request may be forcibly aborted. */
-        export var onAbortRequested: OperationRequestedEvent;
-        /**
-         * Raised when showing a configuration dialog for fileSystemId is requested. If it's handled, the file_system_provider.configurable manfiest option must be set to true.
-         * @since Chrome 44
-         */
-        export var onConfigureRequested: RequestedEvent;
-        /**
-         * Raised when showing a dialog for mounting a new file system is requested. If the extension/app is a file handler, then this event shouldn't be handled. Instead app.runtime.onLaunched should be handled in order to mount new file systems when a file is opened. For multiple mounts, the file_system_provider.multiple_mounts manifest option must be set to true.
-         * @since Chrome 44
-         */
-        export var onMountRequested: OptionlessRequestedEvent;
-        /**
-         * Raised when setting a new directory watcher is requested. If an error occurs, then errorCallback must be called.
+         *
+         * In case of an error, {@link runtime.lastError} will be set will a corresponding error code.
+         *
+         * Can return its result via Promise since Chrome 96.
          * @since Chrome 45
          */
-        export var onAddWatcherRequested: EntryPathRecursiveRequestedEvent;
+        export function notify(options: NotifyOptions): Promise<void>;
+        export function notify(options: NotifyOptions, callback: () => void): void;
+
         /**
-         * Raised when the watcher should be removed. If an error occurs, then errorCallback must be called.
+         * Unmounts a file system with the given `fileSystemId`. It must be called after {@link onUnmountRequested} is invoked. Also, the providing extension can decide to perform unmounting if not requested (eg. in case of lost connection, or a file error).
+         *
+         * In case of an error, {@link runtime.lastError} will be set with a corresponding error code.
+         *
+         * Can return its result via Promise since Chrome 96.
+         */
+        export function unmount(options: UnmountOptions): Promise<void>;
+        export function unmount(options: UnmountOptions, callback: () => void): void;
+
+        /** Raised when aborting an operation with `operationRequestId` is requested. The operation executed with `operationRequestId` must be immediately stopped and `successCallback` of this abort request executed. If aborting fails, then `errorCallback` must be called. Note, that callbacks of the aborted operation must not be called, as they will be ignored. Despite calling `errorCallback`, the request may be forcibly aborted. */
+        export const onAbortRequested: events.Event<
+            (
+                options: AbortRequestedOptions,
+                successCallback: () => void,
+                errorCallback: (error: `${ProviderError}`) => void,
+            ) => void
+        >;
+
+        /**
+         * Raised when setting a new directory watcher is requested. If an error occurs, then `errorCallback` must be called.
          * @since Chrome 45
          */
-        export var onRemoveWatcherRequested: EntryPathRecursiveRequestedEvent;
+        export const onAddWatcherRequested: events.Event<
+            (
+                options: AddWatcherRequestedOptions,
+                successCallback: () => void,
+                errorCallback: (error: `${ProviderError}`) => void,
+            ) => void
+        >;
+
+        /** Raised when opening a file previously opened with `openRequestId` is requested to be closed.*/
+        export const onCloseFileRequested: events.Event<
+            (
+                options: CloseFileRequestedOptions,
+                successCallback: () => void,
+                errorCallback: (error: `${ProviderError}`) => void,
+            ) => void
+        >;
 
         /**
-         * Raised when a list of actions for a set of files or directories at
-         * `entryPaths` is requested. All of the returned actions must
-         * be applicable to each entry. If there are no such actions, an empty array
-         * should be returned. The actions must be returned with the
-         * `successCallback` call. In case of an error,
-         * `errorCallback` must be called.
+         * Raised when showing a configuration dialog for `fileSystemId` is requested. If it's handled, the `file_system_provider.configurable` manifest option must be set to true.
+         * @since Chrome 44
          */
-        export var onGetActionsRequested: GetActionsRequested;
+        export const onConfigureRequested: events.Event<
+            (
+                options: ConfigureRequestedOptions,
+                successCallback: () => void,
+                errorCallback: (error: `${ProviderError}`) => void,
+            ) => void
+        >;
+
+        /** Raised when copying an entry (recursively if a directory) is requested. If an error occurs, then `errorCallback` must be called. */
+        export const onCopyEntryRequested: events.Event<
+            (
+                options: CopyEntryRequestedOptions,
+                successCallback: () => void,
+                errorCallback: (error: `${ProviderError}`) => void,
+            ) => void
+        >;
+
+        /** Raised when creating a directory is requested. The operation must fail with the EXISTS error if the target directory already exists. If `recursive` is true, then all of the missing directories on the directory path must be created. */
+        export const onCreateDirectoryRequested: events.Event<
+            (
+                options: CreateDirectoryRequestedOptions,
+                successCallback: () => void,
+                errorCallback: (
+                    error: `${ProviderError}`,
+                ) => void,
+            ) => void
+        >;
+
+        /** Raised when creating a file is requested. If the file already exists, then `errorCallback` must be called with the `"EXISTS"` error code. */
+        export const onCreateFileRequested: events.Event<
+            (
+                options: CreateFileRequestedOptions,
+                successCallback: () => void,
+                errorCallback: (
+                    error: `${ProviderError}`,
+                ) => void,
+            ) => void
+        >;
+
+        /** Raised when deleting an entry is requested. If `recursive` is true, and the entry is a directory, then all of the entries inside must be recursively deleted as well. */
+        export const onDeleteEntryRequested: events.Event<
+            (
+                options: DeleteEntryRequestedOptions,
+                successCallback: () => void,
+                errorCallback: (
+                    error: `${ProviderError}`,
+                ) => void,
+            ) => void
+        >;
 
         /**
-         * Raised when executing an action for a set of files or directories is
-         * requested. After the action is completed, `successCallback`
-         * must be called. On error, `errorCallback` must be called.
+         * Raised when executing an action for a set of files or directories is\\ requested. After the action is completed, `successCallback` must be called. On error, `errorCallback` must be called.
+         * @since Chrome 48
          */
-        export var onExecuteActionRequested: ExecuteActionRequested;
+        export const onExecuteActionRequested: events.Event<
+            (
+                options: ExecuteActionRequestedOptions,
+                successCallback: () => void,
+                errorCallback: (
+                    error: `${ProviderError}`,
+                ) => void,
+            ) => void
+        >;
+
+        /**
+         * Raised when a list of actions for a set of files or directories at `entryPaths` is requested. All of the returned actions must be applicable to each entry. If there are no such actions, an empty array should be returned. The actions must be returned with the `successCallback` call. In case of an error, `errorCallback` must be called.
+         * @since Chrome 48
+         */
+        export const onGetActionsRequested: events.Event<
+            (
+                options: GetActionsRequestedOptions,
+                successCallback: (
+                    actions: Action[],
+                ) => void,
+                errorCallback: (
+                    error: `${ProviderError}`,
+                ) => void,
+            ) => void
+        >;
+
+        /** Raised when metadata of a file or a directory at `entryPath` is requested. The metadata must be returned with the `successCallback` call. In case of an error, `errorCallback` must be called. */
+        export const onGetMetadataRequested: events.Event<
+            (
+                options: GetMetadataRequestedOptions,
+                successCallback: (
+                    metadata: EntryMetadata,
+                ) => void,
+                errorCallback: (
+                    error: `${ProviderError}`,
+                ) => void,
+            ) => void
+        >;
+
+        /**
+         * Raised when showing a dialog for mounting a new file system is requested. If the extension/app is a file handler, then this event shouldn't be handled. Instead `app.runtime.onLaunched` should be handled in order to mount new file systems when a file is opened. For multiple mounts, the `file_system_provider.multiple_mounts` manifest option must be set to true.
+         * @since Chrome 44
+         */
+        export const onMountRequested: events.Event<
+            (
+                successCallback: () => void,
+                errorCallback: (
+                    error: `${ProviderError}`,
+                ) => void,
+            ) => void
+        >;
+
+        /** Raised when moving an entry (recursively if a directory) is requested. If an error occurs, then `errorCallback` must be called. */
+        export const onMoveEntryRequested: events.Event<
+            (
+                options: MoveEntryRequestedOptions,
+                successCallback: () => void,
+                errorCallback: (
+                    error: `${ProviderError}`,
+                ) => void,
+            ) => void
+        >;
+
+        /** Raised when opening a file at `filePath` is requested. If the file does not exist, then the operation must fail. Maximum number of files opened at once can be specified with `MountOptions`. */
+        export const onOpenFileRequested: events.Event<
+            (
+                options: OpenFileRequestedOptions,
+                successCallback: (
+                    /**
+                     * @since Chrome 125
+                     */
+                    metadata?: EntryMetadata,
+                ) => void,
+                errorCallback: (
+                    error: `${ProviderError}`,
+                ) => void,
+            ) => void
+        >;
+
+        /** Raised when contents of a directory at `directoryPath` are requested. The results must be returned in chunks by calling the `successCallback` several times. In case of an error, `errorCallback` must be called. */
+        export const onReadDirectoryRequested: events.Event<
+            (
+                options: ReadDirectoryRequestedOptions,
+                successCallback: (
+                    entries: EntryMetadata[],
+                    hasMore: boolean,
+                ) => void,
+                errorCallback: (
+                    error: `${ProviderError}`,
+                ) => void,
+            ) => void
+        >;
+
+        /** Raised when reading contents of a file opened previously with `openRequestId` is requested. The results must be returned in chunks by calling `successCallback` several times. In case of an error, `errorCallback` must be called. */
+        export const onReadFileRequested: events.Event<
+            (
+                options: ReadFileRequestedOptions,
+                successCallback: (
+                    data: ArrayBuffer,
+                    hasMore: boolean,
+                ) => void,
+                errorCallback: (
+                    error: `${ProviderError}`,
+                ) => void,
+            ) => void
+        >;
+
+        /**
+         * Raised when the watcher should be removed. If an error occurs, then `errorCallback` must be called.
+         * @since Chrome 45
+         */
+        export const onRemoveWatcherRequested: events.Event<
+            (
+                options: RemoveWatcherRequestedOptions,
+                successCallback: () => void,
+                errorCallback: (
+                    error: `${ProviderError}`,
+                ) => void,
+            ) => void
+        >;
+
+        /** Raised when truncating a file to a desired length is requested. If an error occurs, then `errorCallback` must be called. */
+        export const onTruncateRequested: events.Event<
+            (
+                options: TruncateRequestedOptions,
+                successCallback: () => void,
+                errorCallback: (
+                    error: `${ProviderError}`,
+                ) => void,
+            ) => void
+        >;
+
+        /** Raised when unmounting for the file system with the `fileSystemId` identifier is requested. In the response, the {@link unmount} API method must be called together with `successCallback`. If unmounting is not possible (eg. due to a pending operation), then `errorCallback` must be called. */
+        export const onUnmountRequested: events.Event<
+            (
+                options: UnmountRequestedOptions,
+                successCallback: () => void,
+                errorCallback: (
+                    error: `${ProviderError}`,
+                ) => void,
+            ) => void
+        >;
+
+        /** Raised when writing contents to a file opened previously with `openRequestId` is requested. */
+        export const onWriteFileRequested: events.Event<
+            (
+                options: WriteFileRequestedOptions,
+                successCallback: () => void,
+                errorCallback: (
+                    error: `${ProviderError}`,
+                ) => void,
+            ) => void
+        >;
     }
 
     ////////////////////

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -3215,87 +3215,660 @@ async function testOffscreenDocument() {
     await chrome.offscreen.closeDocument();
 }
 
-// https://developer.chrome.com/docs/extensions/reference/fileSystemProvider/
+// https://developer.chrome.com/docs/extensions/reference/api/fileSystemProvider
 function testFileSystemProvider() {
-    // Checking onGetMetadataRequested, its option and EntryMetadata.
-    chrome.fileSystemProvider.onGetMetadataRequested.addListener(
-        (
-            options: chrome.fileSystemProvider.MetadataRequestedEventOptions,
-            successCallback: (metadata: chrome.fileSystemProvider.EntryMetadata) => void,
-            errorCallback: (error: string) => void,
-        ) => {
-            const entryMetadata: chrome.fileSystemProvider.EntryMetadata = {};
-            if (options.isDirectory) {
-                entryMetadata.isDirectory = true;
-            }
-            if (options.name) {
-                entryMetadata.name = "some-file.txt";
-            }
-            if (options.size) {
-                entryMetadata.size = 42;
-            }
-            if (options.modificationTime) {
-                entryMetadata.modificationTime = new Date();
-            }
-            if (options.mimeType) {
-                entryMetadata.mimeType = "text/plain";
-            }
-            if (options.thumbnail) {
-                entryMetadata.thumbnail = "DaTa:ImAgE/pNg;base64";
-            }
-            if (options.cloudIdentifier) {
-                entryMetadata.cloudIdentifier = { providerName: "provider-name", id: "id" };
-            }
-            if (options.cloudFileInfo) {
-                entryMetadata.cloudFileInfo = { versionTag: "versionA" };
-            }
-        },
-    );
+    chrome.fileSystemProvider.ChangeType.CHANGED === "CHANGED";
+    chrome.fileSystemProvider.ChangeType.DELETED === "DELETED";
 
-    // Checking onReadDirectoryRequested.
-    chrome.fileSystemProvider.onReadDirectoryRequested.addListener(
-        (
-            options: chrome.fileSystemProvider.DirectoryPathRequestedEventOptions,
-            successCallback: (entries: chrome.fileSystemProvider.EntryMetadata[], hasMore: boolean) => void,
-            errorCallback: (error: string) => void,
-        ) => {},
-    );
+    chrome.fileSystemProvider.CommonActionId.OFFLINE_NOT_NECESSARY == "OFFLINE_NOT_NECESSARY";
+    chrome.fileSystemProvider.CommonActionId.SAVE_FOR_OFFLINE == "SAVE_FOR_OFFLINE";
+    chrome.fileSystemProvider.CommonActionId.SHARE == "SHARE";
 
-    // Checking onGetActionsRequested.
-    chrome.fileSystemProvider.onGetActionsRequested.addListener(
-        (
-            options: chrome.fileSystemProvider.GetActionsRequestedOptions,
-            successCallback: (actions: chrome.fileSystemProvider.Action[]) => void,
-            errorCallback: (error: string) => void,
-        ) => {},
-    );
+    chrome.fileSystemProvider.OpenFileMode.READ == "READ";
+    chrome.fileSystemProvider.OpenFileMode.WRITE == "WRITE";
 
-    // Checking onExecuteActionRequested.
-    chrome.fileSystemProvider.onExecuteActionRequested.addListener(
-        (
-            options: chrome.fileSystemProvider.ExecuteActionRequestedOptions,
-            successCallback: () => void,
-            errorCallback: (error: string) => void,
-        ) => {},
-    );
+    chrome.fileSystemProvider.ProviderError.ABORT == "ABORT";
+    chrome.fileSystemProvider.ProviderError.ACCESS_DENIED == "ACCESS_DENIED";
+    chrome.fileSystemProvider.ProviderError.EXISTS == "EXISTS";
+    chrome.fileSystemProvider.ProviderError.FAILED == "FAILED";
+    chrome.fileSystemProvider.ProviderError.INVALID_OPERATION == "INVALID_OPERATION";
+    chrome.fileSystemProvider.ProviderError.INVALID_URL == "INVALID_URL";
+    chrome.fileSystemProvider.ProviderError.IN_USE == "IN_USE";
+    chrome.fileSystemProvider.ProviderError.IO == "IO";
+    chrome.fileSystemProvider.ProviderError.NOT_A_DIRECTORY == "NOT_A_DIRECTORY";
+    chrome.fileSystemProvider.ProviderError.NOT_A_FILE == "NOT_A_FILE";
+    chrome.fileSystemProvider.ProviderError.NOT_EMPTY == "NOT_EMPTY";
+    chrome.fileSystemProvider.ProviderError.NOT_FOUND == "NOT_FOUND";
+    chrome.fileSystemProvider.ProviderError.NO_MEMORY == "NO_MEMORY";
+    chrome.fileSystemProvider.ProviderError.NO_SPACE == "NO_SPACE";
+    chrome.fileSystemProvider.ProviderError.OK == "OK";
+    chrome.fileSystemProvider.ProviderError.SECURITY == "SECURITY";
+    chrome.fileSystemProvider.ProviderError.TOO_MANY_OPENED == "TOO_MANY_OPENED";
 
-    // Checking onCreateDirectoryRequested.
-    chrome.fileSystemProvider.onCreateDirectoryRequested.addListener(
-        (
-            options: chrome.fileSystemProvider.CreateDirectoryRequestedEventOptions,
-            successCallback: Function,
-            errorCallback: (error: string) => void,
-        ) => {},
-    );
+    const fileSystemId = "my-drive" as const;
 
-    // Checking onOpenFileRequested.
-    chrome.fileSystemProvider.onOpenFileRequested.addListener(
-        (
-            options: chrome.fileSystemProvider.OpenFileRequestedEventOptions,
-            successCallback: (metadata?: chrome.fileSystemProvider.EntryMetadata) => void,
-            errorCallback: (error: string) => void,
-        ) => {},
-    );
+    const mountOptions: chrome.fileSystemProvider.MountOptions = {
+        displayName: "My Drive",
+        fileSystemId,
+        openedFilesLimit: 10,
+        persistent: true,
+        supportsNotifyTag: true,
+        writable: true,
+    };
+
+    chrome.fileSystemProvider.get(mountOptions.fileSystemId); // $ExpectType Promise<FileSystemInfo>
+    chrome.fileSystemProvider.get(mountOptions.fileSystemId, (fileSystemInfo) => { // $ExpectType void
+        fileSystemInfo.displayName; // $ExpectType string
+        fileSystemInfo.fileSystemId; // $ExpectType string
+        fileSystemInfo.openedFiles; // $ExpectType OpenedFile[]
+        fileSystemInfo.openedFilesLimit; // $ExpectType number
+        fileSystemInfo.supportsNotifyTag; // $ExpectType boolean | undefined
+        fileSystemInfo.watchers; // $ExpectType Watcher[]
+        fileSystemInfo.writable; // $ExpectType boolean
+    });
+    // @ts-expect-error
+    chrome.fileSystemProvider.get(mountOptions.fileSystemId, () => {}).then(() => {});
+
+    chrome.fileSystemProvider.getAll(); // $ExpectType Promise<FileSystemInfo[]>
+    chrome.fileSystemProvider.getAll(([fileSystemInfo]) => { // $ExpectType void
+        fileSystemInfo.displayName; // $ExpectType string
+        fileSystemInfo.fileSystemId; // $ExpectType string
+        fileSystemInfo.openedFiles; // $ExpectType OpenedFile[]
+        fileSystemInfo.openedFilesLimit; // $ExpectType number
+        fileSystemInfo.supportsNotifyTag; // $ExpectType boolean | undefined
+        fileSystemInfo.watchers; // $ExpectType Watcher[]
+        fileSystemInfo.writable; // $ExpectType boolean
+    });
+    // @ts-expect-error
+    chrome.fileSystemProvider.getAll(() => {}).then(() => {});
+
+    chrome.fileSystemProvider.mount(mountOptions); // $ExpectType Promise<void>
+    chrome.fileSystemProvider.mount(mountOptions, () => void 0); // $ExpectType void
+    // @ts-expect-error
+    chrome.fileSystemProvider.mount(mountOptions, () => void 0).then(() => void 0);
+
+    const notifyOptions: chrome.fileSystemProvider.NotifyOptions = {
+        changeType: "CHANGED",
+        changes: [],
+        fileSystemId,
+        observedPath: "path",
+        recursive: true,
+        tag: "tag",
+    };
+
+    chrome.fileSystemProvider.notify(notifyOptions); // $ExpectType Promise<void>
+    chrome.fileSystemProvider.notify(notifyOptions, () => void 0); // $ExpectType void
+    // @ts-expect-error
+    chrome.fileSystemProvider.notify(notifyOptions, () => void 0).then(() => void 0);
+
+    chrome.fileSystemProvider.unmount({ fileSystemId }); // $ExpectType Promise<void>
+    chrome.fileSystemProvider.unmount({ fileSystemId }, () => void 0); // $ExpectType void
+    // @ts-expect-error
+    chrome.fileSystemProvider.unmount({ fileSystemId }, () => void 0).then(() => void 0);
+
+    // onAbortRequested
+    chrome.fileSystemProvider.onAbortRequested.addListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.fileSystemId; // $ExpectType string
+        options.operationRequestId; // $ExpectType number
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onAbortRequested.removeListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.fileSystemId; // $ExpectType string
+        options.operationRequestId; // $ExpectType number
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onAbortRequested.hasListener((options, successCallback, errorCallback) => { // $ExpectType boolean
+        options.fileSystemId; // $ExpectType string
+        options.operationRequestId; // $ExpectType number
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onAbortRequested.hasListeners(); // $ExpectType boolean
+
+    // onAddWatcherRequested
+    chrome.fileSystemProvider.onAddWatcherRequested.addListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.entryPath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.recursive; // $ExpectType boolean
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onAddWatcherRequested.removeListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.entryPath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.recursive; // $ExpectType boolean
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onAddWatcherRequested.hasListener((options, successCallback, errorCallback) => { // $ExpectType boolean
+        options.entryPath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.recursive; // $ExpectType boolean
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onAddWatcherRequested.hasListeners(); // $ExpectType boolean
+
+    // onCloseFileRequested
+    chrome.fileSystemProvider.onCloseFileRequested.addListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.fileSystemId; // $ExpectType string
+        options.openRequestId; // $ExpectType number
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onCloseFileRequested.removeListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.fileSystemId; // $ExpectType string
+        options.openRequestId; // $ExpectType number
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onCloseFileRequested.hasListener((options, successCallback, errorCallback) => { // $ExpectType boolean
+        options.fileSystemId; // $ExpectType string
+        options.openRequestId; // $ExpectType number
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onCloseFileRequested.hasListeners(); // $ExpectType boolean
+
+    // onConfigureRequested
+    chrome.fileSystemProvider.onConfigureRequested.addListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.fileSystemId; // $ExpectType string
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onConfigureRequested.removeListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.fileSystemId; // $ExpectType string
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onConfigureRequested.hasListener((options, successCallback, errorCallback) => { // $ExpectType boolean
+        options.fileSystemId; // $ExpectType string
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onConfigureRequested.hasListeners(); // $ExpectType boolean
+
+    // onCopyEntryRequested
+    chrome.fileSystemProvider.onCopyEntryRequested.addListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.fileSystemId; // $ExpectType string
+        options.requestId; // $ExpectType number
+        options.sourcePath; // $ExpectType string
+        options.targetPath; // $ExpectType string
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onCopyEntryRequested.removeListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.fileSystemId; // $ExpectType string
+        options.requestId; // $ExpectType number
+        options.sourcePath; // $ExpectType string
+        options.targetPath; // $ExpectType string
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onCopyEntryRequested.hasListener((options, successCallback, errorCallback) => { // $ExpectType boolean
+        options.fileSystemId; // $ExpectType string
+        options.requestId; // $ExpectType number
+        options.sourcePath; // $ExpectType string
+        options.targetPath; // $ExpectType string
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onCopyEntryRequested.hasListeners(); // $ExpectType boolean
+
+    // onCreateDirectoryRequested
+    chrome.fileSystemProvider.onCreateDirectoryRequested.addListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.directoryPath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.recursive; // $ExpectType boolean
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onCreateDirectoryRequested.removeListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.directoryPath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.recursive; // $ExpectType boolean
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onCreateDirectoryRequested.hasListener((options, successCallback, errorCallback) => { // $ExpectType boolean
+        options.directoryPath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.recursive; // $ExpectType boolean
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onCreateDirectoryRequested.hasListeners(); // $ExpectType boolean
+
+    // onCreateFileRequested
+    chrome.fileSystemProvider.onCreateFileRequested.addListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.filePath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onCreateFileRequested.removeListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.filePath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onCreateFileRequested.hasListener((options, successCallback, errorCallback) => { // $ExpectType boolean
+        options.filePath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onCreateFileRequested.hasListeners(); // $ExpectType boolean
+
+    // onDeleteEntryRequested
+    chrome.fileSystemProvider.onDeleteEntryRequested.addListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.entryPath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.recursive; // $ExpectType boolean
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onDeleteEntryRequested.removeListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.entryPath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.recursive; // $ExpectType boolean
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onDeleteEntryRequested.hasListener((options, successCallback, errorCallback) => { // $ExpectType boolean
+        options.entryPath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.recursive; // $ExpectType boolean
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onDeleteEntryRequested.hasListeners(); // $ExpectType boolean
+
+    // onExecuteActionRequested
+    chrome.fileSystemProvider.onExecuteActionRequested.addListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.actionId; // $ExpectType string
+        options.entryPaths; // $ExpectType string[]
+        options.fileSystemId; // $ExpectType string
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onExecuteActionRequested.removeListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.actionId; // $ExpectType string
+        options.entryPaths; // $ExpectType string[]
+        options.fileSystemId; // $ExpectType string
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onExecuteActionRequested.hasListener((options, successCallback, errorCallback) => { // $ExpectType boolean
+        options.actionId; // $ExpectType string
+        options.entryPaths; // $ExpectType string[]
+        options.fileSystemId; // $ExpectType string
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onExecuteActionRequested.hasListeners(); // $ExpectType boolean
+
+    const actions: chrome.fileSystemProvider.Action[] = [{
+        id: "id",
+        title: "title",
+    }];
+
+    // onGetActionsRequested
+    chrome.fileSystemProvider.onGetActionsRequested.addListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.entryPaths; // $ExpectType string[]
+        options.fileSystemId; // $ExpectType string
+        options.requestId; // $ExpectType number
+        successCallback(actions); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onGetActionsRequested.removeListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.entryPaths; // $ExpectType string[]
+        options.fileSystemId; // $ExpectType string
+        options.requestId; // $ExpectType number
+        successCallback(actions); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onGetActionsRequested.hasListener((options, successCallback, errorCallback) => { // $ExpectType boolean
+        options.entryPaths; // $ExpectType string[]
+        options.fileSystemId; // $ExpectType string
+        options.requestId; // $ExpectType number
+        successCallback(actions); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onGetActionsRequested.hasListeners(); // $ExpectType boolean
+
+    const entryMetadata: chrome.fileSystemProvider.EntryMetadata = {
+        cloudFileInfo: { versionTag: "versionA" },
+        cloudIdentifier: { id: "id", providerName: "provider-name" },
+        isDirectory: true,
+        mimeType: "text/plain",
+        modificationTime: new Date(),
+        name: "some-file.txt",
+        size: 42,
+        thumbnail: "DaTa:ImAgE/pNg;base64",
+    };
+
+    // onGetMetadataRequested
+    chrome.fileSystemProvider.onGetMetadataRequested.addListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.cloudFileInfo; // $ExpectType boolean
+        options.cloudIdentifier; // $ExpectType boolean
+        options.entryPath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.isDirectory; // $ExpectType boolean
+        options.mimeType; // $ExpectType boolean
+        options.modificationTime; // $ExpectType boolean
+        options.name; // $ExpectType boolean
+        options.requestId; // $ExpectType number
+        options.size; // $ExpectType boolean
+        options.thumbnail; // $ExpectType boolean
+        successCallback(entryMetadata); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onGetMetadataRequested.removeListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.cloudFileInfo; // $ExpectType boolean
+        options.cloudIdentifier; // $ExpectType boolean
+        options.entryPath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.isDirectory; // $ExpectType boolean
+        options.mimeType; // $ExpectType boolean
+        options.modificationTime; // $ExpectType boolean
+        options.name; // $ExpectType boolean
+        options.requestId; // $ExpectType number
+        options.size; // $ExpectType boolean
+        options.thumbnail; // $ExpectType boolean
+        successCallback(entryMetadata); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onGetMetadataRequested.hasListener((options, successCallback, errorCallback) => { // $ExpectType boolean
+        options.cloudFileInfo; // $ExpectType boolean
+        options.cloudIdentifier; // $ExpectType boolean
+        options.entryPath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.isDirectory; // $ExpectType boolean
+        options.mimeType; // $ExpectType boolean
+        options.modificationTime; // $ExpectType boolean
+        options.name; // $ExpectType boolean
+        options.requestId; // $ExpectType number
+        options.size; // $ExpectType boolean
+        options.thumbnail; // $ExpectType boolean
+        successCallback(entryMetadata); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onGetMetadataRequested.hasListeners(); // $ExpectType boolean
+
+    // onMountRequested
+    chrome.fileSystemProvider.onMountRequested.addListener((successCallback, errorCallback) => { // $ExpectType void
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onMountRequested.removeListener((successCallback, errorCallback) => { // $ExpectType void
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onMountRequested.hasListener((successCallback, errorCallback) => { // $ExpectType boolean
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onMountRequested.hasListeners(); // $ExpectType boolean
+
+    // onMoveEntryRequested
+    chrome.fileSystemProvider.onMoveEntryRequested.addListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.fileSystemId; // $ExpectType string
+        options.requestId; // $ExpectType number
+        options.sourcePath; // $ExpectType string
+        options.targetPath; // $ExpectType string
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onMoveEntryRequested.removeListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.fileSystemId; // $ExpectType string
+        options.requestId; // $ExpectType number
+        options.sourcePath; // $ExpectType string
+        options.targetPath; // $ExpectType string
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onMoveEntryRequested.hasListener((options, successCallback, errorCallback) => { // $ExpectType boolean
+        options.fileSystemId; // $ExpectType string
+        options.requestId; // $ExpectType number
+        options.sourcePath; // $ExpectType string
+        options.targetPath; // $ExpectType string
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onMoveEntryRequested.hasListeners(); // $ExpectType boolean
+
+    // onOpenFileRequested
+    chrome.fileSystemProvider.onOpenFileRequested.addListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.filePath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.mode; // $ExpectType "READ" | "WRITE"
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onOpenFileRequested.removeListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.filePath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.mode; // $ExpectType "READ" | "WRITE"
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onOpenFileRequested.hasListener((options, successCallback, errorCallback) => { // $ExpectType boolean
+        options.filePath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.mode; // $ExpectType "READ" | "WRITE"
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onOpenFileRequested.hasListeners(); // $ExpectType boolean
+
+    // onReadDirectoryRequested
+    chrome.fileSystemProvider.onReadDirectoryRequested.addListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.directoryPath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.isDirectory; // $ExpectType boolean
+        options.mimeType; // $ExpectType boolean
+        options.modificationTime; // $ExpectType boolean
+        options.name; // $ExpectType boolean
+        options.requestId; // $ExpectType number
+        options.size; // $ExpectType boolean
+        options.thumbnail; // $ExpectType boolean
+        successCallback([entryMetadata], true); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onReadDirectoryRequested.removeListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.directoryPath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.isDirectory; // $ExpectType boolean
+        options.mimeType; // $ExpectType boolean
+        options.modificationTime; // $ExpectType boolean
+        options.name; // $ExpectType boolean
+        options.requestId; // $ExpectType number
+        options.size; // $ExpectType boolean
+        options.thumbnail; // $ExpectType boolean
+        successCallback([entryMetadata], true); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onReadDirectoryRequested.hasListener((options, successCallback, errorCallback) => { // $ExpectType boolean
+        options.directoryPath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.isDirectory; // $ExpectType boolean
+        options.mimeType; // $ExpectType boolean
+        options.modificationTime; // $ExpectType boolean
+        options.name; // $ExpectType boolean
+        options.requestId; // $ExpectType number
+        options.size; // $ExpectType boolean
+        options.thumbnail; // $ExpectType boolean
+        successCallback([entryMetadata], true); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onReadDirectoryRequested.hasListeners(); // $ExpectType boolean
+
+    const arrayBuffer = new ArrayBuffer(1);
+
+    // onReadFileRequested
+    chrome.fileSystemProvider.onReadFileRequested.addListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.fileSystemId; // $ExpectType string
+        options.length; // $ExpectType number
+        options.offset; // $ExpectType number
+        options.openRequestId; // $ExpectType number
+        options.requestId; // $ExpectType number
+        successCallback(arrayBuffer, true); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onReadFileRequested.removeListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.fileSystemId; // $ExpectType string
+        options.length; // $ExpectType number
+        options.offset; // $ExpectType number
+        options.openRequestId; // $ExpectType number
+        options.requestId; // $ExpectType number
+        successCallback(arrayBuffer, true); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onReadFileRequested.hasListener((options, successCallback, errorCallback) => { // $ExpectType boolean
+        options.fileSystemId; // $ExpectType string
+        options.length; // $ExpectType number
+        options.offset; // $ExpectType number
+        options.openRequestId; // $ExpectType number
+        options.requestId; // $ExpectType number
+        successCallback(arrayBuffer, true); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onReadFileRequested.hasListeners(); // $ExpectType boolean
+
+    // onRemoveWatcherRequested
+    chrome.fileSystemProvider.onRemoveWatcherRequested.addListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.entryPath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.recursive; // $ExpectType boolean
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onRemoveWatcherRequested.removeListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.entryPath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.recursive; // $ExpectType boolean
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onRemoveWatcherRequested.hasListener((options, successCallback, errorCallback) => { // $ExpectType boolean
+        options.entryPath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.recursive; // $ExpectType boolean
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onRemoveWatcherRequested.hasListeners(); // $ExpectType boolean
+
+    // onTruncateRequested
+    chrome.fileSystemProvider.onTruncateRequested.addListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.filePath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.length; // $ExpectType number
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onTruncateRequested.removeListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.filePath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.length; // $ExpectType number
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onTruncateRequested.hasListener((options, successCallback, errorCallback) => { // $ExpectType boolean
+        options.filePath; // $ExpectType string
+        options.fileSystemId; // $ExpectType string
+        options.length; // $ExpectType number
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onTruncateRequested.hasListeners(); // $ExpectType boolean
+
+    // onUnmountRequested
+    chrome.fileSystemProvider.onUnmountRequested.addListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.fileSystemId; // $ExpectType string
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onUnmountRequested.removeListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.fileSystemId; // $ExpectType string
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onUnmountRequested.hasListener((options, successCallback, errorCallback) => { // $ExpectType boolean
+        options.fileSystemId; // $ExpectType string
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onUnmountRequested.hasListeners(); // $ExpectType boolean
+
+    // onWriteFileRequested
+    chrome.fileSystemProvider.onWriteFileRequested.addListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.data; // $ExpectType ArrayBuffer
+        options.fileSystemId; // $ExpectType string
+        options.offset; // $ExpectType number
+        options.openRequestId; // $ExpectType number
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onWriteFileRequested.removeListener((options, successCallback, errorCallback) => { // $ExpectType void
+        options.data; // $ExpectType ArrayBuffer
+        options.fileSystemId; // $ExpectType string
+        options.offset; // $ExpectType number
+        options.openRequestId; // $ExpectType number
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onWriteFileRequested.hasListener((options, successCallback, errorCallback) => { // $ExpectType boolean
+        options.data; // $ExpectType ArrayBuffer
+        options.fileSystemId; // $ExpectType string
+        options.offset; // $ExpectType number
+        options.openRequestId; // $ExpectType number
+        options.requestId; // $ExpectType number
+        successCallback(); // $ExpectType void
+        errorCallback("OK"); // $ExpectType void
+    });
+    chrome.fileSystemProvider.onWriteFileRequested.hasListeners(); // $ExpectType boolean
 }
 
 // https://developer.chrome.com/docs/extensions/reference/sessions/


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/fileSystemProvider
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes :
- `OpenedFileInfo`:
  - Renamed by `OpenedFile`
  - Update `mode` key
- Update `mode` key in `OpenFileRequestedOptions`
- Rename `FileWatchersInfo` by `Watcher`
- Rename `NotificationChange` by `Change`
- Rename `NotificationOptions` by `NotifyOptions`
- Add `ChangeType` enum
- Add `CommonActionId` enum
- Add `OpenFileMode` enum
- Add `ProviderError` enum
- events: update `errorCallback` param
- methods: can be return a promise 
- Add more tests 

![image](https://github.com/user-attachments/assets/8b1daa04-f313-4908-ba35-1dd88fa7f100)
