### PR TITLE
[mysql] incorrect TypeCast type next() return type (void->any)

### DIFF
--- a/types/mysql/index.d.ts
+++ b/types/mysql/index.d.ts
@@ -286,7 +286,7 @@ export type TypeCast =
             buffer(): null | Buffer;
             geometry(): null | GeometryType;
         },
-        next: () => void,
+        next: () => any,
     ) => any);
 
 export type queryCallback = (err: MysqlError | null, results?: any, fields?: FieldInfo[]) => void;

--- a/types/mysql/mysql-tests.ts
+++ b/types/mysql/mysql-tests.ts
@@ -442,7 +442,7 @@ connection.query({
         if (field.type === "TINY" && field.length === 1) {
             return (field.string() === "1"); // 1 = true, 0 = false
         }
-        next();
+        return next();
     },
 });
 
@@ -456,7 +456,7 @@ connection.query({
             }
             return (JSON.parse(string));
         }
-        next();
+        return next();
     },
 });
 


### PR DESCRIPTION
In mysqljs/mysql, there is a TypeCast type which lets you hook into parsing raw buffers/strings/geometry from DB packets back to native JS types instead of just strings. 

If you look at the code itself, the next() function actually returns a value (such as a string or a Number) so the return value is not void: 
- [next() wrapper definition](https://github.com/mysqljs/mysql/blob/dc9c152a87ec51a1f647447268917243d2eab1fd/lib/protocol/packets/RowDataPacket.js#L24-L26)
- [inner scope _typeCast (typeCast) returns for example Number](https://github.com/mysqljs/mysql/blob/dc9c152a87ec51a1f647447268917243d2eab1fd/lib/protocol/packets/RowDataPacket.js#L101-L105)
- [tests also use return next instead of just calling next](https://github.com/mysqljs/mysql/blob/dc9c152a87ec51a1f647447268917243d2eab1fd/test/integration/connection/test-timezones.js#L95) (opposite to the tests previously in this repo)

The way in which next() is set up is that it can be called to fallback to original internal logic. Additionally, next() **could** be used to build chains of typeCast functions, forwarding the internal fallback through the chain, however given that next() currently also has the wrong type, the return chaining is not possible.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mysqljs/mysql/blob/dc9c152a87ec51a1f647447268917243d2eab1fd/lib/protocol/packets/RowDataPacket.js#L24-L26


