### PR TITLE
fix(node/cluster): correct the return type of Worker.disconnect()

### DIFF
--- a/types/node/cluster.d.ts
+++ b/types/node/cluster.d.ts
@@ -266,7 +266,7 @@ declare module "cluster" {
          * @since v0.7.7
          * @return A reference to `worker`.
          */
-        disconnect(): void;
+        disconnect(): this;
         /**
          * This function returns `true` if the worker is connected to its primary via its
          * IPC channel, `false` otherwise. A worker is connected to its primary after it

--- a/types/node/test/cluster.ts
+++ b/types/node/test/cluster.ts
@@ -25,3 +25,9 @@ cluster.on("setup", (settings: ClusterSettings) => {});
 {
     const workers: NodeJS.Dict<Worker> = cluster.workers!;
 }
+
+{
+    const worker = new Worker();
+    // $ExpectType Worker
+    worker.disconnect();
+}

--- a/types/node/v18/cluster.d.ts
+++ b/types/node/v18/cluster.d.ts
@@ -265,7 +265,7 @@ declare module "cluster" {
          * @since v0.7.7
          * @return A reference to `worker`.
          */
-        disconnect(): void;
+        disconnect(): this;
         /**
          * This function returns `true` if the worker is connected to its primary via its
          * IPC channel, `false` otherwise. A worker is connected to its primary after it

--- a/types/node/v18/test/cluster.ts
+++ b/types/node/v18/test/cluster.ts
@@ -25,3 +25,9 @@ cluster.on("setup", (settings: ClusterSettings) => {});
 {
     const workers: NodeJS.Dict<Worker> = cluster.workers!;
 }
+
+{
+    const worker = new Worker();
+    // $ExpectType Worker
+    worker.disconnect();
+}

--- a/types/node/v20/cluster.d.ts
+++ b/types/node/v20/cluster.d.ts
@@ -265,7 +265,7 @@ declare module "cluster" {
          * @since v0.7.7
          * @return A reference to `worker`.
          */
-        disconnect(): void;
+        disconnect(): this;
         /**
          * This function returns `true` if the worker is connected to its primary via its
          * IPC channel, `false` otherwise. A worker is connected to its primary after it

--- a/types/node/v20/test/cluster.ts
+++ b/types/node/v20/test/cluster.ts
@@ -25,3 +25,9 @@ cluster.on("setup", (settings: ClusterSettings) => {});
 {
     const workers: NodeJS.Dict<Worker> = cluster.workers!;
 }
+
+{
+    const worker = new Worker();
+    // $ExpectType Worker
+    worker.disconnect();
+}


### PR DESCRIPTION
See https://nodejs.org/api/cluster.html#workerdisconnect.

> v7.3.0 | This method now returns a reference to worker.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
