### PR TITLE
[tizen-tv-webapis] add PreviewManager object and associated methods

### DIFF
--- a/types/tizen-tv-webapis/index.d.ts
+++ b/types/tizen-tv-webapis/index.d.ts
@@ -13,6 +13,7 @@ export interface Webapis {
     avplay: AVPlayManager;
     billing: BillingManager;
     network: NetworkManager;
+    preview: PreviewManager;
     productinfo: ProductInfoManager;
     sso: SsoManager;
     systeminfo: SystemInfoManager;
@@ -35,6 +36,8 @@ export const avinfo: AvInfoManager;
 export const billing: BillingManager;
 
 export const network: NetworkManager;
+
+export const preview: PreviewManager;
 
 export const productinfo: ProductInfoManager;
 
@@ -4025,6 +4028,47 @@ export interface ProductInfoConfigChangeCallback {
      * @version 1.0
      */
     (key: ProductInfoConfigKey): void;
+}
+
+/**
+ * This module defines the Preview functionalities provided by the Tizen Samsung Product API.
+ *
+ * @privilegeName http://samsung.com/tv/metadata/use.preview
+ *
+ * @since 2.3
+ */
+export interface PreviewManager {
+    /**
+     * Sets the preview data. Each application can have 1 preview. The preview consists of at least 1 section, which contains at least 1 tile.
+     *
+     * @privilegeName http://samsung.com/tv/metadata/use.preview
+     *
+     * @param previewData_JSON Preview properties
+     *
+     * @param successCallback Callback method to invoke when the call is successful
+     *
+     * @param errorCallback Callback method to invoke if the request fails
+     *
+     * @throws WebAPIException with error type InvalidValuesError, if any input parameter contains an invalid value.
+     *
+     * @throws WebAPIException with error type TypeMismatchError, if any input parameter is not compatible with the expected type for that parameter.
+     *
+     * @throws WebAPIException with error type UnknownError, for any other error.
+     */
+    setPreviewData: (
+        previewData_JSON: string,
+        successCallback?: SuccessCallback,
+        errorCallback?: ErrorCallback,
+    ) => void;
+
+    /**
+     * Retrieves the Preview API version.
+     *
+     * @returns Plugin version
+     *
+     * @throws WebAPIException with error type UnknownError, for any error.
+     */
+    getVersion: () => string;
 }
 
 /**

--- a/types/tizen-tv-webapis/test/tizen-tv-webapis-tests.cjs.ts
+++ b/types/tizen-tv-webapis/test/tizen-tv-webapis-tests.cjs.ts
@@ -5,6 +5,7 @@ import {
     avplay,
     billing,
     network,
+    preview,
     productinfo,
     sso,
     tvinfo,
@@ -17,6 +18,7 @@ avplay.getVersion(); // $ExpectType string
 avinfo.getVersion(); // $ExpectType string
 billing.getVersion(); // $ExpectType string
 network.getVersion(); // $ExpectType string
+preview.getVersion(); // $ExpectType string
 productinfo.getVersion(); // $ExpectType string
 sso.getVersion(); // $ExpectType string
 tvinfo.getVersion(); // $ExpectType string

--- a/types/tizen-tv-webapis/test/tizen-tv-webapis-tests.global.ts
+++ b/types/tizen-tv-webapis/test/tizen-tv-webapis-tests.global.ts
@@ -1,10 +1,11 @@
-const { adinfo, appcommon, avplay, avinfo, billing, network, productinfo, sso, tvinfo, widgetdata } = webapis;
+const { adinfo, appcommon, avplay, avinfo, billing, network, preview, productinfo, sso, tvinfo, widgetdata } = webapis;
 adinfo.getVersion(); // $ExpectType string
 appcommon.getVersion(); // $ExpectType string
 avplay.getVersion(); // $ExpectType string
 avinfo.getVersion(); // $ExpectType string
 billing.getVersion(); // $ExpectType string
 network.getVersion(); // $ExpectType string
+preview.getVersion(); // $ExpectType string
 productinfo.getVersion(); // $ExpectType string
 sso.getVersion(); // $ExpectType string
 tvinfo.getVersion(); // $ExpectType string


### PR DESCRIPTION
I purposefully didn't add the two deprecated methods. Should I?

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.samsung.com/smarttv/develop/api-references/samsung-product-api-references/preview-api.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
