### PR TITLE
improv(lodash/fp): add type guard on isEmpty onto mutable arrays

### DIFF
--- a/types/lodash/fp.d.ts
+++ b/types/lodash/fp.d.ts
@@ -1925,7 +1925,7 @@ declare namespace _ {
     interface LodashIsEmpty {
         <T extends { __trapAny: any }>(value: T): boolean;
         (value: string | null | undefined): value is '' | null | undefined;
-        (value: any[] | null | undefined): boolean;
+        (value: any[] | null | undefined): value is [] | null | undefined;
         (value: readonly any[] | null | undefined): value is Readonly<[]> | null | undefined;
         (value: Map<any, any> | Set<any> | lodash.List<any> | null | undefined): boolean;
         <T extends object>(value: T | null | undefined): value is lodash.EmptyObjectOf<T> | null | undefined;


### PR DESCRIPTION
### Improve `lodash/fp/isEmpty` typings with type guard for mutable arrays

#### Summary

Adds a specific overload for `isEmpty` in `lodash/fp` that acts as a type guard for mutable arrays (`any[]`). This allows TypeScript to narrow types when checking if an array is not empty.

#### Benefits

- Improves type inference in functional code
- Enables safer and cleaner usage without manual type assertions

#### Example

```ts
if (!isEmpty(arr)) {
  // arr is now known to be non-empty
  console.log(arr[0]);
}
