### PR TITLE
RefObject should include null for Ref

### DIFF
--- a/types/react/v18/index.d.ts
+++ b/types/react/v18/index.d.ts
@@ -186,7 +186,7 @@ declare namespace React {
      * @see {@link RefObject}
      */
 
-    type Ref<T> = RefCallback<T> | RefObject<T> | null;
+    type Ref<T> = RefCallback<T> | RefObject<T | null> | null;
     /**
      * A legacy implementation of refs where you can pass a string to a ref prop.
      *


### PR DESCRIPTION
Solves this type error: https://github.com/mantinedev/mantine/issues/7259#issuecomment-2834338431

This is also the type in react 19 types fwiw

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
