### PR TITLE
feat(jscodeshift): Update recast and ast-types to align with jscodeshift dependencies

### DIFF
--- a/types/jscodeshift/package.json
+++ b/types/jscodeshift/package.json
@@ -1,13 +1,13 @@
 {
     "private": true,
     "name": "@types/jscodeshift",
-    "version": "0.12.9999",
+    "version": "17.3.0",
     "projects": [
         "https://github.com/facebook/jscodeshift#readme"
     ],
     "dependencies": {
-        "ast-types": "^0.14.1",
-        "recast": "^0.20.3"
+        "ast-types": "^0.16.1",
+        "recast": "^0.23.11"
     },
     "devDependencies": {
         "@types/jscodeshift": "workspace:."

--- a/types/jscodeshift/package.json
+++ b/types/jscodeshift/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/jscodeshift",
-    "version": "17.3.0",
+    "version": "17.3.9999",
     "projects": [
         "https://github.com/facebook/jscodeshift#readme"
     ],


### PR DESCRIPTION
This aligns the versions of the two dependencies of `@types/jscodeshift` with the dependencies of the actual package. This will make it less likely to have incompatible dependencies. I've also updated the version of the type package, since per the PR template, this is about bringing the definitions with the newer versions of the library.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] N/A
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Current recast version](https://github.com/facebook/jscodeshift/blob/main/package.json#L43) and [current ast-type version](https://github.com/benjamn/recast/blob/master/package.json#L46) (transitive through recast)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.