### PR TITLE
[@types/node] correct `LoadFnOutput.format`

### DIFF
--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -419,7 +419,7 @@ declare module "module" {
             importAttributes: ImportAttributes;
         }
         interface LoadFnOutput {
-            format: ModuleFormat;
+            format: string | null | undefined;
             /**
              * A signal that this hook intends to terminate the chain of `resolve` hooks.
              * @default false

--- a/types/node/test/module.ts
+++ b/types/node/test/module.ts
@@ -204,6 +204,14 @@ Module.Module === Module;
             };
         }
 
+        if (format === null) {
+            return {
+                format,
+                shortCircuit: true,
+                source: "...",
+            };
+        }
+
         return nextLoad(url);
     };
 }

--- a/types/node/v18/module.d.ts
+++ b/types/node/v18/module.d.ts
@@ -198,7 +198,7 @@ declare module "module" {
             importAttributes: ImportAttributes;
         }
         interface LoadFnOutput {
-            format: ModuleFormat;
+            format: string | null | undefined;
             /**
              * A signal that this hook intends to terminate the chain of `resolve` hooks.
              * @default false

--- a/types/node/v18/test/module.ts
+++ b/types/node/v18/test/module.ts
@@ -146,6 +146,14 @@ Module.Module === Module;
             };
         }
 
+        if (format === null) {
+            return {
+                format,
+                shortCircuit: true,
+                source: "...",
+            };
+        }
+
         return nextLoad(url);
     };
 

--- a/types/node/v20/module.d.ts
+++ b/types/node/v20/module.d.ts
@@ -200,7 +200,7 @@ declare module "module" {
             importAttributes: ImportAttributes;
         }
         interface LoadFnOutput {
-            format: ModuleFormat;
+            format: string | null | undefined;
             /**
              * A signal that this hook intends to terminate the chain of `resolve` hooks.
              * @default false

--- a/types/node/v20/test/module.ts
+++ b/types/node/v20/test/module.ts
@@ -163,6 +163,14 @@ Module.Module === Module;
             };
         }
 
+        if (format === null) {
+            return {
+                format,
+                shortCircuit: true,
+                source: "...",
+            };
+        }
+
         return nextLoad(url);
     };
 


### PR DESCRIPTION
A `LoadHook` accepts a `LoadHookContext` object having a `format` of `string | null | undefined`.

`LookHook` implementors often want to pass this value through ([example from docs](https://nodejs.org/api/module.html\#asynchronous-version), which suggests to me that a) it can be falsy, and b) it should be a looser type as established for `ResolveFnOutput` in #71493).

~~A consequence of this is that `ModuleFormat` is no longer referenced anywhere; it can be removed.~~ **UPDATE**: This has been reverted; `ModuleFormat` has not been removed.

* * *

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests). 

> **Testing failed** for me for likely unrelated reasons:
>
    pnpm test node

    > definitely-typed@0.0.3 test /Users/boneskull/projects/definitelytyped/definitelytyped
    > node --enable-source-maps node_modules/@definitelytyped/dtslint/ types "node"

    dtslint@0.2.0
    Error: There is an entry named ts5.6, but 5.6 is not a valid TypeScript version.
        at <anonymous> (/Users/boneskull/projects/definitelytyped/definitelytyped/node_modules/.pnpm/@definitelytyped+header-parser@0.2.0/node_modules/@definitelytyped/header-parser/src/index.ts:301:13)
        at mapDefined (/Users/boneskull/projects/definitelytyped/definitelytyped/node_modules/.pnpm/@definitelytyped+utils@0.1.0/node_modules/@definitelytyped/utils/src/collections.ts:20:17)
        at getTypesVersions (/Users/boneskull/projects/definitelytyped/definitelytyped/node_modules/.pnpm/@definitelytyped+header-parser@0.2.0/node_modules/@definitelytyped/header-parser/src/index.ts:291:20)
        at runTests (/Users/boneskull/projects/definitelytyped/definitelytyped/node_modules/.pnpm/@definitelytyped+dtslint@0.2.0_typescript@5.4.0-dev.20240117/node_modules/@definitelytyped/dtslint/src/index.ts:136:41)
        at async main (/Users/boneskull/projects/definitelytyped/definitelytyped/node_modules/.pnpm/@definitelytyped+dtslint@0.2.0_typescript@5.4.0-dev.20240117/node_modules/@definitelytyped/dtslint/src/index.ts:86:5)
     ELIFECYCLE  Test failed. See above for more details.

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/module.html#asynchronous-version / https://github.com/definitelytyped/definitelytyped/pull/71493
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
