### PR TITLE
Add missing types to `@types/fontkit`

### DIFF
--- a/types/fontkit/fontkit-tests.ts
+++ b/types/fontkit/fontkit-tests.ts
@@ -22,6 +22,18 @@ openV2.then(font => {
     }
 });
 
+// -----------------------
+// API: Font.variationAxes
+// -----------------------
+openV2.then(font => {
+    if (!isCollection(font)) {
+        font.variationAxes.wght?.name; // $ExpectType string | undefined
+        font.variationAxes.wght?.min; // $ExpectType number | undefined
+        font.variationAxes.wght?.default; // $ExpectType number | undefined
+        font.variationAxes.wght?.max; // $ExpectType number | undefined
+    }
+});
+
 // ---------------------
 // API: fontkit.openSync
 // ---------------------

--- a/types/fontkit/fontkit-tests.ts
+++ b/types/fontkit/fontkit-tests.ts
@@ -19,6 +19,7 @@ openV2.then(font => {
     if (!isCollection(font)) {
         const { xAvgCharWidth, fsSelection } = font["OS/2"];
         const isNegative = fsSelection.negative;
+        fsSelection.bold; // $ExpectType boolean
     }
 });
 

--- a/types/fontkit/index.d.ts
+++ b/types/fontkit/index.d.ts
@@ -47,7 +47,7 @@ export interface Font {
     availableFeatures: string[];
 
     /** An object describing the available axes in a variable font. Keys are 4 letter axis tags. */
-    variationAxes: Record<string, { name: string; min: number; default: number; max: number; }>;
+    variationAxes: Partial<Record<string, { name: string; min: number; default: number; max: number; }>>;
 
     /**
      * Returns an array of strings that map to the given glyph id.

--- a/types/fontkit/index.d.ts
+++ b/types/fontkit/index.d.ts
@@ -46,6 +46,9 @@ export interface Font {
     /** an array of all OpenType feature tags (or mapped AAT tags) supported by the font */
     availableFeatures: string[];
 
+    /** An object describing the available axes in a variable font. Keys are 4 letter axis tags. */
+    variationAxes: Record<string, { name: string; min: number; default: number; max: number; }>
+
     /**
      * Returns an array of strings that map to the given glyph id.
      */
@@ -314,6 +317,9 @@ export interface Os2Table {
         underscore: boolean;
         useTypoMetrics: boolean;
         wws: boolean;
+        bold: boolean;
+        regular: boolan;
+        oblique: boolean;
     };
     fsType: {
         bitmapOnly: boolean;

--- a/types/fontkit/index.d.ts
+++ b/types/fontkit/index.d.ts
@@ -47,7 +47,7 @@ export interface Font {
     availableFeatures: string[];
 
     /** An object describing the available axes in a variable font. Keys are 4 letter axis tags. */
-    variationAxes: Partial<Record<string, { name: string; min: number; default: number; max: number; }>>;
+    variationAxes: Partial<Record<string, { name: string; min: number; default: number; max: number }>>;
 
     /**
      * Returns an array of strings that map to the given glyph id.

--- a/types/fontkit/index.d.ts
+++ b/types/fontkit/index.d.ts
@@ -318,7 +318,7 @@ export interface Os2Table {
         useTypoMetrics: boolean;
         wws: boolean;
         bold: boolean;
-        regular: boolan;
+        regular: boolean;
         oblique: boolean;
     };
     fsType: {

--- a/types/fontkit/index.d.ts
+++ b/types/fontkit/index.d.ts
@@ -47,7 +47,7 @@ export interface Font {
     availableFeatures: string[];
 
     /** An object describing the available axes in a variable font. Keys are 4 letter axis tags. */
-    variationAxes: Record<string, { name: string; min: number; default: number; max: number; }>
+    variationAxes: Record<string, { name: string; min: number; default: number; max: number; }>;
 
     /**
      * Returns an array of strings that map to the given glyph id.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
	- Missing `fsSelection` keys: https://github.com/foliojs/fontkit/blob/fbf3b9ef21eebd219eb73e666faed573af0fba09/src/tables/OS2.js#L26-L29
	- Missing `variationAxes` type: https://github.com/foliojs/fontkit/blob/fbf3b9ef21eebd219eb73e666faed573af0fba09/src/TTFFont.js#L437-L461
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
    - It does not; both of the updates are for code from 8–9 years ago.
