### PR TITLE
[Chrome] Remove scriptBadge namespace (old API removed)

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -9797,32 +9797,6 @@ declare namespace chrome {
     }
 
     ////////////////////
-    // Script Badge
-    ////////////////////
-    export namespace scriptBadge {
-        export interface GetPopupDetails {
-            tabId: number;
-        }
-
-        export interface AttentionDetails {
-            tabId: number;
-        }
-
-        export interface SetPopupDetails {
-            tabId: number;
-            popup: string;
-        }
-
-        export interface ScriptBadgeClickedEvent extends chrome.events.Event<(tab: chrome.tabs.Tab) => void> {}
-
-        export function getPopup(details: GetPopupDetails, callback: Function): void;
-        export function getAttention(details: AttentionDetails): void;
-        export function setPopup(details: SetPopupDetails): void;
-
-        export var onClicked: ScriptBadgeClickedEvent;
-    }
-
-    ////////////////////
     // Sessions
     ////////////////////
     /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.


It seems that this is an API that was abandoned many years ago.

**Sources:**  
- https://codereview.chromium.org/730983002
- https://issues.chromium.org/issues/40274167 

 > This API is dead, see https://crbug.com/chromium/302083.
