### PR TITLE
readable-stream: remove safe-buffer dependency

### DIFF
--- a/types/readable-stream/index.d.ts
+++ b/types/readable-stream/index.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="node" />
 
-import * as SafeBuffer from "safe-buffer";
 import type * as NodeStream from "stream";
 
 declare class StringDecoder {
@@ -235,7 +234,7 @@ declare namespace _Readable {
         next: Entry<D> | null;
     }
 
-    interface BufferList<D extends SafeBuffer.Buffer = SafeBuffer.Buffer> {
+    interface BufferList<D extends Buffer = Buffer> {
         head: Entry<D>;
         tail: Entry<D>;
         length: number;

--- a/types/readable-stream/package.json
+++ b/types/readable-stream/package.json
@@ -6,8 +6,7 @@
         "https://github.com/nodejs/readable-stream"
     ],
     "dependencies": {
-        "@types/node": "*",
-        "safe-buffer": "~5.1.1"
+        "@types/node": "*"
     },
     "devDependencies": {
         "@types/readable-stream": "workspace:."


### PR DESCRIPTION
readable-stream's dependency on safe-buffer was dropped prior to v3.0.0.
