### PR TITLE
feat(node/http): add missing ServerOptions

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -270,6 +270,13 @@ declare module "http" {
          */
         connectionsCheckingInterval?: number | undefined;
         /**
+         * Sets the timeout value in milliseconds for receiving the complete HTTP headers from the client.
+         * See {@link Server.headersTimeout} for more information.
+         * @default 60000
+         * @since 18.0.0
+         */
+        headersTimeout?: number | undefined;
+        /**
          * Optionally overrides all `socket`s' `readableHighWaterMark` and `writableHighWaterMark`.
          * This affects `highWaterMark` property of both `IncomingMessage` and `ServerResponse`.
          * Default: @see stream.getDefaultHighWaterMark().
@@ -297,6 +304,13 @@ declare module "http" {
          */
         noDelay?: boolean | undefined;
         /**
+         * If set to `true`, it forces the server to respond with a 400 (Bad Request) status code
+         * to any HTTP/1.1 request message that lacks a Host header (as mandated by the specification).
+         * @default true
+         * @since 20.0.0
+         */
+        requireHostHeader?: boolean | undefined;
+        /**
          * If set to `true`, it enables keep-alive functionality on the socket immediately after a new incoming connection is received,
          * similarly on what is done in `socket.setKeepAlive([enable][, initialDelay])`.
          * @default false
@@ -314,6 +328,12 @@ declare module "http" {
          * If the header's value is an array, the items will be joined using `; `.
          */
         uniqueHeaders?: Array<string | string[]> | undefined;
+        /**
+         * If set to `true`, an error is thrown when writing to an HTTP response which does not have a body.
+         * @default false
+         * @since v18.17.0, v20.2.0
+         */
+        rejectNonStandardBodyWrites?: boolean | undefined;
     }
     type RequestListener<
         Request extends typeof IncomingMessage = typeof IncomingMessage,

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -30,11 +30,15 @@ import * as url from "node:url";
     server = http.createServer(reqListener);
     server = http.createServer({ IncomingMessage: MyIncomingMessage });
     server = http.createServer({ ServerResponse: MyServerResponse }, reqListener);
+    // TODO: add test for all remaining options
     server = http.createServer({
         insecureHTTPParser: true,
         keepAlive: true,
         keepAliveInitialDelay: 1000,
         keepAliveTimeout: 100,
+        headersTimeout: 50000,
+        requireHostHeader: false,
+        rejectNonStandardBodyWrites: false,
     }, reqListener);
 
     server.close();

--- a/types/node/v18/http.d.ts
+++ b/types/node/v18/http.d.ts
@@ -268,6 +268,13 @@ declare module "http" {
          */
         connectionsCheckingInterval?: number | undefined;
         /**
+         * Sets the timeout value in milliseconds for receiving the complete HTTP headers from the client.
+         * See {@link Server.headersTimeout} for more information.
+         * @default 60000
+         * @since 18.0.0
+         */
+        headersTimeout?: number | undefined;
+        /**
          * Optionally overrides all `socket`s' `readableHighWaterMark` and `writableHighWaterMark`.
          * This affects `highWaterMark` property of both `IncomingMessage` and `ServerResponse`.
          * Default: @see stream.getDefaultHighWaterMark().
@@ -313,6 +320,12 @@ declare module "http" {
          * If the header's value is an array, the items will be joined using `; `.
          */
         uniqueHeaders?: Array<string | string[]> | undefined;
+        /**
+         * If set to `true`, an error is thrown when writing to an HTTP response which does not have a body.
+         * @default false
+         * @since v18.17.0, v20.2.0
+         */
+        rejectNonStandardBodyWrites?: boolean | undefined;
     }
     type RequestListener<
         Request extends typeof IncomingMessage = typeof IncomingMessage,

--- a/types/node/v18/test/http.ts
+++ b/types/node/v18/test/http.ts
@@ -30,11 +30,14 @@ import * as url from "node:url";
     server = http.createServer(reqListener);
     server = http.createServer({ IncomingMessage: MyIncomingMessage });
     server = http.createServer({ ServerResponse: MyServerResponse }, reqListener);
+    // TODO: add test for all remaining options
     server = http.createServer({
         insecureHTTPParser: true,
         keepAlive: true,
         keepAliveInitialDelay: 1000,
         keepAliveTimeout: 100,
+        headersTimeout: 50000,
+        rejectNonStandardBodyWrites: false,
     }, reqListener);
 
     server.close();

--- a/types/node/v20/http.d.ts
+++ b/types/node/v20/http.d.ts
@@ -268,6 +268,13 @@ declare module "http" {
          */
         connectionsCheckingInterval?: number | undefined;
         /**
+         * Sets the timeout value in milliseconds for receiving the complete HTTP headers from the client.
+         * See {@link Server.headersTimeout} for more information.
+         * @default 60000
+         * @since 18.0.0
+         */
+        headersTimeout?: number | undefined;
+        /**
          * Optionally overrides all `socket`s' `readableHighWaterMark` and `writableHighWaterMark`.
          * This affects `highWaterMark` property of both `IncomingMessage` and `ServerResponse`.
          * Default: @see stream.getDefaultHighWaterMark().
@@ -295,6 +302,13 @@ declare module "http" {
          */
         noDelay?: boolean | undefined;
         /**
+         * If set to `true`, it forces the server to respond with a 400 (Bad Request) status code
+         * to any HTTP/1.1 request message that lacks a Host header (as mandated by the specification).
+         * @default true
+         * @since 20.0.0
+         */
+        requireHostHeader?: boolean | undefined;
+        /**
          * If set to `true`, it enables keep-alive functionality on the socket immediately after a new incoming connection is received,
          * similarly on what is done in `socket.setKeepAlive([enable][, initialDelay])`.
          * @default false
@@ -312,6 +326,12 @@ declare module "http" {
          * If the header's value is an array, the items will be joined using `; `.
          */
         uniqueHeaders?: Array<string | string[]> | undefined;
+        /**
+         * If set to `true`, an error is thrown when writing to an HTTP response which does not have a body.
+         * @default false
+         * @since v18.17.0, v20.2.0
+         */
+        rejectNonStandardBodyWrites?: boolean | undefined;
     }
     type RequestListener<
         Request extends typeof IncomingMessage = typeof IncomingMessage,

--- a/types/node/v20/test/http.ts
+++ b/types/node/v20/test/http.ts
@@ -30,11 +30,15 @@ import * as url from "node:url";
     server = http.createServer(reqListener);
     server = http.createServer({ IncomingMessage: MyIncomingMessage });
     server = http.createServer({ ServerResponse: MyServerResponse }, reqListener);
+    // TODO: add test for all remaining options
     server = http.createServer({
         insecureHTTPParser: true,
         keepAlive: true,
         keepAliveInitialDelay: 1000,
         keepAliveTimeout: 100,
+        headersTimeout: 50000,
+        requireHostHeader: false,
+        rejectNonStandardBodyWrites: false,
     }, reqListener);
 
     server.close();


### PR DESCRIPTION
## Missing options

### `headersTimeout`

See PR https://github.com/nodejs/node/pull/41263.

> `headersTimeout`, `requestTimeout` and `keepAliveTimeout` are now supported directly in `http.createServer` function and they are sanitized.

### `requireHostHeader`

See PR https://github.com/nodejs/node/pull/45597.

> http: created requireHostHeader field to enable host header check

### `rejectNonStandardBodyWrites`

See PR https://github.com/nodejs/node/pull/47732.

> http: rejecting invalid body writes configurable with option rejectNonStandardBodyWrites
> http: set rejectNonStandardBodyWrites option default to false

## Notes

jsdoc descriptions, default values, and `@since` versions can be tracked in the above PRs, and in nodejs documentation https://nodejs.org/api/http.html#httpcreateserveroptions-requestlistener.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
