### PR TITLE
Update tests in react-plotly.js to be forward-compatible with Plotly v3

### DIFF
--- a/types/react-plotly.js/react-plotly.js-tests.tsx
+++ b/types/react-plotly.js/react-plotly.js-tests.tsx
@@ -19,7 +19,7 @@ export class SimpleChartComponent extends React.PureComponent<any> {
                     },
                     { type: "bar", x: [1, 2, 3], y: [2, 5, 3] },
                 ]}
-                layout={{ width: 320, height: 240, title: "A Fancy Plot" }}
+                layout={{ width: 320, height: 240, title: { text: "A Fancy Plot" } }}
             />
         );
     }
@@ -72,7 +72,7 @@ export class MinChartComponent extends React.PureComponent<any> {
                     },
                     { type: "bar", x: [1, 2, 3], y: [2, 5, 3] },
                 ]}
-                layout={{ width: 320, height: 240, title: "A Fancy Plot" }}
+                layout={{ width: 320, height: 240, title: { text: "A Fancy Plot" } }}
             />
         );
     }
@@ -88,7 +88,7 @@ export const HoverPlot = () => {
                     type: "scatter",
                 },
             ]}
-            layout={{ width: 320, height: 240, title: "A Fancy Plot" }}
+            layout={{ width: 320, height: 240, title: { text: "A Fancy Plot" } }}
             onHover={e => console.log(e)}
             onBeforeHover={e => Boolean(e.points[0].x === 1)}
         />
@@ -105,7 +105,7 @@ export const WebGLPlot = () => {
                     type: "scattergl",
                 },
             ]}
-            layout={{ width: 320, height: 240, title: "A Fancy Plot" }}
+            layout={{ width: 320, height: 240, title: { text: "A Fancy Plot" } }}
             onHover={e => console.log(e)}
             onWebGlContextLost={() => console.log("WebGL context lost")}
         />


### PR DESCRIPTION
Long ago it used to be the standard in Plotly to have separate props for `title` (as a string), `titlefont`, etc. in places like the main plot layout and axis definitions.  This was deprecated in 2018 in favour of a structured object value for `title` with `text`, `font`, etc. as sub-properties.

The old style has been removed entirely in Plotly v3, so this commit updates the _tests_ (only) in `react-plotly.js` to be forward compatible, ready for when the types are updated to v3.  The `react-plotly.js` module does not enforce a runtime dependency on any specific version of Plotly, it will work with whatever version is installed alongside it.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - the old title-as-string format was officially deprecated in https://github.com/plotly/plotly.js/pull/3276
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

I had previously included this in another PR to bring the Plotly type definitions up to date with v3, but I want to re-work that to maintain the v2 types separately (given the large installed base of v2 users) so it makes more sense to fix these tests separately.