### PR TITLE
n3: Accept undefined as a type predicate argument

### DIFF
--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -379,11 +379,11 @@ export interface StoreOptions {
 }
 
 export namespace Util {
-    function isNamedNode(value: RDF.Term | null): value is RDF.NamedNode;
-    function isBlankNode(value: RDF.Term | null): value is RDF.BlankNode;
-    function isLiteral(value: RDF.Term | null): value is RDF.Literal;
-    function isVariable(value: RDF.Term | null): value is RDF.Variable;
-    function isDefaultGraph(value: RDF.Term | null): value is RDF.DefaultGraph;
+    function isNamedNode(value: RDF.Term | null | undefined): value is RDF.NamedNode;
+    function isBlankNode(value: RDF.Term | null | undefined): value is RDF.BlankNode;
+    function isLiteral(value: RDF.Term | null | undefined): value is RDF.Literal;
+    function isVariable(value: RDF.Term | null | undefined): value is RDF.Variable;
+    function isDefaultGraph(value: RDF.Term | null | undefined): value is RDF.DefaultGraph;
     function inDefaultGraph(value: RDF.Quad): boolean;
     function prefix(iri: RDF.NamedNode | string, factory?: RDF.DataFactory): PrefixedToIri;
     function prefixes(

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -467,6 +467,18 @@ function test_doc_utility() {
     if (N3Util.isDefaultGraph(term)) {
         const defaultGraphTerm: RDF.DefaultGraph = term;
     }
+
+    N3Util.isNamedNode(null);
+    N3Util.isBlankNode(null);
+    N3Util.isLiteral(null);
+    N3Util.isVariable(null);
+    N3Util.isDefaultGraph(null);
+
+    N3Util.isNamedNode(undefined);
+    N3Util.isBlankNode(undefined);
+    N3Util.isLiteral(undefined);
+    N3Util.isVariable(undefined);
+    N3Util.isDefaultGraph(undefined);
 }
 
 function test_parser_options() {


### PR DESCRIPTION
This feature is included in N3 tests.

`term: RDF.Term | null | undefined` instead of `term?: RDF.Term | null` to catch users who accidentally don't pass in any argument at all.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

https://github.com/rdfjs/N3.js/blob/5a58e93196a5048b6a4c09a1826847a7b811d283/test/N3Util-test.js#L31-L33

- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
