### PR TITLE
[itemsjs] Rename generics and fix `extends`

### DIFF
--- a/types/itemsjs/itemsjs-tests.ts
+++ b/types/itemsjs/itemsjs-tests.ts
@@ -133,3 +133,8 @@ itemsCustomId.search({
 itemsCustomId.search({
     ids: ["a"],
 });
+
+// @ts-expect-error Can only pass objects
+itemsjs("foo");
+// @ts-expect-error Can only pass objects
+itemsjs(123);


### PR DESCRIPTION
This accomplishes a couple of things:

1. Changes the generics to have much more self-describing names, rather than just being a single character.
2. Changes the `extends` from `{}` to `Record<string, any>`. This is what it should have been from the start.

Changing the names of the generics shouldn't be a breaking change for any use cases, and I'd consider the `extends` change to be more of a bugfix than anything (since it allowed for arbitrary non-object types to be passed).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: **N/A**
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.