### PR TITLE
Fix VS Code settings precedence by splitting

### DIFF
--- a/.vscode/settings.template.json
+++ b/.vscode/settings.template.json
@@ -1,5 +1,29 @@
 {
-    "[typescript][typescriptreact][javascript][javascriptreact][json][jsonc][markdown]": {
+    "[typescript]": {
+        "editor.defaultFormatter": "dprint.dprint",
+        "editor.formatOnSave": true
+    },
+    "[typescriptreact]": {
+        "editor.defaultFormatter": "dprint.dprint",
+        "editor.formatOnSave": true
+    },
+    "[javascript]": {
+        "editor.defaultFormatter": "dprint.dprint",
+        "editor.formatOnSave": true
+    },
+    "[javascriptreact]": {
+        "editor.defaultFormatter": "dprint.dprint",
+        "editor.formatOnSave": true
+    },
+    "[json]": {
+        "editor.defaultFormatter": "dprint.dprint",
+        "editor.formatOnSave": true
+    },
+    "[jsonc]": {
+        "editor.defaultFormatter": "dprint.dprint",
+        "editor.formatOnSave": true
+    },
+    "[markdown]": {
         "editor.defaultFormatter": "dprint.dprint",
         "editor.formatOnSave": true
     }


### PR DESCRIPTION
Following up on a conversation with @jakebailey [on Discord](https://discord.com/channels/508357248330760243/757992230077333655/1356645538241712128), this PR works around microsoft/vscode#168411 by splitting `.vscode/settings.template.json` into multiple sections so that it correctly takes precedence even when `editor.defaultFormatter` is already configured in user-level settings.