### PR TITLE
Update for spdx-satisfies 6.0.0

### DIFF
--- a/types/spdx-satisfies/index.d.ts
+++ b/types/spdx-satisfies/index.d.ts
@@ -1,2 +1,2 @@
-declare function spdxSatisfies(first: string, second: string): boolean;
+declare function spdxSatisfies(spdxExpression: string, arrayOfLicenses: string[]): boolean;
 export = spdxSatisfies;

--- a/types/spdx-satisfies/index.d.ts
+++ b/types/spdx-satisfies/index.d.ts
@@ -1,2 +1,2 @@
-declare function spdxSatisfies(spdxExpression: string, arrayOfLicenses: string[]): boolean;
+declare function spdxSatisfies(spdxExpression: string, arrayOfLicenses: readonly string[]): boolean;
 export = spdxSatisfies;

--- a/types/spdx-satisfies/package.json
+++ b/types/spdx-satisfies/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/spdx-satisfies",
-    "version": "0.1.9999",
+    "version": "6.0.9999",
     "projects": [
         "https://github.com/kemitchell/spdx-satisfies.js#readme"
     ],

--- a/types/spdx-satisfies/spdx-satisfies-tests.ts
+++ b/types/spdx-satisfies/spdx-satisfies-tests.ts
@@ -1,3 +1,3 @@
 import spdxSatisfies = require("spdx-satisfies");
 
-spdxSatisfies("BSD-2-Clause", "(BSD-2-Clause OR MIT)");
+spdxSatisfies("BSD-2-Clause", ["BSD-2-Clause", "MIT"]);


### PR DESCRIPTION
There's a new signature for the satisfies function.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jslicense/spdx-satisfies.js/pull/17
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
