### PR TITLE
feat(chai): add containSubset assert aliases

### DIFF
--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -117,6 +117,9 @@ function equal() {
 function containSubset() {
     expect({}).to.containSubset({});
     ({}).should.containSubset({});
+    assert.containSubset({}, {});
+    assert.containsSubset({}, {});
+    assert.doesNotContainSubset({}, {});
 }
 
 function _typeof() {

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -538,6 +538,24 @@ declare global {
             containSubset(val: any, exp: any, msg?: string): void;
 
             /**
+             * Partially matches actual and expected.
+             *
+             * @param actual   Actual value.
+             * @param expected   Potential subset of the value.
+             * @param message   Message to display on error.
+             */
+            containsSubset(val: any, exp: any, msg?: string): void;
+
+            /**
+             * No partial match between actual and expected exists.
+             *
+             * @param actual   Actual value.
+             * @param expected   Potential subset of the value.
+             * @param message   Message to display on error.
+             */
+            doesNotContainSubset(val: any, exp: any, msg?: string): void;
+
+            /**
              * Asserts valueToCheck is strictly greater than (>) valueToBeAbove.
              *
              * @param valueToCheck   Actual value.


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chaijs/chai/pull/1664
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

In the chai PR implementing `containSubset` into the core package, I added aliases `assert.containsSubset` and `assert.doesNotContainSubset`, the former for semantic consistency with the rest of the package, and the latter due to a lack of an assert-based negation of `containSubset`. These aliases are in the existing latest package, `5.2.0`.