### PR TITLE
fix(node/assert): make partialDeepStrictEqual() assert in compile time

### DIFF
--- a/types/node/assert.d.ts
+++ b/types/node/assert.d.ts
@@ -1008,7 +1008,11 @@ declare module "assert" {
          * ```
          * @since v22.13.0
          */
-        function partialDeepStrictEqual(actual: unknown, expected: unknown, message?: string | Error): void;
+        function partialDeepStrictEqual<T>(
+            actual: unknown,
+            expected: T,
+            message?: string | Error,
+        ): asserts actual is Partial<T>;
         /**
          * In strict assertion mode, non-strict methods behave like their corresponding strict methods. For example,
          * {@link deepEqual} will behave like {@link deepStrictEqual}.

--- a/types/node/test/assert.ts
+++ b/types/node/test/assert.ts
@@ -141,7 +141,15 @@ assert.throws(
 
 assert["fail"](true, true, "works like a charm");
 
-assert.partialDeepStrictEqual({ a: 1, b: 2, c: 3 }, { a: 1, b: 2 });
+declare let partialDeepStrictEqualActual: unknown;
+declare let partialDeepStrictEqualExpected: { a: number; b: number };
+assert.partialDeepStrictEqual(partialDeepStrictEqualActual, partialDeepStrictEqualExpected);
+// $ExpectType Partial<{ a: number, b: number }>
+partialDeepStrictEqualActual;
+// $ExpectType number | undefined
+partialDeepStrictEqualActual.a;
+// $ExpectType number | undefined
+partialDeepStrictEqualActual.b;
 
 {
     const a = null as any;


### PR DESCRIPTION
Following the existing practice of `deepStrictEqual()`, I believe the newly-added `partialDeepStrictEqual()` should also be able to perform compile-time assertion on `actual` parameter.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
