### PR TITLE
[chrome] add certificateProvider namespace

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -1464,6 +1464,246 @@ declare namespace chrome {
     }
 
     ////////////////////
+    // Certificate Provider
+    ////////////////////
+    /**
+     * Use this API to expose certificates to the platform which can use these certificates for TLS authentications.
+     *
+     * Manifest: "certificateProvider"
+     * @platform ChromeOS only
+     * @since Chrome 46
+     */
+    export namespace certificateProvider {
+        /** Types of supported cryptographic signature algorithms. */
+        export enum Algorithm {
+            /**
+             * Specifies the RSASSA PKCS#1 v1.5 signature algorithm with the MD5-SHA-1 hashing. The extension must not prepend a DigestInfo prefix but only add PKCS#1 padding.
+             * @deprecated This algorithm is deprecated and will never be requested by Chrome as of version 109.
+             */
+            RSASSA_PKCS1_V1_5_MD5_SHA1 = "RSASSA_PKCS1_v1_5_MD5_SHA1",
+            /** Specifies the RSASSA PKCS#1 v1.5 signature algorithm with the SHA-1 hash function. */
+            RSASSA_PKCS1_V1_5_SHA1 = "RSASSA_PKCS1_v1_5_SHA1",
+            /** Specifies the RSASSA PKCS#1 v1.5 signature algorithm with the SHA-256 hashing function. */
+            RSASSA_PKCS1_V1_5_SHA256 = "RSASSA_PKCS1_v1_5_SHA256",
+            /** Specifies the RSASSA PKCS#1 v1.5 signature algorithm with the SHA-384 hashing function. */
+            RSASSA_PKCS1_V1_5_SHA384 = "RSASSA_PKCS1_v1_5_SHA384",
+            /** Specifies the RSASSA PKCS#1 v1.5 signature algorithm with the SHA-512 hashing function. */
+            RSASSA_PKCS1_V1_5_SHA512 = "RSASSA_PKCS1_v1_5_SHA512",
+            /** Specifies the RSASSA PSS signature algorithm with the SHA-256 hashing function, MGF1 mask generation function and the salt of the same size as the hash. */
+            RSASSA_PSS_SHA256 = "RSASSA_PSS_SHA256",
+            /** Specifies the RSASSA PSS signature algorithm with the SHA-384 hashing function, MGF1 mask generation function and the salt of the same size as the hash. */
+            RSASSA_PSS_SHA384 = "RSASSA_PSS_SHA384",
+            /** Specifies the RSASSA PSS signature algorithm with the SHA-512 hashing function, MGF1 mask generation function and the salt of the same size as the hash. */
+            RSASSA_PSS_SHA512 = "RSASSA_PSS_SHA512",
+        }
+
+        export interface CertificateInfo {
+            /** Must be the DER encoding of a X.509 certificate. Currently, only certificates of RSA keys are supported. */
+            certificate: ArrayBuffer;
+            /** Must be set to all hashes supported for this certificate. This extension will only be asked for signatures of digests calculated with one of these hash algorithms. This should be in order of decreasing hash preference. */
+            supportedHashes: `${Hash}`[];
+        }
+
+        /** @since Chrome 86 */
+        export interface CertificatesUpdateRequest {
+            /** Request identifier to be passed to {@link setCertificates}. */
+            certificatesRequestId: number;
+        }
+
+        /** @since Chrome 86 */
+        export interface ClientCertificateInfo {
+            /**
+             * The array must contain the DER encoding of the X.509 client certificate as its first element.
+             *
+             * This must include exactly one certificate.
+             */
+            certificateChain: ArrayBuffer[];
+            /** All algorithms supported for this certificate. The extension will only be asked for signatures using one of these algorithms. */
+            supportedAlgorithms: `${Algorithm}`[];
+        }
+
+        /**
+         * Types of errors that the extension can report.
+         * @since Chrome 86
+         */
+        export enum Error {
+            GENERAL_ERROR = "GENERAL_ERROR",
+        }
+
+        /** @deprecated Replaced by {@link Algorithm}.*/
+        export enum Hash {
+            /** Specifies the MD5 and SHA1 hashing algorithms. */
+            MD5_SHA1 = "MD5_SHA1",
+            /** Specifies the SHA1 hashing algorithm. */
+            SHA1 = "SHA1",
+            /** Specifies the SHA256 hashing algorithm. */
+            SHA256 = "SHA256",
+            /** Specifies the SHA384 hashing algorithm. */
+            SHA384 = "SHA384",
+            /** Specifies the SHA512 hashing algorithm. */
+            SHA512 = "SHA512",
+        }
+
+        /**
+         * The types of errors that can be presented to the user through the requestPin function.
+         * @since Chrome 57
+         */
+        export enum PinRequestErrorType {
+            /** Specifies the PIN is invalid. */
+            INVALID_PIN = "INVALID_PIN",
+            /** Specifies the PUK is invalid. */
+            INVALID_PUK = "INVALID_PUK",
+            /** Specifies the maximum attempt number has been exceeded. */
+            MAX_ATTEMPTS_EXCEEDED = "MAX_ATTEMPTS_EXCEEDED",
+            /** Specifies that the error cannot be represented by the above types. */
+            UNKNOWN_ERROR = "UNKNOWN_ERROR",
+        }
+
+        /**
+         * The type of code being requested by the extension with requestPin function.
+         * @since Chrome 57
+         */
+        export enum PinRequestType {
+            /** Specifies the requested code is a PIN. */
+            PIN = "PIN",
+            /** Specifies the requested code is a PUK. */
+            PUK = "PUK",
+        }
+
+        /** @since Chrome 57 */
+        export interface PinResponseDetails {
+            /** The code provided by the user. Empty if user closed the dialog or some other error occurred. */
+            userInput?: string | undefined;
+        }
+
+        /** @since Chrome 86 */
+        export interface ReportSignatureDetails {
+            /** Error that occurred while generating the signature, if any. */
+            error?: `${Error}` | undefined;
+            /** Request identifier that was received via the {@link onSignatureRequested} event. */
+            signRequestId: number;
+            /** The signature, if successfully generated. */
+            signature?: ArrayBuffer | undefined;
+        }
+
+        /** @since Chrome 57 */
+        export interface RequestPinDetails {
+            /** The number of attempts left. This is provided so that any UI can present this information to the user. Chrome is not expected to enforce this, instead stopPinRequest should be called by the extension with errorType = MAX_ATTEMPTS_EXCEEDED when the number of pin requests is exceeded. */
+            attemptsLeft?: number | undefined;
+            /** The error template displayed to the user. This should be set if the previous request failed, to notify the user of the failure reason. */
+            errorType?: `${PinRequestErrorType}` | undefined;
+            /** The type of code requested. Default is PIN. */
+            requestType?: `${PinRequestType}` | undefined;
+            /** The ID given by Chrome in SignRequest. */
+            signRequestId: number;
+        }
+
+        /** @since Chrome 86 */
+        export interface SetCertificatesDetails {
+            /** When called in response to {@link onCertificatesUpdateRequested}, should contain the received `certificatesRequestId` value. Otherwise, should be unset. */
+            certificatesRequestId?: number | undefined;
+            /** List of currently available client certificates. */
+            clientCertificates: ClientCertificateInfo[];
+            /** Error that occurred while extracting the certificates, if any. This error will be surfaced to the user when appropriate. */
+            error?: `${Error}` | undefined;
+        }
+
+        /**  @since Chrome 86 */
+        export interface SignatureRequest {
+            /** Signature algorithm to be used. */
+            algorithm: `${Algorithm}`;
+            /** The DER encoding of a X.509 certificate. The extension must sign `input` using the associated private key. */
+            certificate: ArrayBuffer;
+            /** Data to be signed. Note that the data is not hashed. */
+            input: ArrayBuffer;
+            /** Request identifier to be passed to {@link reportSignature}. */
+            signRequestId: number;
+        }
+
+        export interface SignRequest {
+            /** The DER encoding of a X.509 certificate. The extension must sign `digest` using the associated private key. */
+            certificate: ArrayBuffer;
+            /**  The digest that must be signed. */
+            digest: ArrayBuffer;
+            /** Refers to the hash algorithm that was used to create `digest`. */
+            hash: `${Hash}`;
+            /**
+             * The unique ID to be used by the extension should it need to call a method that requires it, e.g. requestPin.
+             * @since Chrome 57
+             */
+            signRequestId: number;
+        }
+
+        /** @since Chrome 57 */
+        export interface StopPinRequestDetails {
+            /** The error template. If present it is displayed to user. Intended to contain the reason for stopping the flow if it was caused by an error, e.g. MAX\_ATTEMPTS\_EXCEEDED. */
+            errorType?: `${PinRequestErrorType}` | undefined;
+            /** The ID given by Chrome in SignRequest. */
+            signRequestId: number;
+        }
+
+        /**
+         * Should be called as a response to {@link onSignatureRequested}.
+         *
+         * The extension must eventually call this function for every {@link onSignatureRequested} event; the API implementation will stop waiting for this call after some time and respond with a timeout error when this function is called.
+         *
+         * Can return its result via Promise since Chrome 96.
+         * @since Chrome 86
+         */
+        export function reportSignature(details: ReportSignatureDetails): Promise<void>;
+        export function reportSignature(details: ReportSignatureDetails, callback: () => void): void;
+
+        /**
+         * Requests the PIN from the user. Only one ongoing request at a time is allowed. The requests issued while another flow is ongoing are rejected. It's the extension's responsibility to try again later if another flow is in progress.
+         *
+         * Can return its result via Promise since Chrome 96.
+         * @param details Contains the details about the requested dialog.
+         * @since Chrome 57
+         */
+        export function requestPin(details: RequestPinDetails): Promise<PinResponseDetails | undefined>;
+        export function requestPin(
+            details: RequestPinDetails,
+            callback: (details?: PinResponseDetails | undefined) => void,
+        ): void;
+
+        /**
+         * Sets a list of certificates to use in the browser.
+         *
+         * The extension should call this function after initialization and on every change in the set of currently available certificates. The extension should also call this function in response to {@link onCertificatesUpdateRequested} every time this event is received.
+         *
+         * Can return its result via Promise since Chrome 96.
+         * @param details The certificates to set. Invalid certificates will be ignored.
+         * @since Chrome 86
+         */
+        export function setCertificates(details: SetCertificatesDetails): Promise<void>;
+        export function setCertificates(details: SetCertificatesDetails, callback: () => void): void;
+
+        /**
+         * Stops the pin request started by the {@link requestPin} function.
+         *
+         * Can return its result via Promise since Chrome 96.
+         * @param details Contains the details about the reason for stopping the request flow.
+         * @since Chrome 57
+         */
+        export function stopPinRequest(details: StopPinRequestDetails): Promise<void>;
+        export function stopPinRequest(details: StopPinRequestDetails, callback: () => void): void;
+
+        /**
+         * This event fires if the certificates set via {@link setCertificates} are insufficient or the browser requests updated information. The extension must call {@link setCertificates} with the updated list of certificates and the received `certificatesRequestId`.
+         * @since Chrome 86
+         */
+        export const onCertificatesUpdateRequested: events.Event<(request: CertificatesUpdateRequest) => void>;
+
+        /**
+         * This event fires every time the browser needs to sign a message using a certificate provided by this extension via {@link setCertificates}.
+         *
+         * The extension must sign the input data from `request` using the appropriate algorithm and private key and return it by calling {@link reportSignature} with the received `signRequestId`.
+         * @since Chrome 86
+         */
+        export const onSignatureRequested: events.Event<(request: SignatureRequest) => void>;
+    }
+
+    ////////////////////
     // Commands
     ////////////////////
     /**

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -3519,6 +3519,112 @@ async function testBrowsingDataForPromise() {
     await chrome.browsingData.removeIndexedDB({});
 }
 
+// https://developer.chrome.com/docs/extensions/reference/api/certificateProvider
+function testCertificateProvider() {
+    chrome.certificateProvider.Algorithm.RSASSA_PKCS1_V1_5_MD5_SHA1 === "RSASSA_PKCS1_v1_5_MD5_SHA1";
+    chrome.certificateProvider.Algorithm.RSASSA_PKCS1_V1_5_SHA1 === "RSASSA_PKCS1_v1_5_SHA1";
+    chrome.certificateProvider.Algorithm.RSASSA_PKCS1_V1_5_SHA256 === "RSASSA_PKCS1_v1_5_SHA256";
+    chrome.certificateProvider.Algorithm.RSASSA_PKCS1_V1_5_SHA384 === "RSASSA_PKCS1_v1_5_SHA384";
+    chrome.certificateProvider.Algorithm.RSASSA_PKCS1_V1_5_SHA512 === "RSASSA_PKCS1_v1_5_SHA512";
+    chrome.certificateProvider.Algorithm.RSASSA_PSS_SHA256 === "RSASSA_PSS_SHA256";
+    chrome.certificateProvider.Algorithm.RSASSA_PSS_SHA384 === "RSASSA_PSS_SHA384";
+    chrome.certificateProvider.Algorithm.RSASSA_PSS_SHA512 === "RSASSA_PSS_SHA512";
+
+    chrome.certificateProvider.Error.GENERAL_ERROR === "GENERAL_ERROR";
+
+    chrome.certificateProvider.Hash.MD5_SHA1 === "MD5_SHA1";
+    chrome.certificateProvider.Hash.SHA1 === "SHA1";
+    chrome.certificateProvider.Hash.SHA256 === "SHA256";
+    chrome.certificateProvider.Hash.SHA384 === "SHA384";
+    chrome.certificateProvider.Hash.SHA512 === "SHA512";
+
+    chrome.certificateProvider.PinRequestErrorType.INVALID_PIN === "INVALID_PIN";
+    chrome.certificateProvider.PinRequestErrorType.INVALID_PUK === "INVALID_PUK";
+    chrome.certificateProvider.PinRequestErrorType.MAX_ATTEMPTS_EXCEEDED === "MAX_ATTEMPTS_EXCEEDED";
+    chrome.certificateProvider.PinRequestErrorType.UNKNOWN_ERROR === "UNKNOWN_ERROR";
+
+    chrome.certificateProvider.PinRequestType.PIN === "PIN";
+    chrome.certificateProvider.PinRequestType.PUK === "PUK";
+
+    const reportSignatureDetails: chrome.certificateProvider.ReportSignatureDetails = {
+        error: "GENERAL_ERROR",
+        signRequestId: 1,
+    };
+
+    chrome.certificateProvider.reportSignature(reportSignatureDetails); // $ExpectType Promise<void>
+    chrome.certificateProvider.reportSignature(reportSignatureDetails, () => {}); // $ExpectType void
+    // @ts-expect-error
+    chrome.certificateProvider.reportSignature(reportSignatureDetails, () => {}).then(() => {});
+
+    const requestPinDetails: chrome.certificateProvider.RequestPinDetails = {
+        attemptsLeft: 0,
+        errorType: "INVALID_PIN",
+        requestType: "PIN",
+        signRequestId: 0,
+    };
+
+    chrome.certificateProvider.requestPin(requestPinDetails); // $ExpectType Promise<PinResponseDetails | undefined>
+    chrome.certificateProvider.requestPin(requestPinDetails, (details) => { // $ExpectType void
+        details; // $ExpectType PinResponseDetails | undefined
+        if (!details) return;
+        details.userInput; // $ExpectType string | undefined
+    });
+    // @ts-expect-error
+    chrome.certificateProvider.requestPin(requestPinDetails, () => {}).then(() => {});
+
+    const setCertificatesDetails: chrome.certificateProvider.SetCertificatesDetails = {
+        certificatesRequestId: 0,
+        clientCertificates: [{ certificateChain: [], supportedAlgorithms: [] }],
+        error: "GENERAL_ERROR",
+    };
+
+    chrome.certificateProvider.setCertificates(setCertificatesDetails); // $ExpectType Promise<void>
+    chrome.certificateProvider.setCertificates(setCertificatesDetails, () => {}); // $ExpectType void
+    // @ts-expect-error
+    chrome.certificateProvider.setCertificates(setCertificatesDetails, () => {}).then(() => {});
+
+    const stopPinRequestDetails: chrome.certificateProvider.StopPinRequestDetails = {
+        signRequestId: 0,
+        errorType: "INVALID_PIN",
+    };
+
+    chrome.certificateProvider.stopPinRequest(stopPinRequestDetails); // $ExpectType Promise<void>
+    chrome.certificateProvider.stopPinRequest(stopPinRequestDetails, () => {}); // $ExpectType void
+    // @ts-expect-error
+    chrome.certificateProvider.stopPinRequest(stopPinRequestDetails, () => {}).then(() => {});
+
+    chrome.certificateProvider.onCertificatesUpdateRequested.addListener((request) => { // $ExpectType void
+        request.certificatesRequestId; // $ExpectType number
+    });
+    chrome.certificateProvider.onCertificatesUpdateRequested.removeListener((request) => { // $ExpectType void
+        request.certificatesRequestId; // $ExpectType number
+    });
+    chrome.certificateProvider.onCertificatesUpdateRequested.hasListener((request) => { // $ExpectType boolean
+        request.certificatesRequestId; // $ExpectType number
+    });
+    chrome.certificateProvider.onCertificatesUpdateRequested.hasListeners(); // $ExpectType boolean
+
+    chrome.certificateProvider.onSignatureRequested.addListener((request) => { // $ExpectType void
+        request.algorithm; // $ExpectType "RSASSA_PKCS1_v1_5_MD5_SHA1" | "RSASSA_PKCS1_v1_5_SHA1" | "RSASSA_PKCS1_v1_5_SHA256" | "RSASSA_PKCS1_v1_5_SHA384" | "RSASSA_PKCS1_v1_5_SHA512" | "RSASSA_PSS_SHA256" | "RSASSA_PSS_SHA384" | "RSASSA_PSS_SHA512";
+        request.certificate; // $ExpectType ArrayBuffer
+        request.input; // $ExpectType ArrayBuffer
+        request.signRequestId; // $ExpectType number
+    });
+    chrome.certificateProvider.onSignatureRequested.removeListener((request) => { // $ExpectType void
+        request.algorithm; // $ExpectType "RSASSA_PKCS1_v1_5_MD5_SHA1" | "RSASSA_PKCS1_v1_5_SHA1" | "RSASSA_PKCS1_v1_5_SHA256" | "RSASSA_PKCS1_v1_5_SHA384" | "RSASSA_PKCS1_v1_5_SHA512" | "RSASSA_PSS_SHA256" | "RSASSA_PSS_SHA384" | "RSASSA_PSS_SHA512";
+        request.certificate; // $ExpectType ArrayBuffer
+        request.input; // $ExpectType ArrayBuffer
+        request.signRequestId; // $ExpectType number
+    });
+    chrome.certificateProvider.onSignatureRequested.hasListener((request) => { // $ExpectType boolean
+        request.algorithm; // $ExpectType "RSASSA_PKCS1_v1_5_MD5_SHA1" | "RSASSA_PKCS1_v1_5_SHA1" | "RSASSA_PKCS1_v1_5_SHA256" | "RSASSA_PKCS1_v1_5_SHA384" | "RSASSA_PKCS1_v1_5_SHA512" | "RSASSA_PSS_SHA256" | "RSASSA_PSS_SHA384" | "RSASSA_PSS_SHA512";
+        request.certificate; // $ExpectType ArrayBuffer
+        request.input; // $ExpectType ArrayBuffer
+        request.signRequestId; // $ExpectType number
+    });
+    chrome.certificateProvider.onSignatureRequested.hasListeners(); // $ExpectType boolean
+}
+
 // https://developer.chrome.com/docs/extensions/reference/commands
 async function testCommands() {
     await chrome.commands.getAll();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/certificateProvider
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Note : 
- I couldn't fully test all functions/events on my chromebox.

A screenshot of runtime :
![certificatProvider](https://github.com/user-attachments/assets/79439c90-c7ed-4948-aefc-41025c5bf05a)

