### PR TITLE
[chrome]: add userScripts.execute()

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -14843,6 +14843,7 @@ declare namespace chrome {
          */
         export type ExecutionWorld = "MAIN" | "USER_SCRIPT";
 
+        /** @since Chrome 135 */
         export interface InjectionResult {
             /** The document associated with the injection. */
             documentId: string;
@@ -14870,6 +14871,7 @@ declare namespace chrome {
             ids?: string[];
         }
 
+        /** @since Chrome 135 */
         export interface InjectionTarget {
             /** Whether the script should inject into all frames within the tab. Defaults to false. This must not be true if `frameIds` is specified. */
             allFrames?: boolean;
@@ -14907,6 +14909,7 @@ declare namespace chrome {
             worldId?: string;
         }
 
+        /** @since Chrome 135 */
         export interface UserScriptInjection {
             /** Whether the injection should be triggered in the target as soon as possible. Note that this is not a guarantee that injection will occur prior to page load, as the page may have already loaded by the time the script reaches the target. */
             injectImmediately?: boolean;
@@ -14977,10 +14980,6 @@ declare namespace chrome {
          * @since Chrome 135
          */
         export function execute(injection: UserScriptInjection): Promise<InjectionResult[]>;
-        /**
-         * Injects a script into a target context. By default, the script will be run at `document_idle`, or immediately if the page has already loaded. If the `injectImmediately` property is set, the script will inject without waiting, even if the page has not finished loading. If the script evaluates to a promise, the browser will wait for the promise to settle and return the resulting value.
-         * @since Chrome 135
-         */
         export function execute(injection: UserScriptInjection, callback: (result: InjectionResult[]) => void): void;
 
         /**

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -14843,6 +14843,17 @@ declare namespace chrome {
          */
         export type ExecutionWorld = "MAIN" | "USER_SCRIPT";
 
+        export interface InjectionResult {
+            /** The document associated with the injection. */
+            documentId: string;
+            /** The error, if any. `error` and `result` are mutually exclusive. */
+            error?: string;
+            /** The frame associated with the injection. */
+            frameId: number;
+            /** The result of the script execution. */
+            result: any;
+        }
+
         export interface WorldProperties {
             /** Specifies the world csp. The default is the `ISOLATED` world csp. */
             csp?: string;
@@ -14857,6 +14868,17 @@ declare namespace chrome {
 
         export interface UserScriptFilter {
             ids?: string[];
+        }
+
+        export interface InjectionTarget {
+            /** Whether the script should inject into all frames within the tab. Defaults to false. This must not be true if `frameIds` is specified. */
+            allFrames?: boolean;
+            /** The IDs of specific documentIds to inject into. This must not be set if `frameIds` is set. */
+            documentIds?: string[];
+            /** The IDs of specific frames to inject into. */
+            frameIds?: number[];
+            /** The ID of the tab into which to inject. */
+            tabId: number;
         }
 
         export interface RegisteredUserScript {
@@ -14882,6 +14904,19 @@ declare namespace chrome {
              * Specifies the user script world ID to execute in. If omitted, the script will execute in the default user script world. Only valid if `world` is omitted or is `USER_SCRIPT`. Values with leading underscores (`_`) are reserved.
              * @since Chrome 133
              */
+            worldId?: string;
+        }
+
+        export interface UserScriptInjection {
+            /** Whether the injection should be triggered in the target as soon as possible. Note that this is not a guarantee that injection will occur prior to page load, as the page may have already loaded by the time the script reaches the target. */
+            injectImmediately?: boolean;
+            /** The list of ScriptSource objects defining sources of scripts to be injected into the target. */
+            js: ScriptSource[];
+            /** Details specifying the target into which to inject the script. */
+            target: InjectionTarget;
+            /** The JavaScript "world" to run the script in. The default is `USER_SCRIPT`. */
+            world?: ExecutionWorld;
+            /** Specifies the user script world ID to execute in. If omitted, the script will execute in the default user script world. Only valid if `world` is omitted or is `USER_SCRIPT`. Values with leading underscores (`_`) are reserved. */
             worldId?: string;
         }
 
@@ -14936,6 +14971,17 @@ declare namespace chrome {
          */
         export function getWorldConfigurations(): Promise<WorldProperties[]>;
         export function getWorldConfigurations(callback: (worlds: WorldProperties[]) => void): void;
+
+        /**
+         * Injects a script into a target context. By default, the script will be run at `document_idle`, or immediately if the page has already loaded. If the `injectImmediately` property is set, the script will inject without waiting, even if the page has not finished loading. If the script evaluates to a promise, the browser will wait for the promise to settle and return the resulting value.
+         * @since Chrome 135
+        */
+        export function execute(injection: UserScriptInjection): Promise<InjectionResult[]>;
+        /**
+         * Injects a script into a target context. By default, the script will be run at `document_idle`, or immediately if the page has already loaded. If the `injectImmediately` property is set, the script will inject without waiting, even if the page has not finished loading. If the script evaluates to a promise, the browser will wait for the promise to settle and return the resulting value.
+         * @since Chrome 135
+         */
+        export function execute(injection: UserScriptInjection, callback: (result: InjectionResult[]) => void): void;
 
         /**
          * Registers one or more user scripts for this extension.

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -14975,7 +14975,7 @@ declare namespace chrome {
         /**
          * Injects a script into a target context. By default, the script will be run at `document_idle`, or immediately if the page has already loaded. If the `injectImmediately` property is set, the script will inject without waiting, even if the page has not finished loading. If the script evaluates to a promise, the browser will wait for the promise to settle and return the resulting value.
          * @since Chrome 135
-        */
+         */
         export function execute(injection: UserScriptInjection): Promise<InjectionResult[]>;
         /**
          * Injects a script into a target context. By default, the script will be run at `document_idle`, or immediately if the page has already loaded. If the `injectImmediately` property is set, the script will inject without waiting, even if the page has not finished loading. If the script evaluates to a promise, the browser will wait for the promise to settle and return the resulting value.

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -4407,7 +4407,7 @@ function testUserScripts() {
     ];
     const injectionTarget: chrome.userScripts.InjectionTarget = {
         tabId: 46,
-        allFrames: true
+        allFrames: true,
     };
 
     const badExeOptions = {};

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -4430,9 +4430,9 @@ function testUserScripts() {
     // @ts-expect-error
     chrome.userScripts.execute(badExeOptions);
     chrome.userScripts.execute(exeOptions); // $ExpectType Promise<InjectionResult[]>
-    chrome.userScripts.execute(exeOptions, (result) => {
+    chrome.userScripts.execute(exeOptions, (result) => { // $ExpectType void
         result; // $ExpectType InjectionResult[]
-    }); // $ExpectType void
+    });
 
     chrome.userScripts.register(scripts); // $ExpectType Promise<void>
     chrome.userScripts.register(scripts, () => void 0); // $ExpectType void

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -4430,7 +4430,9 @@ function testUserScripts() {
     // @ts-expect-error
     chrome.userScripts.execute(badExeOptions);
     chrome.userScripts.execute(exeOptions); // $ExpectType Promise<InjectionResult[]>
-    chrome.userScripts.execute(exeOptions, () => void 0); // $ExpectType void
+    chrome.userScripts.execute(exeOptions, (result) => {
+        result; // $ExpectType InjectionResult[]
+    }); // $ExpectType void
 
     chrome.userScripts.register(scripts); // $ExpectType Promise<void>
     chrome.userScripts.register(scripts, () => void 0); // $ExpectType void

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -4379,6 +4379,12 @@ function testUserScripts() {
     chrome.userScripts.getScripts(userScriptFilter); // $ExpectType Promise<RegisteredUserScript[]>
     chrome.userScripts.getScripts(userScriptFilter, (scripts: chrome.userScripts.RegisteredUserScript[]) => void 0); // $ExpectType void
 
+    const badScripts = [
+        {
+            id: "badScriptId",
+            matches: ["*://example.com/*"],
+        },
+    ];
     const scripts = [
         {
             id: "scriptId1",
@@ -4391,13 +4397,26 @@ function testUserScripts() {
             matches: ["*://example.org/*"],
         },
     ];
-
-    const badScripts = [
+    const jsInjections: chrome.userScripts.ScriptSource[] = [
         {
-            id: "badScriptId",
-            matches: ["*://example.com/*"],
+            file: "./the/script.js",
+        },
+        {
+            code: "console.log(\"Wow the script works!\");",
         },
     ];
+    const injectionTarget: chrome.userScripts.InjectionTarget = {
+        tabId: 46,
+        allFrames: true
+    };
+
+    const badExeOptions = {};
+    const exeOptions: chrome.userScripts.UserScriptInjection = {
+        injectImmediately: true,
+        js: jsInjections,
+        target: injectionTarget,
+        worldId: "USER_SCRIPT",
+    };
 
     chrome.userScripts.getWorldConfigurations(); // $ExpectType Promise<WorldProperties[]>
     chrome.userScripts.getWorldConfigurations(([world]) => { // $ExpectType void
@@ -4407,6 +4426,11 @@ function testUserScripts() {
     });
     // @ts-expect-error
     chrome.userScripts.getWorldConfigurations(() => {}).then(() => {});
+
+    // @ts-expect-error
+    chrome.userScripts.execute(badExeOptions);
+    chrome.userScripts.execute(exeOptions); // $ExpectType Promise<InjectionResult[]>
+    chrome.userScripts.execute(exeOptions, () => void 0); // $ExpectType void
 
     chrome.userScripts.register(scripts); // $ExpectType Promise<void>
     chrome.userScripts.register(scripts, () => void 0); // $ExpectType void


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [chrome docs](https://developer.chrome.com/docs/extensions/reference/api/userScripts#method-execute)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Reported in #72560
Added execute() and missing interfaces that execute() references.
