### PR TITLE
fix(node/vm): fix CompileFunctionOptions.cachedData type & add jsdoc

### DIFF
--- a/types/node/test/vm.ts
+++ b/types/node/test/vm.ts
@@ -52,7 +52,16 @@ import {
 }
 
 {
-    const fn: Function = compileFunction("console.log(\"test\")", [] as readonly string[], {
+    const code = "console.log(\"test\")";
+    const params = [] as const;
+
+    let fn = compileFunction(code);
+    fn = compileFunction(code, params);
+    fn = compileFunction(code, params, {});
+    fn = compileFunction(code, params, {
+        filename: "",
+        lineOffset: 0,
+        columnOffset: 0,
         parsingContext: createContext(),
         contextExtensions: [{
             a: 1,
@@ -60,6 +69,20 @@ import {
         produceCachedData: false,
         cachedData: Buffer.from("nope"),
     });
+    fn = compileFunction(code, params, {
+        cachedData: new Uint8Array(),
+    });
+    fn = compileFunction(code, params, {
+        cachedData: new DataView(new ArrayBuffer(10)),
+    });
+
+    fn satisfies Function;
+    // $ExpectType Buffer<ArrayBufferLike> | undefined
+    fn.cachedData;
+    // $ExpectType boolean | undefined
+    fn.cachedDataProduced;
+    // $ExpectType boolean | undefined
+    fn.cachedDataRejected;
 }
 
 {

--- a/types/node/v18/test/vm.ts
+++ b/types/node/v18/test/vm.ts
@@ -62,7 +62,16 @@ import {
 }
 
 {
-    const fn: Function = compileFunction("console.log(\"test\")", [] as readonly string[], {
+    const code = "console.log(\"test\")";
+    const params = [] as const;
+
+    let fn = compileFunction(code);
+    fn = compileFunction(code, params);
+    fn = compileFunction(code, params, {});
+    fn = compileFunction(code, params, {
+        filename: "",
+        lineOffset: 0,
+        columnOffset: 0,
         parsingContext: createContext(),
         contextExtensions: [{
             a: 1,
@@ -70,6 +79,20 @@ import {
         produceCachedData: false,
         cachedData: Buffer.from("nope"),
     });
+    fn = compileFunction(code, params, {
+        cachedData: new Uint8Array(),
+    });
+    fn = compileFunction(code, params, {
+        cachedData: new DataView(new ArrayBuffer(10)),
+    });
+
+    fn satisfies Function;
+    // $ExpectType Buffer<ArrayBufferLike> | undefined
+    fn.cachedData;
+    // $ExpectType boolean | undefined
+    fn.cachedDataProduced;
+    // $ExpectType boolean | undefined
+    fn.cachedDataRejected;
 }
 
 {

--- a/types/node/v18/vm.d.ts
+++ b/types/node/v18/vm.d.ts
@@ -58,7 +58,7 @@ declare module "vm" {
     }
     interface ScriptOptions extends BaseOptions {
         /**
-         * V8's code cache data for the supplied source.
+         * Provides an optional data with V8's code cache data for the supplied source.
          */
         cachedData?: Buffer | NodeJS.ArrayBufferView | undefined;
         /** @deprecated in favor of `script.createCachedData()` */
@@ -108,18 +108,24 @@ declare module "vm" {
         microtaskMode?: CreateContextOptions["microtaskMode"];
     }
     interface RunningCodeOptions extends RunningScriptOptions {
-        cachedData?: ScriptOptions["cachedData"];
+        /**
+         * Provides an optional data with V8's code cache data for the supplied source.
+         */
+        cachedData?: ScriptOptions["cachedData"] | undefined;
         importModuleDynamically?: ScriptOptions["importModuleDynamically"];
     }
     interface RunningCodeInNewContextOptions extends RunningScriptInNewContextOptions {
-        cachedData?: ScriptOptions["cachedData"];
+        /**
+         * Provides an optional data with V8's code cache data for the supplied source.
+         */
+        cachedData?: ScriptOptions["cachedData"] | undefined;
         importModuleDynamically?: ScriptOptions["importModuleDynamically"];
     }
     interface CompileFunctionOptions extends BaseOptions {
         /**
          * Provides an optional data with V8's code cache data for the supplied source.
          */
-        cachedData?: Buffer | undefined;
+        cachedData?: ScriptOptions["cachedData"] | undefined;
         /**
          * Specifies whether to produce new cache data.
          * Default: `false`,
@@ -612,6 +618,9 @@ declare module "vm" {
          * @default 'vm:module(i)' where i is a context-specific ascending index.
          */
         identifier?: string | undefined;
+        /**
+         * Provides an optional data with V8's code cache data for the supplied source.
+         */
         cachedData?: ScriptOptions["cachedData"] | undefined;
         context?: Context | undefined;
         lineOffset?: BaseOptions["lineOffset"] | undefined;

--- a/types/node/v20/test/vm.ts
+++ b/types/node/v20/test/vm.ts
@@ -62,7 +62,16 @@ import {
 }
 
 {
-    const fn: Function = compileFunction("console.log(\"test\")", [] as readonly string[], {
+    const code = "console.log(\"test\")";
+    const params = [] as const;
+
+    let fn = compileFunction(code);
+    fn = compileFunction(code, params);
+    fn = compileFunction(code, params, {});
+    fn = compileFunction(code, params, {
+        filename: "",
+        lineOffset: 0,
+        columnOffset: 0,
         parsingContext: createContext(),
         contextExtensions: [{
             a: 1,
@@ -70,6 +79,20 @@ import {
         produceCachedData: false,
         cachedData: Buffer.from("nope"),
     });
+    fn = compileFunction(code, params, {
+        cachedData: new Uint8Array(),
+    });
+    fn = compileFunction(code, params, {
+        cachedData: new DataView(new ArrayBuffer(10)),
+    });
+
+    fn satisfies Function;
+    // $ExpectType Buffer<ArrayBufferLike> | undefined
+    fn.cachedData;
+    // $ExpectType boolean | undefined
+    fn.cachedDataProduced;
+    // $ExpectType boolean | undefined
+    fn.cachedDataRejected;
 }
 
 {

--- a/types/node/v20/vm.d.ts
+++ b/types/node/v20/vm.d.ts
@@ -58,7 +58,7 @@ declare module "vm" {
     }
     interface ScriptOptions extends BaseOptions {
         /**
-         * V8's code cache data for the supplied source.
+         * Provides an optional data with V8's code cache data for the supplied source.
          */
         cachedData?: Buffer | NodeJS.ArrayBufferView | undefined;
         /** @deprecated in favor of `script.createCachedData()` */
@@ -110,18 +110,24 @@ declare module "vm" {
         microtaskMode?: CreateContextOptions["microtaskMode"];
     }
     interface RunningCodeOptions extends RunningScriptOptions {
-        cachedData?: ScriptOptions["cachedData"];
+        /**
+         * Provides an optional data with V8's code cache data for the supplied source.
+         */
+        cachedData?: ScriptOptions["cachedData"] | undefined;
         importModuleDynamically?: ScriptOptions["importModuleDynamically"];
     }
     interface RunningCodeInNewContextOptions extends RunningScriptInNewContextOptions {
-        cachedData?: ScriptOptions["cachedData"];
+        /**
+         * Provides an optional data with V8's code cache data for the supplied source.
+         */
+        cachedData?: ScriptOptions["cachedData"] | undefined;
         importModuleDynamically?: ScriptOptions["importModuleDynamically"];
     }
     interface CompileFunctionOptions extends BaseOptions {
         /**
          * Provides an optional data with V8's code cache data for the supplied source.
          */
-        cachedData?: Buffer | undefined;
+        cachedData?: ScriptOptions["cachedData"] | undefined;
         /**
          * Specifies whether to produce new cache data.
          * @default false
@@ -807,6 +813,9 @@ declare module "vm" {
          * @default 'vm:module(i)' where i is a context-specific ascending index.
          */
         identifier?: string | undefined;
+        /**
+         * Provides an optional data with V8's code cache data for the supplied source.
+         */
         cachedData?: ScriptOptions["cachedData"] | undefined;
         context?: Context | undefined;
         lineOffset?: BaseOptions["lineOffset"] | undefined;

--- a/types/node/vm.d.ts
+++ b/types/node/vm.d.ts
@@ -58,7 +58,7 @@ declare module "vm" {
     }
     interface ScriptOptions extends BaseOptions {
         /**
-         * V8's code cache data for the supplied source.
+         * Provides an optional data with V8's code cache data for the supplied source.
          */
         cachedData?: Buffer | NodeJS.ArrayBufferView | undefined;
         /** @deprecated in favor of `script.createCachedData()` */
@@ -110,18 +110,24 @@ declare module "vm" {
         microtaskMode?: CreateContextOptions["microtaskMode"];
     }
     interface RunningCodeOptions extends RunningScriptOptions {
-        cachedData?: ScriptOptions["cachedData"];
+        /**
+         * Provides an optional data with V8's code cache data for the supplied source.
+         */
+        cachedData?: ScriptOptions["cachedData"] | undefined;
         importModuleDynamically?: ScriptOptions["importModuleDynamically"];
     }
     interface RunningCodeInNewContextOptions extends RunningScriptInNewContextOptions {
-        cachedData?: ScriptOptions["cachedData"];
+        /**
+         * Provides an optional data with V8's code cache data for the supplied source.
+         */
+        cachedData?: ScriptOptions["cachedData"] | undefined;
         importModuleDynamically?: ScriptOptions["importModuleDynamically"];
     }
     interface CompileFunctionOptions extends BaseOptions {
         /**
          * Provides an optional data with V8's code cache data for the supplied source.
          */
-        cachedData?: Buffer | undefined;
+        cachedData?: ScriptOptions["cachedData"] | undefined;
         /**
          * Specifies whether to produce new cache data.
          * @default false
@@ -848,6 +854,9 @@ declare module "vm" {
          * @default 'vm:module(i)' where i is a context-specific ascending index.
          */
         identifier?: string | undefined;
+        /**
+         * Provides an optional data with V8's code cache data for the supplied source.
+         */
         cachedData?: ScriptOptions["cachedData"] | undefined;
         context?: Context | undefined;
         lineOffset?: BaseOptions["lineOffset"] | undefined;


### PR DESCRIPTION
See these links.
- doc: https://nodejs.org/docs/latest/api/vm.html#vmcompilefunctioncode-params-options
- commit: https://github.com/nodejs/node/commit/65fe999ed77c958468ca55c24e9242e193b55f95

Also add / modify jsdoc to unify `cachedData` declaration at various places.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
