### PR TITLE
Correct backbone AddOptions to match annotated source

### DIFF
--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -8,13 +8,7 @@ declare namespace Backbone {
     type _Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
     type _Result<T> = T | (() => T);
     type _StringKey<T> = keyof T & string;
-
-    interface AddOptions extends Silenceable {
-        at?: number | undefined;
-        merge?: boolean | undefined;
-        sort?: boolean | undefined;
-    }
-
+    
     interface CollectionSetOptions extends Parseable, Silenceable {
         add?: boolean | undefined;
         remove?: boolean | undefined;
@@ -22,6 +16,8 @@ declare namespace Backbone {
         at?: number | undefined;
         sort?: boolean | undefined;
     }
+
+    type AddOptions = _Omit<CollectionSetOptions, "add" | "remove">;
 
     interface HistoryOptions extends Silenceable {
         pushState?: boolean | undefined;


### PR DESCRIPTION
```
add: function(models, options) {
      return this.set(models, _.extend({merge: false}, options, addOptions));
    },
```

As seen on https://backbonejs.org/docs/backbone.html

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [x] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [x] Delete the package's directory.
- [x] Add it to `notNeededPackages.json`.
