### PR TITLE
node: revert legacy `NodeJS.ReadableStream` iterator type to `AsyncIterableIterator`

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -209,7 +209,7 @@ declare global {
             unpipe(destination?: WritableStream): this;
             unshift(chunk: string | Uint8Array, encoding?: BufferEncoding): void;
             wrap(oldStream: ReadableStream): this;
-            [Symbol.asyncIterator](): NodeJS.AsyncIterator<string | Buffer>;
+            [Symbol.asyncIterator](): AsyncIterableIterator<string | Buffer>;
         }
 
         interface WritableStream extends EventEmitter {

--- a/types/node/v18/globals.d.ts
+++ b/types/node/v18/globals.d.ts
@@ -196,7 +196,7 @@ declare global {
             unpipe(destination?: WritableStream): this;
             unshift(chunk: string | Uint8Array, encoding?: BufferEncoding): void;
             wrap(oldStream: ReadableStream): this;
-            [Symbol.asyncIterator](): NodeJS.AsyncIterator<string | Buffer>;
+            [Symbol.asyncIterator](): AsyncIterableIterator<string | Buffer>;
         }
 
         interface WritableStream extends EventEmitter {

--- a/types/node/v20/globals.d.ts
+++ b/types/node/v20/globals.d.ts
@@ -196,7 +196,7 @@ declare global {
             unpipe(destination?: WritableStream): this;
             unshift(chunk: string | Uint8Array, encoding?: BufferEncoding): void;
             wrap(oldStream: ReadableStream): this;
-            [Symbol.asyncIterator](): NodeJS.AsyncIterator<string | Buffer>;
+            [Symbol.asyncIterator](): AsyncIterableIterator<string | Buffer>;
         }
 
         interface WritableStream extends EventEmitter {


### PR DESCRIPTION
The `NodeJS.*Stream` interfaces are somewhat vestigial, and aren't returned anywhere from within @types/node itself. However, they still see some use, either to type a function parameter that accepts anything "stream-like", or as extends/implements targets in packages that define stream-like classes.

`NodeJS.ReadableStream`'s iterator type was changed to inherit from `AsyncIteratorObject` in #70648, along with the rest of the library. However, this causes assignability headaches when lib.esnext.disposable is loaded, as it augments `AsyncIteratorObject` with an `@@asyncDispose` method – making `AsyncIterableIterator` and `AsyncIteratorObject` no longer interassignable.

Reverting to `AsyncIterableIterator` for the legacy interface is appropriate, and doesn't affect the `node:stream` definitions.