### PR TITLE
fix(node/net): add missing "error" to connectionAttemptFailed event

### DIFF
--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -377,7 +377,7 @@ declare module "net" {
         addListener(event: "connectionAttempt", listener: (ip: string, port: number, family: number) => void): this;
         addListener(
             event: "connectionAttemptFailed",
-            listener: (ip: string, port: number, family: number) => void,
+            listener: (ip: string, port: number, family: number, error: Error) => void,
         ): this;
         addListener(
             event: "connectionAttemptTimeout",
@@ -397,7 +397,7 @@ declare module "net" {
         emit(event: "close", hadError: boolean): boolean;
         emit(event: "connect"): boolean;
         emit(event: "connectionAttempt", ip: string, port: number, family: number): boolean;
-        emit(event: "connectionAttemptFailed", ip: string, port: number, family: number): boolean;
+        emit(event: "connectionAttemptFailed", ip: string, port: number, family: number, error: Error): boolean;
         emit(event: "connectionAttemptTimeout", ip: string, port: number, family: number): boolean;
         emit(event: "data", data: Buffer): boolean;
         emit(event: "drain"): boolean;
@@ -410,7 +410,10 @@ declare module "net" {
         on(event: "close", listener: (hadError: boolean) => void): this;
         on(event: "connect", listener: () => void): this;
         on(event: "connectionAttempt", listener: (ip: string, port: number, family: number) => void): this;
-        on(event: "connectionAttemptFailed", listener: (ip: string, port: number, family: number) => void): this;
+        on(
+            event: "connectionAttemptFailed",
+            listener: (ip: string, port: number, family: number, error: Error) => void,
+        ): this;
         on(event: "connectionAttemptTimeout", listener: (ip: string, port: number, family: number) => void): this;
         on(event: "data", listener: (data: Buffer) => void): this;
         on(event: "drain", listener: () => void): this;
@@ -425,7 +428,10 @@ declare module "net" {
         once(event: string, listener: (...args: any[]) => void): this;
         once(event: "close", listener: (hadError: boolean) => void): this;
         once(event: "connectionAttempt", listener: (ip: string, port: number, family: number) => void): this;
-        once(event: "connectionAttemptFailed", listener: (ip: string, port: number, family: number) => void): this;
+        once(
+            event: "connectionAttemptFailed",
+            listener: (ip: string, port: number, family: number, error: Error) => void,
+        ): this;
         once(event: "connectionAttemptTimeout", listener: (ip: string, port: number, family: number) => void): this;
         once(event: "connect", listener: () => void): this;
         once(event: "data", listener: (data: Buffer) => void): this;
@@ -444,7 +450,7 @@ declare module "net" {
         prependListener(event: "connectionAttempt", listener: (ip: string, port: number, family: number) => void): this;
         prependListener(
             event: "connectionAttemptFailed",
-            listener: (ip: string, port: number, family: number) => void,
+            listener: (ip: string, port: number, family: number, error: Error) => void,
         ): this;
         prependListener(
             event: "connectionAttemptTimeout",
@@ -469,7 +475,7 @@ declare module "net" {
         ): this;
         prependOnceListener(
             event: "connectionAttemptFailed",
-            listener: (ip: string, port: number, family: number) => void,
+            listener: (ip: string, port: number, family: number, error: Error) => void,
         ): this;
         prependOnceListener(
             event: "connectionAttemptTimeout",

--- a/types/node/test/net.ts
+++ b/types/node/test/net.ts
@@ -177,6 +177,16 @@ import * as net from "node:net";
         bool = had_error;
     });
     _socket = _socket.addListener("connect", () => {});
+    _socket = _socket.addListener("connectionAttemptFailed", (ip, port, family, error) => {
+        // $ExpectType string
+        ip;
+        // $ExpectType number
+        port;
+        // $ExpectType number
+        family;
+        // $ExpectType Error
+        error;
+    });
     _socket = _socket.addListener("data", data => {
         buffer = data;
     });
@@ -202,6 +212,7 @@ import * as net from "node:net";
     /// emit
     bool = _socket.emit("close", bool);
     bool = _socket.emit("connect");
+    bool = _socket.emit("connectionAttemptFailed", str, num, num, error);
     bool = _socket.emit("data", buffer);
     bool = _socket.emit("drain");
     bool = _socket.emit("end");
@@ -216,6 +227,16 @@ import * as net from "node:net";
         bool = had_error;
     });
     _socket = _socket.on("connect", () => {});
+    _socket = _socket.on("connectionAttemptFailed", (ip, port, family, error) => {
+        // $ExpectType string
+        ip;
+        // $ExpectType number
+        port;
+        // $ExpectType number
+        family;
+        // $ExpectType Error
+        error;
+    });
     _socket = _socket.on("data", data => {
         buffer = data;
     });
@@ -243,6 +264,16 @@ import * as net from "node:net";
         bool = had_error;
     });
     _socket = _socket.once("connect", () => {});
+    _socket = _socket.once("connectionAttemptFailed", (ip, port, family, error) => {
+        // $ExpectType string
+        ip;
+        // $ExpectType number
+        port;
+        // $ExpectType number
+        family;
+        // $ExpectType Error
+        error;
+    });
     _socket = _socket.once("data", data => {
         buffer = data;
     });
@@ -270,6 +301,16 @@ import * as net from "node:net";
         bool = had_error;
     });
     _socket = _socket.prependListener("connect", () => {});
+    _socket = _socket.prependListener("connectionAttemptFailed", (ip, port, family, error) => {
+        // $ExpectType string
+        ip;
+        // $ExpectType number
+        port;
+        // $ExpectType number
+        family;
+        // $ExpectType Error
+        error;
+    });
     _socket = _socket.prependListener("data", data => {
         buffer = data;
     });
@@ -297,6 +338,16 @@ import * as net from "node:net";
         bool = had_error;
     });
     _socket = _socket.prependOnceListener("connect", () => {});
+    _socket = _socket.prependOnceListener("connectionAttemptFailed", (ip, port, family, error) => {
+        // $ExpectType string
+        ip;
+        // $ExpectType number
+        port;
+        // $ExpectType number
+        family;
+        // $ExpectType Error
+        error;
+    });
     _socket = _socket.prependOnceListener("data", data => {
         buffer = data;
     });

--- a/types/node/v20/net.d.ts
+++ b/types/node/v20/net.d.ts
@@ -380,7 +380,7 @@ declare module "net" {
         addListener(event: "connectionAttempt", listener: (ip: string, port: number, family: number) => void): this;
         addListener(
             event: "connectionAttemptFailed",
-            listener: (ip: string, port: number, family: number) => void,
+            listener: (ip: string, port: number, family: number, error: Error) => void,
         ): this;
         addListener(
             event: "connectionAttemptTimeout",
@@ -400,7 +400,7 @@ declare module "net" {
         emit(event: "close", hadError: boolean): boolean;
         emit(event: "connect"): boolean;
         emit(event: "connectionAttempt", ip: string, port: number, family: number): boolean;
-        emit(event: "connectionAttemptFailed", ip: string, port: number, family: number): boolean;
+        emit(event: "connectionAttemptFailed", ip: string, port: number, family: number, error: Error): boolean;
         emit(event: "connectionAttemptTimeout", ip: string, port: number, family: number): boolean;
         emit(event: "data", data: Buffer): boolean;
         emit(event: "drain"): boolean;
@@ -413,7 +413,10 @@ declare module "net" {
         on(event: "close", listener: (hadError: boolean) => void): this;
         on(event: "connect", listener: () => void): this;
         on(event: "connectionAttempt", listener: (ip: string, port: number, family: number) => void): this;
-        on(event: "connectionAttemptFailed", listener: (ip: string, port: number, family: number) => void): this;
+        on(
+            event: "connectionAttemptFailed",
+            listener: (ip: string, port: number, family: number, error: Error) => void,
+        ): this;
         on(event: "connectionAttemptTimeout", listener: (ip: string, port: number, family: number) => void): this;
         on(event: "data", listener: (data: Buffer) => void): this;
         on(event: "drain", listener: () => void): this;
@@ -428,7 +431,10 @@ declare module "net" {
         once(event: string, listener: (...args: any[]) => void): this;
         once(event: "close", listener: (hadError: boolean) => void): this;
         once(event: "connectionAttempt", listener: (ip: string, port: number, family: number) => void): this;
-        once(event: "connectionAttemptFailed", listener: (ip: string, port: number, family: number) => void): this;
+        once(
+            event: "connectionAttemptFailed",
+            listener: (ip: string, port: number, family: number, error: Error) => void,
+        ): this;
         once(event: "connectionAttemptTimeout", listener: (ip: string, port: number, family: number) => void): this;
         once(event: "connect", listener: () => void): this;
         once(event: "data", listener: (data: Buffer) => void): this;
@@ -447,7 +453,7 @@ declare module "net" {
         prependListener(event: "connectionAttempt", listener: (ip: string, port: number, family: number) => void): this;
         prependListener(
             event: "connectionAttemptFailed",
-            listener: (ip: string, port: number, family: number) => void,
+            listener: (ip: string, port: number, family: number, error: Error) => void,
         ): this;
         prependListener(
             event: "connectionAttemptTimeout",
@@ -472,7 +478,7 @@ declare module "net" {
         ): this;
         prependOnceListener(
             event: "connectionAttemptFailed",
-            listener: (ip: string, port: number, family: number) => void,
+            listener: (ip: string, port: number, family: number, error: Error) => void,
         ): this;
         prependOnceListener(
             event: "connectionAttemptTimeout",

--- a/types/node/v20/test/net.ts
+++ b/types/node/v20/test/net.ts
@@ -167,6 +167,16 @@ import * as net from "node:net";
         bool = had_error;
     });
     _socket = _socket.addListener("connect", () => {});
+    _socket = _socket.addListener("connectionAttemptFailed", (ip, port, family, error) => {
+        // $ExpectType string
+        ip;
+        // $ExpectType number
+        port;
+        // $ExpectType number
+        family;
+        // $ExpectType Error
+        error;
+    });
     _socket = _socket.addListener("data", data => {
         buffer = data;
     });
@@ -192,6 +202,7 @@ import * as net from "node:net";
     /// emit
     bool = _socket.emit("close", bool);
     bool = _socket.emit("connect");
+    bool = _socket.emit("connectionAttemptFailed", str, num, num, error);
     bool = _socket.emit("data", buffer);
     bool = _socket.emit("drain");
     bool = _socket.emit("end");
@@ -206,6 +217,16 @@ import * as net from "node:net";
         bool = had_error;
     });
     _socket = _socket.on("connect", () => {});
+    _socket = _socket.on("connectionAttemptFailed", (ip, port, family, error) => {
+        // $ExpectType string
+        ip;
+        // $ExpectType number
+        port;
+        // $ExpectType number
+        family;
+        // $ExpectType Error
+        error;
+    });
     _socket = _socket.on("data", data => {
         buffer = data;
     });
@@ -233,6 +254,16 @@ import * as net from "node:net";
         bool = had_error;
     });
     _socket = _socket.once("connect", () => {});
+    _socket = _socket.once("connectionAttemptFailed", (ip, port, family, error) => {
+        // $ExpectType string
+        ip;
+        // $ExpectType number
+        port;
+        // $ExpectType number
+        family;
+        // $ExpectType Error
+        error;
+    });
     _socket = _socket.once("data", data => {
         buffer = data;
     });
@@ -260,6 +291,16 @@ import * as net from "node:net";
         bool = had_error;
     });
     _socket = _socket.prependListener("connect", () => {});
+    _socket = _socket.prependListener("connectionAttemptFailed", (ip, port, family, error) => {
+        // $ExpectType string
+        ip;
+        // $ExpectType number
+        port;
+        // $ExpectType number
+        family;
+        // $ExpectType Error
+        error;
+    });
     _socket = _socket.prependListener("data", data => {
         buffer = data;
     });
@@ -287,6 +328,16 @@ import * as net from "node:net";
         bool = had_error;
     });
     _socket = _socket.prependOnceListener("connect", () => {});
+    _socket = _socket.prependOnceListener("connectionAttemptFailed", (ip, port, family, error) => {
+        // $ExpectType string
+        ip;
+        // $ExpectType number
+        port;
+        // $ExpectType number
+        family;
+        // $ExpectType Error
+        error;
+    });
     _socket = _socket.prependOnceListener("data", data => {
         buffer = data;
     });


### PR DESCRIPTION
See doc, https://nodejs.org/api/net.html#event-connectionattemptfailed.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
