### PR TITLE
[openapi-to-postmanv2] Fix incorrect parameter: `disableOptionalParameters`

### DIFF
--- a/types/openapi-to-postmanv2/index.d.ts
+++ b/types/openapi-to-postmanv2/index.d.ts
@@ -1,6 +1,6 @@
-export {};
+export { };
 
-import { CollectionDefinition } from "postman-collection";
+    import { CollectionDefinition } from "postman-collection";
 
 export interface Input {
     type: "file" | "string" | "json";
@@ -155,11 +155,11 @@ export interface Options {
     allowUrlPathVarMatching?: boolean | undefined;
 
     /**
-     * Whether to set optional parameters as disabled
+     * Whether to set optional parameters as enabled
      *
-     * default: false
+     * default: true
      */
-    disableOptionalParameters?: boolean | undefined;
+    enableOptionalParameters?: boolean | undefined;
 
     /**
      * Whether to keep implicit headers from the OpenAPI specification, which are removed by default.

--- a/types/openapi-to-postmanv2/index.d.ts
+++ b/types/openapi-to-postmanv2/index.d.ts
@@ -1,6 +1,6 @@
-export { };
+export {};
 
-    import { CollectionDefinition } from "postman-collection";
+import { CollectionDefinition } from "postman-collection";
 
 export interface Input {
     type: "file" | "string" | "json";

--- a/types/openapi-to-postmanv2/package.json
+++ b/types/openapi-to-postmanv2/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/openapi-to-postmanv2",
-    "version": "3.2.9999",
+    "version": "4.0.0",
     "projects": [
         "https://github.com/postmanlabs/openapi-to-postman/"
     ],

--- a/types/openapi-to-postmanv2/package.json
+++ b/types/openapi-to-postmanv2/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/openapi-to-postmanv2",
-    "version": "4.0.0",
+    "version": "5.0.0",
     "projects": [
         "https://github.com/postmanlabs/openapi-to-postman/"
     ],

--- a/types/openapi-to-postmanv2/package.json
+++ b/types/openapi-to-postmanv2/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/openapi-to-postmanv2",
-    "version": "5.0.0",
+    "version": "5.0.9999",
     "projects": [
         "https://github.com/postmanlabs/openapi-to-postman/"
     ],


### PR DESCRIPTION
The `disableOptionalParamters` type on the options for this library was wrong. It should be `enableOptionalParameters` to match the [package's documentation](https://github.com/postmanlabs/openapi-to-postman/blob/develop/OPTIONS.md).

This change updates the parameter list to match the official documentation.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/postmanlabs/openapi-to-postman/blob/develop/OPTIONS.md (notice that `disableOptionalParameters` is not on the options list, but `enableOptionalParameters` is)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
