### PR TITLE
fix(node/assert): refine the signature of CallTracker.calls()

### DIFF
--- a/types/node/assert.d.ts
+++ b/types/node/assert.d.ts
@@ -79,7 +79,9 @@ declare module "assert" {
              * @return A function that wraps `fn`.
              */
             calls(exact?: number): () => void;
-            calls<Func extends (...args: any[]) => any>(fn?: Func, exact?: number): Func;
+            calls(fn: undefined, exact?: number): () => void;
+            calls<Func extends (...args: any[]) => any>(fn: Func, exact?: number): Func;
+            calls<Func extends (...args: any[]) => any>(fn?: Func, exact?: number): Func | (() => void);
             /**
              * Example:
              *

--- a/types/node/test/assert.ts
+++ b/types/node/test/assert.ts
@@ -45,6 +45,48 @@ import assert = require("node:assert");
     }
 }
 
+{
+    const tracker = new assert.CallTracker();
+
+    let exact: number | undefined;
+
+    // $ExpectType () => void
+    tracker.calls();
+    // $ExpectType () => void
+    tracker.calls(7);
+    // $ExpectType () => void
+    tracker.calls(exact);
+
+    // $ExpectType () => void
+    tracker.calls(undefined);
+    // $ExpectType () => void
+    tracker.calls(undefined, undefined);
+    // $ExpectType () => void
+    tracker.calls(undefined, 7);
+    // $ExpectType () => void
+    tracker.calls(undefined, exact);
+
+    let f1: (a: number) => number = () => 3;
+    // $ExpectType (a: number) => number
+    tracker.calls(f1);
+    // $ExpectType (a: number) => number
+    tracker.calls(f1, undefined);
+    // $ExpectType (a: number) => number
+    tracker.calls(f1, 42);
+    // $ExpectType (a: number) => number
+    tracker.calls(f1, exact);
+
+    let f2: ((a: number) => number) | undefined;
+    // $ExpectType ((a: number) => number) | (() => void)
+    tracker.calls(f2);
+    // $ExpectType ((a: number) => number) | (() => void)
+    tracker.calls(f2, undefined);
+    // $ExpectType ((a: number) => number) | (() => void)
+    tracker.calls(f2, 42);
+    // $ExpectType ((a: number) => number) | (() => void)
+    tracker.calls(f2, exact);
+}
+
 assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
 
 assert.deepEqual({ x: { y: 3 } }, { x: { y: 3 } }, "DEEP WENT DERP");

--- a/types/node/v18/assert.d.ts
+++ b/types/node/v18/assert.d.ts
@@ -64,7 +64,9 @@ declare module "assert" {
              * @return that wraps `fn`.
              */
             calls(exact?: number): () => void;
-            calls<Func extends (...args: any[]) => any>(fn?: Func, exact?: number): Func;
+            calls(fn: undefined, exact?: number): () => void;
+            calls<Func extends (...args: any[]) => any>(fn: Func, exact?: number): Func;
+            calls<Func extends (...args: any[]) => any>(fn?: Func, exact?: number): Func | (() => void);
             /**
              * Example:
              *

--- a/types/node/v18/test/assert.ts
+++ b/types/node/v18/test/assert.ts
@@ -45,6 +45,48 @@ import assert = require("node:assert");
     }
 }
 
+{
+    const tracker = new assert.CallTracker();
+
+    let exact: number | undefined;
+
+    // $ExpectType () => void
+    tracker.calls();
+    // $ExpectType () => void
+    tracker.calls(7);
+    // $ExpectType () => void
+    tracker.calls(exact);
+
+    // $ExpectType () => void
+    tracker.calls(undefined);
+    // $ExpectType () => void
+    tracker.calls(undefined, undefined);
+    // $ExpectType () => void
+    tracker.calls(undefined, 7);
+    // $ExpectType () => void
+    tracker.calls(undefined, exact);
+
+    let f1: (a: number) => number = () => 3;
+    // $ExpectType (a: number) => number
+    tracker.calls(f1);
+    // $ExpectType (a: number) => number
+    tracker.calls(f1, undefined);
+    // $ExpectType (a: number) => number
+    tracker.calls(f1, 42);
+    // $ExpectType (a: number) => number
+    tracker.calls(f1, exact);
+
+    let f2: ((a: number) => number) | undefined;
+    // $ExpectType ((a: number) => number) | (() => void)
+    tracker.calls(f2);
+    // $ExpectType ((a: number) => number) | (() => void)
+    tracker.calls(f2, undefined);
+    // $ExpectType ((a: number) => number) | (() => void)
+    tracker.calls(f2, 42);
+    // $ExpectType ((a: number) => number) | (() => void)
+    tracker.calls(f2, exact);
+}
+
 assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
 
 assert.deepEqual({ x: { y: 3 } }, { x: { y: 3 } }, "DEEP WENT DERP");

--- a/types/node/v20/assert.d.ts
+++ b/types/node/v20/assert.d.ts
@@ -79,7 +79,9 @@ declare module "assert" {
              * @return A function that wraps `fn`.
              */
             calls(exact?: number): () => void;
-            calls<Func extends (...args: any[]) => any>(fn?: Func, exact?: number): Func;
+            calls(fn: undefined, exact?: number): () => void;
+            calls<Func extends (...args: any[]) => any>(fn: Func, exact?: number): Func;
+            calls<Func extends (...args: any[]) => any>(fn?: Func, exact?: number): Func | (() => void);
             /**
              * Example:
              *

--- a/types/node/v20/test/assert.ts
+++ b/types/node/v20/test/assert.ts
@@ -45,6 +45,48 @@ import assert = require("node:assert");
     }
 }
 
+{
+    const tracker = new assert.CallTracker();
+
+    let exact: number | undefined;
+
+    // $ExpectType () => void
+    tracker.calls();
+    // $ExpectType () => void
+    tracker.calls(7);
+    // $ExpectType () => void
+    tracker.calls(exact);
+
+    // $ExpectType () => void
+    tracker.calls(undefined);
+    // $ExpectType () => void
+    tracker.calls(undefined, undefined);
+    // $ExpectType () => void
+    tracker.calls(undefined, 7);
+    // $ExpectType () => void
+    tracker.calls(undefined, exact);
+
+    let f1: (a: number) => number = () => 3;
+    // $ExpectType (a: number) => number
+    tracker.calls(f1);
+    // $ExpectType (a: number) => number
+    tracker.calls(f1, undefined);
+    // $ExpectType (a: number) => number
+    tracker.calls(f1, 42);
+    // $ExpectType (a: number) => number
+    tracker.calls(f1, exact);
+
+    let f2: ((a: number) => number) | undefined;
+    // $ExpectType ((a: number) => number) | (() => void)
+    tracker.calls(f2);
+    // $ExpectType ((a: number) => number) | (() => void)
+    tracker.calls(f2, undefined);
+    // $ExpectType ((a: number) => number) | (() => void)
+    tracker.calls(f2, 42);
+    // $ExpectType ((a: number) => number) | (() => void)
+    tracker.calls(f2, exact);
+}
+
 assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
 
 assert.deepEqual({ x: { y: 3 } }, { x: { y: 3 } }, "DEEP WENT DERP");


### PR DESCRIPTION
Right now the typedef of `CallTracker.calls()` is not 100% correct. See https://tsplay.dev/NnGd6m. This PR further partition the overload for `fn` param to solve the issue.

Although `CallTracker` on its own is being deprecated, I think it is still worth to be fixed, for downstream consumers who are still using it.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
