### PR TITLE
[chrome] re-enable prefer-namespace eslint rule

### DIFF
--- a/types/chrome/.eslintrc.json
+++ b/types/chrome/.eslintrc.json
@@ -3,7 +3,6 @@
         "@definitelytyped/no-unnecessary-generics": "off",
         "@definitelytyped/strict-export-declare-modifiers": "off",
         "@typescript-eslint/no-wrapper-object-types": "off",
-        "@typescript-eslint/prefer-namespace": "off",
         "@typescript-eslint/no-empty-interface": "off"
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Note : It no longer seems necessary to keep this ESLint rule disabled.








