### PR TITLE
[@babel/traverse]: Add support for recursive `NodePath::get(…)` calls

### DIFF
--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -25,6 +25,7 @@ const MyVisitor2: Visitor = {
     },
     ArrayExpression(path) {
         path.get("elements"); // $ExpectType NodePath<SpreadElement | Expression | null>[]
+        path.get("elements.0"); // $ExpectType NodePath<SpreadElement | Expression | null>
     },
     Program(path) {
         path.parentPath; // $ExpectType null
@@ -374,6 +375,7 @@ const objectTypeAnnotation: NodePath<t.ObjectTypeAnnotation> = new NodePath<t.Ob
 );
 
 objectTypeAnnotation.get("indexers"); // $ExpectType NodePathResult<ObjectTypeIndexer[] | undefined>
+objectTypeAnnotation.get("indexers.0"); // $ExpectType NodePath<ObjectTypeIndexer>
 
 // Test that NodePath can be narrowed from union to single type
 const path: NodePath<t.ExportDefaultDeclaration | t.ExportNamedDeclaration> = new NodePath<t.ExportNamedDeclaration>(
@@ -427,7 +429,9 @@ binding.deopValue();
 binding.clearValue();
 
 binding.reassign(newPath.get("body")[0]);
+binding.reassign(newPath.get("body.0"));
 binding.reference(newPath.get("body")[0]);
+binding.reference(newPath.get("body.0"));
 binding.dereference();
 
 newPath.scope.checkBlockScopedCollisions(binding, "local", "name", {});

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -746,6 +746,7 @@ export class NodePath<T = Node> {
     getAllNextSiblings(): NodePath[];
 
     get<K extends keyof T>(key: K, context?: boolean | TraversalContext): NodePathResult<T[K]>;
+    get<P extends string>(path: P, context?: boolean | TraversalContext): NodePathResult<ImplGetRecursive<T, P>>;
     get(key: string, context?: boolean | TraversalContext): NodePath | NodePath[];
 
     getBindingIdentifiers(duplicates: true): Record<string, t.Identifier[]>;
@@ -1447,6 +1448,24 @@ export interface TraversalContext<S = unknown> {
     state: S;
     opts: TraverseOptions;
 }
+
+// Based on `GetFieldType`s from `@types/lodash/common/object.d.ts`:
+type ImplGetOfArray<T extends readonly unknown[], K extends string> =
+    K extends `${infer N extends number}` ? T[N]
+    : K extends keyof T ? T[K]
+    : never;
+
+type ImplGetByKey<T, K extends string>
+    = T extends readonly unknown[] ? ImplGetOfArray<T, K>
+    : K extends keyof T ? T[K]
+    : K extends `${infer N extends number}`
+        ? N extends keyof T ? T[N] : never
+    : never;
+
+type ImplGetRecursive<T, K extends string>
+    = K extends `${infer L}.${infer R}`
+        ? ImplGetRecursive<ImplGetByKey<T, L>, R>
+        : ImplGetByKey<T, K>;
 
 export type NodePathResult<T> =
     | (Extract<T, Node | null | undefined> extends never ? never : NodePath<Extract<T, Node | null | undefined>>)

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -1450,11 +1450,13 @@ export interface TraversalContext<S = unknown> {
 }
 
 // Based on `GetFieldType`s from `@types/lodash/common/object.d.ts`:
+// dprint-ignore
 type ImplGetOfArray<T extends readonly unknown[], K extends string> =
     K extends `${infer N extends number}` ? T[N]
     : K extends keyof T ? T[K]
     : never;
 
+// dprint-ignore
 type ImplGetByKey<T, K extends string>
     = T extends readonly unknown[] ? ImplGetOfArray<T, K>
     : K extends keyof T ? T[K]
@@ -1462,10 +1464,11 @@ type ImplGetByKey<T, K extends string>
         ? N extends keyof T ? T[N] : never
     : never;
 
+// dprint-ignore
 type ImplGetRecursive<T, K extends string>
     = K extends `${infer L}.${infer R}`
         ? ImplGetRecursive<ImplGetByKey<T, L>, R>
-        : ImplGetByKey<T, K>;
+    : ImplGetByKey<T, K>;
 
 export type NodePathResult<T> =
     | (Extract<T, Node | null | undefined> extends never ? never : NodePath<Extract<T, Node | null | undefined>>)


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/babel/babel/blob/55a194212612b9e2c666cc0877d07a8e1218bc36/packages/babel-traverse/src/path/family.ts#L375-L379> [^1]
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

[^1]: Note that `@babel/traverse`’s internal type definitions don’t support `strictNullChecks`.