### PR TITLE
[splunk-logging] Severity is not actually exported by lib

### DIFF
--- a/types/splunk-logging/index.d.ts
+++ b/types/splunk-logging/index.d.ts
@@ -1,6 +1,11 @@
 import { CoreOptions as RequestOptions } from "request";
 
-export enum Severity {
+export {};
+
+export type Severity = "debug" | "info" | "warn" | "error";
+
+// this enum isn't actually exported, but it is used as an internal value by the Logger.
+declare enum SeverityLevel {
     DEBUG = "debug",
     INFO = "info",
     WARN = "warn",
@@ -44,7 +49,7 @@ export class Logger {
     eventFormatter: EventFormatter;
     requestOptions: RequestOptions;
     readonly serializedContextQueue: any[];
-    readonly levels: typeof Severity;
+    readonly levels: typeof SeverityLevel;
 
     constructor(config: Config);
 

--- a/types/splunk-logging/splunk-logging-tests.ts
+++ b/types/splunk-logging/splunk-logging-tests.ts
@@ -1,4 +1,4 @@
-import { Logger, Severity } from "splunk-logging";
+import { Logger } from "splunk-logging";
 
 const config = {
     token: "your-token-here",
@@ -48,7 +48,7 @@ const fullConfig = {
     path: "splunkPath",
     procotol: "https",
     port: 2,
-    level: Severity.INFO,
+    level: logger.levels.INFO,
     batchInterval: 3,
     maxBatchSize: 4,
     maxBatchCount: 5,


### PR DESCRIPTION
see #72226 - the enum isn't actually an exposed type by the library, but does form an internal type on the Logger.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
