### PR TITLE
Fix constructor parameters for m3u8-parser

### DIFF
--- a/types/m3u8-parser/index.d.ts
+++ b/types/m3u8-parser/index.d.ts
@@ -124,7 +124,7 @@ export interface Manifest {
 
 export class Parser extends Stream {
     constructor(options?: {
-        url?: string;
+        uri?: string;
         mainDefinitions?: Record<string, string>;
     });
     lineStream: LineStream;

--- a/types/m3u8-parser/m3u8-parser-tests.ts
+++ b/types/m3u8-parser/m3u8-parser-tests.ts
@@ -10,7 +10,7 @@ parser.end();
 const parsedManifest = parser.manifest.playlists?.[0].contentProtection?.["com.apple.fps.1_0"]?.attributes.resoltion;
 
 const parser2 = new Parser({
-    url: "https://exmaple.com/video.m3u8?param_a=34&param_b=abc",
+    uri: "https://exmaple.com/video.m3u8?param_a=34&param_b=abc",
     mainDefinitions: {
         param_c: "def",
     },


### PR DESCRIPTION
The option should be `uri` instead of `url` as defined [here](https://github.com/videojs/m3u8-parser/blob/26d880375e1dec76fe118acfed06657cb4688d7c/src/parser.js#L92).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/videojs/m3u8-parser/blob/26d880375e1dec76fe118acfed06657cb4688d7c/src/parser.js#L92>>
