### PR TITLE
Update `@types/aws-cloudfront-function` to include kvs and origin helper methods

### DIFF
--- a/types/aws-cloudfront-function/.eslintrc.json
+++ b/types/aws-cloudfront-function/.eslintrc.json
@@ -1,5 +1,6 @@
 {
     "rules": {
-        "@definitelytyped/no-type-only-packages": "off"
+        "@definitelytyped/no-type-only-packages": "off",
+        "@definitelytyped/no-single-declare-module": "off"
     }
 }

--- a/types/aws-cloudfront-function/aws-cloudfront-function-tests.ts
+++ b/types/aws-cloudfront-function/aws-cloudfront-function-tests.ts
@@ -116,13 +116,60 @@ import cf from "cloudfront";
 
 const kvsHandle = cf.kvs("example-kvs-id");
 
-(async () => {
-    const value1 = await kvsHandle.get("key");
-    const value2 = await kvsHandle.get("key", { format: "string" });
-    const value3 = await kvsHandle.get("key", { format: "bytes" });
-    const value4 = await kvsHandle.get("key", { format: "json" }); 
+async function handler3(event: AWSCloudFrontFunction.Event): Promise<AWSCloudFrontFunction.Request | AWSCloudFrontFunction.Response> {
+    const _value1 = await kvsHandle.get("key");
+    const _value2 = await kvsHandle.get("key", { format: "string" });
+    const _value3 = await kvsHandle.get("key", { format: "bytes" });
+    const _value4 = await kvsHandle.get("key", { format: "json" });
 
-    const exists = await kvsHandle.exists("key");
+    const _exists = await kvsHandle.exists("key");
 
-    const meta = await kvsHandle.meta();
-})();
+    const _meta = await kvsHandle.meta();
+
+    return event.request;
+}
+
+function testUpdateRequestOrigin() {
+    const params: Parameters<typeof cf.updateRequestOrigin>[0] = {
+        domainName: "example.com",
+        originPath: "/new-path",
+        customHeaders: { "x-custom-header": "value" },
+        connectionAttempts: 3,
+        originShield: {
+            enabled: true,
+            region: "us-east-1",
+        },
+        originAccessControlConfig: {
+            enabled: true,
+            signingBehavior: "always",
+            signingProtocol: "sigv4",
+            originType: "s3",
+        },
+        timeouts: {
+            readTimeout: 30,
+            keepAliveTimeout: 15,
+            connectionTimeout: 10,
+        },
+        customOriginConfig: {
+            port: 443,
+            protocol: "https",
+            sslProtocols: ["TLSv1.2", "TLSv1.1"],
+        },
+    };
+    cf.updateRequestOrigin(params);
+}
+
+function testSelectRequestOriginById() {
+    const originId: Parameters<typeof cf.selectRequestOriginById>[0] = "example-origin-id";
+    cf.selectRequestOriginById(originId);
+}
+
+function testCreateRequestOriginGroup() {
+    const params: Parameters<typeof cf.createRequestOriginGroup>[0] = {
+        originIds: ["origin-1", "origin-2"],
+        failoverCriteria: {
+            statusCodes: [500, 502, 503, 504],
+        },
+    };
+    cf.createRequestOriginGroup(params);
+}

--- a/types/aws-cloudfront-function/aws-cloudfront-function-tests.ts
+++ b/types/aws-cloudfront-function/aws-cloudfront-function-tests.ts
@@ -111,3 +111,18 @@ function handler2(event: AWSCloudFrontFunction.Event): AWSCloudFrontFunction.Req
 
     return response(locale, request.uri);
 }
+
+import cf from "cloudfront";
+
+const kvsHandle = cf.kvs("example-kvs-id");
+
+(async () => {
+    const value1 = await kvsHandle.get("key");
+    const value2 = await kvsHandle.get("key", { format: "string" });
+    const value3 = await kvsHandle.get("key", { format: "bytes" });
+    const value4 = await kvsHandle.get("key", { format: "json" }); 
+
+    const exists = await kvsHandle.exists("key");
+
+    const meta = await kvsHandle.meta();
+})();

--- a/types/aws-cloudfront-function/aws-cloudfront-function-tests.ts
+++ b/types/aws-cloudfront-function/aws-cloudfront-function-tests.ts
@@ -116,7 +116,9 @@ import cf from "cloudfront";
 
 const kvsHandle = cf.kvs("example-kvs-id");
 
-async function handler3(event: AWSCloudFrontFunction.Event): Promise<AWSCloudFrontFunction.Request | AWSCloudFrontFunction.Response> {
+async function handler3(
+    event: AWSCloudFrontFunction.Event,
+): Promise<AWSCloudFrontFunction.Request | AWSCloudFrontFunction.Response> {
     const _value1 = await kvsHandle.get("key");
     const _value2 = await kvsHandle.get("key", { format: "string" });
     const _value3 = await kvsHandle.get("key", { format: "bytes" });

--- a/types/aws-cloudfront-function/index.d.ts
+++ b/types/aws-cloudfront-function/index.d.ts
@@ -71,7 +71,7 @@ declare module "cloudfront" {
         get(key: string): Promise<string>;
         get(key: string, options: { format: "string" }): Promise<string>;
         get(key: string, options: { format: "bytes" }): Promise<Uint8Array>;
-        get(options: { format: "json" }): Promise<unknown>;
+        get(key: string, options: { format: "json" }): Promise<unknown>;
 
         /**
          * Check if the key exists in the store.

--- a/types/aws-cloudfront-function/index.d.ts
+++ b/types/aws-cloudfront-function/index.d.ts
@@ -53,3 +53,178 @@ declare namespace AWSCloudFrontFunction {
         };
     }
 }
+
+declare module "cloudfront" {
+    /**
+     * Retrieves a reference to a CloudFront Key-Value Store (KVS) by its ID.
+     * @param kvsId The identifier of the KVS to use.
+     * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-custom-methods.html
+     */
+    function kvs(kvsId: string): KVStore;
+
+    interface KVStore {
+        /**
+         * Retrieve a value from the store.
+         * @param key Key to retrieve.
+         * @throws If key does not exist.
+         */
+        get(key: string): Promise<string>;
+        get(key: string, options: { format: "string" }): Promise<string>;
+        get(key: string, options: { format: "bytes" }): Promise<Uint8Array>;
+        get(options: { format: "json" }): Promise<unknown>;
+
+        /**
+         * Check if the key exists in the store.
+         * @param key Key to check.
+         */
+        exists(key: string): Promise<boolean>;
+
+        /**
+         * Retrieve metadata about the key-value store.
+         */
+        meta(): Promise<{
+            creationDateTime: string;
+            lastUpdatedDateTime: string;
+            keyCount: number;
+        }>;
+    }
+
+    interface OriginAccessControlConfig {
+        enabled: boolean;
+        signingBehavior: "always" | "never" | "no-override";
+        signingProtocol: "sigv4";
+        originType: "s3" | "mediapackagev2" | "mediastore" | "lambda";
+    }
+
+    interface OriginShield {
+        enabled: boolean;
+        region: string;
+    }
+
+    interface Timeouts {
+        /**
+         * Max time (seconds) to wait for a response or next packet. (1–60)
+         */
+        readTimeout?: number;
+
+        /**
+         * Max time (seconds) to keep the connection alive after response. (1–60)
+         */
+        keepAliveTimeout?: number;
+
+        /**
+         * Max time (seconds) to wait for connection establishment. (1–10)
+         */
+        connectionTimeout?: number;
+    }
+
+    interface CustomOriginConfig {
+        /**
+         * Port number of the origin. e.g., 80 or 443
+         */
+        port: number;
+
+        /**
+         * Protocol used to connect. Must be "http" or "https"
+         */
+        protocol: "http" | "https";
+
+        /**
+         * Minimum TLS/SSL version to use for HTTPS connections.
+         */
+        sslProtocols: Array<"SSLv3" | "TLSv1" | "TLSv1.1" | "TLSv1.2">;
+    }
+
+    interface UpdateRequestOriginParams {
+        /**
+         * New origin's domain name. Optional if reusing existing origin's domain.
+         */
+        domainName?: string;
+
+        /**
+         * Path prefix to append when forwarding request to origin.
+         */
+        originPath?: string;
+
+        /**
+         * Override or clear custom headers for the origin request.
+         */
+        customHeaders?: Record<string, string>;
+
+        /**
+         * Number of connection attempts (1–3).
+         */
+        connectionAttempts?: number;
+
+        /**
+         * Origin Shield configuration. Enables shield layer if specified.
+         */
+        originShield?: OriginShield;
+
+        /**
+         * Origin Access Control (OAC) configuration.
+         */
+        originAccessControlConfig?: OriginAccessControlConfig;
+
+        /**
+         * Response and connection timeout configurations.
+         */
+        timeouts?: Timeouts;
+
+        /**
+         * Settings for non-S3 origins or S3 with static website hosting.
+         */
+        customOriginConfig?: CustomOriginConfig;
+    }
+
+    /**
+     * Mutates the current request’s origin.
+     * You can specify a new origin (e.g., S3 or ALB), change custom headers, enable OAC, or enable Origin Shield.
+     * Missing fields will inherit values from the assigned origin.
+     * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/helper-functions-origin-modification.html#update-request-origin-helper-function
+     */
+    function updateRequestOrigin(params: UpdateRequestOriginParams): void;
+
+    /**
+     * Switches to another origin already defined in the distribution by origin ID.
+     * This is more efficient than defining a new one via `updateRequestOrigin()`.
+     * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/helper-functions-origin-modification.html#select-request-origin-id-helper-function
+     */
+    function selectRequestOriginById(originId: string): void;
+
+    interface CreateRequestOriginGroupParams {
+        /**
+         * Two origin IDs to form an origin group.
+         * The first is primary; the second is used for failover.
+         */
+        originIds: [string, string];
+
+        /**
+         * Failover selection strategy: default or media-quality-score.
+         */
+        selectionCriteria?: "default" | "media-quality-score";
+
+        /**
+         * List of status codes that trigger failover to the secondary origin.
+         */
+        failoverCriteria: {
+            statusCodes: number[];
+        };
+    }
+
+    /**
+     * Creates a new origin group for failover logic.
+     * The origin group can be referenced later via origin ID.
+     * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/helper-functions-origin-modification.html#create-request-origin-group-helper-function
+     */
+    function createRequestOriginGroup(params: CreateRequestOriginGroupParams): void;
+
+    const cf: {
+        kvs: typeof kvs;
+        updateRequestOrigin: typeof updateRequestOrigin;
+        selectRequestOriginById: typeof selectRequestOriginById;
+        createRequestOriginGroup: typeof createRequestOriginGroup;
+    };
+
+    export default cf;
+}

--- a/types/aws-cloudfront-function/package.json
+++ b/types/aws-cloudfront-function/package.json
@@ -5,7 +5,9 @@
     "nonNpm": true,
     "nonNpmDescription": "AWS CloudFront Functions",
     "projects": [
-        "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-event-structure.html"
+        "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-event-structure.html",
+        "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-custom-methods.html",
+        "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/helper-functions-origin-modification.html"
     ],
     "devDependencies": {
         "@types/aws-cloudfront-function": "workspace:."


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
- [Helper methods for key value stores](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-custom-methods.html)
- [Helper methods for origin modification](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/helper-functions-origin-modification.html)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

**Change Summary:**

* Updated the **CloudFront Functions** type definitions to include the following helper methods:

  * **`kvs`** method: Access CloudFront Key-Value Store (KVS).
  * **`updateRequestOrigin`**: Update the origin settings for a request.
  * **`selectRequestOriginById`**: Select an origin using an origin ID already defined in the distribution.
  * **`createRequestOriginGroup`**: Create an origin group for failover logic with multiple origins.

**Relevant Links:**

* [CloudFront Functions Custom Methods](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-custom-methods.html)
* [Helper Functions for Origin Modification](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/helper-functions-origin-modification.html)

### Reason for Disabling `@definitelytyped/no-single-declare-module` Rule

The ESLint rule `@definitelytyped/no-single-declare-module` was disabled due to a conflict between the module name defined in the type declaration and the actual AWS module name. Specifically:

* The type definition module is named `aws-cloudfront-function` in the DefinitelyTyped repository.
* However, the AWS-provided module is named `cloudfront`.

When trying to align the names, ESLint throws the following error:

```
Error:
/home/shirayuki/repos/DefinitelyTyped/types/aws-cloudfront-function/index.d.ts
  57:16  error  File has only 1 ambient module declaration. Move the contents outside the ambient module block, rename the file to match the ambient module name, and remove the block  @definitelytyped/no-single-declare-module
```

To prevent this error, I disabled the rule for this case, as the type definition must match the actual AWS module name (`cloudfront`) rather than `aws-cloudfront-function`.
