### PR TITLE
three: delete WebGLRenderer property that never existed (why on earth)

### DIFF
--- a/types/three/src/renderers/WebGLRenderer.d.ts
+++ b/types/three/src/renderers/WebGLRenderer.d.ts
@@ -202,8 +202,6 @@ export class WebGLRenderer {
 
     shadowMap: WebGLShadowMap;
 
-    pixelRatio: number;
-
     capabilities: WebGLCapabilities;
     properties: WebGLProperties;
     renderLists: WebGLRenderLists;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://discourse.threejs.org/t/gtaopass-error-texture-dimensions-must-all-be-greater-than-zero/81751


(I'm apologize, but I'm a bit irritated that this non-existent property wasted hours of my time because I naively considered the type definitions for `three` as the source of truth so I looked in other places for the cause of errors in my app; now I know better than to trust `@types/*`).