### PR TITLE
@types/pdfkit pdfmake: remove unnecessary @types/node dependency 

### DIFF
--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -1,5 +1,3 @@
-/// <reference types="node" />
-
 declare namespace PDFKit {
     interface PDFGradient {
         new(document: any): PDFGradient;
@@ -37,6 +35,45 @@ declare namespace PDFKit {
 }
 
 declare namespace PDFKit.Mixins {
+    /** {{{ From NodeJS */
+
+    class EventEmitter {
+        addListener(event: string | symbol, listener: (...args: any[]) => void): this;
+        on(event: string | symbol, listener: (...args: any[]) => void): this;
+        once(event: string | symbol, listener: (...args: any[]) => void): this;
+        removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+        off(event: string | symbol, listener: (...args: any[]) => void): this;
+        removeAllListeners(event?: string | symbol): this;
+        setMaxListeners(n: number): this;
+        getMaxListeners(): number;
+        listeners(event: string | symbol): Function[];
+        rawListeners(event: string | symbol): Function[];
+        emit(event: string | symbol, ...args: any[]): boolean;
+        listenerCount(type: string | symbol): number;
+        // Added in Node 6...
+        prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
+        prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
+        eventNames(): Array<string | symbol>;
+    }
+
+    type BufferEncoding = "ascii" | "utf8" | "utf-8" | "utf16le" | "ucs2" | "ucs-2" | "base64" | "latin1" | "binary" | "hex";
+
+    interface ReadableStream extends EventEmitter {
+        readable: boolean;
+        read(size?: number): string | Buffer;
+        setEncoding(encoding: string): this;
+        pause(): this;
+        resume(): this;
+        isPaused(): boolean;
+        pipe<T extends WritableStream>(destination: T, options?: { end?: boolean; }): T;
+        unpipe(destination?: WritableStream): this;
+        unshift(chunk: string | Uint8Array, encoding?: BufferEncoding): void;
+        wrap(oldStream: ReadableStream): this;
+        [Symbol.asyncIterator](): AsyncIterableIterator<string | Buffer>;
+    }
+
+    /** }}} */
+
     interface AnnotationOption {
         Type?: string | undefined;
         Rect?: any;
@@ -355,7 +392,7 @@ declare namespace PDFKit.Mixins {
         pattern(bbox: BoundingBox, xStep: number, yStep: number, stream: string): PDFTilingPattern;
     }
 
-    type PDFFontSource = string | Buffer | Uint8Array | ArrayBuffer;
+    type PDFFontSource = string | Uint8Array | ArrayBuffer;
 
     interface PDFFont {
         font(src: PDFFontSource, size?: number): this;
@@ -371,7 +408,7 @@ declare namespace PDFKit.Mixins {
         ): this;
     }
 
-    type ImageSrc = Buffer | ArrayBuffer | string;
+    type ImageSrc = Uint8Array | ArrayBuffer | string;
 
     interface ImageOption {
         width?: number | undefined;
@@ -700,7 +737,7 @@ declare namespace PDFKit {
 
     interface PDFDocument
         extends
-            NodeJS.ReadableStream,
+            Mixins.ReadableStream,
             Mixins.PDFMetadata,
             Mixins.PDFAnnotation,
             Mixins.PDFColor,

--- a/types/pdfkit/package.json
+++ b/types/pdfkit/package.json
@@ -5,9 +5,6 @@
     "projects": [
         "http://pdfkit.org"
     ],
-    "dependencies": {
-        "@types/node": "*"
-    },
     "devDependencies": {
         "@types/pdfkit": "workspace:."
     },

--- a/types/pdfmake/build/pdfmake.d.ts
+++ b/types/pdfmake/build/pdfmake.d.ts
@@ -18,7 +18,7 @@ export interface TCreatedPdf {
 
     getBlob(cb: (result: Blob) => void, options?: BufferOptions): void;
     getBase64(cb: (result: string) => void, options?: BufferOptions): void;
-    getBuffer(cb: (result: Buffer) => void, options?: BufferOptions): void;
+    getBuffer(cb: (result: PDFKit.Mixins.Buffer) => void, options?: BufferOptions): void;
     getDataUrl(cb: (result: string) => void, options?: BufferOptions): void;
     getStream(options?: BufferOptions): PDFKit.PDFDocument; // minimal version 0.1.41
     open(options?: BufferOptions, win?: Window | null): void;

--- a/types/pdfmake/interfaces.d.ts
+++ b/types/pdfmake/interfaces.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 /// <reference types="pdfkit" />
 
 /**

--- a/types/pdfmake/package.json
+++ b/types/pdfmake/package.json
@@ -6,7 +6,6 @@
         "http://pdfmake.org"
     ],
     "dependencies": {
-        "@types/node": "*",
         "@types/pdfkit": "*"
     },
     "devDependencies": {


### PR DESCRIPTION
This PR removes the unnecessary dependency on `@types/node` in `@types/pdfmake`. 
Since `pdfmake` does not depend on Node.js, including this type package can introduce unwanted type conflicts in browser-based projects. 
This change ensures that projects using `pdfmake` without Node.js do not encounter issues related to incorrect type dependencies.  