### PR TITLE
adding missing `api` property to sass-loader LoaderOptions interface

### DIFF
--- a/types/sass-loader/interfaces.d.ts
+++ b/types/sass-loader/interfaces.d.ts
@@ -402,6 +402,7 @@ export interface LoaderOptions {
      * true
      */
     webpackImporter?: boolean | undefined;
+
     /**
      * Treats the @warn rule as a webpack warning.
      *
@@ -433,7 +434,6 @@ export interface LoaderOptions {
      */
     warnRuleAsWarning?: boolean | undefined;
 
-
     /**
      * Default: `"modern"` for `sass (dart-sass)` and `sass-embedded`, or `"legacy"` for `node-sass`
      *
@@ -441,10 +441,10 @@ export interface LoaderOptions {
      *
      * > [!NOTE]
      * > Using modern-compiler and sass-embedded together significantly improve performance and decrease built time. We strongly recommend their use. We will enable them by default in a future major release.
-     * 
+     *
      * > [!WARNING]
      * > The sass options are different for the legacy and modern APIs. Please look at docs how to migrate to the modern options.
-     * 
+     *
      * **webpack.config.js**
      * ```js
      * module.exports = {
@@ -471,7 +471,7 @@ export interface LoaderOptions {
      * };
      * ```
      */
-    api: "legacy" | "modern" | "modern-compiler";
+    api?: "legacy" | "modern" | "modern-compiler";
 }
 
 export namespace LoaderOptions {

--- a/types/sass-loader/interfaces.d.ts
+++ b/types/sass-loader/interfaces.d.ts
@@ -432,6 +432,46 @@ export interface LoaderOptions {
      * ```
      */
     warnRuleAsWarning?: boolean | undefined;
+
+
+    /**
+     * Default: `"modern"` for `sass (dart-sass)` and `sass-embedded`, or `"legacy"` for `node-sass`
+     *
+     * Allows you to switch between the legacy and modern APIs. You can find more information [here](https://sass-lang.com/documentation/js-api). The modern-compiler option enables the modern API with support for [Shared Resources](https://github.com/sass/sass/blob/main/accepted/shared-resources.d.ts.md).
+     *
+     * > [!NOTE]
+     * > Using modern-compiler and sass-embedded together significantly improve performance and decrease built time. We strongly recommend their use. We will enable them by default in a future major release.
+     * 
+     * > [!WARNING]
+     * > The sass options are different for the legacy and modern APIs. Please look at docs how to migrate to the modern options.
+     * 
+     * **webpack.config.js**
+     * ```js
+     * module.exports = {
+     *   module: {
+     *     rules: [
+     *       {
+     *         test: /\.s[ac]ss$/i,
+     *         use: [
+     *           "style-loader",
+     *           "css-loader",
+     *           {
+     *             loader: "sass-loader",
+     *             options: {
+     *               api: "modern-compiler",
+     *               sassOptions: {
+     *                 // Your sass options
+     *               },
+     *             },
+     *           },
+     *         ],
+     *       },
+     *     ],
+     *   },
+     * };
+     * ```
+     */
+    api: "legacy" | "modern" | "modern-compiler";
 }
 
 export namespace LoaderOptions {

--- a/types/sass-loader/package.json
+++ b/types/sass-loader/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/sass-loader",
-    "version": "8.0.9999",
+    "version": "8.1.9999",
     "projects": [
         "https://github.com/webpack-contrib/sass-loader"
     ],

--- a/types/sass-loader/sass-loader-tests.ts
+++ b/types/sass-loader/sass-loader-tests.ts
@@ -15,7 +15,7 @@ const loaderOptions: SassLoader.Options = {
         sourceMap: true,
     },
     webpackImporter: true,
-    api: 'modern-compiler'
+    api: "modern-compiler",
 };
 
 const loaderOptionsWithCallback: SassLoader.Options = {

--- a/types/sass-loader/sass-loader-tests.ts
+++ b/types/sass-loader/sass-loader-tests.ts
@@ -15,6 +15,7 @@ const loaderOptions: SassLoader.Options = {
         sourceMap: true,
     },
     webpackImporter: true,
+    api: 'modern-compiler'
 };
 
 const loaderOptionsWithCallback: SassLoader.Options = {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack-contrib/sass-loader/blob/e403be4c6fdc0447ccf73b030f75e86c0344565a/README.md?plain=1#L680
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
