### PR TITLE
fix(pg): use same version of pg-types that's use in pg itself

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -17,7 +17,7 @@ export interface ClientConfig {
     host?: string | undefined;
     connectionString?: string | undefined;
     keepAlive?: boolean | undefined;
-    stream?: () => stream.Duplex | stream.Duplex | undefined;
+    stream?: () => stream.Duplex | undefined;
     statement_timeout?: false | number | undefined;
     ssl?: boolean | ConnectionOptions | undefined;
     query_timeout?: number | undefined;

--- a/types/pg/package.json
+++ b/types/pg/package.json
@@ -8,7 +8,7 @@
     "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
-        "pg-types": "^4.0.1"
+        "pg-types": "^2.2.0"
     },
     "devDependencies": {
         "@types/pg": "workspace:."


### PR DESCRIPTION
pg uses pg-types ^2 but the types package uses ^4. This pr fixes that.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/brianc/node-postgres/issues/3388#issuecomment-2843873080
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.