### PR TITLE
Fix type of React `bootstrapScripts` and `bootstrapModules` (static)

### DIFF
--- a/types/react-dom/static.d.ts
+++ b/types/react-dom/static.d.ts
@@ -27,10 +27,16 @@ declare global {
 import { ReactNode } from "react";
 import { ErrorInfo } from "./client";
 
+export type BootstrapScriptDescriptor = {
+    src: string;
+    integrity?: string | undefined;
+    crossOrigin?: string | undefined;
+};
+
 export interface PrerenderOptions {
     bootstrapScriptContent?: string;
-    bootstrapScripts?: string[];
-    bootstrapModules?: string[];
+    bootstrapScripts?: Array<string | BootstrapScriptDescriptor>;
+    bootstrapModules?: Array<string | BootstrapScriptDescriptor>;
     identifierPrefix?: string;
     namespaceURI?: string;
     onError?: (error: unknown, errorInfo: ErrorInfo) => string | void;


### PR DESCRIPTION
Same as https://github.com/DefinitelyTyped/DefinitelyTyped/pull/72335 but for `PrerenderOptions`.