### PR TITLE
Add missing optional "MediaStreamTrack audioTrack" argument to the "start" method in the SpeechRecognition API

### DIFF
--- a/types/dom-speech-recognition/dom-speech-recognition-tests.ts
+++ b/types/dom-speech-recognition/dom-speech-recognition-tests.ts
@@ -64,6 +64,11 @@ const speechRecognition2: SpeechRecognition = {
 };
 const speechRecognition3 = new webkitSpeechRecognition();
 
+const speechRecognition4: SpeechRecognition = {
+    ...speechRecognition2,
+    start: (audioTrack: MediaStreamTrack) => undefined,
+};
+
 const speechRecognitionResultList = new SpeechRecognitionResultList();
 
 const speechRecognitionEventInit: SpeechRecognitionEventInit = {

--- a/types/dom-speech-recognition/index.d.ts
+++ b/types/dom-speech-recognition/index.d.ts
@@ -32,7 +32,7 @@ interface SpeechRecognition extends EventTarget {
     onspeechstart: ((this: SpeechRecognition, ev: Event) => any) | null;
     onstart: ((this: SpeechRecognition, ev: Event) => any) | null;
     abort(): void;
-    start(): void;
+    start(audioTrack?: MediaStreamTrack): void;
     stop(): void;
     addEventListener<K extends keyof SpeechRecognitionEventMap>(
         type: K,


### PR DESCRIPTION
Add missing optional "MediaStreamTrack audioTrack" argument to the "start" method in the SpeechRecognition API.

See spec here: https://webaudio.github.io/web-speech-api/#dom-speechrecognition-start.