### PR TITLE
[w3c-image-capture] Align types to match output from TypeScript-DOM-lib-generator

### DIFF
--- a/types/node/test/globals-dom.ts
+++ b/types/node/test/globals-dom.ts
@@ -60,9 +60,9 @@
 {
     const stream = new ReadableStream<string>({ start: (controller) => controller.enqueue("hello") }); // $ExpectType ReadableStream<string>
     const compressionStream = new CompressionStream("gzip");
-    const encodedStream = stream.pipeThrough(new TextEncoderStream()); // $ExpectType ReadableStream<Uint8Array> || ReadableStream<Uint8Array<ArrayBufferLike>>
-    const compressedStream = encodedStream.pipeThrough(compressionStream); // $ExpectType ReadableStream<any> || ReadableStream<Uint8Array<ArrayBufferLike>>
-    compressedStream.pipeThrough(new DecompressionStream("gzip")); // $ExpectType ReadableStream<any> || ReadableStream<Uint8Array<ArrayBufferLike>>
+    const encodedStream = stream.pipeThrough(new TextEncoderStream()); // $ExpectType ReadableStream<Uint8Array> || ReadableStream<Uint8Array<ArrayBufferLike>> || ReadableStream<Uint8Array<ArrayBuffer>>
+    const compressedStream = encodedStream.pipeThrough(compressionStream); // $ExpectType ReadableStream<any> || ReadableStream<Uint8Array<ArrayBufferLike>> || ReadableStream<Uint8Array<ArrayBuffer>>
+    compressedStream.pipeThrough(new DecompressionStream("gzip")); // $ExpectType ReadableStream<any> || ReadableStream<Uint8Array<ArrayBufferLike>> || ReadableStream<Uint8Array<ArrayBuffer>>
     void (async () => {
         const reader = compressedStream.getReader();
         const readNext = async () => {

--- a/types/three/test/integration/three-examples/webgl2_rendertarget_texture2darray.ts
+++ b/types/three/test/integration/three-examples/webgl2_rendertarget_texture2darray.ts
@@ -139,7 +139,7 @@ function init() {
 
     new THREE.FileLoader().setResponseType("arraybuffer").load("textures/3d/head256x256x109.zip", data => {
         const zip = unzipSync(new Uint8Array(data as ArrayBuffer));
-        const array = new Uint8Array(zip["head256x256x109"].buffer);
+        const array = new Uint8Array(zip["head256x256x109"].buffer as ArrayBuffer);
 
         const texture = new THREE.DataArrayTexture(array, DIMENSIONS.width, DIMENSIONS.height, DIMENSIONS.depth);
         texture.format = THREE.RedFormat;

--- a/types/three/test/unit/examples/jsm/exporters/STLExporter.ts
+++ b/types/three/test/unit/examples/jsm/exporters/STLExporter.ts
@@ -11,8 +11,8 @@ function exportASCII() {
 }
 
 function exportBinary() {
-    const result = exporter.parse(mesh, { binary: true });
-    saveArrayBuffer(result, "box.stl");
+    const result = exporter.parse(mesh, { binary: true }); // $ExpectType DataView || DataView<ArrayBufferLike>
+    saveArrayBuffer(result as BufferSource, "box.stl");
 }
 
 const link = document.createElement("a");

--- a/types/w3c-image-capture/index.d.ts
+++ b/types/w3c-image-capture/index.d.ts
@@ -1,8 +1,6 @@
 /// <reference types="webrtc" />
 
-declare class ImageCapture {
-    constructor(videoTrack: MediaStreamTrack);
-
+declare interface ImageCapture {
     takePhoto(photoSettings?: PhotoSettings): Promise<Blob>;
 
     getPhotoCapabilities(): Promise<PhotoCapabilities>;
@@ -14,28 +12,30 @@ declare class ImageCapture {
     readonly track: MediaStreamTrack;
 }
 
+declare var ImageCapture: {
+    prototype: ImageCapture
+    new(videoTrack: MediaStreamTrack): ImageCapture;
+}
+
 interface PhotoCapabilities {
-    readonly redEyeReduction: RedEyeReduction;
-    readonly imageHeight: MediaSettingsRange;
-    readonly imageWidth: MediaSettingsRange;
-    readonly fillLightMode: FillLightMode[];
+    redEyeReduction?: "never" | "always" | "controllable";
+    imageHeight?: MediaSettingsRange;
+    imageWidth?: MediaSettingsRange;
+    fillLightMode?: ("auto" | "off" | "flash")[];
 }
 
 interface PhotoSettings {
-    fillLightMode?: FillLightMode | undefined;
+    fillLightMode?: "auto" | "off" | "flash" | undefined;
     imageHeight?: number | undefined;
     imageWidth?: number | undefined;
     redEyeReduction?: boolean | undefined;
 }
 
 interface MediaSettingsRange {
-    readonly max: number;
-    readonly min: number;
-    readonly step: number;
+    max?: number;
+    min?: number;
+    step?: number;
 }
-
-type RedEyeReduction = "never" | "always" | "controllable";
-type FillLightMode = "auto" | "off" | "flash";
 
 interface MediaTrackCapabilities {
     whiteBalanceMode: MeteringMode[];
@@ -85,7 +85,7 @@ interface MediaTrackConstraintSet {
 }
 
 interface MediaTrackSettings {
-    whiteBalanceMode?: MeteringMode | undefined;
+    whiteBalanceMode?: string | undefined;
     exposureMode?: MeteringMode | undefined;
     focusMode?: MeteringMode | undefined;
     pointsOfInterest?: Point2D[] | undefined;

--- a/types/w3c-image-capture/index.d.ts
+++ b/types/w3c-image-capture/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="webrtc" />
 
-declare interface ImageCapture {
+interface ImageCapture {
     takePhoto(photoSettings?: PhotoSettings): Promise<Blob>;
 
     getPhotoCapabilities(): Promise<PhotoCapabilities>;

--- a/types/w3c-image-capture/w3c-image-capture-tests.ts
+++ b/types/w3c-image-capture/w3c-image-capture-tests.ts
@@ -21,9 +21,9 @@ const updateCameraPanZoomTiltAndTakePhoto = async () => {
 
                 // Map it to a slider element.
                 const input = <HTMLInputElement> document.getElementById(ptz);
-                input.min = capabilities[ptz].min.toString();
-                input.max = capabilities[ptz].max.toString();
-                input.step = capabilities[ptz].step.toString();
+                input.min = capabilities[ptz].min!.toString();
+                input.max = capabilities[ptz].max!.toString();
+                input.step = capabilities[ptz].step!.toString();
                 const settingsPtz = settings[ptz];
                 input.value = (settingsPtz && settingsPtz.toString()) || "0";
                 input.disabled = false;
@@ -155,9 +155,9 @@ const updateFocusAndTrakePhoto = () => {
 
         // Map focus distance to a slider element.
         const input = <HTMLInputElement> document.querySelector("input[type=\"range\"]");
-        input.min = capabilities.focusDistance.min.toString();
-        input.max = capabilities.focusDistance.max.toString();
-        input.step = capabilities.focusDistance.step.toString();
+        input.min = capabilities.focusDistance.min!.toString();
+        input.max = capabilities.focusDistance.max!.toString();
+        input.step = capabilities.focusDistance.step!.toString();
         const focusDistance = track.getSettings().focusDistance;
         input.value = (focusDistance && focusDistance.toString()) || "0";
 


### PR DESCRIPTION
This fixes several [breaks](https://github.com/microsoft/TypeScript/pull/61647#issuecomment-2848120878) after taking the latest DOM types from TypeScript-DOM-lib-generator.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/microsoft/TypeScript/pull/61647
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

