### PR TITLE
[node] Add `NonSharedBuffer`/`AllowSharedBuffer`

### DIFF
--- a/types/fs-extra/test/fs-extra-tests.ts
+++ b/types/fs-extra/test/fs-extra-tests.ts
@@ -868,14 +868,14 @@ fs.readdir(path, { withFileTypes: true }, (err, files) => {
     files; // $ExpectType Dirent[]
 });
 
-fs.readFile(path); // $ExpectType Promise<Buffer> || Promise<Buffer<ArrayBufferLike>>
+fs.readFile(path); // $ExpectType Promise<Buffer> || Promise<Buffer<ArrayBufferLike>> || Promise<NonSharedBuffer>
 fs.readFile(path, "utf-8"); // $ExpectType Promise<string>
 fs.readFile(path, { encoding: "utf-8" }); // $ExpectType Promise<string>
-fs.readFile(path, { flag: "r" }); // $ExpectType Promise<Buffer> || Promise<Buffer<ArrayBufferLike>>
+fs.readFile(path, { flag: "r" }); // $ExpectType Promise<Buffer> || Promise<Buffer<ArrayBufferLike>> || Promise<NonSharedBuffer>
 // $ExpectType void
 fs.readFile(path, (err, data) => {
     err; // $ExpectType ErrnoException | null
-    data; // $ExpectType Buffer || Buffer<ArrayBufferLike>
+    data; // $ExpectType Buffer || Buffer<ArrayBufferLike> || NonSharedBuffer
 });
 // $ExpectType void
 fs.readFile(path, "utf-8", (err, data) => {
@@ -890,12 +890,12 @@ fs.readFile(path, { encoding: "utf-8" }, (err, data) => {
 // $ExpectType void
 fs.readFile(path, { flag: "r" }, (err, data) => {
     err; // $ExpectType ErrnoException | null
-    data; // $ExpectType Buffer || Buffer<ArrayBufferLike>
+    data; // $ExpectType Buffer || Buffer<ArrayBufferLike> || NonSharedBuffer
 });
 // $ExpectType void
 fs.readFile(path, { signal: new AbortController().signal }, (err, data) => {
     err; // $ExpectType ErrnoException | null
-    data; // $ExpectType Buffer || Buffer<ArrayBufferLike>
+    data; // $ExpectType Buffer || Buffer<ArrayBufferLike> || NonSharedBuffer
 });
 
 fs.readlink(path); // $ExpectType Promise<string>

--- a/types/node/buffer.buffer.d.ts
+++ b/types/node/buffer.buffer.d.ts
@@ -451,6 +451,8 @@ declare module "buffer" {
              */
             subarray(start?: number, end?: number): Buffer<TArrayBuffer>;
         }
+        type NonSharedBuffer = Buffer<ArrayBuffer>;
+        type AllowSharedBuffer = Buffer<ArrayBufferLike>;
     }
     /** @deprecated Use `Buffer.allocUnsafeSlow()` instead. */
     var SlowBuffer: {

--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -122,7 +122,7 @@ declare module "buffer" {
      * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
      */
     export function resolveObjectURL(id: string): Blob | undefined;
-    export { Buffer, type NonSharedBuffer, type AllowSharedBuffer };
+    export { type AllowSharedBuffer, Buffer, type NonSharedBuffer };
     /**
      * @experimental
      */

--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -122,7 +122,7 @@ declare module "buffer" {
      * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
      */
     export function resolveObjectURL(id: string): Blob | undefined;
-    export { Buffer };
+    export { Buffer, type NonSharedBuffer, type AllowSharedBuffer };
     /**
      * @experimental
      */

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -2684,7 +2684,7 @@ declare module "fs" {
             } & Abortable)
             | undefined
             | null,
-        callback: (err: NodeJS.ErrnoException | null, data: Buffer) => void,
+        callback: (err: NodeJS.ErrnoException | null, data: NonSharedBuffer) => void,
     ): void;
     /**
      * Asynchronously reads the entire contents of a file.
@@ -2719,7 +2719,7 @@ declare module "fs" {
             | BufferEncoding
             | undefined
             | null,
-        callback: (err: NodeJS.ErrnoException | null, data: string | Buffer) => void,
+        callback: (err: NodeJS.ErrnoException | null, data: string | NonSharedBuffer) => void,
     ): void;
     /**
      * Asynchronously reads the entire contents of a file.
@@ -2728,7 +2728,7 @@ declare module "fs" {
      */
     export function readFile(
         path: PathOrFileDescriptor,
-        callback: (err: NodeJS.ErrnoException | null, data: Buffer) => void,
+        callback: (err: NodeJS.ErrnoException | null, data: NonSharedBuffer) => void,
     ): void;
     export namespace readFile {
         /**
@@ -2744,7 +2744,7 @@ declare module "fs" {
                 encoding?: null | undefined;
                 flag?: string | undefined;
             } | null,
-        ): Promise<Buffer>;
+        ): Promise<NonSharedBuffer>;
         /**
          * Asynchronously reads the entire contents of a file.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
@@ -2778,7 +2778,7 @@ declare module "fs" {
                 })
                 | BufferEncoding
                 | null,
-        ): Promise<string | Buffer>;
+        ): Promise<string | NonSharedBuffer>;
     }
     /**
      * Returns the contents of the `path`.
@@ -2810,7 +2810,7 @@ declare module "fs" {
             encoding?: null | undefined;
             flag?: string | undefined;
         } | null,
-    ): Buffer;
+    ): NonSharedBuffer;
     /**
      * Synchronously reads the entire contents of a file.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
@@ -2842,7 +2842,7 @@ declare module "fs" {
             })
             | BufferEncoding
             | null,
-    ): string | Buffer;
+    ): string | NonSharedBuffer;
     export type WriteFileOptions =
         | (
             & ObjectEncodingOptions

--- a/types/node/ts5.6/buffer.buffer.d.ts
+++ b/types/node/ts5.6/buffer.buffer.d.ts
@@ -448,6 +448,8 @@ declare module "buffer" {
              */
             subarray(start?: number, end?: number): Buffer;
         }
+        type NonSharedBuffer = Buffer;
+        type AllowSharedBuffer = Buffer;
     }
     /** @deprecated Use `Buffer.allocUnsafeSlow()` instead. */
     var SlowBuffer: {

--- a/types/node/v18/buffer.buffer.d.ts
+++ b/types/node/v18/buffer.buffer.d.ts
@@ -445,6 +445,8 @@ declare module "buffer" {
              */
             subarray(start?: number, end?: number): Buffer<TArrayBuffer>;
         }
+        type NonSharedBuffer = Buffer<ArrayBuffer>;
+        type AllowSharedBuffer = Buffer<ArrayBufferLike>;
     }
     /** @deprecated Use `Buffer.allocUnsafeSlow()` instead. */
     var SlowBuffer: {

--- a/types/node/v18/buffer.d.ts
+++ b/types/node/v18/buffer.d.ts
@@ -112,7 +112,7 @@ declare module "buffer" {
      * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
      */
     export function resolveObjectURL(id: string): Blob | undefined;
-    export { Buffer };
+    export { Buffer, type NonSharedBuffer, type AllowSharedBuffer };
     /**
      * @experimental
      */

--- a/types/node/v18/buffer.d.ts
+++ b/types/node/v18/buffer.d.ts
@@ -112,7 +112,7 @@ declare module "buffer" {
      * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
      */
     export function resolveObjectURL(id: string): Blob | undefined;
-    export { Buffer, type NonSharedBuffer, type AllowSharedBuffer };
+    export { type AllowSharedBuffer, Buffer, type NonSharedBuffer };
     /**
      * @experimental
      */

--- a/types/node/v18/fs.d.ts
+++ b/types/node/v18/fs.d.ts
@@ -2695,7 +2695,7 @@ declare module "fs" {
             } & Abortable)
             | undefined
             | null,
-        callback: (err: NodeJS.ErrnoException | null, data: Buffer) => void,
+        callback: (err: NodeJS.ErrnoException | null, data: NonSharedBuffer) => void,
     ): void;
     /**
      * Asynchronously reads the entire contents of a file.
@@ -2730,7 +2730,7 @@ declare module "fs" {
             | BufferEncoding
             | undefined
             | null,
-        callback: (err: NodeJS.ErrnoException | null, data: string | Buffer) => void,
+        callback: (err: NodeJS.ErrnoException | null, data: string | NonSharedBuffer) => void,
     ): void;
     /**
      * Asynchronously reads the entire contents of a file.
@@ -2739,7 +2739,7 @@ declare module "fs" {
      */
     export function readFile(
         path: PathOrFileDescriptor,
-        callback: (err: NodeJS.ErrnoException | null, data: Buffer) => void,
+        callback: (err: NodeJS.ErrnoException | null, data: NonSharedBuffer) => void,
     ): void;
     export namespace readFile {
         /**
@@ -2755,7 +2755,7 @@ declare module "fs" {
                 encoding?: null | undefined;
                 flag?: string | undefined;
             } | null,
-        ): Promise<Buffer>;
+        ): Promise<NonSharedBuffer>;
         /**
          * Asynchronously reads the entire contents of a file.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
@@ -2789,7 +2789,7 @@ declare module "fs" {
                 })
                 | BufferEncoding
                 | null,
-        ): Promise<string | Buffer>;
+        ): Promise<string | NonSharedBuffer>;
     }
     /**
      * Returns the contents of the `path`.
@@ -2821,7 +2821,7 @@ declare module "fs" {
             encoding?: null | undefined;
             flag?: string | undefined;
         } | null,
-    ): Buffer;
+    ): NonSharedBuffer;
     /**
      * Synchronously reads the entire contents of a file.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
@@ -2853,7 +2853,7 @@ declare module "fs" {
             })
             | BufferEncoding
             | null,
-    ): string | Buffer;
+    ): string | NonSharedBuffer;
     export type WriteFileOptions =
         | (
             & ObjectEncodingOptions

--- a/types/node/v18/ts5.6/buffer.buffer.d.ts
+++ b/types/node/v18/ts5.6/buffer.buffer.d.ts
@@ -443,6 +443,8 @@ declare module "buffer" {
              */
             subarray(start?: number, end?: number): Buffer;
         }
+        type NonSharedBuffer = Buffer;
+        type AllowSharedBuffer = Buffer;
     }
     /** @deprecated Use `Buffer.allocUnsafeSlow()` instead. */
     var SlowBuffer: {

--- a/types/node/v20/buffer.buffer.d.ts
+++ b/types/node/v20/buffer.buffer.d.ts
@@ -450,6 +450,8 @@ declare module "buffer" {
              */
             subarray(start?: number, end?: number): Buffer<TArrayBuffer>;
         }
+        type NonSharedBuffer = Buffer<ArrayBuffer>;
+        type AllowSharedBuffer = Buffer<ArrayBufferLike>;
     }
     /** @deprecated Use `Buffer.allocUnsafeSlow()` instead. */
     var SlowBuffer: {

--- a/types/node/v20/buffer.d.ts
+++ b/types/node/v20/buffer.d.ts
@@ -122,7 +122,7 @@ declare module "buffer" {
      * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
      */
     export function resolveObjectURL(id: string): Blob | undefined;
-    export { Buffer, type NonSharedBuffer, type AllowSharedBuffer };
+    export { type AllowSharedBuffer, Buffer, type NonSharedBuffer };
     /**
      * @experimental
      */

--- a/types/node/v20/buffer.d.ts
+++ b/types/node/v20/buffer.d.ts
@@ -122,7 +122,7 @@ declare module "buffer" {
      * @param id A `'blob:nodedata:...` URL string returned by a prior call to `URL.createObjectURL()`.
      */
     export function resolveObjectURL(id: string): Blob | undefined;
-    export { Buffer };
+    export { Buffer, type NonSharedBuffer, type AllowSharedBuffer };
     /**
      * @experimental
      */

--- a/types/node/v20/fs.d.ts
+++ b/types/node/v20/fs.d.ts
@@ -2682,7 +2682,7 @@ declare module "fs" {
             } & Abortable)
             | undefined
             | null,
-        callback: (err: NodeJS.ErrnoException | null, data: Buffer) => void,
+        callback: (err: NodeJS.ErrnoException | null, data: NonSharedBuffer) => void,
     ): void;
     /**
      * Asynchronously reads the entire contents of a file.
@@ -2717,7 +2717,7 @@ declare module "fs" {
             | BufferEncoding
             | undefined
             | null,
-        callback: (err: NodeJS.ErrnoException | null, data: string | Buffer) => void,
+        callback: (err: NodeJS.ErrnoException | null, data: string | NonSharedBuffer) => void,
     ): void;
     /**
      * Asynchronously reads the entire contents of a file.
@@ -2726,7 +2726,7 @@ declare module "fs" {
      */
     export function readFile(
         path: PathOrFileDescriptor,
-        callback: (err: NodeJS.ErrnoException | null, data: Buffer) => void,
+        callback: (err: NodeJS.ErrnoException | null, data: NonSharedBuffer) => void,
     ): void;
     export namespace readFile {
         /**
@@ -2742,7 +2742,7 @@ declare module "fs" {
                 encoding?: null | undefined;
                 flag?: string | undefined;
             } | null,
-        ): Promise<Buffer>;
+        ): Promise<NonSharedBuffer>;
         /**
          * Asynchronously reads the entire contents of a file.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
@@ -2776,7 +2776,7 @@ declare module "fs" {
                 })
                 | BufferEncoding
                 | null,
-        ): Promise<string | Buffer>;
+        ): Promise<string | NonSharedBuffer>;
     }
     /**
      * Returns the contents of the `path`.
@@ -2808,7 +2808,7 @@ declare module "fs" {
             encoding?: null | undefined;
             flag?: string | undefined;
         } | null,
-    ): Buffer;
+    ): NonSharedBuffer;
     /**
      * Synchronously reads the entire contents of a file.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
@@ -2840,7 +2840,7 @@ declare module "fs" {
             })
             | BufferEncoding
             | null,
-    ): string | Buffer;
+    ): string | NonSharedBuffer;
     export type WriteFileOptions =
         | (
             & ObjectEncodingOptions

--- a/types/node/v20/ts5.6/buffer.buffer.d.ts
+++ b/types/node/v20/ts5.6/buffer.buffer.d.ts
@@ -448,6 +448,8 @@ declare module "buffer" {
              */
             subarray(start?: number, end?: number): Buffer;
         }
+        type NonSharedBuffer = Buffer;
+        type AllowSharedBuffer = Buffer;
     }
     /** @deprecated Use `Buffer.allocUnsafeSlow()` instead. */
     var SlowBuffer: {


### PR DESCRIPTION
In order to address several new breaks related to https://github.com/microsoft/TypeScript/pull/61647, this PR introduces a `NonSharedBuffer` type alias that is backwards compatible with TS5.6, allowing us to type `readFile` and `readFileSync` as returning a `NonSharedBuffer` (i.e., `Buffer<ArrayBuffer>` in >=TS5.7 and `Buffer` in <=TS5.6). This also introduces an `AllowSharedBuffer` type alias for cases where you may want to be more explicit. The naming for `AllowSharedBuffer` is based on the DOM `AllowSharedBufferSource` type.

This PR may introduce breaks in other DT packages. Given the number of dependents on Node, I'm opting to allow the DT infrastructure to detect them on my behalf.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/microsoft/TypeScript/pull/61647
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.~~
