### PR TITLE
Lodash intersectioWith, fixing types in comparator's parameters

### DIFF
--- a/types/lodash/common/array.d.ts
+++ b/types/lodash/common/array.d.ts
@@ -760,15 +760,15 @@ declare module "../index" {
          * _.intersectionWith(objects, others, _.isEqual);
          * // => [{ 'x': 1, 'y': 2 }]
          */
-        intersectionWith<T1, T2>(array: List<T1> | null | undefined, values: List<T2>, comparator: Comparator2<T1, T2>): T1[];
+        intersectionWith<T1, T2>(array: List<T1> | null | undefined, values: List<T2>, comparator: Comparator2<T1, T1 | T2>): T1[];
         /**
          * @see _.intersectionWith
          */
-        intersectionWith<T1, T2, T3>(array: List<T1> | null | undefined, values1: List<T2>, values2: List<T3>, comparator: Comparator2<T1, T2 | T3>): T1[];
+        intersectionWith<T1, T2, T3>(array: List<T1> | null | undefined, values1: List<T2>, values2: List<T3>, comparator: Comparator2<T1, T1 | T2 | T3>): T1[];
         /**
          * @see _.intersectionWith
          */
-        intersectionWith<T1, T2, T3, T4>(array: List<T1> | null | undefined, values1: List<T2>, values2: List<T3>, ...values: Array<List<T4> | Comparator2<T1, T2 | T3 | T4>>): T1[];
+        intersectionWith<T1, T2, T3, T4>(array: List<T1> | null | undefined, values1: List<T2>, values2: List<T3>, ...values: Array<List<T4> | Comparator2<T1, T1 | T2 | T3 | T4>>): T1[];
         /**
          * @see _.intersectionWith
          */
@@ -778,7 +778,7 @@ declare module "../index" {
         /**
          * @see _.intersectionWith
          */
-        intersectionWith<T2>(values: List<T2>, comparator: Comparator2<T, T2>): Collection<T>;
+        intersectionWith<T2>(values: List<T2>, comparator: Comparator2<T, T | T2>): Collection<T>;
         /**
          * @see _.intersectionWith
          */
@@ -788,7 +788,7 @@ declare module "../index" {
         /**
          * @see _.intersectionWith
          */
-        intersectionWith<T2>(values: List<T2>, comparator: Comparator2<T, T2>): CollectionChain<T>;
+        intersectionWith<T2>(values: List<T2>, comparator: Comparator2<T, T | T2>): CollectionChain<T>;
         /**
          * @see _.intersectionWith
          */

--- a/types/lodash/fp.d.ts
+++ b/types/lodash/fp.d.ts
@@ -1776,13 +1776,13 @@ declare namespace _ {
     type LodashIntersectionBy1x5<T1> = (array: lodash.List<T1> | null) => T1[];
     type LodashIntersectionBy1x6<T1, T2> = (iteratee: lodash.ValueIteratee<T1 | T2>) => T1[];
     interface LodashIntersectionWith {
-        <T1, T2>(comparator: lodash.Comparator2<T1, T2>): LodashIntersectionWith1x1<T1, T2>;
+        <T1, T2>(comparator: lodash.Comparator2<T1, T1 | T2>): LodashIntersectionWith1x1<T1, T2>;
         <T1>(comparator: lodash.__, array: lodash.List<T1> | null | undefined): LodashIntersectionWith1x2<T1>;
-        <T1, T2>(comparator: lodash.Comparator2<T1, T2>, array: lodash.List<T1> | null | undefined): LodashIntersectionWith1x3<T1, T2>;
+        <T1, T2>(comparator: lodash.Comparator2<T1, T1 | T2>, array: lodash.List<T1> | null | undefined): LodashIntersectionWith1x3<T1, T2>;
         <T2>(comparator: lodash.__, array: lodash.__, values: lodash.List<T2>): LodashIntersectionWith1x4<T2>;
-        <T1, T2>(comparator: lodash.Comparator2<T1, T2>, array: lodash.__, values: lodash.List<T2>): LodashIntersectionWith1x5<T1>;
+        <T1, T2>(comparator: lodash.Comparator2<T1, T1 | T2>, array: lodash.__, values: lodash.List<T2>): LodashIntersectionWith1x5<T1>;
         <T1, T2>(comparator: lodash.__, array: lodash.List<T1> | null | undefined, values: lodash.List<T2>): LodashIntersectionWith1x6<T1, T2>;
-        <T1, T2>(comparator: lodash.Comparator2<T1, T2>, array: lodash.List<T1> | null | undefined, values: lodash.List<T2>): T1[];
+        <T1, T2>(comparator: lodash.Comparator2<T1, T1 | T2>, array: lodash.List<T1> | null | undefined, values: lodash.List<T2>): T1[];
     }
     interface LodashIntersectionWith1x1<T1, T2> {
         (array: lodash.List<T1> | null | undefined): LodashIntersectionWith1x3<T1, T2>;
@@ -1790,18 +1790,18 @@ declare namespace _ {
         (array: lodash.List<T1> | null | undefined, values: lodash.List<T2>): T1[];
     }
     interface LodashIntersectionWith1x2<T1> {
-        <T2>(comparator: lodash.Comparator2<T1, T2>): LodashIntersectionWith1x3<T1, T2>;
+        <T2>(comparator: lodash.Comparator2<T1, T1 | T2>): LodashIntersectionWith1x3<T1, T2>;
         <T2>(comparator: lodash.__, values: lodash.List<T2>): LodashIntersectionWith1x6<T1, T2>;
-        <T2>(comparator: lodash.Comparator2<T1, T2>, values: lodash.List<T2>): T1[];
+        <T2>(comparator: lodash.Comparator2<T1, T1 | T2>, values: lodash.List<T2>): T1[];
     }
     type LodashIntersectionWith1x3<T1, T2> = (values: lodash.List<T2>) => T1[];
     interface LodashIntersectionWith1x4<T2> {
-        <T1>(comparator: lodash.Comparator2<T1, T2>): LodashIntersectionWith1x5<T1>;
+        <T1>(comparator: lodash.Comparator2<T1, T1 | T2>): LodashIntersectionWith1x5<T1>;
         <T1>(comparator: lodash.__, array: lodash.List<T1> | null | undefined): LodashIntersectionWith1x6<T1, T2>;
-        <T1>(comparator: lodash.Comparator2<T1, T2>, array: lodash.List<T1> | null | undefined): T1[];
+        <T1>(comparator: lodash.Comparator2<T1, T1 | T2>, array: lodash.List<T1> | null | undefined): T1[];
     }
     type LodashIntersectionWith1x5<T1> = (array: lodash.List<T1> | null | undefined) => T1[];
-    type LodashIntersectionWith1x6<T1, T2> = (comparator: lodash.Comparator2<T1, T2>) => T1[];
+    type LodashIntersectionWith1x6<T1, T2> = (comparator: lodash.Comparator2<T1, T1 | T2>) => T1[];
     type LodashInvert = (object: object) => lodash.Dictionary<string>;
     interface LodashInvertBy {
         <T>(interatee: lodash.ValueIteratee<T>): LodashInvertBy1x1<T>;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -782,23 +782,49 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType CollectionChain<number>
     // $ExpectType T1[]
     _.intersectionWith([t1], [t2], (a, b) => {
         a; // $ExpectType T1
-        b; // $ExpectType T2
+        b; // $ExpectType T1 | T2
         return true;
     });
     // $ExpectType Collection<T1>
     _([t1]).intersectionWith([t2], (a, b) => {
         a; // $ExpectType T1
-        b; // $ExpectType T2
+        b; // $ExpectType T1 | T2
         return true;
     });
     // $ExpectType CollectionChain<T1>
     _.chain([t1]).intersectionWith([t2], (a, b) => {
         a; // $ExpectType T1
-        b; // $ExpectType T2
+        b; // $ExpectType T1 | T2
         return true;
     });
 
-    fp.intersectionWith((a: T1, b: T2) => true)([t1])([t2]); // $ExpectType T1[]
+    const a1 = [t1];
+    const a2 = [t2];
+    fp.intersectionWith((a: T1, b: T1 | T2) => true)([t1])([t2]); // $ExpectType T1[]
+    // $ExpectType T1[]
+    fp.intersectionWith<T1, T2>((a, b) => {
+        a; // $ExpectType T1;
+        b; // $ExpectType T1 | T2
+        return true;
+    }, a1, a2);
+    // $ExpectType T1[]
+    fp.intersectionWith<T1, T2>(_, a1, a2)((a, b) => {
+        a; // $ExpectType T1;
+        b; // $ExpectType T1 | T2
+        return true;
+    });
+    // $ExpectType T1[]
+    fp.intersectionWith(_, _, a2)(_, a1)((a, b) => {
+        a; // $ExpectType T1;
+        b; // $ExpectType T1 | T2
+        return true;
+    });
+    // $ExpectType T1[]
+    fp.intersectionWith(_, a1)(_, a2)((a, b) => {
+        a; // $ExpectType T1;
+        b; // $ExpectType T1 | T2
+        return true;
+    });
 }
 
 // _.join


### PR DESCRIPTION
Please fill in this template.

- [ x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [ x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [ x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

As described in https://github.com/lodash/lodash/issues/5983
The comparator callback type of intersectionWith function  has this signature:
(a: T1, b: T2) => boolean where T1 is the type of the first array provided to interesectionWith while T2 can be any type of other arrays.
// a1: T
// a2: K1
// a3: K2

_.intersectionWith(a1, a2, a3, (a: T, b: K1 | K2) => {/* ... */})

This assumption is partially wrong because intersectionWith also removes repetitions from a1, so the second parameter of the comparator function can also be T

(a: T, b: T | K1 | K2) => boolean

Demo source code: https://stackblitz.com/edit/js-basic-owah7cwd?file=index.js

