### PR TITLE
feat(node-red__registry): Allow extra properties on messages

### DIFF
--- a/types/node-red__registry/index.d.ts
+++ b/types/node-red__registry/index.d.ts
@@ -184,6 +184,7 @@ declare namespace registry {
         payload?: unknown | undefined;
         topic?: string | undefined;
         _msgid?: string | undefined;
+        [key: string]: unknown;
     }
 
     interface NodeMessageParts {

--- a/types/node-red__registry/node-red__registry-tests.ts
+++ b/types/node-red__registry/node-red__registry-tests.ts
@@ -94,6 +94,14 @@ function registryTests() {
                     topic: "topic",
                 });
 
+                // send messages with additional parameters
+
+                send({
+                    payload: "payload",
+                    foo: "bar",
+                    test: { property: "example" },
+                });
+
                 // send messages to a subset of the outputs
 
                 send([

--- a/types/node-red__util/node-red__util-tests.ts
+++ b/types/node-red__util/node-red__util-tests.ts
@@ -69,8 +69,6 @@ function utilTests(someNode: Node) {
     const msgClone = util.cloneMessage(msg);
     // $ExpectType string
     const msgKey = msgClone.key;
-    // @ts-expect-error
-    const msgWrongKey = msgClone.wrongKey;
 
     // $ExpectType boolean
     util.compareObjects({}, {});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:

As stated in the [node-red documentation](https://nodered.org/docs/user-guide/messages) a node-red message can have any set of properties, thereby the definition is extended.

The change to the util package is needed because the `input` handler otherwise may not receive the extended Messages.

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

