### PR TITLE
add statusBarTranslucent prop to react-native-modalbox

### DIFF
--- a/types/react-native-modalbox/index.d.ts
+++ b/types/react-native-modalbox/index.d.ts
@@ -149,6 +149,13 @@ export interface ModalProps {
      * (useful to change the content of the modal, display a message for example)
      */
     onClosingState?(state: boolean): void;
+
+    /**
+     * (Android only) Determines whether your modal should go under the system statusbar.
+     * 
+     * Default is false
+     */
+    statusBarTranslucent?: boolean | undefined;
 }
 
 export default class Modal extends React.Component<ModalProps> {


### PR DESCRIPTION
https://reactnative.dev/docs/modal#statusbartranslucent

The statusBarTranslucent prop determines whether your modal should go under the system statusbar. This prevents the modal from being cutoff by the status bar in landscape.

https://github.com/maxs15/react-native-modalbox/pull/365