### PR TITLE
Fix Meteor `Mongo.Cursor` iterator return type

### DIFF
--- a/types/meteor/mongo.d.ts
+++ b/types/meteor/mongo.d.ts
@@ -479,8 +479,8 @@ declare module 'meteor/mongo' {
                 callbacks: ObserveChangesCallbacks<T>,
                 options?: { nonMutatingCallbacks?: boolean | undefined },
             ): Meteor.LiveQueryHandle;
-            [Symbol.iterator](): Iterator<T>;
-            [Symbol.asyncIterator](): AsyncIterator<T>;
+            [Symbol.iterator](): Iterator<U>;
+            [Symbol.asyncIterator](): AsyncIterator<U>;
         }
 
         var ObjectID: ObjectIDStatic;

--- a/types/meteor/test/meteor-mongo-tests.ts
+++ b/types/meteor/test/meteor-mongo-tests.ts
@@ -3,27 +3,31 @@ import { Mongo, MongoInternals } from 'meteor/mongo';
 // Tests Mongo Collection Types
 
 // Test without default transform function
-type DBUser = {
+type UserDoc = {
     _id: string;
     name: string;
     surname: string;
 };
 
-// $ExpectType Collection<DBUser, DBUser>
-const Users = new Mongo.Collection<DBUser>('users');
+type UserModel = UserDoc & {
+    fullname(): string;
+};
+
+// $ExpectType Collection<UserDoc, UserModel>
+const Users = new Mongo.Collection<UserDoc, UserModel>('users');
 
 Users.find({}).map(doc => {
-    // $ExpectType DBUser
+    // $ExpectType UserModel
     doc;
     return doc;
 });
 Users.find({}, {}).map(doc => {
-    // $ExpectType DBUser
+    // $ExpectType UserModel
     doc;
     return doc;
 });
 Users.find({}, { transform: null }).map(doc => {
-    // $ExpectType DBUser
+    // $ExpectType UserDoc
     doc;
     return doc;
 });
@@ -31,7 +35,7 @@ Users.find(
     {},
     {
         transform: doc => {
-            // $ExpectType DBUser
+            // $ExpectType UserDoc
             doc;
             return { fullName: `${doc.surname} ${doc.name}` };
         },
@@ -48,32 +52,37 @@ Users.find({}).count();
 // $ExpectType Promise<number>
 Users.find({}).countAsync();
 
-// $ExpectType Promise<DBUser[]>
+// $ExpectType Promise<UserModel[]>
 Users.find({}).mapAsync(doc => {
-    // $ExpectType DBUser
+    // $ExpectType UserModel
     doc;
     return doc;
 });
 
+for (const user of Users.find({})) {
+    // $ExpectType UserModel
+    user;
+}
+
 Users.deny({
     update: (userId, doc) => {
         // $ExpectType string
         userId;
-        // $ExpectType DBUser
+        // $ExpectType UserModel
         doc;
         return true;
     },
     remove: (userId, doc) => {
         // $ExpectType string
         userId;
-        // $ExpectType DBUser
+        // $ExpectType UserModel
         doc;
         return true;
     },
     insert: (userId, doc) => {
         // $ExpectType string
         userId;
-        // $ExpectType DBUser
+        // $ExpectType UserModel
         doc;
         return true;
     },
@@ -83,21 +92,21 @@ Users.deny({
     update: (userId, doc) => {
         // $ExpectType string
         userId;
-        // $ExpectType DBUser
+        // $ExpectType UserDoc
         doc;
         return true;
     },
     remove: (userId, doc) => {
         // $ExpectType string
         userId;
-        // $ExpectType DBUser
+        // $ExpectType UserDoc
         doc;
         return true;
     },
     insert: (userId, doc) => {
         // $ExpectType string
         userId;
-        // $ExpectType DBUser
+        // $ExpectType UserDoc
         doc;
         return true;
     },
@@ -129,28 +138,28 @@ Users.deny({
     },
 
     // Can not figure out why we should define manually type of document
-    transform: (doc: DBUser) => ({ fullName: `${doc.surname} ${doc.name}` }),
+    transform: (doc: UserDoc) => ({ fullName: `${doc.surname} ${doc.name}` }),
 });
 
 Users.allow({
     update: (userId, doc) => {
         // $ExpectType string
         userId;
-        // $ExpectType DBUser
+        // $ExpectType UserModel
         doc;
         return true;
     },
     remove: (userId, doc) => {
         // $ExpectType string
         userId;
-        // $ExpectType DBUser
+        // $ExpectType UserModel
         doc;
         return true;
     },
     insert: (userId, doc) => {
         // $ExpectType string
         userId;
-        // $ExpectType DBUser
+        // $ExpectType UserModel
         doc;
         return true;
     },
@@ -160,21 +169,21 @@ Users.allow({
     update: (userId, doc) => {
         // $ExpectType string
         userId;
-        // $ExpectType DBUser
+        // $ExpectType UserDoc
         doc;
         return true;
     },
     remove: (userId, doc) => {
         // $ExpectType string
         userId;
-        // $ExpectType DBUser
+        // $ExpectType UserDoc
         doc;
         return true;
     },
     insert: (userId, doc) => {
         // $ExpectType string
         userId;
-        // $ExpectType DBUser
+        // $ExpectType UserDoc
         doc;
         return true;
     },
@@ -206,14 +215,14 @@ Users.allow({
     },
 
     // Can not figure out why we should define manually type of document
-    transform: (doc: DBUser) => ({ fullName: `${doc.surname} ${doc.name}` }),
+    transform: (doc: UserDoc) => ({ fullName: `${doc.surname} ${doc.name}` }),
 });
 
 Users.find({}).observe({
     changed: (newDoc, oldDoc) => {
-        // $ExpectType DBUser
+        // $ExpectType UserModel
         newDoc;
-        // $ExpectType DBUser
+        // $ExpectType UserModel
         oldDoc;
         return false;
     },
@@ -223,7 +232,7 @@ Users.find(
     {},
     {
         transform: doc => {
-            // $ExpectType DBUser
+            // $ExpectType UserDoc
             doc;
             return { fullName: `${doc.surname} ${doc.name}` };
         },
@@ -240,26 +249,26 @@ Users.find(
 
 Users.find({}, { transform: null }).observe({
     changed: (newDoc, oldDoc) => {
-        // $ExpectType DBUser
+        // $ExpectType UserDoc
         newDoc;
-        // $ExpectType DBUser
+        // $ExpectType UserDoc
         oldDoc;
         return false;
     },
 });
 
-// $ExpectType DBUser | undefined
+// $ExpectType UserModel | undefined
 Users.findOne({});
-// $ExpectType DBUser | undefined
+// $ExpectType UserModel | undefined
 Users.findOne({}, {});
-// $ExpectType DBUser | undefined
+// $ExpectType UserDoc | undefined
 Users.findOne({}, { transform: null });
 // $ExpectType { fullName: string; } | undefined
 Users.findOne(
     {},
     {
         transform: doc => {
-            // $ExpectType DBUser
+            // $ExpectType UserDoc
             doc;
             return { fullName: `${doc.surname} ${doc.name}` };
         },
@@ -267,15 +276,15 @@ Users.findOne(
 );
 
 // Test with default transform function
-type DBAttachment = {
+type AttachmentDoc = {
     _id: string;
     size: number;
 };
 
-interface AttachmentDocument extends DBAttachment {}
+interface AttachmentModel extends AttachmentDoc {}
 
-class AttachmentDocument {
-    constructor(doc: DBAttachment) {
+class AttachmentModel {
+    constructor(doc: AttachmentDoc) {
         Object.assign(this, doc);
     }
 
@@ -284,27 +293,27 @@ class AttachmentDocument {
     }
 }
 
-// $ExpectType Collection<DBAttachment, AttachmentDocument>
-export const Attachment = new Mongo.Collection<DBAttachment, AttachmentDocument>('attachments', {
+// $ExpectType Collection<AttachmentDoc, AttachmentModel>
+export const Attachment = new Mongo.Collection<AttachmentDoc, AttachmentModel>('attachments', {
     transform: doc => {
-        // $ExpectType DBAttachment
+        // $ExpectType AttachmentDoc
         doc;
-        return new AttachmentDocument(doc);
+        return new AttachmentModel(doc);
     },
 });
 
 Attachment.find({}).map(doc => {
-    // $ExpectType AttachmentDocument
+    // $ExpectType AttachmentModel
     doc;
     return doc;
 });
 Attachment.find({}, {}).map(doc => {
-    // $ExpectType AttachmentDocument
+    // $ExpectType AttachmentModel
     doc;
     return doc;
 });
 Attachment.find({}, { transform: null }).map(doc => {
-    // $ExpectType DBAttachment
+    // $ExpectType AttachmentDoc
     doc;
     return doc;
 });
@@ -312,7 +321,7 @@ Attachment.find(
     {},
     {
         transform: doc => {
-            // $ExpectType DBAttachment
+            // $ExpectType AttachmentDoc
             doc;
             return { fileSize: doc.size };
         },
@@ -323,45 +332,50 @@ Attachment.find(
     return doc;
 });
 
-// $ExpectType AttachmentDocument | undefined
+// $ExpectType AttachmentModel | undefined
 Attachment.findOne({});
-// $ExpectType AttachmentDocument | undefined
+// $ExpectType AttachmentModel | undefined
 Attachment.findOne({}, {});
-// $ExpectType DBAttachment | undefined
+// $ExpectType AttachmentDoc | undefined
 Attachment.findOne({}, { transform: null });
 // $ExpectType { fileSize: number; } | undefined
 Attachment.findOne(
     {},
     {
         transform: doc => {
-            // $ExpectType DBAttachment
+            // $ExpectType AttachmentDoc
             doc;
             return { fileSize: doc.size };
         },
     },
 );
-// $ExpectType Promise<AttachmentDocument | undefined>
+// $ExpectType Promise<AttachmentModel | undefined>
 Attachment.findOneAsync({}, { hint: 'indexName' });
 
+for (const attachment of Attachment.find({})) {
+    // $ExpectType AttachmentModel
+    attachment;
+}
+
 Attachment.deny({
     update: (userId, doc) => {
         // $ExpectType string
         userId;
-        // $ExpectType AttachmentDocument
+        // $ExpectType AttachmentModel
         doc;
         return true;
     },
     remove: (userId, doc) => {
         // $ExpectType string
         userId;
-        // $ExpectType AttachmentDocument
+        // $ExpectType AttachmentModel
         doc;
         return true;
     },
     insert: (userId, doc) => {
         // $ExpectType string
         userId;
-        // $ExpectType AttachmentDocument
+        // $ExpectType AttachmentModel
         doc;
         return true;
     },
@@ -371,21 +385,21 @@ Attachment.deny({
     update: (userId, doc) => {
         // $ExpectType string
         userId;
-        // $ExpectType DBAttachment
+        // $ExpectType AttachmentDoc
         doc;
         return true;
     },
     remove: (userId, doc) => {
         // $ExpectType string
         userId;
-        // $ExpectType DBAttachment
+        // $ExpectType AttachmentDoc
         doc;
         return true;
     },
     insert: (userId, doc) => {
         // $ExpectType string
         userId;
-        // $ExpectType DBAttachment
+        // $ExpectType AttachmentDoc
         doc;
         return true;
     },
@@ -417,28 +431,28 @@ Attachment.deny({
     },
 
     // Can not figure out why we should define manually type of document
-    transform: (doc: DBAttachment) => ({ fileSize: doc.size }),
+    transform: (doc: AttachmentDoc) => ({ fileSize: doc.size }),
 });
 
 Attachment.allow({
     update: (userId, doc) => {
         // $ExpectType string
         userId;
-        // $ExpectType AttachmentDocument
+        // $ExpectType AttachmentModel
         doc;
         return true;
     },
     remove: (userId, doc) => {
         // $ExpectType string
         userId;
-        // $ExpectType AttachmentDocument
+        // $ExpectType AttachmentModel
         doc;
         return true;
     },
     insert: (userId, doc) => {
         // $ExpectType string
         userId;
-        // $ExpectType AttachmentDocument
+        // $ExpectType AttachmentModel
         doc;
         return true;
     },
@@ -448,21 +462,21 @@ Attachment.allow({
     update: (userId, doc) => {
         // $ExpectType string
         userId;
-        // $ExpectType DBAttachment
+        // $ExpectType AttachmentDoc
         doc;
         return true;
     },
     remove: (userId, doc) => {
         // $ExpectType string
         userId;
-        // $ExpectType DBAttachment
+        // $ExpectType AttachmentDoc
         doc;
         return true;
     },
     insert: (userId, doc) => {
         // $ExpectType string
         userId;
-        // $ExpectType DBAttachment
+        // $ExpectType AttachmentDoc
         doc;
         return true;
     },
@@ -494,14 +508,14 @@ Attachment.allow({
     },
 
     // Can not figure out why we should define manually type of document
-    transform: (doc: DBAttachment) => ({ fileSize: doc.size }),
+    transform: (doc: AttachmentDoc) => ({ fileSize: doc.size }),
 });
 
 Attachment.find({}).observe({
     changed: (newDoc, oldDoc) => {
-        // $ExpectType AttachmentDocument
+        // $ExpectType AttachmentModel
         newDoc;
-        // $ExpectType AttachmentDocument
+        // $ExpectType AttachmentModel
         oldDoc;
         return false;
     },
@@ -511,7 +525,7 @@ Attachment.find(
     {},
     {
         transform: doc => {
-            // $ExpectType DBAttachment
+            // $ExpectType AttachmentDoc
             doc;
             return { fileSize: doc.size };
         },
@@ -528,9 +542,9 @@ Attachment.find(
 
 Attachment.find({}, { transform: null }).observe({
     changed: (newDoc, oldDoc) => {
-        // $ExpectType DBAttachment
+        // $ExpectType AttachmentDoc
         newDoc;
-        // $ExpectType DBAttachment
+        // $ExpectType AttachmentDoc
         oldDoc;
         return false;
     },
@@ -557,4 +571,4 @@ Attachment.allow({ transform: { foo: 'foo' } });
 Attachment.deny({ transform: [] });
 
 // @ts-expect-error
-new Mongo.Collection<DBAttachment, AttachmentDocument>('attachments', { transform: '' });
+new Mongo.Collection<AttachmentDoc, AttachmentModel>('attachments', { transform: '' });


### PR DESCRIPTION
Follow up to #71506 with change requests addressed.

This fixes wrong types defined for the `Mongo.Cursor` return value, which affectes the following use case example:

```js
import { Mongo } from 'meteor/mongo';

export class FooData {
  /** @type {string} */
  name;
}

export class Foo extends FooData {
  echo() {
    console.log(this.name);
  }
}

/**
 * @extends {Collection<FooData, Foo>}
 */
export const CollFoo = new Mongo.Collection('collFoo', {
  transform: (doc) => Object.assign(new Foo(), doc),
});

// All of the following use cases are valid
CollFoo.findOne().echo();
CollFoo.find().fetch()[0].echo();
// But this is highlighted in IDE as wrong because `Mong.Cursor[Symbol.iterator]()` return type is set to `FooData` not `Foo`
CollFoo.find()[Symbol.iterator]().next().value.echo();
```