### PR TITLE
feat(pg): add default export

### DIFF
--- a/types/pg/index.d.mts
+++ b/types/pg/index.d.mts
@@ -1,0 +1,21 @@
+import type * as pg from "./index.d.ts";
+
+import TypeOverrides = require("./lib/type-overrides");
+
+export type * from "./index.d.ts";
+
+declare const PG: {
+    defaults: typeof pg.defaults,
+    Client: typeof pg.Client,
+    Query: typeof pg.Query,
+    Pool: typeof pg.Pool,
+    Connection: typeof pg.Connection,
+    types: typeof pg.types,
+    DatabaseError: typeof pg.DatabaseError,
+    TypeOverrides: typeof TypeOverrides,
+    escapeIdentifier: typeof pg.escapeIdentifier,
+    escapeLiteral: typeof pg.escapeLiteral,
+    Result: pg.Result,
+}
+
+export default PG;

--- a/types/pg/index.d.mts
+++ b/types/pg/index.d.mts
@@ -4,6 +4,19 @@ import TypeOverrides = require("./lib/type-overrides");
 
 export type * from "./index.d.ts";
 
+export const defaults: typeof pg.defaults;
+export const Client: typeof pg.Client;
+export const Query: typeof pg.Query;
+export const Pool: typeof pg.Pool;
+export const Connection: typeof pg.Connection;
+export const types: typeof pg.types;
+export const DatabaseError: typeof pg.DatabaseError;
+export const escapeIdentifier: typeof pg.escapeIdentifier;
+export const escapeLiteral: typeof pg.escapeLiteral;
+export const Result: typeof pg.Result;
+
+export { TypeOverrides };
+
 declare const PG: {
     defaults: typeof pg.defaults;
     Client: typeof pg.Client;
@@ -15,7 +28,7 @@ declare const PG: {
     TypeOverrides: typeof TypeOverrides;
     escapeIdentifier: typeof pg.escapeIdentifier;
     escapeLiteral: typeof pg.escapeLiteral;
-    Result: pg.Result;
+    Result: typeof pg.Result;
 };
 
 export default PG;

--- a/types/pg/index.d.mts
+++ b/types/pg/index.d.mts
@@ -5,17 +5,17 @@ import TypeOverrides = require("./lib/type-overrides");
 export type * from "./index.d.ts";
 
 declare const PG: {
-    defaults: typeof pg.defaults,
-    Client: typeof pg.Client,
-    Query: typeof pg.Query,
-    Pool: typeof pg.Pool,
-    Connection: typeof pg.Connection,
-    types: typeof pg.types,
-    DatabaseError: typeof pg.DatabaseError,
-    TypeOverrides: typeof TypeOverrides,
-    escapeIdentifier: typeof pg.escapeIdentifier,
-    escapeLiteral: typeof pg.escapeLiteral,
-    Result: pg.Result,
-}
+    defaults: typeof pg.defaults;
+    Client: typeof pg.Client;
+    Query: typeof pg.Query;
+    Pool: typeof pg.Pool;
+    Connection: typeof pg.Connection;
+    types: typeof pg.types;
+    DatabaseError: typeof pg.DatabaseError;
+    TypeOverrides: typeof TypeOverrides;
+    escapeIdentifier: typeof pg.escapeIdentifier;
+    escapeLiteral: typeof pg.escapeLiteral;
+    Result: pg.Result;
+};
 
 export default PG;

--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -325,4 +325,25 @@ import * as Pg from ".";
 
 export const native: typeof Pg | null;
 
-export { DatabaseError } from "pg-protocol";
+import { DatabaseError } from "pg-protocol";
+export { DatabaseError };
+
+import TypeOverrides = require("./lib/type-overrides");
+
+export type Result = new (rowMode: string, t: typeof types) => QueryResult;
+
+declare const PG: {
+    defaults: typeof defaults,
+    Client: typeof Client,
+    Query: typeof Query,
+    Pool: typeof Pool,
+    Connection: typeof Connection,
+    types: typeof types,
+    DatabaseError: typeof DatabaseError,
+    TypeOverrides: typeof TypeOverrides,
+    escapeIdentifier: typeof escapeIdentifier,
+    escapeLiteral: typeof escapeLiteral,
+    Result: Result,
+}
+
+export default PG;

--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -328,4 +328,4 @@ export const native: typeof Pg | null;
 import { DatabaseError } from "pg-protocol";
 export { DatabaseError };
 
-export type Result = new (rowMode: string, t: typeof types) => QueryResult;
+export type Result = new(rowMode: string, t: typeof types) => QueryResult;

--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -325,7 +325,6 @@ import * as Pg from ".";
 
 export const native: typeof Pg | null;
 
-import { DatabaseError } from "pg-protocol";
-export { DatabaseError };
+export { DatabaseError } from "pg-protocol";
 
 export type Result = new(rowMode: string, t: typeof types) => QueryResult;

--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -328,22 +328,4 @@ export const native: typeof Pg | null;
 import { DatabaseError } from "pg-protocol";
 export { DatabaseError };
 
-import TypeOverrides = require("./lib/type-overrides");
-
 export type Result = new (rowMode: string, t: typeof types) => QueryResult;
-
-declare const PG: {
-    defaults: typeof defaults,
-    Client: typeof Client,
-    Query: typeof Query,
-    Pool: typeof Pool,
-    Connection: typeof Connection,
-    types: typeof types,
-    DatabaseError: typeof DatabaseError,
-    TypeOverrides: typeof TypeOverrides,
-    escapeIdentifier: typeof escapeIdentifier,
-    escapeLiteral: typeof escapeLiteral,
-    Result: Result,
-}
-
-export default PG;

--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -327,4 +327,12 @@ export const native: typeof Pg | null;
 
 export { DatabaseError } from "pg-protocol";
 
-export type Result = new(rowMode: string, t: typeof types) => QueryResult;
+export class Result<R extends QueryResultRow = any> implements QueryResult<R> {
+    command: string;
+    rowCount: number | null;
+    oid: number;
+    fields: FieldDef[];
+    rows: R[];
+
+    constructor(rowMode: string, t: typeof types);
+}

--- a/types/pg/package.json
+++ b/types/pg/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/pg",
-    "version": "8.12.9999",
+    "version": "8.15.9999",
     "projects": [
         "https://github.com/brianc/node-postgres"
     ],

--- a/types/pg/package.json
+++ b/types/pg/package.json
@@ -5,6 +5,13 @@
     "projects": [
         "https://github.com/brianc/node-postgres"
     ],
+    "exports": {
+        ".": {
+            "import": "./index.d.mts",
+            "require": "./index.d.ts"
+        },
+        "./lib/type-overrides": "./lib/type-overrides.d.ts"
+    },
     "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",

--- a/types/pg/package.json
+++ b/types/pg/package.json
@@ -10,7 +10,7 @@
             "import": "./index.d.mts",
             "require": "./index.d.ts"
         },
-        "./lib/type-overrides": "./lib/type-overrides.d.ts"
+        "./lib/*": "./lib/*.d.ts"
     },
     "dependencies": {
         "@types/node": "*",

--- a/types/pg/pg-tests.mts
+++ b/types/pg/pg-tests.mts
@@ -1,14 +1,14 @@
 import pg, {
-    defaults,
     Client,
-    Query,
-    Pool,
     Connection,
-    types,
     DatabaseError,
-    TypeOverrides,
+    defaults,
     escapeIdentifier,
     escapeLiteral,
+    Pool,
+    Query,
+    TypeOverrides,
+    types,
 } from "pg";
 
 const client = new pg.Client({

--- a/types/pg/pg-tests.mts
+++ b/types/pg/pg-tests.mts
@@ -1,0 +1,15 @@
+import pg from "pg";
+
+const client = new pg.Client({
+    host: "my.database-server.com",
+    port: 5334,
+    user: "database-user",
+    password: "secretpassword!!",
+    application_name: "DefinitelyTyped",
+    keepAlive: true,
+});
+client.setTypeParser(20, val => Number(val));
+client.getTypeParser(20);
+
+const res = new pg.Result("array", pg.types);
+res.rows.forEach(row => row);

--- a/types/pg/pg-tests.mts
+++ b/types/pg/pg-tests.mts
@@ -1,4 +1,15 @@
-import pg from "pg";
+import pg, {
+    defaults,
+    Client,
+    Query,
+    Pool,
+    Connection,
+    types,
+    DatabaseError,
+    TypeOverrides,
+    escapeIdentifier,
+    escapeLiteral,
+} from "pg";
 
 const client = new pg.Client({
     host: "my.database-server.com",
@@ -13,3 +24,21 @@ client.getTypeParser(20);
 
 const res = new pg.Result("array", pg.types);
 res.rows.forEach(row => row);
+
+const poolSize: number | undefined = defaults.poolSize;
+const poolIdleTimeout: number | undefined = defaults.poolIdleTimeout;
+const reapIntervalMillis: number | undefined = defaults.reapIntervalMillis;
+const binary: boolean | undefined = defaults.binary;
+const parseInt8: boolean | undefined = defaults.parseInt8;
+const parseInputDatesAsUTC: boolean | undefined = defaults.parseInputDatesAsUTC;
+
+const client2 = new Client({
+    host: "my.database-server.com",
+    port: 5334,
+    user: "database-user",
+    password: "secretpassword!!",
+    application_name: "DefinitelyTyped",
+    keepAlive: true,
+});
+client2.setTypeParser(20, val => Number(val));
+client2.getTypeParser(20);

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -1,6 +1,6 @@
 import { connect } from "net";
 import * as pg from "pg";
-import pgDefault, { Client, Connection, CustomTypesConfig, DatabaseError, defaults, Pool, QueryArrayConfig, types } from "pg";
+import { Client, Connection, CustomTypesConfig, DatabaseError, defaults, Pool, QueryArrayConfig, types } from "pg";
 import TypeOverrides = require("pg/lib/type-overrides");
 import { NoticeMessage } from "pg-protocol/dist/messages.js";
 
@@ -25,20 +25,6 @@ const client = new Client({
 });
 client.setTypeParser(20, val => Number(val));
 client.getTypeParser(20);
-
-const clientFromDefault = new pgDefault.Client({
-    host: "my.database-server.com",
-    port: 5334,
-    user: "database-user",
-    password: "secretpassword!!",
-    application_name: "DefinitelyTyped",
-    keepAlive: true,
-});
-clientFromDefault.setTypeParser(20, val => Number(val));
-clientFromDefault.getTypeParser(20);
-
-const res = new pgDefault.Result("array", pgDefault.types);
-res.rows.forEach(row => row);
 
 const user: string | undefined = client.user;
 const database: string | undefined = client.database;

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -1,6 +1,6 @@
 import { connect } from "net";
 import * as pg from "pg";
-import { Client, Connection, CustomTypesConfig, DatabaseError, defaults, Pool, QueryArrayConfig, types } from "pg";
+import pgDefault, { Client, Connection, CustomTypesConfig, DatabaseError, defaults, Pool, QueryArrayConfig, types } from "pg";
 import TypeOverrides = require("pg/lib/type-overrides");
 import { NoticeMessage } from "pg-protocol/dist/messages.js";
 
@@ -25,6 +25,20 @@ const client = new Client({
 });
 client.setTypeParser(20, val => Number(val));
 client.getTypeParser(20);
+
+const clientFromDefault = new pgDefault.Client({
+    host: "my.database-server.com",
+    port: 5334,
+    user: "database-user",
+    password: "secretpassword!!",
+    application_name: "DefinitelyTyped",
+    keepAlive: true,
+});
+clientFromDefault.setTypeParser(20, val => Number(val));
+clientFromDefault.getTypeParser(20);
+
+const res = new pgDefault.Result("array", pgDefault.types);
+res.rows.forEach(row => row);
 
 const user: string | undefined = client.user;
 const database: string | undefined = client.database;

--- a/types/pg/tsconfig.json
+++ b/types/pg/tsconfig.json
@@ -15,6 +15,7 @@
     },
     "files": [
         "index.d.ts",
-        "pg-tests.ts"
+        "pg-tests.ts",
+        "pg-tests.mts"
     ]
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/brianc/node-postgres/pull/3423
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

esm support was officially added in version 8.15, and pg became available as a default export. I tried to keep it as close as possible as reflected in the source code