### PR TITLE
feat(compression): add brotli options and enforceEncoding support

### DIFF
--- a/types/compression/compression-tests.ts
+++ b/types/compression/compression-tests.ts
@@ -24,8 +24,8 @@ app.use(
         brotli: {
             params: {
                 [zlib.constants.BROTLI_PARAM_QUALITY]: 4,
-                [zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_DEFAULT_MODE
-            }
+                [zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_DEFAULT_MODE,
+            },
         },
         info: true,
     }),
@@ -45,7 +45,7 @@ app.use(
     }),
 );
 
-app.use(compression({ enforceEncoding: 'br' }))
+app.use(compression({ enforceEncoding: "br" }));
 
 // compression.filter
 

--- a/types/compression/compression-tests.ts
+++ b/types/compression/compression-tests.ts
@@ -20,6 +20,13 @@ app.use(
         flush: zlib.constants.Z_NO_FLUSH,
         finishFlush: zlib.constants.Z_FINISH,
         dictionary: Buffer.from("Hello World!"),
+        // brotli options
+        brotli: {
+            params: {
+                [zlib.constants.BROTLI_PARAM_QUALITY]: 4,
+                [zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_DEFAULT_MODE
+            }
+        },
         info: true,
     }),
 );
@@ -37,6 +44,8 @@ app.use(
         },
     }),
 );
+
+app.use(compression({ enforceEncoding: 'br' }))
 
 // compression.filter
 

--- a/types/compression/index.d.ts
+++ b/types/compression/index.d.ts
@@ -87,7 +87,7 @@ declare namespace compression {
          */
         brotli?: zlib.BrotliOptions | undefined;
 
-        /** 
+        /**
          * This is the default encoding to use when the client does not specify an encoding in the request's Accept-Encoding header.
          * @default 'identity'
          */

--- a/types/compression/index.d.ts
+++ b/types/compression/index.d.ts
@@ -1,4 +1,5 @@
 import express = require("express");
+import * as zlib from "zlib";
 
 // This module adds a res.flush() method to force the partially-compressed response to be flushed to the client.
 
@@ -80,6 +81,17 @@ declare namespace compression {
          * @see {@link https://www.npmjs.com/package/compressible|compressible module}
          */
         filter?: CompressionFilter | undefined;
+
+        /**
+         * Options for brotli compression.
+         */
+        brotli?: zlib.BrotliOptions | undefined;
+
+        /** 
+         * This is the default encoding to use when the client does not specify an encoding in the request's Accept-Encoding header.
+         * @default 'identity'
+         */
+        enforceEncoding?: string | undefined;
 
         /**
          * The level of zlib compression to apply to responses. A higher level will result in better compression, but

--- a/types/compression/package.json
+++ b/types/compression/package.json
@@ -6,11 +6,12 @@
         "https://github.com/expressjs/compression"
     ],
     "dependencies": {
-        "@types/express": "*"
+        "@types/express": "*",
+        "@types/node": "*"
+
     },
     "devDependencies": {
-        "@types/compression": "workspace:.",
-        "@types/node": "*"
+        "@types/compression": "workspace:."
     },
     "owners": [
         {

--- a/types/compression/package.json
+++ b/types/compression/package.json
@@ -8,7 +8,6 @@
     "dependencies": {
         "@types/express": "*",
         "@types/node": "*"
-
     },
     "devDependencies": {
         "@types/compression": "workspace:."

--- a/types/compression/package.json
+++ b/types/compression/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/compression",
-    "version": "1.7.9999",
+    "version": "1.8.9999",
     "projects": [
         "https://github.com/expressjs/compression"
     ],


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/expressjs/compression/pull/194, https://github.com/expressjs/compression/pull/191
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
