### PR TITLE
pg: amend pg-protocol path resolution

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -3,7 +3,7 @@
 import events = require("events");
 import stream = require("stream");
 import pgTypes = require("pg-types");
-import { NoticeMessage } from "pg-protocol/dist/messages";
+import { NoticeMessage } from "pg-protocol/dist/messages.js";
 
 import { ConnectionOptions } from "tls";
 

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -2,7 +2,7 @@ import { connect } from "net";
 import * as pg from "pg";
 import { Client, Connection, CustomTypesConfig, DatabaseError, defaults, Pool, QueryArrayConfig, types } from "pg";
 import TypeOverrides = require("pg/lib/type-overrides");
-import { NoticeMessage } from "pg-protocol/dist/messages";
+import { NoticeMessage } from "pg-protocol/dist/messages.js";
 
 // https://github.com/brianc/node-pg-types
 // tslint:disable-next-line no-unnecessary-callback-wrapper


### PR DESCRIPTION
pg-protocol has changed its package format in the latest release. A small backwards-compatible change is required to unblock CI.