### PR TITLE
fix(m3u8-parser): Make Segment.key.iv an optional Uint32Array.

### DIFF
--- a/types/m3u8-parser/index.d.ts
+++ b/types/m3u8-parser/index.d.ts
@@ -43,7 +43,7 @@ export interface Segment {
     key?: {
         method: string;
         uri: string;
-        iv: string;
+        iv?: Uint32Array;
     };
     map?: {
         uri: string;

--- a/types/m3u8-parser/m3u8-parser-tests.ts
+++ b/types/m3u8-parser/m3u8-parser-tests.ts
@@ -29,6 +29,12 @@ parser3.push(manifest);
 parser3.end();
 parser3.manifest.custom;
 
+const segment = parser3.manifest.segments[0];
+
+if (segment && segment.key) {
+    segment.key.iv;
+}
+
 parser3.addTagMapper({
     expression: /#EXAMPLE/,
     map: () => "#NEW-TAG:123",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

The `Segment.key.iv` property does not necessarily exist. It's only added if the playlist specifies it, as per: https://github.com/videojs/m3u8-parser/blob/26d880375e1dec76fe118acfed06657cb4688d7c/src/parser.js#L361-L368

Additionally, according to my tests on a playlist with an IV value specified, the value of this property will be a `Uint32Array`. From my understanding, the code that converts the parsed string into a Uint32Array is located here:
https://github.com/videojs/m3u8-parser/blob/26d880375e1dec76fe118acfed06657cb4688d7c/src/parse-stream.js#L384-L399