### PR TITLE
[facebook-nodejs-business-sdk] Add additional FacebookRequestError attribute typings

### DIFF
--- a/types/facebook-nodejs-business-sdk/src/exceptions.d.ts
+++ b/types/facebook-nodejs-business-sdk/src/exceptions.d.ts
@@ -27,6 +27,6 @@ export declare class FacebookRequestError extends FacebookError {
     headers: { [key: string]: string };
     method: string;
     url: string;
-    data: { data: any[], id: string };
+    data: { data: object[], id: string };
 }
 export { };

--- a/types/facebook-nodejs-business-sdk/src/exceptions.d.ts
+++ b/types/facebook-nodejs-business-sdk/src/exceptions.d.ts
@@ -13,5 +13,20 @@ export declare class FacebookRequestError extends FacebookError {
      * @param  {Object}   data
      */
     constructor(response: any, method: any, url: any, data: any);
+
+    name: string;
+    message: string;
+    stack: string;
+    status: number;
+    response: {
+        message: string;
+        type: string;
+        code: number;
+        fbtrace_id: string;
+    }
+    headers: { [key: string]: string };
+    method: string;
+    url: string;
+    data: { data: any[], id: string };
 }
-export {};
+export { };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/facebook-nodejs-business-sdk/blob/4a73348474f969e4fc4d55b65b70217896486747/src/exceptions.js#L26-L48
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

This will provide the ability to dig into error messages when catching Facebook API errors and capture things like the response code which users like myself might want to perform logic on, depending on what underlying issue was present.

Documentation for the `FacebookRequestError` is pretty sparse. To determine an example error response I generated a few errors myself in testing. These typings are not new, and were only left out of previous DefinitelyTyped versions. An example error response:
```
{
  name: 'FacebookRequestError',
  message: 'Invalid OAuth access token - Cannot parse access token',
  stack: 'Error: \n' +
    '    at FacebookRequestError.FacebookError [as constructor] (/<redacted>/node_modules/facebook-nodejs-business-sdk/dist/exceptions.js:18:16)\n' +
    '    at new FacebookRequestError (/<redacted>/node_modules/facebook-nodejs-business-sdk/dist/cjs.js:371:129)\n' +
    '    at /<redacted>/node_modules/facebook-nodejs-business-sdk/dist/api.js:153:15\n' +
    '    at processTicksAndRejections (node:internal/process/task_queues:95:5)',
  status: 400,
  response: {
    message: 'Invalid OAuth access token - Cannot parse access token',
    type: 'OAuthException',
    code: 190,
    fbtrace_id: 'AoQK_mx0Z6MrW4sLxHo-lW6'
  },
  headers: Object [AxiosHeaders] {
    'error-mid': 'fbd81c80b60dcfceb52b1223b7744fea',
    vary: 'Origin',
    'access-control-allow-origin': '*',
    'content-type': 'application/json',
    'www-authenticate': 'OAuth "Facebook Platform" "invalid_token" "Invalid OAuth access token - Cannot parse access token"',
    'strict-transport-security': 'max-age=15552000; preload',
    pragma: 'no-cache',
    'cache-control': 'no-store',
    expires: 'Sat, 01 Jan 2000 00:00:00 GMT',
    'x-fb-request-id': 'AoQK_mx0Z6MrW4sLxHo-lW6',
    'x-fb-trace-id': 'EGlymi49Vz+',
    'x-fb-rev': '1021131837',
    'x-fb-debug': '1a95pjm2h+0AXYVUquyNMsKEVDlIJktQSvuN2h7LMoIxyPl3zCXzt9MLMFhAbsLnfByd8V8DuM+lcA/F72qO7g==',
    date: 'Fri, 21 Mar 2025 20:59:02 GMT',
    'proxy-status': 'http_request_error; e_fb_responsebytes="AcI1MSNB2T3Iqn_a9nPK5F9ExUFQkJR1C5B-FPDghcFDEsWSaXjpfPTNzBle"; e_fb_requesttime="AcJFBJyoaf2EIuU0DKjNA6Hq6yf47r01Kg3ZvjFmVcle80PutZEmFmidGDb0zWVUX-yz9itYMA"; e_proxy="AcIYPgaqMWl8KUbUqbuVAbmWz2NzUvGQRlT2vx4j051zFOmBHUP_k2sNTYPzDF5HufrM7i2pI4-HZDxmW8WE"; e_fb_twtaskhandle="AcJleJhduKM1Xm6lg3xxRkxETTfM53kNtSlcofDhusnPcZkUif3lzbCAU2dzH0qoOsM2iVizjgft-LTXCAyIS9tcr8d7_Rxv6Er6Qj7DVGH4NQ"; e_fb_requestsequencenumber="AcKj7m2teQjpu60RGJfb_WCZCbEyjUCVbrW3IM3WCYMzR0zQ_a9NLzMHZDTC"; e_upip="AcIR0ZXXuamyh_Hjt9En9RG0Pk6tltdjvrxKPGQfiV7NuO6oCi0C5SM2lRu67Rg44FYn-ugcvQzZvp7Ft78z3hvSkgt24A-Yk1Ivqdg"; e_fb_zone="AcKFmdDJHowVtvXyikemTTL6sO8mcstifwSJYvhUFNY3h7GAuhGH3OEVosW0ZO9Q"; e_fb_binaryversion="AcJjpeT5VWXE5J6IZqXIb6LNqLXK4XnOmRwPFL7foNb1H4ZLttbj3FOYt-o6dJ4JJ4ZJQW91oC0RDTC5vk92-QIxIao_6rhs6pQ"; e_fb_httpversion="AcK8Y1oeEb7YehfuP7iGCoHrPkv1s9NktzJVCe9jIRtlY_xhJ3lyHHsPdmrW"; e_fb_requesthandler="AcJChyQ5Xcgcs0XF9ib51TlC2xirGhs8gV8FzVqgnVEh4P1pPjjMwqGN6ky9qVvxOlrhPiQCbhNRIqHTSyRhbvVQVQ"; e_fb_configversion="AcLc620UqnASJQYx8uwFyJVD4Pcyc2WMT799pP7zcbcajM4NaLw97WeT3ROiDA"; e_fb_vipaddr="AcKTQeG4F4MZNQCank1YRGjf9QsLv0sGqQdI8I0I5GlWGG5L3cGuZxHvGACw5io9TfBU1dGNp1TaLV3jC8qf532vM68lauM0c2Y"; e_fb_hostheader="AcJoiI9Fsb3d_7tzlruxkEfmZ8vKFDMG_BEkRS4-IXBoO07L4KrWV3k8qLcWeKDjwnKDTWvmMj4LbNiL"; e_fb_builduser="AcKuvXyfV1UcCg_KSNSWFdhNqSxpm8VBF7qDnqMEenDlWS-M97A-hft7z4fuoC5OnOs"; e_fb_vipport="AcLwLeQYdLfTYcQtodvyzjTUrKvp0pBLq5-PQsi45AjaYSCphHvflQnY5RXm"; e_clientaddr="AcISNP3DmBwPUjQzTwajWleEXXlVDB2S7GX-0Ma_jdrgvscH9Jg3vWtX5mwt9VzWe4uEHctSPjlRCbGjjUcKTlZ9sud_reQ19wrHjAuGj_5PBlzmqQ", http_request_error; e_fb_responsebytes="AcLn9-yk886_Py7SaY5QmJ_aQg1hDkZV1e0ZYhKrlICnfp3lvxNo89tfNilK"; e_fb_requesttime="AcLifH4qYxR24rdLlByZMqyI3G3wm8vqXSzcPPvp8gBvCFl7_sLxg5lXgsT_KT1V7a6NkhP2lg"; e_proxy="AcJ3R-e417rg0Xyp7GXPJanGuXN_Vqr-2KGqpFMuOMpIWnEKsW695K2Wtxz8AlGj0KXyhdCErIoXTV-c"; e_fb_twtaskhandle="AcJxbveeD0aYw8zcmlmGvEGAVaVuFEBMQd4EmmQL1_9jrSGh6JlBKCwamW61sV45JzyxogoNEgAP5C1znqeDpM_jYZzM5KPDcDea"; e_fb_requestsequencenumber="AcLjFXVi_1MidCXeSEyIXYOLx1BbaQfvP48F-WtqXr4M8bzIOOgsZAXQIA"; e_upip="AcJo29P7zFP_YTeEf9TbRqicJSH_uFXiU_y2ios2_F9T4K-FxFPGcXvOk8BMbhogqX67qthR6d1RKaTso_dy9MYB0mCFVdDBP04"; e_fb_zone="AcKI0snR2jbSXaWSFZptdKCq1phlfCrS6zcvjFAay2MUITGDAEzi63NVtVw0yw"; e_fb_binaryversion="AcJfpnrQYUi6RoEJufOlS47BjVHzl1RtS4BDFFHn_nyRQmWXHkLS80RfmAxZr_91u4S0I8u8No09Dgmo_pITF8DwrxUkaWCp9dE"; e_fb_httpversion="AcLYZ8uHfBGaf23lWn335BQG3MxPmjaEh5bwJe_WN-MuxmQO5idnYXHYdAR7"; e_fb_requesthandler="AcKPF7KFQvCSsyhnijdSqsYAOauLD5JbC5PLFnYIawo-bdjBA2FhcPoojyr_fsL4Fd2s2n--9l_5HID5NTQox8onEA"; e_fb_configversion="AcI_gGDReCmk0RYRMuVIoI15GU7aO_pV6IQYG-sh-XMXTW6BWIFGi3eOUay8qA"; e_fb_vipaddr="AcJ8Y8GFcS_1XtIVJ3ITmxgRm0qfjk7-eLIrvMxdzi_dNEhTdko-KHwagUu_dGPOMPX37w"; e_fb_hostheader="AcKzaT-c1wcN5XKR1e6kPzOY3jAMLjsinPnTjGs0Bmg98vunGE4xSTJoaCCJx_LbiqMwa7EFQOT9WLyf"; e_fb_builduser="AcLo4YxQZlqyKVaVmqCSIZp2-6tFU2MLygpHqPB7NySY8mb98i9OYp9atp_l3valLzY"; e_fb_vipport="AcJEw_iPowZF40QK_RiPms5bZBwOTdbUMEviIepIg-loRuZ7rljxF_Elu_C7"; e_clientaddr="AcKL5QmbEEEDINGCr7Zg35R5Z9PaqRVOzmlSo7AnVrMKLMJyUdXXU2PZc8_SvZeDG5WGf6lcOXxUtdyM9A"',
    'x-fb-connection-quality': 'EXCELLENT; q=0.9, rtt=13, rtx=0, c=10, mss=1380, tbw=3403, tp=-1, tpl=-1, uplat=20, ullat=0',
    'alt-svc': 'h3=":443"; ma=86400',
    connection: 'close',
    'content-length': '152'
  },
  method: 'POST',
  url: 'https://graph.facebook.com/v22.0/12e84811-28ad-4912-8b91-f3074e9030fe/events?access_token=0517589b-aa8e-464c-bbee-52cb655ce1cb',
  data: { data: [ [Object] ], id: '12e84811-28ad-4912-8b91-f3074e9030fe' }
}
```
