### PR TITLE
[forge-apis] Make webhook hubId option optional

### DIFF
--- a/types/forge-apis/index.d.ts
+++ b/types/forge-apis/index.d.ts
@@ -1659,7 +1659,7 @@ export namespace WebhooksApi {
         hookAttribute?: any;
         tenant?: string | undefined;
         filter?: string | undefined;
-        hubId: string;
+        hubId?: string | undefined;
         projectId?: string | undefined;
         hookExpiry?: string | undefined;
     }


### PR DESCRIPTION
Fixing WebhooksApi types as per https://github.com/Autodesk-Forge/forge-api-nodejs-client/blob/master/src/api/WebhooksApi.js:
`@param {String} opts.hubId Optional field which should...`
Notice the **optional**. Currently in this repo they are mandatory