### PR TITLE
Fixed return type of openOrClosedShadowRoot in @types/chrome

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -3519,7 +3519,7 @@ declare namespace chrome {
          * Requests chrome to return the open/closed shadow roots else return null.
          * @param element reference of HTMLElement.
          */
-        export function openOrClosedShadowRoot(element: HTMLElement): ShadowRoot;
+        export function openOrClosedShadowRoot(element: HTMLElement): ShadowRoot | null;
     }
 
     ////////////////////

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -5080,3 +5080,8 @@ function testReadingList() {
         onEntryUpdated.hasListeners(); // $ExpectType boolean
     };
 }
+
+// https://developer.chrome.com/docs/extensions/reference/api/dom
+function testDom() {
+    chrome.dom.openOrClosedShadowRoot(document.body); // $ExpectType ShadowRoot | null
+}


### PR DESCRIPTION
# Modification template

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [chrome.dom](https://developer.chrome.com/docs/extensions/reference/api/dom)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

# API Verification

Since the docs are somewhat vague concerning the return type of the `chrome.dom.openOrClosedShadowRoot` API, below is a sample Chromium extension that verifies this API can return nullish values.

> package.json

```json
{
    "devDependencies": {
        "@types/chrome": "^0.0.308"
    }
}
```

> manifest.json

```json
{
    "manifest_version": 3,
    "name": "dom_test",
    "version": "1.0",
    "permissions": ["scripting", "activeTab"],
    "action": {},
    "background": {
        "service_worker": "background.js"
    }
}
```

> background.js

```js
// Injecting content script on popup action
chrome.action.onClicked.addListener((tab) => {
    if (tab.id != null) {
        chrome.scripting.executeScript({
            target: { tabId: tab.id },
            files: ['content.js']
        });
    }
});
```

> content.js

```js
// Detecting shadow roots, if any
(() => {
    let noShadowHost     = /** @type {HTMLElement} */ (document.getElementById('no-shadow-host'));
    let openShadowHost   = /** @type {HTMLElement} */ (document.getElementById('open-shadow-host'));
    let closedShadowHost = /** @type {HTMLElement} */ (document.getElementById('closed-shadow-host'));
    let shadowHosts = [noShadowHost, openShadowHost, closedShadowHost];

    for (let shadowHost of shadowHosts) {
        /** @type {ShadowRoot | null} */
        let shadowRoot = chrome.dom.openOrClosedShadowRoot(shadowHost);
        
        if (shadowRoot === null) {
            shadowHost.innerHTML += `<p>This element has no shadow root!</p>`;
        }
        else {
            shadowRoot.innerHTML += `<p>This shadow root is ${shadowRoot.mode}!</p>`;
        }
    }
})();
```

And below is a sample webpage to run the extension on:

> test.html

```html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <title>DOM Test</title>
</head>
<body>
    <noscript>This demo requires JavaScript</noscript>
    <div id="no-shadow-host"><h1>No shadow root</h1></div>
    <div id="open-shadow-host"></div>
    <div id="closed-shadow-host"></div>
    <script>
        let openShadowHost   = document.getElementById('open-shadow-host');
        let closedShadowHost = document.getElementById('closed-shadow-host');
        let openShadow   = openShadowHost  .attachShadow({ mode: 'open' });
        let closedShadow = closedShadowHost.attachShadow({ mode: 'closed' });
        
        openShadow.innerHTML   = `<h1>Open shadow root</h1>`;
        closedShadow.innerHTML = `<h1>Closed shadow root</h1>`;
    </script>
</body>
</html>
```

Usage:

- Place these files in the same directory. The webpage can go anywhere.
- Go to `chrome://extensions` and, in developer mode, load the unpacked extension and enable it. Pinning the extension is recommended.
- Visit the test webpage
- Click on the extension icon in the extension toolbar

The following output is expected:
![Text is added below each of the page headers indicating the shadow root's mode, if one is attached.](https://github.com/user-attachments/assets/b86dddd9-cf3f-4236-a85a-2de54b9e500f)

Therefore, `openOrClosedShadowRoot` indeed returns null when the input element has no shadow root, justifying this small but necessary change.

Thanks for your time.