### PR TITLE
CI: Mark meteor-roles as `nonNpm: "conflict"`

### DIFF
--- a/types/meteor-roles/package.json
+++ b/types/meteor-roles/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "@types/meteor-roles",
     "version": "1.2.9999",
-    "nonNpm": true,
+    "nonNpm": "conflict",
     "nonNpmDescription": "meteor-roles",
     "projects": [
         "https://github.com/alanning/meteor-roles/"


### PR DESCRIPTION
The usual story of a dodgy malware stub usurping the root name of a non-npm @types package. Assuming that this will get replaced with a security stub at some point soon, this will remain necessary to unblock upstream CI.