### PR TITLE
[aws-lambda] Fix typo in AWS GuardDuty scanResultStatus

### DIFF
--- a/types/aws-lambda/test/guard-duty-event-notification-tests.ts
+++ b/types/aws-lambda/test/guard-duty-event-notification-tests.ts
@@ -23,7 +23,7 @@ const guardDutyScanResultNotificationEvent: GuardDutyScanResultNotificationEvent
             s3Throttled: false,
         },
         scanResultDetails: {
-            scanResultStatus: "THREAT_FOUND",
+            scanResultStatus: "THREATS_FOUND",
             threats: [
                 {
                     name: "foobar",

--- a/types/aws-lambda/trigger/guard-duty-event-notification.d.ts
+++ b/types/aws-lambda/trigger/guard-duty-event-notification.d.ts
@@ -24,7 +24,7 @@ export interface GuardDutyScanResultNotificationEventDetail {
         s3Throttled: boolean;
     };
     scanResultDetails: {
-        scanResultStatus: "NO_THREATS_FOUND" | "THREAT_FOUND" | "UNSUPPORTED" | "ACCESS_DENIED" | "FAILED";
+        scanResultStatus: "NO_THREATS_FOUND" | "THREATS_FOUND" | "UNSUPPORTED" | "ACCESS_DENIED" | "FAILED";
         threats: GuardDutyThreatDetail[] | null;
     };
 }


### PR DESCRIPTION
I have received the scan result status: `"THREATS_FOUND"` in real AWS GuardDuty.
However, this value does not match for type definition of `@types/aws-lambda`.

This PR fixes the type definition: `GuardDutyScanResultNotificationEventDetail["scanResultDetails"]["scanResultStatus"]`.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/guardduty/latest/ug/monitor-with-eventbridge-s3-malware-protection.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
