### PR TITLE
feat(node): Add `HTTPMethod` union type

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -1546,7 +1546,43 @@ declare module "http" {
          */
         destroy(): void;
     }
-    const METHODS: string[];
+    type HTTPMethod =
+    | 'ACL'
+    | 'BIND'
+    | 'CHECKOUT'
+    | 'CONNECT'
+    | 'COPY'
+    | 'DELETE'
+    | 'GET'
+    | 'HEAD'
+    | 'LINK'
+    | 'LOCK'
+    | 'M-SEARCH'
+    | 'MERGE'
+    | 'MKACTIVITY'
+    | 'MKCALENDAR'
+    | 'MKCOL'
+    | 'MOVE'
+    | 'NOTIFY'
+    | 'OPTIONS'
+    | 'PATCH'
+    | 'POST'
+    | 'PROPFIND'
+    | 'PROPPATCH'
+    | 'PURGE'
+    | 'PUT'
+    | 'QUERY'
+    | 'REBIND'
+    | 'REPORT'
+    | 'SEARCH'
+    | 'SOURCE'
+    | 'SUBSCRIBE'
+    | 'TRACE'
+    | 'UNBIND'
+    | 'UNLINK'
+    | 'UNLOCK'
+    | 'UNSUBSCRIBE';
+    const METHODS: HTTPMethod[];
     const STATUS_CODES: {
         [errorCode: number]: string | undefined;
         [errorCode: string]: string | undefined;

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -1006,7 +1006,7 @@ declare module "http" {
          * The request method.
          * @since v0.1.97
          */
-        method: string;
+        method: HTTPMethod;
         /**
          * The request path.
          * @since v0.4.0

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -317,7 +317,7 @@ import * as url from "node:url";
     req.path = "/";
 
     // method
-    const method: string = req.method;
+    const method: http.HTTPMethod = req.method;
 
     // maxHeadersCount
     const maxHeadersCount: number = req.maxHeadersCount;

--- a/types/node/v20/http.d.ts
+++ b/types/node/v20/http.d.ts
@@ -1544,7 +1544,43 @@ declare module "http" {
          */
         destroy(): void;
     }
-    const METHODS: string[];
+    type HTTPMethod =
+    | 'ACL'
+    | 'BIND'
+    | 'CHECKOUT'
+    | 'CONNECT'
+    | 'COPY'
+    | 'DELETE'
+    | 'GET'
+    | 'HEAD'
+    | 'LINK'
+    | 'LOCK'
+    | 'M-SEARCH'
+    | 'MERGE'
+    | 'MKACTIVITY'
+    | 'MKCALENDAR'
+    | 'MKCOL'
+    | 'MOVE'
+    | 'NOTIFY'
+    | 'OPTIONS'
+    | 'PATCH'
+    | 'POST'
+    | 'PROPFIND'
+    | 'PROPPATCH'
+    | 'PURGE'
+    | 'PUT'
+    | 'QUERY'
+    | 'REBIND'
+    | 'REPORT'
+    | 'SEARCH'
+    | 'SOURCE'
+    | 'SUBSCRIBE'
+    | 'TRACE'
+    | 'UNBIND'
+    | 'UNLINK'
+    | 'UNLOCK'
+    | 'UNSUBSCRIBE';
+    const METHODS: HTTPMethod[];
     const STATUS_CODES: {
         [errorCode: number]: string | undefined;
         [errorCode: string]: string | undefined;


### PR DESCRIPTION
## Description
`METHODS` previously was defined as just a string array which provided no type safety for what actual values could be used and what existed in METHODS. Which was problematic.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/nodejs/node/blob/fab6906c5d1c16b046187485a7cb136b3659d42b/deps/llhttp/include/llhttp.h#L331C1-L366C25>>
