### PR TITLE
node/fs: Add type definition for fs.read with buffer and options parameter

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -2544,6 +2544,12 @@ declare module "fs" {
         options: ReadAsyncOptions<TBuffer>,
         callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: TBuffer) => void,
     ): void;
+    export function read<TBuffer extends NodeJS.ArrayBufferView>(
+        fd: number,
+        buffer: TBuffer,
+        options: ReadSyncOptions,
+        callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: TBuffer) => void,
+    ): void;
     export function read(
         fd: number,
         callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: NodeJS.ArrayBufferView) => void,

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -2550,6 +2550,11 @@ declare module "fs" {
         options: ReadSyncOptions,
         callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: TBuffer) => void,
     ): void;
+    export function read<TBuffer extends NodeJS.ArrayBufferView>(
+        fd: number,
+        buffer: TBuffer,
+        callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: TBuffer) => void,
+    ): void;
     export function read(
         fd: number,
         callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: NodeJS.ArrayBufferView) => void,

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -123,6 +123,7 @@ import { CopyOptions, CopySyncOptions, cp, cpSync, glob, globSync } from "fs";
     );
     fs.read(1, { buffer: Buffer.from("test"), position: 123n }, () => {});
     fs.read(1, Buffer.from("test"), { position: 123n }, () => {});
+    fs.read(1, Buffer.from("test"), () => {});
     // 2-param version using all-default options:
     fs.read(1, (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: NodeJS.ArrayBufferView) => {});
     fs.read(1, () => {});

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -122,7 +122,7 @@ import { CopyOptions, CopySyncOptions, cp, cpSync, glob, globSync } from "fs";
         (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: NodeJS.ArrayBufferView) => {},
     );
     fs.read(1, { buffer: Buffer.from("test"), position: 123n }, () => {});
-    fs.read(1, Buffer.from("test"),{  position: 123n }, () => {});
+    fs.read(1, Buffer.from("test"), { position: 123n }, () => {});
     // 2-param version using all-default options:
     fs.read(1, (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: NodeJS.ArrayBufferView) => {});
     fs.read(1, () => {});

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -122,6 +122,7 @@ import { CopyOptions, CopySyncOptions, cp, cpSync, glob, globSync } from "fs";
         (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: NodeJS.ArrayBufferView) => {},
     );
     fs.read(1, { buffer: Buffer.from("test"), position: 123n }, () => {});
+    fs.read(1, Buffer.from("test"),{  position: 123n }, () => {});
     // 2-param version using all-default options:
     fs.read(1, (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: NodeJS.ArrayBufferView) => {});
     fs.read(1, () => {});

--- a/types/node/v18/fs.d.ts
+++ b/types/node/v18/fs.d.ts
@@ -2562,6 +2562,11 @@ declare module "fs" {
         options: ReadSyncOptions,
         callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: TBuffer) => void,
     ): void;
+    export function read<TBuffer extends NodeJS.ArrayBufferView>(
+        fd: number,
+        buffer: TBuffer,
+        callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: TBuffer) => void,
+    ): void;
     export function read(
         fd: number,
         callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: NodeJS.ArrayBufferView) => void,

--- a/types/node/v18/fs.d.ts
+++ b/types/node/v18/fs.d.ts
@@ -2556,6 +2556,12 @@ declare module "fs" {
         options: ReadAsyncOptions<TBuffer>,
         callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: TBuffer) => void,
     ): void;
+    export function read<TBuffer extends NodeJS.ArrayBufferView>(
+        fd: number,
+        buffer: TBuffer,
+        options: ReadSyncOptions,
+        callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: TBuffer) => void,
+    ): void;
     export function read(
         fd: number,
         callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: NodeJS.ArrayBufferView) => void,

--- a/types/node/v20/fs.d.ts
+++ b/types/node/v20/fs.d.ts
@@ -2542,6 +2542,12 @@ declare module "fs" {
         options: ReadAsyncOptions<TBuffer>,
         callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: TBuffer) => void,
     ): void;
+    export function read<TBuffer extends NodeJS.ArrayBufferView>(
+        fd: number,
+        buffer: TBuffer,
+        options: ReadSyncOptions,
+        callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: TBuffer) => void,
+    ): void;
     export function read(
         fd: number,
         callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: NodeJS.ArrayBufferView) => void,

--- a/types/node/v20/fs.d.ts
+++ b/types/node/v20/fs.d.ts
@@ -2548,6 +2548,11 @@ declare module "fs" {
         options: ReadSyncOptions,
         callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: TBuffer) => void,
     ): void;
+    export function read<TBuffer extends NodeJS.ArrayBufferView>(
+        fd: number,
+        buffer: TBuffer,
+        callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: TBuffer) => void,
+    ): void;
     export function read(
         fd: number,
         callback: (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: NodeJS.ArrayBufferView) => void,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/blob/a7f8b23642fffa6fb81322e38e6cbae806934fcb/lib/fs.js#L594-L598
 target document: https://nodejs.org/docs/latest-v22.x/api/fs.html#fsreadfd-buffer-options-callback
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
