### PR TITLE
[node] Allow the `err` parameter to the `net.Socket#write` callback (in case of success) to be `null` as well as `undefined`

### DIFF
--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -109,8 +109,8 @@ declare module "net" {
          * @since v0.1.90
          * @param [encoding='utf8'] Only used when data is `string`.
          */
-        write(buffer: Uint8Array | string, cb?: (err?: Error) => void): boolean;
-        write(str: Uint8Array | string, encoding?: BufferEncoding, cb?: (err?: Error) => void): boolean;
+        write(buffer: Uint8Array | string, cb?: (err?: Error | null) => void): boolean;
+        write(str: Uint8Array | string, encoding?: BufferEncoding, cb?: (err?: Error | null) => void): boolean;
         /**
          * Initiate a connection on a given socket.
          *

--- a/types/node/test/net.ts
+++ b/types/node/test/net.ts
@@ -63,6 +63,9 @@ import * as net from "node:net";
     });
 
     let bool: boolean;
+    let uint8array: Uint8Array = new Uint8Array(0);
+    let bufferEncoding: BufferEncoding = "utf8";
+    let str = "123";
 
     bool = _socket.connecting;
     bool = _socket.destroyed;
@@ -75,6 +78,20 @@ import * as net from "node:net";
     _socket = _socket.setEncoding("utf8");
     _socket = _socket.resume();
     _socket = _socket.resetAndDestroy();
+
+    // write callback parameter can be either null/undefined or an error
+    bool = _socket.write(uint8array, (err) => {
+        if (err) { const _err: Error = err; }
+    });
+    bool = _socket.write(str, (err) => {
+        if (err) { const _err: Error = err; }
+    });
+    bool = _socket.write(uint8array, bufferEncoding, (err) => {
+        if (err) { const _err: Error = err; }
+    });
+    bool = _socket.write(str, bufferEncoding, (err) => {
+        if (err) { const _err: Error = err; }
+    });
 
     _socket = _socket.end();
     _socket = _socket.destroy();
@@ -132,6 +149,8 @@ import * as net from "node:net";
     let error = new Error("asd");
     let str = "123";
     let num = 123;
+    let uint8array: Uint8Array = new Uint8Array(0);
+    let bufferEncoding: BufferEncoding = "utf8";
 
     const ipcConnectOpts: net.IpcSocketConnectOpts = {
         path: "/",
@@ -318,6 +337,20 @@ import * as net from "node:net";
     });
     _socket = _socket.prependOnceListener("ready", () => {});
     _socket = _socket.prependOnceListener("timeout", () => {});
+
+    // write callback parameter can be either null/undefined or an error
+    bool = _socket.write(uint8array, (err) => {
+        if (err) { const _err: Error = err; }
+    });
+    bool = _socket.write(str, (err) => {
+        if (err) { const _err: Error = err; }
+    });
+    bool = _socket.write(uint8array, bufferEncoding, (err) => {
+        if (err) { const _err: Error = err; }
+    });
+    bool = _socket.write(str, bufferEncoding, (err) => {
+        if (err) { const _err: Error = err; }
+    });
 
     _socket.destroy().destroy();
     _socket.readyState; // $ExpectType SocketReadyState

--- a/types/node/v20/net.d.ts
+++ b/types/node/v20/net.d.ts
@@ -112,8 +112,8 @@ declare module "net" {
          * @since v0.1.90
          * @param [encoding='utf8'] Only used when data is `string`.
          */
-        write(buffer: Uint8Array | string, cb?: (err?: Error) => void): boolean;
-        write(str: Uint8Array | string, encoding?: BufferEncoding, cb?: (err?: Error) => void): boolean;
+        write(buffer: Uint8Array | string, cb?: (err?: Error | null) => void): boolean;
+        write(str: Uint8Array | string, encoding?: BufferEncoding, cb?: (err?: Error | null) => void): boolean;
         /**
          * Initiate a connection on a given socket.
          *

--- a/types/node/v20/test/net.ts
+++ b/types/node/v20/test/net.ts
@@ -53,6 +53,9 @@ import * as net from "node:net";
     });
 
     let bool: boolean;
+    let uint8array: Uint8Array = new Uint8Array(0);
+    let bufferEncoding: BufferEncoding = "utf8";
+    let str = "123";
 
     bool = _socket.connecting;
     bool = _socket.destroyed;
@@ -65,6 +68,20 @@ import * as net from "node:net";
     _socket = _socket.setEncoding("utf8");
     _socket = _socket.resume();
     _socket = _socket.resetAndDestroy();
+
+    // write callback parameter can be either null/undefined or an error
+    bool = _socket.write(uint8array, (err) => {
+        if (err) { const _err: Error = err; }
+    });
+    bool = _socket.write(str, (err) => {
+        if (err) { const _err: Error = err; }
+    });
+    bool = _socket.write(uint8array, bufferEncoding, (err) => {
+        if (err) { const _err: Error = err; }
+    });
+    bool = _socket.write(str, bufferEncoding, (err) => {
+        if (err) { const _err: Error = err; }
+    });
 
     _socket = _socket.end();
     _socket = _socket.destroy();
@@ -122,6 +139,8 @@ import * as net from "node:net";
     let error = new Error("asd");
     let str = "123";
     let num = 123;
+    let uint8array: Uint8Array = new Uint8Array(0);
+    let bufferEncoding: BufferEncoding = "utf8";
 
     const ipcConnectOpts: net.IpcSocketConnectOpts = {
         path: "/",
@@ -308,6 +327,20 @@ import * as net from "node:net";
     });
     _socket = _socket.prependOnceListener("ready", () => {});
     _socket = _socket.prependOnceListener("timeout", () => {});
+
+    // write callback parameter can be either null/undefined or an error
+    bool = _socket.write(uint8array, (err) => {
+        if (err) { const _err: Error = err; }
+    });
+    bool = _socket.write(str, (err) => {
+        if (err) { const _err: Error = err; }
+    });
+    bool = _socket.write(uint8array, bufferEncoding, (err) => {
+        if (err) { const _err: Error = err; }
+    });
+    bool = _socket.write(str, bufferEncoding, (err) => {
+        if (err) { const _err: Error = err; }
+    });
 
     _socket.destroy().destroy();
     _socket.readyState; // $ExpectType SocketReadyState


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/72657>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

(It _appears_ to me that it's always been possible to have `null` as the affected parameter value -- it was just much less common before the changes linked to/described in the discussion.  Hence changing this for all Node versions, and not tied to any particular new Node version.  Unfortunately because this will frequently require users to update their callback functions to handle this "new" `null` argument value, it's a breaking change for everyone, unless they coded particularly defensively.)

I am extremely not certain whether I've done all the necessary things correctly here, but I'm at a point where only someone who knows stuff is going to find it, it's not going to be me at this point finding lapses.