### PR TITLE
feat(emscripten): Add `preinitializedWebGPUDevice` option to EmscriptenModule

### DIFF
--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -23,6 +23,15 @@ declare namespace Emscripten {
     }
 }
 
+// Infers the type only in TypeScript environments where GPU types are available
+type MaybeGPUDevice = Navigator extends {
+    gpu: {
+        requestAdapter(...args: any[]): Promise<null | {
+            requestDevice(...args: any[]): Promise<null | infer T>
+        }>
+    }
+} ? T : never;
+
 interface EmscriptenModule {
     print(str: string): void;
     printErr(str: string): void;
@@ -34,6 +43,7 @@ interface EmscriptenModule {
     onAbort: { (what: any): void };
     onRuntimeInitialized: { (): void };
     preinitializedWebGLContext: WebGLRenderingContext;
+    preinitializedWebGPUDevice: MaybeGPUDevice;
     noInitialRun: boolean;
     noExitRuntime: boolean;
     logReadFiles: boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Admittedly, I'm not able to find information on this option in the emscripten docs or repo. I became aware of the option
in [another project](https://github.com/Twinklebear/demo-jupyter-wasm-widget/blob/3b1a98582eae60b93bb520af11de707f57afbc18/ts/widget.ts#L63-L78) where the type was missing but necessary.

For testing, I'm not entirely sure how to test the conditional type. I can confirm it correctly infers when `@types/webgpu` are available but a suggestion of how to test that condition (along with without) would be appreciated.

cc: @Twinklebear
