### PR TITLE
[dockerode] Support full NetworkCreateOptions

### DIFF
--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -425,6 +425,35 @@ docker.createNetwork({
     });
 });
 
+// Should support all network create IPAM config options
+// See: https://github.com/moby/moby/blob/5d7550e9ef36f860738af643d321a132539452af/api/types/network/ipam.go#L11-L24
+docker.createNetwork({
+    Name: "ipamNetwork",
+    IPAM: {
+        Driver: "default",
+        Config: [
+            {
+                Subnet: "172.28.0.0/16",
+                IPRange: "172.28.5.0/24",
+                Gateway: "172.28.5.254",
+                AuxiliaryAddresses: {
+                    host1: "172.28.1.5",
+                    host2: "172.28.1.6",
+                    host3: "172.28.1.7",
+                },
+            },
+        ],
+        Options: {
+            foo: "bar",
+            bar: "0",
+        },
+    },
+}, (err, network) => {
+    network.remove((err, data) => {
+        // NOOP
+    });
+});
+
 docker.createVolume();
 
 docker.createVolume({ Name: "volumeName", abortSignal: new AbortController().signal });

--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -387,6 +387,44 @@ docker.createNetwork({ Name: "networkName" }, (err, network) => {
     });
 });
 
+// Should support all network create options
+// See: https://github.com/moby/moby/blob/7ea613d780be40e08665f0fc15bf53f5993455a9/api/types/network/network.go#L23-L46
+docker.createNetwork({
+    Name: "networkName",
+    CheckDuplicate: true,
+    abortSignal: new AbortController().signal,
+    Driver: "bridge",
+    Scope: "local",
+    EnableIPv4: true,
+    EnableIPv6: true,
+    IPAM: {
+        Driver: "default",
+        Options: {
+            foo: "bar",
+        },
+        Config: [
+            {
+                Subnet: "172.28.0.0/16",
+                IPRange: "172.28.1.0/24",
+                Gateway: "172.28.0.1",
+            },
+        ],
+    },
+    Internal: true,
+    Attachable: true,
+    Ingress: true,
+    // Docker doesn't accept ConfigFrom & ConfigOnly together,
+    // but that's not dockerode's job to enforce.
+    ConfigOnly: true,
+    ConfigFrom: { Network: "configOnlyNetwork" },
+    Options: { someOption: "someValue" },
+    Labels: { someLabel: "someValue" },
+}, (err, network) => {
+    network.remove((err, data) => {
+        // NOOP
+    });
+});
+
 docker.createVolume();
 
 docker.createVolume({ Name: "volumeName", abortSignal: new AbortController().signal });

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -475,11 +475,15 @@ declare namespace Dockerode {
         Name: string;
         CheckDuplicate?: boolean | undefined;
         Driver?: string | undefined;
+        Scope?: string | undefined;
+        EnableIPv4?: boolean | undefined;
+        EnableIPv6?: boolean | undefined;
+        IPAM?: IPAM | undefined;
         Internal?: boolean | undefined;
         Attachable?: boolean | undefined;
         Ingress?: boolean | undefined;
-        IPAM?: IPAM | undefined;
-        EnableIPv6?: boolean | undefined;
+        ConfigOnly?: boolean | undefined;
+        ConfigFrom?: { Network?: string } | undefined;
         Options?: { [option: string]: string } | undefined;
         Labels?: { [label: string]: string } | undefined;
 

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -503,13 +503,18 @@ declare namespace Dockerode {
         IPv6Address: string;
     }
 
-    /* tslint:disable:interface-name */
     interface IPAM {
-        Driver: string;
-        Config?: Array<{ [key: string]: string }> | undefined;
+        Driver?: string;
         Options?: { [key: string]: string } | undefined;
+        Config?:
+            | Array<{
+                Subnet?: string | undefined;
+                IPRange?: string | undefined;
+                Gateway?: string | undefined;
+                AuxiliaryAddresses?: Partial<{ [host: string]: string }> | undefined;
+            }>
+            | undefined;
     }
-    /* tslint:enable:interface-name */
 
     interface VolumeCreateOptions {
         Name?: string | undefined;


### PR DESCRIPTION
Changes:
- Support `Scope`, `EnableIPv4`, `ConfigOnly`, and `ConfigFrom` for `NetworkCreateOptions` ([upstream ref](https://github.com/moby/moby/blob/7ea613d780be40e08665f0fc15bf53f5993455a9/api/types/network/network.go#L23-L46)). Dockerode already supports passing these opts.
- Support `IPAM.Config.[].AuxiliaryAddresses` as a string map ([upstream ref](https://github.com/moby/moby/blob/5d7550e9ef36f860738af643d321a132539452af/api/types/network/ipam.go#L11-L24)). Dockerode also already supports passing these opts.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.) **See test script [here](https://gist.github.com/cywang117/19a48e621113228bdbcbd6d588bdac74)**
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [upstream ref1](https://github.com/moby/moby/blob/7ea613d780be40e08665f0fc15bf53f5993455a9/api/types/network/network.go#L23-L46), [upstream ref2](https://github.com/moby/moby/blob/5d7550e9ef36f860738af643d321a132539452af/api/types/network/ipam.go#L11-L24)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json` - Not necessary, as dockerode also already supports passing these opts. Their types just aren't in line with the current dockerode interface.