### PR TITLE
fix(node/vm): correct SourceTextModuleOptions["importModuleDynamically"] 

### DIFF
--- a/types/node/test/vm.ts
+++ b/types/node/test/vm.ts
@@ -153,7 +153,7 @@ import {
             console.log(importAttributes); // { type: 'json' }
             const m = new SyntheticModule(["bar"], () => {});
             await m.link(() => {
-                throw new Error();
+                throw new Error("unreachable");
             });
             m.setExport("bar", { hello: "world" });
             return m;
@@ -167,7 +167,7 @@ import {
             console.log(importAttributes); // { type: 'json' }
             const m = new SyntheticModule(["bar"], () => {});
             await m.link(() => {
-                throw new Error();
+                throw new Error("unreachable");
             });
             m.setExport("bar", { hello: "world" });
             return m;

--- a/types/node/test/vm.ts
+++ b/types/node/test/vm.ts
@@ -148,9 +148,9 @@ import {
 {
     const script = new Script("import(\"foo.json\", { with: { type: \"json\" } })", {
         async importModuleDynamically(specifier, referrer, importAttributes) {
-            console.log(specifier); // 'foo.json'
-            console.log(referrer); // The compiled vm.Script
-            console.log(importAttributes); // { type: 'json' }
+            specifier; // $ExpectType string
+            referrer; // $ExpectType Script
+            importAttributes; // $ExpectType ImportAttributes
             const m = new SyntheticModule(["bar"], () => {});
             await m.link(() => {
                 throw new Error("unreachable");
@@ -162,9 +162,9 @@ import {
 
     const module = new SourceTextModule("import(\"foo.json\", { with: { type: \"json\" } })", {
         async importModuleDynamically(specifier, referrer, importAttributes) {
-            console.log(specifier); // 'foo.json'
-            console.log(referrer); // The compiled vm.SourceTextModule
-            console.log(importAttributes); // { type: 'json' }
+            specifier; // $ExpectType string
+            referrer; // $ExpectType SourceTextModule
+            importAttributes; // $ExpectType ImportAttributes
             const m = new SyntheticModule(["bar"], () => {});
             await m.link(() => {
                 throw new Error("unreachable");

--- a/types/node/test/vm.ts
+++ b/types/node/test/vm.ts
@@ -144,3 +144,33 @@ import {
         this.setExport("default", obj);
     });
 });
+
+{
+    const script = new Script("import(\"foo.json\", { with: { type: \"json\" } })", {
+        async importModuleDynamically(specifier, referrer, importAttributes) {
+            console.log(specifier); // 'foo.json'
+            console.log(referrer); // The compiled vm.Script
+            console.log(importAttributes); // { type: 'json' }
+            const m = new SyntheticModule(["bar"], () => {});
+            await m.link(() => {
+                throw new Error();
+            });
+            m.setExport("bar", { hello: "world" });
+            return m;
+        },
+    });
+
+    const module = new SourceTextModule("import(\"foo.json\", { with: { type: \"json\" } })", {
+        async importModuleDynamically(specifier, referrer, importAttributes) {
+            console.log(specifier); // 'foo.json'
+            console.log(referrer); // The compiled vm.SourceTextModule
+            console.log(importAttributes); // { type: 'json' }
+            const m = new SyntheticModule(["bar"], () => {});
+            await m.link(() => {
+                throw new Error();
+            });
+            m.setExport("bar", { hello: "world" });
+            return m;
+        },
+    });
+}

--- a/types/node/v18/test/vm.ts
+++ b/types/node/v18/test/vm.ts
@@ -152,3 +152,33 @@ import {
         this.setExport("default", obj);
     });
 });
+
+{
+    const script = new Script("import(\"foo.json\", { with: { type: \"json\" } })", {
+        async importModuleDynamically(specifier, referrer, importAttributes) {
+            console.log(specifier); // 'foo.json'
+            console.log(referrer); // The compiled vm.Script
+            console.log(importAttributes); // { type: 'json' }
+            const m = new SyntheticModule(["bar"], () => {});
+            await m.link(() => {
+                throw new Error("unreachable");
+            });
+            m.setExport("bar", { hello: "world" });
+            return m;
+        },
+    });
+
+    const module = new SourceTextModule("import(\"foo.json\", { with: { type: \"json\" } })", {
+        async importModuleDynamically(specifier, referrer, importAttributes) {
+            console.log(specifier); // 'foo.json'
+            console.log(referrer); // The compiled vm.SourceTextModule
+            console.log(importAttributes); // { type: 'json' }
+            const m = new SyntheticModule(["bar"], () => {});
+            await m.link(() => {
+                throw new Error("unreachable");
+            });
+            m.setExport("bar", { hello: "world" });
+            return m;
+        },
+    });
+}

--- a/types/node/v18/test/vm.ts
+++ b/types/node/v18/test/vm.ts
@@ -156,9 +156,9 @@ import {
 {
     const script = new Script("import(\"foo.json\", { with: { type: \"json\" } })", {
         async importModuleDynamically(specifier, referrer, importAttributes) {
-            console.log(specifier); // 'foo.json'
-            console.log(referrer); // The compiled vm.Script
-            console.log(importAttributes); // { type: 'json' }
+            specifier; // $ExpectType string
+            referrer; // $ExpectType Script
+            importAttributes; // $ExpectType ImportAttributes
             const m = new SyntheticModule(["bar"], () => {});
             await m.link(() => {
                 throw new Error("unreachable");
@@ -170,9 +170,9 @@ import {
 
     const module = new SourceTextModule("import(\"foo.json\", { with: { type: \"json\" } })", {
         async importModuleDynamically(specifier, referrer, importAttributes) {
-            console.log(specifier); // 'foo.json'
-            console.log(referrer); // The compiled vm.SourceTextModule
-            console.log(importAttributes); // { type: 'json' }
+            specifier; // $ExpectType string
+            referrer; // $ExpectType SourceTextModule
+            importAttributes; // $ExpectType ImportAttributes
             const m = new SyntheticModule(["bar"], () => {});
             await m.link(() => {
                 throw new Error("unreachable");

--- a/types/node/v18/vm.d.ts
+++ b/types/node/v18/vm.d.ts
@@ -68,7 +68,7 @@ declare module "vm" {
          * If this option is not specified, calls to `import()` will reject with `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING`.
          */
         importModuleDynamically?:
-            | ((specifier: string, script: Script, importAttributes: ImportAttributes) => Module)
+            | ((specifier: string, script: Script, importAttributes: ImportAttributes) => Module | Promise<Module>)
             | undefined;
     }
     interface RunningScriptOptions extends BaseOptions {
@@ -620,7 +620,13 @@ declare module "vm" {
          * Called during evaluation of this module to initialize the `import.meta`.
          */
         initializeImportMeta?: ((meta: ImportMeta, module: SourceTextModule) => void) | undefined;
-        importModuleDynamically?: ScriptOptions["importModuleDynamically"] | undefined;
+        importModuleDynamically?:
+            | ((
+                specifier: string,
+                referrer: SourceTextModule,
+                importAttributes: ImportAttributes,
+            ) => Module | Promise<Module>)
+            | undefined;
     }
     class SourceTextModule extends Module {
         /**

--- a/types/node/v20/test/vm.ts
+++ b/types/node/v20/test/vm.ts
@@ -152,3 +152,33 @@ import {
         this.setExport("default", obj);
     });
 });
+
+{
+    const script = new Script("import(\"foo.json\", { with: { type: \"json\" } })", {
+        async importModuleDynamically(specifier, referrer, importAttributes) {
+            console.log(specifier); // 'foo.json'
+            console.log(referrer); // The compiled vm.Script
+            console.log(importAttributes); // { type: 'json' }
+            const m = new SyntheticModule(["bar"], () => {});
+            await m.link(() => {
+                throw new Error("unreachable");
+            });
+            m.setExport("bar", { hello: "world" });
+            return m;
+        },
+    });
+
+    const module = new SourceTextModule("import(\"foo.json\", { with: { type: \"json\" } })", {
+        async importModuleDynamically(specifier, referrer, importAttributes) {
+            console.log(specifier); // 'foo.json'
+            console.log(referrer); // The compiled vm.SourceTextModule
+            console.log(importAttributes); // { type: 'json' }
+            const m = new SyntheticModule(["bar"], () => {});
+            await m.link(() => {
+                throw new Error("unreachable");
+            });
+            m.setExport("bar", { hello: "world" });
+            return m;
+        },
+    });
+}

--- a/types/node/v20/test/vm.ts
+++ b/types/node/v20/test/vm.ts
@@ -156,9 +156,9 @@ import {
 {
     const script = new Script("import(\"foo.json\", { with: { type: \"json\" } })", {
         async importModuleDynamically(specifier, referrer, importAttributes) {
-            console.log(specifier); // 'foo.json'
-            console.log(referrer); // The compiled vm.Script
-            console.log(importAttributes); // { type: 'json' }
+            specifier; // $ExpectType string
+            referrer; // $ExpectType Script
+            importAttributes; // $ExpectType ImportAttributes
             const m = new SyntheticModule(["bar"], () => {});
             await m.link(() => {
                 throw new Error("unreachable");
@@ -170,9 +170,9 @@ import {
 
     const module = new SourceTextModule("import(\"foo.json\", { with: { type: \"json\" } })", {
         async importModuleDynamically(specifier, referrer, importAttributes) {
-            console.log(specifier); // 'foo.json'
-            console.log(referrer); // The compiled vm.SourceTextModule
-            console.log(importAttributes); // { type: 'json' }
+            specifier; // $ExpectType string
+            referrer; // $ExpectType SourceTextModule
+            importAttributes; // $ExpectType ImportAttributes
             const m = new SyntheticModule(["bar"], () => {});
             await m.link(() => {
                 throw new Error("unreachable");

--- a/types/node/v20/vm.d.ts
+++ b/types/node/v20/vm.d.ts
@@ -69,7 +69,7 @@ declare module "vm" {
          * [Support of dynamic `import()` in compilation APIs](https://nodejs.org/docs/latest-v20.x/api/vm.html#support-of-dynamic-import-in-compilation-apis).
          */
         importModuleDynamically?:
-            | ((specifier: string, script: Script, importAttributes: ImportAttributes) => Module)
+            | ((specifier: string, script: Script, importAttributes: ImportAttributes) => Module | Promise<Module>)
             | typeof constants.USE_MAIN_CONTEXT_DEFAULT_LOADER
             | undefined;
     }
@@ -815,7 +815,13 @@ declare module "vm" {
          * Called during evaluation of this module to initialize the `import.meta`.
          */
         initializeImportMeta?: ((meta: ImportMeta, module: SourceTextModule) => void) | undefined;
-        importModuleDynamically?: ScriptOptions["importModuleDynamically"] | undefined;
+        importModuleDynamically?:
+            | ((
+                specifier: string,
+                referrer: SourceTextModule,
+                importAttributes: ImportAttributes,
+            ) => Module | Promise<Module>)
+            | undefined;
     }
     /**
      * This feature is only available with the `--experimental-vm-modules` command

--- a/types/node/vm.d.ts
+++ b/types/node/vm.d.ts
@@ -856,7 +856,13 @@ declare module "vm" {
          * Called during evaluation of this module to initialize the `import.meta`.
          */
         initializeImportMeta?: ((meta: ImportMeta, module: SourceTextModule) => void) | undefined;
-        importModuleDynamically?: ScriptOptions["importModuleDynamically"] | undefined;
+        importModuleDynamically?:
+            | ((
+                specifier: string,
+                referrer: SourceTextModule,
+                importAttributes: ImportAttributes,
+            ) => Module | Promise<Module>)
+            | undefined;
     }
     /**
      * This feature is only available with the `--experimental-vm-modules` command


### PR DESCRIPTION
`SourceTextModuleOptions["importModuleDynamically"]` is not the same as `ScriptOptions["importModuleDynamically"]`.  
 According to <https://nodejs.org/docs/latest-v22.x/api/vm.html#when-importmoduledynamically-is-a-function>, the referrer is ... the compiled vm.SourceTextModule for new vm.SourceTextModule.  

Note that `importModuleDynamically` cannot be `vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER` here, it may only be a function according to the [docs](https://nodejs.org/docs/latest-v22.x/api/vm.html#new-vmsourcetextmodulecode-options).

```
node:internal/vm/module:283
      validateFunction(importModuleDynamically, 'options.importModuleDynamically');
      ^

TypeError [ERR_INVALID_ARG_TYPE]: The "options.importModuleDynamically" property must be of type function. Received type symbol (Symbol(vm_dynamic_import_main_context_default))
    at new SourceTextModule (node:internal/vm/module:283:7)
```
---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://nodejs.org/docs/latest-v22.x/api/vm.html#new-vmsourcetextmodulecode-options>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.