### PR TITLE
[npm-registry-fetch] fix `retry` object option property names

### DIFF
--- a/types/npm-registry-fetch/index.d.ts
+++ b/types/npm-registry-fetch/index.d.ts
@@ -141,6 +141,26 @@ declare namespace fetch {
         fetchRetryMaxtimeout?: number | undefined;
     }
 
+    interface FetchRetryObjectOptions {
+        /**
+         * The "retries" config for `retry` to use when fetching packages from
+         * the registry.
+         */
+        retries?: number | undefined;
+        /**
+         * The "factor" config for `retry` to use when fetching packages.
+         */
+        factor?: number | undefined;
+        /**
+         * The "minTimeout" config for `retry` to use when fetching packages.
+         */
+        minTimeout?: number | undefined;
+        /**
+         * The "maxTimeout" config for `retry` to use when fetching packages.
+         */
+        maxTimeout?: number | undefined;
+    }
+
     /**
      * Extra options:
      *
@@ -391,7 +411,7 @@ declare namespace fetch {
          * Single-object configuration for request retry settings. If passed in,
          * will override individually-passed `fetchRetry*` settings.
          */
-        retry?: Partial<FetchRetryOptions> | undefined;
+        retry?: Partial<FetchRetryObjectOptions> | undefined;
         /**
          * Associate an operation with a scope for a scoped registry. This
          * option can force lookup of scope-specific registries and

--- a/types/npm-registry-fetch/npm-registry-fetch-tests.ts
+++ b/types/npm-registry-fetch/npm-registry-fetch-tests.ts
@@ -59,7 +59,7 @@ const opts: fetch.Options = {
     proxy: "https://my.proxy",
     query: { foo: "bar" },
     registry: "https://registry.npmjs.org",
-    retry,
+    ...retry,
     scope: "scope",
     spec: "@scope/package",
     timeout: 60000,
@@ -71,8 +71,20 @@ const opts: fetch.Options = {
     "//registry.npmjs.org/:username": "nobody",
 };
 
+const retryObject: fetch.FetchRetryObjectOptions = {
+    retries: 42,
+    factor: 10,
+    maxTimeout: 10000,
+    minTimeout: 60000,
+};
+
+const optsWithRetry: fetch.Options = {
+    retry: retryObject,
+}
+
 fetch("/"); // $ExpectType Promise<Response>
 fetch("/", opts); // $ExpectType Promise<Response>
+fetch("/", optsWithRetry); // $ExpectType Promise<Response>
 fetch.json("/"); // $ExpectType Promise<Record<string, unknown>>
 fetch.json("/", opts); // $ExpectType Promise<Record<string, unknown>>
 fetch.json.stream("/-/user/zkat/package", "$*"); // $ExpectType ReadWriteStream

--- a/types/npm-registry-fetch/npm-registry-fetch-tests.ts
+++ b/types/npm-registry-fetch/npm-registry-fetch-tests.ts
@@ -80,7 +80,7 @@ const retryObject: fetch.FetchRetryObjectOptions = {
 
 const optsWithRetry: fetch.Options = {
     retry: retryObject,
-}
+};
 
 fetch("/"); // $ExpectType Promise<Response>
 fetch("/", opts); // $ExpectType Promise<Response>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/npm/npm-registry-fetch/blob/v8.0.3/index.js#L116-L121
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
  - No, this is a fix and does not include any changes from a newer version
