### PR TITLE
fix(jasmine): Add Clock.autoTick from jasmine 5.7

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -466,6 +466,7 @@ declare namespace jasmine {
     }
 
     interface Clock {
+        autoTick(): void;
         install(): Clock;
         uninstall(): void;
         /** Calls to any registered callback are triggered when the clock is ticked forward via the jasmine.clock().tick function, which takes a number of milliseconds. */

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -1734,6 +1734,14 @@ describe("Manually ticking the Jasmine Clock", () => {
     });
 });
 
+describe("Automatically ticking the Jasmine Clock", () => {
+    it("ticks automatically", async () => {
+        jasmine.clock().install().autoTick();
+        await new Promise(resolve => setTimeout(resolve));
+        jasmine.clock().uninstall();
+    });
+});
+
 describe("Asynchronous specs", () => {
     var value: number;
     beforeEach((done: DoneFn) => {


### PR DESCRIPTION
There is a new autoTick method on Clock as of jasmine 5.7 https://jasmine.github.io/api/5.7/Clock.html#autoTick
