### PR TITLE
Mark microsoft-graph as conflicting

### DIFF
--- a/types/microsoft-graph/package.json
+++ b/types/microsoft-graph/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "@types/microsoft-graph",
     "version": "2.40.9999",
-    "nonNpm": "conflicit",
+    "nonNpm": "conflict",
     "nonNpmDescription": "microsoft-graph",
     "projects": [
         "https://github.com/microsoftgraph/msgraph-typescript-typings"

--- a/types/microsoft-graph/package.json
+++ b/types/microsoft-graph/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "@types/microsoft-graph",
     "version": "2.40.9999",
-    "nonNpm": true,
+    "nonNpm": "conflicit",
     "nonNpmDescription": "microsoft-graph",
     "projects": [
         "https://github.com/microsoftgraph/msgraph-typescript-typings"


### PR DESCRIPTION
https://www.npmjs.com/package/microsoft-graph now exists on npm and is a different package.

This is a problem for `@types/microsoft-graph` as the npm package will take precedence if installed, but it's unclear if anyone will acutally do so.