### PR TITLE
[postman-collection] Add "description" types to the collection's "info" object

### DIFF
--- a/types/postman-collection/index.d.ts
+++ b/types/postman-collection/index.d.ts
@@ -180,6 +180,11 @@ export interface CollectionDefinition extends ItemGroupDefinition {
         id?: string | undefined;
         name?: string | undefined;
         version?: string | undefined;
+        description?: {
+            content?: string | undefined;
+            type?: string | undefined;
+            version?: string | undefined;
+        } | undefined;
     } | undefined;
     variable?: VariableDefinition[] | undefined;
 }

--- a/types/postman-collection/postman-collection-tests.ts
+++ b/types/postman-collection/postman-collection-tests.ts
@@ -153,7 +153,7 @@ pmCollection.ItemGroup.isItemGroup(ig); // $ExpectType boolean
 
 // CollectionDefinition Tests
 const colDef: pmCollection.CollectionDefinition = {};
-colDef.info; // $ExpectType { id?: string | undefined; name?: string | undefined; version?: string | undefined; } | undefined
+colDef.info; // $ExpectType { id?: string | undefined; name?: string | undefined; version?: string | undefined; description?: { content?: string | undefined; type?: string | undefined; version?: string | undefined; } | undefined; } | undefined
 colDef.variable; // $ExpectType VariableDefinition[] | undefined
 
 let collection: pmCollection.Collection;


### PR DESCRIPTION
These types are missing the `description` object for the Collection's `info` property. See [the Postman documentation](https://learning.postman.com/collection-format/reference/info/) for what this object should look like.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://learning.postman.com/collection-format/reference/info/
