### PR TITLE
[Chrome] remove useless jquery deps

### DIFF
--- a/types/chrome/package.json
+++ b/types/chrome/package.json
@@ -3,16 +3,14 @@
     "name": "@types/chrome",
     "version": "0.0.9999",
     "projects": [
-        "http://developer.chrome.com/extensions/"
+        "https://developer.chrome.com/docs/extensions"
     ],
     "dependencies": {
         "@types/filesystem": "*",
         "@types/har-format": "*"
     },
     "devDependencies": {
-        "@types/chrome": "workspace:.",
-        "@types/jquery": "*",
-        "@types/jqueryui": "*"
+        "@types/chrome": "workspace:."
     },
     "owners": [
         {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Notes :
- `http://developer.chrome.com/extensions` redirect to  `https://developer.chrome.com/docs/extensions`
- Remove `@types/jquery` and `@types/jqueryui` from devDependencies (useless since https://github.com/DefinitelyTyped/DefinitelyTyped/commit/726c318421452fb8eafc2569a0d4eb2f5cf2fbf2)