### PR TITLE
[Chrome] update permisions and optional_permissions lists

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -8943,7 +8943,7 @@ declare namespace chrome {
             default_popup?: string | undefined;
         }
 
-        // Source: https://developer.chrome.com/docs/extensions/mv3/declare_permissions/
+        /** Source: https://developer.chrome.com/docs/extensions/reference/permissions-list */
         export type ManifestPermissions =
             | "accessibilityFeatures.modify"
             | "accessibilityFeatures.read"
@@ -9000,11 +9000,11 @@ declare namespace chrome {
             | "privacy"
             | "processes"
             | "proxy"
+            | "readingList"
             | "scripting"
             | "search"
             | "sessions"
             | "sidePanel"
-            | "signedInDevices"
             | "storage"
             | "system.cpu"
             | "system.display"
@@ -9026,6 +9026,23 @@ declare namespace chrome {
             | "webRequest"
             | "webRequestBlocking"
             | "webRequestAuthProvider";
+
+        /** Source : https://developer.chrome.com/docs/extensions/reference/api/permissions */
+        export type ManifestOptionalPermissions = Exclude<
+            ManifestPermissions,
+            | "debugger"
+            | "declarativeNetRequest"
+            | "devtools"
+            | "experimental"
+            | "fontSettings"
+            | "geolocation"
+            | "proxy"
+            | "tts"
+            | "ttsEngine"
+            | "unlimitedStorage"
+            | "wallpaper"
+            | "webAuthenticationProxy"
+        >;
 
         export interface SearchProvider {
             name?: string | undefined;
@@ -9246,8 +9263,8 @@ declare namespace chrome {
                 }
                 | undefined;
             content_security_policy?: string | undefined;
-            optional_permissions?: string[] | undefined;
-            permissions?: string[] | undefined;
+            optional_permissions?: ManifestOptionalPermissions[] | string[] | undefined;
+            permissions?: ManifestPermissions[] | string[] | undefined;
             web_accessible_resources?: string[] | undefined;
         }
 
@@ -9282,7 +9299,7 @@ declare namespace chrome {
                 sandbox?: string;
             };
             host_permissions?: string[] | undefined;
-            optional_permissions?: ManifestPermissions[] | undefined;
+            optional_permissions?: ManifestOptionalPermissions[] | undefined;
             optional_host_permissions?: string[] | undefined;
             permissions?: ManifestPermissions[] | undefined;
             web_accessible_resources?: Array<{ resources: string[]; matches: string[] }> | undefined;

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -731,8 +731,8 @@ function testGetManifest() {
         manifest.content_security_policy; // $ExpectType string | undefined
 
         manifest.host_permissions; // $ExpectType any
-        manifest.optional_permissions; // $ExpectType string[] | undefined
-        manifest.permissions; // $ExpectType string[] | undefined
+        manifest.optional_permissions; // $ExpectType ManifestOptionalPermissions[] | string[] | undefined
+        manifest.permissions; // $ExpectType ManifestPermissions[] |string[] | undefined
 
         manifest.web_accessible_resources; // $ExpectType string[] | undefined
     } else if (manifest.manifest_version === 3) {
@@ -746,13 +746,38 @@ function testGetManifest() {
         };
 
         manifest.host_permissions; // $ExpectType string[] | undefined
-        manifest.optional_permissions; // $ExpectType ManifestPermissions[] | undefined
+        manifest.optional_permissions; // $ExpectType ManifestOptionalPermissions[] | undefined
         manifest.optional_host_permissions; // $ExpectType string[] | undefined
         manifest.permissions; // $ExpectType ManifestPermissions[] | undefined
 
         manifest.web_accessible_resources = [{ matches: ["https://*/*"], resources: ["resource.js"] }];
         // @ts-expect-error
         manifest.web_accessible_resources = ["script.js"];
+
+        // @ts-expect-error Permission 'debugger' cannot be listed as optional. This permission will be omitted.
+        manifest.optional_permissions = ["debugger"];
+        // @ts-expect-error Permission 'declarativeNetRequest' cannot be listed as optional. This permission will be omitted.
+        manifest.optional_permissions = ["declarativeNetRequest"];
+        // @ts-expect-error Permission 'devtools' cannot be listed as optional. This permission will be omitted.
+        manifest.optional_permissions = ["devtools"];
+        // @ts-expect-error Permission 'experimental' cannot be listed as optional. This permission will be omitted.
+        manifest.optional_permissions = ["experimental"];
+        // @ts-expect-error Permission 'fontSettings' cannot be listed as optional. This permission will be omitted.
+        manifest.optional_permissions = ["fontSettings"];
+        // @ts-expect-error Permission 'geolocation' cannot be listed as optional. This permission will be omitted.
+        manifest.optional_permissions = ["geolocation"];
+        // @ts-expect-error Permission 'proxy' cannot be listed as optional. This permission will be omitted.
+        manifest.optional_permissions = ["proxy"];
+        // @ts-expect-error Permission 'tts' cannot be listed as optional. This permission will be omitted.
+        manifest.optional_permissions = ["tts"];
+        // @ts-expect-error Permission 'ttsEngine' cannot be listed as optional. This permission will be omitted.
+        manifest.optional_permissions = ["ttsEngine"];
+        // @ts-expect-error Permission 'unlimitedStorage' cannot be listed as optional. This permission will be omitted.
+        manifest.optional_permissions = ["unlimitedStorage"];
+        // @ts-expect-error Permission 'wallpaper' cannot be listed as optional. This permission will be omitted.
+        manifest.optional_permissions = ["wallpaper"];
+        // @ts-expect-error Permission 'webAuthenticationProxy' cannot be listed as optional. This permission will be omitted.
+        manifest.optional_permissions = ["webAuthenticationProxy"];
     }
 
     const mv2: chrome.runtime.Manifest = {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://developer.chrome.com/docs/extensions/reference/permissions-list
  - https://developer.chrome.com/docs/extensions/reference/api/readingList
  - https://issues.chromium.org/issues/40103774
  - https://developer.chrome.com/docs/extensions/reference/api/permissions
  https://developer.chrome.com/docs/extensions/mv2/reference/api/permissions
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

**Notes :** 
- Remove `signedInDevices` MV2 permissions ([deleted](https://issues.chromium.org/issues/40103774))
- Add `readingList` MV3 permissions ([missing](https://developer.chrome.com/docs/extensions/reference/api/readingList))
- Exclude some permissions that cannot be optional ([mv2](https://developer.chrome.com/docs/extensions/mv2/reference/permissions#step_2_declare_optional_permissions_in_the_manifest), [mv3](https://developer.chrome.com/docs/extensions/reference/api/permissions#step_2_declare_optional_permissions_in_the_manifest))
- `fontSettings`, `unlimitedStorage` and `webAuthenticationProxy` permissions seem to be non-optional even though they are not documented (see screenshot)
  <img src="https://github.com/user-attachments/assets/3d4fe664-02f6-4c04-be4d-66962a487c0a" width="500">  
- [MV2](https://developer.chrome.com/docs/extensions/mv2/reference/permissions#type-Permissions) seems to allow origins as permissions.
  > The list of host permissions, including those specified in the optional_permissions or permissions keys in the manifest, and those associated with [Content Scripts](https://developer.chrome.com/docs/extensions/develop/concepts/content-scripts).