### PR TITLE
[@types/node]: Allow passing undefined to delete key in `setEnvironmentData`

### DIFF
--- a/types/node/test/worker_threads.ts
+++ b/types/node/test/worker_threads.ts
@@ -151,6 +151,7 @@ import { createContext } from "node:vm";
 {
     workerThreads.setEnvironmentData("test", 1);
     workerThreads.setEnvironmentData(123, { a: 1 });
+    workerThreads.setEnvironmentData(123, undefined);
     workerThreads.getEnvironmentData("test"); // $ExpectType Serializable
     workerThreads.getEnvironmentData(1); // $ExpectType Serializable
 }

--- a/types/node/v18/worker_threads.d.ts
+++ b/types/node/v18/worker_threads.d.ts
@@ -648,7 +648,7 @@ declare module "worker_threads" {
      * @param value Any arbitrary, cloneable JavaScript value that will be cloned and passed automatically to all new `Worker` instances. If `value` is passed as `undefined`, any previously set value
      * for the `key` will be deleted.
      */
-    function setEnvironmentData(key: Serializable, value: Serializable): void;
+    function setEnvironmentData(key: Serializable, value?: Serializable): void;
 
     import {
         BroadcastChannel as _BroadcastChannel,

--- a/types/node/v20/worker_threads.d.ts
+++ b/types/node/v20/worker_threads.d.ts
@@ -649,7 +649,7 @@ declare module "worker_threads" {
      * @param value Any arbitrary, cloneable JavaScript value that will be cloned and passed automatically to all new `Worker` instances. If `value` is passed as `undefined`, any previously set value
      * for the `key` will be deleted.
      */
-    function setEnvironmentData(key: Serializable, value: Serializable): void;
+    function setEnvironmentData(key: Serializable, value?: Serializable): void;
 
     import {
         BroadcastChannel as _BroadcastChannel,

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -701,7 +701,7 @@ declare module "worker_threads" {
      * @param value Any arbitrary, cloneable JavaScript value that will be cloned and passed automatically to all new `Worker` instances. If `value` is passed as `undefined`, any previously set value
      * for the `key` will be deleted.
      */
-    function setEnvironmentData(key: Serializable, value: Serializable | undefined): void;
+    function setEnvironmentData(key: Serializable, value?: Serializable): void;
 
     import {
         BroadcastChannel as _BroadcastChannel,

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -701,7 +701,7 @@ declare module "worker_threads" {
      * @param value Any arbitrary, cloneable JavaScript value that will be cloned and passed automatically to all new `Worker` instances. If `value` is passed as `undefined`, any previously set value
      * for the `key` will be deleted.
      */
-    function setEnvironmentData(key: Serializable, value: Serializable): void;
+    function setEnvironmentData(key: Serializable, value: Serializable | undefined): void;
 
     import {
         BroadcastChannel as _BroadcastChannel,


### PR DESCRIPTION
According to the JSDoc:

> If `value` is passed as `undefined`, any previously set value for the `key` will be deleted.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/blob/0bbe5d34e74e8b4cc161a4777b161bfb917cf1e5/lib/internal/worker.js#L115-L120