### PR TITLE
fix(chrome): add missing `lineNumber` param to `setOpenResourceHandler`

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2986,9 +2986,10 @@ declare namespace chrome {
          * Specifies the function to be called when the user clicks a resource link in the Developer Tools window. To unset the handler, either call the method with no parameters or pass null as the parameter.
          * @param callback A function that is called when the user clicks on a valid resource link in Developer Tools window. Note that if the user clicks an invalid URL or an XHR, this function is not called.
          * Parameter resource: A devtools.inspectedWindow.Resource object for the resource that was clicked.
+         * Parameter lineNumber: A specific line number within the resource.
          */
         export function setOpenResourceHandler(
-            callback?: (resource: chrome.devtools.inspectedWindow.Resource) => void,
+            callback?: (resource: chrome.devtools.inspectedWindow.Resource, lineNumber: number) => void,
         ): void;
         /**
          * @since Chrome 38

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2986,7 +2986,7 @@ declare namespace chrome {
          * Specifies the function to be called when the user clicks a resource link in the Developer Tools window. To unset the handler, either call the method with no parameters or pass null as the parameter.
          * @param callback A function that is called when the user clicks on a valid resource link in Developer Tools window. Note that if the user clicks an invalid URL or an XHR, this function is not called.
          * Parameter resource: A devtools.inspectedWindow.Resource object for the resource that was clicked.
-         * Parameter lineNumber: A specific line number within the resource.
+         * Parameter lineNumber: Specifies the line number within the resource that was clicked.
          */
         export function setOpenResourceHandler(
             callback?: (resource: chrome.devtools.inspectedWindow.Resource, lineNumber: number) => void,

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1423,6 +1423,11 @@ function testDevtools() {
     };
     chrome.devtools.recorder.registerRecorderExtensionPlugin({}, "MyPlugin", "application/json"); // $ExpectType void
     chrome.devtools.recorder.registerRecorderExtensionPlugin(plugin, "MyPlugin", "application/json"); // $ExpectType void
+
+    chrome.devtools.panels.setOpenResourceHandler((resource, lineNumber) => { // $ExpectType void
+        resource; // $ExpectType Resource
+        lineNumber; // $ExpectType number
+    });
 }
 
 function testAssistiveWindow() {


### PR DESCRIPTION
The callback registered by `chrome.devtools.panels.setOpenResourceHandler` takes one parameter in addition to `resource`: the requested `lineNumber`.

This can be seen in the unit tests for `setOpenResourceHandler` in the Chrome codebase: <https://chromium.googlesource.com/chromium/blink/+/HEAD/LayoutTests/inspector/extensions/extensions-panel.html#173>

Note that this parameter is not listed in the Chrome Devtools Extension API docs: https://developer.chrome.com/docs/extensions/reference/api/devtools/panels#method-setOpenResourceHandler but this seems to be an inaccuracy. Here's an upstream issue on the docs to track the status of this: https://issuetracker.google.com/issues/413587589

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://chromium.googlesource.com/chromium/blink/+/HEAD/LayoutTests/inspector/extensions/extensions-panel.html#173>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

