### PR TITLE
[google_interactive_media_ads_types]Add missing getContentType method

### DIFF
--- a/types/google_interactive_media_ads_types/google_interactive_media_ads_types-tests.ts
+++ b/types/google_interactive_media_ads_types/google_interactive_media_ads_types-tests.ts
@@ -4,5 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// Placeholder test file.
-google.ima;
+function createAd(): google.ima.Ad {
+    throw new Error("Cannot create");
+}
+
+const ad = createAd();
+
+// $ExpectType string
+const contentType = ad.getContentType();

--- a/types/google_interactive_media_ads_types/index.d.ts
+++ b/types/google_interactive_media_ads_types/index.d.ts
@@ -60,9 +60,9 @@ declare namespace google.ima {
             settings?: CompanionAdSelectionSettings,
         ): CompanionAd[];
         /**
-         * Returns the content type of the currently selected creative, 
-         * or empty string if no creative is selected or the content type is unavailable. 
-         * For linear ads, the content type is only going to be available after the START event, 
+         * Returns the content type of the currently selected creative,
+         * or empty string if no creative is selected or the content type is unavailable.
+         * For linear ads, the content type is only going to be available after the START event,
          * when the media file is selected.
          * @return the content type of the currently selected creative
          */

--- a/types/google_interactive_media_ads_types/index.d.ts
+++ b/types/google_interactive_media_ads_types/index.d.ts
@@ -60,6 +60,14 @@ declare namespace google.ima {
             settings?: CompanionAdSelectionSettings,
         ): CompanionAd[];
         /**
+         * Returns the content type of the currently selected creative, 
+         * or empty string if no creative is selected or the content type is unavailable. 
+         * For linear ads, the content type is only going to be available after the START event, 
+         * when the media file is selected.
+         * @return the content type of the currently selected creative
+         */
+        getContentType(): string;
+        /**
          * Returns the ISCI (Industry Standard Commercial Identifier) code for an
          * ad, or empty string if the code is unavailable. This is the Ad-ID of the
          * creative in the VAST response.


### PR DESCRIPTION

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [getContentType](https://developers.google.com/interactive-media-ads/docs/sdks/html5/client-side/reference/js/google.ima.Ad#getContentType)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
