### PR TITLE
fix(node): update options of filehandle.readFile()

### DIFF
--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -284,7 +284,7 @@ declare module "fs/promises" {
          */
         readFile(
             options?:
-                | ({ encoding?: null | undefined; } & Abortable)
+                | ({ encoding?: null | undefined } & Abortable)
                 | null,
         ): Promise<Buffer>;
         /**
@@ -293,7 +293,7 @@ declare module "fs/promises" {
          */
         readFile(
             options:
-                | ({ encoding: BufferEncoding; } & Abortable)
+                | ({ encoding: BufferEncoding } & Abortable)
                 | BufferEncoding,
         ): Promise<string>;
         /**

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -283,36 +283,26 @@ declare module "fs/promises" {
          * data will be a string.
          */
         readFile(
-            options?: {
-                encoding?: null | undefined;
-                flag?: OpenMode | undefined;
-            } | null,
+            options?:
+                | ({ encoding?: null | undefined; } & Abortable)
+                | null,
         ): Promise<Buffer>;
         /**
          * Asynchronously reads the entire contents of a file. The underlying file will _not_ be closed automatically.
          * The `FileHandle` must have been opened for reading.
-         * @param options An object that may contain an optional flag.
-         * If a flag is not provided, it defaults to `'r'`.
          */
         readFile(
             options:
-                | {
-                    encoding: BufferEncoding;
-                    flag?: OpenMode | undefined;
-                }
+                | ({ encoding: BufferEncoding; } & Abortable)
                 | BufferEncoding,
         ): Promise<string>;
         /**
          * Asynchronously reads the entire contents of a file. The underlying file will _not_ be closed automatically.
          * The `FileHandle` must have been opened for reading.
-         * @param options An object that may contain an optional flag.
-         * If a flag is not provided, it defaults to `'r'`.
          */
         readFile(
             options?:
-                | (ObjectEncodingOptions & {
-                    flag?: OpenMode | undefined;
-                })
+                | (ObjectEncodingOptions & Abortable)
                 | BufferEncoding
                 | null,
         ): Promise<string | Buffer>;

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -1094,4 +1094,8 @@ const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Ma
     fd.appendFile("test", { signal: new AbortSignal(), encoding: "utf-8" });
     // @ts-expect-error
     fd.appendFile("test", { mode: 0o777, flush: true, flag: "a" });
+
+    fd.readFile({ signal: new AbortSignal(), encoding: "utf-8" });
+    // @ts-expect-error
+    fd.readFile({ encoding: "utf-8", flag: "r" });
 });

--- a/types/node/v18/fs/promises.d.ts
+++ b/types/node/v18/fs/promises.d.ts
@@ -271,36 +271,26 @@ declare module "fs/promises" {
          * data will be a string.
          */
         readFile(
-            options?: {
-                encoding?: null | undefined;
-                flag?: OpenMode | undefined;
-            } | null,
+            options?:
+                | ({ encoding?: null | undefined; } & Abortable)
+                | null,
         ): Promise<Buffer>;
         /**
          * Asynchronously reads the entire contents of a file. The underlying file will _not_ be closed automatically.
          * The `FileHandle` must have been opened for reading.
-         * @param options An object that may contain an optional flag.
-         * If a flag is not provided, it defaults to `'r'`.
          */
         readFile(
             options:
-                | {
-                    encoding: BufferEncoding;
-                    flag?: OpenMode | undefined;
-                }
+                | ({ encoding: BufferEncoding; } & Abortable)
                 | BufferEncoding,
         ): Promise<string>;
         /**
          * Asynchronously reads the entire contents of a file. The underlying file will _not_ be closed automatically.
          * The `FileHandle` must have been opened for reading.
-         * @param options An object that may contain an optional flag.
-         * If a flag is not provided, it defaults to `'r'`.
          */
         readFile(
             options?:
-                | (ObjectEncodingOptions & {
-                    flag?: OpenMode | undefined;
-                })
+                | (ObjectEncodingOptions & Abortable)
                 | BufferEncoding
                 | null,
         ): Promise<string | Buffer>;

--- a/types/node/v18/fs/promises.d.ts
+++ b/types/node/v18/fs/promises.d.ts
@@ -272,7 +272,7 @@ declare module "fs/promises" {
          */
         readFile(
             options?:
-                | ({ encoding?: null | undefined; } & Abortable)
+                | ({ encoding?: null | undefined } & Abortable)
                 | null,
         ): Promise<Buffer>;
         /**
@@ -281,7 +281,7 @@ declare module "fs/promises" {
          */
         readFile(
             options:
-                | ({ encoding: BufferEncoding; } & Abortable)
+                | ({ encoding: BufferEncoding } & Abortable)
                 | BufferEncoding,
         ): Promise<string>;
         /**

--- a/types/node/v18/test/fs.ts
+++ b/types/node/v18/test/fs.ts
@@ -883,4 +883,8 @@ const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Ma
     fd.appendFile("test", { signal: new AbortSignal(), encoding: "utf-8" });
     // @ts-expect-error
     fd.appendFile("test", { mode: 0o777, flush: true, flag: "a" });
+
+    fd.readFile({ signal: new AbortSignal(), encoding: "utf-8" });
+    // @ts-expect-error
+    fd.readFile({ encoding: "utf-8", flag: "r" });
 });

--- a/types/node/v20/fs/promises.d.ts
+++ b/types/node/v20/fs/promises.d.ts
@@ -276,36 +276,26 @@ declare module "fs/promises" {
          * data will be a string.
          */
         readFile(
-            options?: {
-                encoding?: null | undefined;
-                flag?: OpenMode | undefined;
-            } | null,
+            options?:
+                | ({ encoding?: null | undefined; } & Abortable)
+                | null,
         ): Promise<Buffer>;
         /**
          * Asynchronously reads the entire contents of a file. The underlying file will _not_ be closed automatically.
          * The `FileHandle` must have been opened for reading.
-         * @param options An object that may contain an optional flag.
-         * If a flag is not provided, it defaults to `'r'`.
          */
         readFile(
             options:
-                | {
-                    encoding: BufferEncoding;
-                    flag?: OpenMode | undefined;
-                }
+                | ({ encoding: BufferEncoding; } & Abortable)
                 | BufferEncoding,
         ): Promise<string>;
         /**
          * Asynchronously reads the entire contents of a file. The underlying file will _not_ be closed automatically.
          * The `FileHandle` must have been opened for reading.
-         * @param options An object that may contain an optional flag.
-         * If a flag is not provided, it defaults to `'r'`.
          */
         readFile(
             options?:
-                | (ObjectEncodingOptions & {
-                    flag?: OpenMode | undefined;
-                })
+                | (ObjectEncodingOptions & Abortable)
                 | BufferEncoding
                 | null,
         ): Promise<string | Buffer>;

--- a/types/node/v20/fs/promises.d.ts
+++ b/types/node/v20/fs/promises.d.ts
@@ -277,7 +277,7 @@ declare module "fs/promises" {
          */
         readFile(
             options?:
-                | ({ encoding?: null | undefined; } & Abortable)
+                | ({ encoding?: null | undefined } & Abortable)
                 | null,
         ): Promise<Buffer>;
         /**
@@ -286,7 +286,7 @@ declare module "fs/promises" {
          */
         readFile(
             options:
-                | ({ encoding: BufferEncoding; } & Abortable)
+                | ({ encoding: BufferEncoding } & Abortable)
                 | BufferEncoding,
         ): Promise<string>;
         /**

--- a/types/node/v20/test/fs.ts
+++ b/types/node/v20/test/fs.ts
@@ -912,4 +912,8 @@ const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Ma
     fd.appendFile("test", { signal: new AbortSignal(), encoding: "utf-8" });
     // @ts-expect-error
     fd.appendFile("test", { mode: 0o777, flush: true, flag: "a" });
+
+    fd.readFile({ signal: new AbortSignal(), encoding: "utf-8" });
+    // @ts-expect-error
+    fd.readFile({ encoding: "utf-8", flag: "r" });
 });


### PR DESCRIPTION
Similar to https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71782 , this PR updates the type definition of  `filehandle.readFile()` to match the Nodejs documentation.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://nodejs.org/docs/latest-v22.x/api/fs.html#filehandlereadfileoptions>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
