### PR TITLE
[zendesk-web-widget] add resetWidget signature

### DIFF
--- a/types/zendesk-web-widget/index.d.ts
+++ b/types/zendesk-web-widget/index.d.ts
@@ -87,6 +87,11 @@ declare function zE(
  * @see https://developer.zendesk.com/api-reference/widget-messaging/web/core/#set-conversation-tags
  */
 declare function zE(scope: "messenger:set", method: "conversationTags", value: string[]): void;
+/**
+ * Clears all widget local state, including user data, conversations, and connections.
+ * @see https://developer.zendesk.com/api-reference/widget-messaging/web/core/#reset-widget
+ */
+declare function zE(scope: "messenger", method: "resetWidget", value: () => void): void;
 
 /**
  * @see https://developer.zendesk.com/api-reference/widget-messaging/introduction/

--- a/types/zendesk-web-widget/zendesk-web-widget-tests.ts
+++ b/types/zendesk-web-widget/zendesk-web-widget-tests.ts
@@ -46,3 +46,6 @@ const openWidget = () => {
 };
 zE("messenger:set", "conversationFields", [{ id: "123456789", value: 100.50 }], openWidget);
 zE("messenger:set", "conversationTags", ["sales", "computer_accessories"]);
+
+zE("messenger", "resetWidget", function() {
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.zendesk.com/api-reference/widget-messaging/web/core/#reset-widget
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. 
  - The zendesk web widget does not provide a versioning system, as it provides its single function to be backwards compatible. I would use a date-based version, but they also dont seem to have a changelog entry for all updates to the web widget API, so a date-based version would be hard to actually keep track of what changes correspond to which date.
