### PR TITLE
[@types/node] Change `createHistogram` creation options (min,max → lowest,highest)

### DIFF
--- a/types/node/perf_hooks.d.ts
+++ b/types/node/perf_hooks.d.ts
@@ -866,12 +866,12 @@ declare module "perf_hooks" {
          * The minimum recordable value. Must be an integer value greater than 0.
          * @default 1
          */
-        min?: number | bigint | undefined;
+        lowest?: number | bigint | undefined;
         /**
          * The maximum recordable value. Must be an integer value greater than min.
          * @default Number.MAX_SAFE_INTEGER
          */
-        max?: number | bigint | undefined;
+        highest?: number | bigint | undefined;
         /**
          * The number of accuracy digits. Must be a number between 1 and 5.
          * @default 3

--- a/types/node/test/perf_hooks.ts
+++ b/types/node/test/perf_hooks.ts
@@ -72,8 +72,8 @@ const exceeds: number = monitor.exceeds;
 
 let histogram: RecordableHistogram = createHistogram({
     figures: 123,
-    min: 1,
-    max: 2,
+    lowest: 1,
+    highest: 2,
 });
 histogram = createHistogram();
 

--- a/types/node/v18/perf_hooks.d.ts
+++ b/types/node/v18/perf_hooks.d.ts
@@ -823,12 +823,12 @@ declare module "perf_hooks" {
          * The minimum recordable value. Must be an integer value greater than 0.
          * @default 1
          */
-        min?: number | bigint | undefined;
+        lowest?: number | bigint | undefined;
         /**
          * The maximum recordable value. Must be an integer value greater than min.
          * @default Number.MAX_SAFE_INTEGER
          */
-        max?: number | bigint | undefined;
+        highest?: number | bigint | undefined;
         /**
          * The number of accuracy digits. Must be a number between 1 and 5.
          * @default 3

--- a/types/node/v18/test/perf_hooks.ts
+++ b/types/node/v18/test/perf_hooks.ts
@@ -72,8 +72,8 @@ const exceeds: number = monitor.exceeds;
 
 let histogram: RecordableHistogram = createHistogram({
     figures: 123,
-    min: 1,
-    max: 2,
+    lowest: 1,
+    highest: 2,
 });
 histogram = createHistogram();
 

--- a/types/node/v20/perf_hooks.d.ts
+++ b/types/node/v20/perf_hooks.d.ts
@@ -830,12 +830,12 @@ declare module "perf_hooks" {
          * The minimum recordable value. Must be an integer value greater than 0.
          * @default 1
          */
-        min?: number | bigint | undefined;
+        lowest?: number | bigint | undefined;
         /**
          * The maximum recordable value. Must be an integer value greater than min.
          * @default Number.MAX_SAFE_INTEGER
          */
-        max?: number | bigint | undefined;
+        highest?: number | bigint | undefined;
         /**
          * The number of accuracy digits. Must be a number between 1 and 5.
          * @default 3

--- a/types/node/v20/test/perf_hooks.ts
+++ b/types/node/v20/test/perf_hooks.ts
@@ -72,8 +72,8 @@ const exceeds: number = monitor.exceeds;
 
 let histogram: RecordableHistogram = createHistogram({
     figures: 123,
-    min: 1,
-    max: 2,
+    lowest: 1,
+    highest: 2,
 });
 histogram = createHistogram();
 


### PR DESCRIPTION
From reading the Node.js source code, the `createHistogram` API does not accept min/max but instead accepts lowest/highest. This PR makes that change

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/blob/53944c44629b651425f8d18c4d33f9bc99657d37/lib/internal/histogram.js#L366-L383