### PR TITLE
fix(forge-viewer): add optional RegExp parameters to getPropertyHashes

### DIFF
--- a/types/forge-viewer/forge-viewer-tests.ts
+++ b/types/forge-viewer/forge-viewer-tests.ts
@@ -689,6 +689,7 @@ async function selectiveLoadingTest(viewer: Autodesk.Viewing.GuiViewer3D): Promi
     await viewer.waitForLoadDone();
 
     const propHashes = await fakeLoadedModel.getPropertyHashes();
+    const propHashesWithFiltering = await fakeLoadedModel.getPropertyHashes(/name/, /category/);
     viewer.unloadDocumentNode(fakeLoadedModel.getDocumentNode());
 
     const matches = JSON.stringify(query).matchAll(/(["'])\?([\w\d\s]+)\1/g);

--- a/types/forge-viewer/index.d.ts
+++ b/types/forge-viewer/index.d.ts
@@ -783,7 +783,7 @@ declare namespace Autodesk {
                     needsExternalId?: boolean | undefined;
                 },
             ): Promise<PropertySet>;
-            getPropertyHashes(): Promise<string[]>;
+            getPropertyHashes(nameRE?: RegExp, categoryRE?: RegExp): Promise<string[]>;
             geomPolyCount(): number;
             getDefaultCamera(): THREE.Camera;
             getDisplayUnit(): string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://aps.autodesk.com/en/docs/viewer/v7/reference/Viewing/Model/#getpropertyhashes-namere-categoryre)>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.


📝 Description:
This PR updates the type definition for the `getPropertyHashes` method to:

1. Add support for name and category RegExp filtering parameters
2. Make these parameters optional to match the actual implementation

The existing APS SDK viewer works without providing these parameters (as seen in the test file), but the type definition previously didn't account for optional filtering. After examining the actual implementation code and the official documentation (https://aps.autodesk.com/en/docs/viewer/v7/reference/Viewing/Model/#getpropertyhashes-namere-categoryre), I've updated the signature to better reflect how the method behaves in practice.

The official documentation confirms these parameters are meant for filtering results by property name and category using regular expressions, but the implementation allows calling the method without parameters to get all property hashes.

Changes:
- Updated `getPropertyHashes()` in index.d.ts to accept optional RegExp parameters
- Added a new implementation in the test file showing how to use the filtering