### PR TITLE
node/stream: Update undefined->void in line with TS 5.8 changes

### DIFF
--- a/types/node/stream/web.d.ts
+++ b/types/node/stream/web.d.ts
@@ -97,7 +97,7 @@ declare module "stream/web" {
         signal?: AbortSignal;
     }
     interface ReadableStreamGenericReader {
-        readonly closed: Promise<undefined>;
+        readonly closed: Promise<void>;
         cancel(reason?: any): Promise<void>;
     }
     type ReadableStreamController<T> = ReadableStreamDefaultController<T>;
@@ -307,9 +307,9 @@ declare module "stream/web" {
      * sink.
      */
     interface WritableStreamDefaultWriter<W = any> {
-        readonly closed: Promise<undefined>;
+        readonly closed: Promise<void>;
         readonly desiredSize: number | null;
-        readonly ready: Promise<undefined>;
+        readonly ready: Promise<void>;
         abort(reason?: any): Promise<void>;
         close(): Promise<void>;
         releaseLock(): void;

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -811,7 +811,7 @@ async function testTransferringStreamWithPostMessage() {
     // $ExpectType Promise<void>
     byobReader.cancel("reason");
 
-    // $ExpectType Promise<undefined>
+    // $ExpectType Promise<void>
     byobReader.closed;
 
     // $ExpectType Promise<ReadableStreamReadResult<Uint8Array<ArrayBuffer>>>

--- a/types/node/v18/stream/web.d.ts
+++ b/types/node/v18/stream/web.d.ts
@@ -97,7 +97,7 @@ declare module "stream/web" {
         signal?: AbortSignal;
     }
     interface ReadableStreamGenericReader {
-        readonly closed: Promise<undefined>;
+        readonly closed: Promise<void>;
         cancel(reason?: any): Promise<void>;
     }
     type ReadableStreamController<T> = ReadableStreamDefaultController<T>;
@@ -301,9 +301,9 @@ declare module "stream/web" {
      * sink.
      */
     interface WritableStreamDefaultWriter<W = any> {
-        readonly closed: Promise<undefined>;
+        readonly closed: Promise<void>;
         readonly desiredSize: number | null;
-        readonly ready: Promise<undefined>;
+        readonly ready: Promise<void>;
         abort(reason?: any): Promise<void>;
         close(): Promise<void>;
         releaseLock(): void;

--- a/types/node/v18/test/stream.ts
+++ b/types/node/v18/test/stream.ts
@@ -731,7 +731,7 @@ async function testTransferringStreamWithPostMessage() {
     // $ExpectType Promise<void>
     byobReader.cancel("reason");
 
-    // $ExpectType Promise<undefined>
+    // $ExpectType Promise<void>
     byobReader.closed;
 
     // $ExpectType Promise<ReadableStreamReadResult<Uint8Array<ArrayBuffer>>>

--- a/types/node/v20/stream/web.d.ts
+++ b/types/node/v20/stream/web.d.ts
@@ -97,7 +97,7 @@ declare module "stream/web" {
         signal?: AbortSignal;
     }
     interface ReadableStreamGenericReader {
-        readonly closed: Promise<undefined>;
+        readonly closed: Promise<void>;
         cancel(reason?: any): Promise<void>;
     }
     type ReadableStreamController<T> = ReadableStreamDefaultController<T>;
@@ -307,9 +307,9 @@ declare module "stream/web" {
      * sink.
      */
     interface WritableStreamDefaultWriter<W = any> {
-        readonly closed: Promise<undefined>;
+        readonly closed: Promise<void>;
         readonly desiredSize: number | null;
-        readonly ready: Promise<undefined>;
+        readonly ready: Promise<void>;
         abort(reason?: any): Promise<void>;
         close(): Promise<void>;
         releaseLock(): void;

--- a/types/node/v20/test/stream.ts
+++ b/types/node/v20/test/stream.ts
@@ -811,7 +811,7 @@ async function testTransferringStreamWithPostMessage() {
     // $ExpectType Promise<void>
     byobReader.cancel("reason");
 
-    // $ExpectType Promise<undefined>
+    // $ExpectType Promise<void>
     byobReader.closed;
 
     // $ExpectType Promise<ReadableStreamReadResult<Uint8Array<ArrayBuffer>>>


### PR DESCRIPTION
TypeScript changed the `closed` and `ready` stream properties from `Promise<undefined>` to `Promise<void>` in microsoft/TypeScript@66e1b24.  This change is required for streams returned from `toWeb()` to be structurally compatible.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: microsoft/TypeScript@66e1b24
- [ ] (N/A) If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
