### PR TITLE
[Luxon] Fix output types of DateTime min/max

### DIFF
--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -1596,18 +1596,30 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      *
      * @param dateTimes - the DateTimes from which to choose the minimum
      */
-    static min<AllValid extends boolean>(
-        ...dateTimes: Array<DateTime<AllValid>>
-    ): (AllValid extends true ? DateTime<Valid> : never) | (AllValid extends false ? DateTime<Invalid> : never);
+    static min<Values extends Array<DateTime<boolean>>>(
+        ...dateTimes: Values
+    ): Values extends [] ? undefined
+        :
+            | (Values extends Array<DateTime<infer AllValues>> ? AllValues extends true ? DateTime<Valid> : never
+                : never)
+            | (Values extends Array<DateTime<infer AllValues>> ? AllValues extends false ? DateTime<Invalid> : never
+                : never)
+            | ([] extends Values ? undefined : never);
 
     /**
      * Return the max of several date times
      *
      * @param dateTimes - the DateTimes from which to choose the maximum
      */
-    static max<AllValid extends boolean>(
-        ...dateTimes: Array<DateTime<AllValid>>
-    ): (AllValid extends true ? DateTime<Valid> : never) | (AllValid extends false ? DateTime<Invalid> : never);
+    static max<Values extends Array<DateTime<boolean>>>(
+        ...dateTimes: Values
+    ): Values extends [] ? undefined
+        :
+            | (Values extends Array<DateTime<infer AllValues>> ? AllValues extends true ? DateTime<Valid> : never
+                : never)
+            | (Values extends Array<DateTime<infer AllValues>> ? AllValues extends false ? DateTime<Invalid> : never
+                : never)
+            | ([] extends Values ? undefined : never);
 
     // MISC
 

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -233,8 +233,13 @@ DateTime.local().toUTC(); // $ExpectType DateTime<true>
 DateTime.utc().toLocal(); // $ExpectType DateTime<true>
 
 DateTime.max(dt, now); // $ExpectType DateTime<true> | DateTime<false>
+DateTime.max(now, now); // $ExpectType DateTime<true>
+DateTime.max(...[dt, now].filter(date => date)); // $ExpectType DateTime<true> | DateTime<false> | undefined
+DateTime.max(); // $ExpectType undefined
 DateTime.min(dt, now); // $ExpectType DateTime<true> | DateTime<false>
 DateTime.min(now, now); // $ExpectType DateTime<true>
+DateTime.min(...[dt, now].filter(date => date)); // $ExpectType DateTime<true> | DateTime<false> | undefined
+DateTime.min(); // $ExpectType undefined
 
 const anything: unknown = 0;
 if (DateTime.isDateTime(anything)) {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/moment/luxon/blob/master/src/impl/util.js#L66>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
