### PR TITLE
fix(node/child_process): refine exec() and execFile() signature

### DIFF
--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -66,7 +66,6 @@
  * @see [source](https://github.com/nodejs/node/blob/v24.x/lib/child_process.js)
  */
 declare module "child_process" {
-    import { ObjectEncodingOptions } from "node:fs";
     import { Abortable, EventEmitter } from "node:events";
     import * as dgram from "node:dgram";
     import * as net from "node:net";
@@ -887,12 +886,13 @@ declare module "child_process" {
         signal?: AbortSignal | undefined;
         maxBuffer?: number | undefined;
         killSignal?: NodeJS.Signals | number | undefined;
+        encoding?: string | null | undefined;
     }
     interface ExecOptionsWithStringEncoding extends ExecOptions {
-        encoding: BufferEncoding;
+        encoding?: BufferEncoding | undefined;
     }
     interface ExecOptionsWithBufferEncoding extends ExecOptions {
-        encoding: BufferEncoding | null; // specify `null`.
+        encoding: "buffer" | null; // specify `null`.
     }
     interface ExecException extends Error {
         cmd?: string | undefined;
@@ -995,38 +995,19 @@ declare module "child_process" {
     // `options` with `"buffer"` or `null` for `encoding` means stdout/stderr are definitely `Buffer`.
     function exec(
         command: string,
-        options: {
-            encoding: "buffer" | null;
-        } & ExecOptions,
+        options: ExecOptionsWithBufferEncoding,
         callback?: (error: ExecException | null, stdout: Buffer, stderr: Buffer) => void,
     ): ChildProcess;
-    // `options` with well known `encoding` means stdout/stderr are definitely `string`.
+    // `options` with well-known or absent `encoding` means stdout/stderr are definitely `string`.
     function exec(
         command: string,
-        options: {
-            encoding: BufferEncoding;
-        } & ExecOptions,
-        callback?: (error: ExecException | null, stdout: string, stderr: string) => void,
-    ): ChildProcess;
-    // `options` with an `encoding` whose type is `string` means stdout/stderr could either be `Buffer` or `string`.
-    // There is no guarantee the `encoding` is unknown as `string` is a superset of `BufferEncoding`.
-    function exec(
-        command: string,
-        options: {
-            encoding: BufferEncoding;
-        } & ExecOptions,
-        callback?: (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
-    ): ChildProcess;
-    // `options` without an `encoding` means stdout/stderr are definitely `string`.
-    function exec(
-        command: string,
-        options: ExecOptions,
+        options: ExecOptionsWithStringEncoding,
         callback?: (error: ExecException | null, stdout: string, stderr: string) => void,
     ): ChildProcess;
     // fallback if nothing else matches. Worst case is always `string | Buffer`.
     function exec(
         command: string,
-        options: (ObjectEncodingOptions & ExecOptions) | undefined | null,
+        options: ExecOptions | undefined | null,
         callback?: (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
     ): ChildProcess;
     interface PromiseWithChild<T> extends Promise<T> {
@@ -1039,32 +1020,21 @@ declare module "child_process" {
         }>;
         function __promisify__(
             command: string,
-            options: {
-                encoding: "buffer" | null;
-            } & ExecOptions,
+            options: ExecOptionsWithBufferEncoding,
         ): PromiseWithChild<{
             stdout: Buffer;
             stderr: Buffer;
         }>;
         function __promisify__(
             command: string,
-            options: {
-                encoding: BufferEncoding;
-            } & ExecOptions,
+            options: ExecOptionsWithStringEncoding,
         ): PromiseWithChild<{
             stdout: string;
             stderr: string;
         }>;
         function __promisify__(
             command: string,
-            options: ExecOptions,
-        ): PromiseWithChild<{
-            stdout: string;
-            stderr: string;
-        }>;
-        function __promisify__(
-            command: string,
-            options?: (ObjectEncodingOptions & ExecOptions) | null,
+            options: ExecOptions | undefined | null,
         ): PromiseWithChild<{
             stdout: string | Buffer;
             stderr: string | Buffer;
@@ -1076,16 +1046,16 @@ declare module "child_process" {
         windowsVerbatimArguments?: boolean | undefined;
         shell?: boolean | string | undefined;
         signal?: AbortSignal | undefined;
+        encoding?: string | null | undefined;
     }
     interface ExecFileOptionsWithStringEncoding extends ExecFileOptions {
-        encoding: BufferEncoding;
+        encoding?: BufferEncoding | undefined;
     }
     interface ExecFileOptionsWithBufferEncoding extends ExecFileOptions {
         encoding: "buffer" | null;
     }
-    interface ExecFileOptionsWithOtherEncoding extends ExecFileOptions {
-        encoding: BufferEncoding;
-    }
+    /** @deprecated Use `ExecFileOptions` instead. */
+    interface ExecFileOptionsWithOtherEncoding extends ExecFileOptions {}
     type ExecFileException =
         & Omit<ExecException, "code">
         & Omit<NodeJS.ErrnoException, "code">
@@ -1154,80 +1124,44 @@ declare module "child_process" {
      * @param args List of string arguments.
      * @param callback Called with the output when process terminates.
      */
-    function execFile(file: string): ChildProcess;
-    function execFile(
-        file: string,
-        options: (ObjectEncodingOptions & ExecFileOptions) | undefined | null,
-    ): ChildProcess;
-    function execFile(file: string, args?: readonly string[] | null): ChildProcess;
-    function execFile(
-        file: string,
-        args: readonly string[] | undefined | null,
-        options: (ObjectEncodingOptions & ExecFileOptions) | undefined | null,
-    ): ChildProcess;
     // no `options` definitely means stdout/stderr are `string`.
     function execFile(
         file: string,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+        callback?: (error: ExecFileException | null, stdout: string, stderr: string) => void,
     ): ChildProcess;
     function execFile(
         file: string,
         args: readonly string[] | undefined | null,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+        callback?: (error: ExecFileException | null, stdout: string, stderr: string) => void,
     ): ChildProcess;
     // `options` with `"buffer"` or `null` for `encoding` means stdout/stderr are definitely `Buffer`.
     function execFile(
         file: string,
         options: ExecFileOptionsWithBufferEncoding,
-        callback: (error: ExecFileException | null, stdout: Buffer, stderr: Buffer) => void,
+        callback?: (error: ExecFileException | null, stdout: Buffer, stderr: Buffer) => void,
     ): ChildProcess;
     function execFile(
         file: string,
         args: readonly string[] | undefined | null,
         options: ExecFileOptionsWithBufferEncoding,
-        callback: (error: ExecFileException | null, stdout: Buffer, stderr: Buffer) => void,
+        callback?: (error: ExecFileException | null, stdout: Buffer, stderr: Buffer) => void,
     ): ChildProcess;
-    // `options` with well known `encoding` means stdout/stderr are definitely `string`.
+    // `options` with well-known or absent `encoding` means stdout/stderr are definitely `string`.
     function execFile(
         file: string,
         options: ExecFileOptionsWithStringEncoding,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+        callback?: (error: ExecFileException | null, stdout: string, stderr: string) => void,
     ): ChildProcess;
     function execFile(
         file: string,
         args: readonly string[] | undefined | null,
         options: ExecFileOptionsWithStringEncoding,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
-    ): ChildProcess;
-    // `options` with an `encoding` whose type is `string` means stdout/stderr could either be `Buffer` or `string`.
-    // There is no guarantee the `encoding` is unknown as `string` is a superset of `BufferEncoding`.
-    function execFile(
-        file: string,
-        options: ExecFileOptionsWithOtherEncoding,
-        callback: (error: ExecFileException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
-    ): ChildProcess;
-    function execFile(
-        file: string,
-        args: readonly string[] | undefined | null,
-        options: ExecFileOptionsWithOtherEncoding,
-        callback: (error: ExecFileException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
-    ): ChildProcess;
-    // `options` without an `encoding` means stdout/stderr are definitely `string`.
-    function execFile(
-        file: string,
-        options: ExecFileOptions,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
-    ): ChildProcess;
-    function execFile(
-        file: string,
-        args: readonly string[] | undefined | null,
-        options: ExecFileOptions,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+        callback?: (error: ExecFileException | null, stdout: string, stderr: string) => void,
     ): ChildProcess;
     // fallback if nothing else matches. Worst case is always `string | Buffer`.
     function execFile(
         file: string,
-        options: (ObjectEncodingOptions & ExecFileOptions) | undefined | null,
+        options: ExecFileOptions | undefined | null,
         callback:
             | ((error: ExecFileException | null, stdout: string | Buffer, stderr: string | Buffer) => void)
             | undefined
@@ -1236,7 +1170,7 @@ declare module "child_process" {
     function execFile(
         file: string,
         args: readonly string[] | undefined | null,
-        options: (ObjectEncodingOptions & ExecFileOptions) | undefined | null,
+        options: ExecFileOptions | undefined | null,
         callback:
             | ((error: ExecFileException | null, stdout: string | Buffer, stderr: string | Buffer) => void)
             | undefined
@@ -1286,7 +1220,7 @@ declare module "child_process" {
         }>;
         function __promisify__(
             file: string,
-            options: ExecFileOptionsWithOtherEncoding,
+            options: ExecFileOptions | undefined | null,
         ): PromiseWithChild<{
             stdout: string | Buffer;
             stderr: string | Buffer;
@@ -1294,37 +1228,7 @@ declare module "child_process" {
         function __promisify__(
             file: string,
             args: readonly string[] | undefined | null,
-            options: ExecFileOptionsWithOtherEncoding,
-        ): PromiseWithChild<{
-            stdout: string | Buffer;
-            stderr: string | Buffer;
-        }>;
-        function __promisify__(
-            file: string,
-            options: ExecFileOptions,
-        ): PromiseWithChild<{
-            stdout: string;
-            stderr: string;
-        }>;
-        function __promisify__(
-            file: string,
-            args: readonly string[] | undefined | null,
-            options: ExecFileOptions,
-        ): PromiseWithChild<{
-            stdout: string;
-            stderr: string;
-        }>;
-        function __promisify__(
-            file: string,
-            options: (ObjectEncodingOptions & ExecFileOptions) | undefined | null,
-        ): PromiseWithChild<{
-            stdout: string | Buffer;
-            stderr: string | Buffer;
-        }>;
-        function __promisify__(
-            file: string,
-            args: readonly string[] | undefined | null,
-            options: (ObjectEncodingOptions & ExecFileOptions) | undefined | null,
+            options: ExecFileOptions | undefined | null,
         ): PromiseWithChild<{
             stdout: string | Buffer;
             stderr: string | Buffer;

--- a/types/node/test/child_process.ts
+++ b/types/node/test/child_process.ts
@@ -37,6 +37,148 @@ import { promisify } from "node:util";
 }
 
 {
+    const cmd = "echo test";
+    const promisifiedExec = promisify(childProcess.exec);
+    const boolFlag = Math.random() < 1;
+
+    // $ExpectType ChildProcess
+    childProcess.exec(cmd);
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExec(cmd);
+
+    // without encoding
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        {},
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExec(cmd, {});
+
+    // with optional options
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        {
+            windowsHide: true,
+            timeout: 0,
+            shell: "bash",
+            signal: new AbortSignal(),
+            maxBuffer: 1024,
+            killSignal: "SIGABRT",
+        },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExec(
+        cmd,
+        {
+            windowsHide: true,
+            timeout: 0,
+            shell: "bash",
+            signal: new AbortSignal(),
+            maxBuffer: 1024,
+            killSignal: "SIGABRT",
+        },
+    );
+
+    // with encoding: 'buffer' | null
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        { encoding: boolFlag ? "buffer" : null },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: Buffer<ArrayBufferLike>; stderr: Buffer<ArrayBufferLike>; }>
+    promisifiedExec(cmd, { encoding: boolFlag ? "buffer" : null });
+
+    // with known encoding
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        { encoding: "utf16le" },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExec(cmd, { encoding: "utf16le" });
+
+    // with unknown encoding
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        { encoding: "unknown" },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }>
+    promisifiedExec(cmd, { encoding: "unknown" });
+
+    // with nullish encoding
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        boolFlag ? { encoding: "unknown" } : null,
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }>
+    promisifiedExec(cmd, boolFlag ? { encoding: "unknown" } : null);
+}
+
+{
     childProcess.execSync("echo test"); // $ExpectType Buffer || Buffer<ArrayBufferLike>
     childProcess.execSync("echo test", {}); // $ExpectType Buffer || Buffer<ArrayBufferLike>
     childProcess.execSync("echo test", { encoding: "buffer" }); // $ExpectType Buffer || Buffer<ArrayBufferLike>
@@ -59,49 +201,275 @@ import { promisify } from "node:util";
 }
 
 {
-    childProcess.execFile("npm", () => {});
-    childProcess.execFile("npm", { windowsHide: true, signal: new AbortSignal() }, () => {});
-    childProcess.execFile("npm", { shell: true }, () => {});
-    childProcess.execFile("npm", { shell: "/bin/sh" }, () => {});
-    childProcess.execFile("npm", ["-v"] as readonly string[], () => {});
+    const cmd = "echo test";
+    const promisifiedExecFile = promisify(childProcess.execFile);
+    const boolFlag = Math.random() < 1;
+    const args = boolFlag ? ["arg"] as const : boolFlag ? null : undefined;
+
+    // $ExpectType ChildProcess
+    childProcess.execFile(cmd);
+    // $ExpectType ChildProcess
     childProcess.execFile(
-        "npm",
-        ["-v"] as readonly string[],
-        { windowsHide: true, encoding: "utf-8" },
-        (stdout, stderr) => {
-            assert(stdout instanceof String);
+        cmd,
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
         },
     );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(cmd);
+
+    // $ExpectType ChildProcess
+    childProcess.execFile(cmd, args);
+    // $ExpectType ChildProcess
     childProcess.execFile(
-        "npm",
-        ["-v"] as readonly string[],
-        { windowsHide: true, encoding: "buffer" },
-        (stdout, stderr) => {
-            assert(stdout instanceof Buffer);
+        cmd,
+        args,
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
         },
     );
-    childProcess.execFile("npm", { encoding: "utf-8" }, (stdout, stderr) => {
-        assert(stdout instanceof String);
-    });
-    childProcess.execFile("npm", { encoding: "buffer" }, (stdout, stderr) => {
-        assert(stdout instanceof Buffer);
-    });
-    childProcess.execFile("npm", (err) => {
-        if (err && err.errno) assert(err.code === "ENOENT");
-    });
-    childProcess.execFile("npm", (err) => {
-        if (err !== null) {
-            if (typeof err.code === "string") {
-                console.log(err.code.charCodeAt(0));
-            } else if (typeof err.code === "number") {
-                console.log(err.code.toExponential());
-            } else if (err.code === null) {
-                // @ts-expect-error -- since err.code is null, this assignment has a type error
-                const x: string = err.code;
-                console.log(x);
-            }
-        }
-    });
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(cmd, args);
+
+    // without encoding
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        {},
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(cmd, {});
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        {},
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(cmd, args, {});
+
+    // with optional options
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        {
+            maxBuffer: 1024,
+            killSignal: "SIGABRT",
+            windowsVerbatimArguments: true,
+            shell: "bash",
+            signal: new AbortSignal(),
+        },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(
+        cmd,
+        {
+            maxBuffer: 1024,
+            killSignal: "SIGABRT",
+            windowsVerbatimArguments: true,
+            shell: "bash",
+            signal: new AbortSignal(),
+        },
+    );
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        {
+            maxBuffer: 1024,
+            killSignal: "SIGABRT",
+            windowsVerbatimArguments: true,
+            shell: "bash",
+            signal: new AbortSignal(),
+        },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(
+        cmd,
+        args,
+        {
+            maxBuffer: 1024,
+            killSignal: "SIGABRT",
+            windowsVerbatimArguments: true,
+            shell: "bash",
+            signal: new AbortSignal(),
+        },
+    );
+
+    // with encoding: 'buffer' | null
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        { encoding: boolFlag ? "buffer" : null },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: Buffer<ArrayBufferLike>; stderr: Buffer<ArrayBufferLike>; }>
+    promisifiedExecFile(cmd, { encoding: boolFlag ? "buffer" : null });
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        { encoding: boolFlag ? "buffer" : null },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: Buffer<ArrayBufferLike>; stderr: Buffer<ArrayBufferLike>; }>
+    promisifiedExecFile(cmd, args, { encoding: boolFlag ? "buffer" : null });
+
+    // with known encoding
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        { encoding: "utf16le" },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(cmd, { encoding: "utf16le" });
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        { encoding: "utf16le" },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(cmd, { encoding: "utf16le" });
+
+    // with unknown encoding
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        { encoding: "unknown" },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }>
+    promisifiedExecFile(cmd, { encoding: "unknown" });
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        { encoding: "unknown" },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }>
+    promisifiedExecFile(cmd, args, { encoding: "unknown" });
+
+    // with nullish encoding
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        boolFlag ? { encoding: "unknown" } : null,
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }>
+    promisifiedExecFile(cmd, boolFlag ? { encoding: "unknown" } : null);
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        boolFlag ? { encoding: "unknown" } : null,
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }>
+    promisifiedExecFile(cmd, args, boolFlag ? { encoding: "unknown" } : null);
 }
 
 {

--- a/types/node/v18/child_process.d.ts
+++ b/types/node/v18/child_process.d.ts
@@ -66,7 +66,6 @@
  * @see [source](https://github.com/nodejs/node/blob/v18.0.0/lib/child_process.js)
  */
 declare module "child_process" {
-    import { ObjectEncodingOptions } from "node:fs";
     import { Abortable, EventEmitter } from "node:events";
     import * as net from "node:net";
     import { Pipe, Readable, Stream, Writable } from "node:stream";
@@ -889,12 +888,13 @@ declare module "child_process" {
         signal?: AbortSignal | undefined;
         maxBuffer?: number | undefined;
         killSignal?: NodeJS.Signals | number | undefined;
+        encoding?: string | null | undefined;
     }
     interface ExecOptionsWithStringEncoding extends ExecOptions {
-        encoding: BufferEncoding;
+        encoding?: BufferEncoding | undefined;
     }
     interface ExecOptionsWithBufferEncoding extends ExecOptions {
-        encoding: BufferEncoding | null; // specify `null`.
+        encoding: "buffer" | null; // specify `null`.
     }
     interface ExecException extends Error {
         cmd?: string | undefined;
@@ -995,38 +995,19 @@ declare module "child_process" {
     // `options` with `"buffer"` or `null` for `encoding` means stdout/stderr are definitely `Buffer`.
     function exec(
         command: string,
-        options: {
-            encoding: "buffer" | null;
-        } & ExecOptions,
+        options: ExecOptionsWithBufferEncoding,
         callback?: (error: ExecException | null, stdout: Buffer, stderr: Buffer) => void,
     ): ChildProcess;
-    // `options` with well known `encoding` means stdout/stderr are definitely `string`.
+    // `options` with well-known or absent `encoding` means stdout/stderr are definitely `string`.
     function exec(
         command: string,
-        options: {
-            encoding: BufferEncoding;
-        } & ExecOptions,
-        callback?: (error: ExecException | null, stdout: string, stderr: string) => void,
-    ): ChildProcess;
-    // `options` with an `encoding` whose type is `string` means stdout/stderr could either be `Buffer` or `string`.
-    // There is no guarantee the `encoding` is unknown as `string` is a superset of `BufferEncoding`.
-    function exec(
-        command: string,
-        options: {
-            encoding: BufferEncoding;
-        } & ExecOptions,
-        callback?: (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
-    ): ChildProcess;
-    // `options` without an `encoding` means stdout/stderr are definitely `string`.
-    function exec(
-        command: string,
-        options: ExecOptions,
+        options: ExecOptionsWithStringEncoding,
         callback?: (error: ExecException | null, stdout: string, stderr: string) => void,
     ): ChildProcess;
     // fallback if nothing else matches. Worst case is always `string | Buffer`.
     function exec(
         command: string,
-        options: (ObjectEncodingOptions & ExecOptions) | undefined | null,
+        options: ExecOptions | undefined | null,
         callback?: (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
     ): ChildProcess;
     interface PromiseWithChild<T> extends Promise<T> {
@@ -1039,32 +1020,21 @@ declare module "child_process" {
         }>;
         function __promisify__(
             command: string,
-            options: {
-                encoding: "buffer" | null;
-            } & ExecOptions,
+            options: ExecOptionsWithBufferEncoding,
         ): PromiseWithChild<{
             stdout: Buffer;
             stderr: Buffer;
         }>;
         function __promisify__(
             command: string,
-            options: {
-                encoding: BufferEncoding;
-            } & ExecOptions,
+            options: ExecOptionsWithStringEncoding,
         ): PromiseWithChild<{
             stdout: string;
             stderr: string;
         }>;
         function __promisify__(
             command: string,
-            options: ExecOptions,
-        ): PromiseWithChild<{
-            stdout: string;
-            stderr: string;
-        }>;
-        function __promisify__(
-            command: string,
-            options?: (ObjectEncodingOptions & ExecOptions) | null,
+            options: ExecOptions | undefined | null,
         ): PromiseWithChild<{
             stdout: string | Buffer;
             stderr: string | Buffer;
@@ -1076,16 +1046,16 @@ declare module "child_process" {
         windowsVerbatimArguments?: boolean | undefined;
         shell?: boolean | string | undefined;
         signal?: AbortSignal | undefined;
+        encoding?: string | null | undefined;
     }
     interface ExecFileOptionsWithStringEncoding extends ExecFileOptions {
-        encoding: BufferEncoding;
+        encoding?: BufferEncoding | undefined;
     }
     interface ExecFileOptionsWithBufferEncoding extends ExecFileOptions {
         encoding: "buffer" | null;
     }
-    interface ExecFileOptionsWithOtherEncoding extends ExecFileOptions {
-        encoding: BufferEncoding;
-    }
+    /** @deprecated Use `ExecFileOptions` instead. */
+    interface ExecFileOptionsWithOtherEncoding extends ExecFileOptions {}
     type ExecFileException =
         & Omit<ExecException, "code">
         & Omit<NodeJS.ErrnoException, "code">
@@ -1154,80 +1124,44 @@ declare module "child_process" {
      * @param args List of string arguments.
      * @param callback Called with the output when process terminates.
      */
-    function execFile(file: string): ChildProcess;
-    function execFile(
-        file: string,
-        options: (ObjectEncodingOptions & ExecFileOptions) | undefined | null,
-    ): ChildProcess;
-    function execFile(file: string, args?: readonly string[] | null): ChildProcess;
-    function execFile(
-        file: string,
-        args: readonly string[] | undefined | null,
-        options: (ObjectEncodingOptions & ExecFileOptions) | undefined | null,
-    ): ChildProcess;
     // no `options` definitely means stdout/stderr are `string`.
     function execFile(
         file: string,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+        callback?: (error: ExecFileException | null, stdout: string, stderr: string) => void,
     ): ChildProcess;
     function execFile(
         file: string,
         args: readonly string[] | undefined | null,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+        callback?: (error: ExecFileException | null, stdout: string, stderr: string) => void,
     ): ChildProcess;
     // `options` with `"buffer"` or `null` for `encoding` means stdout/stderr are definitely `Buffer`.
     function execFile(
         file: string,
         options: ExecFileOptionsWithBufferEncoding,
-        callback: (error: ExecFileException | null, stdout: Buffer, stderr: Buffer) => void,
+        callback?: (error: ExecFileException | null, stdout: Buffer, stderr: Buffer) => void,
     ): ChildProcess;
     function execFile(
         file: string,
         args: readonly string[] | undefined | null,
         options: ExecFileOptionsWithBufferEncoding,
-        callback: (error: ExecFileException | null, stdout: Buffer, stderr: Buffer) => void,
+        callback?: (error: ExecFileException | null, stdout: Buffer, stderr: Buffer) => void,
     ): ChildProcess;
-    // `options` with well known `encoding` means stdout/stderr are definitely `string`.
+    // `options` with well-known or absent `encoding` means stdout/stderr are definitely `string`.
     function execFile(
         file: string,
         options: ExecFileOptionsWithStringEncoding,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+        callback?: (error: ExecFileException | null, stdout: string, stderr: string) => void,
     ): ChildProcess;
     function execFile(
         file: string,
         args: readonly string[] | undefined | null,
         options: ExecFileOptionsWithStringEncoding,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
-    ): ChildProcess;
-    // `options` with an `encoding` whose type is `string` means stdout/stderr could either be `Buffer` or `string`.
-    // There is no guarantee the `encoding` is unknown as `string` is a superset of `BufferEncoding`.
-    function execFile(
-        file: string,
-        options: ExecFileOptionsWithOtherEncoding,
-        callback: (error: ExecFileException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
-    ): ChildProcess;
-    function execFile(
-        file: string,
-        args: readonly string[] | undefined | null,
-        options: ExecFileOptionsWithOtherEncoding,
-        callback: (error: ExecFileException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
-    ): ChildProcess;
-    // `options` without an `encoding` means stdout/stderr are definitely `string`.
-    function execFile(
-        file: string,
-        options: ExecFileOptions,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
-    ): ChildProcess;
-    function execFile(
-        file: string,
-        args: readonly string[] | undefined | null,
-        options: ExecFileOptions,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+        callback?: (error: ExecFileException | null, stdout: string, stderr: string) => void,
     ): ChildProcess;
     // fallback if nothing else matches. Worst case is always `string | Buffer`.
     function execFile(
         file: string,
-        options: (ObjectEncodingOptions & ExecFileOptions) | undefined | null,
+        options: ExecFileOptions | undefined | null,
         callback:
             | ((error: ExecFileException | null, stdout: string | Buffer, stderr: string | Buffer) => void)
             | undefined
@@ -1236,7 +1170,7 @@ declare module "child_process" {
     function execFile(
         file: string,
         args: readonly string[] | undefined | null,
-        options: (ObjectEncodingOptions & ExecFileOptions) | undefined | null,
+        options: ExecFileOptions | undefined | null,
         callback:
             | ((error: ExecFileException | null, stdout: string | Buffer, stderr: string | Buffer) => void)
             | undefined
@@ -1286,7 +1220,7 @@ declare module "child_process" {
         }>;
         function __promisify__(
             file: string,
-            options: ExecFileOptionsWithOtherEncoding,
+            options: ExecFileOptions | undefined | null,
         ): PromiseWithChild<{
             stdout: string | Buffer;
             stderr: string | Buffer;
@@ -1294,37 +1228,7 @@ declare module "child_process" {
         function __promisify__(
             file: string,
             args: readonly string[] | undefined | null,
-            options: ExecFileOptionsWithOtherEncoding,
-        ): PromiseWithChild<{
-            stdout: string | Buffer;
-            stderr: string | Buffer;
-        }>;
-        function __promisify__(
-            file: string,
-            options: ExecFileOptions,
-        ): PromiseWithChild<{
-            stdout: string;
-            stderr: string;
-        }>;
-        function __promisify__(
-            file: string,
-            args: readonly string[] | undefined | null,
-            options: ExecFileOptions,
-        ): PromiseWithChild<{
-            stdout: string;
-            stderr: string;
-        }>;
-        function __promisify__(
-            file: string,
-            options: (ObjectEncodingOptions & ExecFileOptions) | undefined | null,
-        ): PromiseWithChild<{
-            stdout: string | Buffer;
-            stderr: string | Buffer;
-        }>;
-        function __promisify__(
-            file: string,
-            args: readonly string[] | undefined | null,
-            options: (ObjectEncodingOptions & ExecFileOptions) | undefined | null,
+            options: ExecFileOptions | undefined | null,
         ): PromiseWithChild<{
             stdout: string | Buffer;
             stderr: string | Buffer;

--- a/types/node/v18/test/child_process.ts
+++ b/types/node/v18/test/child_process.ts
@@ -36,6 +36,148 @@ import { promisify } from "node:util";
 }
 
 {
+    const cmd = "echo test";
+    const promisifiedExec = promisify(childProcess.exec);
+    const boolFlag = Math.random() < 1;
+
+    // $ExpectType ChildProcess
+    childProcess.exec(cmd);
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExec(cmd);
+
+    // without encoding
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        {},
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExec(cmd, {});
+
+    // with optional options
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        {
+            windowsHide: true,
+            timeout: 0,
+            shell: "bash",
+            signal: new AbortSignal(),
+            maxBuffer: 1024,
+            killSignal: "SIGABRT",
+        },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExec(
+        cmd,
+        {
+            windowsHide: true,
+            timeout: 0,
+            shell: "bash",
+            signal: new AbortSignal(),
+            maxBuffer: 1024,
+            killSignal: "SIGABRT",
+        },
+    );
+
+    // with encoding: 'buffer' | null
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        { encoding: boolFlag ? "buffer" : null },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: Buffer<ArrayBufferLike>; stderr: Buffer<ArrayBufferLike>; }>
+    promisifiedExec(cmd, { encoding: boolFlag ? "buffer" : null });
+
+    // with known encoding
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        { encoding: "utf16le" },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExec(cmd, { encoding: "utf16le" });
+
+    // with unknown encoding
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        { encoding: "unknown" },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }>
+    promisifiedExec(cmd, { encoding: "unknown" });
+
+    // with nullish encoding
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        boolFlag ? { encoding: "unknown" } : null,
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }>
+    promisifiedExec(cmd, boolFlag ? { encoding: "unknown" } : null);
+}
+
+{
     childProcess.execSync("echo test"); // $ExpectType Buffer || Buffer<ArrayBufferLike>
     childProcess.execSync("echo test", {}); // $ExpectType Buffer || Buffer<ArrayBufferLike>
     childProcess.execSync("echo test", { encoding: "buffer" }); // $ExpectType Buffer || Buffer<ArrayBufferLike>
@@ -58,49 +200,275 @@ import { promisify } from "node:util";
 }
 
 {
-    childProcess.execFile("npm", () => {});
-    childProcess.execFile("npm", { windowsHide: true, signal: new AbortSignal() }, () => {});
-    childProcess.execFile("npm", { shell: true }, () => {});
-    childProcess.execFile("npm", { shell: "/bin/sh" }, () => {});
-    childProcess.execFile("npm", ["-v"] as readonly string[], () => {});
+    const cmd = "echo test";
+    const promisifiedExecFile = promisify(childProcess.execFile);
+    const boolFlag = Math.random() < 1;
+    const args = boolFlag ? ["arg"] as const : boolFlag ? null : undefined;
+
+    // $ExpectType ChildProcess
+    childProcess.execFile(cmd);
+    // $ExpectType ChildProcess
     childProcess.execFile(
-        "npm",
-        ["-v"] as readonly string[],
-        { windowsHide: true, encoding: "utf-8" },
-        (stdout, stderr) => {
-            assert(stdout instanceof String);
+        cmd,
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
         },
     );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(cmd);
+
+    // $ExpectType ChildProcess
+    childProcess.execFile(cmd, args);
+    // $ExpectType ChildProcess
     childProcess.execFile(
-        "npm",
-        ["-v"] as readonly string[],
-        { windowsHide: true, encoding: "buffer" },
-        (stdout, stderr) => {
-            assert(stdout instanceof Buffer);
+        cmd,
+        args,
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
         },
     );
-    childProcess.execFile("npm", { encoding: "utf-8" }, (stdout, stderr) => {
-        assert(stdout instanceof String);
-    });
-    childProcess.execFile("npm", { encoding: "buffer" }, (stdout, stderr) => {
-        assert(stdout instanceof Buffer);
-    });
-    childProcess.execFile("npm", (err) => {
-        if (err && err.errno) assert(err.code === "ENOENT");
-    });
-    childProcess.execFile("npm", (err) => {
-        if (err !== null) {
-            if (typeof err.code === "string") {
-                console.log(err.code.charCodeAt(0));
-            } else if (typeof err.code === "number") {
-                console.log(err.code.toExponential());
-            } else if (err.code === null) {
-                // @ts-expect-error -- since err.code is null, this assignment has a type error
-                const x: string = err.code;
-                console.log(x);
-            }
-        }
-    });
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(cmd, args);
+
+    // without encoding
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        {},
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(cmd, {});
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        {},
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(cmd, args, {});
+
+    // with optional options
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        {
+            maxBuffer: 1024,
+            killSignal: "SIGABRT",
+            windowsVerbatimArguments: true,
+            shell: "bash",
+            signal: new AbortSignal(),
+        },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(
+        cmd,
+        {
+            maxBuffer: 1024,
+            killSignal: "SIGABRT",
+            windowsVerbatimArguments: true,
+            shell: "bash",
+            signal: new AbortSignal(),
+        },
+    );
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        {
+            maxBuffer: 1024,
+            killSignal: "SIGABRT",
+            windowsVerbatimArguments: true,
+            shell: "bash",
+            signal: new AbortSignal(),
+        },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(
+        cmd,
+        args,
+        {
+            maxBuffer: 1024,
+            killSignal: "SIGABRT",
+            windowsVerbatimArguments: true,
+            shell: "bash",
+            signal: new AbortSignal(),
+        },
+    );
+
+    // with encoding: 'buffer' | null
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        { encoding: boolFlag ? "buffer" : null },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: Buffer<ArrayBufferLike>; stderr: Buffer<ArrayBufferLike>; }>
+    promisifiedExecFile(cmd, { encoding: boolFlag ? "buffer" : null });
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        { encoding: boolFlag ? "buffer" : null },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: Buffer<ArrayBufferLike>; stderr: Buffer<ArrayBufferLike>; }>
+    promisifiedExecFile(cmd, args, { encoding: boolFlag ? "buffer" : null });
+
+    // with known encoding
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        { encoding: "utf16le" },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(cmd, { encoding: "utf16le" });
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        { encoding: "utf16le" },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(cmd, { encoding: "utf16le" });
+
+    // with unknown encoding
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        { encoding: "unknown" },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }>
+    promisifiedExecFile(cmd, { encoding: "unknown" });
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        { encoding: "unknown" },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }>
+    promisifiedExecFile(cmd, args, { encoding: "unknown" });
+
+    // with nullish encoding
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        boolFlag ? { encoding: "unknown" } : null,
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }>
+    promisifiedExecFile(cmd, boolFlag ? { encoding: "unknown" } : null);
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        boolFlag ? { encoding: "unknown" } : null,
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }>
+    promisifiedExecFile(cmd, args, boolFlag ? { encoding: "unknown" } : null);
 }
 
 {

--- a/types/node/v20/child_process.d.ts
+++ b/types/node/v20/child_process.d.ts
@@ -66,7 +66,6 @@
  * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/child_process.js)
  */
 declare module "child_process" {
-    import { ObjectEncodingOptions } from "node:fs";
     import { Abortable, EventEmitter } from "node:events";
     import * as dgram from "node:dgram";
     import * as net from "node:net";
@@ -887,12 +886,13 @@ declare module "child_process" {
         signal?: AbortSignal | undefined;
         maxBuffer?: number | undefined;
         killSignal?: NodeJS.Signals | number | undefined;
+        encoding?: string | null | undefined;
     }
     interface ExecOptionsWithStringEncoding extends ExecOptions {
-        encoding: BufferEncoding;
+        encoding?: BufferEncoding | undefined;
     }
     interface ExecOptionsWithBufferEncoding extends ExecOptions {
-        encoding: BufferEncoding | null; // specify `null`.
+        encoding: "buffer" | null; // specify `null`.
     }
     interface ExecException extends Error {
         cmd?: string | undefined;
@@ -995,38 +995,19 @@ declare module "child_process" {
     // `options` with `"buffer"` or `null` for `encoding` means stdout/stderr are definitely `Buffer`.
     function exec(
         command: string,
-        options: {
-            encoding: "buffer" | null;
-        } & ExecOptions,
+        options: ExecOptionsWithBufferEncoding,
         callback?: (error: ExecException | null, stdout: Buffer, stderr: Buffer) => void,
     ): ChildProcess;
-    // `options` with well known `encoding` means stdout/stderr are definitely `string`.
+    // `options` with well-known or absent `encoding` means stdout/stderr are definitely `string`.
     function exec(
         command: string,
-        options: {
-            encoding: BufferEncoding;
-        } & ExecOptions,
-        callback?: (error: ExecException | null, stdout: string, stderr: string) => void,
-    ): ChildProcess;
-    // `options` with an `encoding` whose type is `string` means stdout/stderr could either be `Buffer` or `string`.
-    // There is no guarantee the `encoding` is unknown as `string` is a superset of `BufferEncoding`.
-    function exec(
-        command: string,
-        options: {
-            encoding: BufferEncoding;
-        } & ExecOptions,
-        callback?: (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
-    ): ChildProcess;
-    // `options` without an `encoding` means stdout/stderr are definitely `string`.
-    function exec(
-        command: string,
-        options: ExecOptions,
+        options: ExecOptionsWithStringEncoding,
         callback?: (error: ExecException | null, stdout: string, stderr: string) => void,
     ): ChildProcess;
     // fallback if nothing else matches. Worst case is always `string | Buffer`.
     function exec(
         command: string,
-        options: (ObjectEncodingOptions & ExecOptions) | undefined | null,
+        options: ExecOptions | undefined | null,
         callback?: (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
     ): ChildProcess;
     interface PromiseWithChild<T> extends Promise<T> {
@@ -1039,32 +1020,21 @@ declare module "child_process" {
         }>;
         function __promisify__(
             command: string,
-            options: {
-                encoding: "buffer" | null;
-            } & ExecOptions,
+            options: ExecOptionsWithBufferEncoding,
         ): PromiseWithChild<{
             stdout: Buffer;
             stderr: Buffer;
         }>;
         function __promisify__(
             command: string,
-            options: {
-                encoding: BufferEncoding;
-            } & ExecOptions,
+            options: ExecOptionsWithStringEncoding,
         ): PromiseWithChild<{
             stdout: string;
             stderr: string;
         }>;
         function __promisify__(
             command: string,
-            options: ExecOptions,
-        ): PromiseWithChild<{
-            stdout: string;
-            stderr: string;
-        }>;
-        function __promisify__(
-            command: string,
-            options?: (ObjectEncodingOptions & ExecOptions) | null,
+            options: ExecOptions | undefined | null,
         ): PromiseWithChild<{
             stdout: string | Buffer;
             stderr: string | Buffer;
@@ -1076,16 +1046,16 @@ declare module "child_process" {
         windowsVerbatimArguments?: boolean | undefined;
         shell?: boolean | string | undefined;
         signal?: AbortSignal | undefined;
+        encoding?: string | null | undefined;
     }
     interface ExecFileOptionsWithStringEncoding extends ExecFileOptions {
-        encoding: BufferEncoding;
+        encoding?: BufferEncoding | undefined;
     }
     interface ExecFileOptionsWithBufferEncoding extends ExecFileOptions {
         encoding: "buffer" | null;
     }
-    interface ExecFileOptionsWithOtherEncoding extends ExecFileOptions {
-        encoding: BufferEncoding;
-    }
+    /** @deprecated Use `ExecFileOptions` instead. */
+    interface ExecFileOptionsWithOtherEncoding extends ExecFileOptions {}
     type ExecFileException =
         & Omit<ExecException, "code">
         & Omit<NodeJS.ErrnoException, "code">
@@ -1153,80 +1123,44 @@ declare module "child_process" {
      * @param args List of string arguments.
      * @param callback Called with the output when process terminates.
      */
-    function execFile(file: string): ChildProcess;
-    function execFile(
-        file: string,
-        options: (ObjectEncodingOptions & ExecFileOptions) | undefined | null,
-    ): ChildProcess;
-    function execFile(file: string, args?: readonly string[] | null): ChildProcess;
-    function execFile(
-        file: string,
-        args: readonly string[] | undefined | null,
-        options: (ObjectEncodingOptions & ExecFileOptions) | undefined | null,
-    ): ChildProcess;
     // no `options` definitely means stdout/stderr are `string`.
     function execFile(
         file: string,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+        callback?: (error: ExecFileException | null, stdout: string, stderr: string) => void,
     ): ChildProcess;
     function execFile(
         file: string,
         args: readonly string[] | undefined | null,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+        callback?: (error: ExecFileException | null, stdout: string, stderr: string) => void,
     ): ChildProcess;
     // `options` with `"buffer"` or `null` for `encoding` means stdout/stderr are definitely `Buffer`.
     function execFile(
         file: string,
         options: ExecFileOptionsWithBufferEncoding,
-        callback: (error: ExecFileException | null, stdout: Buffer, stderr: Buffer) => void,
+        callback?: (error: ExecFileException | null, stdout: Buffer, stderr: Buffer) => void,
     ): ChildProcess;
     function execFile(
         file: string,
         args: readonly string[] | undefined | null,
         options: ExecFileOptionsWithBufferEncoding,
-        callback: (error: ExecFileException | null, stdout: Buffer, stderr: Buffer) => void,
+        callback?: (error: ExecFileException | null, stdout: Buffer, stderr: Buffer) => void,
     ): ChildProcess;
-    // `options` with well known `encoding` means stdout/stderr are definitely `string`.
+    // `options` with well-known or absent `encoding` means stdout/stderr are definitely `string`.
     function execFile(
         file: string,
         options: ExecFileOptionsWithStringEncoding,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+        callback?: (error: ExecFileException | null, stdout: string, stderr: string) => void,
     ): ChildProcess;
     function execFile(
         file: string,
         args: readonly string[] | undefined | null,
         options: ExecFileOptionsWithStringEncoding,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
-    ): ChildProcess;
-    // `options` with an `encoding` whose type is `string` means stdout/stderr could either be `Buffer` or `string`.
-    // There is no guarantee the `encoding` is unknown as `string` is a superset of `BufferEncoding`.
-    function execFile(
-        file: string,
-        options: ExecFileOptionsWithOtherEncoding,
-        callback: (error: ExecFileException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
-    ): ChildProcess;
-    function execFile(
-        file: string,
-        args: readonly string[] | undefined | null,
-        options: ExecFileOptionsWithOtherEncoding,
-        callback: (error: ExecFileException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
-    ): ChildProcess;
-    // `options` without an `encoding` means stdout/stderr are definitely `string`.
-    function execFile(
-        file: string,
-        options: ExecFileOptions,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
-    ): ChildProcess;
-    function execFile(
-        file: string,
-        args: readonly string[] | undefined | null,
-        options: ExecFileOptions,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+        callback?: (error: ExecFileException | null, stdout: string, stderr: string) => void,
     ): ChildProcess;
     // fallback if nothing else matches. Worst case is always `string | Buffer`.
     function execFile(
         file: string,
-        options: (ObjectEncodingOptions & ExecFileOptions) | undefined | null,
+        options: ExecFileOptions | undefined | null,
         callback:
             | ((error: ExecFileException | null, stdout: string | Buffer, stderr: string | Buffer) => void)
             | undefined
@@ -1235,7 +1169,7 @@ declare module "child_process" {
     function execFile(
         file: string,
         args: readonly string[] | undefined | null,
-        options: (ObjectEncodingOptions & ExecFileOptions) | undefined | null,
+        options: ExecFileOptions | undefined | null,
         callback:
             | ((error: ExecFileException | null, stdout: string | Buffer, stderr: string | Buffer) => void)
             | undefined
@@ -1285,7 +1219,7 @@ declare module "child_process" {
         }>;
         function __promisify__(
             file: string,
-            options: ExecFileOptionsWithOtherEncoding,
+            options: ExecFileOptions | undefined | null,
         ): PromiseWithChild<{
             stdout: string | Buffer;
             stderr: string | Buffer;
@@ -1293,37 +1227,7 @@ declare module "child_process" {
         function __promisify__(
             file: string,
             args: readonly string[] | undefined | null,
-            options: ExecFileOptionsWithOtherEncoding,
-        ): PromiseWithChild<{
-            stdout: string | Buffer;
-            stderr: string | Buffer;
-        }>;
-        function __promisify__(
-            file: string,
-            options: ExecFileOptions,
-        ): PromiseWithChild<{
-            stdout: string;
-            stderr: string;
-        }>;
-        function __promisify__(
-            file: string,
-            args: readonly string[] | undefined | null,
-            options: ExecFileOptions,
-        ): PromiseWithChild<{
-            stdout: string;
-            stderr: string;
-        }>;
-        function __promisify__(
-            file: string,
-            options: (ObjectEncodingOptions & ExecFileOptions) | undefined | null,
-        ): PromiseWithChild<{
-            stdout: string | Buffer;
-            stderr: string | Buffer;
-        }>;
-        function __promisify__(
-            file: string,
-            args: readonly string[] | undefined | null,
-            options: (ObjectEncodingOptions & ExecFileOptions) | undefined | null,
+            options: ExecFileOptions | undefined | null,
         ): PromiseWithChild<{
             stdout: string | Buffer;
             stderr: string | Buffer;

--- a/types/node/v20/test/child_process.ts
+++ b/types/node/v20/test/child_process.ts
@@ -37,6 +37,148 @@ import { promisify } from "node:util";
 }
 
 {
+    const cmd = "echo test";
+    const promisifiedExec = promisify(childProcess.exec);
+    const boolFlag = Math.random() < 1;
+
+    // $ExpectType ChildProcess
+    childProcess.exec(cmd);
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExec(cmd);
+
+    // without encoding
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        {},
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExec(cmd, {});
+
+    // with optional options
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        {
+            windowsHide: true,
+            timeout: 0,
+            shell: "bash",
+            signal: new AbortSignal(),
+            maxBuffer: 1024,
+            killSignal: "SIGABRT",
+        },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExec(
+        cmd,
+        {
+            windowsHide: true,
+            timeout: 0,
+            shell: "bash",
+            signal: new AbortSignal(),
+            maxBuffer: 1024,
+            killSignal: "SIGABRT",
+        },
+    );
+
+    // with encoding: 'buffer' | null
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        { encoding: boolFlag ? "buffer" : null },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: Buffer<ArrayBufferLike>; stderr: Buffer<ArrayBufferLike>; }>
+    promisifiedExec(cmd, { encoding: boolFlag ? "buffer" : null });
+
+    // with known encoding
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        { encoding: "utf16le" },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExec(cmd, { encoding: "utf16le" });
+
+    // with unknown encoding
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        { encoding: "unknown" },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }>
+    promisifiedExec(cmd, { encoding: "unknown" });
+
+    // with nullish encoding
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        boolFlag ? { encoding: "unknown" } : null,
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }>
+    promisifiedExec(cmd, boolFlag ? { encoding: "unknown" } : null);
+}
+
+{
     childProcess.execSync("echo test"); // $ExpectType Buffer || Buffer<ArrayBufferLike>
     childProcess.execSync("echo test", {}); // $ExpectType Buffer || Buffer<ArrayBufferLike>
     childProcess.execSync("echo test", { encoding: "buffer" }); // $ExpectType Buffer || Buffer<ArrayBufferLike>
@@ -59,49 +201,275 @@ import { promisify } from "node:util";
 }
 
 {
-    childProcess.execFile("npm", () => {});
-    childProcess.execFile("npm", { windowsHide: true, signal: new AbortSignal() }, () => {});
-    childProcess.execFile("npm", { shell: true }, () => {});
-    childProcess.execFile("npm", { shell: "/bin/sh" }, () => {});
-    childProcess.execFile("npm", ["-v"] as readonly string[], () => {});
+    const cmd = "echo test";
+    const promisifiedExecFile = promisify(childProcess.execFile);
+    const boolFlag = Math.random() < 1;
+    const args = boolFlag ? ["arg"] as const : boolFlag ? null : undefined;
+
+    // $ExpectType ChildProcess
+    childProcess.execFile(cmd);
+    // $ExpectType ChildProcess
     childProcess.execFile(
-        "npm",
-        ["-v"] as readonly string[],
-        { windowsHide: true, encoding: "utf-8" },
-        (stdout, stderr) => {
-            assert(stdout instanceof String);
+        cmd,
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
         },
     );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(cmd);
+
+    // $ExpectType ChildProcess
+    childProcess.execFile(cmd, args);
+    // $ExpectType ChildProcess
     childProcess.execFile(
-        "npm",
-        ["-v"] as readonly string[],
-        { windowsHide: true, encoding: "buffer" },
-        (stdout, stderr) => {
-            assert(stdout instanceof Buffer);
+        cmd,
+        args,
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
         },
     );
-    childProcess.execFile("npm", { encoding: "utf-8" }, (stdout, stderr) => {
-        assert(stdout instanceof String);
-    });
-    childProcess.execFile("npm", { encoding: "buffer" }, (stdout, stderr) => {
-        assert(stdout instanceof Buffer);
-    });
-    childProcess.execFile("npm", (err) => {
-        if (err && err.errno) assert(err.code === "ENOENT");
-    });
-    childProcess.execFile("npm", (err) => {
-        if (err !== null) {
-            if (typeof err.code === "string") {
-                console.log(err.code.charCodeAt(0));
-            } else if (typeof err.code === "number") {
-                console.log(err.code.toExponential());
-            } else if (err.code === null) {
-                // @ts-expect-error -- since err.code is null, this assignment has a type error
-                const x: string = err.code;
-                console.log(x);
-            }
-        }
-    });
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(cmd, args);
+
+    // without encoding
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        {},
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(cmd, {});
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        {},
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(cmd, args, {});
+
+    // with optional options
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        {
+            maxBuffer: 1024,
+            killSignal: "SIGABRT",
+            windowsVerbatimArguments: true,
+            shell: "bash",
+            signal: new AbortSignal(),
+        },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(
+        cmd,
+        {
+            maxBuffer: 1024,
+            killSignal: "SIGABRT",
+            windowsVerbatimArguments: true,
+            shell: "bash",
+            signal: new AbortSignal(),
+        },
+    );
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        {
+            maxBuffer: 1024,
+            killSignal: "SIGABRT",
+            windowsVerbatimArguments: true,
+            shell: "bash",
+            signal: new AbortSignal(),
+        },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(
+        cmd,
+        args,
+        {
+            maxBuffer: 1024,
+            killSignal: "SIGABRT",
+            windowsVerbatimArguments: true,
+            shell: "bash",
+            signal: new AbortSignal(),
+        },
+    );
+
+    // with encoding: 'buffer' | null
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        { encoding: boolFlag ? "buffer" : null },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: Buffer<ArrayBufferLike>; stderr: Buffer<ArrayBufferLike>; }>
+    promisifiedExecFile(cmd, { encoding: boolFlag ? "buffer" : null });
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        { encoding: boolFlag ? "buffer" : null },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: Buffer<ArrayBufferLike>; stderr: Buffer<ArrayBufferLike>; }>
+    promisifiedExecFile(cmd, args, { encoding: boolFlag ? "buffer" : null });
+
+    // with known encoding
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        { encoding: "utf16le" },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(cmd, { encoding: "utf16le" });
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        { encoding: "utf16le" },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(cmd, { encoding: "utf16le" });
+
+    // with unknown encoding
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        { encoding: "unknown" },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }>
+    promisifiedExecFile(cmd, { encoding: "unknown" });
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        { encoding: "unknown" },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }>
+    promisifiedExecFile(cmd, args, { encoding: "unknown" });
+
+    // with nullish encoding
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        boolFlag ? { encoding: "unknown" } : null,
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }>
+    promisifiedExecFile(cmd, boolFlag ? { encoding: "unknown" } : null);
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        boolFlag ? { encoding: "unknown" } : null,
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }>
+    promisifiedExecFile(cmd, args, boolFlag ? { encoding: "unknown" } : null);
 }
 
 {

--- a/types/node/v22/child_process.d.ts
+++ b/types/node/v22/child_process.d.ts
@@ -66,7 +66,6 @@
  * @see [source](https://github.com/nodejs/node/blob/v22.x/lib/child_process.js)
  */
 declare module "child_process" {
-    import { ObjectEncodingOptions } from "node:fs";
     import { Abortable, EventEmitter } from "node:events";
     import * as dgram from "node:dgram";
     import * as net from "node:net";
@@ -887,12 +886,13 @@ declare module "child_process" {
         signal?: AbortSignal | undefined;
         maxBuffer?: number | undefined;
         killSignal?: NodeJS.Signals | number | undefined;
+        encoding?: string | null | undefined;
     }
     interface ExecOptionsWithStringEncoding extends ExecOptions {
-        encoding: BufferEncoding;
+        encoding?: BufferEncoding | undefined;
     }
     interface ExecOptionsWithBufferEncoding extends ExecOptions {
-        encoding: BufferEncoding | null; // specify `null`.
+        encoding: "buffer" | null; // specify `null`.
     }
     interface ExecException extends Error {
         cmd?: string | undefined;
@@ -995,38 +995,19 @@ declare module "child_process" {
     // `options` with `"buffer"` or `null` for `encoding` means stdout/stderr are definitely `Buffer`.
     function exec(
         command: string,
-        options: {
-            encoding: "buffer" | null;
-        } & ExecOptions,
+        options: ExecOptionsWithBufferEncoding,
         callback?: (error: ExecException | null, stdout: Buffer, stderr: Buffer) => void,
     ): ChildProcess;
-    // `options` with well known `encoding` means stdout/stderr are definitely `string`.
+    // `options` with well-known or absent `encoding` means stdout/stderr are definitely `string`.
     function exec(
         command: string,
-        options: {
-            encoding: BufferEncoding;
-        } & ExecOptions,
-        callback?: (error: ExecException | null, stdout: string, stderr: string) => void,
-    ): ChildProcess;
-    // `options` with an `encoding` whose type is `string` means stdout/stderr could either be `Buffer` or `string`.
-    // There is no guarantee the `encoding` is unknown as `string` is a superset of `BufferEncoding`.
-    function exec(
-        command: string,
-        options: {
-            encoding: BufferEncoding;
-        } & ExecOptions,
-        callback?: (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
-    ): ChildProcess;
-    // `options` without an `encoding` means stdout/stderr are definitely `string`.
-    function exec(
-        command: string,
-        options: ExecOptions,
+        options: ExecOptionsWithStringEncoding,
         callback?: (error: ExecException | null, stdout: string, stderr: string) => void,
     ): ChildProcess;
     // fallback if nothing else matches. Worst case is always `string | Buffer`.
     function exec(
         command: string,
-        options: (ObjectEncodingOptions & ExecOptions) | undefined | null,
+        options: ExecOptions | undefined | null,
         callback?: (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
     ): ChildProcess;
     interface PromiseWithChild<T> extends Promise<T> {
@@ -1039,32 +1020,21 @@ declare module "child_process" {
         }>;
         function __promisify__(
             command: string,
-            options: {
-                encoding: "buffer" | null;
-            } & ExecOptions,
+            options: ExecOptionsWithBufferEncoding,
         ): PromiseWithChild<{
             stdout: Buffer;
             stderr: Buffer;
         }>;
         function __promisify__(
             command: string,
-            options: {
-                encoding: BufferEncoding;
-            } & ExecOptions,
+            options: ExecOptionsWithStringEncoding,
         ): PromiseWithChild<{
             stdout: string;
             stderr: string;
         }>;
         function __promisify__(
             command: string,
-            options: ExecOptions,
-        ): PromiseWithChild<{
-            stdout: string;
-            stderr: string;
-        }>;
-        function __promisify__(
-            command: string,
-            options?: (ObjectEncodingOptions & ExecOptions) | null,
+            options: ExecOptions | undefined | null,
         ): PromiseWithChild<{
             stdout: string | Buffer;
             stderr: string | Buffer;
@@ -1076,16 +1046,16 @@ declare module "child_process" {
         windowsVerbatimArguments?: boolean | undefined;
         shell?: boolean | string | undefined;
         signal?: AbortSignal | undefined;
+        encoding?: string | null | undefined;
     }
     interface ExecFileOptionsWithStringEncoding extends ExecFileOptions {
-        encoding: BufferEncoding;
+        encoding?: BufferEncoding | undefined;
     }
     interface ExecFileOptionsWithBufferEncoding extends ExecFileOptions {
         encoding: "buffer" | null;
     }
-    interface ExecFileOptionsWithOtherEncoding extends ExecFileOptions {
-        encoding: BufferEncoding;
-    }
+    /** @deprecated Use `ExecFileOptions` instead. */
+    interface ExecFileOptionsWithOtherEncoding extends ExecFileOptions {}
     type ExecFileException =
         & Omit<ExecException, "code">
         & Omit<NodeJS.ErrnoException, "code">
@@ -1154,80 +1124,44 @@ declare module "child_process" {
      * @param args List of string arguments.
      * @param callback Called with the output when process terminates.
      */
-    function execFile(file: string): ChildProcess;
-    function execFile(
-        file: string,
-        options: (ObjectEncodingOptions & ExecFileOptions) | undefined | null,
-    ): ChildProcess;
-    function execFile(file: string, args?: readonly string[] | null): ChildProcess;
-    function execFile(
-        file: string,
-        args: readonly string[] | undefined | null,
-        options: (ObjectEncodingOptions & ExecFileOptions) | undefined | null,
-    ): ChildProcess;
     // no `options` definitely means stdout/stderr are `string`.
     function execFile(
         file: string,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+        callback?: (error: ExecFileException | null, stdout: string, stderr: string) => void,
     ): ChildProcess;
     function execFile(
         file: string,
         args: readonly string[] | undefined | null,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+        callback?: (error: ExecFileException | null, stdout: string, stderr: string) => void,
     ): ChildProcess;
     // `options` with `"buffer"` or `null` for `encoding` means stdout/stderr are definitely `Buffer`.
     function execFile(
         file: string,
         options: ExecFileOptionsWithBufferEncoding,
-        callback: (error: ExecFileException | null, stdout: Buffer, stderr: Buffer) => void,
+        callback?: (error: ExecFileException | null, stdout: Buffer, stderr: Buffer) => void,
     ): ChildProcess;
     function execFile(
         file: string,
         args: readonly string[] | undefined | null,
         options: ExecFileOptionsWithBufferEncoding,
-        callback: (error: ExecFileException | null, stdout: Buffer, stderr: Buffer) => void,
+        callback?: (error: ExecFileException | null, stdout: Buffer, stderr: Buffer) => void,
     ): ChildProcess;
-    // `options` with well known `encoding` means stdout/stderr are definitely `string`.
+    // `options` with well-known or absent `encoding` means stdout/stderr are definitely `string`.
     function execFile(
         file: string,
         options: ExecFileOptionsWithStringEncoding,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+        callback?: (error: ExecFileException | null, stdout: string, stderr: string) => void,
     ): ChildProcess;
     function execFile(
         file: string,
         args: readonly string[] | undefined | null,
         options: ExecFileOptionsWithStringEncoding,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
-    ): ChildProcess;
-    // `options` with an `encoding` whose type is `string` means stdout/stderr could either be `Buffer` or `string`.
-    // There is no guarantee the `encoding` is unknown as `string` is a superset of `BufferEncoding`.
-    function execFile(
-        file: string,
-        options: ExecFileOptionsWithOtherEncoding,
-        callback: (error: ExecFileException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
-    ): ChildProcess;
-    function execFile(
-        file: string,
-        args: readonly string[] | undefined | null,
-        options: ExecFileOptionsWithOtherEncoding,
-        callback: (error: ExecFileException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
-    ): ChildProcess;
-    // `options` without an `encoding` means stdout/stderr are definitely `string`.
-    function execFile(
-        file: string,
-        options: ExecFileOptions,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
-    ): ChildProcess;
-    function execFile(
-        file: string,
-        args: readonly string[] | undefined | null,
-        options: ExecFileOptions,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+        callback?: (error: ExecFileException | null, stdout: string, stderr: string) => void,
     ): ChildProcess;
     // fallback if nothing else matches. Worst case is always `string | Buffer`.
     function execFile(
         file: string,
-        options: (ObjectEncodingOptions & ExecFileOptions) | undefined | null,
+        options: ExecFileOptions | undefined | null,
         callback:
             | ((error: ExecFileException | null, stdout: string | Buffer, stderr: string | Buffer) => void)
             | undefined
@@ -1236,7 +1170,7 @@ declare module "child_process" {
     function execFile(
         file: string,
         args: readonly string[] | undefined | null,
-        options: (ObjectEncodingOptions & ExecFileOptions) | undefined | null,
+        options: ExecFileOptions | undefined | null,
         callback:
             | ((error: ExecFileException | null, stdout: string | Buffer, stderr: string | Buffer) => void)
             | undefined
@@ -1286,7 +1220,7 @@ declare module "child_process" {
         }>;
         function __promisify__(
             file: string,
-            options: ExecFileOptionsWithOtherEncoding,
+            options: ExecFileOptions | undefined | null,
         ): PromiseWithChild<{
             stdout: string | Buffer;
             stderr: string | Buffer;
@@ -1294,37 +1228,7 @@ declare module "child_process" {
         function __promisify__(
             file: string,
             args: readonly string[] | undefined | null,
-            options: ExecFileOptionsWithOtherEncoding,
-        ): PromiseWithChild<{
-            stdout: string | Buffer;
-            stderr: string | Buffer;
-        }>;
-        function __promisify__(
-            file: string,
-            options: ExecFileOptions,
-        ): PromiseWithChild<{
-            stdout: string;
-            stderr: string;
-        }>;
-        function __promisify__(
-            file: string,
-            args: readonly string[] | undefined | null,
-            options: ExecFileOptions,
-        ): PromiseWithChild<{
-            stdout: string;
-            stderr: string;
-        }>;
-        function __promisify__(
-            file: string,
-            options: (ObjectEncodingOptions & ExecFileOptions) | undefined | null,
-        ): PromiseWithChild<{
-            stdout: string | Buffer;
-            stderr: string | Buffer;
-        }>;
-        function __promisify__(
-            file: string,
-            args: readonly string[] | undefined | null,
-            options: (ObjectEncodingOptions & ExecFileOptions) | undefined | null,
+            options: ExecFileOptions | undefined | null,
         ): PromiseWithChild<{
             stdout: string | Buffer;
             stderr: string | Buffer;

--- a/types/node/v22/test/child_process.ts
+++ b/types/node/v22/test/child_process.ts
@@ -37,6 +37,148 @@ import { promisify } from "node:util";
 }
 
 {
+    const cmd = "echo test";
+    const promisifiedExec = promisify(childProcess.exec);
+    const boolFlag = Math.random() < 1;
+
+    // $ExpectType ChildProcess
+    childProcess.exec(cmd);
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExec(cmd);
+
+    // without encoding
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        {},
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExec(cmd, {});
+
+    // with optional options
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        {
+            windowsHide: true,
+            timeout: 0,
+            shell: "bash",
+            signal: new AbortSignal(),
+            maxBuffer: 1024,
+            killSignal: "SIGABRT",
+        },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExec(
+        cmd,
+        {
+            windowsHide: true,
+            timeout: 0,
+            shell: "bash",
+            signal: new AbortSignal(),
+            maxBuffer: 1024,
+            killSignal: "SIGABRT",
+        },
+    );
+
+    // with encoding: 'buffer' | null
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        { encoding: boolFlag ? "buffer" : null },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: Buffer<ArrayBufferLike>; stderr: Buffer<ArrayBufferLike>; }>
+    promisifiedExec(cmd, { encoding: boolFlag ? "buffer" : null });
+
+    // with known encoding
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        { encoding: "utf16le" },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExec(cmd, { encoding: "utf16le" });
+
+    // with unknown encoding
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        { encoding: "unknown" },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }>
+    promisifiedExec(cmd, { encoding: "unknown" });
+
+    // with nullish encoding
+    // $ExpectType ChildProcess
+    childProcess.exec(
+        cmd,
+        boolFlag ? { encoding: "unknown" } : null,
+        (error, stdout, stderr) => {
+            // $ExpectType ExecException | null
+            error;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }>
+    promisifiedExec(cmd, boolFlag ? { encoding: "unknown" } : null);
+}
+
+{
     childProcess.execSync("echo test"); // $ExpectType Buffer || Buffer<ArrayBufferLike>
     childProcess.execSync("echo test", {}); // $ExpectType Buffer || Buffer<ArrayBufferLike>
     childProcess.execSync("echo test", { encoding: "buffer" }); // $ExpectType Buffer || Buffer<ArrayBufferLike>
@@ -59,49 +201,275 @@ import { promisify } from "node:util";
 }
 
 {
-    childProcess.execFile("npm", () => {});
-    childProcess.execFile("npm", { windowsHide: true, signal: new AbortSignal() }, () => {});
-    childProcess.execFile("npm", { shell: true }, () => {});
-    childProcess.execFile("npm", { shell: "/bin/sh" }, () => {});
-    childProcess.execFile("npm", ["-v"] as readonly string[], () => {});
+    const cmd = "echo test";
+    const promisifiedExecFile = promisify(childProcess.execFile);
+    const boolFlag = Math.random() < 1;
+    const args = boolFlag ? ["arg"] as const : boolFlag ? null : undefined;
+
+    // $ExpectType ChildProcess
+    childProcess.execFile(cmd);
+    // $ExpectType ChildProcess
     childProcess.execFile(
-        "npm",
-        ["-v"] as readonly string[],
-        { windowsHide: true, encoding: "utf-8" },
-        (stdout, stderr) => {
-            assert(stdout instanceof String);
+        cmd,
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
         },
     );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(cmd);
+
+    // $ExpectType ChildProcess
+    childProcess.execFile(cmd, args);
+    // $ExpectType ChildProcess
     childProcess.execFile(
-        "npm",
-        ["-v"] as readonly string[],
-        { windowsHide: true, encoding: "buffer" },
-        (stdout, stderr) => {
-            assert(stdout instanceof Buffer);
+        cmd,
+        args,
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
         },
     );
-    childProcess.execFile("npm", { encoding: "utf-8" }, (stdout, stderr) => {
-        assert(stdout instanceof String);
-    });
-    childProcess.execFile("npm", { encoding: "buffer" }, (stdout, stderr) => {
-        assert(stdout instanceof Buffer);
-    });
-    childProcess.execFile("npm", (err) => {
-        if (err && err.errno) assert(err.code === "ENOENT");
-    });
-    childProcess.execFile("npm", (err) => {
-        if (err !== null) {
-            if (typeof err.code === "string") {
-                console.log(err.code.charCodeAt(0));
-            } else if (typeof err.code === "number") {
-                console.log(err.code.toExponential());
-            } else if (err.code === null) {
-                // @ts-expect-error -- since err.code is null, this assignment has a type error
-                const x: string = err.code;
-                console.log(x);
-            }
-        }
-    });
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(cmd, args);
+
+    // without encoding
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        {},
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(cmd, {});
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        {},
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(cmd, args, {});
+
+    // with optional options
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        {
+            maxBuffer: 1024,
+            killSignal: "SIGABRT",
+            windowsVerbatimArguments: true,
+            shell: "bash",
+            signal: new AbortSignal(),
+        },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(
+        cmd,
+        {
+            maxBuffer: 1024,
+            killSignal: "SIGABRT",
+            windowsVerbatimArguments: true,
+            shell: "bash",
+            signal: new AbortSignal(),
+        },
+    );
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        {
+            maxBuffer: 1024,
+            killSignal: "SIGABRT",
+            windowsVerbatimArguments: true,
+            shell: "bash",
+            signal: new AbortSignal(),
+        },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(
+        cmd,
+        args,
+        {
+            maxBuffer: 1024,
+            killSignal: "SIGABRT",
+            windowsVerbatimArguments: true,
+            shell: "bash",
+            signal: new AbortSignal(),
+        },
+    );
+
+    // with encoding: 'buffer' | null
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        { encoding: boolFlag ? "buffer" : null },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: Buffer<ArrayBufferLike>; stderr: Buffer<ArrayBufferLike>; }>
+    promisifiedExecFile(cmd, { encoding: boolFlag ? "buffer" : null });
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        { encoding: boolFlag ? "buffer" : null },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: Buffer<ArrayBufferLike>; stderr: Buffer<ArrayBufferLike>; }>
+    promisifiedExecFile(cmd, args, { encoding: boolFlag ? "buffer" : null });
+
+    // with known encoding
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        { encoding: "utf16le" },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(cmd, { encoding: "utf16le" });
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        { encoding: "utf16le" },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string
+            stdout;
+            // $ExpectType string
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string; stderr: string; }>
+    promisifiedExecFile(cmd, { encoding: "utf16le" });
+
+    // with unknown encoding
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        { encoding: "unknown" },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }>
+    promisifiedExecFile(cmd, { encoding: "unknown" });
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        { encoding: "unknown" },
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }>
+    promisifiedExecFile(cmd, args, { encoding: "unknown" });
+
+    // with nullish encoding
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        boolFlag ? { encoding: "unknown" } : null,
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }>
+    promisifiedExecFile(cmd, boolFlag ? { encoding: "unknown" } : null);
+    // $ExpectType ChildProcess
+    childProcess.execFile(
+        cmd,
+        args,
+        boolFlag ? { encoding: "unknown" } : null,
+        (error, stdout, stderr) => {
+            // $ExpectType ExecFileException | null
+            error;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stdout;
+            // $ExpectType string | Buffer<ArrayBufferLike>
+            stderr;
+        },
+    );
+    // $ExpectType PromiseWithChild<{ stdout: string | Buffer<ArrayBufferLike>; stderr: string | Buffer<ArrayBufferLike>; }>
+    promisifiedExecFile(cmd, args, boolFlag ? { encoding: "unknown" } : null);
 }
 
 {


### PR DESCRIPTION
This PR aims to solve an edge case for `child_process.exec()` and `child_process.execFile()`.

Currently, comments on the overloaded types mention that
> // `options` with an `encoding` whose type is `string` means stdout/stderr could either be `Buffer` or `string`
> // There is no guarantee the `encoding` is unknown as `string` is a superset of `BufferEncoding`.
>
> // fallback if nothing else matches. Worst case is always `string | Buffer`.

However, for these overloaded types, `ObjectEncodingOptions` from `fs` is used. Such interface only covers `BufferEncoding | null | undefined`, but not the intended `string | null | undefined`. It may lead to typecheck failure as one can reproduce in https://tsplay.dev/w2yZ8W.

This PR addresses this issue, by introducing a new `Exec(File)OptionsWithNullishEncoding` encoding shape. This new interface, together with other existing shapes, are now better aligned to supply a more proper overloads to the callback versions and promosified versions for the two methods.

Below is the exhaustive list of `exec(File)` option shapes as of this PR.
- `Exec(File)Options`
- `Exec(File)OptionsWithStringEncoding`
- `Exec(File)OptionsWithBufferEncoding`
- `Exec(File)OptionsWithOtherEncoding`

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
