### PR TITLE
Update accept-language-parser to accept readonly language options

### DIFF
--- a/types/accept-language-parser/accept-language-parser-tests.ts
+++ b/types/accept-language-parser/accept-language-parser-tests.ts
@@ -24,14 +24,19 @@ type Lang = "en-US" | "ko-KR";
 const enUs: Lang = "en-US";
 const koKr: Lang = "ko-KR";
 
+const readonlyLocales: readonly string[] = ["bg", "en"];
+const readonlyLangs: readonly Lang[] = [enUs, koKr];
+
 const parsed1: AcceptLanguageParser.Language[] = AcceptLanguageParser.parse("");
 const parsed: AcceptLanguageParser.Language[] = AcceptLanguageParser.parse();
 const pick1: string | null = AcceptLanguageParser.pick([""], "");
 const pick2: string | null = AcceptLanguageParser.pick([""], [l1, l2, l3]);
 const pick3: string | null = AcceptLanguageParser.pick([""], "", {});
 const pick4: string | null = AcceptLanguageParser.pick([""], "", { loose: true });
-const pick5: Lang | null = AcceptLanguageParser.pick<Lang>([enUs, koKr], [l1, l2, l3]);
-const pick6: Lang | null = AcceptLanguageParser.pick([enUs, koKr], [l1, l2, l3]);
+const pick5: string | null = AcceptLanguageParser.pick(readonlyLocales, [l1, l2, l3]);
+const pick6: Lang | null = AcceptLanguageParser.pick<Lang>([enUs, koKr], [l1, l2, l3]);
+const pick7: Lang | null = AcceptLanguageParser.pick([enUs, koKr], [l1, l2, l3]);
+const pick8: Lang | null = AcceptLanguageParser.pick(readonlyLangs, [l1, l2, l3]);
 
 const pickOptions: AcceptLanguageParser.PickOptions = {
     loose: true,

--- a/types/accept-language-parser/index.d.ts
+++ b/types/accept-language-parser/index.d.ts
@@ -2,7 +2,7 @@
 
 export function parse(acceptLanguage?: string): Language[];
 export function pick<T extends string>(
-    supportedLanguages: T[],
+    supportedLanguages: readonly T[],
     acceptLanguage: string | Language[],
     options?: PickOptions,
 ): T | null;


### PR DESCRIPTION
When defining supported languages (locales), it's somewhat common to make the arrays storing the locales immutable. When you try to pass such an array to the `pick` function, TypeScript shows the following error: 

```
     │     The type 'readonly ["bg", "en"]' is 'readonly' and cannot be assigned to the mutable type 'string[]'. typescript (2345) [19, 58]
```

The pick function's code is not mutating the array. Therefore, I assume it's okay if we accept the structurally more broader type of `readonly T[]` which would allow both mutable and immutable entries to be passed.

[Url to function's code](https://github.com/opentable/accept-language-parser/blob/03bac2683a77e7254687f8c4996e8115a59d2ee2/index.js#L42)