### PR TITLE
node/fs:  Add null to the position type

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -4012,7 +4012,7 @@ declare module "fs" {
     export function writev(
         fd: number,
         buffers: readonly NodeJS.ArrayBufferView[],
-        position: number,
+        position: number | null,
         cb: (err: NodeJS.ErrnoException | null, bytesWritten: number, buffers: NodeJS.ArrayBufferView[]) => void,
     ): void;
     export interface WriteVResult {
@@ -4057,7 +4057,7 @@ declare module "fs" {
     export function readv(
         fd: number,
         buffers: readonly NodeJS.ArrayBufferView[],
-        position: number,
+        position: number | null,
         cb: (err: NodeJS.ErrnoException | null, bytesRead: number, buffers: NodeJS.ArrayBufferView[]) => void,
     ): void;
     export interface ReadVResult {

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -425,6 +425,20 @@ async function testPromisify() {
         (err: NodeJS.ErrnoException | null, bytesWritten: number, buffers: NodeJS.ArrayBufferView[]) => {
         },
     );
+    fs.writev(
+        1,
+        [Buffer.from("123")] as readonly NodeJS.ArrayBufferView[],
+        123,
+        (err: NodeJS.ErrnoException | null, bytesWritten: number, buffers: NodeJS.ArrayBufferView[]) => {
+        },
+    );
+    fs.writev(
+        1,
+        [Buffer.from("123")] as readonly NodeJS.ArrayBufferView[],
+        null,
+        (err: NodeJS.ErrnoException | null, bytesWritten: number, buffers: NodeJS.ArrayBufferView[]) => {
+        },
+    );
     const bytesWritten = fs.writevSync(1, [Buffer.from("123")] as readonly NodeJS.ArrayBufferView[]);
 }
 
@@ -619,6 +633,13 @@ async function testPromisify() {
         123,
         [Buffer.from("wut")] as readonly NodeJS.ArrayBufferView[],
         123,
+        (err: NodeJS.ErrnoException | null, bytesRead: number, buffers: NodeJS.ArrayBufferView[]) => {
+        },
+    );
+    fs.readv(
+        123,
+        [Buffer.from("wut")] as readonly NodeJS.ArrayBufferView[],
+        null,
         (err: NodeJS.ErrnoException | null, bytesRead: number, buffers: NodeJS.ArrayBufferView[]) => {
         },
     );

--- a/types/node/v18/fs.d.ts
+++ b/types/node/v18/fs.d.ts
@@ -4023,7 +4023,7 @@ declare module "fs" {
     export function writev(
         fd: number,
         buffers: readonly NodeJS.ArrayBufferView[],
-        position: number,
+        position: number | null,
         cb: (err: NodeJS.ErrnoException | null, bytesWritten: number, buffers: NodeJS.ArrayBufferView[]) => void,
     ): void;
     export interface WriteVResult {
@@ -4066,7 +4066,7 @@ declare module "fs" {
     export function readv(
         fd: number,
         buffers: readonly NodeJS.ArrayBufferView[],
-        position: number,
+        position: number | null,
         cb: (err: NodeJS.ErrnoException | null, bytesRead: number, buffers: NodeJS.ArrayBufferView[]) => void,
     ): void;
     export interface ReadVResult {

--- a/types/node/v20/fs.d.ts
+++ b/types/node/v20/fs.d.ts
@@ -4013,7 +4013,7 @@ declare module "fs" {
     export function writev(
         fd: number,
         buffers: readonly NodeJS.ArrayBufferView[],
-        position: number,
+        position: number | null,
         cb: (err: NodeJS.ErrnoException | null, bytesWritten: number, buffers: NodeJS.ArrayBufferView[]) => void,
     ): void;
     export interface WriteVResult {
@@ -4058,7 +4058,7 @@ declare module "fs" {
     export function readv(
         fd: number,
         buffers: readonly NodeJS.ArrayBufferView[],
-        position: number,
+        position: number | null,
         cb: (err: NodeJS.ErrnoException | null, bytesRead: number, buffers: NodeJS.ArrayBufferView[]) => void,
     ): void;
     export interface ReadVResult {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [readv](https://nodejs.org/docs/latest-v22.x/api/fs.html#fsreadvfd-buffers-position-callback)
  - [writev](https://nodejs.org/docs/latest-v22.x/api/fs.html#fswritevfd-buffers-position-callback)

Aligned with the existing nullable 'position' parameter in the [write](https://nodejs.org/docs/latest-v22.x/api/fs.html#fswritefd-buffer-offset-length-position-callback) method.

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
