### PR TITLE
fix(node/diagnostics_channel): fix runStores() & trace*() signatures

### DIFF
--- a/types/node/diagnostics_channel.d.ts
+++ b/types/node/diagnostics_channel.d.ts
@@ -297,7 +297,12 @@ declare module "diagnostics_channel" {
          * @param thisArg The receiver to be used for the function call.
          * @param args Optional arguments to pass to the function.
          */
-        runStores(): void;
+        runStores<ThisArg = any, Args extends any[] = any[], Result = any>(
+            context: ContextType,
+            fn: (this: ThisArg, ...args: Args) => Result,
+            thisArg?: ThisArg,
+            ...args: Args
+        ): Result;
     }
     interface TracingChannelSubscribers<ContextType extends object> {
         start: (message: ContextType) => void;
@@ -441,12 +446,12 @@ declare module "diagnostics_channel" {
          * @param args Optional arguments to pass to the function
          * @return The return value of the given function
          */
-        traceSync<ThisArg = any, Args extends any[] = any[]>(
-            fn: (this: ThisArg, ...args: Args) => any,
+        traceSync<ThisArg = any, Args extends any[] = any[], Result = any>(
+            fn: (this: ThisArg, ...args: Args) => Result,
             context?: ContextType,
             thisArg?: ThisArg,
             ...args: Args
-        ): void;
+        ): Result;
         /**
          * Trace a promise-returning function call. This will always produce a `start event` and `end event` around the synchronous portion of the
          * function execution, and will produce an `asyncStart event` and `asyncEnd event` when a promise continuation is reached. It may also
@@ -476,12 +481,12 @@ declare module "diagnostics_channel" {
          * @param args Optional arguments to pass to the function
          * @return Chained from promise returned by the given function
          */
-        tracePromise<ThisArg = any, Args extends any[] = any[]>(
-            fn: (this: ThisArg, ...args: Args) => Promise<any>,
+        tracePromise<ThisArg = any, Args extends any[] = any[], Result = any>(
+            fn: (this: ThisArg, ...args: Args) => Promise<Result>,
             context?: ContextType,
             thisArg?: ThisArg,
             ...args: Args
-        ): void;
+        ): Promise<Result>;
         /**
          * Trace a callback-receiving function call. This will always produce a `start event` and `end event` around the synchronous portion of the
          * function execution, and will produce a `asyncStart event` and `asyncEnd event` around the callback execution. It may also produce an `error event` if the given function throws an error or
@@ -540,13 +545,13 @@ declare module "diagnostics_channel" {
          * @param args Optional arguments to pass to the function
          * @return The return value of the given function
          */
-        traceCallback<Fn extends (this: any, ...args: any[]) => any>(
-            fn: Fn,
+        traceCallback<ThisArg = any, Args extends any[] = any[], Result = any>(
+            fn: (this: ThisArg, ...args: Args) => Result,
             position?: number,
             context?: ContextType,
-            thisArg?: any,
-            ...args: Parameters<Fn>
-        ): void;
+            thisArg?: ThisArg,
+            ...args: Args
+        ): Result;
         /**
          * `true` if any of the individual channels has a subscriber, `false` if not.
          *

--- a/types/node/test/diagnostics_channel.ts
+++ b/types/node/test/diagnostics_channel.ts
@@ -79,6 +79,7 @@ const hasSubs = hasSubscribers("test");
     const a: number = 1;
     const b: string = "2";
 
+    // $ExpectType string
     channels.traceSync(
         function(a, b) {
             this; // $ExpectType string
@@ -92,10 +93,12 @@ const hasSubs = hasSubscribers("test");
         b,
     );
 
+    // $ExpectType string
     channels.traceSync(function() {
         return "something";
     }, { requestId: 42 });
 
+    // $ExpectType Promise<string>
     channels.tracePromise(
         async function(a, b) {
             this; // $ExpectType string
@@ -109,34 +112,32 @@ const hasSubs = hasSubscribers("test");
         b,
     );
 
+    // $ExpectType Promise<string>
     channels.tracePromise(async function() {
         return "something";
     }, { requestId: 42 });
 
     const callback = (err: unknown, result: string) => {};
 
+    // $ExpectType void
     channels.traceCallback(
-        function(arg1, callback) {
+        function(arg1, arg2, arg3, callback): void {
+            // $ExpectType number
+            arg1;
+            // $ExpectType number
+            arg2;
+            // $ExpectType string
+            arg3;
             callback(null, "result");
         },
-        1,
+        3,
         {
             requestId: 42,
         },
         "thisArg",
         42,
-        callback,
-    );
-
-    channels.traceCallback(
-        function(callback) {
-            callback(null, "result");
-        },
-        undefined,
-        {
-            requestId: 42,
-        },
-        undefined,
+        1,
+        "k",
         callback,
     );
 

--- a/types/node/v18/diagnostics_channel.d.ts
+++ b/types/node/v18/diagnostics_channel.d.ts
@@ -298,7 +298,12 @@ declare module "diagnostics_channel" {
          * @param thisArg The receiver to be used for the function call.
          * @param args Optional arguments to pass to the function.
          */
-        runStores(): void;
+        runStores<ThisArg = any, Args extends any[] = any[], Result = any>(
+            context: ContextType,
+            fn: (this: ThisArg, ...args: Args) => Result,
+            thisArg?: ThisArg,
+            ...args: Args
+        ): Result;
     }
     interface TracingChannelSubscribers<ContextType extends object> {
         start: (message: ContextType) => void;
@@ -439,12 +444,12 @@ declare module "diagnostics_channel" {
          * @param args Optional arguments to pass to the function
          * @return The return value of the given function
          */
-        traceSync<ThisArg = any, Args extends any[] = any[]>(
-            fn: (this: ThisArg, ...args: Args) => any,
+        traceSync<ThisArg = any, Args extends any[] = any[], Result = any>(
+            fn: (this: ThisArg, ...args: Args) => Result,
             context?: ContextType,
             thisArg?: ThisArg,
             ...args: Args
-        ): void;
+        ): Result;
         /**
          * Trace a promise-returning function call. This will always produce a `start event` and `end event` around the synchronous portion of the
          * function execution, and will produce an `asyncStart event` and `asyncEnd event` when a promise continuation is reached. It may also
@@ -471,12 +476,12 @@ declare module "diagnostics_channel" {
          * @param args Optional arguments to pass to the function
          * @return Chained from promise returned by the given function
          */
-        tracePromise<ThisArg = any, Args extends any[] = any[]>(
-            fn: (this: ThisArg, ...args: Args) => Promise<any>,
+        tracePromise<ThisArg = any, Args extends any[] = any[], Result = any>(
+            fn: (this: ThisArg, ...args: Args) => Promise<Result>,
             context?: ContextType,
             thisArg?: ThisArg,
             ...args: Args
-        ): void;
+        ): Promise<Result>;
         /**
          * Trace a callback-receiving function call. This will always produce a `start event` and `end event` around the synchronous portion of the
          * function execution, and will produce a `asyncStart event` and `asyncEnd event` around the callback execution. It may also produce an `error event` if the given function throws an error or
@@ -532,13 +537,13 @@ declare module "diagnostics_channel" {
          * @param args Optional arguments to pass to the function
          * @return The return value of the given function
          */
-        traceCallback<Fn extends (this: any, ...args: any) => any>(
-            fn: Fn,
-            position: number | undefined,
-            context: ContextType | undefined,
-            thisArg: any,
-            ...args: Parameters<Fn>
-        ): void;
+        traceCallback<ThisArg = any, Args extends any[] = any[], Result = any>(
+            fn: (this: ThisArg, ...args: Args) => Result,
+            position?: number,
+            context?: ContextType,
+            thisArg?: ThisArg,
+            ...args: Args
+        ): Result;
     }
 }
 declare module "node:diagnostics_channel" {

--- a/types/node/v18/test/diagnostics_channel.ts
+++ b/types/node/v18/test/diagnostics_channel.ts
@@ -79,6 +79,7 @@ const hasSubs = hasSubscribers("test");
     const a: number = 1;
     const b: string = "2";
 
+    // $ExpectType string
     channels.traceSync(
         function(a, b) {
             this; // $ExpectType string
@@ -92,10 +93,12 @@ const hasSubs = hasSubscribers("test");
         b,
     );
 
+    // $ExpectType string
     channels.traceSync(function() {
         return "something";
     }, { requestId: 42 });
 
+    // $ExpectType Promise<string>
     channels.tracePromise(
         async function(a, b) {
             this; // $ExpectType string
@@ -109,34 +112,32 @@ const hasSubs = hasSubscribers("test");
         b,
     );
 
+    // $ExpectType Promise<string>
     channels.tracePromise(async function() {
         return "something";
     }, { requestId: 42 });
 
     const callback = (err: unknown, result: string) => {};
 
+    // $ExpectType void
     channels.traceCallback(
-        function(arg1, callback) {
+        function(arg1, arg2, arg3, callback): void {
+            // $ExpectType number
+            arg1;
+            // $ExpectType number
+            arg2;
+            // $ExpectType string
+            arg3;
             callback(null, "result");
         },
-        1,
+        3,
         {
             requestId: 42,
         },
         "thisArg",
         42,
-        callback,
-    );
-
-    channels.traceCallback(
-        function(callback) {
-            callback(null, "result");
-        },
-        undefined,
-        {
-            requestId: 42,
-        },
-        undefined,
+        1,
+        "k",
         callback,
     );
 }

--- a/types/node/v20/diagnostics_channel.d.ts
+++ b/types/node/v20/diagnostics_channel.d.ts
@@ -297,7 +297,12 @@ declare module "diagnostics_channel" {
          * @param thisArg The receiver to be used for the function call.
          * @param args Optional arguments to pass to the function.
          */
-        runStores(): void;
+        runStores<ThisArg = any, Args extends any[] = any[], Result = any>(
+            context: ContextType,
+            fn: (this: ThisArg, ...args: Args) => Result,
+            thisArg?: ThisArg,
+            ...args: Args
+        ): Result;
     }
     interface TracingChannelSubscribers<ContextType extends object> {
         start: (message: ContextType) => void;
@@ -441,12 +446,12 @@ declare module "diagnostics_channel" {
          * @param args Optional arguments to pass to the function
          * @return The return value of the given function
          */
-        traceSync<ThisArg = any, Args extends any[] = any[]>(
-            fn: (this: ThisArg, ...args: Args) => any,
+        traceSync<ThisArg = any, Args extends any[] = any[], Result = any>(
+            fn: (this: ThisArg, ...args: Args) => Result,
             context?: ContextType,
             thisArg?: ThisArg,
             ...args: Args
-        ): void;
+        ): Result;
         /**
          * Trace a promise-returning function call. This will always produce a `start event` and `end event` around the synchronous portion of the
          * function execution, and will produce an `asyncStart event` and `asyncEnd event` when a promise continuation is reached. It may also
@@ -476,12 +481,12 @@ declare module "diagnostics_channel" {
          * @param args Optional arguments to pass to the function
          * @return Chained from promise returned by the given function
          */
-        tracePromise<ThisArg = any, Args extends any[] = any[]>(
-            fn: (this: ThisArg, ...args: Args) => Promise<any>,
+        tracePromise<ThisArg = any, Args extends any[] = any[], Result = any>(
+            fn: (this: ThisArg, ...args: Args) => Promise<Result>,
             context?: ContextType,
             thisArg?: ThisArg,
             ...args: Args
-        ): void;
+        ): Promise<Result>;
         /**
          * Trace a callback-receiving function call. This will always produce a `start event` and `end event` around the synchronous portion of the
          * function execution, and will produce a `asyncStart event` and `asyncEnd event` around the callback execution. It may also produce an `error event` if the given function throws an error or
@@ -540,13 +545,13 @@ declare module "diagnostics_channel" {
          * @param args Optional arguments to pass to the function
          * @return The return value of the given function
          */
-        traceCallback<Fn extends (this: any, ...args: any) => any>(
-            fn: Fn,
-            position: number | undefined,
-            context: ContextType | undefined,
-            thisArg: any,
-            ...args: Parameters<Fn>
-        ): void;
+        traceCallback<ThisArg = any, Args extends any[] = any[], Result = any>(
+            fn: (this: ThisArg, ...args: Args) => Result,
+            position?: number,
+            context?: ContextType,
+            thisArg?: ThisArg,
+            ...args: Args
+        ): Result;
         /**
          * `true` if any of the individual channels has a subscriber, `false` if not.
          *

--- a/types/node/v20/test/diagnostics_channel.ts
+++ b/types/node/v20/test/diagnostics_channel.ts
@@ -79,6 +79,7 @@ const hasSubs = hasSubscribers("test");
     const a: number = 1;
     const b: string = "2";
 
+    // $ExpectType string
     channels.traceSync(
         function(a, b) {
             this; // $ExpectType string
@@ -92,10 +93,12 @@ const hasSubs = hasSubscribers("test");
         b,
     );
 
+    // $ExpectType string
     channels.traceSync(function() {
         return "something";
     }, { requestId: 42 });
 
+    // $ExpectType Promise<string>
     channels.tracePromise(
         async function(a, b) {
             this; // $ExpectType string
@@ -109,34 +112,32 @@ const hasSubs = hasSubscribers("test");
         b,
     );
 
+    // $ExpectType Promise<string>
     channels.tracePromise(async function() {
         return "something";
     }, { requestId: 42 });
 
     const callback = (err: unknown, result: string) => {};
 
+    // $ExpectType void
     channels.traceCallback(
-        function(arg1, callback) {
+        function(arg1, arg2, arg3, callback): void {
+            // $ExpectType number
+            arg1;
+            // $ExpectType number
+            arg2;
+            // $ExpectType string
+            arg3;
             callback(null, "result");
         },
-        1,
+        3,
         {
             requestId: 42,
         },
         "thisArg",
         42,
-        callback,
-    );
-
-    channels.traceCallback(
-        function(callback) {
-            callback(null, "result");
-        },
-        undefined,
-        {
-            requestId: 42,
-        },
-        undefined,
+        1,
+        "k",
         callback,
     );
 


### PR DESCRIPTION
Unify the signature of similar exported methods with the same generic paramater list, `<ThisArg = any, Args extends any[] = any[], Result = any>`.

Also add a number of positional-based overloads to `traceCallback()`, making typecheck more accurate within `position: undefined | 0 | 1 | 2 | 3 | 4`.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
