### PR TITLE
Remove ImageTrack etc. from dom-webcodecs

### DIFF
--- a/types/dom-webcodecs/webcodecs.generated.d.ts
+++ b/types/dom-webcodecs/webcodecs.generated.d.ts
@@ -318,48 +318,6 @@ declare var EncodedVideoChunk: {
     new(init: EncodedVideoChunkInit): EncodedVideoChunk;
 };
 
-/** Available only in secure contexts. */
-interface ImageDecoder {
-    readonly complete: boolean;
-    readonly completed: Promise<void>;
-    readonly tracks: ImageTrackList;
-    readonly type: string;
-    close(): void;
-    decode(options?: ImageDecodeOptions): Promise<ImageDecodeResult>;
-    reset(): void;
-}
-
-declare var ImageDecoder: {
-    prototype: ImageDecoder;
-    new(init: ImageDecoderInit): ImageDecoder;
-    isTypeSupported(type: string): Promise<boolean>;
-};
-
-interface ImageTrack {
-    readonly animated: boolean;
-    readonly frameCount: number;
-    readonly repetitionCount: number;
-    selected: boolean;
-}
-
-declare var ImageTrack: {
-    prototype: ImageTrack;
-    new(): ImageTrack;
-};
-
-interface ImageTrackList {
-    readonly length: number;
-    readonly ready: Promise<void>;
-    readonly selectedIndex: number;
-    readonly selectedTrack: ImageTrack | null;
-    [index: number]: ImageTrack;
-}
-
-declare var ImageTrackList: {
-    prototype: ImageTrackList;
-    new(): ImageTrackList;
-};
-
 interface VideoColorSpace {
     readonly fullRange: boolean | null;
     readonly matrix: VideoMatrixCoefficients | null;


### PR DESCRIPTION
These were added to the DOM types that are shipped by default with TypeScript in TS 5.8. Specifically the index signature in ImageTrackList causes a "Duplicate index signature" error in TS 5.8 due to the duplicate declarations, so I think these were supposed to be removed.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/microsoft/TypeScript/pull/60987 https://github.com/DefinitelyTyped/DefinitelyTyped/pull/72080
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
