### PR TITLE
[ssh2] Typing update to add client.setNoDelay

### DIFF
--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -701,7 +701,7 @@ export class Client extends EventEmitter {
     /**
      * Calls setNoDelay() on the underlying socket. Disabling Nagle's algorithm improves latency at the expense of lower throughput.
      */
-    setNoDelay(noDelay: boolean): this;
+    setNoDelay(noDelay?: boolean): this;
 }
 
 export type HostVerifier = (key: Buffer, verify: VerifyCallback) => void;

--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -697,6 +697,11 @@ export class Client extends EventEmitter {
      * the server.
      */
     openssh_forwardOutStreamLocal(socketPath: string, cb: ClientCallback): this;
+
+    /**
+     * Calls setNoDelay() on the underlying socket. Disabling Nagle's algorithm improves latency at the expense of lower throughput.
+     */
+    setNoDelay(noDelay: boolean): this;
 }
 
 export type HostVerifier = (key: Buffer, verify: VerifyCallback) => void;

--- a/types/ssh2/ssh2-tests.ts
+++ b/types/ssh2/ssh2-tests.ts
@@ -342,6 +342,10 @@ const sshconfig: ssh2.ConnectConfig = {
     },
 };
 
+// setNoDelay
+var Client = require("ssh2").Client;
+var conn = new Client().setNoDelay(true);
+
 //
 // # Server Examples
 //


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

[Source](https://github.com/mscdex/ssh2/blob/v1.16.0/lib/client.js#L1617)
[ReadMe](https://github.com/mscdex/ssh2/blob/v1.16.0/README.md#client-methods:~:text=setNoDelay(%5B%3C%20boolean%20%3EnoDelay%5D)%20%2D%20Client%20%2D%20Calls%20setNoDelay()%20on%20the%20underlying%20socket.%20Disabling%20Nagle%27s%20algorithm%20improves%20latency%20at%20the%20expense%20of%20lower%20throughput.)

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
Was already present in v1.12.0 (https://github.com/mscdex/ssh2/commit/d312c3ef3e137d2ba61412eb45948127bdc1c764)
