### PR TITLE
[chrome] no wrapper object types

### DIFF
--- a/types/chrome/.eslintrc.json
+++ b/types/chrome/.eslintrc.json
@@ -2,7 +2,6 @@
     "rules": {
         "@definitelytyped/no-unnecessary-generics": "off",
         "@definitelytyped/strict-export-declare-modifiers": "off",
-        "@typescript-eslint/no-wrapper-object-types": "off",
         "@typescript-eslint/no-empty-interface": "off"
     }
 }

--- a/types/chrome/chrome-cast/index.d.ts
+++ b/types/chrome/chrome-cast/index.d.ts
@@ -210,7 +210,7 @@ declare namespace chrome {
              * @param opt_details
              * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.Error
              */
-            constructor(code: chrome.cast.ErrorCode, description?: string, details?: Object);
+            constructor(code: chrome.cast.ErrorCode, description?: string, details?: object);
 
             code: chrome.cast.ErrorCode;
             description: string | null;
@@ -513,9 +513,9 @@ declare namespace chrome {
              */
             constructor(mediaInfo: chrome.cast.media.MediaInfo);
 
-            activeTrackIds: Number[];
+            activeTrackIds: number[];
             autoplay: boolean;
-            customData: Object;
+            customData: object;
             itemId: number;
             media: chrome.cast.media.MediaInfo;
             preloadTime: number;
@@ -529,7 +529,7 @@ declare namespace chrome {
              */
             constructor(items: chrome.cast.media.QueueItem[]);
 
-            customData: Object;
+            customData: object;
             items: chrome.cast.media.QueueItem[];
             repeatMode: chrome.cast.media.RepeatMode;
             startIndex: number;
@@ -542,7 +542,7 @@ declare namespace chrome {
              */
             constructor(itemsToInsert: chrome.cast.media.QueueItem[]);
 
-            customData: Object;
+            customData: object;
             insertBefore: number;
             items: chrome.cast.media.QueueItem[];
         }
@@ -554,7 +554,7 @@ declare namespace chrome {
              */
             constructor(itemIdsToRemove: number[]);
 
-            customData: Object;
+            customData: object;
             itemIds: number[];
         }
 
@@ -565,7 +565,7 @@ declare namespace chrome {
              */
             constructor(itemIdsToReorder: number[]);
 
-            customData: Object;
+            customData: object;
             insertBefore: number;
             itemIds: number[];
         }
@@ -577,7 +577,7 @@ declare namespace chrome {
              */
             constructor(itemsToUpdate: chrome.cast.media.QueueItem[]);
 
-            customData: Object;
+            customData: object;
             item: chrome.cast.media.QueueItem[];
         }
 
@@ -650,7 +650,7 @@ declare namespace chrome {
              */
             constructor();
 
-            customData: Object;
+            customData: object;
         }
 
         export class PauseRequest {
@@ -659,7 +659,7 @@ declare namespace chrome {
              */
             constructor();
 
-            customData: Object;
+            customData: object;
         }
 
         export class PlayRequest {
@@ -668,7 +668,7 @@ declare namespace chrome {
              */
             constructor();
 
-            customData: Object;
+            customData: object;
         }
 
         export class SeekRequest {
@@ -679,7 +679,7 @@ declare namespace chrome {
 
             currentTime: number;
             resumeState: chrome.cast.media.ResumeState;
-            customData: Object;
+            customData: object;
         }
 
         export class StopRequest {
@@ -688,7 +688,7 @@ declare namespace chrome {
              */
             constructor();
 
-            customData: Object;
+            customData: object;
         }
 
         export class VolumeRequest {
@@ -699,7 +699,7 @@ declare namespace chrome {
             constructor(volume: chrome.cast.Volume);
 
             volume: chrome.cast.Volume;
-            customData: Object;
+            customData: object;
         }
 
         export class LoadRequest {
@@ -712,7 +712,7 @@ declare namespace chrome {
             activeTrackIds: number[];
             autoplay: boolean;
             currentTime: number;
-            customData: Object;
+            customData: object;
             media: chrome.cast.media.MediaInfo;
             playbackRate?: number | undefined;
         }
@@ -847,7 +847,7 @@ declare namespace chrome {
             duration?: number | null;
             tracks?: chrome.cast.media.Track[] | null;
             textTrackStyle?: chrome.cast.media.TextTrackStyle | null;
-            customData?: Object | null;
+            customData?: object | null;
         }
 
         export class Media {
@@ -860,7 +860,7 @@ declare namespace chrome {
 
             activeTrackIds?: number[] | null;
             currentItemId?: number | null;
-            customData?: Object | null;
+            customData?: object | null;
             idleReason: chrome.cast.media.IdleReason | null;
             items?: chrome.cast.media.QueueItem[] | null;
             liveSeekableRange?: chrome.cast.media.LiveSeekableRange | undefined;
@@ -1095,7 +1095,7 @@ declare namespace chrome {
             name: string;
             language: string;
             subtype: chrome.cast.media.TextTrackType;
-            customData: Object;
+            customData: object;
         }
 
         export class TextTrackStyle {
@@ -1115,7 +1115,7 @@ declare namespace chrome {
             fontFamily: string;
             fontGenericFamily: chrome.cast.media.TextTrackFontGenericFamily;
             fontStyle: chrome.cast.media.TextTrackFontStyle;
-            customData: Object;
+            customData: object;
         }
 
         export class LiveSeekableRange {

--- a/types/chrome/chrome-cast/index.d.ts
+++ b/types/chrome/chrome-cast/index.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-wrapper-object-types */
 declare namespace chrome {
     ////////////////////
     // Cast
@@ -210,7 +211,7 @@ declare namespace chrome {
              * @param opt_details
              * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.Error
              */
-            constructor(code: chrome.cast.ErrorCode, description?: string, details?: object);
+            constructor(code: chrome.cast.ErrorCode, description?: string, details?: Object);
 
             code: chrome.cast.ErrorCode;
             description: string | null;
@@ -513,9 +514,9 @@ declare namespace chrome {
              */
             constructor(mediaInfo: chrome.cast.media.MediaInfo);
 
-            activeTrackIds: number[];
+            activeTrackIds: Number[];
             autoplay: boolean;
-            customData: object;
+            customData: Object;
             itemId: number;
             media: chrome.cast.media.MediaInfo;
             preloadTime: number;
@@ -529,7 +530,7 @@ declare namespace chrome {
              */
             constructor(items: chrome.cast.media.QueueItem[]);
 
-            customData: object;
+            customData: Object;
             items: chrome.cast.media.QueueItem[];
             repeatMode: chrome.cast.media.RepeatMode;
             startIndex: number;
@@ -542,7 +543,7 @@ declare namespace chrome {
              */
             constructor(itemsToInsert: chrome.cast.media.QueueItem[]);
 
-            customData: object;
+            customData: Object;
             insertBefore: number;
             items: chrome.cast.media.QueueItem[];
         }
@@ -554,7 +555,7 @@ declare namespace chrome {
              */
             constructor(itemIdsToRemove: number[]);
 
-            customData: object;
+            customData: Object;
             itemIds: number[];
         }
 
@@ -565,7 +566,7 @@ declare namespace chrome {
              */
             constructor(itemIdsToReorder: number[]);
 
-            customData: object;
+            customData: Object;
             insertBefore: number;
             itemIds: number[];
         }
@@ -577,7 +578,7 @@ declare namespace chrome {
              */
             constructor(itemsToUpdate: chrome.cast.media.QueueItem[]);
 
-            customData: object;
+            customData: Object;
             item: chrome.cast.media.QueueItem[];
         }
 
@@ -650,7 +651,7 @@ declare namespace chrome {
              */
             constructor();
 
-            customData: object;
+            customData: Object;
         }
 
         export class PauseRequest {
@@ -659,7 +660,7 @@ declare namespace chrome {
              */
             constructor();
 
-            customData: object;
+            customData: Object;
         }
 
         export class PlayRequest {
@@ -668,7 +669,7 @@ declare namespace chrome {
              */
             constructor();
 
-            customData: object;
+            customData: Object;
         }
 
         export class SeekRequest {
@@ -679,7 +680,7 @@ declare namespace chrome {
 
             currentTime: number;
             resumeState: chrome.cast.media.ResumeState;
-            customData: object;
+            customData: Object;
         }
 
         export class StopRequest {
@@ -688,7 +689,7 @@ declare namespace chrome {
              */
             constructor();
 
-            customData: object;
+            customData: Object;
         }
 
         export class VolumeRequest {
@@ -699,7 +700,7 @@ declare namespace chrome {
             constructor(volume: chrome.cast.Volume);
 
             volume: chrome.cast.Volume;
-            customData: object;
+            customData: Object;
         }
 
         export class LoadRequest {
@@ -712,7 +713,7 @@ declare namespace chrome {
             activeTrackIds: number[];
             autoplay: boolean;
             currentTime: number;
-            customData: object;
+            customData: Object;
             media: chrome.cast.media.MediaInfo;
             playbackRate?: number | undefined;
         }
@@ -847,7 +848,7 @@ declare namespace chrome {
             duration?: number | null;
             tracks?: chrome.cast.media.Track[] | null;
             textTrackStyle?: chrome.cast.media.TextTrackStyle | null;
-            customData?: object | null;
+            customData?: Object | null;
         }
 
         export class Media {
@@ -860,7 +861,7 @@ declare namespace chrome {
 
             activeTrackIds?: number[] | null;
             currentItemId?: number | null;
-            customData?: object | null;
+            customData?: Object | null;
             idleReason: chrome.cast.media.IdleReason | null;
             items?: chrome.cast.media.QueueItem[] | null;
             liveSeekableRange?: chrome.cast.media.LiveSeekableRange | undefined;
@@ -1095,7 +1096,7 @@ declare namespace chrome {
             name: string;
             language: string;
             subtype: chrome.cast.media.TextTrackType;
-            customData: object;
+            customData: Object;
         }
 
         export class TextTrackStyle {
@@ -1115,7 +1116,7 @@ declare namespace chrome {
             fontFamily: string;
             fontGenericFamily: chrome.cast.media.TextTrackFontGenericFamily;
             fontStyle: chrome.cast.media.TextTrackFontStyle;
-            customData: object;
+            customData: Object;
         }
 
         export class LiveSeekableRange {

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2355,12 +2355,12 @@ declare namespace chrome {
         export function sendCommand(
             target: DebuggerSession,
             method: string,
-            commandParams?: object,
+            commandParams?: { [key: string]: unknown },
         ): Promise<object | undefined>;
         export function sendCommand(
             target: DebuggerSession,
             method: string,
-            commandParams?: object,
+            commandParams?: { [key: string]: unknown },
             callback?: (result?: object) => void,
         ): void;
 
@@ -2942,13 +2942,13 @@ declare namespace chrome {
              * @param rootTitle An optional title for the root of the expression tree.
              * @param callback A callback invoked after the sidebar is updated with the object.
              */
-            setObject(jsonObject: object, rootTitle?: string, callback?: () => void): void;
+            setObject(jsonObject: { [key: string]: unknown }, rootTitle?: string, callback?: () => void): void;
             /**
              * Sets a JSON-compliant object to be displayed in the sidebar pane.
              * @param jsonObject An object to be displayed in context of the inspected page. Evaluated in the context of the caller (API client).
              * @param callback A callback invoked after the sidebar is updated with the object.
              */
-            setObject(jsonObject: object, callback?: () => void): void;
+            setObject(jsonObject: { [key: string]: unknown }, callback?: () => void): void;
             /**
              * Sets an HTML page to be displayed in the sidebar pane.
              * @param path Relative path of an extension page to display within the sidebar.
@@ -3035,19 +3035,19 @@ declare namespace chrome {
              * @param recording A recording of the user interaction with the page. This should match [Puppeteer's recording schema](https://github.com/puppeteer/replay/blob/main/docs/api/interfaces/Schema.UserFlow.md).
              * @since Chrome 112
              */
-            replay?(recording: object): void;
+            replay?(recording: { [key: string]: unknown }): void;
 
             /**
              * Converts a recording from the Recorder panel format into a string.
              * @param recording A recording of the user interaction with the page. This should match [Puppeteer's recording schema](https://github.com/puppeteer/replay/blob/main/docs/api/interfaces/Schema.UserFlow.md).
              */
-            stringify?(recording: object): void;
+            stringify?(recording: { [key: string]: unknown }): void;
 
             /**
              * Converts a step of the recording from the Recorder panel format into a string.
              * @param step A step of the recording of a user interaction with the page. This should match [Puppeteer's step schema](https://github.com/puppeteer/replay/blob/main/docs/api/modules/Schema.md#step).
              */
-            stringifyStep?(step: object): void;
+            stringifyStep?(step: { [key: string]: unknown }): void;
         }
 
         /**
@@ -5412,25 +5412,25 @@ declare namespace chrome {
          * @param details This parameter is currently unused.
          * @return The `getDefaultFontSize` method provides its result via callback or returned as a `Promise` (MV3 only).
          */
-        export function getDefaultFontSize(details?: object): Promise<FontSizeDetails>;
+        export function getDefaultFontSize(details?: unknown): Promise<FontSizeDetails>;
         /**
          * Gets the default font size.
          * @param details This parameter is currently unused.
          */
         export function getDefaultFontSize(callback: (options: FontSizeDetails) => void): void;
-        export function getDefaultFontSize(details: object, callback: (options: FontSizeDetails) => void): void;
+        export function getDefaultFontSize(details: unknown, callback: (options: FontSizeDetails) => void): void;
         /**
          * Gets the minimum font size.
          * @param details This parameter is currently unused.
          * @return The `getMinimumFontSize` method provides its result via callback or returned as a `Promise` (MV3 only).
          */
-        export function getMinimumFontSize(details?: object): Promise<FontSizeDetails>;
+        export function getMinimumFontSize(details?: unknown): Promise<FontSizeDetails>;
         /**
          * Gets the minimum font size.
          * @param details This parameter is currently unused.
          */
         export function getMinimumFontSize(callback: (options: FontSizeDetails) => void): void;
-        export function getMinimumFontSize(details: object, callback: (options: FontSizeDetails) => void): void;
+        export function getMinimumFontSize(details: unknown, callback: (options: FontSizeDetails) => void): void;
         /**
          * Sets the minimum font size.
          * @return The `setMinimumFontSize` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
@@ -5445,25 +5445,25 @@ declare namespace chrome {
          * @param details This parameter is currently unused.
          * @return The `getDefaultFixedFontSize` method provides its result via callback or returned as a `Promise` (MV3 only).
          */
-        export function getDefaultFixedFontSize(details?: object): Promise<FontSizeDetails>;
+        export function getDefaultFixedFontSize(details?: unknown): Promise<FontSizeDetails>;
         /**
          * Gets the default size for fixed width fonts.
          * @param details This parameter is currently unused.
          */
         export function getDefaultFixedFontSize(callback: (details: FontSizeDetails) => void): void;
-        export function getDefaultFixedFontSize(details: object, callback: (details: FontSizeDetails) => void): void;
+        export function getDefaultFixedFontSize(details: unknown, callback: (details: FontSizeDetails) => void): void;
         /**
          * Clears the default font size set by this extension, if any.
          * @param details This parameter is currently unused.
          * @return The `clearDefaultFontSize` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
          */
-        export function clearDefaultFontSize(details?: object): Promise<void>;
+        export function clearDefaultFontSize(details?: unknown): Promise<void>;
         /**
          * Clears the default font size set by this extension, if any.
          * @param details This parameter is currently unused.
          */
         export function clearDefaultFontSize(callback: () => void): void;
-        export function clearDefaultFontSize(details: object, callback: () => void): void;
+        export function clearDefaultFontSize(details: unknown, callback: () => void): void;
         /**
          * Sets the default size for fixed width fonts.
          * @return The `setDefaultFixedFontSize` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
@@ -5496,13 +5496,13 @@ declare namespace chrome {
          * @param details This parameter is currently unused.
          * @return The `clearMinimumFontSize` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
          */
-        export function clearMinimumFontSize(details?: object): Promise<void>;
+        export function clearMinimumFontSize(details?: unknown): Promise<void>;
         /**
          * Clears the minimum font size set by this extension, if any.
          * @param details This parameter is currently unused.
          */
         export function clearMinimumFontSize(callback: () => void): void;
-        export function clearMinimumFontSize(details: object, callback: () => void): void;
+        export function clearMinimumFontSize(details: unknown, callback: () => void): void;
         /**
          * Gets a list of fonts on the system.
          * @return The `getFontList` method provides its result via callback or returned as a `Promise` (MV3 only).
@@ -5517,12 +5517,12 @@ declare namespace chrome {
          * @param details This parameter is currently unused.
          * @return The `clearDefaultFixedFontSize` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
          */
-        export function clearDefaultFixedFontSize(details: object): Promise<void>;
+        export function clearDefaultFixedFontSize(details: unknown): Promise<void>;
         /**
          * Clears the default fixed font size set by this extension, if any.
          * @param details This parameter is currently unused.
          */
-        export function clearDefaultFixedFontSize(details: object, callback: () => void): void;
+        export function clearDefaultFixedFontSize(details: unknown, callback: () => void): void;
 
         /** Fired when the default fixed font size setting changes. */
         export var onDefaultFixedFontSizeChanged: DefaultFixedFontSizeChangedEvent;
@@ -5551,12 +5551,12 @@ declare namespace chrome {
             /** Optional. Time-to-live of the message in seconds. If it is not possible to send the message within that time, an onSendError event will be raised. A time-to-live of 0 indicates that the message should be sent immediately or fail if it's not possible. The maximum and a default value of time-to-live is 86400 seconds (1 day). */
             timeToLive?: number | undefined;
             /** Message data to send to the server. Case-insensitive goog. and google, as well as case-sensitive collapse_key are disallowed as key prefixes. Sum of all key/value pairs should not exceed gcm.MAX_MESSAGE_SIZE. */
-            data: object;
+            data: { [key: string]: unknown };
         }
 
         export interface IncomingMessage {
             /** The message data. */
-            data: object;
+            data: { [key: string]: unknown };
             /**
              * Optional.
              * The sender who issued the message.
@@ -6245,7 +6245,7 @@ declare namespace chrome {
         }
 
         export interface MenuItemParameters {
-            items: object[];
+            items: MenuItem[];
             engineId: string;
         }
 
@@ -7186,7 +7186,7 @@ declare namespace chrome {
          * @since Chrome 29
          * @param callback Returns the set of notification_ids currently in the system.
          */
-        export function getAll(callback: (notifications: object) => void): void;
+        export function getAll(callback: (notifications: { [key: string]: true }) => void): void;
         /**
          * Retrieves whether the user has enabled notifications from this app or extension.
          * @since Chrome 32
@@ -7626,7 +7626,7 @@ declare namespace chrome {
          */
         export function getKeyPair(
             certificate: ArrayBuffer,
-            parameters: object,
+            parameters: { [key: string]: unknown },
             callback: (publicKey: CryptoKey, privateKey: CryptoKey | null) => void,
         ): void;
         /**
@@ -7640,7 +7640,7 @@ declare namespace chrome {
          */
         export function getKeyPairBySpki(
             publicKeySpkiDer: ArrayBuffer,
-            parameters: object,
+            parameters: { [key: string]: unknown },
             callback: (publicKey: CryptoKey, privateKey: CryptoKey | null) => void,
         ): void;
         /** An implementation of WebCrypto's  SubtleCrypto that allows crypto operations on keys of client certificates that are available to this extension. */
@@ -7716,7 +7716,7 @@ declare namespace chrome {
             /** The print job title. */
             title: string;
             /** Print ticket in  CJT format. */
-            ticket: object;
+            ticket: { [key: string]: unknown };
             /** The document content type. Supported formats are "application/pdf" and "image/pwg-raster". */
             contentType: string;
             /** Blob containing the document data to print. Format must match |contentType|. */
@@ -9508,7 +9508,7 @@ declare namespace chrome {
          */
         export function sendNativeMessage(
             application: string,
-            message: object,
+            message: { [key: string]: unknown },
             responseCallback: (response: any) => void,
         ): void;
         /**
@@ -9519,7 +9519,7 @@ declare namespace chrome {
          */
         export function sendNativeMessage(
             application: string,
-            message: object,
+            message: { [key: string]: unknown },
         ): Promise<any>;
         /**
          * Sets the URL to be visited upon uninstallation. This may be used to clean up server-side data, do analytics, and implement surveys. Maximum 255 characters.
@@ -10205,7 +10205,11 @@ declare namespace chrome {
             address: string;
         }
 
-        export function create(type: string, options?: object, callback?: (createInfo: CreateInfo) => void): void;
+        export function create(
+            type: string,
+            options?: { [key: string]: unknown },
+            callback?: (createInfo: CreateInfo) => void,
+        ): void;
         export function destroy(socketId: number): void;
         export function connect(
             socketId: number,
@@ -12840,7 +12844,7 @@ declare namespace chrome {
         export interface VpnConfigRemovalEvent extends chrome.events.Event<(id: string) => void> {}
 
         export interface VpnConfigCreationEvent
-            extends chrome.events.Event<(id: string, name: string, data: object) => void>
+            extends chrome.events.Event<(id: string, name: string, data: { [key: string]: unknown }) => void>
         {}
 
         export interface VpnUiEvent extends chrome.events.Event<(event: string, id?: string) => void> {}

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2355,13 +2355,13 @@ declare namespace chrome {
         export function sendCommand(
             target: DebuggerSession,
             method: string,
-            commandParams?: Object,
-        ): Promise<Object | undefined>;
+            commandParams?: object,
+        ): Promise<object | undefined>;
         export function sendCommand(
             target: DebuggerSession,
             method: string,
-            commandParams?: Object,
-            callback?: (result?: Object) => void,
+            commandParams?: object,
+            callback?: (result?: object) => void,
         ): void;
 
         /**
@@ -2375,7 +2375,7 @@ declare namespace chrome {
         /** Fired when browser terminates debugging session for the tab. This happens when either the tab is being closed or Chrome DevTools is being invoked for the attached tab. */
         export const onDetach: chrome.events.Event<(source: Debuggee, reason: `${DetachReason}`) => void>;
         /** Fired whenever debugging target issues instrumentation event. */
-        export const onEvent: chrome.events.Event<(source: DebuggerSession, method: string, params?: Object) => void>;
+        export const onEvent: chrome.events.Event<(source: DebuggerSession, method: string, params?: object) => void>;
     }
 
     export { _debugger as debugger };
@@ -2669,7 +2669,7 @@ declare namespace chrome {
                     /**
                      * Set to undefined if the resource content was set successfully; describes error otherwise.
                      */
-                    error?: Object,
+                    error?: object,
                 ) => void,
             ): void;
         }
@@ -2942,13 +2942,13 @@ declare namespace chrome {
              * @param rootTitle An optional title for the root of the expression tree.
              * @param callback A callback invoked after the sidebar is updated with the object.
              */
-            setObject(jsonObject: Object, rootTitle?: string, callback?: () => void): void;
+            setObject(jsonObject: object, rootTitle?: string, callback?: () => void): void;
             /**
              * Sets a JSON-compliant object to be displayed in the sidebar pane.
              * @param jsonObject An object to be displayed in context of the inspected page. Evaluated in the context of the caller (API client).
              * @param callback A callback invoked after the sidebar is updated with the object.
              */
-            setObject(jsonObject: Object, callback?: () => void): void;
+            setObject(jsonObject: object, callback?: () => void): void;
             /**
              * Sets an HTML page to be displayed in the sidebar pane.
              * @param path Relative path of an extension page to display within the sidebar.
@@ -4516,7 +4516,7 @@ declare namespace chrome {
 
         export interface SelectionResult {
             /** Optional. Selected file entry. It will be null if a file hasn't been selected.  */
-            entry?: Object | null | undefined;
+            entry?: object | null | undefined;
             /** Whether the file has been selected. */
             success: boolean;
         }
@@ -5412,13 +5412,13 @@ declare namespace chrome {
          * @param details This parameter is currently unused.
          * @return The `getDefaultFontSize` method provides its result via callback or returned as a `Promise` (MV3 only).
          */
-        export function getDefaultFontSize(details?: Object): Promise<FontSizeDetails>;
+        export function getDefaultFontSize(details?: object): Promise<FontSizeDetails>;
         /**
          * Gets the default font size.
          * @param details This parameter is currently unused.
          */
         export function getDefaultFontSize(callback: (options: FontSizeDetails) => void): void;
-        export function getDefaultFontSize(details: Object, callback: (options: FontSizeDetails) => void): void;
+        export function getDefaultFontSize(details: object, callback: (options: FontSizeDetails) => void): void;
         /**
          * Gets the minimum font size.
          * @param details This parameter is currently unused.
@@ -5445,25 +5445,25 @@ declare namespace chrome {
          * @param details This parameter is currently unused.
          * @return The `getDefaultFixedFontSize` method provides its result via callback or returned as a `Promise` (MV3 only).
          */
-        export function getDefaultFixedFontSize(details?: Object): Promise<FontSizeDetails>;
+        export function getDefaultFixedFontSize(details?: object): Promise<FontSizeDetails>;
         /**
          * Gets the default size for fixed width fonts.
          * @param details This parameter is currently unused.
          */
         export function getDefaultFixedFontSize(callback: (details: FontSizeDetails) => void): void;
-        export function getDefaultFixedFontSize(details: Object, callback: (details: FontSizeDetails) => void): void;
+        export function getDefaultFixedFontSize(details: object, callback: (details: FontSizeDetails) => void): void;
         /**
          * Clears the default font size set by this extension, if any.
          * @param details This parameter is currently unused.
          * @return The `clearDefaultFontSize` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
          */
-        export function clearDefaultFontSize(details?: Object): Promise<void>;
+        export function clearDefaultFontSize(details?: object): Promise<void>;
         /**
          * Clears the default font size set by this extension, if any.
          * @param details This parameter is currently unused.
          */
         export function clearDefaultFontSize(callback: () => void): void;
-        export function clearDefaultFontSize(details: Object, callback: () => void): void;
+        export function clearDefaultFontSize(details: object, callback: () => void): void;
         /**
          * Sets the default size for fixed width fonts.
          * @return The `setDefaultFixedFontSize` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
@@ -5496,13 +5496,13 @@ declare namespace chrome {
          * @param details This parameter is currently unused.
          * @return The `clearMinimumFontSize` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
          */
-        export function clearMinimumFontSize(details?: Object): Promise<void>;
+        export function clearMinimumFontSize(details?: object): Promise<void>;
         /**
          * Clears the minimum font size set by this extension, if any.
          * @param details This parameter is currently unused.
          */
         export function clearMinimumFontSize(callback: () => void): void;
-        export function clearMinimumFontSize(details: Object, callback: () => void): void;
+        export function clearMinimumFontSize(details: object, callback: () => void): void;
         /**
          * Gets a list of fonts on the system.
          * @return The `getFontList` method provides its result via callback or returned as a `Promise` (MV3 only).
@@ -5517,12 +5517,12 @@ declare namespace chrome {
          * @param details This parameter is currently unused.
          * @return The `clearDefaultFixedFontSize` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
          */
-        export function clearDefaultFixedFontSize(details: Object): Promise<void>;
+        export function clearDefaultFixedFontSize(details: object): Promise<void>;
         /**
          * Clears the default fixed font size set by this extension, if any.
          * @param details This parameter is currently unused.
          */
-        export function clearDefaultFixedFontSize(details: Object, callback: () => void): void;
+        export function clearDefaultFixedFontSize(details: object, callback: () => void): void;
 
         /** Fired when the default fixed font size setting changes. */
         export var onDefaultFixedFontSizeChanged: DefaultFixedFontSizeChangedEvent;
@@ -5551,12 +5551,12 @@ declare namespace chrome {
             /** Optional. Time-to-live of the message in seconds. If it is not possible to send the message within that time, an onSendError event will be raised. A time-to-live of 0 indicates that the message should be sent immediately or fail if it's not possible. The maximum and a default value of time-to-live is 86400 seconds (1 day). */
             timeToLive?: number | undefined;
             /** Message data to send to the server. Case-insensitive goog. and google, as well as case-sensitive collapse_key are disallowed as key prefixes. Sum of all key/value pairs should not exceed gcm.MAX_MESSAGE_SIZE. */
-            data: Object;
+            data: object;
         }
 
         export interface IncomingMessage {
             /** The message data. */
-            data: Object;
+            data: object;
             /**
              * Optional.
              * The sender who issued the message.
@@ -5576,7 +5576,7 @@ declare namespace chrome {
             /** Optional. The ID of the message with this error, if error is related to a specific message. */
             messageId?: string | undefined;
             /** Additional details related to the error, when available. */
-            detail: Object;
+            detail: object;
         }
 
         export interface MessageReceptionEvent extends chrome.events.Event<(message: IncomingMessage) => void> {}
@@ -6245,7 +6245,7 @@ declare namespace chrome {
         }
 
         export interface MenuItemParameters {
-            items: Object[];
+            items: object[];
             engineId: string;
         }
 
@@ -7186,7 +7186,7 @@ declare namespace chrome {
          * @since Chrome 29
          * @param callback Returns the set of notification_ids currently in the system.
          */
-        export function getAll(callback: (notifications: Object) => void): void;
+        export function getAll(callback: (notifications: object) => void): void;
         /**
          * Retrieves whether the user has enabled notifications from this app or extension.
          * @since Chrome 32
@@ -7626,7 +7626,7 @@ declare namespace chrome {
          */
         export function getKeyPair(
             certificate: ArrayBuffer,
-            parameters: Object,
+            parameters: object,
             callback: (publicKey: CryptoKey, privateKey: CryptoKey | null) => void,
         ): void;
         /**
@@ -7640,7 +7640,7 @@ declare namespace chrome {
          */
         export function getKeyPairBySpki(
             publicKeySpkiDer: ArrayBuffer,
-            parameters: Object,
+            parameters: object,
             callback: (publicKey: CryptoKey, privateKey: CryptoKey | null) => void,
         ): void;
         /** An implementation of WebCrypto's  SubtleCrypto that allows crypto operations on keys of client certificates that are available to this extension. */
@@ -7716,7 +7716,7 @@ declare namespace chrome {
             /** The print job title. */
             title: string;
             /** Print ticket in  CJT format. */
-            ticket: Object;
+            ticket: object;
             /** The document content type. Supported formats are "application/pdf" and "image/pwg-raster". */
             contentType: string;
             /** Blob containing the document data to print. Format must match |contentType|. */
@@ -9508,7 +9508,7 @@ declare namespace chrome {
          */
         export function sendNativeMessage(
             application: string,
-            message: Object,
+            message: object,
             responseCallback: (response: any) => void,
         ): void;
         /**
@@ -9519,7 +9519,7 @@ declare namespace chrome {
          */
         export function sendNativeMessage(
             application: string,
-            message: Object,
+            message: object,
         ): Promise<any>;
         /**
          * Sets the URL to be visited upon uninstallation. This may be used to clean up server-side data, do analytics, and implement surveys. Maximum 255 characters.
@@ -10205,7 +10205,7 @@ declare namespace chrome {
             address: string;
         }
 
-        export function create(type: string, options?: Object, callback?: (createInfo: CreateInfo) => void): void;
+        export function create(type: string, options?: object, callback?: (createInfo: CreateInfo) => void): void;
         export function destroy(socketId: number): void;
         export function connect(
             socketId: number,
@@ -12840,7 +12840,7 @@ declare namespace chrome {
         export interface VpnConfigRemovalEvent extends chrome.events.Event<(id: string) => void> {}
 
         export interface VpnConfigCreationEvent
-            extends chrome.events.Event<(id: string, name: string, data: Object) => void>
+            extends chrome.events.Event<(id: string, name: string, data: object) => void>
         {}
 
         export interface VpnUiEvent extends chrome.events.Event<(event: string, id?: string) => void> {}

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -9508,7 +9508,7 @@ declare namespace chrome {
          */
         export function sendNativeMessage(
             application: string,
-            message: { [key: string]: unknown },
+            message: object,
             responseCallback: (response: any) => void,
         ): void;
         /**
@@ -9519,7 +9519,7 @@ declare namespace chrome {
          */
         export function sendNativeMessage(
             application: string,
-            message: { [key: string]: unknown },
+            message: object,
         ): Promise<any>;
         /**
          * Sets the URL to be visited upon uninstallation. This may be used to clean up server-side data, do analytics, and implement surveys. Maximum 255 characters.

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -3005,8 +3005,8 @@ function testRuntimeSendMessage() {
 }
 
 function testRuntimeSendNativeMessage() {
-    chrome.runtime.sendNativeMessage("application", console.log).then(() => {});
-    chrome.runtime.sendNativeMessage("application", console.log, (num: number) => alert(num + 1));
+    chrome.runtime.sendNativeMessage("application", {}).then(() => {});
+    chrome.runtime.sendNativeMessage("application", {}, (num: number) => alert(num + 1));
 }
 
 function testTabsSendRequest() {

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -920,9 +920,9 @@ function testDebugger() {
         sessionId: "123",
     };
 
-    chrome.debugger.sendCommand(debuggerSession, "Debugger.Cmd", {}); // $ExpectType Promise<Object | undefined>
+    chrome.debugger.sendCommand(debuggerSession, "Debugger.Cmd", {}); // $ExpectType Promise<object | undefined>
     chrome.debugger.sendCommand(debuggerSession, "Debugger.Cmd", {}, (result) => { // $ExpectType void
-        result; // $ExpectType Object | undefined
+        result; // $ExpectType object | undefined
     });
     // @ts-expect-error
     chrome.debugger.sendCommand(debuggerSession, "Debugger.Cmd", {}, () => {}).then(() => {});
@@ -930,17 +930,17 @@ function testDebugger() {
     chrome.debugger.onEvent.addListener((source, methodName, params) => { // $ExpectType void
         source; // $ExpectType DebuggerSession
         methodName; // $ExpectType string
-        params; // $ExpectType Object | undefined
+        params; // $ExpectType object | undefined
     });
     chrome.debugger.onEvent.removeListener((source, methodName, params) => { // $ExpectType void
         source; // $ExpectType DebuggerSession
         methodName; // $ExpectType string
-        params; // $ExpectType Object | undefined
+        params; // $ExpectType object | undefined
     });
     chrome.debugger.onEvent.hasListener((source, methodName, params) => { // $ExpectType boolean
         source; // $ExpectType DebuggerSession
         methodName; // $ExpectType string
-        params; // $ExpectType Object | undefined
+        params; // $ExpectType object | undefined
     });
     chrome.debugger.onEvent.hasListeners(); // $ExpectType boolean
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

I followed DefinitelyTyped's recommendation by re-enabling the ESLint rule [@typescript-eslint/no-wrapper-object-types](https://typescript-eslint.io/rules/no-wrapper-object-types).

> If the only known fact about the type is that it's some object, use the type `object`, not `Object` or `{ [key: string]: any }`.

This prevents users from mistakenly using `string` instead of an `object`.
