### PR TITLE
[chrome] add devtools.recorder namespace

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -3072,6 +3072,71 @@ declare namespace chrome {
     }
 
     ////////////////////
+    // Dev Tools - Recorder
+    ////////////////////
+    /**
+     * Use the `chrome.devtools.recorder` API to customize the Recorder panel in DevTools.
+     * @since Chrome 105
+     */
+    export namespace devtools.recorder {
+        /** A plugin interface that the Recorder panel invokes to customize the Recorder panel. */
+        export interface RecorderExtensionPlugin {
+            /**
+             * Allows the extension to implement custom replay functionality.
+             *
+             * @param recording A recording of the user interaction with the page. This should match [Puppeteer's recording schema](https://github.com/puppeteer/replay/blob/main/docs/api/interfaces/Schema.UserFlow.md).
+             * @since Chrome 112
+             */
+            replay?(recording: object): void;
+
+            /**
+             * Converts a recording from the Recorder panel format into a string.
+             * @param recording A recording of the user interaction with the page. This should match [Puppeteer's recording schema](https://github.com/puppeteer/replay/blob/main/docs/api/interfaces/Schema.UserFlow.md).
+             */
+            stringify?(recording: object): void;
+
+            /**
+             * Converts a step of the recording from the Recorder panel format into a string.
+             * @param step A step of the recording of a user interaction with the page. This should match [Puppeteer's step schema](https://github.com/puppeteer/replay/blob/main/docs/api/modules/Schema.md#step).
+             */
+            stringifyStep?(step: object): void;
+        }
+
+        /**
+         * Represents a view created by extension to be embedded inside the Recorder panel.
+         * @since Chrome 112
+         */
+        export interface RecorderView {
+            /** Fired when the view is hidden. */
+            onHidden: events.Event<() => void>;
+            /** Fired when the view is shown. */
+            onShown: events.Event<() => void>;
+            /** Indicates that the extension wants to show this view in the Recorder panel. */
+            show(): void;
+        }
+
+        /**
+         * Creates a view that can handle the replay. This view will be embedded inside the Recorder panel.
+         * @param title Title that is displayed next to the extension icon in the Developer Tools toolbar.
+         * @param pagePath Path of the panel's HTML page relative to the extension directory.
+         * @since Chrome 112
+         */
+        export function createView(title: string, pagePath: string): RecorderView;
+
+        /**
+         * Registers a Recorder extension plugin.
+         * @param plugin An instance implementing the RecorderExtensionPlugin interface.
+         * @param name The name of the plugin.
+         * @param mediaType The media type of the string content that the plugin produces.
+         */
+        export function registerRecorderExtensionPlugin(
+            plugin: RecorderExtensionPlugin,
+            name: string,
+            mediaType: string,
+        ): void;
+    }
+
+    ////////////////////
     // Document Scan
     ////////////////////
     /**

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1314,25 +1314,25 @@ function testRuntimeOnMessageAddListener() {
     });
 }
 
-chrome.devtools.network.onRequestFinished.addListener((request: chrome.devtools.network.Request) => {
-    request; // $ExpectType Request
-    console.log("request: ", request);
-});
-
-chrome.devtools.performance.onProfilingStarted.addListener(() => {
-    console.log("Profiling started");
-});
-
-chrome.devtools.performance.onProfilingStopped.addListener(() => {
-    console.log("Profiling stopped");
-});
-
-chrome.devtools.network.getHAR((harLog: chrome.devtools.network.HARLog) => {
-    harLog; // $ExpectType HARLog
-    console.log("harLog: ", harLog);
-});
-
 function testDevtools() {
+    chrome.devtools.network.onRequestFinished.addListener((request: chrome.devtools.network.Request) => {
+        request; // $ExpectType Request
+        console.log("request: ", request);
+    });
+
+    chrome.devtools.performance.onProfilingStarted.addListener(() => {
+        console.log("Profiling started");
+    });
+
+    chrome.devtools.performance.onProfilingStopped.addListener(() => {
+        console.log("Profiling stopped");
+    });
+
+    chrome.devtools.network.getHAR((harLog: chrome.devtools.network.HARLog) => {
+        harLog; // $ExpectType HARLog
+        console.log("harLog: ", harLog);
+    });
+
     chrome.devtools.inspectedWindow.eval("1+1", undefined, result => {
         console.log(result);
     });
@@ -1344,6 +1344,25 @@ function testDevtools() {
         ignoreCache: true,
         injectedScript: "console.log(\"Hello World!\")",
     });
+
+    const view = chrome.devtools.recorder.createView("title", "replay.html"); // $ExpectType RecorderView
+    view.onHidden.addListener(() => {}); // $ExpectType void
+    view.onHidden.removeListener(() => {}); // $ExpectType void
+    view.onHidden.hasListener(() => {}); // $ExpectType boolean
+    view.onHidden.hasListeners(); // $ExpectType boolean
+    view.onShown.addListener(() => {}); // $ExpectType void
+    view.onShown.removeListener(() => {}); // $ExpectType void
+    view.onShown.hasListener(() => {}); // $ExpectType boolean
+    view.onShown.hasListeners(); // $ExpectType boolean
+    view.show(); // $ExpectType void
+
+    const plugin: chrome.devtools.recorder.RecorderExtensionPlugin = {
+        replay: () => {},
+        stringify: () => {},
+        stringifyStep: () => {},
+    };
+    chrome.devtools.recorder.registerRecorderExtensionPlugin({}, "MyPlugin", "application/json"); // $ExpectType void
+    chrome.devtools.recorder.registerRecorderExtensionPlugin(plugin, "MyPlugin", "application/json"); // $ExpectType void
 }
 
 function testAssistiveWindow() {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/devtools/recorder
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes :
- The keys of `RecorderExtensionPlugin` can be optional ([official example](https://github.com/puppeteer/replay/blob/main/examples/chrome-extension-replay/DevToolsPlugin.js))
- We can certainly improve the `object` typing by adding the dependency `@puppeteer/replay`, but that means we will have to keep up with its updates.
- A function `unregisterRecorderExtensionPlugin` exists but is not documented
  ![image](https://github.com/user-attachments/assets/4bfc1893-fad9-4fb9-a38a-eed92d10ad72)
