### PR TITLE
fix(node/vm): refine the typing for all options.importModuleDynamically

### DIFF
--- a/types/node/test/vm.ts
+++ b/types/node/test/vm.ts
@@ -6,6 +6,7 @@ import {
     isContext,
     measureMemory,
     MemoryMeasurement,
+    runInContext,
     runInNewContext,
     runInThisContext,
     Script,
@@ -169,31 +170,118 @@ import {
 });
 
 {
-    const script = new Script("import(\"foo.json\", { with: { type: \"json\" } })", {
-        async importModuleDynamically(specifier, referrer, importAttributes) {
+    let code = "import(\"foo.json\", { with: { type: \"json\" } })";
+    let context = createContext();
+
+    // $ExpectType Script
+    new Script(code, {
+        importModuleDynamically(specifier, referrer, importAttributes) {
             specifier; // $ExpectType string
             referrer; // $ExpectType Script
             importAttributes; // $ExpectType ImportAttributes
-            const m = new SyntheticModule(["bar"], () => {});
-            await m.link(() => {
-                throw new Error("unreachable");
-            });
-            m.setExport("bar", { hello: "world" });
-            return m;
+
+            const module = new SyntheticModule(["bar"], () => {});
+            return Math.random() < 1 ? module : new Promise(res => res(module));
         },
     });
 
-    const module = new SourceTextModule("import(\"foo.json\", { with: { type: \"json\" } })", {
-        async importModuleDynamically(specifier, referrer, importAttributes) {
+    // $ExpectType Script
+    new Script(code, {
+        importModuleDynamically: constants.USE_MAIN_CONTEXT_DEFAULT_LOADER,
+    });
+
+    runInThisContext(code, {
+        importModuleDynamically(specifier, referrer, importAttributes) {
+            specifier; // $ExpectType string
+            referrer; // $ExpectType Script
+            importAttributes; // $ExpectType ImportAttributes
+
+            const module = new SyntheticModule(["bar"], () => {});
+            return Math.random() < 1 ? module : new Promise(res => res(module));
+        },
+    });
+
+    runInThisContext(code, {
+        importModuleDynamically: constants.USE_MAIN_CONTEXT_DEFAULT_LOADER,
+    });
+
+    runInContext(code, context, {
+        importModuleDynamically(specifier, referrer, importAttributes) {
+            specifier; // $ExpectType string
+            referrer; // $ExpectType Script
+            importAttributes; // $ExpectType ImportAttributes
+
+            const module = new SyntheticModule(["bar"], () => {});
+            return Math.random() < 1 ? module : new Promise(res => res(module));
+        },
+    });
+
+    runInContext(code, context, {
+        importModuleDynamically: constants.USE_MAIN_CONTEXT_DEFAULT_LOADER,
+    });
+
+    runInNewContext(code, context, {
+        importModuleDynamically(specifier, referrer, importAttributes) {
+            specifier; // $ExpectType string
+            referrer; // $ExpectType Script
+            importAttributes; // $ExpectType ImportAttributes
+
+            const module = new SyntheticModule(["bar"], () => {});
+            return Math.random() < 1 ? module : new Promise(res => res(module));
+        },
+    });
+
+    runInNewContext(code, context, {
+        importModuleDynamically: constants.USE_MAIN_CONTEXT_DEFAULT_LOADER,
+    });
+
+    compileFunction(code, ["param"], {
+        importModuleDynamically(specifier, referrer, importAttributes) {
+            specifier; // $ExpectType string
+            referrer; // $ExpectType Function & { cachedData?: Buffer<ArrayBufferLike> | undefined; cachedDataProduced?: boolean | undefined; cachedDataRejected?: boolean | undefined; }
+            importAttributes; // $ExpectType ImportAttributes
+
+            const module = new SyntheticModule(["bar"], () => {});
+            return Math.random() < 1 ? module : new Promise(res => res(module));
+        },
+    });
+
+    compileFunction(code, ["param"], {
+        importModuleDynamically: constants.USE_MAIN_CONTEXT_DEFAULT_LOADER,
+    });
+
+    // $ExpectType SourceTextModule
+    new SourceTextModule(code, {
+        importModuleDynamically(specifier, referrer, importAttributes) {
             specifier; // $ExpectType string
             referrer; // $ExpectType SourceTextModule
             importAttributes; // $ExpectType ImportAttributes
-            const m = new SyntheticModule(["bar"], () => {});
-            await m.link(() => {
-                throw new Error("unreachable");
-            });
-            m.setExport("bar", { hello: "world" });
-            return m;
+
+            const module = new SyntheticModule(["bar"], () => {});
+            return Math.random() < 1 ? module : new Promise(res => res(module));
         },
+    });
+
+    // $ExpectType SourceTextModule
+    new SourceTextModule(code, {
+        // @ts-expect-error - `options.importModuleDynamically` is not supported in SourceTextModule
+        importModuleDynamically: constants.USE_MAIN_CONTEXT_DEFAULT_LOADER,
+    });
+
+    // $ExpectType Context
+    createContext(context, {
+        importModuleDynamically(specifier, referrer, importAttributes) {
+            specifier; // $ExpectType string
+            referrer; // $ExpectType Context
+            importAttributes; // $ExpectType ImportAttributes
+
+            const module = new SyntheticModule(["bar"], () => {});
+            return Math.random() < 1 ? module : new Promise(res => res(module));
+        },
+    });
+
+    // $ExpectType Context
+    createContext(context, {
+        importModuleDynamically: constants.USE_MAIN_CONTEXT_DEFAULT_LOADER,
     });
 }

--- a/types/node/v18/test/vm.ts
+++ b/types/node/v18/test/vm.ts
@@ -5,6 +5,7 @@ import {
     isContext,
     measureMemory,
     MemoryMeasurement,
+    runInContext,
     runInNewContext,
     runInThisContext,
     Script,
@@ -177,31 +178,74 @@ import {
 });
 
 {
-    const script = new Script("import(\"foo.json\", { with: { type: \"json\" } })", {
-        async importModuleDynamically(specifier, referrer, importAttributes) {
+    let code = "import(\"foo.json\", { with: { type: \"json\" } })";
+    let context = createContext();
+
+    // $ExpectType Script
+    new Script(code, {
+        importModuleDynamically(specifier, referrer, importAttributes) {
             specifier; // $ExpectType string
             referrer; // $ExpectType Script
             importAttributes; // $ExpectType ImportAttributes
-            const m = new SyntheticModule(["bar"], () => {});
-            await m.link(() => {
-                throw new Error("unreachable");
-            });
-            m.setExport("bar", { hello: "world" });
-            return m;
+
+            const module = new SyntheticModule(["bar"], () => {});
+            return Math.random() < 1 ? module : new Promise(res => res(module));
         },
     });
 
-    const module = new SourceTextModule("import(\"foo.json\", { with: { type: \"json\" } })", {
-        async importModuleDynamically(specifier, referrer, importAttributes) {
+    runInThisContext(code, {
+        importModuleDynamically(specifier, referrer, importAttributes) {
+            specifier; // $ExpectType string
+            referrer; // $ExpectType Script
+            importAttributes; // $ExpectType ImportAttributes
+
+            const module = new SyntheticModule(["bar"], () => {});
+            return Math.random() < 1 ? module : new Promise(res => res(module));
+        },
+    });
+
+    runInContext(code, context, {
+        importModuleDynamically(specifier, referrer, importAttributes) {
+            specifier; // $ExpectType string
+            referrer; // $ExpectType Script
+            importAttributes; // $ExpectType ImportAttributes
+
+            const module = new SyntheticModule(["bar"], () => {});
+            return Math.random() < 1 ? module : new Promise(res => res(module));
+        },
+    });
+
+    runInNewContext(code, context, {
+        importModuleDynamically(specifier, referrer, importAttributes) {
+            specifier; // $ExpectType string
+            referrer; // $ExpectType Script
+            importAttributes; // $ExpectType ImportAttributes
+
+            const module = new SyntheticModule(["bar"], () => {});
+            return Math.random() < 1 ? module : new Promise(res => res(module));
+        },
+    });
+
+    compileFunction(code, ["param"], {
+        importModuleDynamically(specifier, referrer, importAttributes) {
+            specifier; // $ExpectType string
+            referrer; // $ExpectType Function & { cachedData?: Buffer<ArrayBufferLike> | undefined; cachedDataProduced?: boolean | undefined; cachedDataRejected?: boolean | undefined; }
+            importAttributes; // $ExpectType ImportAttributes
+
+            const module = new SyntheticModule(["bar"], () => {});
+            return Math.random() < 1 ? module : new Promise(res => res(module));
+        },
+    });
+
+    // $ExpectType SourceTextModule
+    new SourceTextModule(code, {
+        importModuleDynamically(specifier, referrer, importAttributes) {
             specifier; // $ExpectType string
             referrer; // $ExpectType SourceTextModule
             importAttributes; // $ExpectType ImportAttributes
-            const m = new SyntheticModule(["bar"], () => {});
-            await m.link(() => {
-                throw new Error("unreachable");
-            });
-            m.setExport("bar", { hello: "world" });
-            return m;
+
+            const module = new SyntheticModule(["bar"], () => {});
+            return Math.random() < 1 ? module : new Promise(res => res(module));
         },
     });
 }

--- a/types/node/v18/vm.d.ts
+++ b/types/node/v18/vm.d.ts
@@ -56,6 +56,11 @@ declare module "vm" {
          */
         columnOffset?: number | undefined;
     }
+    type DynamicModuleLoader<T> = (
+        specifier: string,
+        referrer: T,
+        importAttributes: ImportAttributes,
+    ) => Module | Promise<Module>;
     interface ScriptOptions extends BaseOptions {
         /**
          * Provides an optional data with V8's code cache data for the supplied source.
@@ -66,10 +71,10 @@ declare module "vm" {
         /**
          * Called during evaluation of this module when `import()` is called.
          * If this option is not specified, calls to `import()` will reject with `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING`.
+         * This option is part of the experimental modules API. We do not recommend using it in a production environment.
+         * If `--experimental-vm-modules` isn't set, this callback will be ignored and calls to `import()` will reject with `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG`.
          */
-        importModuleDynamically?:
-            | ((specifier: string, script: Script, importAttributes: ImportAttributes) => Module | Promise<Module>)
-            | undefined;
+        importModuleDynamically?: DynamicModuleLoader<Script> | undefined;
     }
     interface RunningScriptOptions extends BaseOptions {
         /**
@@ -112,14 +117,26 @@ declare module "vm" {
          * Provides an optional data with V8's code cache data for the supplied source.
          */
         cachedData?: ScriptOptions["cachedData"] | undefined;
-        importModuleDynamically?: ScriptOptions["importModuleDynamically"];
+        /**
+         * Called during evaluation of this module when `import()` is called.
+         * If this option is not specified, calls to `import()` will reject with `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING`.
+         * This option is part of the experimental modules API. We do not recommend using it in a production environment.
+         * If `--experimental-vm-modules` isn't set, this callback will be ignored and calls to `import()` will reject with `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG`.
+         */
+        importModuleDynamically?: DynamicModuleLoader<Script> | undefined;
     }
     interface RunningCodeInNewContextOptions extends RunningScriptInNewContextOptions {
         /**
          * Provides an optional data with V8's code cache data for the supplied source.
          */
         cachedData?: ScriptOptions["cachedData"] | undefined;
-        importModuleDynamically?: ScriptOptions["importModuleDynamically"];
+        /**
+         * Called during evaluation of this module when `import()` is called.
+         * If this option is not specified, calls to `import()` will reject with `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING`.
+         * This option is part of the experimental modules API. We do not recommend using it in a production environment.
+         * If `--experimental-vm-modules` isn't set, this callback will be ignored and calls to `import()` will reject with `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG`.
+         */
+        importModuleDynamically?: DynamicModuleLoader<Script> | undefined;
     }
     interface CompileFunctionOptions extends BaseOptions {
         /**
@@ -139,6 +156,13 @@ declare module "vm" {
          * An array containing a collection of context extensions (objects wrapping the current scope) to be applied while compiling
          */
         contextExtensions?: Object[] | undefined;
+        /**
+         * Called during evaluation of this module when `import()` is called.
+         * If this option is not specified, calls to `import()` will reject with `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING`.
+         * This option is part of the experimental modules API. We do not recommend using it in a production environment.
+         * If `--experimental-vm-modules` isn't set, this callback will be ignored and calls to `import()` will reject with `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG`.
+         */
+        importModuleDynamically?: DynamicModuleLoader<ReturnType<typeof compileFunction>> | undefined;
     }
     interface CreateContextOptions {
         /**
@@ -629,13 +653,12 @@ declare module "vm" {
          * Called during evaluation of this module to initialize the `import.meta`.
          */
         initializeImportMeta?: ((meta: ImportMeta, module: SourceTextModule) => void) | undefined;
-        importModuleDynamically?:
-            | ((
-                specifier: string,
-                referrer: SourceTextModule,
-                importAttributes: ImportAttributes,
-            ) => Module | Promise<Module>)
-            | undefined;
+        /**
+         * Called during evaluation of this module when `import()` is called.
+         * If this option is not specified, calls to `import()` will reject with `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING`.
+         * If `--experimental-vm-modules` isn't set, this callback will be ignored and calls to `import()` will reject with `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG`.
+         */
+        importModuleDynamically?: DynamicModuleLoader<SourceTextModule> | undefined;
     }
     class SourceTextModule extends Module {
         /**

--- a/types/node/v20/test/vm.ts
+++ b/types/node/v20/test/vm.ts
@@ -1,10 +1,12 @@
 import { inspect } from "node:util";
 import {
     compileFunction,
+    constants,
     createContext,
     isContext,
     measureMemory,
     MemoryMeasurement,
+    runInContext,
     runInNewContext,
     runInThisContext,
     Script,
@@ -177,31 +179,118 @@ import {
 });
 
 {
-    const script = new Script("import(\"foo.json\", { with: { type: \"json\" } })", {
-        async importModuleDynamically(specifier, referrer, importAttributes) {
+    let code = "import(\"foo.json\", { with: { type: \"json\" } })";
+    let context = createContext();
+
+    // $ExpectType Script
+    new Script(code, {
+        importModuleDynamically(specifier, referrer, importAttributes) {
             specifier; // $ExpectType string
             referrer; // $ExpectType Script
             importAttributes; // $ExpectType ImportAttributes
-            const m = new SyntheticModule(["bar"], () => {});
-            await m.link(() => {
-                throw new Error("unreachable");
-            });
-            m.setExport("bar", { hello: "world" });
-            return m;
+
+            const module = new SyntheticModule(["bar"], () => {});
+            return Math.random() < 1 ? module : new Promise(res => res(module));
         },
     });
 
-    const module = new SourceTextModule("import(\"foo.json\", { with: { type: \"json\" } })", {
-        async importModuleDynamically(specifier, referrer, importAttributes) {
+    // $ExpectType Script
+    new Script(code, {
+        importModuleDynamically: constants.USE_MAIN_CONTEXT_DEFAULT_LOADER,
+    });
+
+    runInThisContext(code, {
+        importModuleDynamically(specifier, referrer, importAttributes) {
+            specifier; // $ExpectType string
+            referrer; // $ExpectType Script
+            importAttributes; // $ExpectType ImportAttributes
+
+            const module = new SyntheticModule(["bar"], () => {});
+            return Math.random() < 1 ? module : new Promise(res => res(module));
+        },
+    });
+
+    runInThisContext(code, {
+        importModuleDynamically: constants.USE_MAIN_CONTEXT_DEFAULT_LOADER,
+    });
+
+    runInContext(code, context, {
+        importModuleDynamically(specifier, referrer, importAttributes) {
+            specifier; // $ExpectType string
+            referrer; // $ExpectType Script
+            importAttributes; // $ExpectType ImportAttributes
+
+            const module = new SyntheticModule(["bar"], () => {});
+            return Math.random() < 1 ? module : new Promise(res => res(module));
+        },
+    });
+
+    runInContext(code, context, {
+        importModuleDynamically: constants.USE_MAIN_CONTEXT_DEFAULT_LOADER,
+    });
+
+    runInNewContext(code, context, {
+        importModuleDynamically(specifier, referrer, importAttributes) {
+            specifier; // $ExpectType string
+            referrer; // $ExpectType Script
+            importAttributes; // $ExpectType ImportAttributes
+
+            const module = new SyntheticModule(["bar"], () => {});
+            return Math.random() < 1 ? module : new Promise(res => res(module));
+        },
+    });
+
+    runInNewContext(code, context, {
+        importModuleDynamically: constants.USE_MAIN_CONTEXT_DEFAULT_LOADER,
+    });
+
+    compileFunction(code, ["param"], {
+        importModuleDynamically(specifier, referrer, importAttributes) {
+            specifier; // $ExpectType string
+            referrer; // $ExpectType Function & { cachedData?: Buffer<ArrayBufferLike> | undefined; cachedDataProduced?: boolean | undefined; cachedDataRejected?: boolean | undefined; }
+            importAttributes; // $ExpectType ImportAttributes
+
+            const module = new SyntheticModule(["bar"], () => {});
+            return Math.random() < 1 ? module : new Promise(res => res(module));
+        },
+    });
+
+    compileFunction(code, ["param"], {
+        importModuleDynamically: constants.USE_MAIN_CONTEXT_DEFAULT_LOADER,
+    });
+
+    // $ExpectType SourceTextModule
+    new SourceTextModule(code, {
+        importModuleDynamically(specifier, referrer, importAttributes) {
             specifier; // $ExpectType string
             referrer; // $ExpectType SourceTextModule
             importAttributes; // $ExpectType ImportAttributes
-            const m = new SyntheticModule(["bar"], () => {});
-            await m.link(() => {
-                throw new Error("unreachable");
-            });
-            m.setExport("bar", { hello: "world" });
-            return m;
+
+            const module = new SyntheticModule(["bar"], () => {});
+            return Math.random() < 1 ? module : new Promise(res => res(module));
         },
+    });
+
+    // $ExpectType SourceTextModule
+    new SourceTextModule(code, {
+        // @ts-expect-error - `options.importModuleDynamically` is not supported in SourceTextModule
+        importModuleDynamically: constants.USE_MAIN_CONTEXT_DEFAULT_LOADER,
+    });
+
+    // $ExpectType Context
+    createContext(context, {
+        importModuleDynamically(specifier, referrer, importAttributes) {
+            specifier; // $ExpectType string
+            referrer; // $ExpectType Context
+            importAttributes; // $ExpectType ImportAttributes
+
+            const module = new SyntheticModule(["bar"], () => {});
+            return Math.random() < 1 ? module : new Promise(res => res(module));
+        },
+    });
+
+    // $ExpectType Context
+    createContext(context, {
+        importModuleDynamically: constants.USE_MAIN_CONTEXT_DEFAULT_LOADER,
     });
 }

--- a/types/node/v20/vm.d.ts
+++ b/types/node/v20/vm.d.ts
@@ -56,6 +56,11 @@ declare module "vm" {
          */
         columnOffset?: number | undefined;
     }
+    type DynamicModuleLoader<T> = (
+        specifier: string,
+        referrer: T,
+        importAttributes: ImportAttributes,
+    ) => Module | Promise<Module>;
     interface ScriptOptions extends BaseOptions {
         /**
          * Provides an optional data with V8's code cache data for the supplied source.
@@ -69,7 +74,7 @@ declare module "vm" {
          * [Support of dynamic `import()` in compilation APIs](https://nodejs.org/docs/latest-v20.x/api/vm.html#support-of-dynamic-import-in-compilation-apis).
          */
         importModuleDynamically?:
-            | ((specifier: string, script: Script, importAttributes: ImportAttributes) => Module | Promise<Module>)
+            | DynamicModuleLoader<Script>
             | typeof constants.USE_MAIN_CONTEXT_DEFAULT_LOADER
             | undefined;
     }
@@ -114,14 +119,30 @@ declare module "vm" {
          * Provides an optional data with V8's code cache data for the supplied source.
          */
         cachedData?: ScriptOptions["cachedData"] | undefined;
-        importModuleDynamically?: ScriptOptions["importModuleDynamically"];
+        /**
+         * Used to specify how the modules should be loaded during the evaluation of this script when `import()` is called. This option is
+         * part of the experimental modules API. We do not recommend using it in a production environment. For detailed information, see
+         * [Support of dynamic `import()` in compilation APIs](https://nodejs.org/docs/latest-v22.x/api/vm.html#support-of-dynamic-import-in-compilation-apis).
+         */
+        importModuleDynamically?:
+            | DynamicModuleLoader<Script>
+            | typeof constants.USE_MAIN_CONTEXT_DEFAULT_LOADER
+            | undefined;
     }
     interface RunningCodeInNewContextOptions extends RunningScriptInNewContextOptions {
         /**
          * Provides an optional data with V8's code cache data for the supplied source.
          */
         cachedData?: ScriptOptions["cachedData"] | undefined;
-        importModuleDynamically?: ScriptOptions["importModuleDynamically"];
+        /**
+         * Used to specify how the modules should be loaded during the evaluation of this script when `import()` is called. This option is
+         * part of the experimental modules API. We do not recommend using it in a production environment. For detailed information, see
+         * [Support of dynamic `import()` in compilation APIs](https://nodejs.org/docs/latest-v22.x/api/vm.html#support-of-dynamic-import-in-compilation-apis).
+         */
+        importModuleDynamically?:
+            | DynamicModuleLoader<Script>
+            | typeof constants.USE_MAIN_CONTEXT_DEFAULT_LOADER
+            | undefined;
     }
     interface CompileFunctionOptions extends BaseOptions {
         /**
@@ -141,6 +162,15 @@ declare module "vm" {
          * An array containing a collection of context extensions (objects wrapping the current scope) to be applied while compiling
          */
         contextExtensions?: Object[] | undefined;
+        /**
+         * Used to specify how the modules should be loaded during the evaluation of this script when `import()` is called. This option is
+         * part of the experimental modules API. We do not recommend using it in a production environment. For detailed information, see
+         * [Support of dynamic `import()` in compilation APIs](https://nodejs.org/docs/latest-v22.x/api/vm.html#support-of-dynamic-import-in-compilation-apis).
+         */
+        importModuleDynamically?:
+            | DynamicModuleLoader<ReturnType<typeof compileFunction>>
+            | typeof constants.USE_MAIN_CONTEXT_DEFAULT_LOADER
+            | undefined;
     }
     interface CreateContextOptions {
         /**
@@ -175,6 +205,15 @@ declare module "vm" {
          * If set to `afterEvaluate`, microtasks will be run immediately after the script has run.
          */
         microtaskMode?: "afterEvaluate" | undefined;
+        /**
+         * Used to specify how the modules should be loaded during the evaluation of this script when `import()` is called. This option is
+         * part of the experimental modules API. We do not recommend using it in a production environment. For detailed information, see
+         * [Support of dynamic `import()` in compilation APIs](https://nodejs.org/docs/latest-v22.x/api/vm.html#support-of-dynamic-import-in-compilation-apis).
+         */
+        importModuleDynamically?:
+            | DynamicModuleLoader<Context>
+            | typeof constants.USE_MAIN_CONTEXT_DEFAULT_LOADER
+            | undefined;
     }
     type MeasureMemoryMode = "summary" | "detailed";
     interface MeasureMemoryOptions {
@@ -824,13 +863,12 @@ declare module "vm" {
          * Called during evaluation of this module to initialize the `import.meta`.
          */
         initializeImportMeta?: ((meta: ImportMeta, module: SourceTextModule) => void) | undefined;
-        importModuleDynamically?:
-            | ((
-                specifier: string,
-                referrer: SourceTextModule,
-                importAttributes: ImportAttributes,
-            ) => Module | Promise<Module>)
-            | undefined;
+        /**
+         * Used to specify how the modules should be loaded during the evaluation of this script when `import()` is called. This option is
+         * part of the experimental modules API. We do not recommend using it in a production environment. For detailed information, see
+         * [Support of dynamic `import()` in compilation APIs](https://nodejs.org/docs/latest-v22.x/api/vm.html#support-of-dynamic-import-in-compilation-apis).
+         */
+        importModuleDynamically?: DynamicModuleLoader<SourceTextModule> | undefined;
     }
     /**
      * This feature is only available with the `--experimental-vm-modules` command

--- a/types/node/vm.d.ts
+++ b/types/node/vm.d.ts
@@ -56,6 +56,11 @@ declare module "vm" {
          */
         columnOffset?: number | undefined;
     }
+    type DynamicModuleLoader<T> = (
+        specifier: string,
+        referrer: T,
+        importAttributes: ImportAttributes,
+    ) => Module | Promise<Module>;
     interface ScriptOptions extends BaseOptions {
         /**
          * Provides an optional data with V8's code cache data for the supplied source.
@@ -69,7 +74,7 @@ declare module "vm" {
          * [Support of dynamic `import()` in compilation APIs](https://nodejs.org/docs/latest-v22.x/api/vm.html#support-of-dynamic-import-in-compilation-apis).
          */
         importModuleDynamically?:
-            | ((specifier: string, script: Script, importAttributes: ImportAttributes) => Module | Promise<Module>)
+            | DynamicModuleLoader<Script>
             | typeof constants.USE_MAIN_CONTEXT_DEFAULT_LOADER
             | undefined;
     }
@@ -114,14 +119,30 @@ declare module "vm" {
          * Provides an optional data with V8's code cache data for the supplied source.
          */
         cachedData?: ScriptOptions["cachedData"] | undefined;
-        importModuleDynamically?: ScriptOptions["importModuleDynamically"];
+        /**
+         * Used to specify how the modules should be loaded during the evaluation of this script when `import()` is called. This option is
+         * part of the experimental modules API. We do not recommend using it in a production environment. For detailed information, see
+         * [Support of dynamic `import()` in compilation APIs](https://nodejs.org/docs/latest-v22.x/api/vm.html#support-of-dynamic-import-in-compilation-apis).
+         */
+        importModuleDynamically?:
+            | DynamicModuleLoader<Script>
+            | typeof constants.USE_MAIN_CONTEXT_DEFAULT_LOADER
+            | undefined;
     }
     interface RunningCodeInNewContextOptions extends RunningScriptInNewContextOptions {
         /**
          * Provides an optional data with V8's code cache data for the supplied source.
          */
         cachedData?: ScriptOptions["cachedData"] | undefined;
-        importModuleDynamically?: ScriptOptions["importModuleDynamically"];
+        /**
+         * Used to specify how the modules should be loaded during the evaluation of this script when `import()` is called. This option is
+         * part of the experimental modules API. We do not recommend using it in a production environment. For detailed information, see
+         * [Support of dynamic `import()` in compilation APIs](https://nodejs.org/docs/latest-v22.x/api/vm.html#support-of-dynamic-import-in-compilation-apis).
+         */
+        importModuleDynamically?:
+            | DynamicModuleLoader<Script>
+            | typeof constants.USE_MAIN_CONTEXT_DEFAULT_LOADER
+            | undefined;
     }
     interface CompileFunctionOptions extends BaseOptions {
         /**
@@ -141,6 +162,15 @@ declare module "vm" {
          * An array containing a collection of context extensions (objects wrapping the current scope) to be applied while compiling
          */
         contextExtensions?: Object[] | undefined;
+        /**
+         * Used to specify how the modules should be loaded during the evaluation of this script when `import()` is called. This option is
+         * part of the experimental modules API. We do not recommend using it in a production environment. For detailed information, see
+         * [Support of dynamic `import()` in compilation APIs](https://nodejs.org/docs/latest-v22.x/api/vm.html#support-of-dynamic-import-in-compilation-apis).
+         */
+        importModuleDynamically?:
+            | DynamicModuleLoader<ReturnType<typeof compileFunction>>
+            | typeof constants.USE_MAIN_CONTEXT_DEFAULT_LOADER
+            | undefined;
     }
     interface CreateContextOptions {
         /**
@@ -175,6 +205,15 @@ declare module "vm" {
          * If set to `afterEvaluate`, microtasks will be run immediately after the script has run.
          */
         microtaskMode?: "afterEvaluate" | undefined;
+        /**
+         * Used to specify how the modules should be loaded during the evaluation of this script when `import()` is called. This option is
+         * part of the experimental modules API. We do not recommend using it in a production environment. For detailed information, see
+         * [Support of dynamic `import()` in compilation APIs](https://nodejs.org/docs/latest-v22.x/api/vm.html#support-of-dynamic-import-in-compilation-apis).
+         */
+        importModuleDynamically?:
+            | DynamicModuleLoader<Context>
+            | typeof constants.USE_MAIN_CONTEXT_DEFAULT_LOADER
+            | undefined;
     }
     type MeasureMemoryMode = "summary" | "detailed";
     interface MeasureMemoryOptions {
@@ -865,13 +904,12 @@ declare module "vm" {
          * Called during evaluation of this module to initialize the `import.meta`.
          */
         initializeImportMeta?: ((meta: ImportMeta, module: SourceTextModule) => void) | undefined;
-        importModuleDynamically?:
-            | ((
-                specifier: string,
-                referrer: SourceTextModule,
-                importAttributes: ImportAttributes,
-            ) => Module | Promise<Module>)
-            | undefined;
+        /**
+         * Used to specify how the modules should be loaded during the evaluation of this script when `import()` is called. This option is
+         * part of the experimental modules API. We do not recommend using it in a production environment. For detailed information, see
+         * [Support of dynamic `import()` in compilation APIs](https://nodejs.org/docs/latest-v22.x/api/vm.html#support-of-dynamic-import-in-compilation-apis).
+         */
+        importModuleDynamically?: DynamicModuleLoader<SourceTextModule> | undefined;
     }
     /**
      * This feature is only available with the `--experimental-vm-modules` command


### PR DESCRIPTION
Introduce the complete typing for `importModuleDynamically` based on documentation, https://nodejs.org/docs/latest/api/vm.html#support-of-dynamic-import-in-compilation-apis.

- Noted that v22 & v20 adapt the same code change. 
- Since v18 does not have support for *When `importModuleDynamically` is `vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER`*, the type change there is slightly different than the change in v2x one.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
