### PR TITLE
webpack-livereload-plugin: Support Webpack 5

### DIFF
--- a/types/webpack-livereload-plugin/index.d.ts
+++ b/types/webpack-livereload-plugin/index.d.ts
@@ -1,19 +1,18 @@
 import { ServerOptions } from "https";
-import { Plugin, Stats } from "webpack";
-import webpack = require("webpack");
+import { Compilation, Compiler, WebpackPluginInstance, Stats } from "webpack";
 
-declare class LiveReloadPlugin extends Plugin {
+declare class LiveReloadPlugin implements WebpackPluginInstance {
     readonly isRunning: boolean;
     constructor(options?: LiveReloadPlugin.Options);
 
-    apply(compiler: webpack.Compiler): void;
+    apply(compiler: Compiler): void;
 
     start(watching: any, cb: () => void): void;
     done(stats: Stats): void;
     failed(): void;
     autoloadJs(): string;
     scriptTag(source: string): string;
-    applyCompilation(compilation: webpack.compilation.Compilation): void;
+    applyCompilation(compilation: Compilation): void;
 }
 
 declare namespace LiveReloadPlugin {

--- a/types/webpack-livereload-plugin/index.d.ts
+++ b/types/webpack-livereload-plugin/index.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 
 import { ServerOptions } from "https";
-import { Compilation, Compiler, WebpackPluginInstance, Stats } from "webpack";
+import { Compilation, Compiler, Stats, WebpackPluginInstance } from "webpack";
 
 declare class LiveReloadPlugin implements WebpackPluginInstance {
     readonly isRunning: boolean;

--- a/types/webpack-livereload-plugin/index.d.ts
+++ b/types/webpack-livereload-plugin/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 import { ServerOptions } from "https";
 import { Compilation, Compiler, WebpackPluginInstance, Stats } from "webpack";
 

--- a/types/webpack-livereload-plugin/package.json
+++ b/types/webpack-livereload-plugin/package.json
@@ -1,12 +1,12 @@
 {
     "private": true,
     "name": "@types/webpack-livereload-plugin",
-    "version": "2.3.9999",
+    "version": "3.0.9999",
     "projects": [
         "https://github.com/statianzo/webpack-livereload-plugin#readme"
     ],
     "dependencies": {
-        "@types/webpack": "^4"
+        "webpack": "^5"
     },
     "devDependencies": {
         "@types/webpack-livereload-plugin": "workspace:."

--- a/types/webpack-livereload-plugin/package.json
+++ b/types/webpack-livereload-plugin/package.json
@@ -6,6 +6,7 @@
         "https://github.com/statianzo/webpack-livereload-plugin#readme"
     ],
     "dependencies": {
+        "@types/node": "*",
         "webpack": "^5"
     },
     "devDependencies": {

--- a/types/webpack-livereload-plugin/webpack-livereload-plugin-tests.ts
+++ b/types/webpack-livereload-plugin/webpack-livereload-plugin-tests.ts
@@ -1,7 +1,7 @@
 import LiveReloadPlugin = require("webpack-livereload-plugin");
-import { Plugin } from "webpack";
+import { WebpackPluginInstance } from "webpack";
 
-const plugins: Plugin[] = [
+const plugins: WebpackPluginInstance[] = [
     new LiveReloadPlugin(),
     new LiveReloadPlugin({}),
     new LiveReloadPlugin({


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://webpack.js.org/blog/2020-10-10-webpack-5-release/#typescript-typings
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

I'm doing this to try to resolve conflicts when using this types package alongside webpack 5. Different package managers are hoisting things differently and I'm seeing conflicts occurring between webpack 4 and 5 types. I've set this as a major bump as I believe it is a breaking change however I'm not sure it aligns with the original js package.
