### PR TITLE
node, readable-stream: add `Writable.prototype.writableAborted`

### DIFF
--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -738,6 +738,12 @@ declare module "stream" {
              */
             readonly writable: boolean;
             /**
+             * Returns whether the stream was destroyed or errored before emitting `'finish'`.
+             * @since v18.0.0, v16.17.0
+             * @experimental
+             */
+            readonly writableAborted: boolean;
+            /**
              * Is `true` after `writable.end()` has been called. This property
              * does not indicate whether the data has been flushed, for this use `writable.writableFinished` instead.
              * @since v12.9.0

--- a/types/node/v18/stream.d.ts
+++ b/types/node/v18/stream.d.ts
@@ -730,6 +730,12 @@ declare module "stream" {
              */
             readonly writable: boolean;
             /**
+             * Returns whether the stream was destroyed or errored before emitting `'finish'`.
+             * @since v18.0.0, v16.17.0
+             * @experimental
+             */
+            readonly writableAborted: boolean;
+            /**
              * Is `true` after `writable.end()` has been called. This property
              * does not indicate whether the data has been flushed, for this use `writable.writableFinished` instead.
              * @since v12.9.0

--- a/types/node/v20/stream.d.ts
+++ b/types/node/v20/stream.d.ts
@@ -738,6 +738,12 @@ declare module "stream" {
              */
             readonly writable: boolean;
             /**
+             * Returns whether the stream was destroyed or errored before emitting `'finish'`.
+             * @since v18.0.0, v16.17.0
+             * @experimental
+             */
+            readonly writableAborted: boolean;
+            /**
              * Is `true` after `writable.end()` has been called. This property
              * does not indicate whether the data has been flushed, for this use `writable.writableFinished` instead.
              * @since v12.9.0

--- a/types/readable-stream/index.d.ts
+++ b/types/readable-stream/index.d.ts
@@ -302,6 +302,7 @@ declare namespace _Readable {
 
         readonly readableAborted: boolean;
         readonly readableDidRead: boolean;
+        readonly writableAborted: boolean;
         readonly writableEnded: boolean;
         readonly writableFinished: boolean;
         readonly writableCorked: number;
@@ -651,6 +652,7 @@ declare namespace _Readable {
     }
 
     class Writable extends _Writable {
+        readonly writableAborted: boolean;
         readonly writableEnded: boolean;
         readonly writableFinished: boolean;
         readonly writableObjectMode: boolean;


### PR DESCRIPTION
An experimental getter that was missing from @types/node v18.0 and @types/readable-stream v4.0.

Graduates to stable in v24, and needs to be added to both packages to avoid assignability issues with readable-stream.