### PR TITLE
[@rails/activestorage] Update types for @rails/activestorage v8.0

### DIFF
--- a/types/rails__activestorage/index.d.ts
+++ b/types/rails__activestorage/index.d.ts
@@ -9,7 +9,7 @@ export class DirectUpload {
 
     constructor(file: File, url: string, delegate?: DirectUploadDelegate, customHeaders?: Record<string, string>);
 
-    create(callback: (error: Error, blob: Blob) => void): void;
+    create(callback: (error: Error | null, blob?: Blob) => void): void;
 }
 
 export interface DirectUploadDelegate {

--- a/types/rails__activestorage/package.json
+++ b/types/rails__activestorage/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/rails__activestorage",
-    "version": "7.1.9999",
+    "version": "8.0.9999",
     "projects": [
         "https://github.com/rails/rails/tree/master/activestorage/app/javascript",
         "http://rubyonrails.org/"

--- a/types/rails__activestorage/rails__activestorage-tests.ts
+++ b/types/rails__activestorage/rails__activestorage-tests.ts
@@ -25,10 +25,16 @@ const d = new ActiveStorage.DirectUpload(
     customHeaders,
 );
 
-d.create((error, blob) => {
+d.create((error: Error | null) => {
     if (error) {
         console.log(error.message);
-    } else {
+    }
+});
+
+d.create((error: Error | null, blob?: ActiveStorage.Blob) => {
+    if (error) {
+        console.log(error.message);
+    } else if (blob) {
         const { byte_size, checksum, content_type, filename, signed_id } = blob;
         console.log({ byte_size, checksum, content_type, filename, signed_id });
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rails/rails/blob/17cde11cd13cf07a7d6c712cb1593881496abacb/activestorage/app/javascript/activestorage/direct_upload.js#L32-L38
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

This updates the DirectUpload create callback error argument type to be nullable and the blob argument type to be optional to more closely match the Rails JavaScript implementation. The [`error` argument is `null` when the direct upload succeeds, and the `blob` argument is not present when there is an `error`](https://github.com/rails/rails/blob/17cde11cd13cf07a7d6c712cb1593881496abacb/activestorage/app/javascript/activestorage/direct_upload.js#L32-L38):

```js
upload.create(error => {
  if (error) {
    callback(error)
  } else {
    callback(null, blob.toJSON())
  }
})
```