### PR TITLE
node: do not reference generic TypedArrays in test suite

### DIFF
--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -165,11 +165,11 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as readonly Uint8Array[
 
     // ArrayLike or string
     {
-        const arrayOrString = "foo" as number[] | string;
+        let arrayOrString!: number[] | string;
         // $ExpectType Buffer || Buffer<ArrayBuffer>
         Buffer.from(arrayOrString);
 
-        const typedArrayOrString = "foo" as Uint8Array<ArrayBuffer> | string;
+        let typedArrayOrString!: Uint8Array | string;
         // $ExpectType Buffer || Buffer<ArrayBuffer>
         Buffer.from(typedArrayOrString);
     }

--- a/types/node/v18/test/buffer.ts
+++ b/types/node/v18/test/buffer.ts
@@ -164,11 +164,11 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as readonly Uint8Array[
 
     // ArrayLike or string
     {
-        const arrayOrString = "foo" as number[] | string;
+        let arrayOrString!: number[] | string;
         // $ExpectType Buffer || Buffer<ArrayBuffer>
         Buffer.from(arrayOrString);
 
-        const typedArrayOrString = "foo" as Uint8Array<ArrayBuffer> | string;
+        let typedArrayOrString!: Uint8Array | string;
         // $ExpectType Buffer || Buffer<ArrayBuffer>
         Buffer.from(typedArrayOrString);
     }

--- a/types/node/v20/test/buffer.ts
+++ b/types/node/v20/test/buffer.ts
@@ -165,11 +165,11 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as readonly Uint8Array[
 
     // ArrayLike or string
     {
-        const arrayOrString = "foo" as number[] | string;
+        let arrayOrString!: number[] | string;
         // $ExpectType Buffer || Buffer<ArrayBuffer>
         Buffer.from(arrayOrString);
 
-        const typedArrayOrString = "foo" as Uint8Array<ArrayBuffer> | string;
+        let typedArrayOrString!: Uint8Array | string;
         // $ExpectType Buffer || Buffer<ArrayBuffer>
         Buffer.from(typedArrayOrString);
     }


### PR DESCRIPTION
Pointing tsc at the /types/node tests under TS 5.6 currently fails, due to the addition of a generic TypedArray reference to the test suite in #72097. (Surprised that dtslint hasn't complained...)