### PR TITLE
[elm] allow specifying `Elm.*` namespace

### DIFF
--- a/types/elm/.eslintrc.json
+++ b/types/elm/.eslintrc.json
@@ -1,8 +1,5 @@
 {
     "rules": {
-        "@definitelytyped/no-type-only-packages": "off",
-        "@typescript-eslint/no-unsafe-function-type": "off",
-        "@typescript-eslint/no-wrapper-object-types": "off",
-        "@typescript-eslint/no-empty-interface": "off"
+        "@definitelytyped/no-type-only-packages": "off"
     }
 }

--- a/types/elm/elm-tests.ts
+++ b/types/elm/elm-tests.ts
@@ -1,7 +1,13 @@
-declare var Elm: ElmInstance<ShanghaiPorts>;
+declare var Elm: ElmInstance<ShanghaiPorts, ShanghaiFlags>;
+
+interface ShanghaiFlags {
+    coordinates: [number, number];
+    incomingShip: Ship;
+    outgoingShip: string;
+}
 
 interface ShanghaiPorts {
-    coordinates: PortToElm<number[]>;
+    coordinates: PortToElm<[number, number]>;
     incomingShip: PortToElm<Ship>;
     outgoingShip: PortToElm<string>;
     totalCapacity: PortFromElm<number>;
@@ -22,7 +28,7 @@ var shanghai = Elm.Main.init({
     },
 });
 
-function logger(x: any) {
+function logger(x: number) {
     console.log(x);
 }
 shanghai.ports.totalCapacity.subscribe(logger);

--- a/types/elm/elm-tests.ts
+++ b/types/elm/elm-tests.ts
@@ -1,4 +1,12 @@
-declare var Elm: ElmInstance<ShanghaiPorts, ShanghaiFlags>;
+declare var Elm: ElmInstance<{}, {}>;
+
+Elm.Main.init();
+
+declare var Shanghai: ElmInstance<
+    ShanghaiPorts,
+    ShanghaiFlags, // eslint-disable-next-line @definitelytyped/no-single-element-tuple-type
+    ["Shanghai"]
+>;
 
 interface ShanghaiFlags {
     coordinates: [number, number];
@@ -20,7 +28,7 @@ interface Ship {
 
 // initialize the Shanghai component which keeps track of
 // shipping data in and out of the Port of Shanghai.
-var shanghai = Elm.Main.init({
+var shanghai = Shanghai.Shanghai.init({
     flags: {
         coordinates: [0, 0],
         incomingShip: { name: "", capacity: 0 },

--- a/types/elm/index.d.ts
+++ b/types/elm/index.d.ts
@@ -1,9 +1,19 @@
-interface ElmInstance<P = {}> {
-    Main: ElmMain<P>;
-}
+type ElmInstance<
+    P,
+    F,
+    Entrypoints extends string[] =
+        // eslint-disable-next-line @definitelytyped/no-single-element-tuple-type
+        ["Main"],
+> = NestedEntrypoints<Entrypoints, P, F>;
 
-interface ElmMain<P> {
-    init(options: { node?: Node | undefined; flags?: any }): ElmApp<P>;
+type NestedEntrypoints<Entrypoints extends string[], P, F> = Entrypoints extends [
+    infer First extends string,
+    ...infer Rest extends string[],
+] ? { [K in First]: NestedEntrypoints<Rest, P, F> }
+    : ElmMain<P, F>;
+
+interface ElmMain<P, F> {
+    init(options?: { node?: Node | undefined; flags: F } | undefined): ElmApp<P>;
 }
 
 interface ElmApp<P> {

--- a/types/elm/tsconfig.json
+++ b/types/elm/tsconfig.json
@@ -5,10 +5,8 @@
             "es6",
             "dom"
         ],
-        "noImplicitAny": true,
-        "noImplicitThis": true,
-        "strictNullChecks": true,
-        "strictFunctionTypes": true,
+        "strict": true,
+        "exactOptionalPropertyTypes": true,
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
Traditionally, Elm code is compiled to `Elm.Main`, but not always. This ports over the code I wrote for elm-review to allow specifying a namespace.

While I was at it, I gave the package a bit of love.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://guide.elm-lang.org/interop/ports
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
