### PR TITLE
fix definition for qz-tray

### DIFF
--- a/types/qz-tray/index.d.ts
+++ b/types/qz-tray/index.d.ts
@@ -231,6 +231,7 @@ export type HidGetFeatureReportsDeviceInfoInput = HidDeviceInfoInput & {
     responseSize: string;
 };
 export type HidOpenStreamDeviceInfoInput = HidDeviceInfoInput & {
+    responseSize: string | number
     interval?: number;
 };
 export type HidReadDataDeviceInfoInput = HidDeviceInfoInput & {

--- a/types/qz-tray/qz-tray-tests.ts
+++ b/types/qz-tray/qz-tray-tests.ts
@@ -49,7 +49,7 @@ const isClaimedFn = async () =>
     qz.hid.isClaimed({ vendorId: "01x10", productId: "1x", usagePage: "09x6546565", serial: "1" });
 const listDevicesFn = async () => qz.hid.listDevices();
 const openStreamFn = async () =>
-    qz.hid.openStream({ vendorId: "01x10", productId: "1x", usagePage: "09x6546565", serial: "1" });
+    qz.hid.openStream({ vendorId: "01x10", productId: "1x", usagePage: "09x6546565", serial: "1", responseSize: "8" });
 const readData = async () =>
     qz.hid.readData({ vendorId: "01x10", productId: "1x", usagePage: "09x6546565", serial: "1", responseSize: "20" });
 const releaseDeviceFn = async () =>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

  - [documentation shows responseSize as a parameter with no default](https://qz.io/api/qz.hid#.openStream)
  - [code comment shows attribute's existence](https://qz.io/api/qz-tray.js#line2377)
  - in my own testing, the callback function set with `qz.hid.setHidCallbacks` is never called if `responseSize` is missing from `HidOpenStreamDeviceInfoInput` when opening a stream with `qz.hid.openStream`
  - [code in the index file mentioned in the getting started guide](https://qz.io/docs/getting-started#background) shows this usage:
 
```
// excerpt
const openHidStreamConfig = {
  vendorId: $("#hidVendor").val(),
  productId: $("#hidProduct").val(),
  usagePage: $("#hidUsagePage").val(),
  serial: $("#hidSerial").val(),
  responseSize: $("#hidResponse").val(),
  interval: $("#hidStream").val()
};
console.log('openHidStream', openHidStreamConfig)
qz.hid.openStream(openHidStreamConfig)
```


- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
