### PR TITLE
fix(pdf-parse): move @types/node to dep, modify pagerender return type

### DIFF
--- a/types/pdf-parse/index.d.ts
+++ b/types/pdf-parse/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 export = PdfParse;
 
 declare function PdfParse(dataBuffer: Buffer, options?: PdfParse.Options): Promise<PdfParse.Result>;
@@ -13,7 +15,7 @@ declare namespace PdfParse {
         text: string;
     }
     interface Options {
-        pagerender?: ((pageData: any) => string) | undefined;
+        pagerender?: ((pageData: any) => string | Promise<string>) | undefined;
         max?: number | undefined;
         version?: Version | undefined;
     }

--- a/types/pdf-parse/package.json
+++ b/types/pdf-parse/package.json
@@ -5,8 +5,10 @@
     "projects": [
         "https://gitlab.com/autokent/pdf-parse"
     ],
+    "dependencies": {
+        "@types/node": "*"
+    },
     "devDependencies": {
-        "@types/node": "*",
         "@types/pdf-parse": "workspace:."
     },
     "owners": [

--- a/types/pdf-parse/pdf-parse-tests.ts
+++ b/types/pdf-parse/pdf-parse-tests.ts
@@ -27,12 +27,17 @@ let options: pdfParse.Options;
 options = {};
 
 options = {
-    pagerender: pageData => {
-        const _pageData: any = pageData;
+    pagerender: () => {
         return "modified callback";
     },
     max: 0,
     version: "v1.10.100",
+};
+
+options = {
+    pagerender: async () => {
+        return "modified callback";
+    },
 };
 
 pdfParse(dataBuffer, options);


### PR DESCRIPTION
See the [published code on npm](https://www.npmjs.com/package/pdf-parse?activeTab=code). In `/pdf-parse/lib/pdf-parse.js`, `pagerender()` should be able to return either `string` or `Promise<string>`.

Resolves discussion https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/72210.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
