### PR TITLE
mz: fix default exec/execFile encoding

### DIFF
--- a/types/mz/child_process.d.ts
+++ b/types/mz/child_process.d.ts
@@ -1,13 +1,7 @@
 // Modified from the node.js definitions.
 // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/child_process.d.ts
 
-import {
-    ChildProcess,
-    ExecException,
-    ExecFileOptions,
-    ExecFileOptionsWithStringEncoding,
-    ExecOptions,
-} from "child_process";
+import { ChildProcess, ExecException, ExecFileOptions, ExecOptions } from "child_process";
 export * from "child_process";
 
 export function exec(
@@ -16,7 +10,7 @@ export function exec(
 ): ChildProcess;
 export function exec(
     command: string,
-    options: { encoding: "buffer" | null | undefined } & ExecOptions,
+    options: { encoding: "buffer" | null } & ExecOptions,
     callback: (error: ExecException | null, stdout: Buffer, stderr: Buffer) => void,
 ): ChildProcess;
 export function exec(
@@ -32,7 +26,7 @@ export function exec(
 
 export function exec(
     command: string,
-    options: { encoding: "buffer" | null | undefined } & ExecOptions,
+    options: { encoding: "buffer" | null } & ExecOptions,
 ): Promise<[Buffer, Buffer]>;
 export function exec(
     command: string,
@@ -42,14 +36,6 @@ export function exec(
     command: string,
     options?: ({ encoding?: string | null | undefined } & ExecOptions) | null,
 ): Promise<[string | Buffer, string | Buffer]>;
-
-interface ExecFileOptionsWithBufferEncoding extends ExecFileOptions {
-    encoding: "buffer" | null | undefined;
-}
-
-interface ExecFileOptionsWithOtherEncoding extends ExecFileOptions {
-    encoding?: string | null | undefined;
-}
 
 // no `options` definitely means stdout/stderr are `string`.
 export function execFile(
@@ -65,28 +51,26 @@ export function execFile(
 // `options` with `"buffer"` or `null` for `encoding` means stdout/stderr are definitely `Buffer`.
 export function execFile(
     file: string,
-    options: ExecFileOptionsWithBufferEncoding,
+    options: { encoding: "buffer" | null } & ExecFileOptions,
     callback: (error: Error | null, stdout: Buffer, stderr: Buffer) => void,
 ): ChildProcess;
 export function execFile(
     file: string,
     args: readonly string[] | null | undefined,
-    options: ExecFileOptionsWithBufferEncoding,
+    options: { encoding: "buffer" | null } & ExecFileOptions,
     callback: (error: Error | null, stdout: Buffer, stderr: Buffer) => void,
 ): ChildProcess;
 
 // `options` without an or with a well known `encoding` means stdout/stderr are definitely `string`.
 export function execFile(
     file: string,
-    // `options` can't be mixed into `args`
-    // tslint:disable-next-line: unified-signatures
-    options: ExecFileOptions | ExecFileOptionsWithStringEncoding,
+    options: ({ encoding?: BufferEncoding | undefined } & ExecFileOptions) | null | undefined,
     callback: (error: Error | null, stdout: string, stderr: string) => void,
 ): ChildProcess;
 export function execFile(
     file: string,
     args: readonly string[] | null | undefined,
-    options: ExecFileOptions | ExecFileOptionsWithStringEncoding,
+    options: ({ encoding?: BufferEncoding | undefined } & ExecFileOptions) | null | undefined,
     callback: (error: Error | null, stdout: string, stderr: string) => void,
 ): ChildProcess;
 
@@ -94,37 +78,40 @@ export function execFile(
 // There is no guarantee the `encoding` is unknown as `string` is a superset of `BufferEncoding`.
 export function execFile(
     file: string,
-    options: ExecFileOptionsWithOtherEncoding | null | undefined,
+    options: ({ encoding?: string | null | undefined } & ExecFileOptions) | null | undefined,
     callback: (error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void,
 ): ChildProcess;
 export function execFile(
     file: string,
     args: readonly string[] | null | undefined,
-    options: ExecFileOptionsWithOtherEncoding | null | undefined,
+    options: ({ encoding?: string | null | undefined } & ExecFileOptions) | null | undefined,
     callback: (error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void,
 ): ChildProcess;
 
 export function execFile(
     file: string,
     args: string[] | null | undefined,
-    options: ExecFileOptionsWithBufferEncoding,
+    options: { encoding: "buffer" | null } & ExecFileOptions,
 ): Promise<[Buffer, Buffer]>;
-export function execFile(file: string, options: ExecFileOptionsWithBufferEncoding): Promise<[Buffer, Buffer]>;
+export function execFile(
+    file: string,
+    options: { encoding: "buffer" | null } & ExecFileOptions,
+): Promise<[Buffer, Buffer]>;
 export function execFile(
     file: string,
     args?: string[] | null,
-    options?: ExecFileOptions | ExecFileOptionsWithStringEncoding | null,
+    options?: ({ encoding?: BufferEncoding | undefined } & ExecFileOptions) | null,
 ): Promise<[string, string]>;
 export function execFile(
     file: string,
-    options?: ExecFileOptions | ExecFileOptionsWithStringEncoding | null,
+    options?: ({ encoding?: BufferEncoding | undefined } & ExecFileOptions) | null,
 ): Promise<[string, string]>;
 export function execFile(
     file: string,
     args?: string[] | null,
-    options?: ExecFileOptionsWithOtherEncoding | null,
+    options?: ({ encoding?: string | null | undefined } & ExecFileOptions) | null,
 ): Promise<[string | Buffer, string | Buffer]>;
 export function execFile(
     file: string,
-    options?: ExecFileOptionsWithOtherEncoding | null,
+    options?: ({ encoding?: string | null | undefined } & ExecFileOptions) | null,
 ): Promise<[string | Buffer, string | Buffer]>;

--- a/types/mz/test/child_process.test.ts
+++ b/types/mz/test/child_process.test.ts
@@ -17,8 +17,8 @@ declare function execStringCallback(err: cp.ExecException | null, stdout: string
 declare function execBufferCallback(err: cp.ExecException | null, stdout: Buffer, stderr: Buffer): void;
 
 declare const command: string;
-declare const stringEncoding: BufferEncoding;
-declare const bufferEncoding: "buffer" | null | undefined;
+declare const stringEncoding: BufferEncoding | undefined;
+declare const bufferEncoding: "buffer" | null;
 declare const anyEncoding: string | null | undefined;
 
 declare const unknownEncodingObject: { encoding: typeof anyEncoding } | null | undefined;


### PR DESCRIPTION
Tests for #72733 inadvertently revealed that the mz child_process definitions were incorrect, in that the signatures for `exec()`/`execFile()` fell back in certain circumstances to a default encoding of "buffer", whereas the correct default encoding is "utf-8" (ie. string output).