### PR TITLE
[@types/backbone] fix `off` and `stopListening` definition.

### DIFF
--- a/types/backbone/backbone-tests.ts
+++ b/types/backbone/backbone-tests.ts
@@ -9,6 +9,12 @@ function test_events() {
 
     object.off("change", onChange);
     object.off("change");
+    object.off({
+        change: onChange,
+    });
+    object.off({
+        change: onChange,
+    }, context);
     object.off(null, onChange);
     object.off(null, null, context);
     object.off();
@@ -402,7 +408,11 @@ namespace v1Changes {
             const view = new Backbone.View<Employee>();
             view.stopListening(model, "invalid", () => {});
             view.stopListening(model, "invalid");
+            view.stopListening(model, {
+                invalid: () => {},
+            });
             view.stopListening(model);
+            view.stopListening();
         }
     }
 

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -148,6 +148,7 @@ declare namespace Backbone {
     }
     interface Events_Off<BaseT> {
         <T extends BaseT>(this: T, eventName?: string | null, callback?: EventHandler | null, context?: any): T;
+        <T extends BaseT>(this: T, eventMap: EventMap, context?: any): T;
     }
     interface Events_Trigger<BaseT> {
         <T extends BaseT>(this: T, eventName: string, ...args: any[]): T;
@@ -158,6 +159,7 @@ declare namespace Backbone {
     }
     interface Events_Stop<BaseT> {
         <T extends BaseT>(this: T, object?: any, events?: string, callback?: EventHandler): T;
+        <T extends BaseT>(this: T, object: any, eventMap: EventMap): T;
     }
 
     /**
@@ -174,6 +176,7 @@ declare namespace Backbone {
         on(eventName: string, callback: EventHandler, context?: any): this;
         on(eventMap: EventMap, context?: any): this;
         off(eventName?: string | null, callback?: EventHandler | null, context?: any): this;
+        off(eventMap: EventMap, context?: any): this;
         trigger(eventName: string, ...args: any[]): this;
         bind(eventName: string, callback: EventHandler, context?: any): this;
         bind(eventMap: EventMap, context?: any): this;
@@ -186,6 +189,7 @@ declare namespace Backbone {
         listenToOnce(object: any, events: string, callback: EventHandler): this;
         listenToOnce(object: any, eventMap: EventMap): this;
         stopListening(object?: any, events?: string, callback?: EventHandler): this;
+        stopListening(object: any, eventMap: EventMap): this;
     }
 
     class ModelBase extends EventsMixin {


### PR DESCRIPTION
In BackboneJS, it is possible to stop listening on events by using the event map syntax (like for `on` method).

It is possible because the code `Events.off` uses `eventsApi` (https://backbonejs.org/docs/backbone.html#section-34). And the third argument of `eventsApi`
(https://backbonejs.org/docs/backbone.html#section-23), `name`, can be an object which is for the "event map" syntax
(https://backbonejs.org/docs/backbone.html#section-23).

`Events.stopListening` uses `Events.off`
(https://backbonejs.org/docs/backbone.html#section-35) so it also supports the event map syntax.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test backbone`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [url of Backbone code documentation](https://backbonejs.org/docs/backbone.html) (more details in commit message)
