### PR TITLE
Update express query to new default and allow for override

### DIFF
--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -137,14 +137,28 @@ app.route("/:foo").get<{}, any, any, { q: string }>(req => {
     req.query.a;
 });
 
+// Query can use the helper extended type
+app.get<{}, any, any, { q: express.ExtendedQuery }>("/:foo", req => {
+    req.query.q; // $ExpectType ExtendedQuery
+    // @ts-expect-error
+    req.query.a;
+});
+
+// Query can the helper extended type - under route
+app.route("/:foo").get<{}, any, any, { q: express.ExtendedQuery }>(req => {
+    req.query.q; // $ExpectType ExtendedQuery
+    // @ts-expect-error
+    req.query.a;
+});
+
 // Query will be defaulted to Query type
 app.get("/:foo", req => {
-    req.query; // $ExpectType ParsedQs
+    req.query; // $ExpectType Query
 });
 
 // Query will be defaulted to Query type - under route
 app.route("/:foo").get(req => {
-    req.query; // $ExpectType ParsedQs
+    req.query; // $ExpectType Query
 });
 
 // Next can receive a Error parameter to delegate to Error handler
@@ -342,6 +356,8 @@ app.get("/:readonly", req => {
     req.stale = true;
     // @ts-expect-error
     req.xhr = true;
+    // @ts-expect-error
+    req.query = true;
 });
 
 // Starting with Express 5 RequestHandler can be async

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -3,6 +3,11 @@
 
 import { SendOptions } from "send";
 import { ParsedQs } from "qs";
+import { ParsedUrlQuery } from "querystring";
+
+export interface SimpleQuery extends ParsedUrlQuery {}
+
+export interface ExtendedQuery extends ParsedQs {}
 
 declare global {
     namespace Express {
@@ -13,7 +18,7 @@ declare global {
         interface Locals {}
         interface Application {}
 
-        interface Query extends ParsedQs {}
+        interface Query extends SimpleQuery {}
     }
 }
 
@@ -49,11 +54,13 @@ export type Params = ParamsDictionary | ParamsArray;
 
 export interface Locals extends Express.Locals {}
 
+export interface Query extends Express.Query {}
+
 export interface RequestHandler<
     P = ParamsDictionary,
     ResBody = any,
     ReqBody = any,
-    ReqQuery = Express.Query,
+    ReqQuery = Query,
     LocalsObj extends Record<string, any> = Record<string, any>,
 > {
     // tslint:disable-next-line callable-types (This is extended from and can't extend from a type alias in ts<2.2)
@@ -68,7 +75,7 @@ export type ErrorRequestHandler<
     P = ParamsDictionary,
     ResBody = any,
     ReqBody = any,
-    ReqQuery = Express.Query,
+    ReqQuery = Query,
     LocalsObj extends Record<string, any> = Record<string, any>,
 > = (
     err: any,
@@ -83,7 +90,7 @@ export type RequestHandlerParams<
     P = ParamsDictionary,
     ResBody = any,
     ReqBody = any,
-    ReqQuery = Express.Query,
+    ReqQuery = Query,
     LocalsObj extends Record<string, any> = Record<string, any>,
 > =
     | RequestHandler<P, ResBody, ReqBody, ReqQuery, LocalsObj>
@@ -122,7 +129,7 @@ export interface IRouterMatcher<
         P = RouteParameters<Route>,
         ResBody = any,
         ReqBody = any,
-        ReqQuery = Express.Query,
+        ReqQuery = Query,
         LocalsObj extends Record<string, any> = Record<string, any>,
     >(
         // (it's used as the default type parameter for P)
@@ -135,7 +142,7 @@ export interface IRouterMatcher<
         P = RouteParameters<Path>,
         ResBody = any,
         ReqBody = any,
-        ReqQuery = Express.Query,
+        ReqQuery = Query,
         LocalsObj extends Record<string, any> = Record<string, any>,
     >(
         // (it's used as the default type parameter for P)
@@ -147,7 +154,7 @@ export interface IRouterMatcher<
         P = ParamsDictionary,
         ResBody = any,
         ReqBody = any,
-        ReqQuery = Express.Query,
+        ReqQuery = Query,
         LocalsObj extends Record<string, any> = Record<string, any>,
     >(
         path: PathParams,
@@ -158,7 +165,7 @@ export interface IRouterMatcher<
         P = ParamsDictionary,
         ResBody = any,
         ReqBody = any,
-        ReqQuery = Express.Query,
+        ReqQuery = Query,
         LocalsObj extends Record<string, any> = Record<string, any>,
     >(
         path: PathParams,
@@ -175,7 +182,7 @@ export interface IRouterHandler<T, Route extends string = string> {
         P = RouteParameters<Route>,
         ResBody = any,
         ReqBody = any,
-        ReqQuery = Express.Query,
+        ReqQuery = Query,
         LocalsObj extends Record<string, any> = Record<string, any>,
     >(
         // (This generic is meant to be passed explicitly.)
@@ -186,7 +193,7 @@ export interface IRouterHandler<T, Route extends string = string> {
         P = RouteParameters<Route>,
         ResBody = any,
         ReqBody = any,
-        ReqQuery = Express.Query,
+        ReqQuery = Query,
         LocalsObj extends Record<string, any> = Record<string, any>,
     >(
         // (This generic is meant to be passed explicitly.)
@@ -197,7 +204,7 @@ export interface IRouterHandler<T, Route extends string = string> {
         P = ParamsDictionary,
         ResBody = any,
         ReqBody = any,
-        ReqQuery = Express.Query,
+        ReqQuery = Query,
         LocalsObj extends Record<string, any> = Record<string, any>,
     >(
         // (This generic is meant to be passed explicitly.)
@@ -208,7 +215,7 @@ export interface IRouterHandler<T, Route extends string = string> {
         P = ParamsDictionary,
         ResBody = any,
         ReqBody = any,
-        ReqQuery = Express.Query,
+        ReqQuery = Query,
         LocalsObj extends Record<string, any> = Record<string, any>,
     >(
         // (This generic is meant to be passed explicitly.)
@@ -396,7 +403,7 @@ export interface Request<
     P = ParamsDictionary,
     ResBody = any,
     ReqBody = any,
-    ReqQuery = Express.Query,
+    ReqQuery = Query,
     LocalsObj extends Record<string, any> = Record<string, any>,
 > extends http.IncomingMessage, Express.Request {
     /**

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -2,6 +2,7 @@
 /// <reference types="node" />
 
 import { SendOptions } from "send";
+import { ParsedQs } from "qs";
 
 declare global {
     namespace Express {
@@ -11,17 +12,16 @@ declare global {
         interface Response {}
         interface Locals {}
         interface Application {}
+
+        interface Query extends ParsedQs {}
     }
 }
 
 import { EventEmitter } from "events";
 import * as http from "http";
-import { ParsedQs } from "qs";
 import { Options as RangeParserOptions, Ranges as RangeParserRanges, Result as RangeParserResult } from "range-parser";
 
 export {};
-
-export type Query = ParsedQs;
 
 export interface NextFunction {
     (err?: any): void;
@@ -53,7 +53,7 @@ export interface RequestHandler<
     P = ParamsDictionary,
     ResBody = any,
     ReqBody = any,
-    ReqQuery = ParsedQs,
+    ReqQuery = Express.Query,
     LocalsObj extends Record<string, any> = Record<string, any>,
 > {
     // tslint:disable-next-line callable-types (This is extended from and can't extend from a type alias in ts<2.2)
@@ -68,7 +68,7 @@ export type ErrorRequestHandler<
     P = ParamsDictionary,
     ResBody = any,
     ReqBody = any,
-    ReqQuery = ParsedQs,
+    ReqQuery = Express.Query,
     LocalsObj extends Record<string, any> = Record<string, any>,
 > = (
     err: any,
@@ -83,7 +83,7 @@ export type RequestHandlerParams<
     P = ParamsDictionary,
     ResBody = any,
     ReqBody = any,
-    ReqQuery = ParsedQs,
+    ReqQuery = Express.Query,
     LocalsObj extends Record<string, any> = Record<string, any>,
 > =
     | RequestHandler<P, ResBody, ReqBody, ReqQuery, LocalsObj>
@@ -122,7 +122,7 @@ export interface IRouterMatcher<
         P = RouteParameters<Route>,
         ResBody = any,
         ReqBody = any,
-        ReqQuery = ParsedQs,
+        ReqQuery = Express.Query,
         LocalsObj extends Record<string, any> = Record<string, any>,
     >(
         // (it's used as the default type parameter for P)
@@ -135,7 +135,7 @@ export interface IRouterMatcher<
         P = RouteParameters<Path>,
         ResBody = any,
         ReqBody = any,
-        ReqQuery = ParsedQs,
+        ReqQuery = Express.Query,
         LocalsObj extends Record<string, any> = Record<string, any>,
     >(
         // (it's used as the default type parameter for P)
@@ -147,7 +147,7 @@ export interface IRouterMatcher<
         P = ParamsDictionary,
         ResBody = any,
         ReqBody = any,
-        ReqQuery = ParsedQs,
+        ReqQuery = Express.Query,
         LocalsObj extends Record<string, any> = Record<string, any>,
     >(
         path: PathParams,
@@ -158,7 +158,7 @@ export interface IRouterMatcher<
         P = ParamsDictionary,
         ResBody = any,
         ReqBody = any,
-        ReqQuery = ParsedQs,
+        ReqQuery = Express.Query,
         LocalsObj extends Record<string, any> = Record<string, any>,
     >(
         path: PathParams,
@@ -175,7 +175,7 @@ export interface IRouterHandler<T, Route extends string = string> {
         P = RouteParameters<Route>,
         ResBody = any,
         ReqBody = any,
-        ReqQuery = ParsedQs,
+        ReqQuery = Express.Query,
         LocalsObj extends Record<string, any> = Record<string, any>,
     >(
         // (This generic is meant to be passed explicitly.)
@@ -186,7 +186,7 @@ export interface IRouterHandler<T, Route extends string = string> {
         P = RouteParameters<Route>,
         ResBody = any,
         ReqBody = any,
-        ReqQuery = ParsedQs,
+        ReqQuery = Express.Query,
         LocalsObj extends Record<string, any> = Record<string, any>,
     >(
         // (This generic is meant to be passed explicitly.)
@@ -197,7 +197,7 @@ export interface IRouterHandler<T, Route extends string = string> {
         P = ParamsDictionary,
         ResBody = any,
         ReqBody = any,
-        ReqQuery = ParsedQs,
+        ReqQuery = Express.Query,
         LocalsObj extends Record<string, any> = Record<string, any>,
     >(
         // (This generic is meant to be passed explicitly.)
@@ -208,7 +208,7 @@ export interface IRouterHandler<T, Route extends string = string> {
         P = ParamsDictionary,
         ResBody = any,
         ReqBody = any,
-        ReqQuery = ParsedQs,
+        ReqQuery = Express.Query,
         LocalsObj extends Record<string, any> = Record<string, any>,
     >(
         // (This generic is meant to be passed explicitly.)
@@ -396,7 +396,7 @@ export interface Request<
     P = ParamsDictionary,
     ResBody = any,
     ReqBody = any,
-    ReqQuery = ParsedQs,
+    ReqQuery = Express.Query,
     LocalsObj extends Record<string, any> = Record<string, any>,
 > extends http.IncomingMessage, Express.Request {
     /**

--- a/types/express-serve-static-core/package.json
+++ b/types/express-serve-static-core/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/express-serve-static-core",
-    "version": "5.0.9999",
+    "version": "5.1.9999",
     "projects": [
         "http://expressjs.com"
     ],


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Express 5](https://expressjs.com/en/5x/api.html#app.set) documentation shows that req.query is now defaulted to "simple", but has other options that should be easy to override at the root of the types.
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

