### PR TITLE
fix(nodegit): replace deprecated type names

### DIFF
--- a/types/nodegit/nodegit-tests.ts
+++ b/types/nodegit/nodegit-tests.ts
@@ -226,3 +226,9 @@ Git.Clone("repo_url", "local_path", cloneOptions).then(repoClone => {
     // Use Repo
     repoClone.cleanup();
 });
+
+// Test the Reference.TYPE enum values
+Git.Reference.TYPE.INVALID; // $ExpectType TYPE.INVALID
+Git.Reference.TYPE.DIRECT; // $ExpectType TYPE.DIRECT
+Git.Reference.TYPE.SYMBOLIC; // $ExpectType TYPE.SYMBOLIC
+Git.Reference.TYPE.ALL; // $ExpectType TYPE.ALL

--- a/types/nodegit/reference.d.ts
+++ b/types/nodegit/reference.d.ts
@@ -5,8 +5,12 @@ import { Repository } from "./repository";
 export namespace Reference {
     const enum TYPE {
         INVALID = 0,
+        /** @deprecated Use {@link DIRECT} instead. */
+        OID = 1,
         DIRECT = 1,
         SYMBOLIC = 2,
+        /** @deprecated Use {@link ALL} instead. */
+        LISTALL = 3,
         ALL = 3,
     }
 

--- a/types/nodegit/reference.d.ts
+++ b/types/nodegit/reference.d.ts
@@ -5,13 +5,13 @@ import { Repository } from "./repository";
 export namespace Reference {
     const enum TYPE {
         INVALID = 0,
+        DIRECT = 1,
         /** @deprecated Use {@link DIRECT} instead. */
         OID = 1,
-        DIRECT = 1,
         SYMBOLIC = 2,
+        ALL = 3,
         /** @deprecated Use {@link ALL} instead. */
         LISTALL = 3,
-        ALL = 3,
     }
 
     const enum NORMALIZE {

--- a/types/nodegit/reference.d.ts
+++ b/types/nodegit/reference.d.ts
@@ -5,9 +5,9 @@ import { Repository } from "./repository";
 export namespace Reference {
     const enum TYPE {
         INVALID = 0,
-        OID = 1,
+        DIRECT = 1,
         SYMBOLIC = 2,
-        LISTALL = 3,
+        ALL = 3,
     }
 
     const enum NORMALIZE {


### PR DESCRIPTION
OID is now called DIRECT and LISTALL is now called ALL. ref:
https://github.com/nodegit/nodegit/blob/8f485fab/lib/reference.js#L190-L202

- add deprecation notices to deprecated names
- add new names

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodegit/nodegit/blob/8f485fab/lib/reference.js#L190-L202
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
