### PR TITLE
fix: move ioredis from dependencies to peerDependencies in @types/ior…

### DIFF
--- a/types/ioredis-mock/index.d.ts
+++ b/types/ioredis-mock/index.d.ts
@@ -1,5 +1,3 @@
-/// <reference types="node" />
-
 import ioredis = require("ioredis");
 
 export type RedisOptions = { data?: Record<string, unknown> } & ioredis.RedisOptions;

--- a/types/ioredis-mock/package.json
+++ b/types/ioredis-mock/package.json
@@ -5,11 +5,12 @@
     "projects": [
         "https://github.com/stipsan/ioredis-mock#readme"
     ],
-    "dependencies": {
-        "@types/node": "*",
+    "peerDependencies": {
         "ioredis": ">=5"
     },
     "devDependencies": {
+        "@types/node": "*",
+        "ioredis": ">=5",
         "@types/ioredis-mock": "workspace:."
     },
     "owners": [


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`@types` packages should not have runtime dependencies](https://github.com/DefinitelyTyped/DefinitelyTyped#definition-owner)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.