### PR TITLE
[chrome] add printing.getJobStatus() since Chrome 135

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -7882,6 +7882,13 @@ declare namespace chrome {
         export function cancelJob(jobId: string, callback: () => void): void;
 
         /**
+         * Returns the status of the print job. This call will fail with a runtime error if the print job with the given `jobId` doesn't exist. `jobId`: The id of the print job to return the status of. This should be the same id received in a {@link SubmitJobResponse}.
+         * @since Chrome 135
+         */
+        export function getJobStatus(jobId: string): Promise<`${JobStatus}`>;
+        export function getJobStatus(jobId: string, callback: (status: `${JobStatus}`) => void): void;
+
+        /**
          * Returns the status and capabilities of the printer in CDD format. This call will fail with a runtime error if no printers with given id are installed.
          * Can return its result via Promise in Manifest V3 or later since Chrome 100.
          */
@@ -7905,7 +7912,7 @@ declare namespace chrome {
         /**
          * Event fired when the status of the job is changed. This is only fired for the jobs created by this extension.
          */
-        export const onJobStatusChanged: chrome.events.Event<(jobId: string, status: JobStatus) => void>;
+        export const onJobStatusChanged: chrome.events.Event<(jobId: string, status: `${JobStatus}`) => void>;
     }
 
     ////////////////////

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -4563,6 +4563,13 @@ function testPrinting() {
     // @ts-expect-error
     chrome.printing.cancelJob("", () => {}).then(() => {});
 
+    chrome.printing.getJobStatus(""); // $ExpectType Promise<"PENDING" | "IN_PROGRESS" | "FAILED" | "CANCELED" | "PRINTED">
+    chrome.printing.getJobStatus("", status => { // $ExpectType void
+        status; // $ExpectType "PENDING" | "IN_PROGRESS" | "FAILED" | "CANCELED" | "PRINTED"
+    });
+    // @ts-expect-error
+    chrome.printing.getJobStatus("", status => {}).then(status => {});
+
     chrome.printing.getPrinterInfo(""); // $ExpectType Promise<GetPrinterInfoResponse>
     chrome.printing.getPrinterInfo("", response => {}); // $ExpectType void
     // @ts-expect-error
@@ -4589,15 +4596,15 @@ function testPrinting() {
 
     chrome.printing.onJobStatusChanged.addListener((jobId, status) => {
         jobId; // $ExpectType string
-        status; // $ExpectType JobStatus
+        status; // $ExpectType "PENDING" | "IN_PROGRESS" | "FAILED" | "CANCELED" | "PRINTED"
     });
     chrome.printing.onJobStatusChanged.removeListener((jobId, status) => {
         jobId; // $ExpectType string
-        status; // $ExpectType JobStatus
+        status; // $ExpectType "PENDING" | "IN_PROGRESS" | "FAILED" | "CANCELED" | "PRINTED"
     });
     chrome.printing.onJobStatusChanged.hasListener((jobId, status) => {
         jobId; // $ExpectType string
-        status; // $ExpectType JobStatus
+        status; // $ExpectType "PENDING" | "IN_PROGRESS" | "FAILED" | "CANCELED" | "PRINTED"
     });
     chrome.printing.onJobStatusChanged.hasListeners();
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/printing#method-getPrinterInfo
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Note : 
- Add `getJobStatus()` method
- Fix `onJobStatusChanged` type
