### PR TITLE
Fix mapbox-gl-draw 'getFeature' interface

### DIFF
--- a/types/mapbox__mapbox-gl-draw/index.d.ts
+++ b/types/mapbox__mapbox-gl-draw/index.d.ts
@@ -195,7 +195,7 @@ declare namespace MapboxDraw {
 
         isSelected(id: string): boolean;
 
-        getFeature(id: string): DrawFeature;
+        getFeature(id: string): DrawFeature | undefined;
 
         select(id: string): void;
 

--- a/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
+++ b/types/mapbox__mapbox-gl-draw/mapbox__mapbox-gl-draw-tests.ts
@@ -107,7 +107,7 @@ const customMode: CustomMode = {
         this.setSelected("1");
         this.setSelected(["1", "2"]);
 
-        // $ExpectType DrawFeature
+        // $ExpectType DrawFeature | undefined
         this.getFeature("1");
 
         // $ExpectType number


### PR DESCRIPTION
Fix the return type of `getFeature` which can return `undefined` if the feature does not exist.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
