### PR TITLE
chore(node-apple-receipt-verify): Add missing `originalTransactionId` param

### DIFF
--- a/types/node-apple-receipt-verify/index.d.ts
+++ b/types/node-apple-receipt-verify/index.d.ts
@@ -66,6 +66,7 @@ export interface PurchasedProducts {
     originalPurchaseDate?: number | undefined; // only if extended = true
     applicationVersion?: string | undefined; // only if extended = true
     originalApplicationVersion?: string | undefined; // only if extended = true
+    originalTransactionId?: string | undefined; // only if extended = true
 }
 
 export interface ValidationError extends Error {

--- a/types/node-apple-receipt-verify/node-apple-receipt-verify-tests.ts
+++ b/types/node-apple-receipt-verify/node-apple-receipt-verify-tests.ts
@@ -16,8 +16,39 @@ appleReceiptVerify.validate({ receipt: "test-receipt" }, (err: appleReceiptVerif
 appleReceiptVerify
     .validate({ receipt: "test-receipt" })
     .then((products: appleReceiptVerify.PurchasedProducts[]) => {
-        console.log(products.map((p) => p.productId));
-    })
+        products.forEach((p) => {
+         const {
+                bundleId,
+                transactionId,
+                productId,
+                purchaseDate,
+                quantity,
+                expirationDate,
+                isTrialPeriod,
+                isInIntroOfferPeriod,
+                environment,
+                originalPurchaseDate,
+                applicationVersion,
+                originalApplicationVersion,
+            } = p
+        
+            console.log({
+                bundleId,
+                transactionId,
+                productId,
+                purchaseDate,
+                quantity,
+                expirationDate,
+                isTrialPeriod,
+                isInIntroOfferPeriod,
+                environment,
+                originalPurchaseDate,
+                applicationVersion,
+                originalApplicationVersion
+            })
+        })}
+     )
     .catch((err: appleReceiptVerify.ValidationError) => {
         console.error(err);
     });
+

--- a/types/node-apple-receipt-verify/node-apple-receipt-verify-tests.ts
+++ b/types/node-apple-receipt-verify/node-apple-receipt-verify-tests.ts
@@ -30,6 +30,7 @@ appleReceiptVerify
                 originalPurchaseDate,
                 applicationVersion,
                 originalApplicationVersion,
+                originalTransactionId
             } = p
         
             console.log({
@@ -44,7 +45,8 @@ appleReceiptVerify
                 environment,
                 originalPurchaseDate,
                 applicationVersion,
-                originalApplicationVersion
+                originalApplicationVersion,
+                originalTransactionId
             })
         })}
      )

--- a/types/node-apple-receipt-verify/node-apple-receipt-verify-tests.ts
+++ b/types/node-apple-receipt-verify/node-apple-receipt-verify-tests.ts
@@ -1,24 +1,23 @@
-import { error } from "server/router";
 import appleReceiptVerify = require("node-apple-receipt-verify");
 
 appleReceiptVerify.config({
     secret: "test-secret",
 });
 
-appleReceiptVerify.validate({ receipt: "test-reciept" }, (err, products) => {
+appleReceiptVerify.validate({ receipt: "test-receipt" }, (err: appleReceiptVerify.ValidationError, products: appleReceiptVerify.PurchasedProducts[]) => {
     if (err) {
         console.error(err.appleStatus);
         console.error(err.isRetryable);
         return;
     }
-    console.log(products.map((p: appleReceiptVerify.PurchasedProducts) => p.bundleId));
+    console.log(products.map((p) => p.bundleId));
 });
 
 appleReceiptVerify
-    .validate({ receipt: "test-reciept" })
-    .then(products => {
-        console.log(products.map((p: appleReceiptVerify.PurchasedProducts) => p.productId));
+    .validate({ receipt: "test-receipt" })
+    .then((products: appleReceiptVerify.PurchasedProducts[]) => {
+        console.log(products.map((p) => p.productId));
     })
-    .catch(err => {
+    .catch((err: appleReceiptVerify.ValidationError) => {
         console.error(err);
     });


### PR DESCRIPTION
This PR corrects `node-apple-receipt-verify`'s `validate` method return types, where the `originalTransactionId` is missing.