### PR TITLE
fix(textarea-caret): Fix global name attached to window

### DIFF
--- a/types/textarea-caret/index.d.ts
+++ b/types/textarea-caret/index.d.ts
@@ -1,4 +1,4 @@
-export = textarea_caret;
+export = getCaretCoordinates;
 
 interface Caret {
     top: number;
@@ -10,4 +10,6 @@ interface Options {
     debug?: boolean | undefined;
 }
 
-declare function textarea_caret(element: HTMLElement, position: number, options?: Options): Caret;
+declare global {
+  function getCaretCoordinates(element: HTMLElement, position: number, options?: Options): Caret;
+}

--- a/types/textarea-caret/index.d.ts
+++ b/types/textarea-caret/index.d.ts
@@ -11,5 +11,5 @@ interface Options {
 }
 
 declare global {
-  function getCaretCoordinates(element: HTMLElement, position: number, options?: Options): Caret;
+    function getCaretCoordinates(element: HTMLElement, position: number, options?: Options): Caret;
 }

--- a/types/textarea-caret/index.d.ts
+++ b/types/textarea-caret/index.d.ts
@@ -10,6 +10,6 @@ interface Options {
     debug?: boolean | undefined;
 }
 
-declare global {
-    function getCaretCoordinates(element: HTMLElement, position: number, options?: Options): Caret;
-}
+declare function getCaretCoordinates(element: HTMLElement, position: number, options?: Options): Caret;
+
+export as namespace getCaretCoordinates;

--- a/types/textarea-caret/textarea-caret-tests.ts
+++ b/types/textarea-caret/textarea-caret-tests.ts
@@ -1,8 +1,17 @@
-import getCaretCoordinates = require("textarea-caret");
+import anyNameYouLike = require("textarea-caret");
 
 const element = document.querySelector("textarea");
 
-element!.addEventListener("input", function() {
-    const caret = getCaretCoordinates(this, this.selectionEnd);
-    console.log("(top, left, height) = (%s, %s, %s)", caret.top, caret.left, caret.height);
-});
+function testImportedLibrary() {
+    element!.addEventListener("input", function() {
+        const caret = anyNameYouLike(this, this.selectionEnd);
+        console.log("(top, left, height) = (%s, %s, %s)", caret.top, caret.left, caret.height);
+    });
+}
+
+function testGlobalName() {
+    element!.addEventListener("input", function() {
+        const caret = getCaretCoordinates(this, this.selectionEnd);
+        console.log("(top, left, height) = (%s, %s, %s)", caret.top, caret.left, caret.height);
+    });
+}

--- a/types/textarea-caret/textarea-caret-tests.ts
+++ b/types/textarea-caret/textarea-caret-tests.ts
@@ -11,7 +11,7 @@ function testImportedLibrary() {
 
 function testGlobalName() {
     element!.addEventListener("input", function() {
-        const caret = getCaretCoordinates(this, this.selectionEnd);
+        const caret = window.getCaretCoordinates(this, this.selectionEnd);
         console.log("(top, left, height) = (%s, %s, %s)", caret.top, caret.left, caret.height);
     });
 }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/component/textarea-caret-position/blob/b5845a4c39cf094b56925183c086f92c8f8fec68/index.js#L152
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

-----

Further explanation:

`textarea-caret` exposes the function name `getCaretCoordinates` on `window` when loaded as a script.  When required as a module, it exports the same function.

The old .d.ts exposed the exported module, but used a different name and didn't make it global.

This corrects the function name and makes it global.