### PR TITLE
Use `[Async]IteratorObject` as return type for iterator method overrides in @types/node-derived classes in TS5.6+

### DIFF
--- a/types/klaw/index.d.ts
+++ b/types/klaw/index.d.ts
@@ -4,6 +4,15 @@ declare module "klaw" {
     import * as fs from "fs";
     import { Readable, ReadableOptions } from "stream";
 
+    // forward-compatible iterator type for TS <5.6
+    global {
+        // eslint-disable-next-line @typescript-eslint/no-empty-interface
+        interface AsyncIteratorObject<T, TReturn, TNext> {}
+    }
+    interface StreamIterator<T> extends AsyncIterator<T, any, any>, AsyncIteratorObject<T, any, any> {
+        [Symbol.asyncIterator](): StreamIterator<T>;
+    }
+
     function K(root: string, options?: K.Options): K.Walker;
 
     namespace K {
@@ -33,7 +42,7 @@ declare module "klaw" {
             on(event: "readable", listener: () => void): this;
             on(event: "error", listener: (err: Error) => void): this;
             read(): Item;
-            [Symbol.asyncIterator](): AsyncIterableIterator<Item>;
+            [Symbol.asyncIterator](): StreamIterator<Item>;
         }
     }
 

--- a/types/readable-stream/index.d.ts
+++ b/types/readable-stream/index.d.ts
@@ -17,6 +17,15 @@ declare var NoAsyncDispose: {
         : {};
 };
 
+// forward-compatible iterator type for TS <5.6
+declare global {
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface AsyncIteratorObject<T, TReturn, TNext> {}
+}
+interface StreamIterator<T> extends AsyncIterator<T, any, any>, AsyncIteratorObject<T, any, any> {
+    [Symbol.asyncIterator](): StreamIterator<T>;
+}
+
 type ComposeFnParam = (source: any) => void;
 
 interface _IEventEmitter {
@@ -58,7 +67,7 @@ interface _IReadable extends _IEventEmitter {
     unshift(chunk: any): void;
     wrap(oldStream: _Readable.Readable): this;
     push(chunk: any, encoding?: string): boolean;
-    iterator(options?: { destroyOnReturn?: boolean }): AsyncIterableIterator<any>;
+    iterator(options?: { destroyOnReturn?: boolean }): StreamIterator<any>;
     map(fn: (data: any, options?: SignalOption) => any, options?: ArrayOptions): _Readable.Readable;
     filter(
         fn: (data: any, options?: SignalOption) => boolean | Promise<boolean>,
@@ -215,8 +224,8 @@ declare class _Readable extends NoAsyncDispose implements _IReadable {
     listenerCount(eventName: string | symbol): number;
     eventNames(): Array<string | symbol>;
 
-    iterator(options?: { destroyOnReturn?: boolean }): AsyncIterableIterator<any>;
-    [Symbol.asyncIterator](): AsyncIterableIterator<any>;
+    iterator(options?: { destroyOnReturn?: boolean }): StreamIterator<any>;
+    [Symbol.asyncIterator](): StreamIterator<any>;
 
     // static ReadableState: _Readable.ReadableState;
     _readableState: _Readable.ReadableState;
@@ -357,8 +366,8 @@ declare namespace _Readable {
         on(ev: string | symbol, fn: (...args: any[]) => void): this;
 
         _undestroy(): void;
-        iterator(options?: { destroyOnReturn?: boolean }): AsyncIterableIterator<any>;
-        [Symbol.asyncIterator](): AsyncIterableIterator<any>;
+        iterator(options?: { destroyOnReturn?: boolean }): StreamIterator<any>;
+        [Symbol.asyncIterator](): StreamIterator<any>;
         // end-Readable
 
         constructor(options?: DuplexOptions);

--- a/types/tar-stream/index.d.ts
+++ b/types/tar-stream/index.d.ts
@@ -2,6 +2,16 @@
 
 import stream = require("stream");
 
+// forward-compatible iterator type for TS <5.6
+export {}; // do not export StreamIterator
+declare global {
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface AsyncIteratorObject<T, TReturn, TNext> {}
+}
+interface StreamIterator<T> extends AsyncIterator<T, any, any>, AsyncIteratorObject<T, any, any> {
+    [Symbol.asyncIterator](): StreamIterator<T>;
+}
+
 export type Callback = (err?: Error | null) => any;
 
 // see https://github.com/mafintosh/tar-stream/blob/master/headers.js
@@ -41,12 +51,12 @@ export interface Pack extends stream.Readable {
     entry(headers: Headers, callback?: Callback): stream.Writable;
     entry(headers: Headers, buffer?: string | Buffer, callback?: Callback): stream.Writable;
     finalize(): void;
-    [Symbol.asyncIterator](): AsyncIterableIterator<Buffer>;
+    [Symbol.asyncIterator](): StreamIterator<Buffer>;
 }
 
 export interface Entry extends stream.Readable {
     header: Headers;
-    [Symbol.asyncIterator](): AsyncIterableIterator<Buffer>;
+    [Symbol.asyncIterator](): StreamIterator<Buffer>;
 }
 
 export interface Extract extends stream.Writable {
@@ -55,7 +65,7 @@ export interface Extract extends stream.Writable {
         event: "entry",
         listener: (headers: Headers, stream: stream.PassThrough, next: (error?: unknown) => void) => void,
     ): this;
-    [Symbol.asyncIterator](): AsyncIterator<Entry>;
+    [Symbol.asyncIterator](): AsyncIterableIterator<Entry>;
 }
 
 export interface ExtractOptions extends stream.WritableOptions {


### PR DESCRIPTION
Iterable @types/node APIs were configured to use the new `IteratorObject` and `AsyncIteratorObject` interfaces in #70648, making them eligible for augmentation with iterator helper types in esnext. Specifically, there are now two libraries that mutate iterator objects:
- lib.esnext.disposable: augments `[Async]IteratorObject` with disposability methods
- lib.esnext.iterator: augments `IteratorObject` with iterator helper methods

This comes with a subtle side-effect: third-party packages that were defining classes derived from iterable @types/node classes, and then overriding their iterator methods with `[Async]IterableIterator` return types, would now raise "incorrectly extends" errors in environments where `[Async]IteratorObject` has been augmented with any additional methods.

The DT packages touched by this PR all exhibit this behaviour, and hence currently error in TS5.6+ if the relevant esnext libs are loaded; CI didn't identify this issue, as the tests don't run with those libs. An example from [tar-stream](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/bda68a6d19efbc1cf3465e75f68e31355be5ac39/types/tar-stream/index.d.ts#L47-L50), with target=esnext:
```
Interface 'Entry' incorrectly extends interface 'Readable'.
  The types returned by '[Symbol.asyncIterator]()' are incompatible between these types.
    Property '[Symbol.asyncDispose]' is missing in type 'AsyncIterableIterator<Buffer>' but required in type 'AsyncIterator<any, any, any>'
```

This applies both to compiling the DT packages themselves, and to any downstream projects that have esnext libs loaded and skipLibCheck disabled.

This change ensures that those affected iterators honour iterator augmentation under TS5.6+/esnext.