### PR TITLE
http-cache-semantics: upgrade types to match upstream release 4.2.0

### DIFF
--- a/types/http-cache-semantics/http-cache-semantics-tests.ts
+++ b/types/http-cache-semantics/http-cache-semantics-tests.ts
@@ -13,7 +13,11 @@ new CachePolicy(req, res, { trustServerDate: true });
 policy.storable(); // $ExpectType boolean
 policy.satisfiesWithoutRevalidation(req); // $ExpectType boolean
 policy.responseHeaders(); // $ExpectType Headers
+policy.stale(); // $ExpectType boolean
+policy.age(); // $ExpectType number
+policy.maxAge(); // $ExpectType number
 policy.timeToLive(); // $ExpectType number
 CachePolicy.fromObject(policy.toObject()); // $ExpectType CachePolicy
 policy.revalidationHeaders(req); // $ExpectType Headers
 policy.revalidatedPolicy(req, res); // $ExpectType RevalidationPolicy
+policy.evaluateRequest(req); // $ExpectType EvaluateRequestResult

--- a/types/http-cache-semantics/package.json
+++ b/types/http-cache-semantics/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/http-cache-semantics",
-    "version": "4.0.9999",
+    "version": "4.2.9999",
     "projects": [
         "https://github.com/kornelski/http-cache-semantics#readme"
     ],


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kornelski/http-cache-semantics/compare/v4.1.1...b78c925fd088945375402efeb9c61aa8a6725d1b
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.


NOTE: this is actually for `http-cache-semantics` v4.2.0, which is currently in beta.