### PR TITLE
[payu-emea-sdk] Add enable installments option to secure form

### DIFF
--- a/types/payu-emea-sdk/index.d.ts
+++ b/types/payu-emea-sdk/index.d.ts
@@ -82,6 +82,7 @@ declare namespace payu {
         lang?: lang | undefined;
         disabled?: boolean | undefined;
         cardIcon?: boolean | undefined;
+        enableInstallments?: boolean | undefined;
     }
 
     type fontWeight = "normal" | "bold" | "lighter" | "bolder" | "inherit" | "initial" | "unset" | fontWeightNumber;

--- a/types/payu-emea-sdk/index.d.ts
+++ b/types/payu-emea-sdk/index.d.ts
@@ -124,6 +124,7 @@ declare namespace payu {
         update(options: SecureFormOptions): SecureForm;
         on(event: eventTypes, handler: () => void): SecureForm;
         on(event: "change", handler: (body: SecureFormChangeResponse) => void): SecureForm;
+        on(event: "installmentsChange", handler: (body: SecureFormInstallmentsChangeResponse) => void): SecureForm
         clear(): SecureForm;
         focus(): SecureForm;
         remove(): SecureForm;
@@ -158,6 +159,11 @@ declare namespace payu {
         error: false | SecureFormErrorMessage[];
         brand?: "visa" | "mastercard" | "maestro" | undefined;
         length?: number | undefined;
+    }
+
+    interface SecureFormInstallmentsChangeResponse {
+        numbers: number[];
+        provider: string;
     }
 
     interface TokenizeResultSuccess {

--- a/types/payu-emea-sdk/index.d.ts
+++ b/types/payu-emea-sdk/index.d.ts
@@ -124,7 +124,7 @@ declare namespace payu {
         update(options: SecureFormOptions): SecureForm;
         on(event: eventTypes, handler: () => void): SecureForm;
         on(event: "change", handler: (body: SecureFormChangeResponse) => void): SecureForm;
-        on(event: "installmentsChange", handler: (body: SecureFormInstallmentsChangeResponse) => void): SecureForm
+        on(event: "installmentsChange", handler: (body: SecureFormInstallmentsChangeResponse) => void): SecureForm;
         clear(): SecureForm;
         focus(): SecureForm;
         remove(): SecureForm;

--- a/types/payu-emea-sdk/payu-emea-sdk-tests.ts
+++ b/types/payu-emea-sdk/payu-emea-sdk-tests.ts
@@ -38,6 +38,7 @@ const options = {
     frameTitle: "TITLE",
     disabled: false,
     cardIcon: false,
+    enableInstallments: true,
 };
 
 const optionsWithError = {


### PR DESCRIPTION
Adding a parameter to enable installments for certain merchants for payu-emea-sdk [PayU Secure Form](https://developers.payu.com/europe/pl/docs/checkout/secure-form/)