### PR TITLE
[ws] Update type of finishRequest to match documentation.

### DIFF
--- a/types/ws/index.d.mts
+++ b/types/ws/index.d.mts
@@ -237,7 +237,7 @@ declare namespace WebSocket {
      * headers. If finishRequest is set, then it has the responsibility to call
      * request.end() once it is done setting request headers.
      */
-    type FinishRequestCallback = (request: IncomingMessage, websocket: WebSocket) => void;
+    type FinishRequestCallback = (request: ClientRequest, websocket: WebSocket) => void;
 
     interface ClientOptions extends SecureContextOptions {
         protocol?: string | undefined;

--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -240,7 +240,7 @@ declare namespace WebSocket {
      * headers. If finishRequest is set, then it has the responsibility to call
      * request.end() once it is done setting request headers.
      */
-    type FinishRequestCallback = (request: IncomingMessage, websocket: WebSocket) => void;
+    type FinishRequestCallback = (request: ClientRequest, websocket: WebSocket) => void;
 
     interface ClientOptions extends SecureContextOptions {
         protocol?: string | undefined;

--- a/types/ws/ws-tests.mts
+++ b/types/ws/ws-tests.mts
@@ -525,7 +525,7 @@ declare module "ws" {
         autoPong: false,
         createConnection: net.createConnection,
         finishRequest: (req, socket) => {
-            // $ExpectType IncomingMessage
+            // $ExpectType ClientRequest
             req;
 
             // $ExpectType WebSocket

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -517,7 +517,7 @@ declare module "ws" {
         autoPong: false,
         createConnection: net.createConnection,
         finishRequest: (req, socket) => {
-            // $ExpectType IncomingMessage
+            // $ExpectType ClientRequest
             req;
 
             // $ExpectType WebSocket


### PR DESCRIPTION
For some reason, the original PR in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70991 set the type of the request as `IncomingMessage`, whereas the document explicitly mentions that it is a `ClientRequest`.

This PR fixes that.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketaddress-protocols-options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.