### PR TITLE
[aws-synthetics-puppeteer] Bump to 10.0 and upgrade puppeteer-core

### DIFF
--- a/types/aws-synthetics-puppeteer/package.json
+++ b/types/aws-synthetics-puppeteer/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/aws-synthetics-puppeteer",
-    "version": "9.0.9999",
+    "version": "10.0.9999",
     "nonNpm": true,
     "nonNpmDescription": "aws-synthetics-puppeteer",
     "projects": [
@@ -9,8 +9,8 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "puppeteer-core": "22.12.1",
-        "aws-xray-sdk-core": "=3.3.1"
+        "puppeteer-core": "24.2.0",
+        "aws-xray-sdk-core": "3.10.3"
     },
     "devDependencies": {
         "@types/aws-synthetics-puppeteer": "workspace:."


### PR DESCRIPTION
…and aws-xray-sdk-core

This PR brings these type definitions up-to-date.
The latest AWS provided runtime is version syn-nodejs-puppeteer-10.0 with
- Puppeteer-core version 24.2.0

See https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Library_nodejs_puppeteer.html

This PR also fixes GHSA-pq67-2wwv-3xjx via an upgrade to puppeteer-core.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Library_nodejs_puppeteer.html
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

