### PR TITLE
node/fs: support Buffer as Dirent.name and refine types for readdir/readdirSync with encoding: "buffer"

### DIFF
--- a/types/fs-extra/test/fs-extra-tests.ts
+++ b/types/fs-extra/test/fs-extra-tests.ts
@@ -836,7 +836,7 @@ fs.readdir(path, "utf-8"); // $ExpectType Promise<string[]>
 fs.readdir(path, "buffer"); // $ExpectType Promise<Buffer[]> || Promise<Buffer<ArrayBufferLike>[]>
 fs.readdir(path, { encoding: "buffer" }); // $ExpectType Promise<Buffer[]> || Promise<Buffer<ArrayBufferLike>[]>
 fs.readdir(path, { encoding: "utf-8" }); // $ExpectType Promise<string[]>
-fs.readdir(path, { withFileTypes: true }); // $ExpectType Promise<Dirent[]>
+fs.readdir(path, { withFileTypes: true }); // $ExpectType Promise<Dirent<string>[]>
 // $ExpectType void
 fs.readdir(path, (err, files) => {
     err; // $ExpectType ErrnoException | null
@@ -865,7 +865,7 @@ fs.readdir(path, { encoding: "utf-8" }, (err, files) => {
 // $ExpectType void
 fs.readdir(path, { withFileTypes: true }, (err, files) => {
     err; // $ExpectType ErrnoException | null
-    files; // $ExpectType Dirent[]
+    files; // $ExpectType Dirent<string>[]
 });
 
 fs.readFile(path); // $ExpectType Promise<Buffer> || Promise<Buffer<ArrayBufferLike>>

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -2045,7 +2045,7 @@ declare module "fs" {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options Must include `withFileTypes: true` and `encoding: 'buffer'`.
      */
-     export function readdir(
+    export function readdir(
         path: PathLike,
         options: {
             encoding: "buffer";

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -198,7 +198,7 @@ declare module "fs" {
      * the `withFileTypes` option set to `true`, the resulting array is filled with `fs.Dirent` objects, rather than strings or `Buffer` s.
      * @since v10.10.0
      */
-    export class Dirent {
+    export class Dirent<Name extends string | Buffer = string> {
         /**
          * Returns `true` if the `fs.Dirent` object describes a regular file.
          * @since v10.10.0
@@ -241,7 +241,7 @@ declare module "fs" {
          * value is determined by the `options.encoding` passed to {@link readdir} or {@link readdirSync}.
          * @since v10.10.0
          */
-        name: string;
+        name: Name;
         /**
          * The base path that this `fs.Dirent` object refers to.
          * @since v20.12.0

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -2040,6 +2040,20 @@ declare module "fs" {
         },
         callback: (err: NodeJS.ErrnoException | null, files: Dirent[]) => void,
     ): void;
+    /**
+     * Asynchronous readdir(3) - read a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options Must include `withFileTypes: true` and `encoding: 'buffer'`.
+     */
+     export function readdir(
+        path: PathLike,
+        options: {
+            encoding: "buffer";
+            withFileTypes: true;
+            recursive?: boolean | undefined;
+        },
+        callback: (err: NodeJS.ErrnoException | null, files: Dirent<Buffer>[]) => void,
+    ): void;
     export namespace readdir {
         /**
          * Asynchronous readdir(3) - read a directory.
@@ -2099,6 +2113,19 @@ declare module "fs" {
                 recursive?: boolean | undefined;
             },
         ): Promise<Dirent[]>;
+        /**
+         * Asynchronous readdir(3) - read a directory.
+         * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+         * @param options Must include `withFileTypes: true` and `encoding: 'buffer'`.
+         */
+        function __promisify__(
+            path: PathLike,
+            options: {
+                encoding: "buffer";
+                withFileTypes: true;
+                recursive?: boolean | undefined;
+            },
+        ): Promise<Dirent<Buffer>[]>;
     }
     /**
      * Reads the contents of the directory.
@@ -2166,6 +2193,19 @@ declare module "fs" {
             recursive?: boolean | undefined;
         },
     ): Dirent[];
+    /**
+     * Synchronous readdir(3) - read a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options Must include `withFileTypes: true` and `encoding: 'buffer'`.
+     */
+    export function readdirSync(
+        path: PathLike,
+        options: {
+            encoding: "buffer";
+            withFileTypes: true;
+            recursive?: boolean | undefined;
+        },
+    ): Dirent<Buffer>[];
     /**
      * Closes the file descriptor. No arguments other than a possible exception are
      * given to the completion callback.

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -735,6 +735,19 @@ declare module "fs/promises" {
         },
     ): Promise<Dirent[]>;
     /**
+     * Asynchronous readdir(3) - read a directory.
+     * @param path A path to a directory. If a URL is provided, it must use the `file:` protocol.
+     * @param options Must include `withFileTypes: true` and `encoding: 'buffer'`.
+     */
+    function readdir(
+        path: PathLike,
+        options: {
+            encoding: "buffer";
+            withFileTypes: true;
+            recursive?: boolean | undefined;
+        },
+    ): Promise<Dirent<Buffer>[]>;
+    /**
      * Reads the contents of the symbolic link referred to by `path`. See the POSIX [`readlink(2)`](http://man7.org/linux/man-pages/man2/readlink.2.html) documentation for more detail. The promise is
      * fulfilled with the`linkString` upon success.
      *

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -174,7 +174,11 @@ import { CopyOptions, CopySyncOptions, cp, cpSync, glob, globSync } from "fs";
     fs.readdirSync("path", {});
 
     fs.readdir("path", { withFileTypes: true }, (err: NodeJS.ErrnoException | null, files: fs.Dirent[]) => {});
-    fs.readdir("path", { withFileTypes: true , encoding: "buffer" }, (err: NodeJS.ErrnoException | null, files: fs.Dirent<Buffer>[]) => {});
+    fs.readdir(
+        "path",
+        { withFileTypes: true, encoding: "buffer" },
+        (err: NodeJS.ErrnoException | null, files: fs.Dirent<Buffer>[]) => {},
+    );
 }
 
 async function testPromisify() {

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -173,7 +173,7 @@ import { CopyOptions, CopySyncOptions, cp, cpSync, glob, globSync } from "fs";
     fs.readdirSync("path", { encoding: enc });
     fs.readdirSync("path", {});
 
-    fs.readdir("path", {withFileTypes: true }, (err: NodeJS.ErrnoException | null, files: fs.Dirent[]) => {});
+    fs.readdir("path", { withFileTypes: true }, (err: NodeJS.ErrnoException | null, files: fs.Dirent[]) => {});
     fs.readdir("path", { withFileTypes: true , encoding: "buffer" }, (err: NodeJS.ErrnoException | null, files: fs.Dirent<Buffer>[]) => {});
 }
 

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -163,6 +163,7 @@ import { CopyOptions, CopySyncOptions, cp, cpSync, glob, globSync } from "fs";
     const listDir: fs.Dirent[] = fs.readdirSync("path", { withFileTypes: true });
     const listDir2: Buffer[] = fs.readdirSync("path", { withFileTypes: false, encoding: "buffer" });
     const listDir3: fs.Dirent[] = fs.readdirSync("path", { encoding: "utf8", withFileTypes: true });
+    const listDir4: fs.Dirent<Buffer>[] = fs.readdirSync("path", { encoding: "buffer", withFileTypes: true });
 
     let listB: Buffer[];
     listB = fs.readdirSync("path", { encoding: "buffer" });
@@ -172,7 +173,8 @@ import { CopyOptions, CopySyncOptions, cp, cpSync, glob, globSync } from "fs";
     fs.readdirSync("path", { encoding: enc });
     fs.readdirSync("path", {});
 
-    fs.readdir("path", { withFileTypes: true }, (err: NodeJS.ErrnoException | null, files: fs.Dirent[]) => {});
+    fs.readdir("path", {withFileTypes: true }, (err: NodeJS.ErrnoException | null, files: fs.Dirent[]) => {});
+    fs.readdir("path", { withFileTypes: true , encoding: "buffer" }, (err: NodeJS.ErrnoException | null, files: fs.Dirent<Buffer>[]) => {});
 }
 
 async function testPromisify() {
@@ -414,10 +416,12 @@ async function testPromisify() {
     let names: Promise<string[]>;
     let buffers: Promise<Buffer[]>;
     let entries: Promise<fs.Dirent[]>;
+    let bufferEntries: Promise<fs.Dirent<Buffer>[]>;
 
     names = fs.promises.readdir("/path/to/dir", { encoding: "utf8", withFileTypes: false, recursive: true });
     buffers = fs.promises.readdir("/path/to/dir", { encoding: "buffer", withFileTypes: false, recursive: true });
     entries = fs.promises.readdir("/path/to/dir", { encoding: "utf8", withFileTypes: true, recursive: true });
+    bufferEntries = fs.promises.readdir("/path/to/dir", { encoding: "buffer", withFileTypes: true });
 }
 
 {
@@ -962,10 +966,10 @@ const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Ma
         entry; // $ExpectType string
     }
     for await (const entry of globAsync("**/*.js", { withFileTypes: true })) {
-        entry; // $ExpectType Dirent
+        entry; // $ExpectType Dirent<string>
     }
     for await (const entry of globAsync("**/*.js", { withFileTypes: Math.random() > 0.5 })) {
-        entry; // $ExpectType Dirent | string
+        entry; // $ExpectType Dirent<string> | string
     }
 
     for await (
@@ -982,33 +986,33 @@ const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Ma
         const entry of globAsync("**/*.js", {
             withFileTypes: true,
             exclude(fileName) {
-                fileName; // $ExpectType Dirent
+                fileName; // $ExpectType Dirent<string>
                 return false;
             },
         })
     ) {
-        entry; // $ExpectType Dirent
+        entry; // $ExpectType Dirent<string>
     }
     for await (
         const entry of globAsync("**/*.js", {
             withFileTypes: Math.random() > 0.5,
             exclude(fileName) {
-                fileName; // $ExpectType Dirent | string
+                fileName; // $ExpectType Dirent<string> | string
                 return false;
             },
         })
     ) {
-        entry; // $ExpectType Dirent | string
+        entry; // $ExpectType Dirent<string> | string
     }
 
     glob("**/*.js", (err, matches) => {
         matches; // $ExpectType string[]
     });
     glob("**/*.js", { withFileTypes: true }, (err, matches) => {
-        matches; // $ExpectType Dirent[]
+        matches; // $ExpectType Dirent<string>[]
     });
     glob("**/*.js", { withFileTypes: Math.random() > 0.5 }, (err, matches) => {
-        matches; // $ExpectType Dirent[] | string[]
+        matches; // $ExpectType Dirent<string>[] | string[]
     });
 
     glob(
@@ -1028,12 +1032,12 @@ const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Ma
         {
             withFileTypes: true,
             exclude: (fileName) => {
-                fileName; // $ExpectType Dirent
+                fileName; // $ExpectType Dirent<string>
                 return false;
             },
         },
         (err, matches) => {
-            matches; // $ExpectType Dirent[]
+            matches; // $ExpectType Dirent<string>[]
         },
     );
     glob(
@@ -1041,12 +1045,12 @@ const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Ma
         {
             withFileTypes: Math.random() > 0.5,
             exclude: (fileName) => {
-                fileName; // $ExpectType Dirent | string
+                fileName; // $ExpectType Dirent<string> | string
                 return false;
             },
         },
         (err, matches) => {
-            matches; // $ExpectType Dirent[] | string[]
+            matches; // $ExpectType Dirent<string>[] | string[]
         },
     );
     glob("**/*.js", { exclude: ["**/*.generated.js"] }, (err, matches) => {
@@ -1055,8 +1059,8 @@ const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Ma
 
     globSync("**/*.js"); // $ExpectType string[]
     globSync("**/*.js", { cwd: "/" }); // $ExpectType string[]
-    globSync("**/*.js", { withFileTypes: true }); // $ExpectType Dirent[]
-    globSync("**/*.js", { withFileTypes: Math.random() > 0.5 }); // $ExpectType string[] | Dirent[]
+    globSync("**/*.js", { withFileTypes: true }); // $ExpectType Dirent<string>[]
+    globSync("**/*.js", { withFileTypes: Math.random() > 0.5 }); // $ExpectType string[] | Dirent<string>[]
 
     // $ExpectType string[]
     globSync("**/*.js", {
@@ -1069,15 +1073,15 @@ const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Ma
     globSync("**/*.js", {
         withFileTypes: true,
         exclude: (fileName) => {
-            fileName; // $ExpectType Dirent
+            fileName; // $ExpectType Dirent<string>
             return false;
         },
     });
-    // $ExpectType string[] | Dirent[]
+    // $ExpectType string[] | Dirent<string>[]
     globSync("**/*.js", {
         withFileTypes: Math.random() > 0.5,
         exclude: (fileName) => {
-            fileName; // $ExpectType Dirent | string
+            fileName; // $ExpectType Dirent<string> | string
             return false;
         },
     });

--- a/types/node/v18/fs.d.ts
+++ b/types/node/v18/fs.d.ts
@@ -2057,6 +2057,20 @@ declare module "fs" {
         },
         callback: (err: NodeJS.ErrnoException | null, files: Dirent[]) => void,
     ): void;
+    /**
+     * Asynchronous readdir(3) - read a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options Must include `withFileTypes: true` and `encoding: 'buffer'`.
+     */
+    export function readdir(
+        path: PathLike,
+        options: {
+            encoding: "buffer";
+            withFileTypes: true;
+            recursive?: boolean | undefined;
+        },
+        callback: (err: NodeJS.ErrnoException | null, files: Dirent<Buffer>[]) => void,
+    ): void;
     export namespace readdir {
         /**
          * Asynchronous readdir(3) - read a directory.
@@ -2116,6 +2130,19 @@ declare module "fs" {
                 recursive?: boolean | undefined;
             },
         ): Promise<Dirent[]>;
+        /**
+         * Asynchronous readdir(3) - read a directory.
+         * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+         * @param options Must include `withFileTypes: true` and `encoding: 'buffer'`.
+         */
+        function __promisify__(
+            path: PathLike,
+            options: {
+                encoding: "buffer";
+                withFileTypes: true;
+                recursive?: boolean | undefined;
+            },
+        ): Promise<Dirent<Buffer>[]>;
     }
     /**
      * Reads the contents of the directory.
@@ -2183,6 +2210,19 @@ declare module "fs" {
             recursive?: boolean | undefined;
         },
     ): Dirent[];
+    /**
+     * Synchronous readdir(3) - read a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options Must include `withFileTypes: true` and `encoding: 'buffer'`.
+     */
+    export function readdirSync(
+        path: PathLike,
+        options: {
+            encoding: "buffer";
+            withFileTypes: true;
+            recursive?: boolean | undefined;
+        },
+    ): Dirent<Buffer>[];
     /**
      * Closes the file descriptor. No arguments other than a possible exception are
      * given to the completion callback.

--- a/types/node/v18/fs.d.ts
+++ b/types/node/v18/fs.d.ts
@@ -176,7 +176,7 @@ declare module "fs" {
      * the `withFileTypes` option set to `true`, the resulting array is filled with `fs.Dirent` objects, rather than strings or `Buffer` s.
      * @since v10.10.0
      */
-    export class Dirent {
+    export class Dirent<Name extends string | Buffer = string> {
         /**
          * Returns `true` if the `fs.Dirent` object describes a regular file.
          * @since v10.10.0
@@ -219,7 +219,7 @@ declare module "fs" {
          * value is determined by the `options.encoding` passed to {@link readdir} or {@link readdirSync}.
          * @since v10.10.0
          */
-        name: string;
+        name: Name;
         /**
          * The base path that this `fs.Dirent` object refers to.
          * @since v18.20.0

--- a/types/node/v18/fs/promises.d.ts
+++ b/types/node/v18/fs/promises.d.ts
@@ -705,6 +705,19 @@ declare module "fs/promises" {
         },
     ): Promise<Dirent[]>;
     /**
+     * Asynchronous readdir(3) - read a directory.
+     * @param path A path to a directory. If a URL is provided, it must use the `file:` protocol.
+     * @param options Must include `withFileTypes: true` and `encoding: 'buffer'`.
+     */
+    function readdir(
+        path: PathLike,
+        options: {
+            encoding: "buffer";
+            withFileTypes: true;
+            recursive?: boolean | undefined;
+        },
+    ): Promise<Dirent<Buffer>[]>;
+    /**
      * Reads the contents of the symbolic link referred to by `path`. See the POSIX [`readlink(2)`](http://man7.org/linux/man-pages/man2/readlink.2.html) documentation for more detail. The promise is
      * resolved with the`linkString` upon success.
      *

--- a/types/node/v20/fs.d.ts
+++ b/types/node/v20/fs.d.ts
@@ -196,7 +196,7 @@ declare module "fs" {
      * the `withFileTypes` option set to `true`, the resulting array is filled with `fs.Dirent` objects, rather than strings or `Buffer` s.
      * @since v10.10.0
      */
-    export class Dirent {
+    export class Dirent<Name extends string | Buffer = string> {
         /**
          * Returns `true` if the `fs.Dirent` object describes a regular file.
          * @since v10.10.0
@@ -239,7 +239,7 @@ declare module "fs" {
          * value is determined by the `options.encoding` passed to {@link readdir} or {@link readdirSync}.
          * @since v10.10.0
          */
-        name: string;
+        name: Name;
         /**
          * The base path that this `fs.Dirent` object refers to.
          * @since v20.12.0

--- a/types/node/v20/fs.d.ts
+++ b/types/node/v20/fs.d.ts
@@ -2038,6 +2038,20 @@ declare module "fs" {
         },
         callback: (err: NodeJS.ErrnoException | null, files: Dirent[]) => void,
     ): void;
+    /**
+     * Asynchronous readdir(3) - read a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options Must include `withFileTypes: true` and `encoding: 'buffer'`.
+     */
+    export function readdir(
+        path: PathLike,
+        options: {
+            encoding: "buffer";
+            withFileTypes: true;
+            recursive?: boolean | undefined;
+        },
+        callback: (err: NodeJS.ErrnoException | null, files: Dirent<Buffer>[]) => void,
+    ): void;
     export namespace readdir {
         /**
          * Asynchronous readdir(3) - read a directory.
@@ -2097,6 +2111,19 @@ declare module "fs" {
                 recursive?: boolean | undefined;
             },
         ): Promise<Dirent[]>;
+        /**
+         * Asynchronous readdir(3) - read a directory.
+         * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+         * @param options Must include `withFileTypes: true` and `encoding: 'buffer'`.
+         */
+        function __promisify__(
+            path: PathLike,
+            options: {
+                encoding: "buffer";
+                withFileTypes: true;
+                recursive?: boolean | undefined;
+            },
+        ): Promise<Dirent<Buffer>[]>;
     }
     /**
      * Reads the contents of the directory.
@@ -2164,6 +2191,19 @@ declare module "fs" {
             recursive?: boolean | undefined;
         },
     ): Dirent[];
+    /**
+     * Synchronous readdir(3) - read a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options Must include `withFileTypes: true` and `encoding: 'buffer'`.
+     */
+    export function readdirSync(
+        path: PathLike,
+        options: {
+            encoding: "buffer";
+            withFileTypes: true;
+            recursive?: boolean | undefined;
+        },
+    ): Dirent<Buffer>[];
     /**
      * Closes the file descriptor. No arguments other than a possible exception are
      * given to the completion callback.

--- a/types/node/v20/fs/promises.d.ts
+++ b/types/node/v20/fs/promises.d.ts
@@ -721,6 +721,19 @@ declare module "fs/promises" {
         },
     ): Promise<Dirent[]>;
     /**
+     * Asynchronous readdir(3) - read a directory.
+     * @param path A path to a directory. If a URL is provided, it must use the `file:` protocol.
+     * @param options Must include `withFileTypes: true` and `encoding: 'buffer'`.
+     */
+    function readdir(
+        path: PathLike,
+        options: {
+            encoding: "buffer";
+            withFileTypes: true;
+            recursive?: boolean | undefined;
+        },
+    ): Promise<Dirent<Buffer>[]>;
+    /**
      * Reads the contents of the symbolic link referred to by `path`. See the POSIX [`readlink(2)`](http://man7.org/linux/man-pages/man2/readlink.2.html) documentation for more detail. The promise is
      * fulfilled with the`linkString` upon success.
      *


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [Dirent.name](https://nodejs.org/docs/latest-v23.x/api/fs.html#direntname)
  - [fs.readdir](https://nodejs.org/docs/latest-v23.x/api/fs.html#fsreaddirpath-options-callback)
  - [fs.readdirSync](https://nodejs.org/docs/latest-v23.x/api/fs.html#fspromisesreaddirpath-options)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

I made this change because when `withFileTypes: true` is used with `encoding: "buffer",` `Dirent.name` returns a `Buffer`.