### PR TITLE
Remove `express.query` type for `express` v5

### DIFF
--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -5,10 +5,6 @@ import * as http from "http";
 namespace express_tests {
     const app = express();
 
-    // Disable and use the same built-in query parser
-    app.disable("query parser");
-    app.use(express.query({}));
-
     app.engine("jade", require("jade").__express);
     app.engine("html", require("ejs").renderFile);
 

--- a/types/express/index.d.ts
+++ b/types/express/index.d.ts
@@ -10,7 +10,6 @@
 
 import * as bodyParser from "body-parser";
 import * as core from "express-serve-static-core";
-import * as qs from "qs";
 import * as serveStatic from "serve-static";
 
 /**
@@ -54,11 +53,6 @@ declare namespace e {
      * @since 4.16.0
      */
     var urlencoded: typeof bodyParser.urlencoded;
-
-    /**
-     * This is a built-in middleware function in Express. It parses incoming request query parameters.
-     */
-    export function query(options: qs.IParseOptions | typeof qs.parse): Handler;
 
     export function Router(options?: RouterOptions): core.Router;
 

--- a/types/express/package.json
+++ b/types/express/package.json
@@ -8,7 +8,6 @@
     "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
-        "@types/qs": "*",
         "@types/serve-static": "*"
     },
     "devDependencies": {


### PR DESCRIPTION
Reverts #43217 for Express 5 — the feature was removed in v5.0.0-alpha.1

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/expressjs/express/blob/master/History.md#500-alpha1--2014-11-06
