### PR TITLE
[react] Restore context parameter in legacy class Component lifecycles

### DIFF
--- a/types/react-addons-shallow-compare/react-addons-shallow-compare-tests.tsx
+++ b/types/react-addons-shallow-compare/react-addons-shallow-compare-tests.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import shallowCompare = require("react-addons-shallow-compare");
 
 export class MyComponent extends React.Component {
-    shouldComponentUpdate(nextProps: any, nextState: any): boolean {
+    shouldComponentUpdate(nextProps: any, nextState: any, nextContext: any): boolean {
         return shallowCompare(this, nextProps, nextState);
     }
 

--- a/types/react-lifecycle-component/react-lifecycle-component-tests.tsx
+++ b/types/react-lifecycle-component/react-lifecycle-component-tests.tsx
@@ -64,8 +64,9 @@ function mapDispatchToProps(dispatch: Dispatch): MapDispatchProps {
         componentDidMount() {
             dispatch({ type: "ComponentDidMount" });
         },
-        componentWillUpdate(nextProps, nextState) {
+        componentWillUpdate(nextProps, nextState, nextContext) {
             const fooIsEqual: boolean = nextProps.propsFoo === nextState.stateFoo;
+            const hasNextContext: boolean = !!nextContext;
             dispatch({ type: "ComponentWillUpdate" });
         },
         componentDidUpdate(nextProps, nextState, nextContext) {
@@ -73,15 +74,17 @@ function mapDispatchToProps(dispatch: Dispatch): MapDispatchProps {
             const hasNextContext: boolean = !!nextContext;
             dispatch({ type: "ComponentDidUpdate" });
         },
-        componentWillReceiveProps(nextProps) {
+        componentWillReceiveProps(nextProps, nextContext) {
             const fooIsGreaterThanZero: boolean = nextProps.propsFoo > 0;
+            const hasNextContext: boolean = !!nextContext;
             dispatch({ type: "ComponentWillReceiveProps" });
         },
         componentWillUnmount() {
             dispatch({ type: "ComponentWillUnmount" });
         },
-        shouldComponentUpdate(nextProps, nextState) {
+        shouldComponentUpdate(nextProps, nextState, nextContext) {
             const fooIsEqual: boolean = nextProps.propsFoo === nextState.stateFoo;
+            const hasNextContext: boolean = !!nextContext;
             return !fooIsEqual;
         },
     };

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1177,7 +1177,7 @@ declare namespace React {
          * If false is returned, {@link Component.render}, `componentWillUpdate`
          * and `componentDidUpdate` will not be called.
          */
-        shouldComponentUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>): boolean;
+        shouldComponentUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): boolean;
         /**
          * Called immediately before a component is destroyed. Perform any necessary cleanup in this method, such as
          * cancelled network requests, or cleaning up any DOM elements created in `componentDidMount`.
@@ -1276,7 +1276,7 @@ declare namespace React {
          * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props}
          * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path}
          */
-        componentWillReceiveProps?(nextProps: Readonly<P>): void;
+        componentWillReceiveProps?(nextProps: Readonly<P>, nextContext: any): void;
         /**
          * Called when the component may be receiving new props.
          * React may call this even if props have not changed, so be sure to compare new and existing
@@ -1294,7 +1294,7 @@ declare namespace React {
          * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props}
          * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path}
          */
-        UNSAFE_componentWillReceiveProps?(nextProps: Readonly<P>): void;
+        UNSAFE_componentWillReceiveProps?(nextProps: Readonly<P>, nextContext: any): void;
         /**
          * Called immediately before rendering when new props or state is received. Not called for the initial render.
          *
@@ -1308,7 +1308,7 @@ declare namespace React {
          * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#reading-dom-properties-before-an-update}
          * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path}
          */
-        componentWillUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>): void;
+        componentWillUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): void;
         /**
          * Called immediately before rendering when new props or state is received. Not called for the initial render.
          *
@@ -1324,7 +1324,7 @@ declare namespace React {
          * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#reading-dom-properties-before-an-update}
          * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path}
          */
-        UNSAFE_componentWillUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>): void;
+        UNSAFE_componentWillUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): void;
     }
 
     function createRef<T>(): RefObject<T | null>;

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -1176,7 +1176,7 @@ declare namespace React {
          * If false is returned, {@link Component.render}, `componentWillUpdate`
          * and `componentDidUpdate` will not be called.
          */
-        shouldComponentUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>): boolean;
+        shouldComponentUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): boolean;
         /**
          * Called immediately before a component is destroyed. Perform any necessary cleanup in this method, such as
          * cancelled network requests, or cleaning up any DOM elements created in `componentDidMount`.
@@ -1275,7 +1275,7 @@ declare namespace React {
          * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props}
          * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path}
          */
-        componentWillReceiveProps?(nextProps: Readonly<P>): void;
+        componentWillReceiveProps?(nextProps: Readonly<P>, nextContext: any): void;
         /**
          * Called when the component may be receiving new props.
          * React may call this even if props have not changed, so be sure to compare new and existing
@@ -1293,7 +1293,7 @@ declare namespace React {
          * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props}
          * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path}
          */
-        UNSAFE_componentWillReceiveProps?(nextProps: Readonly<P>): void;
+        UNSAFE_componentWillReceiveProps?(nextProps: Readonly<P>, nextContext: any): void;
         /**
          * Called immediately before rendering when new props or state is received. Not called for the initial render.
          *
@@ -1307,7 +1307,7 @@ declare namespace React {
          * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#reading-dom-properties-before-an-update}
          * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path}
          */
-        componentWillUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>): void;
+        componentWillUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): void;
         /**
          * Called immediately before rendering when new props or state is received. Not called for the initial render.
          *
@@ -1323,7 +1323,7 @@ declare namespace React {
          * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#reading-dom-properties-before-an-update}
          * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path}
          */
-        UNSAFE_componentWillUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>): void;
+        UNSAFE_componentWillUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): void;
     }
 
     function createRef<T>(): RefObject<T | null>;


### PR DESCRIPTION
[`db7b653` (#69022)](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69022/commits/db7b653eb76c2ca67b286b066ccdb305b39203da) removed some legit context parameters in legacy Class component lifecycles.