### PR TITLE
[chrome] not force to use enum in declarativeNetRequest namespace

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -13982,7 +13982,7 @@ declare namespace chrome {
             tabId: number;
 
             /** The resource type of the request. */
-            type: ResourceType;
+            type: `${ResourceType}`;
 
             /** The URL of the request. */
             url: string;
@@ -14024,7 +14024,7 @@ declare namespace chrome {
             responseHeaders?: ModifyHeaderInfo[] | undefined;
 
             /** The type of action to perform. */
-            type: RuleActionType;
+            type: `${RuleActionType}`;
         }
 
         export interface RuleCondition {
@@ -14032,7 +14032,7 @@ declare namespace chrome {
              * Specifies whether the network request is first-party or third-party to the domain from which it originated.
              * If omitted, all requests are accepted.
              */
-            domainType?: DomainType | undefined;
+            domainType?: `${DomainType}` | undefined;
 
             /**
          * @deprecated since Chrome 101. Use initiatorDomains instead.
@@ -14119,7 +14119,7 @@ declare namespace chrome {
              * Only one of requestMethods and excludedRequestMethods should be specified.
              * If neither of them is specified, all request methods are matched.
              */
-            excludedRequestMethods?: RequestMethod[] | undefined;
+            excludedRequestMethods?: `${RequestMethod}`[] | undefined;
 
             /**
              * List of resource types which the rule won't match.
@@ -14127,7 +14127,7 @@ declare namespace chrome {
              * and {@link chrome.declarativeNetRequest.RuleCondition.excludedResourceTypes} should be specified.
              * If neither of them is specified, all resource types except "main_frame" are blocked.
              */
-            excludedResourceTypes?: ResourceType[] | undefined;
+            excludedResourceTypes?: `${ResourceType}`[] | undefined;
 
             /**
              * List of {@link chrome.tabs.Tab.id} which the rule should not match.
@@ -14158,7 +14158,7 @@ declare namespace chrome {
              * Note: Specifying a {@link chrome.declarativeNetRequest.RuleCondition.requestMethods} rule condition will also exclude non-HTTP(s) requests,
              * whereas specifying {@link chrome.declarativeNetRequest.RuleCondition.excludedRequestMethods} will not.
              */
-            requestMethods?: RequestMethod[];
+            requestMethods?: `${RequestMethod}`[] | undefined;
 
             /**
              * List of {@link chrome.tabs.Tab.id} which the rule should not match.
@@ -14200,7 +14200,7 @@ declare namespace chrome {
              *
              * Note: this must be specified for allowAllRequests rules and may only include the sub_frame and main_frame resource types.
              */
-            resourceTypes?: ResourceType[] | undefined;
+            resourceTypes?: `${ResourceType}`[] | undefined;
 
             /**
              * Rule does not match if the request matches any response header condition in this list (if specified). If both `excludedResponseHeaders` and `responseHeaders` are specified, then the `excludedResponseHeaders` property takes precedence.
@@ -14270,7 +14270,7 @@ declare namespace chrome {
             header: string;
 
             /** The operation to be performed on a header. */
-            operation: HeaderOperation;
+            operation: `${HeaderOperation}`;
 
             /** The new value for the header.
              * Must be specified for append and set operations.
@@ -14352,7 +14352,7 @@ declare namespace chrome {
             /** Specifies the reason why the regular expression is not supported.
              * Only provided if isSupported is false.
              */
-            reason?: UnsupportedRegexReason | undefined;
+            reason?: `${UnsupportedRegexReason}` | undefined;
         }
 
         export interface TabActionCountUpdate {

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -2976,8 +2976,19 @@ async function testDeclarativeNetRequest() {
     // @ts-expect-error
     chrome.declarativeNetRequest.testMatchOutcome(testMatchRequestDetails, () => {}).then(() => {});
 
+    const rule: chrome.declarativeNetRequest.Rule = {
+        id: 1,
+        priority: 1,
+        action: { type: "allow", requestHeaders: [], responseHeaders: [] },
+        condition: {
+            domainType: "firstParty",
+            excludedResourceTypes: [chrome.declarativeNetRequest.ResourceType.IMAGE, "object"],
+            excludedRequestMethods: [chrome.declarativeNetRequest.RequestMethod.POST, "get"],
+        },
+    };
+
     const updateRuleOptions: chrome.declarativeNetRequest.UpdateRuleOptions = {
-        addRules: [],
+        addRules: [rule],
         removeRuleIds: [1, 2, 3],
     };
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

It is not mandatory to use enum, example :
![image](https://github.com/user-attachments/assets/bf2895af-9653-4270-9577-771684c56f0b)


Related issue: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/72610