### PR TITLE
n3: Fix addQuad, removeQuad, getQuads and readQuads accepting array of objects

### DIFF
--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -310,7 +310,7 @@ export class Store<
     addQuad(
         subject: Q_RDF["subject"],
         predicate: Q_RDF["predicate"],
-        object: Q_RDF["object"] | Array<Q_RDF["object"]>,
+        object: Q_RDF["object"],
         graph?: Q_RDF["graph"],
         done?: () => void,
     ): void;
@@ -322,7 +322,7 @@ export class Store<
     removeQuad(
         subject: Q_RDF["subject"],
         predicate: Q_RDF["predicate"],
-        object: Q_RDF["object"] | Array<Q_RDF["object"]>,
+        object: Q_RDF["object"],
         graph?: Q_RDF["graph"],
         done?: () => void,
     ): void;
@@ -336,8 +336,8 @@ export class Store<
         graph?: Term | null,
     ): EventEmitter;
     deleteGraph(graph: Q_RDF["graph"] | string): EventEmitter;
-    getQuads(subject: OTerm, predicate: OTerm, object: OTerm | OTerm[], graph: OTerm): Quad[];
-    readQuads(subject: OTerm, predicate: OTerm, object: OTerm | OTerm[], graph: OTerm): Iterable<OutQuad>;
+    getQuads(subject: OTerm, predicate: OTerm, object: OTerm, graph: OTerm): Quad[];
+    readQuads(subject: OTerm, predicate: OTerm, object: OTerm, graph: OTerm): Iterable<OutQuad>;
     match(
         subject?: Term | null,
         predicate?: Term | null,

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -320,6 +320,14 @@ function test_doc_storing() {
         N3.DataFactory.namedNode("http://ex.org/Dog"),
     );
     store.addQuad(
+        N3.DataFactory.namedNode("http://ex.org/Pluto"),
+        N3.DataFactory.namedNode("http://ex.org/type"),
+        // @ts-expect-error
+        [
+            N3.DataFactory.namedNode("http://ex.org/Dog"),
+        ],
+    );
+    store.addQuad(
         N3.DataFactory.quad(
             N3.DataFactory.namedNode("http://ex.org/Mickey"),
             N3.DataFactory.namedNode("http://ex.org/type"),
@@ -337,6 +345,14 @@ function test_doc_storing() {
         N3.DataFactory.namedNode("http://ex.org/Mickey"),
         N3.DataFactory.namedNode("http://ex.org/type"),
         N3.DataFactory.namedNode("http://ex.org/Mouse"),
+    );
+    store.removeQuad(
+        N3.DataFactory.namedNode("http://ex.org/Mickey"),
+        N3.DataFactory.namedNode("http://ex.org/type"),
+        // @ts-expect-error
+        [
+            N3.DataFactory.namedNode("http://ex.org/Mouse"),
+        ],
     );
     store.removeQuad(
         N3.DataFactory.quad(


### PR DESCRIPTION
`Store.addQuad` and `Store.removeQuad` do not allow passing in an array of objects, and as far as I can tell never have.

Edit: `Store.getQuads` and `Store.readQuads` similarly don't support arrays of objects.

~~No tests because it doesn't make sense to test for a feature that doesn't exist.~~ Added `@ts-expect-error` tests.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

`Store.addQuad`: https://github.com/rdfjs/N3.js/blob/5a58e93196a5048b6a4c09a1826847a7b811d283/src/N3Store.js#L353-L389
`Store.removeQuad`: https://github.com/rdfjs/N3.js/blob/5a58e93196a5048b6a4c09a1826847a7b811d283/src/N3Store.js#L417-L446
`Store.getQuads`: https://github.com/rdfjs/N3.js/blob/5a58e93196a5048b6a4c09a1826847a7b811d283/src/N3Store.js#L485-L489
`Store.readQuads`: https://github.com/rdfjs/N3.js/blob/5a58e93196a5048b6a4c09a1826847a7b811d283/src/N3Store.js#L491-L534

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
