### PR TITLE
shelljs: Add missing types for 'cmd' function

### DIFF
--- a/types/shelljs/index.d.ts
+++ b/types/shelljs/index.d.ts
@@ -848,30 +848,30 @@ export interface ExecOutputReturnValue {
 export const cmd: CmdFunction;
 
 export interface CmdFunction {
-	(arg1: string, ...args: [...string[], string | CmdOptions]): ShellString;
+    (arg1: string, ...args: [...string[], string | CmdOptions]): ShellString;
 }
 
 export interface CmdOptions {
-	/**
-	 * Change the current working directory only for this `cmd()` invocation.
-	 *
-	 * @default process.cwd()
-	 */
-	cwd?: string;
+    /**
+     * Change the current working directory only for this `cmd()` invocation.
+     *
+     * @default process.cwd()
+     */
+    cwd?: string;
 
-	/**
-	 * Raise or decrease the default buffer size for stdout/stderr.
-	 *
-	 * @default 20,971,520 (or 20 * 1024 * 1024)
- 	 */
-	maxBuffer?: number;
+    /**
+     * Raise or decrease the default buffer size for stdout/stderr.
+     *
+     * @default 20,971,520 (or 20 * 1024 * 1024)
+     */
+    maxBuffer?: number;
 
-	/**
-	 * Change the default timeout.
-	 *
-	 * @default 0
-	 */
-	timeout?: number;
+    /**
+     * Change the default timeout.
+     *
+     * @default 0
+     */
+    timeout?: number;
 }
 
 export interface ShellReturnValue extends ExecOutputReturnValue {

--- a/types/shelljs/index.d.ts
+++ b/types/shelljs/index.d.ts
@@ -827,6 +827,53 @@ export interface ExecOutputReturnValue {
     stderr: string;
 }
 
+/**
+ * Executes the given command synchronously. This is intended as an easier
+ * alternative for `exec()`], with better security around globbing, comamnd
+ * injection, and variable expansion. This is guaranteed to only run one
+ * external command, and won't give special treatment for any shell characters
+ * (ex. this treats `|` as a literal character, not as a shell pipeline).
+ *
+ * By default, this performs globbing on all platforms, but you can disable this
+ * with `set('-f')`.
+ *
+ * This **does not** support asynchronous mode. If you need asynchronous
+ * command execution, check out [execa](https://www.npmjs.com/package/execa) or
+ * the node builtin `child_process.execFile()` instead.
+ *
+ * @param arg1 Command to run.
+ * @param args Any number of arguments of arguments. If the last argument given
+ * 	           is an object, it will be created as a `CmdOptions` object.
+ */
+export const cmd: CmdFunction;
+
+export interface CmdFunction {
+	(arg1: string, ...args: [...string[], string | CmdOptions]): ShellString;
+}
+
+export interface CmdOptions {
+	/**
+	 * Change the current working directory only for this `cmd()` invocation.
+	 *
+	 * @default process.cwd()
+	 */
+	cwd?: string;
+
+	/**
+	 * Raise or decrease the default buffer size for stdout/stderr.
+	 *
+	 * @default 20,971,520 (or 20 * 1024 * 1024)
+ 	 */
+	maxBuffer?: number;
+
+	/**
+	 * Change the default timeout.
+	 *
+	 * @default 0
+	 */
+	timeout?: number;
+}
+
 export interface ShellReturnValue extends ExecOutputReturnValue {
     /**
      * Analogous to the redirection operator `>` in Unix, but works with JavaScript strings

--- a/types/shelljs/make.d.ts
+++ b/types/shelljs/make.d.ts
@@ -13,6 +13,7 @@ declare global {
     const cat: typeof shelljs.cat;
     const cd: typeof shelljs.cd;
     const chmod: typeof shelljs.chmod;
+    const cmd: typeof shelljs.cmd;
     const config: typeof shelljs.config;
     const cp: typeof shelljs.cp;
     const dirs: typeof shelljs.dirs;

--- a/types/shelljs/shelljs-tests.ts
+++ b/types/shelljs/shelljs-tests.ts
@@ -126,6 +126,15 @@ const childProc = shell.exec("node --version", (code: number) => {
 });
 pid = childProc.pid;
 
+const cmdVersion = shell.cmd('node', '--version').stdout;
+
+// $ExpectType ShellString
+shell.cmd('echo', '1st arg', '2nd arg');
+shell.cmd('echo', '1st arg', '2nd arg', {});
+shell.cmd('echo', '1st arg', '2nd arg', { cwd: '~/', timeout: 1000 });
+shell.cmd('echo', '1st arg', '2nd arg', { maxBuffer: 20 * 1024, timeout: 1000 });
+shell.cmd('echo', '1st arg', '2nd arg', { timeout: 1000 });
+
 shell.set("+e");
 shell.set("-e");
 shell.set("+v");

--- a/types/shelljs/shelljs-tests.ts
+++ b/types/shelljs/shelljs-tests.ts
@@ -126,14 +126,14 @@ const childProc = shell.exec("node --version", (code: number) => {
 });
 pid = childProc.pid;
 
-const cmdVersion = shell.cmd('node', '--version').stdout;
+const cmdVersion = shell.cmd("node", "--version").stdout;
 
 // $ExpectType ShellString
-shell.cmd('echo', '1st arg', '2nd arg');
-shell.cmd('echo', '1st arg', '2nd arg', {});
-shell.cmd('echo', '1st arg', '2nd arg', { cwd: '~/', timeout: 1000 });
-shell.cmd('echo', '1st arg', '2nd arg', { maxBuffer: 20 * 1024, timeout: 1000 });
-shell.cmd('echo', '1st arg', '2nd arg', { timeout: 1000 });
+shell.cmd("echo", "1st arg", "2nd arg");
+shell.cmd("echo", "1st arg", "2nd arg", {});
+shell.cmd("echo", "1st arg", "2nd arg", { cwd: "~/", timeout: 1000 });
+shell.cmd("echo", "1st arg", "2nd arg", { maxBuffer: 20 * 1024, timeout: 1000 });
+shell.cmd("echo", "1st arg", "2nd arg", { timeout: 1000 });
 
 shell.set("+e");
 shell.set("-e");


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/shelljs/shelljs/blob/33db5147e23f8d76e768eefc2f1d4a82da449ed3/README.md#cmdarg1-arg2---options
	- The `cmd` function was added in [v0.9.0](https://github.com/shelljs/shelljs/releases/tag/v0.9.0)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
