### PR TITLE
node: correct transferables, canonicalise Transferable

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -266,11 +266,6 @@ declare global {
 
     // Global DOM types
 
-    function structuredClone<T>(
-        value: T,
-        transfer?: { transfer: ReadonlyArray<import("worker_threads").TransferListItem> },
-    ): T;
-
     interface DOMException extends _DOMException {}
     var DOMException: typeof globalThis extends { onmessage: any; DOMException: infer T } ? T
         : NodeDOMExceptionConstructor;

--- a/types/node/test/globals.ts
+++ b/types/node/test/globals.ts
@@ -60,17 +60,6 @@ declare var RANDOM_GLOBAL_VARIABLE: true;
     }
 }
 
-// structuredClone
-{
-    structuredClone(123); // $ExpectType 123
-    structuredClone("hello"); // $ExpectType "hello"
-    structuredClone({ test: 123 }); // $ExpectType { test: number; }
-    structuredClone([{ test: 123 }]); // $ExpectType { test: number; }[]
-
-    const arrayBuffer = new ArrayBuffer(0);
-    structuredClone({ test: arrayBuffer }, { transfer: [arrayBuffer] }); // $ExpectType { test: ArrayBuffer; }
-}
-
 // Array.prototype.at()
 {
     const mutableArray = ["a"];

--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -479,9 +479,11 @@ const errorMap: Map<number, [string, string]> = util.getSystemErrorMap();
 }
 
 {
-    const controller: AbortController = util.transferableAbortController();
-    const signal: AbortSignal = util.transferableAbortSignal(controller.signal);
-    util.aborted(signal, {}).then(() => {});
+    const controller = util.transferableAbortController();
+    structuredClone(controller.signal, { transfer: [controller.signal] });
+
+    const signal = util.transferableAbortSignal(new AbortController().signal);
+    structuredClone(signal, { transfer: [signal] });
 }
 
 {

--- a/types/node/test/worker_threads.ts
+++ b/types/node/test/worker_threads.ts
@@ -46,7 +46,7 @@ import { createContext } from "node:vm";
         const subChannel = new workerThreads.MessageChannel();
         worker.postMessage(
             { hereIsYourPort: subChannel.port1 },
-            [subChannel.port1] as readonly workerThreads.TransferListItem[],
+            [subChannel.port1],
         );
         subChannel.port2.on("message", (value) => {
             console.log("received:", value);
@@ -100,7 +100,7 @@ import { createContext } from "node:vm";
     workerThreads.isMarkedAsUntransferable(pooledBuffer); // $ExpectType boolean
 
     const { port1 } = new workerThreads.MessageChannel();
-    port1.postMessage(typedArray1, [typedArray1.buffer] as readonly workerThreads.TransferListItem[]);
+    port1.postMessage(typedArray1, [typedArray1.buffer]);
 
     console.log(typedArray1);
     console.log(typedArray2);
@@ -122,7 +122,7 @@ import { createContext } from "node:vm";
     (async () => {
         const fileHandle = await fs.promises.open("thefile.txt", "r");
         const worker = new workerThreads.Worker(__filename);
-        worker.postMessage("some message", [fileHandle] as readonly workerThreads.TransferListItem[]);
+        worker.postMessage("some message", [fileHandle]);
     })();
 }
 
@@ -224,4 +224,15 @@ import { createContext } from "node:vm";
             }, 125);
         });
     }
+}
+
+// structuredClone
+{
+    structuredClone(123); // $ExpectType 123
+    structuredClone("hello"); // $ExpectType "hello"
+    structuredClone({ test: 123 }); // $ExpectType { test: number; }
+    structuredClone([{ test: 123 }]); // $ExpectType { test: number; }[]
+
+    const arrayBuffer = new ArrayBuffer(0);
+    structuredClone({ test: arrayBuffer }, { transfer: [arrayBuffer] }); // $ExpectType { test: ArrayBuffer; }
 }

--- a/types/node/v18/globals.d.ts
+++ b/types/node/v18/globals.d.ts
@@ -249,11 +249,6 @@ declare global {
 
     // Global DOM types
 
-    function structuredClone<T>(
-        value: T,
-        transfer?: { transfer: ReadonlyArray<import("worker_threads").TransferListItem> },
-    ): T;
-
     interface DOMException extends _DOMException {}
     var DOMException: typeof globalThis extends { onmessage: any; DOMException: infer T } ? T
         : NodeDOMExceptionConstructor;

--- a/types/node/v18/test/globals.ts
+++ b/types/node/v18/test/globals.ts
@@ -59,17 +59,6 @@ declare var RANDOM_GLOBAL_VARIABLE: true;
     }
 }
 
-// structuredClone
-{
-    structuredClone(123); // $ExpectType 123
-    structuredClone("hello"); // $ExpectType "hello"
-    structuredClone({ test: 123 }); // $ExpectType { test: number; }
-    structuredClone([{ test: 123 }]); // $ExpectType { test: number; }[]
-
-    const arrayBuffer = new ArrayBuffer(0);
-    structuredClone({ test: arrayBuffer }, { transfer: [arrayBuffer] }); // $ExpectType { test: ArrayBuffer; }
-}
-
 // Array.prototype.at()
 {
     const mutableArray = ["a"];

--- a/types/node/v18/test/util.ts
+++ b/types/node/v18/test/util.ts
@@ -350,9 +350,11 @@ access("file/that/does/not/exist", (err) => {
 }
 
 {
-    const controller: AbortController = util.transferableAbortController();
-    const signal: AbortSignal = util.transferableAbortSignal(controller.signal);
-    util.aborted(signal, {}).then(() => {});
+    const controller = util.transferableAbortController();
+    structuredClone(controller.signal, { transfer: [controller.signal] });
+
+    const signal = util.transferableAbortSignal(new AbortController().signal);
+    structuredClone(signal, { transfer: [signal] });
 }
 
 {

--- a/types/node/v18/test/worker_threads.ts
+++ b/types/node/v18/test/worker_threads.ts
@@ -208,3 +208,14 @@ import { createContext } from "node:vm";
         });
     }
 }
+
+// structuredClone
+{
+    structuredClone(123); // $ExpectType 123
+    structuredClone("hello"); // $ExpectType "hello"
+    structuredClone({ test: 123 }); // $ExpectType { test: number; }
+    structuredClone([{ test: 123 }]); // $ExpectType { test: number; }[]
+
+    const arrayBuffer = new ArrayBuffer(0);
+    structuredClone({ test: arrayBuffer }, { transfer: [arrayBuffer] }); // $ExpectType { test: ArrayBuffer; }
+}

--- a/types/node/v18/worker_threads.d.ts
+++ b/types/node/v18/worker_threads.d.ts
@@ -52,14 +52,13 @@
  * @see [source](https://github.com/nodejs/node/blob/v18.0.0/lib/worker_threads.js)
  */
 declare module "worker_threads" {
-    import { Blob } from "node:buffer";
     import { Context } from "node:vm";
     import { EventEmitter } from "node:events";
     import { EventLoopUtilityFunction } from "node:perf_hooks";
     import { FileHandle } from "node:fs/promises";
     import { Readable, Writable } from "node:stream";
+    import { ReadableStream, TransformStream, WritableStream } from "node:stream/web";
     import { URL } from "node:url";
-    import { X509Certificate } from "node:crypto";
     const isMainThread: boolean;
     const parentPort: null | MessagePort;
     const resourceLimits: ResourceLimits;
@@ -88,7 +87,16 @@ declare module "worker_threads" {
     interface WorkerPerformance {
         eventLoopUtilization: EventLoopUtilityFunction;
     }
-    type TransferListItem = ArrayBuffer | MessagePort | FileHandle | X509Certificate | Blob;
+    type Transferable =
+        | ArrayBuffer
+        | MessagePort
+        | AbortSignal
+        | FileHandle
+        | ReadableStream
+        | WritableStream
+        | TransformStream;
+    /** @deprecated Use `import { Transferable } from "node:worker_threads"` instead. */
+    type TransferListItem = Transferable;
     /**
      * Instances of the `worker.MessagePort` class represent one end of an
      * asynchronous, two-way communications channel. It can be used to transfer
@@ -173,7 +181,7 @@ declare module "worker_threads" {
          * behind this API, see the `serialization API of the v8 module`.
          * @since v10.5.0
          */
-        postMessage(value: any, transferList?: readonly TransferListItem[]): void;
+        postMessage(value: any, transferList?: readonly Transferable[]): void;
         /**
          * Opposite of `unref()`. Calling `ref()` on a previously `unref()`ed port does _not_ let the program exit if it's the only active handle left (the default
          * behavior). If the port is `ref()`ed, calling `ref()` again has no effect.
@@ -260,7 +268,7 @@ declare module "worker_threads" {
         /**
          * Additional data to send in the first worker message.
          */
-        transferList?: TransferListItem[] | undefined;
+        transferList?: Transferable[] | undefined;
         /**
          * @default true
          */
@@ -407,7 +415,7 @@ declare module "worker_threads" {
          * See `port.postMessage()` for more details.
          * @since v10.5.0
          */
-        postMessage(value: any, transferList?: readonly TransferListItem[]): void;
+        postMessage(value: any, transferList?: readonly Transferable[]): void;
         /**
          * Opposite of `unref()`, calling `ref()` on a previously `unref()`ed worker does _not_ let the program exit if it's the only active handle left (the default
          * behavior). If the worker is `ref()`ed, calling `ref()` again has
@@ -656,6 +664,10 @@ declare module "worker_threads" {
         MessagePort as _MessagePort,
     } from "worker_threads";
     global {
+        function structuredClone<T>(
+            value: T,
+            options?: { transfer?: Transferable[] },
+        ): T;
         /**
          * `BroadcastChannel` class is a global reference for `import { BroadcastChannel } from 'node:worker_threads'`
          * https://nodejs.org/api/globals.html#broadcastchannel

--- a/types/node/v20/globals.d.ts
+++ b/types/node/v20/globals.d.ts
@@ -251,11 +251,6 @@ declare global {
 
     // Global DOM types
 
-    function structuredClone<T>(
-        value: T,
-        transfer?: { transfer: ReadonlyArray<import("worker_threads").TransferListItem> },
-    ): T;
-
     interface DOMException extends _DOMException {}
     var DOMException: typeof globalThis extends { onmessage: any; DOMException: infer T } ? T
         : NodeDOMExceptionConstructor;

--- a/types/node/v20/test/globals.ts
+++ b/types/node/v20/test/globals.ts
@@ -60,17 +60,6 @@ declare var RANDOM_GLOBAL_VARIABLE: true;
     }
 }
 
-// structuredClone
-{
-    structuredClone(123); // $ExpectType 123
-    structuredClone("hello"); // $ExpectType "hello"
-    structuredClone({ test: 123 }); // $ExpectType { test: number; }
-    structuredClone([{ test: 123 }]); // $ExpectType { test: number; }[]
-
-    const arrayBuffer = new ArrayBuffer(0);
-    structuredClone({ test: arrayBuffer }, { transfer: [arrayBuffer] }); // $ExpectType { test: ArrayBuffer; }
-}
-
 // Array.prototype.at()
 {
     const mutableArray = ["a"];

--- a/types/node/v20/test/util.ts
+++ b/types/node/v20/test/util.ts
@@ -418,9 +418,11 @@ access("file/that/does/not/exist", (err) => {
 }
 
 {
-    const controller: AbortController = util.transferableAbortController();
-    const signal: AbortSignal = util.transferableAbortSignal(controller.signal);
-    util.aborted(signal, {}).then(() => {});
+    const controller = util.transferableAbortController();
+    structuredClone(controller.signal, { transfer: [controller.signal] });
+
+    const signal = util.transferableAbortSignal(new AbortController().signal);
+    structuredClone(signal, { transfer: [signal] });
 }
 
 {

--- a/types/node/v20/test/worker_threads.ts
+++ b/types/node/v20/test/worker_threads.ts
@@ -208,3 +208,14 @@ import { createContext } from "node:vm";
         });
     }
 }
+
+// structuredClone
+{
+    structuredClone(123); // $ExpectType 123
+    structuredClone("hello"); // $ExpectType "hello"
+    structuredClone({ test: 123 }); // $ExpectType { test: number; }
+    structuredClone([{ test: 123 }]); // $ExpectType { test: number; }[]
+
+    const arrayBuffer = new ArrayBuffer(0);
+    structuredClone({ test: arrayBuffer }, { transfer: [arrayBuffer] }); // $ExpectType { test: ArrayBuffer; }
+}

--- a/types/node/v20/worker_threads.d.ts
+++ b/types/node/v20/worker_threads.d.ts
@@ -52,14 +52,13 @@
  * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/worker_threads.js)
  */
 declare module "worker_threads" {
-    import { Blob } from "node:buffer";
     import { Context } from "node:vm";
     import { EventEmitter } from "node:events";
     import { EventLoopUtilityFunction } from "node:perf_hooks";
     import { FileHandle } from "node:fs/promises";
     import { Readable, Writable } from "node:stream";
+    import { ReadableStream, TransformStream, WritableStream } from "node:stream/web";
     import { URL } from "node:url";
-    import { X509Certificate } from "node:crypto";
     const isMainThread: boolean;
     const parentPort: null | MessagePort;
     const resourceLimits: ResourceLimits;
@@ -88,7 +87,16 @@ declare module "worker_threads" {
     interface WorkerPerformance {
         eventLoopUtilization: EventLoopUtilityFunction;
     }
-    type TransferListItem = ArrayBuffer | MessagePort | FileHandle | X509Certificate | Blob;
+    type Transferable =
+        | ArrayBuffer
+        | MessagePort
+        | AbortSignal
+        | FileHandle
+        | ReadableStream
+        | WritableStream
+        | TransformStream;
+    /** @deprecated Use `import { Transferable } from "node:worker_threads"` instead. */
+    type TransferListItem = Transferable;
     /**
      * Instances of the `worker.MessagePort` class represent one end of an
      * asynchronous, two-way communications channel. It can be used to transfer
@@ -173,7 +181,7 @@ declare module "worker_threads" {
          * behind this API, see the `serialization API of the node:v8 module`.
          * @since v10.5.0
          */
-        postMessage(value: any, transferList?: readonly TransferListItem[]): void;
+        postMessage(value: any, transferList?: readonly Transferable[]): void;
         /**
          * Opposite of `unref()`. Calling `ref()` on a previously `unref()`ed port does _not_ let the program exit if it's the only active handle left (the default
          * behavior). If the port is `ref()`ed, calling `ref()` again has no effect.
@@ -260,7 +268,7 @@ declare module "worker_threads" {
         /**
          * Additional data to send in the first worker message.
          */
-        transferList?: TransferListItem[] | undefined;
+        transferList?: Transferable[] | undefined;
         /**
          * @default true
          */
@@ -408,7 +416,7 @@ declare module "worker_threads" {
          * See `port.postMessage()` for more details.
          * @since v10.5.0
          */
-        postMessage(value: any, transferList?: readonly TransferListItem[]): void;
+        postMessage(value: any, transferList?: readonly Transferable[]): void;
         /**
          * Opposite of `unref()`, calling `ref()` on a previously `unref()`ed worker does _not_ let the program exit if it's the only active handle left (the default
          * behavior). If the worker is `ref()`ed, calling `ref()` again has
@@ -657,6 +665,10 @@ declare module "worker_threads" {
         MessagePort as _MessagePort,
     } from "worker_threads";
     global {
+        function structuredClone<T>(
+            value: T,
+            options?: { transfer?: Transferable[] },
+        ): T;
         /**
          * `BroadcastChannel` class is a global reference for `import { BroadcastChannel } from 'node:worker_threads'`
          * https://nodejs.org/api/globals.html#broadcastchannel

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -52,14 +52,13 @@
  * @see [source](https://github.com/nodejs/node/blob/v22.x/lib/worker_threads.js)
  */
 declare module "worker_threads" {
-    import { Blob } from "node:buffer";
     import { Context } from "node:vm";
     import { EventEmitter } from "node:events";
     import { EventLoopUtilityFunction } from "node:perf_hooks";
     import { FileHandle } from "node:fs/promises";
     import { Readable, Writable } from "node:stream";
+    import { ReadableStream, TransformStream, WritableStream } from "node:stream/web";
     import { URL } from "node:url";
-    import { X509Certificate } from "node:crypto";
     const isInternalThread: boolean;
     const isMainThread: boolean;
     const parentPort: null | MessagePort;
@@ -89,7 +88,17 @@ declare module "worker_threads" {
     interface WorkerPerformance {
         eventLoopUtilization: EventLoopUtilityFunction;
     }
-    type TransferListItem = ArrayBuffer | MessagePort | FileHandle | X509Certificate | Blob;
+    type Transferable =
+        | ArrayBuffer
+        | MessagePort
+        | AbortSignal
+        | FileHandle
+        | ReadableStream
+        | WritableStream
+        | TransformStream;
+    /** @deprecated Use `import { Transferable } from "node:worker_threads"` instead. */
+    // TODO: remove in a future major @types/node version.
+    type TransferListItem = Transferable;
     /**
      * Instances of the `worker.MessagePort` class represent one end of an
      * asynchronous, two-way communications channel. It can be used to transfer
@@ -174,7 +183,7 @@ declare module "worker_threads" {
          * behind this API, see the `serialization API of the node:v8 module`.
          * @since v10.5.0
          */
-        postMessage(value: any, transferList?: readonly TransferListItem[]): void;
+        postMessage(value: any, transferList?: readonly Transferable[]): void;
         /**
          * Opposite of `unref()`. Calling `ref()` on a previously `unref()`ed port does _not_ let the program exit if it's the only active handle left (the default
          * behavior). If the port is `ref()`ed, calling `ref()` again has no effect.
@@ -261,7 +270,7 @@ declare module "worker_threads" {
         /**
          * Additional data to send in the first worker message.
          */
-        transferList?: TransferListItem[] | undefined;
+        transferList?: Transferable[] | undefined;
         /**
          * @default true
          */
@@ -409,7 +418,7 @@ declare module "worker_threads" {
          * See `port.postMessage()` for more details.
          * @since v10.5.0
          */
-        postMessage(value: any, transferList?: readonly TransferListItem[]): void;
+        postMessage(value: any, transferList?: readonly Transferable[]): void;
         /**
          * Sends a value to another worker, identified by its thread ID.
          * @param threadId The target thread ID. If the thread ID is invalid, a `ERR_WORKER_MESSAGING_FAILED` error will be thrown.
@@ -425,7 +434,7 @@ declare module "worker_threads" {
         postMessageToThread(
             threadId: number,
             value: any,
-            transferList: readonly TransferListItem[],
+            transferList: readonly Transferable[],
             timeout?: number,
         ): Promise<void>;
         /**
@@ -709,6 +718,10 @@ declare module "worker_threads" {
         MessagePort as _MessagePort,
     } from "worker_threads";
     global {
+        function structuredClone<T>(
+            value: T,
+            options?: { transfer?: Transferable[] },
+        ): T;
         /**
          * `BroadcastChannel` class is a global reference for `import { BroadcastChannel } from 'worker_threads'`
          * https://nodejs.org/api/globals.html#broadcastchannel


### PR DESCRIPTION
Node.js's set of transferable objects doesn't match that of the web IDL, and there is no codified list in the documentation.

There appears to have been some confusion with what constitutes a transferable in @types/node, dating back to when marking an object as cloneable in the source was easy to mistake at a glance for marking it as transferable.
- `Blob` and `X509Certificate` are cloneable, but not transferable.
- `AbortSignal` has the potential to be transferable if marked as such (eg. `util.transferableAbortSignal()`).
- Web streams are transferable unless locked.

This corrects the type union, canonicalises it as `Transferable` rather than `TransferListItem` for consistency with the web API, and re-homes the `structuredClone()` definition.