### PR TITLE
[@types/docusign-esign] fix: Include updateEnvelopeDocGenFormFields in EnvelopeApi types

### DIFF
--- a/types/docusign-esign/docusign-esign-tests.ts
+++ b/types/docusign-esign/docusign-esign-tests.ts
@@ -49,6 +49,16 @@ const getEnvelopeDocGenFormFields = async (envelopeId: string) => {
     return results;
 };
 
+const updateEnvelopeDocGenFormFields = async (envelopeId: string) => {
+    const params = await getDsRequestParams();
+    const client = await getClient(params.token);
+    const envelopesApi = new docusign.EnvelopesApi(client);
+
+    const formFields = await envelopesApi.getEnvelopeDocGenFormFields(params.accountId, envelopeId);
+    const results = await envelopesApi.updateEnvelopeDocGenFormFields(params.accountId, envelopeId, formFields);
+    return results;
+};
+
 const getEnvelopeWithStoredConfiguredClient = async (
     envelopeId: string,
     options: { advancedUpdate?: string | undefined; include?: string | undefined },

--- a/types/docusign-esign/docusign-esign-tests.ts
+++ b/types/docusign-esign/docusign-esign-tests.ts
@@ -49,16 +49,6 @@ const getEnvelopeDocGenFormFields = async (envelopeId: string) => {
     return results;
 };
 
-const updateEnvelopeDocGenFormFields = async (envelopeId: string) => {
-    const params = await getDsRequestParams();
-    const client = await getClient(params.token);
-    const envelopesApi = new docusign.EnvelopesApi(client);
-
-    const formFields = await envelopesApi.getEnvelopeDocGenFormFields(params.accountId, envelopeId);
-    const results = await envelopesApi.updateEnvelopeDocGenFormFields(params.accountId, envelopeId, formFields);
-    return results;
-};
-
 const getEnvelopeWithStoredConfiguredClient = async (
     envelopeId: string,
     options: { advancedUpdate?: string | undefined; include?: string | undefined },
@@ -170,5 +160,15 @@ const getDocumentWithCallback = async (envelopeId: string, documentId: string, o
     const client = apiClient();
     const envelopesApi = new docusign.EnvelopesApi(client);
     const results = await envelopesApi.getDocument(params.accountId, envelopeId, documentId, options, callback);
+    return results;
+};
+
+const updateEnvelopeDocGenFormFields = async (envelopeId: string) => {
+    const params = await getDsRequestParams();
+    const client = await getClient(params.token);
+    const envelopesApi = new docusign.EnvelopesApi(client);
+
+    const formFields = await envelopesApi.getEnvelopeDocGenFormFields(params.accountId, envelopeId);
+    const results = await envelopesApi.updateEnvelopeDocGenFormFields(params.accountId, envelopeId, formFields);
     return results;
 };

--- a/types/docusign-esign/index.d.ts
+++ b/types/docusign-esign/index.d.ts
@@ -1592,6 +1592,13 @@ export class EnvelopesApi {
         callback?: (() => void) | ((error: any, data: any, response: any) => void),
     ): Promise<EmailSettings>;
 
+    updateEnvelopeDocGenFormFields(
+        accountId: string,
+        envelopeId: string,
+        optsOrCallback?: any,
+        callback?: (() => void) | ((error: any, data: any, response: any) => void),
+    ): Promise<DocGenFormFieldResponse>;
+
     updateEnvelopeTransferRule(
         accountId: string,
         envelopeTransferRuleId: string,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [docusign-esign-node-client updateEnvelopeDocGenFormFields documentation](https://docusign.github.io/docusign-esign-node-client/module-api_EnvelopesApi.html#updateEnvelopeDocGenFormFields).

Looking forward to your review!
