### PR TITLE
Add `fallbackFileNameForBase64` option

### DIFF
--- a/types/pdfobject/index.d.ts
+++ b/types/pdfobject/index.d.ts
@@ -8,6 +8,7 @@ export interface Options {
     page?: boolean | undefined;
     pdfOpenParams?: Record<string, string | number | boolean> | undefined;
     fallbackLink?: boolean | string | undefined;
+    fallbackFileNameForBase64?: string | undefined;
     width?: string | undefined;
     height?: string | undefined;
     assumptionMode?: boolean | undefined;


### PR DESCRIPTION
I know I should follow the guidelines below, but I just don't have much time for that right now. And because the change is quite simple, I don't want to invest much time to make a complete checkup. Sorry for that. This PR is just a kind of one drawing attention for required changes.

See [`fallbackFileNameForBase64` option at https://pdfobject.com/api/#fallbackfilenameforbase64](https://pdfobject.com/api/#fallbackfilenameforbase64)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <[`fallbackFileNameForBase64` option at https://pdfobject.com/api/#fallbackfilenameforbase64](https://pdfobject.com/api/#fallbackfilenameforbase64)>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.