### PR TITLE
[react] Backport #63076 and #65621 to v17

### DIFF
--- a/types/react/v17/index.d.ts
+++ b/types/react/v17/index.d.ts
@@ -2520,6 +2520,9 @@ declare namespace React {
         width?: number | string | undefined;
         disablePictureInPicture?: boolean | undefined;
         disableRemotePlayback?: boolean | undefined;
+
+        onResize?: ReactEventHandler<T> | undefined;
+        onResizeCapture?: ReactEventHandler<T> | undefined;
     }
 
     // this list is "complete" in that it contains every SVG attribute

--- a/types/react/v17/index.d.ts
+++ b/types/react/v17/index.d.ts
@@ -1591,6 +1591,16 @@ declare namespace React {
          * presented if they are made.
          */
         "aria-autocomplete"?: "none" | "inline" | "list" | "both" | undefined;
+        /**
+         * Defines a string value that labels the current element, which is intended to be converted into Braille.
+         * @see aria-label.
+         */
+        "aria-braillelabel"?: string | undefined;
+        /**
+         * Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.
+         * @see aria-roledescription.
+         */
+        "aria-brailleroledescription"?: string | undefined;
         /** Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user. */
         "aria-busy"?: Booleanish | undefined;
         /**
@@ -1609,6 +1619,11 @@ declare namespace React {
          */
         "aria-colindex"?: number | undefined;
         /**
+         * Defines a human readable text alternative of aria-colindex.
+         * @see aria-rowindextext.
+         */
+        "aria-colindextext"?: string | undefined;
+        /**
          * Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
          * @see aria-colindex @see aria-rowspan.
          */
@@ -1625,6 +1640,11 @@ declare namespace React {
          * @see aria-labelledby
          */
         "aria-describedby"?: string | undefined;
+        /**
+         * Defines a string value that describes or annotates the current element.
+         * @see related aria-describedby.
+         */
+        "aria-description"?: string | undefined;
         /**
          * Identifies the element that provides a detailed, extended description for the object.
          * @see aria-describedby.
@@ -1749,6 +1769,11 @@ declare namespace React {
          * @see aria-rowcount @see aria-rowspan.
          */
         "aria-rowindex"?: number | undefined;
+        /**
+         * Defines a human readable text alternative of aria-rowindex.
+         * @see aria-colindextext.
+         */
+        "aria-rowindextext"?: string | undefined;
         /**
          * Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
          * @see aria-rowindex @see aria-colspan.

--- a/types/react/v17/test/elementAttributes.tsx
+++ b/types/react/v17/test/elementAttributes.tsx
@@ -32,7 +32,7 @@ const testCases = [
     <svg>
         <image crossOrigin="anonymous" />
     </svg>,
-    <details open={true} onToggle={() => {}} name="foo" />,
+    <details open={true} onToggle={() => { }} name="foo" />,
     <input value={["one", "two"] as readonly string[]} />,
     <input value={["one", "two"] as string[]} />,
     <input value={["one", "two"]} />,
@@ -110,6 +110,7 @@ const eventCallbacksTestCases = [
     <meter onClick={e => e.currentTarget.optimum} />,
     <output onClick={e => e.currentTarget.value} />,
     <time onClick={e => e.currentTarget.dateTime} />,
+    <video onResize={e => e.currentTarget} onResizeCapture={e => e.currentTarget} />
 ];
 
 const ariaAttributesTestCases = [

--- a/types/react/v17/test/elementAttributes.tsx
+++ b/types/react/v17/test/elementAttributes.tsx
@@ -111,3 +111,11 @@ const eventCallbacksTestCases = [
     <output onClick={e => e.currentTarget.value} />,
     <time onClick={e => e.currentTarget.dateTime} />,
 ];
+
+const ariaAttributesTestCases = [
+    <a aria-braillelabel="a" />,
+    <a aria-brailleroledescription="a" />,
+    <a aria-colindextext="a" />,
+    <a aria-rowindextext="a" />,
+    <a aria-description="a" />,
+]


### PR DESCRIPTION
Backport type fixes in v18 #63076 and #65621 to v17 to add missing attributes:

- `aria-braillelabel`
- `aria-brailleroledescription`
- `aria-colindextext`
- `aria-description`
- `aria-rowindextext`
- `onResize` and `onResizeCapture` on `<video>`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://github.com/DefinitelyTyped/DefinitelyTyped/pull/63076
  - https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65621 
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
