### PR TITLE
Revert express/express-serve-static handler return from 8093416

### DIFF
--- a/types/express-oauth-server/express-oauth-server-tests.ts
+++ b/types/express-oauth-server/express-oauth-server-tests.ts
@@ -56,12 +56,12 @@ let resultingTokenMiddleware: (
     request: express.Request,
     response: express.Response,
     next: express.NextFunction,
-) => Promise<void>;
+) => Promise<OAuth2Server.Token>;
 let resultingAuthorizationCodeMiddleware: (
     request: express.Request,
     response: express.Response,
     next: express.NextFunction,
-) => Promise<void>;
+) => Promise<OAuth2Server.AuthorizationCode>;
 
 oAuthServer = expressOAuthServer.server;
 resultingTokenMiddleware = expressOAuthServer.authenticate();

--- a/types/express-oauth-server/index.d.ts
+++ b/types/express-oauth-server/index.d.ts
@@ -17,19 +17,19 @@ declare class ExpressOAuthServer {
         request: express.Request,
         response: express.Response,
         next: express.NextFunction,
-    ) => Promise<void>;
+    ) => Promise<OAuth2Server.Token>;
 
     authorize(options?: OAuth2Server.AuthorizeOptions): (
         request: express.Request,
         response: express.Response,
         next: express.NextFunction,
-    ) => Promise<void>;
+    ) => Promise<OAuth2Server.AuthorizationCode>;
 
     token(options?: OAuth2Server.TokenOptions): (
         request: express.Request,
         response: express.Response,
         next: express.NextFunction,
-    ) => Promise<void>;
+    ) => Promise<OAuth2Server.Token>;
 }
 
 export = ExpressOAuthServer;

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -61,7 +61,7 @@ export interface RequestHandler<
         req: Request<P, ResBody, ReqBody, ReqQuery, LocalsObj>,
         res: Response<ResBody, LocalsObj>,
         next: NextFunction,
-    ): void | Promise<void>;
+    ): void;
 }
 
 export type ErrorRequestHandler<
@@ -75,7 +75,7 @@ export type ErrorRequestHandler<
     req: Request<P, ResBody, ReqBody, ReqQuery, LocalsObj>,
     res: Response<ResBody, LocalsObj>,
     next: NextFunction,
-) => void | Promise<void>;
+) => void;
 
 export type PathParams = string | RegExp | Array<string | RegExp>;
 

--- a/types/express-serve-static-core/package.json
+++ b/types/express-serve-static-core/package.json
@@ -34,6 +34,10 @@
         {
             "name": "Shin Ando",
             "githubUsername": "andoshin11"
+        },
+        {
+            "name": "Jon Church",
+            "githubUsername": "jonchurch"
         }
     ]
 }

--- a/types/express/package.json
+++ b/types/express/package.json
@@ -30,6 +30,10 @@
         {
             "name": "Dylan Frankland",
             "githubUsername": "dfrankland"
+        },
+        {
+            "name": "Jon Church",
+            "githubUsername": "jonchurch"
         }
     ]
 }

--- a/types/feathersjs__express/feathersjs__express-tests.ts
+++ b/types/feathersjs__express/feathersjs__express-tests.ts
@@ -13,6 +13,7 @@ const feathersServiceDummy = {
 };
 const expressMiddlewareDummy = (req: express.Request, res: express.Response, next: express.NextFunction) => {
     next();
+    return app;
 };
 
 app.use(express.json());

--- a/types/logfmt/logfmt-tests.ts
+++ b/types/logfmt/logfmt-tests.ts
@@ -43,10 +43,7 @@ http.createServer((req, res) => {
 const app = express();
 app.use(logfmt.bodyParserStream());
 app.post("/logs", (req, res) => {
-    if (!req.body) {
-        res.send("OK");
-        return;
-    }
+    if (!req.body) return res.send("OK");
 
     req.body.pipe(through((line) => {
         console.dir(line);

--- a/types/mock-req-res/mock-req-res-tests.ts
+++ b/types/mock-req-res/mock-req-res-tests.ts
@@ -2,7 +2,7 @@ import { Request, RequestHandler, Response } from "express";
 import { mockRequest, mockResponse } from "mock-req-res";
 
 const handler: RequestHandler = (req: Request, res: Response) => {
-    res.status(200).json(`Hello from handler with an originalUrl value of '${req.originalUrl}'`);
+    return res.status(200).json(`Hello from handler with an originalUrl value of '${req.originalUrl}'`);
 };
 
 const req = mockRequest({ originalUrl: "/" });

--- a/types/mongoose-aggregate-paginate-v2/mongoose-aggregate-paginate-v2-tests.ts
+++ b/types/mongoose-aggregate-paginate-v2/mongoose-aggregate-paginate-v2-tests.ts
@@ -65,10 +65,10 @@ router.get("/users.json", async (req: Request, res: Response) => {
         console.log("offset: " + value.offset);
         console.log("docs: ");
         console.dir(value.docsCustom);
-        res.json(value);
+        return res.json(value);
     } catch (err) {
         console.log(err);
-        res.status(500).send(err);
+        return res.status(500).send(err);
     }
 });
 
@@ -90,10 +90,10 @@ router.get("/stats/hobbies.json", async (req: Request, res: Response) => {
 
     try {
         const value: AggregatePaginateResult<HobbyStats> = await UserModel.aggregatePaginate(aggregate, options);
-        res.json(value);
+        return res.json(value);
     } catch (err) {
         console.log(err);
-        res.status(500).send(err);
+        return res.status(500).send(err);
     }
 });
 
@@ -117,10 +117,10 @@ router.get("/stats/hobbies.json", async (req: Request, res: Response) => {
 
     try {
         const value: AggregatePaginateResult<HobbyStats> = await UserModel.aggregatePaginate(aggregate, options);
-        res.json(value);
+        return res.json(value);
     } catch (err) {
         console.log(err);
-        res.status(500).send(err);
+        return res.status(500).send(err);
     }
 });
 // #endregion

--- a/types/swaggerize-express/swaggerize-express-tests.ts
+++ b/types/swaggerize-express/swaggerize-express-tests.ts
@@ -27,9 +27,7 @@ app.use(swaggerize({
         "api": {
             "v1": {
                 "version": {
-                    "$get": (req: express.Request, res: express.Response) => {
-                        res.send("v1");
-                    },
+                    "$get": (req: express.Request, res: express.Response) => res.send("v1"),
                 },
             },
         },


### PR DESCRIPTION
## The Problem
When #70563 landed it broke builds for existing express v5 applications (and v4 applications upgrading to v5) because it narrowed the return type of `RequestHandler` and `ErrorRequestHandler`. This forces developers to refactor away from common control flow idioms used in express applications ala:
```js
app.post('/foo', (req, res, next) => {
  if (!req.user) return res.send('nope')
  // ...
} 
```

And 
```js
app.get('/foo', (req, res) => res.send('bar'))
app.get('/baz', (req, res) => {
  return res.json({qux: 'quux'})
}
```

This doesn't just force refactoring on v5 upgrade, it breaks expressive, idiomatic patterns commonly used in real world express apps.

```js
// needed to sprinkle voids in
app.get('/foo', (req, res) => void res.send('bar')

// or refactor to not return response
app.post('baz', (req, res) => {
  if (!req.user) {
    res.send('qux'
    return
  }
 // ...
}
```

express handlers can return Promises in v5, and express will observe them to catch async errors, but it does not use their resolved values. control flow is still based on `next()` or thrown exceptions, not what the handler returns.

**`() => void` is still the correct type for request handlers. The crux of why is elaborated on in the Context section below.**

> there's been previous discussions around this e.g. https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70696 which assumed that this was an intentional breaking change in v5, but it is not intended from the express team.

## The Fix

this PR reverts the `RequestHandler` return type in v5 from `() => void | Promise<void>` back to `() => void`, restoring the original structural typing behavior consistent with express v4/v5 and runtime behavior.

**(it also adds me 👋, an express TC member, to the owners of `express` and `express-serve-static` for help with future reviews)**

### Also Considered
`() => unknown` - this works, but is semantically very different from `() => void`.  
it says “this returns *something*, but we don’t know what.”  
what we want to express instead is: “you can return something, but the type system, and express, won’t use it.”

### Context

`() => void` in TypeScript is **structurally typed**, accepts any function regardless of its return value because the value is ignored. this allows both sync or async functions to be assigned without constraint.

the subtlety comes in when adding `Promise<void>` to the return union, switching `void` to a **concrete** type. TypeScript now requires that returned values match at least one union member exactly, breaking valid code like `return res.send(...)`.

`() => void` communicates that the return value is structurally ignored by the consumer. which is exactly what Express intends. this behavior is described in the [Typescript FAQ](https://github.com/microsoft/TypeScript/wiki/FAQ#why-are-functions-returning-non-void-assignable-to-function-returning-void)

express does internally observe returned Promises to catch rejections and forward them to `next()`. however, the resolved value of the Promise (like any sync return) is not used for control flow or routing. return values are structurally ignored.

`() => void` models this behavior correctly, allows async functions, permits returning values for control flow convenience, and signals to the type system that **the return is not consumed**. this aligns with express's design and developer expectations.

the return type change originated in #69846 as a workaround for the `@typescript-eslint/no-misused-promises` rule. **that lint rule will still fail with this PR, but that is acceptable and can be configured without refactoring**

> for express maintainers and folks working on types: this is a good example of how type accuracy needs to be balanced with real world usage.
even if a type is technically correct, it can still cause friction if it doesn’t match how people actually write their code.
>
> here we're choosing a return type that better reflects how express works in practice. handlers can return things, but express doesn't use the return value.
so the type says "you can return something if you want — just don’t expect express to care."
that’s more honest to the framework than **enforcing a restriction it doesn’t actually impose**

This change:
- restores compatibility with existing Express code that returns from handlers for sake of control flow (e.g., `return res.send(...)`) by updating ResponseHandlers back to `() => void`
- avoids unnecessary breakage or rewrites in user projects upgrading to express v5
- restores the tests that were changed in #70563 in order to accommodate the return type change

thanks for reviewing! happy to answer questions or discuss tradeoffs here.
----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

> ran tests for `express, express-serve-static-core, logfmt, express-oauth-server, feathersjs__express, mock-req-res, mongoose-aggregate-paginate-v2, swaggerize-express`

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pillarjs/router/blob/master/lib/layer.js#L160C1-L161C1
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.


> this fix took a few days to fully unwind and validate. working on open source full-time has given me the freedom to do the kind of deep, slow, careful work that rarely fits into a sprint. that freedom made this fix possible.
>
> if this kind of work resonates with you, or you want to connect about open source systems work more broadly, feel free to reach out.

