### PR TITLE
fix(node/http2): refine SessionOptions typings, add jsdoc

### DIFF
--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -1223,14 +1223,66 @@ declare module "http2" {
     }
     // Http2Server
     export interface SessionOptions {
+        /**
+         * Sets the maximum dynamic table size for deflating header fields.
+         * @default 4Kib
+         */
         maxDeflateDynamicTableSize?: number | undefined;
+        /**
+         * Sets the maximum number of settings entries per `SETTINGS` frame.
+         * The minimum value allowed is `1`.
+         * @default 32
+         */
+        maxSettings?: number | undefined;
+        /**
+         * Sets the maximum memory that the `Http2Session` is permitted to use.
+         * The value is expressed in terms of number of megabytes, e.g. `1` equal 1 megabyte.
+         * The minimum value allowed is `1`.
+         * This is a credit based limit, existing `Http2Stream`s may cause this limit to be exceeded,
+         * but new `Http2Stream` instances will be rejected while this limit is exceeded.
+         * The current number of `Http2Stream` sessions, the current memory use of the header compression tables,
+         * current data queued to be sent, and unacknowledged `PING` and `SETTINGS` frames are all counted towards the current limit.
+         * @default 10
+         */
         maxSessionMemory?: number | undefined;
+        /**
+         * Sets the maximum number of header entries.
+         * This is similar to `server.maxHeadersCount` or `request.maxHeadersCount` in the `node:http` module.
+         * The minimum value is `1`.
+         * @default 128
+         */
         maxHeaderListPairs?: number | undefined;
+        /**
+         * Sets the maximum number of outstanding, unacknowledged pings.
+         * @default 10
+         */
         maxOutstandingPings?: number | undefined;
+        /**
+         * Sets the maximum allowed size for a serialized, compressed block of headers.
+         * Attempts to send headers that exceed this limit will result in
+         * a `'frameError'` event being emitted and the stream being closed and destroyed.
+         */
         maxSendHeaderBlockLength?: number | undefined;
+        /**
+         * Strategy used for determining the amount of padding to use for `HEADERS` and `DATA` frames.
+         * @default http2.constants.PADDING_STRATEGY_NONE
+         */
         paddingStrategy?: number | undefined;
+        /**
+         * Sets the maximum number of concurrent streams for the remote peer as if a `SETTINGS` frame had been received.
+         * Will be overridden if the remote peer sets its own value for `maxConcurrentStreams`.
+         * @default 100
+         */
         peerMaxConcurrentStreams?: number | undefined;
+        /**
+         * The initial settings to send to the remote peer upon connection.
+         */
         settings?: Settings | undefined;
+        /**
+         * The array of integer values determines the settings types,
+         * which are included in the `CustomSettings`-property of the received remoteSettings.
+         * Please see the `CustomSettings`-property of the `Http2Settings` object for more information, on the allowed setting types.
+         */
         remoteCustomSettings?: number[] | undefined;
         /**
          * Specifies a timeout in milliseconds that
@@ -1239,11 +1291,27 @@ declare module "http2" {
          * @default 100000
          */
         unknownProtocolTimeout?: number | undefined;
-        selectPadding?(frameLen: number, maxFrameLen: number): number;
     }
     export interface ClientSessionOptions extends SessionOptions {
+        /**
+         * Sets the maximum number of reserved push streams the client will accept at any given time.
+         * Once the current number of currently reserved push streams exceeds reaches this limit,
+         * new push streams sent by the server will be automatically rejected.
+         * The minimum allowed value is 0. The maximum allowed value is 2<sup>32</sup>-1.
+         * A negative value sets this option to the maximum allowed value.
+         * @default 200
+         */
         maxReservedRemoteStreams?: number | undefined;
+        /**
+         * An optional callback that receives the `URL` instance passed to `connect` and the `options` object,
+         * and returns any `Duplex` stream that is to be used as the connection for this session.
+         */
         createConnection?: ((authority: url.URL, option: SessionOptions) => stream.Duplex) | undefined;
+        /**
+         * The protocol to connect with, if not set in the `authority`.
+         * Value may be either `'http:'` or `'https:'`.
+         * @default 'https:'
+         */
         protocol?: "http:" | "https:" | undefined;
     }
     export interface ServerSessionOptions<

--- a/types/node/test/http2.ts
+++ b/types/node/test/http2.ts
@@ -259,14 +259,18 @@ import { URL } from "node:url";
     let settings: Settings = {};
     const serverOptions: ServerOptions = {
         maxDeflateDynamicTableSize: 0,
+        maxSettings: 32,
+        maxSessionMemory: 10,
+        maxHeaderListPairs: 128,
+        maxOutstandingPings: 10,
         maxSendHeaderBlockLength: 0,
         paddingStrategy: 0,
         peerMaxConcurrentStreams: 0,
-        selectPadding: (frameLen: number, maxFrameLen: number) => 0,
         settings,
+        remoteCustomSettings: [0],
+        unknownProtocolTimeout: 100000,
         streamResetBurst: 1000,
         streamResetRate: 33,
-        unknownProtocolTimeout: 123,
     };
     const secureServerOptions: SecureServerOptions = { ...serverOptions, ca: "..." };
     const onRequestHandler = (request: Http2ServerRequest, response: Http2ServerResponse) => {
@@ -376,13 +380,25 @@ import { URL } from "node:url";
 
     const clientSessionOptions: ClientSessionOptions = {
         maxDeflateDynamicTableSize: 0,
-        maxReservedRemoteStreams: 0,
+        maxSettings: 32,
+        maxSessionMemory: 10,
+        maxHeaderListPairs: 128,
+        maxOutstandingPings: 10,
         maxSendHeaderBlockLength: 0,
         paddingStrategy: 0,
         peerMaxConcurrentStreams: 0,
-        protocol: "https:",
-        selectPadding: (frameLen: number, maxFrameLen: number) => 0,
         settings,
+        remoteCustomSettings: [0],
+        unknownProtocolTimeout: 100000,
+        maxReservedRemoteStreams: 0,
+        createConnection: (authority, option) => {
+            // $ExpectType URL
+            authority;
+            // $ExpectType SessionOptions
+            option;
+            return new Duplex();
+        },
+        protocol: "https:",
     };
     const secureClientSessionOptions: SecureClientSessionOptions = { ...clientSessionOptions, ca: "..." };
     const onConnectHandler = (session: Http2Session, socket: Socket) => {};
@@ -474,12 +490,18 @@ import { URL } from "node:url";
 
     const serverOptions: ServerOptions = {
         maxDeflateDynamicTableSize: 0,
+        maxSettings: 32,
+        maxSessionMemory: 10,
+        maxHeaderListPairs: 128,
+        maxOutstandingPings: 10,
         maxSendHeaderBlockLength: 0,
         paddingStrategy: 0,
         peerMaxConcurrentStreams: 0,
-        selectPadding: (frameLen: number, maxFrameLen: number) => 0,
         settings,
-        unknownProtocolTimeout: 123,
+        remoteCustomSettings: [0],
+        unknownProtocolTimeout: 100000,
+        streamResetBurst: 1000,
+        streamResetRate: 33,
     };
 
     const http2Stream: Http2Stream = {} as any;

--- a/types/node/v18/http2.d.ts
+++ b/types/node/v18/http2.d.ts
@@ -1223,13 +1223,60 @@ declare module "http2" {
     }
     // Http2Server
     export interface SessionOptions {
+        /**
+         * Sets the maximum dynamic table size for deflating header fields.
+         * @default 4Kib
+         */
         maxDeflateDynamicTableSize?: number | undefined;
+        /**
+         * Sets the maximum number of settings entries per `SETTINGS` frame.
+         * The minimum value allowed is `1`.
+         * @default 32
+         */
+        maxSettings?: number | undefined;
+        /**
+         * Sets the maximum memory that the `Http2Session` is permitted to use.
+         * The value is expressed in terms of number of megabytes, e.g. `1` equal 1 megabyte.
+         * The minimum value allowed is `1`.
+         * This is a credit based limit, existing `Http2Stream`s may cause this limit to be exceeded,
+         * but new `Http2Stream` instances will be rejected while this limit is exceeded.
+         * The current number of `Http2Stream` sessions, the current memory use of the header compression tables,
+         * current data queued to be sent, and unacknowledged `PING` and `SETTINGS` frames are all counted towards the current limit.
+         * @default 10
+         */
         maxSessionMemory?: number | undefined;
+        /**
+         * Sets the maximum number of header entries.
+         * This is similar to `server.maxHeadersCount` or `request.maxHeadersCount` in the `node:http` module.
+         * The minimum value is `1`.
+         * @default 128
+         */
         maxHeaderListPairs?: number | undefined;
+        /**
+         * Sets the maximum number of outstanding, unacknowledged pings.
+         * @default 10
+         */
         maxOutstandingPings?: number | undefined;
+        /**
+         * Sets the maximum allowed size for a serialized, compressed block of headers.
+         * Attempts to send headers that exceed this limit will result in
+         * a `'frameError'` event being emitted and the stream being closed and destroyed.
+         */
         maxSendHeaderBlockLength?: number | undefined;
+        /**
+         * Strategy used for determining the amount of padding to use for `HEADERS` and `DATA` frames.
+         * @default http2.constants.PADDING_STRATEGY_NONE
+         */
         paddingStrategy?: number | undefined;
+        /**
+         * Sets the maximum number of concurrent streams for the remote peer as if a `SETTINGS` frame had been received.
+         * Will be overridden if the remote peer sets its own value for `maxConcurrentStreams`.
+         * @default 100
+         */
         peerMaxConcurrentStreams?: number | undefined;
+        /**
+         * The initial settings to send to the remote peer upon connection.
+         */
         settings?: Settings | undefined;
         /**
          * Specifies a timeout in milliseconds that
@@ -1238,11 +1285,27 @@ declare module "http2" {
          * @default 100000
          */
         unknownProtocolTimeout?: number | undefined;
-        selectPadding?(frameLen: number, maxFrameLen: number): number;
     }
     export interface ClientSessionOptions extends SessionOptions {
+        /**
+         * Sets the maximum number of reserved push streams the client will accept at any given time.
+         * Once the current number of currently reserved push streams exceeds reaches this limit,
+         * new push streams sent by the server will be automatically rejected.
+         * The minimum allowed value is 0. The maximum allowed value is 2<sup>32</sup>-1.
+         * A negative value sets this option to the maximum allowed value.
+         * @default 200
+         */
         maxReservedRemoteStreams?: number | undefined;
+        /**
+         * An optional callback that receives the `URL` instance passed to `connect` and the `options` object,
+         * and returns any `Duplex` stream that is to be used as the connection for this session.
+         */
         createConnection?: ((authority: url.URL, option: SessionOptions) => stream.Duplex) | undefined;
+        /**
+         * The protocol to connect with, if not set in the `authority`.
+         * Value may be either `'http:'` or `'https:'`.
+         * @default 'https:'
+         */
         protocol?: "http:" | "https:" | undefined;
     }
     export interface ServerSessionOptions<

--- a/types/node/v18/test/http2.ts
+++ b/types/node/v18/test/http2.ts
@@ -258,12 +258,15 @@ import { URL } from "node:url";
     let settings: Settings = {};
     const serverOptions: ServerOptions = {
         maxDeflateDynamicTableSize: 0,
+        maxSettings: 32,
+        maxSessionMemory: 10,
+        maxHeaderListPairs: 128,
+        maxOutstandingPings: 10,
         maxSendHeaderBlockLength: 0,
         paddingStrategy: 0,
         peerMaxConcurrentStreams: 0,
-        selectPadding: (frameLen: number, maxFrameLen: number) => 0,
         settings,
-        unknownProtocolTimeout: 123,
+        unknownProtocolTimeout: 100000,
     };
     // tslint:disable-next-line prefer-object-spread (ts2.1 feature)
     const secureServerOptions: SecureServerOptions = Object.assign({}, serverOptions);
@@ -375,13 +378,24 @@ import { URL } from "node:url";
 
     const clientSessionOptions: ClientSessionOptions = {
         maxDeflateDynamicTableSize: 0,
-        maxReservedRemoteStreams: 0,
+        maxSettings: 32,
+        maxSessionMemory: 10,
+        maxHeaderListPairs: 128,
+        maxOutstandingPings: 10,
         maxSendHeaderBlockLength: 0,
         paddingStrategy: 0,
         peerMaxConcurrentStreams: 0,
-        protocol: "https:",
-        selectPadding: (frameLen: number, maxFrameLen: number) => 0,
         settings,
+        unknownProtocolTimeout: 100000,
+        maxReservedRemoteStreams: 0,
+        createConnection: (authority, option) => {
+            // $ExpectType URL
+            authority;
+            // $ExpectType SessionOptions
+            option;
+            return new Duplex();
+        },
+        protocol: "https:",
     };
     // tslint:disable-next-line prefer-object-spread (ts2.1 feature)
     const secureClientSessionOptions: SecureClientSessionOptions = Object.assign({}, clientSessionOptions);

--- a/types/node/v20/http2.d.ts
+++ b/types/node/v20/http2.d.ts
@@ -1223,14 +1223,66 @@ declare module "http2" {
     }
     // Http2Server
     export interface SessionOptions {
+        /**
+         * Sets the maximum dynamic table size for deflating header fields.
+         * @default 4Kib
+         */
         maxDeflateDynamicTableSize?: number | undefined;
+        /**
+         * Sets the maximum number of settings entries per `SETTINGS` frame.
+         * The minimum value allowed is `1`.
+         * @default 32
+         */
+        maxSettings?: number | undefined;
+        /**
+         * Sets the maximum memory that the `Http2Session` is permitted to use.
+         * The value is expressed in terms of number of megabytes, e.g. `1` equal 1 megabyte.
+         * The minimum value allowed is `1`.
+         * This is a credit based limit, existing `Http2Stream`s may cause this limit to be exceeded,
+         * but new `Http2Stream` instances will be rejected while this limit is exceeded.
+         * The current number of `Http2Stream` sessions, the current memory use of the header compression tables,
+         * current data queued to be sent, and unacknowledged `PING` and `SETTINGS` frames are all counted towards the current limit.
+         * @default 10
+         */
         maxSessionMemory?: number | undefined;
+        /**
+         * Sets the maximum number of header entries.
+         * This is similar to `server.maxHeadersCount` or `request.maxHeadersCount` in the `node:http` module.
+         * The minimum value is `1`.
+         * @default 128
+         */
         maxHeaderListPairs?: number | undefined;
+        /**
+         * Sets the maximum number of outstanding, unacknowledged pings.
+         * @default 10
+         */
         maxOutstandingPings?: number | undefined;
+        /**
+         * Sets the maximum allowed size for a serialized, compressed block of headers.
+         * Attempts to send headers that exceed this limit will result in
+         * a `'frameError'` event being emitted and the stream being closed and destroyed.
+         */
         maxSendHeaderBlockLength?: number | undefined;
+        /**
+         * Strategy used for determining the amount of padding to use for `HEADERS` and `DATA` frames.
+         * @default http2.constants.PADDING_STRATEGY_NONE
+         */
         paddingStrategy?: number | undefined;
+        /**
+         * Sets the maximum number of concurrent streams for the remote peer as if a `SETTINGS` frame had been received.
+         * Will be overridden if the remote peer sets its own value for `maxConcurrentStreams`.
+         * @default 100
+         */
         peerMaxConcurrentStreams?: number | undefined;
+        /**
+         * The initial settings to send to the remote peer upon connection.
+         */
         settings?: Settings | undefined;
+        /**
+         * The array of integer values determines the settings types,
+         * which are included in the `CustomSettings`-property of the received remoteSettings.
+         * Please see the `CustomSettings`-property of the `Http2Settings` object for more information, on the allowed setting types.
+         */
         remoteCustomSettings?: number[] | undefined;
         /**
          * Specifies a timeout in milliseconds that
@@ -1239,11 +1291,27 @@ declare module "http2" {
          * @default 100000
          */
         unknownProtocolTimeout?: number | undefined;
-        selectPadding?(frameLen: number, maxFrameLen: number): number;
     }
     export interface ClientSessionOptions extends SessionOptions {
+        /**
+         * Sets the maximum number of reserved push streams the client will accept at any given time.
+         * Once the current number of currently reserved push streams exceeds reaches this limit,
+         * new push streams sent by the server will be automatically rejected.
+         * The minimum allowed value is 0. The maximum allowed value is 2<sup>32</sup>-1.
+         * A negative value sets this option to the maximum allowed value.
+         * @default 200
+         */
         maxReservedRemoteStreams?: number | undefined;
+        /**
+         * An optional callback that receives the `URL` instance passed to `connect` and the `options` object,
+         * and returns any `Duplex` stream that is to be used as the connection for this session.
+         */
         createConnection?: ((authority: url.URL, option: SessionOptions) => stream.Duplex) | undefined;
+        /**
+         * The protocol to connect with, if not set in the `authority`.
+         * Value may be either `'http:'` or `'https:'`.
+         * @default 'https:'
+         */
         protocol?: "http:" | "https:" | undefined;
     }
     export interface ServerSessionOptions<

--- a/types/node/v20/test/http2.ts
+++ b/types/node/v20/test/http2.ts
@@ -259,12 +259,16 @@ import { URL } from "node:url";
     let settings: Settings = {};
     const serverOptions: ServerOptions = {
         maxDeflateDynamicTableSize: 0,
+        maxSettings: 32,
+        maxSessionMemory: 10,
+        maxHeaderListPairs: 128,
+        maxOutstandingPings: 10,
         maxSendHeaderBlockLength: 0,
         paddingStrategy: 0,
         peerMaxConcurrentStreams: 0,
-        selectPadding: (frameLen: number, maxFrameLen: number) => 0,
         settings,
-        unknownProtocolTimeout: 123,
+        remoteCustomSettings: [0],
+        unknownProtocolTimeout: 100000,
     };
     // tslint:disable-next-line prefer-object-spread (ts2.1 feature)
     const secureServerOptions: SecureServerOptions = Object.assign({}, serverOptions);
@@ -376,13 +380,25 @@ import { URL } from "node:url";
 
     const clientSessionOptions: ClientSessionOptions = {
         maxDeflateDynamicTableSize: 0,
-        maxReservedRemoteStreams: 0,
+        maxSettings: 32,
+        maxSessionMemory: 10,
+        maxHeaderListPairs: 128,
+        maxOutstandingPings: 10,
         maxSendHeaderBlockLength: 0,
         paddingStrategy: 0,
         peerMaxConcurrentStreams: 0,
-        protocol: "https:",
-        selectPadding: (frameLen: number, maxFrameLen: number) => 0,
         settings,
+        remoteCustomSettings: [0],
+        unknownProtocolTimeout: 100000,
+        maxReservedRemoteStreams: 0,
+        createConnection: (authority, option) => {
+            // $ExpectType URL
+            authority;
+            // $ExpectType SessionOptions
+            option;
+            return new Duplex();
+        },
+        protocol: "https:",
     };
     // tslint:disable-next-line prefer-object-spread (ts2.1 feature)
     const secureClientSessionOptions: SecureClientSessionOptions = Object.assign({}, clientSessionOptions);
@@ -476,12 +492,16 @@ import { URL } from "node:url";
 
     const serverOptions: ServerOptions = {
         maxDeflateDynamicTableSize: 0,
+        maxSettings: 32,
+        maxSessionMemory: 10,
+        maxHeaderListPairs: 128,
+        maxOutstandingPings: 10,
         maxSendHeaderBlockLength: 0,
         paddingStrategy: 0,
         peerMaxConcurrentStreams: 0,
-        selectPadding: (frameLen: number, maxFrameLen: number) => 0,
         settings,
-        unknownProtocolTimeout: 123,
+        remoteCustomSettings: [0],
+        unknownProtocolTimeout: 100000,
     };
 
     const http2Stream: Http2Stream = {} as any;


### PR DESCRIPTION
## SessionOptions

- Add `maxSettings`. From node doc, it exists since v14.4.0, v12.18.0, v10.21.0.
- Remove `selectPadding`. From node doc, it is removed since v13.0.0.

## connect()

- Simplify `ClientSessionOptions | SecureClientSessionOptions` to `SecureClientSessionOptions`, since one is already extending the other.

https://nodejs.org/docs/latest/api/http2.html.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
