### PR TITLE
feat(pg): add connection property to Client

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -289,6 +289,7 @@ export class Client extends ClientBase {
     host: string;
     password?: string | undefined;
     ssl: boolean;
+    readonly connection: Connection;
 
     constructor(config?: string | ClientConfig);
 

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -208,6 +208,12 @@ customTypeOverrides.setTypeParser(types.builtins.INT8, BigInt);
 const customCustomTypeOverrides = new TypeOverrides(customTypes);
 customTypeOverrides.setTypeParser(types.builtins.INT8, BigInt);
 
+client.connection.once('rowDescription', () => {
+    console.log("client connection rowDescription event");
+});
+// @ts-expect-error – connection is readonly
+client.connection = new Connection();
+
 // pg.Pool
 // https://node-postgres.com/apis/pool
 

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -208,7 +208,7 @@ customTypeOverrides.setTypeParser(types.builtins.INT8, BigInt);
 const customCustomTypeOverrides = new TypeOverrides(customTypes);
 customTypeOverrides.setTypeParser(types.builtins.INT8, BigInt);
 
-client.connection.once('rowDescription', () => {
+client.connection.once("rowDescription", () => {
     console.log("client connection rowDescription event");
 });
 // @ts-expect-error – connection is readonly


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

> - [x] Provide a URL to documentation or source code which provides context for the suggested changes:

**Long story short:** the maintainers of `pg` suggested at multiple occasions to use the `connection` property available in the `Client` class but not declared in `DefinetelyTyped` package. When I pointed this out, one of the maintainer encouraged me to make a PR here. 😊

More context is available here: https://github.com/brianc/node-postgres/issues/3420#issuecomment-2818335793

The added property in DefinetelyTyped is visible here: https://github.com/brianc/node-postgres/blob/7a009381e669895098686e99e7e304555b246855/packages/pg/lib/client.js#L47

> - [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

The property `connection` exists in `pg.Client` since v8.3.2 ([git blame shows it's been there for at least 5 years](https://github.com/brianc/node-postgres/blame/7a009381e669895098686e99e7e304555b246855/packages/pg/lib/client.js#L47))
