### PR TITLE
node/fs: Add options argument to fs.write method's third parameter

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -2323,15 +2323,15 @@ declare module "fs" {
         /**
          * @default 0
          */
-        offset?: number;
+        offset?: number | undefined;
         /**
          * @default `buffer.byteLength - offset`
          */
-        length?: number;
+        length?: number | undefined;
         /**
          * @default null
          */
-        position?: number | null;
+        position?: number | undefined | null;
     }
     /**
      * Write `buffer` to the file specified by `fd`.

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -2319,6 +2319,20 @@ declare module "fs" {
      * @since v0.1.96
      */
     export function fsyncSync(fd: number): void;
+    export interface WriteOptions {
+        /**
+         * @default 0
+         */
+        offset?: number;
+        /**
+         * @default `buffer.byteLength - offset`
+         */
+        length?: number;
+        /**
+         * @default null
+         */
+        position?: number | null;
+    }
     /**
      * Write `buffer` to the file specified by `fd`.
      *
@@ -2388,6 +2402,20 @@ declare module "fs" {
         callback: (err: NodeJS.ErrnoException | null, written: number, buffer: TBuffer) => void,
     ): void;
     /**
+     * Asynchronously writes `buffer` to the file referenced by the supplied file descriptor.
+     * @param fd A file descriptor.
+     * @param options An object with the following properties:
+     * * `offset` The part of the buffer to be written. If not supplied, defaults to `0`.
+     * * `length` The number of bytes to write. If not supplied, defaults to `buffer.length - offset`.
+     * * `position` The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
+     */
+    export function write<TBuffer extends NodeJS.ArrayBufferView>(
+        fd: number,
+        buffer: TBuffer,
+        options: WriteOptions,
+        callback: (err: NodeJS.ErrnoException | null, written: number, buffer: TBuffer) => void,
+    ): void;
+    /**
      * Asynchronously writes `string` to the file referenced by the supplied file descriptor.
      * @param fd A file descriptor.
      * @param string A string to write.
@@ -2437,6 +2465,22 @@ declare module "fs" {
             offset?: number,
             length?: number,
             position?: number | null,
+        ): Promise<{
+            bytesWritten: number;
+            buffer: TBuffer;
+        }>;
+        /**
+         * Asynchronously writes `buffer` to the file referenced by the supplied file descriptor.
+         * @param fd A file descriptor.
+         * @param options An object with the following properties:
+         * * `offset` The part of the buffer to be written. If not supplied, defaults to `0`.
+         * * `length` The number of bytes to write. If not supplied, defaults to `buffer.length - offset`.
+         * * `position` The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
+         */
+        function __promisify__<TBuffer extends NodeJS.ArrayBufferView>(
+            fd: number,
+            buffer?: TBuffer,
+            options?: WriteOptions,
         ): Promise<{
             bytesWritten: number;
             buffer: TBuffer;

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -19,6 +19,9 @@ import { CopyOptions, CopySyncOptions, cp, cpSync, glob, globSync } from "fs";
     fs.writeFile("thebible.txt", "Do unto others as you would have them do unto you.", assert.ifError);
 
     fs.write(1234, "test", () => {});
+    fs.write(1234, Buffer.from("test"), () => {});
+    fs.write(1234, Buffer.from("test"), { offset: 10, length: 10, position: 10 }, () => {});
+    fs.write(1234, Buffer.from("test"), { position: null }, () => {});
 
     fs.writeFile("Harry Potter", "\"You be wizzing, Harry,\" jived Dumbledore.", {
         encoding: "ascii",

--- a/types/node/v18/fs.d.ts
+++ b/types/node/v18/fs.d.ts
@@ -2337,6 +2337,20 @@ declare module "fs" {
      * @since v0.1.96
      */
     export function fsyncSync(fd: number): void;
+    export interface WriteOptions {
+        /**
+         * @default 0
+         */
+        offset?: number;
+        /**
+         * @default `buffer.byteLength - offset`
+         */
+        length?: number;
+        /**
+         * @default null
+         */
+        position?: number | null;
+    }
     /**
      * Write `buffer` to the file specified by `fd`.
      *
@@ -2403,6 +2417,20 @@ declare module "fs" {
         callback: (err: NodeJS.ErrnoException | null, written: number, buffer: TBuffer) => void,
     ): void;
     /**
+     * Asynchronously writes `buffer` to the file referenced by the supplied file descriptor.
+     * @param fd A file descriptor.
+     * @param options An object with the following properties:
+     * * `offset` The part of the buffer to be written. If not supplied, defaults to `0`.
+     * * `length` The number of bytes to write. If not supplied, defaults to `buffer.length - offset`.
+     * * `position` The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
+     */
+    export function write<TBuffer extends NodeJS.ArrayBufferView>(
+        fd: number,
+        buffer: TBuffer,
+        options: WriteOptions,
+        callback: (err: NodeJS.ErrnoException | null, written: number, buffer: TBuffer) => void,
+    ): void;
+    /**
      * Asynchronously writes `string` to the file referenced by the supplied file descriptor.
      * @param fd A file descriptor.
      * @param string A string to write.
@@ -2452,6 +2480,22 @@ declare module "fs" {
             offset?: number,
             length?: number,
             position?: number | null,
+        ): Promise<{
+            bytesWritten: number;
+            buffer: TBuffer;
+        }>;
+        /**
+         * Asynchronously writes `buffer` to the file referenced by the supplied file descriptor.
+         * @param fd A file descriptor.
+         * @param options An object with the following properties:
+         * * `offset` The part of the buffer to be written. If not supplied, defaults to `0`.
+         * * `length` The number of bytes to write. If not supplied, defaults to `buffer.length - offset`.
+         * * `position` The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
+         */
+        function __promisify__<TBuffer extends NodeJS.ArrayBufferView>(
+            fd: number,
+            buffer?: TBuffer,
+            options?: WriteOptions,
         ): Promise<{
             bytesWritten: number;
             buffer: TBuffer;

--- a/types/node/v18/fs.d.ts
+++ b/types/node/v18/fs.d.ts
@@ -2341,15 +2341,15 @@ declare module "fs" {
         /**
          * @default 0
          */
-        offset?: number;
+        offset?: number | undefined;
         /**
          * @default `buffer.byteLength - offset`
          */
-        length?: number;
+        length?: number | undefined;
         /**
          * @default null
          */
-        position?: number | null;
+        position?: number | undefined | null;
     }
     /**
      * Write `buffer` to the file specified by `fd`.

--- a/types/node/v20/fs.d.ts
+++ b/types/node/v20/fs.d.ts
@@ -2321,15 +2321,15 @@ declare module "fs" {
         /**
          * @default 0
          */
-        offset?: number;
+        offset?: number | undefined;
         /**
          * @default `buffer.byteLength - offset`
          */
-        length?: number;
+        length?: number | undefined;
         /**
          * @default null
          */
-        position?: number | null;
+        position?: number | undefined | null;
     }
     /**
      * Write `buffer` to the file specified by `fd`.

--- a/types/node/v20/fs.d.ts
+++ b/types/node/v20/fs.d.ts
@@ -2317,6 +2317,20 @@ declare module "fs" {
      * @since v0.1.96
      */
     export function fsyncSync(fd: number): void;
+    export interface WriteOptions {
+        /**
+         * @default 0
+         */
+        offset?: number;
+        /**
+         * @default `buffer.byteLength - offset`
+         */
+        length?: number;
+        /**
+         * @default null
+         */
+        position?: number | null;
+    }
     /**
      * Write `buffer` to the file specified by `fd`.
      *
@@ -2386,6 +2400,20 @@ declare module "fs" {
         callback: (err: NodeJS.ErrnoException | null, written: number, buffer: TBuffer) => void,
     ): void;
     /**
+     * Asynchronously writes `buffer` to the file referenced by the supplied file descriptor.
+     * @param fd A file descriptor.
+     * @param options An object with the following properties:
+     * * `offset` The part of the buffer to be written. If not supplied, defaults to `0`.
+     * * `length` The number of bytes to write. If not supplied, defaults to `buffer.length - offset`.
+     * * `position` The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
+     */
+    export function write<TBuffer extends NodeJS.ArrayBufferView>(
+        fd: number,
+        buffer: TBuffer,
+        options: WriteOptions,
+        callback: (err: NodeJS.ErrnoException | null, written: number, buffer: TBuffer) => void,
+    ): void;
+    /**
      * Asynchronously writes `string` to the file referenced by the supplied file descriptor.
      * @param fd A file descriptor.
      * @param string A string to write.
@@ -2435,6 +2463,22 @@ declare module "fs" {
             offset?: number,
             length?: number,
             position?: number | null,
+        ): Promise<{
+            bytesWritten: number;
+            buffer: TBuffer;
+        }>;
+        /**
+         * Asynchronously writes `buffer` to the file referenced by the supplied file descriptor.
+         * @param fd A file descriptor.
+         * @param options An object with the following properties:
+         * * `offset` The part of the buffer to be written. If not supplied, defaults to `0`.
+         * * `length` The number of bytes to write. If not supplied, defaults to `buffer.length - offset`.
+         * * `position` The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
+         */
+        function __promisify__<TBuffer extends NodeJS.ArrayBufferView>(
+            fd: number,
+            buffer?: TBuffer,
+            options?: WriteOptions,
         ): Promise<{
             bytesWritten: number;
             buffer: TBuffer;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v23.x/api/fs.html#fswritefd-buffer-options-callback
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
