### PR TITLE
[@types/react] Remove duplicate useReducer type definition

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1694,20 +1694,6 @@ declare namespace React {
      * @version 16.8.0
      * @see {@link https://react.dev/reference/react/useReducer}
      */
-    function useReducer<S, A extends AnyActionArg>(
-        reducer: (prevState: S, ...args: A) => S,
-        initialState: S,
-    ): [S, ActionDispatch<A>];
-    /**
-     * An alternative to `useState`.
-     *
-     * `useReducer` is usually preferable to `useState` when you have complex state logic that involves
-     * multiple sub-values. It also lets you optimize performance for components that trigger deep
-     * updates because you can pass `dispatch` down instead of callbacks.
-     *
-     * @version 16.8.0
-     * @see {@link https://react.dev/reference/react/useReducer}
-     */
     function useReducer<S, I, A extends AnyActionArg>(
         reducer: (prevState: S, ...args: A) => S,
         initialArg: I,

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -1693,20 +1693,6 @@ declare namespace React {
      * @version 16.8.0
      * @see {@link https://react.dev/reference/react/useReducer}
      */
-    function useReducer<S, A extends AnyActionArg>(
-        reducer: (prevState: S, ...args: A) => S,
-        initialState: S,
-    ): [S, ActionDispatch<A>];
-    /**
-     * An alternative to `useState`.
-     *
-     * `useReducer` is usually preferable to `useState` when you have complex state logic that involves
-     * multiple sub-values. It also lets you optimize performance for components that trigger deep
-     * updates because you can pass `dispatch` down instead of callbacks.
-     *
-     * @version 16.8.0
-     * @see {@link https://react.dev/reference/react/useReducer}
-     */
     function useReducer<S, I, A extends AnyActionArg>(
         reducer: (prevState: S, ...args: A) => S,
         initialArg: I,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/72751>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
