### PR TITLE
[n3] Turn type checking functions into type predicates

### DIFF
--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -373,11 +373,11 @@ export interface StoreOptions {
 }
 
 export namespace Util {
-    function isNamedNode(value: RDF.Term | null): boolean;
-    function isBlankNode(value: RDF.Term | null): boolean;
-    function isLiteral(value: RDF.Term | null): boolean;
-    function isVariable(value: RDF.Term | null): boolean;
-    function isDefaultGraph(value: RDF.Term | null): boolean;
+    function isNamedNode(value: RDF.Term | null): value is RDF.NamedNode;
+    function isBlankNode(value: RDF.Term | null): value is RDF.BlankNode;
+    function isLiteral(value: RDF.Term | null): value is RDF.Literal;
+    function isVariable(value: RDF.Term | null): value is RDF.Variable;
+    function isDefaultGraph(value: RDF.Term | null): value is RDF.DefaultGraph;
     function inDefaultGraph(value: RDF.Quad): boolean;
     function prefix(iri: RDF.NamedNode | string, factory?: RDF.DataFactory): PrefixedToIri;
     function prefixes(

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -434,6 +434,23 @@ function test_doc_utility() {
     const namedNode1: RDF.NamedNode = N3Util.prefix("http://www.w3.org/2000/01/rdf-schema#")("label");
     const namedNode2: RDF.NamedNode = N3Util.prefixes(prefixes)("rdfs")("label");
     const namedNode3: N3.NamedNode = N3Util.prefixes(prefixes)("rdfs")("label");
+
+    const term = N3.DataFactory.literal("Mickey Mouse") as RDF.Term;
+    if (N3Util.isNamedNode(term)) {
+        const namedNodeTerm: RDF.NamedNode = term;
+    }
+    if (N3Util.isBlankNode(term)) {
+        const blankNodeTerm: RDF.BlankNode = term;
+    }
+    if (N3Util.isLiteral(term)) {
+        const literalTerm: RDF.Literal = term;
+    }
+    if (N3Util.isVariable(term)) {
+        const variableTerm: RDF.Variable = term;
+    }
+    if (N3Util.isDefaultGraph(term)) {
+        const defaultGraphTerm: RDF.DefaultGraph = term;
+    }
 }
 
 function test_parser_options() {


### PR DESCRIPTION
This is a simple change, but there's a nuance: the functions only check if the `term` is truthy, and if its `termType` property matches a string appropriate for that term type. This means the `n3` type predicate functions will return `true` for any term implementation compliant with a `@rdfjs/types` term, and does not guarantee that the `n3`-specific extensions, like `toJSON()`, exist in that term implementation.

This means the utility functions should get typed as type predicate functions for types from `@rdfjs/types` (like `RDF.NamedNode`). I suppose checking if a term is the `n3`-provided implementation can be done with `instanceof`.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    https://github.com/rdfjs/N3.js/blob/5a58e93196a5048b6a4c09a1826847a7b811d283/src/N3Util.js#L6-L28
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
