### PR TITLE
fix(webxr): wrong type for XRProjectionLayer.ignoreDepthValues

### DIFF
--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -954,7 +954,7 @@ interface XRProjectionLayer extends XRCompositionLayer {
     readonly textureWidth: number;
     readonly textureHeight: number;
     readonly textureArrayLength: number;
-    readonly ignoreDepthValues: number;
+    readonly ignoreDepthValues: boolean;
     fixedFoveation: number;
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. 

**_Erroring in the main three.js repo._**

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [MDN official doc](https://developer.mozilla.org/en-US/docs/Web/API/XRProjectionLayer/ignoreDepthValues)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

![image](https://github.com/user-attachments/assets/641e85c9-1631-448d-a7c1-6cc971b4271e)
