### PR TITLE
Fix type for babel declare function in babel__helper-plugin-utils

### DIFF
--- a/types/babel__helper-plugin-utils/index.d.ts
+++ b/types/babel__helper-plugin-utils/index.d.ts
@@ -3,7 +3,7 @@ import type * as babel from "@babel/core";
 export type BabelAPI = typeof babel & babel.ConfigAPI;
 export function declare<
     O extends Record<string, any>,
-    R extends babel.PluginObj = babel.PluginObj,
+    R extends babel.PluginObj<any> = babel.PluginObj,
 >(
     builder: (api: BabelAPI, options: O, dirname: string) => R,
 ): (api: object, options: O | null | undefined, dirname: string) => R;


### PR DESCRIPTION
`PluginObj` is a parameterized type, but the parameter defaults to `PluginPass` if none is passed.

When trying to create my own babel plugin, I'm unable to set a unique type for state because of this, since it isn't exactly matching `PluginPass` (but does extend `PluginPass`).

Example:
```
type Options = {};

interface PluginState extends PluginPass {
  _shouldImport?: boolean;
}

declare<Options, PluginObj<PluginState>>(...); // errors because PluginObj<PluginState> does not satisfy the constraint of PluginObj<PluginPass>
```


- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>