### PR TITLE
[codemirror] Add 'origin' parameter to replaceSelection(s)

### DIFF
--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -538,13 +538,18 @@ declare namespace CodeMirror {
 
         /**
          * Adjust the indentation of the given line.
+         *
          * The second argument (which defaults to "smart") may be one of:
-         * "prev" Base indentation on the indentation of the previous line.
-         * "smart" Use the mode's smart indentation if available, behave like "prev" otherwise.
-         * "add" Increase the indentation of the line by one indent unit.
-         * "subtract" Reduce the indentation of the line.
+         * - "prev" Base indentation on the indentation of the previous line.
+         * - "smart" Use the mode's smart indentation if available, behave like "prev" otherwise.
+         * - "add" Increase the indentation of the line by one indent unit.
+         * - "subtract" Reduce the indentation of the line.
+         *
+         * When aggressive is false (typically set to true for forced single-line indents), empty
+         * lines are not indented, and places where the mode returns Pass
+         * are left alone.
          */
-        indentLine(line: number, dir?: string): void;
+        indentLine(line: number, dir?: string | null, aggresive?: boolean): void;
 
         /** Indent a selection */
         indentSelection(how: string): void;
@@ -880,14 +885,14 @@ declare namespace CodeMirror {
          * Replace the selection with the given string. By default, the new selection will span the inserted text.
          * The optional collapse argument can be used to change this -- passing "start" or "end" will collapse the selection to the start or end of the inserted text.
          */
-        replaceSelection(replacement: string, collapse?: string): void;
+        replaceSelection(replacement: string, collapse?: string | null, origin?: string | null): void;
 
         /**
          * Replaces the content of the selections with the strings in the array.
          * The length of the given array should be the same as the number of active selections.
          * The collapse argument works the same as in replaceSelection.
          */
-        replaceSelections(replacements: string[], collapse?: string): void;
+        replaceSelections(replacements: string[], collapse?: string | null, origin?: string | null): void;
 
         /**
          * start is a an optional string indicating which end of the selection to return.
@@ -1283,12 +1288,12 @@ declare namespace CodeMirror {
         value?: string | Doc | undefined;
 
         /**
-         * string|object. The mode to use. When not given, this will default to the first mode that was loaded.
+         * The mode to use. When not given, this will default to the first mode that was loaded.
          * It may be a string, which either simply names the mode or is a MIME type associated with the mode.
          * Alternatively, it may be an object containing configuration options for the mode,
          * with a name property that names the mode (for example {name: "javascript", json: true}).
          */
-        mode?: string | ModeSpec<ModeSpecOptions> | undefined;
+        mode?: string | ModeSpec<ModeSpecOptions> | null | undefined;
 
         /**
          * Explicitly set the line separator for the editor. By default (value null), the document will be split on CRLFs as well

--- a/types/codemirror/package.json
+++ b/types/codemirror/package.json
@@ -56,6 +56,10 @@
         {
             "name": "ficristo",
             "githubUsername": "ficristo"
+        },
+        {
+            "name": "Mateusz Turcza",
+            "githubUsername": "xemlock"
         }
     ]
 }

--- a/types/codemirror/test/index.ts
+++ b/types/codemirror/test/index.ts
@@ -112,3 +112,10 @@ const marks = myCodeMirror.getAllMarks();
 
 // $ExpectType TextMarker<MarkerRange | Position> || TextMarker<Position | MarkerRange>
 const mark = marks[0];
+
+// Based on https://github.com/codemirror/codemirror5/blob/5.65.19/test/test.js#L384
+myCodeMirror.replaceSelection("abc", null, "dontmerge");
+myCodeMirror.operation(function() {
+    myCodeMirror.setCursor(CodeMirror.Pos(0, 0));
+    myCodeMirror.replaceSelection("abc", null, "dontmerge");
+});


### PR DESCRIPTION
This PR adds third parameter (`origin`) to [replaceSelection]( https://github.com/codemirror/codemirror5/blob/5.65.19/src/model/Doc.js#L169) and [replaceSelections](https://github.com/codemirror/codemirror5/blob/5.65.19/src/model/Doc.js#L175). This parameter was present as a part of the example [in the official doc](https://codemirror.net/3/doc/manual.html#keymaps).

Also second paramater (`collapse`) may be `null`, as can be [seen in tests](https://github.com/codemirror/codemirror5/blob/5.65.19/test/test.js#L385).

Additionally, the following adjustments are made:

- add third parameter (`aggressive`) to [indentLine](https://github.com/codemirror/codemirror5/blob/5.65.19/src/edit/methods.js#L90), as it is [used by addons](https://github.com/search?q=repo:codemirror/codemirror5+indentLine+path:addon/&type=code).

- allow `null` value for `mode` parameter in `setOption`, as this is [the default value](https://github.com/codemirror/codemirror5/blob/5.65.19/src/edit/options.js#L41) of the option, and we should be able to reset this option to this particular value.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    _See description at the top_ ⬆️ 

