### PR TITLE
[navermaps] Update the ReverseGeocodeResponse type

### DIFF
--- a/types/navermaps/index.d.ts
+++ b/types/navermaps/index.d.ts
@@ -1,4 +1,4 @@
-// NAVER Maps JavaScript API Version: 3.8
+// NAVER Maps JavaScript API Version: 3.9
 
 /// <reference types="geojson" />
 
@@ -2276,7 +2276,6 @@ declare namespace naver.maps {
             area2: Area;
             area3: Area;
             area4: Area;
-            land: Land;
             addition0: Addition;
             addition1: Addition;
             addition2: Addition;
@@ -2292,6 +2291,7 @@ declare namespace naver.maps {
                 mappingId: string;
             };
             region: Region;
+            land: Land;
         }
 
         interface ReverseGeocodeResponse {

--- a/types/navermaps/navermaps-tests.ts
+++ b/types/navermaps/navermaps-tests.ts
@@ -325,6 +325,7 @@ naver.maps.Service.reverseGeocode(
         results[0].name;
         results[0].code;
         results[0].region;
+        results[0].land;
 
         const v2Status = response.v2.status;
         v2Status.code;

--- a/types/navermaps/package.json
+++ b/types/navermaps/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/navermaps",
-    "version": "3.7.9999",
+    "version": "3.9.0",
     "nonNpm": true,
     "nonNpmDescription": "NAVER Maps JavaScript API",
     "projects": [

--- a/types/navermaps/package.json
+++ b/types/navermaps/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/navermaps",
-    "version": "3.9.0",
+    "version": "3.9.9999",
     "nonNpm": true,
     "nonNpmDescription": "NAVER Maps JavaScript API",
     "projects": [


### PR DESCRIPTION
This PR follows the ReverseGeocodeResponse documentation.
- https://api.ncloud-docs.com/docs/application-maps-reversegeocoding#%EC%9D%91%EB%8B%B5-%EB%B0%94%EB%94%94

**The `land` property has been moved from under `Region` to under `ReverseGeocodeResponse > ResultItem`**

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

