### PR TITLE
feat: add BaseIRI to type exports

### DIFF
--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -66,6 +66,12 @@ export class DefaultGraph implements RDF.DefaultGraph {
     static subclass(type: any): void;
 }
 
+export class BaseIRI {
+    constructor(base: string);
+    static supports(base: string): boolean;
+    toRelative(iri: string): string;
+}
+
 export type Quad_Subject = NamedNode | BlankNode | Variable;
 export type Quad_Predicate = NamedNode | Variable;
 export type Quad_Object = NamedNode | Literal | BlankNode | Variable;

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -585,5 +585,16 @@ function test_reasoner() {
     new N3.Reasoner(store).reason(new N3.Store<RDF.BaseQuad>());
 }
 
+function test_base_iri_constructor() {
+    // Test BaseIRI constructor with various base IRIs
+    const baseIri: N3.BaseIRI = new N3.BaseIRI("http://example.org/");
+
+    // Test BaseIRI.supports static method
+    const supported1: boolean = N3.BaseIRI.supports("http://example.org/");
+
+    // Test converting absolute IRIs to relative
+    const relative1: string = baseIri.toRelative("http://example.org/path/resource");
+}
+
 export const namedNode: ReturnType<RDF.DataFactory["namedNode"]> = N3.DataFactory.namedNode("hello world");
 export const df: RDF.DataFactory = N3.DataFactory;

--- a/types/n3/package.json
+++ b/types/n3/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/n3",
-    "version": "1.24.9999",
+    "version": "1.25.9999",
     "projects": [
         "https://github.com/rdfjs/n3.js"
     ],


### PR DESCRIPTION
The `BaseIRI` class has been exported from N3 for a while, but lacking a type declaration.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/rdfjs/N3.js/blob/main/src/BaseIRI.js>
- [NA] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
