### PR TITLE
feat(react/v19): update RefCallback typing

### DIFF
--- a/types/react-slider/index.d.ts
+++ b/types/react-slider/index.d.ts
@@ -179,7 +179,7 @@ export interface ReactSliderProps<T extends number | readonly number[] = number>
      *
      * @default props => <div {...props} />
      */
-    renderMark?: ((props: HTMLPropsWithRefCallback<HTMLSpanElement>) => JSX.Element | null) | undefined;
+    renderMark?: ((props: HTMLPropsWithRefCallback<HTMLSpanElement | null>) => JSX.Element | null) | undefined;
 
     /**
      * Provide a custom render function for dynamic thumb content.

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -169,14 +169,46 @@ declare namespace React {
      * @example
      *
      * ```tsx
+     * const withCleanup: RefCallback<HTMLElement> = (element) => {
+     *   // attached logic...
+     *
+     *   // Cleanup logic
+     *   return () => {
+     *     // ...
+     *   };
+     * }
+     * <div ref={withCleanup} />
+     *
+     * const withoutCleanup: RefCallback<HTMLElement | null> = (element) => {
+     *   // attached logic...
+     * }
+     * <div ref={withCleanup} />
+     * ```
+     */
+    type RefCallback<T> = (current: T) =>
+        | VoidOrUndefinedOnly
+        | (null extends T ? never : (() => VoidOrUndefinedOnly))
+        | DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES[
+            keyof DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES
+        ];
+    /**
+     * The default shape for the callback fired whenever the ref's value changes.
+     *
+     * @template T The type of the ref's value.
+     *
+     * @see {@link https://react.dev/reference/react-dom/components/common#ref-callback React Docs}
+     *
+     * @example
+     *
+     * ```tsx
      * <div ref={(node) => console.log(node)} />
      * ```
      */
-    type RefCallback<T> = {
+    type RefCallbackDefault<T> = {
         bivarianceHack(
             instance: T | null,
         ):
-            | void
+            | VoidOrUndefinedOnly
             | (() => VoidOrUndefinedOnly)
             | DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES[
                 keyof DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES
@@ -186,11 +218,11 @@ declare namespace React {
     /**
      * A union type of all possible shapes for React refs.
      *
-     * @see {@link RefCallback}
+     * @see {@link RefCallbackDefault}
      * @see {@link RefObject}
      */
 
-    type Ref<T> = RefCallback<T> | RefObject<T | null> | null;
+    type Ref<T> = RefCallbackDefault<T> | RefObject<T | null> | null;
     /**
      * @deprecated Use `Ref` instead. String refs are no longer supported.
      * If you're typing a library with support for React versions with string refs, use `RefAttributes<T>['ref']` instead.

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -864,7 +864,7 @@ function managingRefs() {
     // ref cleanup
     const ref: React.RefCallback<HTMLDivElement> = current => {
         // Should be non-nullable
-        // $ExpectType HTMLDivElement | null
+        // $ExpectType HTMLDivElement
         current;
         return function refCleanup() {
         };
@@ -893,4 +893,68 @@ function managingRefs() {
             };
         }}
     />;
+    // ref cleanup, with explicit React.RefCallback, non-nullable
+    {
+        let ref: React.RefCallback<HTMLDivElement>;
+
+        ref = current => {
+            // $ExpectType HTMLDivElement
+            current;
+            return function refCleanup() {
+            };
+        };
+
+        ref = current => {
+            // $ExpectType HTMLDivElement
+            current;
+        };
+
+        <div ref={ref} />;
+    }
+    // ref cleanup, with explicit React.RefCallback, nullable
+    {
+        let ref: React.RefCallback<HTMLDivElement | null>;
+
+        ref = current => {
+            // $ExpectType HTMLDivElement | null
+            current;
+        };
+
+        // @ts-expect-error - With a cleanup callback as return value, element can never be null
+        ref = current => {
+            // $ExpectType HTMLDivElement | null
+            current;
+            return () => {
+            };
+        };
+
+        <div ref={ref} />;
+    }
+    // ref cleanup, with inline ref
+    {
+        <div
+            ref={current => {
+                // Should be non-nullable
+                // $ExpectType HTMLDivElement | null
+                current;
+                return function refCleanup() {
+                };
+            }}
+        />;
+        <div
+            // @ts-expect-error ref cleanup does not accept arguments
+            ref={current => {
+                // @ts-expect-error
+                return function refCleanup(implicitAny) {
+                };
+            }}
+        />;
+        <div
+            // @ts-expect-error ref cleanup does not accept arguments
+            ref={current => {
+                return function refCleanup(neverPassed: string) {
+                };
+            }}
+        />;
+    }
 }

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -169,14 +169,46 @@ declare namespace React {
      * @example
      *
      * ```tsx
+     * const withCleanup: RefCallback<HTMLElement> = (element) => {
+     *   // attached logic...
+     *
+     *   // Cleanup logic
+     *   return () => {
+     *     // ...
+     *   };
+     * }
+     * <div ref={withCleanup} />
+     *
+     * const withoutCleanup: RefCallback<HTMLElement | null> = (element) => {
+     *   // attached logic...
+     * }
+     * <div ref={withCleanup} />
+     * ```
+     */
+    type RefCallback<T> = (current: T) =>
+        | VoidOrUndefinedOnly
+        | (null extends T ? never : (() => VoidOrUndefinedOnly))
+        | DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES[
+            keyof DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES
+        ];
+    /**
+     * The default shape for the callback fired whenever the ref's value changes.
+     *
+     * @template T The type of the ref's value.
+     *
+     * @see {@link https://react.dev/reference/react-dom/components/common#ref-callback React Docs}
+     *
+     * @example
+     *
+     * ```tsx
      * <div ref={(node) => console.log(node)} />
      * ```
      */
-    type RefCallback<T> = {
+    type RefCallbackDefault<T> = {
         bivarianceHack(
             instance: T | null,
         ):
-            | void
+            | VoidOrUndefinedOnly
             | (() => VoidOrUndefinedOnly)
             | DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES[
                 keyof DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES
@@ -186,11 +218,11 @@ declare namespace React {
     /**
      * A union type of all possible shapes for React refs.
      *
-     * @see {@link RefCallback}
+     * @see {@link RefCallbackDefault}
      * @see {@link RefObject}
      */
 
-    type Ref<T> = RefCallback<T> | RefObject<T | null> | null;
+    type Ref<T> = RefCallbackDefault<T> | RefObject<T | null> | null;
     /**
      * @deprecated Use `Ref` instead. String refs are no longer supported.
      * If you're typing a library with support for React versions with string refs, use `RefAttributes<T>['ref']` instead.

--- a/types/react/ts5.0/test/tsx.tsx
+++ b/types/react/ts5.0/test/tsx.tsx
@@ -868,7 +868,7 @@ function managingRefs() {
     // ref cleanup
     const ref: React.RefCallback<HTMLDivElement> = current => {
         // Should be non-nullable
-        // $ExpectType HTMLDivElement | null
+        // $ExpectType HTMLDivElement
         current;
         return function refCleanup() {
         };
@@ -897,4 +897,68 @@ function managingRefs() {
             };
         }}
     />;
+    // ref cleanup, with explicit React.RefCallback, non-nullable
+    {
+        let ref: React.RefCallback<HTMLDivElement>;
+
+        ref = current => {
+            // $ExpectType HTMLDivElement
+            current;
+            return function refCleanup() {
+            };
+        };
+
+        ref = current => {
+            // $ExpectType HTMLDivElement
+            current;
+        };
+
+        <div ref={ref} />;
+    }
+    // ref cleanup, with explicit React.RefCallback, nullable
+    {
+        let ref: React.RefCallback<HTMLDivElement | null>;
+
+        ref = current => {
+            // $ExpectType HTMLDivElement | null
+            current;
+        };
+
+        // @ts-expect-error - With a cleanup callback as return value, element can never be null
+        ref = current => {
+            // $ExpectType HTMLDivElement | null
+            current;
+            return () => {
+            };
+        };
+
+        <div ref={ref} />;
+    }
+    // ref cleanup, with inline ref
+    {
+        <div
+            ref={current => {
+                // Should be non-nullable
+                // $ExpectType HTMLDivElement | null
+                current;
+                return function refCleanup() {
+                };
+            }}
+        />;
+        <div
+            // @ts-expect-error ref cleanup does not accept arguments
+            ref={current => {
+                // @ts-expect-error
+                return function refCleanup(implicitAny) {
+                };
+            }}
+        />;
+        <div
+            // @ts-expect-error ref cleanup does not accept arguments
+            ref={current => {
+                return function refCleanup(neverPassed: string) {
+                };
+            }}
+        />;
+    }
 }


### PR DESCRIPTION
Open this PR in answering discussion https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/72776.

> React 19 added support for ref cleanup functions: https://react.dev/blog/2024/12/05/react-19#cleanup-functions-for-refs
>
> React docs: https://react.dev/reference/react-dom/components/common#ref-callback
>
> When returning a cleanup function, the ref callback argument can never be `null`.
>
> Would it be possible to update the `RefCallback` type to reflect this?
>
> ```tsx
> import type { RefCallback } from 'react';
>
> const ref: RefCallback<HTMLElement> = (el) => {
>   // Expected type: `HTMLElement` only
>   // Actual type: `HTMLElement | null`
>   el;
>   return () => {};
> };
> ```

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
