### PR TITLE
[mjml-core] Fix registerComponent function typing

### DIFF
--- a/types/mjml-core/index.d.ts
+++ b/types/mjml-core/index.d.ts
@@ -157,7 +157,10 @@ export const components: { [componentName: string]: Component | undefined };
 /**
  * Registers a component for use in mjml
  */
-export function registerComponent(ComponentClass: typeof Component): void;
+export function registerComponent(
+    ComponentClass: typeof Component, 
+    options?: { registerDependencies?: boolean }
+): void;
 
 export abstract class BodyComponent extends Component {
     constructor(initialData: unknown);

--- a/types/mjml-core/index.d.ts
+++ b/types/mjml-core/index.d.ts
@@ -157,10 +157,7 @@ export const components: { [componentName: string]: Component | undefined };
 /**
  * Registers a component for use in mjml
  */
-export function registerComponent(
-    ComponentClass: typeof Component, 
-    options?: { registerDependencies?: boolean }
-): void;
+export function registerComponent(ComponentClass: typeof Component, options?: { registerDependencies?: boolean }): void;
 
 export abstract class BodyComponent extends Component {
     constructor(initialData: unknown);

--- a/types/mjml-core/mjml-core-tests.ts
+++ b/types/mjml-core/mjml-core-tests.ts
@@ -39,7 +39,7 @@ class MjBreakpoint extends HeadComponent {
 }
 
 registerComponent(MjBreakpoint);
-registerComponent(NewBodyComponent);
+registerComponent(NewBodyComponent, { registerDependencies: true });
 
 const skeleton: MJMLJsonObject = {
     tagName: "mjml",

--- a/types/mjml-core/package.json
+++ b/types/mjml-core/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/mjml-core",
-    "version": "4.15.9999",
+    "version": "4.15.3",
     "projects": [
         "https://mjml.io"
     ],

--- a/types/mjml-core/package.json
+++ b/types/mjml-core/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/mjml-core",
-    "version": "4.15.3",
+    "version": "4.15.9999",
     "projects": [
         "https://mjml.io"
     ],


### PR DESCRIPTION
`registerDependencies` function typing is outdated, here is the new function signature: https://github.com/mjmlio/mjml/blob/master/packages/mjml-core/src/components.js#L12

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
