### PR TITLE
Define Node.js util.styleText options

### DIFF
--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -71,6 +71,12 @@ console.log(
 console.log(
     util.styleText(["red", "green"], "text"),
 );
+console.log(
+    util.styleText("blue", "text", { validateStream: false }),
+);
+console.log(
+    util.styleText("yellow", "text", { stream: process.stdout }),
+);
 
 // util.callbackify
 class callbackifyTest {

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -1375,12 +1375,12 @@ declare module "util" {
          * When true, `stream` is checked to see if it can handle colors.
          * @default true
          */
-        validateStream?: boolean;
+        validateStream?: boolean | undefined;
         /**
          * A stream that will be validated if it can be colored.
          * @default process.stdout
          */
-        stream?: NodeJS.WritableStream;
+        stream?: NodeJS.WritableStream | undefined;
     }
     /**
      * This function returns a formatted text considering the `format` passed.

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -1370,6 +1370,18 @@ declare module "util" {
         | "reset"
         | "strikethrough"
         | "underline";
+    export interface StyleTextOptions {
+        /**
+         * When true, `stream` is checked to see if it can handle colors.
+         * @default true
+         */
+        validateStream?: boolean;
+        /**
+         * A stream that will be validated if it can be colored.
+         * @default process.stdout
+         */
+        stream?: NodeJS.WritableStream;
+    }
     /**
      * This function returns a formatted text considering the `format` passed.
      *
@@ -1408,6 +1420,7 @@ declare module "util" {
             | Modifiers
             | Array<ForegroundColors | BackgroundColors | Modifiers>,
         text: string,
+        options?: StyleTextOptions,
     ): string;
     /**
      * An implementation of the [WHATWG Encoding Standard](https://encoding.spec.whatwg.org/) `TextDecoder` API.

--- a/types/node/v20/test/util.ts
+++ b/types/node/v20/test/util.ts
@@ -71,6 +71,12 @@ console.log(
 console.log(
     util.styleText(["red", "green"], "text"),
 );
+console.log(
+    util.styleText("blue", "text", { validateStream: false }),
+);
+console.log(
+    util.styleText("yellow", "text", { stream: process.stdout }),
+);
 
 // util.callbackify
 class callbackifyTest {

--- a/types/node/v20/util.d.ts
+++ b/types/node/v20/util.d.ts
@@ -1241,6 +1241,18 @@ declare module "util" {
         | "reset"
         | "strikethrough"
         | "underline";
+    export interface StyleTextOptions {
+        /**
+         * When true, `stream` is checked to see if it can handle colors.
+         * @default true
+         */
+        validateStream?: boolean;
+        /**
+         * A stream that will be validated if it can be colored.
+         * @default process.stdout
+         */
+        stream?: NodeJS.WritableStream;
+    }
     /**
      * Stability: 1.1 - Active development
      *
@@ -1281,6 +1293,7 @@ declare module "util" {
             | Modifiers
             | Array<ForegroundColors | BackgroundColors | Modifiers>,
         text: string,
+        options?: StyleTextOptions,
     ): string;
     /**
      * An implementation of the [WHATWG Encoding Standard](https://encoding.spec.whatwg.org/) `TextDecoder` API.

--- a/types/node/v20/util.d.ts
+++ b/types/node/v20/util.d.ts
@@ -1246,12 +1246,12 @@ declare module "util" {
          * When true, `stream` is checked to see if it can handle colors.
          * @default true
          */
-        validateStream?: boolean;
+        validateStream?: boolean | undefined;
         /**
          * A stream that will be validated if it can be colored.
          * @default process.stdout
          */
-        stream?: NodeJS.WritableStream;
+        stream?: NodeJS.WritableStream | undefined;
     }
     /**
      * Stability: 1.1 - Active development


### PR DESCRIPTION
The Node.js builtin `util.styleText` accepts some options.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v22.x/api/util.html#utilstyletextformat-text-options
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
