### PR TITLE
[stremio-addon-sdk] Fix incorrect `Manifest.config[].options` type

### DIFF
--- a/types/stremio-addon-sdk/index.d.ts
+++ b/types/stremio-addon-sdk/index.d.ts
@@ -570,7 +570,7 @@ export interface ManifestConfig {
     /**
      * List of (string) choices for `type: "select"`
      */
-    options?: string;
+    options?: string[];
 
     /**
      * If the value is required or not. Only applies to the following types: "string", "number". (default is `false`)


### PR DESCRIPTION
As the name and description suggested already - this is supposed to be an array of strings.

See also https://github.com/Stremio/stremio-addon-sdk/blob/3950d5707680b6d51908bdf5c7be45661dbcc987/docs/api/responses/manifest.md#config-format

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
