### PR TITLE
fix(node): export parseArgs options config types

### DIFF
--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -412,7 +412,7 @@ access("file/that/does/not/exist", (err) => {
 }
 
 {
-    let optionConfig: util.ParseArgsOptionConfig;
+    let optionConfig: util.ParseArgsOptionDescriptor;
 
     optionConfig = {
         type: "boolean",

--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -412,6 +412,49 @@ access("file/that/does/not/exist", (err) => {
 }
 
 {
+    let optionConfig: util.ParseArgsOptionConfig;
+
+    optionConfig = {
+        type: "boolean",
+    };
+
+    optionConfig = {
+        default: "default",
+        multiple: false,
+        short: "s",
+        type: "string",
+    };
+
+    optionConfig = {
+        default: ["a", "b", "c"],
+        multiple: true,
+        type: "string",
+    };
+
+    util.parseArgs({
+        options: {
+            longOption: optionConfig,
+        },
+    });
+
+    let optionsConfig: util.ParseArgsOptionsConfig;
+
+    optionsConfig = {};
+
+    optionsConfig = {
+        longOption: optionConfig,
+    };
+
+    util.parseArgs(optionsConfig);
+}
+
+{
+    let argsType: util.ParseArgsOptionsType;
+    argsType = "boolean";
+    argsType = "string";
+}
+
+{
     const controller: AbortController = util.transferableAbortController();
     const signal: AbortSignal = util.transferableAbortSignal(controller.signal);
     util.aborted(signal, {}).then(() => {});

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -1505,7 +1505,7 @@ declare module "util" {
      */
     export type ParseArgsOptionsType = "boolean" | "string";
 
-    export interface ParseArgsOptionConfig {
+    export interface ParseArgsOptionDescriptor {
         /**
          * Type of argument.
          */

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -1530,7 +1530,7 @@ declare module "util" {
         default?: string | boolean | string[] | boolean[] | undefined;
     }
     export interface ParseArgsOptionsConfig {
-        [longOption: string]: ParseArgsOptionConfig;
+        [longOption: string]: ParseArgsOptionDescriptor;
     }
     export interface ParseArgsConfig {
         /**

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -1499,11 +1499,17 @@ declare module "util" {
      * @return The parsed command line arguments:
      */
     export function parseArgs<T extends ParseArgsConfig>(config?: T): ParsedResults<T>;
-    interface ParseArgsOptionConfig {
+
+    /**
+     * Type of argument used in {@link parseArgs}.
+     */
+    export type ParseArgsOptionsType = "boolean" | "string";
+
+    export interface ParseArgsOptionConfig {
         /**
          * Type of argument.
          */
-        type: "string" | "boolean";
+        type: ParseArgsOptionsType;
         /**
          * Whether this option can be provided multiple times.
          * If `true`, all values will be collected in an array.
@@ -1523,7 +1529,7 @@ declare module "util" {
          */
         default?: string | boolean | string[] | boolean[] | undefined;
     }
-    interface ParseArgsOptionsConfig {
+    export interface ParseArgsOptionsConfig {
         [longOption: string]: ParseArgsOptionConfig;
     }
     export interface ParseArgsConfig {

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -1582,7 +1582,7 @@ declare module "util" {
         : T extends true ? IfTrue
         : IfFalse;
 
-    type ExtractOptionValue<T extends ParseArgsConfig, O extends ParseArgsOptionConfig> = IfDefaultsTrue<
+    type ExtractOptionValue<T extends ParseArgsConfig, O extends ParseArgsOptionDescriptor> = IfDefaultsTrue<
         T["strict"],
         O["type"] extends "string" ? string : O["type"] extends "boolean" ? boolean : string | boolean,
         string | boolean
@@ -1615,7 +1615,7 @@ declare module "util" {
 
     type PreciseTokenForOptions<
         K extends string,
-        O extends ParseArgsOptionConfig,
+        O extends ParseArgsOptionDescriptor,
     > = O["type"] extends "string" ? {
             kind: "option";
             index: number;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: _(n/a)_
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. _(n/a)_

Exports types that were visible externally but previously not exported. Those types were effectively violating the proposed _"export all types used in exports"_ rule from https://github.com/typescript-eslint/typescript-eslint/issues/7670.