### PR TITLE
[express-session]: expand Store to expose EventEmitter generic

### DIFF
--- a/types/express-session/express-session-tests.ts
+++ b/types/express-session/express-session-tests.ts
@@ -113,7 +113,7 @@ app.use((req, res, next) => {
 
 // Custom Session Store
 
-class MyStore extends Store {
+class MyStore extends Store<{ test: [number, string] }> {
     private sessions: { [sid: string]: string | undefined };
 
     constructor() {
@@ -130,6 +130,7 @@ class MyStore extends Store {
     set = (sid: string, session: SessionData, callback?: (err?: any) => void): void => {
         this.sessions[sid] = JSON.stringify(session);
         if (callback) callback();
+        this.emit("test", 1, "test");
     };
 
     touch = (sid: string, session: SessionData, callback?: (err?: any) => void) => {

--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -334,7 +334,8 @@ declare namespace session {
         sameSite?: boolean | "lax" | "strict" | "none" | undefined;
     }
 
-    abstract class Store extends EventEmitter {
+    // eslint-disable-next-line @definitelytyped/no-single-element-tuple-type
+    abstract class Store<T extends Record<keyof T, any[]> | [never] = [never]> extends EventEmitter<T> {
         regenerate(req: express.Request, callback: (err?: any) => any): void;
 
         load(sid: string, callback: (err: any, session?: SessionData) => any): void;


### PR DESCRIPTION
Extended the Store to expose the generic of the EventEmitter, so classes that extend from Store can improved the typing information about what events they emit and what typing those events have

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [url](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3e33e063ca78e91056f2fc7bf7a61b6e8b5937d4/types/node/events.d.ts#L133)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
