### PR TITLE
fix(node/net): correct Server.getConnections() return type

### DIFF
--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -662,7 +662,7 @@ declare module "net" {
          * Callback should take two arguments `err` and `count`.
          * @since v0.9.7
          */
-        getConnections(cb: (error: Error | null, count: number) => void): void;
+        getConnections(cb: (error: Error | null, count: number) => void): this;
         /**
          * Opposite of `unref()`, calling `ref()` on a previously `unref`ed server will _not_ let the program exit if it's the only server left (the default behavior).
          * If the server is `ref`ed calling `ref()` again will have no effect.

--- a/types/node/test/net.ts
+++ b/types/node/test/net.ts
@@ -446,6 +446,18 @@ import * as net from "node:net";
 }
 
 {
+    let _server = net.createServer();
+
+    // $ExpectType Server
+    _server.getConnections((error, count) => {
+        // $ExpectType Error | null
+        error;
+        // $ExpectType number
+        count;
+    });
+}
+
+{
     const sockAddr: net.SocketAddress = new net.SocketAddress({
         address: "123.123.123.123",
         family: "ipv4",

--- a/types/node/v18/net.d.ts
+++ b/types/node/v18/net.d.ts
@@ -594,7 +594,7 @@ declare module "net" {
          * Callback should take two arguments `err` and `count`.
          * @since v0.9.7
          */
-        getConnections(cb: (error: Error | null, count: number) => void): void;
+        getConnections(cb: (error: Error | null, count: number) => void): this;
         /**
          * Opposite of `unref()`, calling `ref()` on a previously `unref`ed server will _not_ let the program exit if it's the only server left (the default behavior).
          * If the server is `ref`ed calling `ref()` again will have no effect.

--- a/types/node/v18/test/net.ts
+++ b/types/node/v18/test/net.ts
@@ -385,6 +385,18 @@ import * as net from "node:net";
 }
 
 {
+    let _server = net.createServer();
+
+    // $ExpectType Server
+    _server.getConnections((error, count) => {
+        // $ExpectType Error | null
+        error;
+        // $ExpectType number
+        count;
+    });
+}
+
+{
     const sockAddr: net.SocketAddress = new net.SocketAddress({
         address: "123.123.123.123",
         family: "ipv4",

--- a/types/node/v20/net.d.ts
+++ b/types/node/v20/net.d.ts
@@ -655,7 +655,7 @@ declare module "net" {
          * Callback should take two arguments `err` and `count`.
          * @since v0.9.7
          */
-        getConnections(cb: (error: Error | null, count: number) => void): void;
+        getConnections(cb: (error: Error | null, count: number) => void): this;
         /**
          * Opposite of `unref()`, calling `ref()` on a previously `unref`ed server will _not_ let the program exit if it's the only server left (the default behavior).
          * If the server is `ref`ed calling `ref()` again will have no effect.

--- a/types/node/v20/test/net.ts
+++ b/types/node/v20/test/net.ts
@@ -436,6 +436,18 @@ import * as net from "node:net";
 }
 
 {
+    let _server = net.createServer();
+
+    // $ExpectType Server
+    _server.getConnections((error, count) => {
+        // $ExpectType Error | null
+        error;
+        // $ExpectType number
+        count;
+    });
+}
+
+{
     const sockAddr: net.SocketAddress = new net.SocketAddress({
         address: "123.123.123.123",
         family: "ipv4",


### PR DESCRIPTION
See https://github.com/nodejs/node/blob/main/lib/net.js and https://nodejs.org/docs/latest/api/net.html#servergetconnectionscallback.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
