### PR TITLE
fix: update dragFromOutsideItem type to allow correct function return type

### DIFF
--- a/types/react-big-calendar/lib/addons/dragAndDrop.d.ts
+++ b/types/react-big-calendar/lib/addons/dragAndDrop.d.ts
@@ -32,7 +32,7 @@ export interface withDragAndDropProps<TEvent extends object = Event, TResource e
     onDragStart?: ((args: OnDragStartArgs<TEvent>) => void) | undefined;
     onDragOver?: ((event: React.DragEvent) => void) | undefined;
     onDropFromOutside?: ((args: DragFromOutsideItemArgs) => void) | undefined;
-    dragFromOutsideItem?: (() => keyof TEvent | ((event: TEvent) => Date)) | undefined;
+    dragFromOutsideItem?: (() => TEvent) | undefined;
     draggableAccessor?: keyof TEvent | ((event: TEvent) => boolean) | undefined;
     resizableAccessor?: keyof TEvent | ((event: TEvent) => boolean) | undefined;
     selectable?: true | false | "ignoreEvents" | undefined;

--- a/types/react-big-calendar/package.json
+++ b/types/react-big-calendar/package.json
@@ -77,6 +77,10 @@
         {
             "name": "decimoseptimo",
             "githubUsername": "decimoseptimo"
+        },
+        {
+            "name": "Lee SeongJin",
+            "githubUsername": "leeseongjinca"
         }
     ]
 }

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -206,6 +206,7 @@ class CalendarResource {
             onEventResize={handleEventMove}
             onDragStart={console.log}
             onDropFromOutside={console.log}
+            dragFromOutsideItem={() => getEvents()[0]}
             draggableAccessor={() => true}
             resizableAccessor={() => true}
             elementProps={{ id: "myCalendar" }}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jquense/react-big-calendar/blob/master/src/addons/dragAndDrop/withDragAndDrop.js#L23

- Example usage: <EventContainerWrapper> – https://github.com/jquense/react-big-calendar/blob/master/src/addons/dragAndDrop/EventContainerWrapper.js#L139-L140
- Example usage 2: <EventContainerWrapper> - https://github.com/jquense/react-big-calendar/blob/master/src/addons/dragAndDrop/EventContainerWrapper.js#L45-L60


- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.