### PR TITLE
feat(sanitize-html): add onOpenTag and onCloseTag options

### DIFF
--- a/types/sanitize-html/index.d.ts
+++ b/types/sanitize-html/index.d.ts
@@ -78,6 +78,8 @@ declare namespace sanitize {
          */
         enforceHtmlBoundary?: boolean | undefined;
         nonBooleanAttributes?: string[];
+        onOpenTag?: ((name: string, attribs: Attributes) => void) | undefined;
+        onCloseTag?: ((name: string, isImplied: boolean) => void) | undefined;
     }
 
     const defaults: IDefaults;

--- a/types/sanitize-html/package.json
+++ b/types/sanitize-html/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/sanitize-html",
-    "version": "2.15.9999",
+    "version": "2.16.9999",
     "projects": [
         "https://github.com/punkave/sanitize-html"
     ],

--- a/types/sanitize-html/sanitize-html-tests.ts
+++ b/types/sanitize-html/sanitize-html-tests.ts
@@ -45,6 +45,8 @@ const options: IOptions = {
     allowedScriptDomains: ["test.com"],
     allowedScriptHostnames: ["test.com"],
     nonBooleanAttributes: ["href"],
+    onOpenTag: (name: string, attribs: Attributes) => {},
+    onCloseTag: (name: string, isImplied: boolean) => {},
 };
 
 sanitize.defaults.allowedAttributes; // $ExpectType Record<string, AllowedAttribute[]>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/apostrophecms/sanitize-html/pull/692
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
