### PR TITLE
Replace prettier script with format using dprint

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "clean-node-modules": "node scripts/clean-node-modules.js",
         "test": "node --enable-source-maps node_modules/@definitelytyped/dtslint/ types",
         "lint": "node --enable-source-maps node_modules/@definitelytyped/dtslint/ types",
-        "prettier": "prettier",
+        "format": "dprint fmt",
         "setup-hooks": "husky install"
     },
     "devDependencies": {


### PR DESCRIPTION
It was confusing to see a prettier script in package.json when prettier isn't used. I saw in the readme that dprint is used instead, so having a format command here that runs dprint would be more clear and convenient.

The PR template doesn't apply since I'm not changing a package, so I removed it from this description.