### PR TITLE
[braintree] add shipping tax amount to TransactionRequest

### DIFF
--- a/types/braintree/braintree-tests.ts
+++ b/types/braintree/braintree-tests.ts
@@ -117,7 +117,7 @@ const gateway: BraintreeGateway = new braintree.BraintreeGateway({
 (async () => {
     const transactionRequest: braintree.TransactionRequest = {
         amount: "128.00",
-        shippingTaxAmount: "10.00"
+        shippingTaxAmount: "10.00",
     };
     const response = await gateway.transaction.sale(transactionRequest).catch(console.error);
     if (!response) return;

--- a/types/braintree/braintree-tests.ts
+++ b/types/braintree/braintree-tests.ts
@@ -117,6 +117,7 @@ const gateway: BraintreeGateway = new braintree.BraintreeGateway({
 (async () => {
     const transactionRequest: braintree.TransactionRequest = {
         amount: "128.00",
+        shippingTaxAmount: "10.00"
     };
     const response = await gateway.transaction.sale(transactionRequest).catch(console.error);
     if (!response) return;

--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -1857,6 +1857,7 @@ declare namespace braintree {
             | undefined;
         shippingAddressId?: string | undefined;
         shippingAmount?: string | undefined;
+        shippingTaxAmount?: string | undefined;
         shipsFromPostalCode?: string | undefined;
         taxAmount?: string | undefined;
         taxExempt?: boolean | undefined;

--- a/types/braintree/package.json
+++ b/types/braintree/package.json
@@ -21,16 +21,12 @@
             "githubUsername": "acdr"
         },
         {
-            "name": "Sanders DeNardi",
-            "githubUsername": "sedenardi"
-        },
-        {
             "name": "Sebastian Campos",
             "githubUsername": "sebacampos"
         },
         {
             "name": "Claudio Wilson",
             "githubUsername": "claudiowilson"
-	      }
+        }
     ]
 }

--- a/types/braintree/package.json
+++ b/types/braintree/package.json
@@ -27,6 +27,10 @@
         {
             "name": "Sebastian Campos",
             "githubUsername": "sebacampos"
-        }
+        },
+        {
+            "name": "Claudio Wilson",
+            "githubUsername": "claudiowilson"
+	      }
     ]
 }


### PR DESCRIPTION
This change adds shippingTaxAmount into the interface for a `TransactionRequest`, currently this isn't there and will result in a compilation error if this valid field is included.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Braintree Documentation](https://developer.paypal.com/braintree/docs/reference/request/transaction/sale/node#shipping_tax_amount) as well as [JS Github Definition](https://github.com/braintree/braintree_node/blob/a595d697a34a3c0c36aaad18316e7681fb96f3c9/lib/braintree/transaction_gateway.js#L353)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

