### PR TITLE
fix(git-url-parse): port is string in v16

### DIFF
--- a/types/git-url-parse/git-url-parse-tests.ts
+++ b/types/git-url-parse/git-url-parse-tests.ts
@@ -3,6 +3,7 @@ import gitUrlParse = require("git-url-parse");
 gitUrlParse("git@github.com:IonicaBizau/node-git-url-parse.git"); // $ExpectType GitUrl
 gitUrlParse("git@github.com:IonicaBizau/node-git-url-parse.git").toString(); // $ExpectType string
 gitUrlParse("git@github.com:IonicaBizau/node-git-url-parse.git").toString("git+ssh"); // $ExpectType string
+gitUrlParse("git@github.com:IonicaBizau/node-git-url-parse.git").port; // $ExpectType string
 
 gitUrlParse.stringify(gitUrlParse("git@github.com:IonicaBizau/node-git-url-parse.git")); // $ExpectType string
 gitUrlParse.stringify(gitUrlParse("git@github.com:IonicaBizau/node-git-url-parse.git"), "https"); // $ExpectType string

--- a/types/git-url-parse/index.d.ts
+++ b/types/git-url-parse/index.d.ts
@@ -2,7 +2,7 @@ declare namespace gitUrlParse {
     interface GitUrl {
         /** An array with the url protocols (usually it has one element). */
         protocols: string[];
-        port: number | null;
+        port: string;
         /** The url domain (including subdomains). */
         resource: string;
         /** The authentication user (usually for ssh urls). */

--- a/types/git-url-parse/package.json
+++ b/types/git-url-parse/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/git-url-parse",
-    "version": "9.0.9999",
+    "version": "16.0.9999",
     "projects": [
         "https://github.com/IonicaBizau/git-url-parse"
     ],


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/IonicaBizau/parse-path/blob/87f71f273da90f85f6845937a70b7c032eeae4e3/lib/index.js#L14
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
