### PR TITLE
feat(itemsjs): add missing `ids` parameter to SearchOptions

### DIFF
--- a/types/itemsjs/index.d.ts
+++ b/types/itemsjs/index.d.ts
@@ -45,7 +45,7 @@ declare namespace itemsjs {
         /** @default false */
         is_all_filtered_items?: boolean | undefined;
 
-        /** Restricts results to items matching the custom ID field (default: "id"). */
+        /** Restricts results to items whose values match the ID field (`id` by default or as defined in `custom_id_field`). */
         ids?: I[IdField][];
     }
 

--- a/types/itemsjs/index.d.ts
+++ b/types/itemsjs/index.d.ts
@@ -39,6 +39,8 @@ declare namespace itemsjs {
         removeStopWordFilter?: boolean | undefined;
         /** @default false */
         is_all_filtered_items?: boolean | undefined;
+        /** A list of item IDs to restrict the search results to */
+        ids?: Array<I extends { id: infer ID } ? ID : unknown>;
     }
 
     interface AggregationOptions<A extends string> {

--- a/types/itemsjs/index.d.ts
+++ b/types/itemsjs/index.d.ts
@@ -26,7 +26,7 @@ declare namespace itemsjs {
         I extends {},
         S extends string,
         A extends keyof I & string,
-        IdField extends keyof I & string
+        IdField extends keyof I & string,
     > {
         query?: string | undefined;
         /** @default 1 */
@@ -73,7 +73,7 @@ declare namespace itemsjs {
         I extends {},
         S extends string,
         A extends keyof I & string,
-        IdField extends keyof I & string
+        IdField extends keyof I & string,
     > {
         /** Search items */
         search(options?: SearchOptions<I, S, A, IdField>): {
@@ -142,7 +142,7 @@ declare namespace itemsjs {
         I extends {},
         S extends string,
         A extends keyof I & string,
-        IdField extends string = 'id'
+        IdField extends string = "id",
     > {
         sortings?: Record<S, Sorting<I>> | undefined;
         aggregations?: Record<A, Aggregation> | undefined;
@@ -168,12 +168,10 @@ declare function itemsjs<
     I extends Record<string, any> = Record<string, any>,
     S extends string = string,
     A extends keyof I & string = keyof I & string,
-    IdField extends keyof I & string = 'id'
+    IdField extends keyof I & string = "id",
 >(
     items: I[],
-    configuration?: itemsjs.Configuration<I, S, A, IdField>
+    configuration?: itemsjs.Configuration<I, S, A, IdField>,
 ): itemsjs.ItemsJs<I, S, A, IdField>;
-
-
 
 export = itemsjs;

--- a/types/itemsjs/index.d.ts
+++ b/types/itemsjs/index.d.ts
@@ -22,7 +22,12 @@ declare namespace itemsjs {
         total: number;
     }
 
-    interface SearchOptions<I extends {}, S extends string, A extends keyof I & string> {
+    interface SearchOptions<
+        I extends {},
+        S extends string,
+        A extends keyof I & string,
+        IdField extends keyof I & string
+    > {
         query?: string | undefined;
         /** @default 1 */
         page?: number | undefined;
@@ -39,8 +44,9 @@ declare namespace itemsjs {
         removeStopWordFilter?: boolean | undefined;
         /** @default false */
         is_all_filtered_items?: boolean | undefined;
-        /** A list of item IDs to restrict the search results to */
-        ids?: Array<I extends { id: infer ID } ? ID : unknown>;
+
+        /** Restricts results to items matching the custom ID field (default: "id"). */
+        ids?: I[IdField][];
     }
 
     interface AggregationOptions<A extends string> {
@@ -63,9 +69,14 @@ declare namespace itemsjs {
         per_page?: number | undefined;
     }
 
-    interface ItemsJs<I extends {}, S extends string, A extends keyof I & string> {
+    interface ItemsJs<
+        I extends {},
+        S extends string,
+        A extends keyof I & string,
+        IdField extends keyof I & string
+    > {
         /** Search items */
-        search(options?: SearchOptions<I, S, A>): {
+        search(options?: SearchOptions<I, S, A, IdField>): {
             data: {
                 items: I[];
                 allFilteredItems: I[] | null;
@@ -88,10 +99,10 @@ declare namespace itemsjs {
 
         /**
          * Find similar items.
-         * Uses the `id` key on items to check for uniqueness
+         * Uses the `id` key or the one set via `custom_id_field` to check for uniqueness..
          */
         similar(
-            id: I extends { id: infer ID } ? ID : unknown,
+            id: I[IdField],
             options: SimilarOptions<I>,
         ): {
             data: { items: Array<I & { _id: number; intersection_length: number }> };
@@ -127,26 +138,42 @@ declare namespace itemsjs {
     }
 
     /** Configuration for itemsjs */
-    interface Configuration<I extends {}, S extends string, A extends keyof I & string> {
+    interface Configuration<
+        I extends {},
+        S extends string,
+        A extends keyof I & string,
+        IdField extends string = 'id'
+    > {
         sortings?: Record<S, Sorting<I>> | undefined;
         aggregations?: Record<A, Aggregation> | undefined;
         /** @default [] */
         searchableFields?: Array<keyof I> | undefined;
         /** @default true */
         native_search_enabled?: boolean | undefined;
+        /** @default 'id' — defines which field represents the unique ID */
+        custom_id_field?: IdField;
     }
 }
 
 /**
  * Main itemsjs function
  * @param items The items to index
- * @param configuration itemsjs
+ * @param configuration Configuration options including sortings, aggregations, and optionally a custom ID field.
  * @template I The type of items being indexed
+ * @template S The keys of sortings defined in the configuration.
+ * @template A The keys of aggregations defined in the configuration.
+ * @template IdField The field used as the unique identifier for items (defaults to "id").
  */
 declare function itemsjs<
-    I extends {} = Record<any, unknown>,
+    I extends Record<string, any> = Record<string, any>,
     S extends string = string,
     A extends keyof I & string = keyof I & string,
->(items: I[], configuration?: itemsjs.Configuration<I, S, A>): itemsjs.ItemsJs<I, S, A>;
+    IdField extends keyof I & string = 'id'
+>(
+    items: I[],
+    configuration?: itemsjs.Configuration<I, S, A, IdField>
+): itemsjs.ItemsJs<I, S, A, IdField>;
+
+
 
 export = itemsjs;

--- a/types/itemsjs/itemsjs-tests.ts
+++ b/types/itemsjs/itemsjs-tests.ts
@@ -106,33 +106,30 @@ itemsIds.similar(0, {});
 
 itemsIds.similar(0, { field: "name" });
 
-
 // Custom id field should be an existing key in the object
 itemsjs(myitems, {
-    custom_id_field: 'name',
+    custom_id_field: "name",
 });
 
 itemsjs(myitems, {
     // @ts-expect-error
-    custom_id_field: 'keyThatDoesNotExist',
+    custom_id_field: "keyThatDoesNotExist",
 });
-
-
 
 // Ids types should match the custom_id_field type
 const itemsCustomId = itemsjs(myitems, {
-    custom_id_field: 'name',
+    custom_id_field: "name",
 });
-// @ts-expect-error 
-itemsCustomId.search({ ids: [1, 2] })
+// @ts-expect-error
+itemsCustomId.search({ ids: [1, 2] });
 // @ts-expect-error
 itemsCustomId.similar(1, { field: "name" });
-itemsCustomId.similar('a', { field: 'name' });
-itemsCustomId.search({ ids: ["foo", "bar"] })
+itemsCustomId.similar("a", { field: "name" });
+itemsCustomId.search({ ids: ["foo", "bar"] });
 itemsCustomId.search({
     // @ts-expect-error
     ids: [1],
 });
 itemsCustomId.search({
-    ids: ['a'],
+    ids: ["a"],
 });

--- a/types/itemsjs/itemsjs-tests.ts
+++ b/types/itemsjs/itemsjs-tests.ts
@@ -105,3 +105,34 @@ itemsIds.similar(0);
 itemsIds.similar(0, {});
 
 itemsIds.similar(0, { field: "name" });
+
+
+// Custom id field should be an existing key in the object
+itemsjs(myitems, {
+    custom_id_field: 'name',
+});
+
+itemsjs(myitems, {
+    // @ts-expect-error
+    custom_id_field: 'keyThatDoesNotExist',
+});
+
+
+
+// Ids types should match the custom_id_field type
+const itemsCustomId = itemsjs(myitems, {
+    custom_id_field: 'name',
+});
+// @ts-expect-error 
+itemsCustomId.search({ ids: [1, 2] })
+// @ts-expect-error
+itemsCustomId.similar(1, { field: "name" });
+itemsCustomId.similar('a', { field: 'name' });
+itemsCustomId.search({ ids: ["foo", "bar"] })
+itemsCustomId.search({
+    // @ts-expect-error
+    ids: [1],
+});
+itemsCustomId.search({
+    ids: ['a'],
+});


### PR DESCRIPTION
I also opened a PR to update the documentation: https://github.com/itemsapi/itemsjs/pull/144  
**It might be best to wait for that PR to be reviewed and accepted before merging this one.**

The `ids` parameter is used to limit search results to specific item IDs, especially useful when integrating with external full-text search engines like MiniSearch.

This option is already supported by ItemsJS but was missing from the type definition.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test itemsjs`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

### If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/itemsapi/itemsjs/blob/master/docs/minisearch-integration.md#example
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
