### PR TITLE
[react-router-bootstrap] Fix tests

### DIFF
--- a/types/react-router-bootstrap/package.json
+++ b/types/react-router-bootstrap/package.json
@@ -9,7 +9,7 @@
         "@types/react": "*"
     },
     "devDependencies": {
-        "@types/react-bootstrap": "<2",
+        "@types/react-bootstrap": "^0.32.0",
         "@types/react-router-bootstrap": "workspace:."
     },
     "owners": [


### PR DESCRIPTION
`<2` matches `@types/react-bootstrap@1.1.0` which is just a stub package without type definitions thus breaking tests: https://github.com/DefinitelyTyped/DefinitelyTyped/actions/runs/15117687651/job/42492494543?pr=72826