### PR TITLE
Update dockerode types to include manifest information.

### DIFF
--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -87,7 +87,7 @@ async function foo() {
         const imageSharedSize: number = image.SharedSize;
         const imageContainers: number = image.Containers;
         const foo = await docker5.getImage(image.Id);
-        const inspect = await foo.inspect({manifests: true});
+        const inspect = await foo.inspect({ manifests: true });
         const imageDescriptor = inspect.Descriptor;
         const imageManifests = inspect.Manifests;
         await foo.remove();

--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -87,8 +87,9 @@ async function foo() {
         const imageSharedSize: number = image.SharedSize;
         const imageContainers: number = image.Containers;
         const foo = await docker5.getImage(image.Id);
-        const inspect = await foo.inspect();
+        const inspect = await foo.inspect({manifests: true});
         const imageDescriptor = inspect.Descriptor;
+        const imageManifests = inspect.Manifests;
         await foo.remove();
     }
 
@@ -299,6 +300,16 @@ docker.listImages({
 docker.listImages({
     all: true,
     filters: { "dangling": ["true"] },
+    digests: true,
+    abortSignal: new AbortController().signal,
+}).then(images => {
+    return images.map(image => docker.getImage(image.Id));
+});
+
+docker.listImages({
+    all: true,
+    filters: { "dangling": ["true"] },
+    manifests: true,
     digests: true,
     abortSignal: new AbortController().signal,
 }).then(images => {

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -336,6 +336,25 @@ declare namespace Dockerode {
 
     type Duration = number;
 
+    interface ImageDescriptor {
+        mediaType: string;
+        digest: string;
+        size: number;
+        urls?: string[] | undefined;
+        annotations?: { [key: string]: string } | undefined;
+        data?: string | undefined;
+        platform?:
+            | {
+                architecture: string;
+                os: string;
+                "os.version"?: string | undefined;
+                "os.features"?: string[] | undefined;
+                variant?: string | undefined;
+            }
+            | undefined;
+        artifactType?: string | undefined;
+    }
+
     interface ImageInfo {
         Id: string;
         ParentId: string;
@@ -347,47 +366,11 @@ declare namespace Dockerode {
         SharedSize: number;
         Labels: { [label: string]: string };
         Containers: number;
-        Descriptor?:
-            | {
-                mediaType: string;
-                digest: string;
-                size: number;
-                urls?: string[] | undefined;
-                annotations?: { [key: string]: string } | undefined;
-                data?: string | undefined;
-                platform?:
-                    | {
-                        architecture: string;
-                        os: string;
-                        "os.version"?: string | undefined;
-                        "os.features"?: string[] | undefined;
-                        variant?: string | undefined;
-                    }
-                    | undefined;
-                artifactType?: string | undefined;
-            }
-            | undefined;
+        Descriptor?: ImageDescriptor | undefined;
         Manifests?:
             | {
                 ID: string;
-                Descriptor: {
-                    mediaType: string;
-                    digest: string;
-                    size: number;
-                    urls?: string[] | undefined;
-                    annotations?: { [key: string]: string } | undefined;
-                    data?: string | undefined;
-                    platform?:
-                        | {
-                            architecture: string;
-                            os: string;
-                            "os.version"?: string | undefined;
-                            "os.features"?: string[] | undefined;
-                            variant?: string | undefined;
-                        }
-                        | undefined;
-                    artifactType?: string | undefined;
-                };
+                Descriptor: ImageDescriptor;
                 Available: boolean;
                 Size: {
                     Total: number;
@@ -405,8 +388,7 @@ declare namespace Dockerode {
                         };
                         Containers: string[];
                         Size: {
-                            Total: number;
-                            Content: number;
+                            Unpacked: number;
                         };
                     }
                     | undefined;

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -356,14 +356,14 @@ declare namespace Dockerode {
                 annotations?: { [key: string]: string } | undefined;
                 data?: string | undefined;
                 platform?:
-                | {
-                    architecture: string;
-                    os: string;
-                    'os.version'?: string | undefined;
-                    'os.features'?: string[] | undefined;
-                    variant?: string | undefined;
+                    | {
+                        architecture: string;
+                        os: string;
+                        "os.version"?: string | undefined;
+                        "os.features"?: string[] | undefined;
+                        variant?: string | undefined;
                     }
-                | undefined;
+                    | undefined;
                 artifactType?: string | undefined;
             }
             | undefined;
@@ -371,50 +371,50 @@ declare namespace Dockerode {
             | {
                 ID: string;
                 Descriptor: {
-                mediaType: string;
-                digest: string;
-                size: number;
-                urls?: string[] | undefined;
-                annotations?: { [key: string]: string } | undefined;
-                data?: string | undefined;
-                platform?:
-                    | {
-                        architecture: string;
-                        os: string;
-                        'os.version'?: string | undefined;
-                        'os.features'?: string[] | undefined;
-                        variant?: string | undefined;
-                    }
-                    | undefined;
-                artifactType?: string | undefined;
+                    mediaType: string;
+                    digest: string;
+                    size: number;
+                    urls?: string[] | undefined;
+                    annotations?: { [key: string]: string } | undefined;
+                    data?: string | undefined;
+                    platform?:
+                        | {
+                            architecture: string;
+                            os: string;
+                            "os.version"?: string | undefined;
+                            "os.features"?: string[] | undefined;
+                            variant?: string | undefined;
+                        }
+                        | undefined;
+                    artifactType?: string | undefined;
                 };
                 Available: boolean;
                 Size: {
-                Total: number;
-                Content: number;
+                    Total: number;
+                    Content: number;
                 };
-                Kind: 'image' | 'attestation' | 'unknown';
+                Kind: "image" | "attestation" | "unknown";
                 ImageData?:
-                | {
-                    Platform: {
-                        architecture: string;
-                        os: string;
-                        'os.version'?: string | undefined;
-                        'os.features'?: string[] | undefined;
-                        variant?: string | undefined;
-                    };
-                    Containers: string[];
-                    Size: {
-                        Total: number;
-                        Content: number;
-                    };
+                    | {
+                        Platform: {
+                            architecture: string;
+                            os: string;
+                            "os.version"?: string | undefined;
+                            "os.features"?: string[] | undefined;
+                            variant?: string | undefined;
+                        };
+                        Containers: string[];
+                        Size: {
+                            Total: number;
+                            Content: number;
+                        };
                     }
-                | undefined;
+                    | undefined;
                 AttestationData?:
-                | {
-                    For: string;
+                    | {
+                        For: string;
                     }
-                | undefined;
+                    | undefined;
             }[]
             | undefined;
     }
@@ -1027,14 +1027,14 @@ declare namespace Dockerode {
                 annotations?: { [key: string]: string } | undefined;
                 data?: string | undefined;
                 platform?:
-                | {
-                    architecture: string;
-                    os: string;
-                    'os.version'?: string | undefined;
-                    'os.features'?: string[] | undefined;
-                    variant?: string | undefined;
-                }
-                | undefined;
+                    | {
+                        architecture: string;
+                        os: string;
+                        "os.version"?: string | undefined;
+                        "os.features"?: string[] | undefined;
+                        variant?: string | undefined;
+                    }
+                    | undefined;
                 artifactType?: string | undefined;
             }
             | undefined;
@@ -1049,14 +1049,14 @@ declare namespace Dockerode {
                     annotations?: { [key: string]: string } | undefined;
                     data?: string | undefined;
                     platform?:
-                    | {
-                        architecture: string;
-                        os: string;
-                        'os.version'?: string | undefined;
-                        'os.features'?: string[] | undefined;
-                        variant?: string | undefined;
-                    }
-                    | undefined;
+                        | {
+                            architecture: string;
+                            os: string;
+                            "os.version"?: string | undefined;
+                            "os.features"?: string[] | undefined;
+                            variant?: string | undefined;
+                        }
+                        | undefined;
                     artifactType?: string | undefined;
                 };
                 Available: boolean;
@@ -1064,28 +1064,28 @@ declare namespace Dockerode {
                     Total: number;
                     Content: number;
                 };
-                Kind: 'image' | 'attestation' | 'unknown';
+                Kind: "image" | "attestation" | "unknown";
                 ImageData?:
-                | {
-                    Platform: {
-                        architecture: string;
-                        os: string;
-                        'os.version'?: string | undefined;
-                        'os.features'?: string[] | undefined;
-                        variant?: string | undefined;
-                    };
-                    Containers: string[];
-                    Size: {
-                        Total: number;
-                        Content: number;
-                    };
-                }
-                | undefined;
+                    | {
+                        Platform: {
+                            architecture: string;
+                            os: string;
+                            "os.version"?: string | undefined;
+                            "os.features"?: string[] | undefined;
+                            variant?: string | undefined;
+                        };
+                        Containers: string[];
+                        Size: {
+                            Total: number;
+                            Content: number;
+                        };
+                    }
+                    | undefined;
                 AttestationData?:
-                | {
-                    For: string;
-                }
-                | undefined;
+                    | {
+                        For: string;
+                    }
+                    | undefined;
             }[]
             | undefined;
     }

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -120,8 +120,9 @@ declare namespace Dockerode {
         modem: any;
         id: string;
 
+        inspect(options: ImageInspectOptions, callback: Callback<ImageInspectInfo>): void;
         inspect(callback: Callback<ImageInspectInfo>): void;
-        inspect(): Promise<ImageInspectInfo>;
+        inspect(options?: ImageInspectOptions): Promise<ImageInspectInfo>;
 
         history(callback: Callback<any>): void;
         history(): Promise<any>;
@@ -346,6 +347,76 @@ declare namespace Dockerode {
         SharedSize: number;
         Labels: { [label: string]: string };
         Containers: number;
+        Descriptor?:
+            | {
+                mediaType: string;
+                digest: string;
+                size: number;
+                urls?: string[] | undefined;
+                annotations?: { [key: string]: string } | undefined;
+                data?: string | undefined;
+                platform?:
+                | {
+                    architecture: string;
+                    os: string;
+                    'os.version'?: string | undefined;
+                    'os.features'?: string[] | undefined;
+                    variant?: string | undefined;
+                    }
+                | undefined;
+                artifactType?: string | undefined;
+            }
+            | undefined;
+        Manifests?:
+            | {
+                ID: string;
+                Descriptor: {
+                mediaType: string;
+                digest: string;
+                size: number;
+                urls?: string[] | undefined;
+                annotations?: { [key: string]: string } | undefined;
+                data?: string | undefined;
+                platform?:
+                    | {
+                        architecture: string;
+                        os: string;
+                        'os.version'?: string | undefined;
+                        'os.features'?: string[] | undefined;
+                        variant?: string | undefined;
+                    }
+                    | undefined;
+                artifactType?: string | undefined;
+                };
+                Available: boolean;
+                Size: {
+                Total: number;
+                Content: number;
+                };
+                Kind: 'image' | 'attestation' | 'unknown';
+                ImageData?:
+                | {
+                    Platform: {
+                        architecture: string;
+                        os: string;
+                        'os.version'?: string | undefined;
+                        'os.features'?: string[] | undefined;
+                        variant?: string | undefined;
+                    };
+                    Containers: string[];
+                    Size: {
+                        Total: number;
+                        Content: number;
+                    };
+                    }
+                | undefined;
+                AttestationData?:
+                | {
+                    For: string;
+                    }
+                | undefined;
+            }[]
+            | undefined;
     }
 
     interface ContainerInfo {
@@ -929,7 +1000,9 @@ declare namespace Dockerode {
             Labels: { [label: string]: string };
         };
         Architecture: string;
+        Variant?: string | undefined;
         Os: string;
+        OsVersion?: string | undefined;
         Size: number;
         VirtualSize: number;
         GraphDriver: {
@@ -945,22 +1018,76 @@ declare namespace Dockerode {
             Layers?: string[] | undefined;
             BaseLayer?: string | undefined;
         };
-        Descriptor?: {
-            mediaType: string;
-            digest: string;
-            size: number;
-            urls?: string[] | undefined;
-            annotations?: { [key: string]: string } | undefined;
-            data?: string | undefined;
-            platform?: {
-                architecture: string;
-                os: string;
-                "os.version"?: string | undefined;
-                "os.features"?: string[] | undefined;
-                variant?: string | undefined;
-            } | undefined;
-            artifactType?: string | undefined;
-        } | undefined;
+        Descriptor?:
+            | {
+                mediaType: string;
+                digest: string;
+                size: number;
+                urls?: string[] | undefined;
+                annotations?: { [key: string]: string } | undefined;
+                data?: string | undefined;
+                platform?:
+                | {
+                    architecture: string;
+                    os: string;
+                    'os.version'?: string | undefined;
+                    'os.features'?: string[] | undefined;
+                    variant?: string | undefined;
+                }
+                | undefined;
+                artifactType?: string | undefined;
+            }
+            | undefined;
+        Manifests?:
+            | {
+                ID: string;
+                Descriptor: {
+                    mediaType: string;
+                    digest: string;
+                    size: number;
+                    urls?: string[] | undefined;
+                    annotations?: { [key: string]: string } | undefined;
+                    data?: string | undefined;
+                    platform?:
+                    | {
+                        architecture: string;
+                        os: string;
+                        'os.version'?: string | undefined;
+                        'os.features'?: string[] | undefined;
+                        variant?: string | undefined;
+                    }
+                    | undefined;
+                    artifactType?: string | undefined;
+                };
+                Available: boolean;
+                Size: {
+                    Total: number;
+                    Content: number;
+                };
+                Kind: 'image' | 'attestation' | 'unknown';
+                ImageData?:
+                | {
+                    Platform: {
+                        architecture: string;
+                        os: string;
+                        'os.version'?: string | undefined;
+                        'os.features'?: string[] | undefined;
+                        variant?: string | undefined;
+                    };
+                    Containers: string[];
+                    Size: {
+                        Total: number;
+                        Content: number;
+                    };
+                }
+                | undefined;
+                AttestationData?:
+                | {
+                    For: string;
+                }
+                | undefined;
+            }[]
+            | undefined;
     }
 
     interface ImageBuildOptions {
@@ -1004,6 +1131,10 @@ declare namespace Dockerode {
     interface ImageDistributionOptions {
         authconfig?: AuthConfig | undefined;
         abortSignal?: AbortSignal;
+    }
+
+    interface ImageInspectOptions {
+        manifests?: boolean | undefined;
     }
 
     interface ImagePushOptions {
@@ -1869,6 +2000,7 @@ declare namespace Dockerode {
         all?: boolean | undefined;
         filters?: string | { [key: string]: string[] } | undefined;
         digests?: boolean | undefined;
+        manifests?: boolean | undefined;
         abortSignal?: AbortSignal;
     }
 


### PR DESCRIPTION
- Update dockerode types to include options when doing Image.inspect.
- Add manifests option to ListImagesOptions.
- Update the dockerode ImageInfo and ImageInspectInfo interfaces.


- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/apocas/dockerode/pull/800/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. https://www.npmjs.com/package/dockerode/v/4.0.6