### PR TITLE
[chrome] update downloads namespace

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -3719,58 +3719,70 @@ declare namespace chrome {
             value: string;
         }
 
-        export type FilenameConflictAction = "uniquify" | "overwrite" | "prompt";
+        export enum FilenameConflictAction {
+            /** To avoid duplication, the filename is changed to include a counter before the filename extension. */
+            UNIQUIFY = "uniquify",
+            /** The existing file will be overwritten with the new file. */
+            OVERWRITE = "overwrite",
+            /** The user will be prompted with a file chooser dialog. */
+            PROMPT = "prompt",
+        }
+
+        export enum HttpMethod {
+            GET = "GET",
+            POST = "POST",
+        }
 
         export interface DownloadOptions {
-            /** Optional. Post body.  */
+            /** Post body. */
             body?: string | undefined;
-            /** Optional. Use a file-chooser to allow the user to select a filename regardless of whether filename is set or already exists.  */
+            /** Use a file-chooser to allow the user to select a filename regardless of whether `filename` is set or already exists. */
             saveAs?: boolean | undefined;
             /** The URL to download. */
             url: string;
-            /** Optional. A file path relative to the Downloads directory to contain the downloaded file, possibly containing subdirectories. Absolute paths, empty paths, and paths containing back-references ".." will cause an error. onDeterminingFilename allows suggesting a filename after the file's MIME type and a tentative filename have been determined.  */
+            /** A file path relative to the Downloads directory to contain the downloaded file, possibly containing subdirectories. Absolute paths, empty paths, and paths containing back-references ".." will cause an error. {@link onDeterminingFilename} allows suggesting a filename after the file's MIME type and a tentative filename have been determined. */
             filename?: string | undefined;
-            /** Optional. Extra HTTP headers to send with the request if the URL uses the HTTP[s] protocol. Each header is represented as a dictionary containing the keys name and either value or binaryValue, restricted to those allowed by XMLHttpRequest.  */
+            /** Extra HTTP headers to send with the request if the URL uses the HTTP[s] protocol. Each header is represented as a dictionary containing the keys `name` and either `value` or `binaryValue`, restricted to those allowed by XMLHttpRequest. */
             headers?: HeaderNameValuePair[] | undefined;
-            /** Optional. The HTTP method to use if the URL uses the HTTP[S] protocol.  */
-            method?: "GET" | "POST" | undefined;
-            /** Optional. The action to take if filename already exists.  */
-            conflictAction?: FilenameConflictAction | undefined;
+            /** The HTTP method to use if the URL uses the HTTP[S] protocol. */
+            method?: `${HttpMethod}` | undefined;
+            /** The action to take if `filename` already exists. */
+            conflictAction?: `${FilenameConflictAction}` | undefined;
         }
 
         export interface DownloadDelta {
-            /** The id of the DownloadItem that changed. */
+            /** The id of the {@link DownloadItem} that changed. */
             id: number;
-            /** Optional. The change in danger, if any.  */
+            /** The change in `danger`, if any. */
             danger?: StringDelta | undefined;
-            /** Optional. The change in url, if any.  */
+            /** The change in `url`, if any. */
             url?: StringDelta | undefined;
             /**
-             * Optional. The change in finalUrl, if any.
+             * The change in `finalUrl`, if any.
              * @since Chrome 54
              */
             finalUrl?: StringDelta | undefined;
-            /** Optional. The change in totalBytes, if any.  */
+            /** The change in `totalBytes`, if any. */
             totalBytes?: DoubleDelta | undefined;
-            /** Optional. The change in filename, if any.  */
+            /** The change in `filename`, if any. */
             filename?: StringDelta | undefined;
-            /** Optional. The change in paused, if any.  */
+            /** The change in `paused`, if any. */
             paused?: BooleanDelta | undefined;
-            /** Optional. The change in state, if any.  */
+            /** The change in `state`, if any. */
             state?: StringDelta | undefined;
-            /** Optional. The change in mime, if any.  */
+            /** The change in `mime`, if any. */
             mime?: StringDelta | undefined;
-            /** Optional. The change in fileSize, if any.  */
+            /** The change in `fileSize`, if any. */
             fileSize?: DoubleDelta | undefined;
-            /** Optional. The change in startTime, if any.  */
+            /** The change in `startTime`, if any. */
             startTime?: StringDelta | undefined;
-            /** Optional. The change in error, if any.  */
+            /** The change in `error`, if any. */
             error?: StringDelta | undefined;
-            /** Optional. The change in endTime, if any.  */
+            /** The change in `endTime`, if any. */
             endTime?: StringDelta | undefined;
-            /** Optional. The change in canResume, if any.  */
+            /** The change in `canResume`, if any. */
             canResume?: BooleanDelta | undefined;
-            /** Optional. The change in exists, if any.  */
+            /** The change in `exists`, if any. */
             exists?: BooleanDelta | undefined;
         }
 
@@ -3779,7 +3791,6 @@ declare namespace chrome {
             previous?: boolean | undefined;
         }
 
-        /** @since Chrome 34 */
         export interface DoubleDelta {
             current?: number | undefined;
             previous?: number | undefined;
@@ -3790,46 +3801,85 @@ declare namespace chrome {
             previous?: string | undefined;
         }
 
-        export type DownloadInterruptReason =
-            | "FILE_FAILED"
-            | "FILE_ACCESS_DENIED"
-            | "FILE_NO_SPACE"
-            | "FILE_NAME_TOO_LONG"
-            | "FILE_TOO_LARGE"
-            | "FILE_VIRUS_INFECTED"
-            | "FILE_TRANSIENT_ERROR"
-            | "FILE_BLOCKED"
-            | "FILE_SECURITY_CHECK_FAILED"
-            | "FILE_TOO_SHORT"
-            | "FILE_HASH_MISMATCH"
-            | "FILE_SAME_AS_SOURCE"
-            | "NETWORK_FAILED"
-            | "NETWORK_TIMEOUT"
-            | "NETWORK_DISCONNECTED"
-            | "NETWORK_SERVER_DOWN"
-            | "NETWORK_INVALID_REQUEST"
-            | "SERVER_FAILED"
-            | "SERVER_NO_RANGE"
-            | "SERVER_BAD_CONTENT"
-            | "SERVER_UNAUTHORIZED"
-            | "SERVER_CERT_PROBLEM"
-            | "SERVER_FORBIDDEN"
-            | "SERVER_UNREACHABLE"
-            | "SERVER_CONTENT_LENGTH_MISMATCH"
-            | "SERVER_CROSS_ORIGIN_REDIRECT"
-            | "USER_CANCELED"
-            | "USER_SHUTDOWN"
-            | "CRASH";
+        export enum InterruptReason {
+            FILE_FAILED = "FILE_FAILED",
+            FILE_ACCESS_DENIED = "FILE_ACCESS_DENIED",
+            FILE_NO_SPACE = "FILE_NO_SPACE",
+            FILE_NAME_TOO_LONG = "FILE_NAME_TOO_LONG",
+            FILE_TOO_LARGE = "FILE_TOO_LARGE",
+            FILE_VIRUS_INFECTED = "FILE_VIRUS_INFECTED",
+            FILE_TRANSIENT_ERROR = "FILE_TRANSIENT_ERROR",
+            FILE_BLOCKED = "FILE_BLOCKED",
+            FILE_SECURITY_CHECK_FAILED = "FILE_SECURITY_CHECK_FAILED",
+            FILE_TOO_SHORT = "FILE_TOO_SHORT",
+            FILE_HASH_MISMATCH = "FILE_HASH_MISMATCH",
+            FILE_SAME_AS_SOURCE = "FILE_SAME_AS_SOURCE",
+            NETWORK_FAILED = "NETWORK_FAILED",
+            NETWORK_TIMEOUT = "NETWORK_TIMEOUT",
+            NETWORK_DISCONNECTED = "NETWORK_DISCONNECTED",
+            NETWORK_SERVER_DOWN = "NETWORK_SERVER_DOWN",
+            NETWORK_INVALID_REQUEST = "NETWORK_INVALID_REQUEST",
+            SERVER_FAILED = "SERVER_FAILED",
+            SERVER_NO_RANGE = "SERVER_NO_RANGE",
+            SERVER_BAD_CONTENT = "SERVER_BAD_CONTENT",
+            SERVER_UNAUTHORIZED = "SERVER_UNAUTHORIZED",
+            SERVER_CERT_PROBLEM = "SERVER_CERT_PROBLEM",
+            SERVER_FORBIDDEN = "SERVER_FORBIDDEN",
+            SERVER_UNREACHABLE = "SERVER_UNREACHABLE",
+            SERVER_CONTENT_LENGTH_MISMATCH = "SERVER_CONTENT_LENGTH_MISMATCH",
+            SERVER_CROSS_ORIGIN_REDIRECT = "SERVER_CROSS_ORIGIN_REDIRECT",
+            USER_CANCELED = "USER_CANCELED",
+            USER_SHUTDOWN = "USER_SHUTDOWN",
+            CRASH = "CRASH",
+        }
 
-        export type DownloadState = "in_progress" | "interrupted" | "complete";
+        export enum State {
+            /** The download is currently receiving data from the server. */
+            IN_PROGRESS = "in_progress",
+            /** An error broke the connection with the file host. */
+            INTERRUPTED = "interrupted",
+            /** The download completed successfully. */
+            COMPLETE = "complete",
+        }
 
-        export type DangerType = "file" | "url" | "content" | "uncommon" | "host" | "unwanted" | "safe" | "accepted";
+        export enum DangerType {
+            /** The download's filename is suspicious. */
+            FILE = "file",
+            /** The download's URL is known to be malicious. */
+            URL = "url",
+            /** The downloaded file is known to be malicious. */
+            CONTENT = "content",
+            /** The download's URL is not commonly downloaded and could be dangerous. */
+            UNCOMMON = "uncommon",
+            /** The download came from a host known to distribute malicious binaries and is likely dangerous. */
+            HOST = "host",
+            /** The download is potentially unwanted or unsafe. E.g. it could make changes to browser or computer settings. */
+            UNWANTED = "unwanted",
+            /** The download presents no known danger to the user's computer. */
+            SAFE = "safe",
+            /** The user has accepted the dangerous download. */
+            ACCEPTED = "accepted",
+            ALLOWLISTED_BY_POLICY = "allowlistedByPolicy",
+            ASYNC_SCANNING = "asyncScanning",
+            ASYNC_LOCAL_PASSWORD_SCANNING = "asyncLocalPasswordScanning",
+            PASSWORD_PROTECTED = "passwordProtected",
+            BLOCKED_TOO_LARGE = "blockedTooLarge",
+            SENSITIVE_CONTENT_WARNING = "sensitiveContentWarning",
+            SENSITIVE_CONTENT_BLOCK = "sensitiveContentBlock",
+            DEEP_SCANNED_FAILED = "deepScannedFailed",
+            DEEP_SCANNED_SAFE = "deepScannedSafe",
+            DEEP_SCANNED_OPENED_DANGEROUS = "deepScannedOpenedDangerous",
+            PROMPT_FOR_SCANNING = "promptForScanning",
+            PROMPT_FOR_LOCAL_PASSWORD_SCANNING = "promptForLocalPasswordScanning",
+            ACCOUNT_COMPROMISE = "accountCompromise",
+            BLOCKED_SCAN_FAILED = "blockedScanFailed",
+        }
 
         export interface DownloadItem {
             /** Number of bytes received so far from the host, without considering file compression. */
             bytesReceived: number;
             /** Indication of whether this download is thought to be safe or known to be suspicious. */
-            danger: DangerType;
+            danger: `${DangerType}`;
             /** The absolute URL that this download initiated from, before any redirects. */
             url: string;
             /**
@@ -3844,16 +3894,16 @@ declare namespace chrome {
             /** True if the download has stopped reading data from the host, but kept the connection open. */
             paused: boolean;
             /** Indicates whether the download is progressing, interrupted, or complete. */
-            state: DownloadState;
+            state: `${State}`;
             /** The file's MIME type. */
             mime: string;
             /** Number of bytes in the whole file post-decompression, or -1 if unknown. */
             fileSize: number;
-            /** The time when the download began in ISO 8601 format. May be passed directly to the Date constructor: chrome.downloads.search({}, function(items){items.forEach(function(item){console.log(new Date(item.startTime))})}) */
+            /** The time when the download began in ISO 8601 format. May be passed directly to the Date constructor: `chrome.downloads.search({}, function(items){items.forEach(function(item){console.log(new Date(item.startTime))})})` */
             startTime: string;
-            /** Optional. Why the download was interrupted. Several kinds of HTTP errors may be grouped under one of the errors beginning with SERVER_. Errors relating to the network begin with NETWORK_, errors relating to the process of writing the file to the file system begin with FILE_, and interruptions initiated by the user begin with USER_.  */
-            error?: DownloadInterruptReason | undefined;
-            /** Optional. The time when the download ended in ISO 8601 format. May be passed directly to the Date constructor: chrome.downloads.search({}, function(items){items.forEach(function(item){if (item.endTime) console.log(new Date(item.endTime))})})  */
+            /** Why the download was interrupted. Several kinds of HTTP errors may be grouped under one of the errors beginning with `SERVER_`. Errors relating to the network begin with `NETWORK_`, errors relating to the process of writing the file to the file system begin with `FILE_`, and interruptions initiated by the user begin with `USER_`. */
+            error?: `${InterruptReason}` | undefined;
+            /** The time when the download ended in ISO 8601 format. May be passed directly to the Date constructor: `chrome.downloads.search({}, function(items){items.forEach(function(item){if (item.endTime) console.log(new Date(item.endTime))})})` */
             endTime?: string | undefined;
             /** An identifier that is persistent across browser sessions. */
             id: number;
@@ -3861,248 +3911,232 @@ declare namespace chrome {
             incognito: boolean;
             /** Absolute URL. */
             referrer: string;
-            /** Optional. Estimated time when the download will complete in ISO 8601 format. May be passed directly to the Date constructor: chrome.downloads.search({}, function(items){items.forEach(function(item){if (item.estimatedEndTime) console.log(new Date(item.estimatedEndTime))})})  */
+            /** Estimated time when the download will complete in ISO 8601 format. May be passed directly to the Date constructor: `chrome.downloads.search({}, function(items){items.forEach(function(item){if (item.estimatedEndTime) console.log(new Date(item.estimatedEndTime))})})` */
             estimatedEndTime?: string | undefined;
             /** True if the download is in progress and paused, or else if it is interrupted and can be resumed starting from where it was interrupted. */
             canResume: boolean;
-            /** Whether the downloaded file still exists. This information may be out of date because Chrome does not automatically watch for file removal. Call search() in order to trigger the check for file existence. When the existence check completes, if the file has been deleted, then an onChanged event will fire. Note that search() does not wait for the existence check to finish before returning, so results from search() may not accurately reflect the file system. Also, search() may be called as often as necessary, but will not check for file existence any more frequently than once every 10 seconds. */
+            /** Whether the downloaded file still exists. This information may be out of date because Chrome does not automatically watch for file removal. Call {@link search}() in order to trigger the check for file existence. When the existence check completes, if the file has been deleted, then an {@link onChanged} event will fire. Note that {@link search}() does not wait for the existence check to finish before returning, so results from {@link search}() may not accurately reflect the file system. Also, {@link search}() may be called as often as necessary, but will not check for file existence any more frequently than once every 10 seconds. */
             exists: boolean;
-            /** Optional. The identifier for the extension that initiated this download if this download was initiated by an extension. Does not change once it is set.  */
+            /** The identifier for the extension that initiated this download if this download was initiated by an extension. Does not change once it is set. */
             byExtensionId?: string | undefined;
-            /** Optional. The localized name of the extension that initiated this download if this download was initiated by an extension. May change if the extension changes its name or if the user changes their locale.  */
+            /** The localized name of the extension that initiated this download if this download was initiated by an extension. May change if the extension changes its name or if the user changes their locale. */
             byExtensionName?: string | undefined;
         }
 
         export interface GetFileIconOptions {
-            /** Optional. * The size of the returned icon. The icon will be square with dimensions size * size pixels. The default and largest size for the icon is 32x32 pixels. The only supported sizes are 16 and 32. It is an error to specify any other size.
-             */
+            /** The size of the returned icon. The icon will be square with dimensions size * size pixels. The default and largest size for the icon is 32x32 pixels. The only supported sizes are 16 and 32. It is an error to specify any other size. */
             size?: 16 | 32 | undefined;
         }
 
         export interface DownloadQuery {
-            /** Optional. Set elements of this array to DownloadItem properties in order to sort search results. For example, setting orderBy=['startTime'] sorts the DownloadItem by their start time in ascending order. To specify descending order, prefix with a hyphen: '-startTime'.  */
+            /** Set elements of this array to {@link DownloadItem} properties in order to sort search results. For example, setting `orderBy=['startTime']` sorts the {@link DownloadItem} by their start time in ascending order. To specify descending order, prefix with a hyphen: '-startTime'. */
             orderBy?: string[] | undefined;
-            /** Optional. Limits results to DownloadItem whose url matches the given regular expression.  */
+            /** Limits results to {@link DownloadItem} whose `url` matches the given regular expression. */
             urlRegex?: string | undefined;
-            /** Optional. Limits results to DownloadItem that ended before the time in ISO 8601 format.  */
+            /** Limits results to {@link DownloadItem} that ended before the time in ISO 8601 format. */
             endedBefore?: string | undefined;
-            /** Optional. Limits results to DownloadItem whose totalBytes is greater than the given integer.  */
+            /** Limits results to {@link DownloadItem} whose `totalBytes` is greater than the given integer. */
             totalBytesGreater?: number | undefined;
-            /** Optional. Indication of whether this download is thought to be safe or known to be suspicious.  */
-            danger?: string | undefined;
-            /** Optional. Number of bytes in the whole file, without considering file compression, or -1 if unknown.  */
+            /** Indication of whether this download is thought to be safe or known to be suspicious. */
+            danger?: `${DangerType}` | undefined;
+            /** Number of bytes in the whole file, without considering file compression, or -1 if unknown. */
             totalBytes?: number | undefined;
-            /** Optional. True if the download has stopped reading data from the host, but kept the connection open.  */
+            /** True if the download has stopped reading data from the host, but kept the connection open. */
             paused?: boolean | undefined;
-            /** Optional. Limits results to DownloadItem whose filename matches the given regular expression.  */
+            /** Limits results to {@link DownloadItem} whose `filename` matches the given regular expression. */
             filenameRegex?: string | undefined;
-            /** Optional. This array of search terms limits results to DownloadItem whose filename or url contain all of the search terms that do not begin with a dash '-' and none of the search terms that do begin with a dash.  */
+            /**
+             * The absolute URL that this download is being made from, after all redirects.
+             * @since Chrome 54
+             */
+            finalUrl?: string;
+            /**
+             * Limits results to {@link DownloadItem} whose `finalUrl` matches the given regular expression.
+             * @since Chrome 54
+             */
+            finalUrlRegex?: string;
+            /** This array of search terms limits results to {@link DownloadItem} whose `filename` or `url` or `finalUrl` contain all of the search terms that do not begin with a dash '-' and none of the search terms that do begin with a dash. */
             query?: string[] | undefined;
-            /** Optional. Limits results to DownloadItem whose totalBytes is less than the given integer.  */
+            /** Limits results to {@link DownloadItem} whose `totalBytes` is less than the given integer. */
             totalBytesLess?: number | undefined;
-            /** Optional. The id of the DownloadItem to query.  */
+            /** The `id` of the {@link DownloadItem} to query. */
             id?: number | undefined;
-            /** Optional. Number of bytes received so far from the host, without considering file compression.  */
+            /** Number of bytes received so far from the host, without considering file compression. */
             bytesReceived?: number | undefined;
-            /** Optional. Limits results to DownloadItem that ended after the time in ISO 8601 format.  */
+            /** Limits results to {@link DownloadItem} that ended after the time in ISO 8601 format. */
             endedAfter?: string | undefined;
-            /** Optional. Absolute local path.  */
+            /** Absolute local path. */
             filename?: string | undefined;
-            /** Optional. Indicates whether the download is progressing, interrupted, or complete.  */
-            state?: string | undefined;
-            /** Optional. Limits results to DownloadItem that started after the time in ISO 8601 format.  */
+            /** Indicates whether the download is progressing, interrupted, or complete. */
+            state?: `${State}` | undefined;
+            /** Limits results to {@link DownloadItem} that started after the time in ISO 8601 format. */
             startedAfter?: string | undefined;
-            /** Optional. The file's MIME type.  */
+            /** The file's MIME type. */
             mime?: string | undefined;
-            /** Optional. Number of bytes in the whole file post-decompression, or -1 if unknown.  */
+            /** Number of bytes in the whole file post-decompression, or -1 if unknown. */
             fileSize?: number | undefined;
-            /** Optional. The time when the download began in ISO 8601 format.  */
+            /** The time when the download began in ISO 8601 format. */
             startTime?: string | undefined;
-            /** Optional. Absolute URL.  */
+            /** The absolute URL that this download initiated from, before any redirects. */
             url?: string | undefined;
-            /** Optional. Limits results to DownloadItem that started before the time in ISO 8601 format.  */
+            /** Limits results to {@link DownloadItem} that started before the time in ISO 8601 format. */
             startedBefore?: string | undefined;
-            /** Optional. The maximum number of matching DownloadItem returned. Defaults to 1000. Set to 0 in order to return all matching DownloadItem. See search for how to page through results.  */
+            /** The maximum number of matching {@link DownloadItem} returned. Defaults to 1000. Set to 0 in order to return all matching {@link DownloadItem}. See {@link search} for how to page through results. */
             limit?: number | undefined;
-            /** Optional. Why a download was interrupted.  */
-            error?: number | undefined;
-            /** Optional. The time when the download ended in ISO 8601 format.  */
+            /** Why a download was interrupted. */
+            error?: `${InterruptReason}` | undefined;
+            /** The time when the download ended in ISO 8601 format. */
             endTime?: string | undefined;
-            /** Optional. Whether the downloaded file exists;  */
+            /** Whether the downloaded file exists; */
             exists?: boolean | undefined;
         }
 
-        export interface DownloadFilenameSuggestion {
-            /** The DownloadItem's new target DownloadItem.filename, as a path relative to the user's default Downloads directory, possibly containing subdirectories. Absolute paths, empty paths, and paths containing back-references ".." will be ignored. */
+        export interface FilenameSuggestion {
+            /** The {@link DownloadItem}'s new target {@link DownloadItem.filename}, as a path relative to the user's default Downloads directory, possibly containing subdirectories. Absolute paths, empty paths, and paths containing back-references ".." will be ignored. `filename` is ignored if there are any {@link onDeterminingFilename} listeners registered by any extensions. */
             filename: string;
-            /** Optional. The action to take if filename already exists.  */
-            conflictAction?: string | undefined;
+            /** The action to take if `filename` already exists. */
+            conflictAction?: `${FilenameConflictAction}` | undefined;
         }
 
+        /** @since Chrome 105 */
         export interface UiOptions {
             /** Enable or disable the download UI. */
             enabled: boolean;
         }
 
-        export interface DownloadChangedEvent extends chrome.events.Event<(downloadDelta: DownloadDelta) => void> {}
-
-        export interface DownloadCreatedEvent extends chrome.events.Event<(downloadItem: DownloadItem) => void> {}
-
-        export interface DownloadErasedEvent extends chrome.events.Event<(downloadId: number) => void> {}
-
-        export interface DownloadDeterminingFilenameEvent extends
-            chrome.events.Event<
-                (downloadItem: DownloadItem, suggest: (suggestion?: DownloadFilenameSuggestion) => void) => void
-            >
-        {}
-
         /**
-         * Find DownloadItem. Set query to the empty object to get all DownloadItem. To get a specific DownloadItem, set only the id field. To page through a large number of items, set orderBy: ['-startTime'], set limit to the number of items per page, and set startedAfter to the startTime of the last item from the last page.
-         * @return The `search` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+         * Find {@link DownloadItem}. Set `query` to the empty object to get all {@link DownloadItem}. To get a specific {@link DownloadItem}, set only the `id` field. To page through a large number of items, set `orderBy: ['-startTime']`, set `limit` to the number of items per page, and set `startedAfter` to the `startTime` of the last item from the last page.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 96.
          */
         export function search(query: DownloadQuery): Promise<DownloadItem[]>;
-        /**
-         * Find DownloadItem. Set query to the empty object to get all DownloadItem. To get a specific DownloadItem, set only the id field. To page through a large number of items, set orderBy: ['-startTime'], set limit to the number of items per page, and set startedAfter to the startTime of the last item from the last page.
-         */
         export function search(query: DownloadQuery, callback: (results: DownloadItem[]) => void): void;
+
         /**
-         * Pause the download. If the request was successful the download is in a paused state. Otherwise runtime.lastError contains an error message. The request will fail if the download is not active.
+         * Pause the download. If the request was successful the download is in a paused state. Otherwise {@link runtime.lastError} contains an error message. The request will fail if the download is not active.
          * @param downloadId The id of the download to pause.
-         * @return The `pause` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 96.
          */
         export function pause(downloadId: number): Promise<void>;
-        /**
-         * Pause the download. If the request was successful the download is in a paused state. Otherwise runtime.lastError contains an error message. The request will fail if the download is not active.
-         * @param downloadId The id of the download to pause.
-         * @param callback Called when the pause request is completed.
-         */
         export function pause(downloadId: number, callback: () => void): void;
+
         /**
-         * Retrieve an icon for the specified download. For new downloads, file icons are available after the onCreated event has been received. The image returned by this function while a download is in progress may be different from the image returned after the download is complete. Icon retrieval is done by querying the underlying operating system or toolkit depending on the platform. The icon that is returned will therefore depend on a number of factors including state of the download, platform, registered file types and visual theme. If a file icon cannot be determined, runtime.lastError will contain an error message.
+         * Retrieve an icon for the specified download. For new downloads, file icons are available after the {@link onCreated} event has been received. The image returned by this function while a download is in progress may be different from the image returned after the download is complete. Icon retrieval is done by querying the underlying operating system or toolkit depending on the platform. The icon that is returned will therefore depend on a number of factors including state of the download, platform, registered file types and visual theme. If a file icon cannot be determined, {@link runtime.lastError} will contain an error message.
          * @param downloadId The identifier for the download.
-         * @return The `getFileIcon` method provides its result via callback or returned as a `Promise` (MV3 only).
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 96.
          */
-        export function getFileIcon(downloadId: number, options?: GetFileIconOptions): Promise<string>;
-        /**
-         * Retrieve an icon for the specified download. For new downloads, file icons are available after the onCreated event has been received. The image returned by this function while a download is in progress may be different from the image returned after the download is complete. Icon retrieval is done by querying the underlying operating system or toolkit depending on the platform. The icon that is returned will therefore depend on a number of factors including state of the download, platform, registered file types and visual theme. If a file icon cannot be determined, runtime.lastError will contain an error message.
-         * @param downloadId The identifier for the download.
-         * @param callback A URL to an image that represents the download.
-         */
-        export function getFileIcon(downloadId: number, callback: (iconURL: string) => void): void;
-        /**
-         * Retrieve an icon for the specified download. For new downloads, file icons are available after the onCreated event has been received. The image returned by this function while a download is in progress may be different from the image returned after the download is complete. Icon retrieval is done by querying the underlying operating system or toolkit depending on the platform. The icon that is returned will therefore depend on a number of factors including state of the download, platform, registered file types and visual theme. If a file icon cannot be determined, runtime.lastError will contain an error message.
-         * @param downloadId The identifier for the download.
-         * @param callback A URL to an image that represents the download.
-         */
+        export function getFileIcon(downloadId: number, options?: GetFileIconOptions): Promise<string | undefined>;
+        export function getFileIcon(downloadId: number, callback: (iconURL?: string) => void): void;
         export function getFileIcon(
             downloadId: number,
             options: GetFileIconOptions,
-            callback: (iconURL: string) => void,
+            callback: (iconURL?: string) => void,
         ): void;
+
         /**
-         * Resume a paused download. If the request was successful the download is in progress and unpaused. Otherwise runtime.lastError contains an error message. The request will fail if the download is not active.
+         * Resume a paused download. If the request was successful the download is in progress and unpaused. Otherwise {@link runtime.lastError} contains an error message. The request will fail if the download is not active.
          * @param downloadId The id of the download to resume.
-         * @return The `resume` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 96.
          */
         export function resume(downloadId: number): Promise<void>;
-        /**
-         * Resume a paused download. If the request was successful the download is in progress and unpaused. Otherwise runtime.lastError contains an error message. The request will fail if the download is not active.
-         * @param downloadId The id of the download to resume.
-         * @param callback  Called when the resume request is completed.
-         */
         export function resume(downloadId: number, callback: () => void): void;
+
         /**
-         * Cancel a download. When callback is run, the download is cancelled, completed, interrupted or doesn't exist anymore.
+         * Cancel a download. When `callback` is run, the download is cancelled, completed, interrupted or doesn't exist anymore.
          * @param downloadId The id of the download to cancel.
-         * @return The `cancel` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 96.
          */
         export function cancel(downloadId: number): Promise<void>;
-        /**
-         * Cancel a download. When callback is run, the download is cancelled, completed, interrupted or doesn't exist anymore.
-         * @param downloadId The id of the download to cancel.
-         * @param callback Called when the cancel request is completed.
-         */
         export function cancel(downloadId: number, callback: () => void): void;
+
         /**
-         * Download a URL. If the URL uses the HTTP[S] protocol, then the request will include all cookies currently set for its hostname. If both filename and saveAs are specified, then the Save As dialog will be displayed, pre-populated with the specified filename. If the download started successfully, callback will be called with the new DownloadItem's downloadId. If there was an error starting the download, then callback will be called with downloadId=undefined and runtime.lastError will contain a descriptive string. The error strings are not guaranteed to remain backwards compatible between releases. Extensions must not parse it.
+         * Download a URL. If the URL uses the HTTP[S] protocol, then the request will include all cookies currently set for its hostname. If both `filename` and `saveAs` are specified, then the Save As dialog will be displayed, pre-populated with the specified `filename`. If the download started successfully, `callback` will be called with the new {@link DownloadItem}'s `downloadId`. If there was an error starting the download, then `callback` will be called with `downloadId=undefined` and {@link runtime.lastError} will contain a descriptive string. The error strings are not guaranteed to remain backwards compatible between releases. Extensions must not parse it.
          * @param options What to download and how.
-         * @return The `download` method provides its result via callback or returned as a `Promise` (MV3 only).
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 96.
          */
         export function download(options: DownloadOptions): Promise<number>;
-        /**
-         * Download a URL. If the URL uses the HTTP[S] protocol, then the request will include all cookies currently set for its hostname. If both filename and saveAs are specified, then the Save As dialog will be displayed, pre-populated with the specified filename. If the download started successfully, callback will be called with the new DownloadItem's downloadId. If there was an error starting the download, then callback will be called with downloadId=undefined and runtime.lastError will contain a descriptive string. The error strings are not guaranteed to remain backwards compatible between releases. Extensions must not parse it.
-         * @param options What to download and how.
-         * @param callback Called with the id of the new DownloadItem.
-         */
         export function download(options: DownloadOptions, callback: (downloadId: number) => void): void;
+
         /**
-         * Open the downloaded file now if the DownloadItem is complete; otherwise returns an error through runtime.lastError. Requires the "downloads.open" permission in addition to the "downloads" permission. An onChanged event will fire when the item is opened for the first time.
+         * Opens the downloaded file now if the {@link DownloadItem} is complete; otherwise returns an error through {@link runtime.lastError}. This method requires the `"downloads.open"` permission in addition to the `"downloads"` permission. An {@link onChanged} event fires when the item is opened for the first time. This method can only be called in response to a user gesture.
          * @param downloadId The identifier for the downloaded file.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 123.
          */
-        export function open(downloadId: number): void;
+        export function open(downloadId: number): Promise<void>;
+        export function open(
+            downloadId: number,
+            /** @since Chrome 123 */
+            callback: () => void,
+        ): void;
+
         /**
          * Show the downloaded file in its folder in a file manager.
          * @param downloadId The identifier for the downloaded file.
          */
         export function show(downloadId: number): void;
+
         /** Show the default Downloads folder in a file manager. */
         export function showDefaultFolder(): void;
+
         /**
-         * Erase matching DownloadItem from history without deleting the downloaded file. An onErased event will fire for each DownloadItem that matches query, then callback will be called.
-         * @return The `erase` method provides its result via callback or returned as a `Promise` (MV3 only).
+         * Erase matching {@link DownloadItem} from history without deleting the downloaded file. An {@link onErased} event will fire for each {@link DownloadItem} that matches `query`, then `callback` will be called.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 96.
          */
         export function erase(query: DownloadQuery): Promise<number[]>;
-        /**
-         * Erase matching DownloadItem from history without deleting the downloaded file. An onErased event will fire for each DownloadItem that matches query, then callback will be called.
-         */
         export function erase(query: DownloadQuery, callback: (erasedIds: number[]) => void): void;
+
         /**
-         * Remove the downloaded file if it exists and the DownloadItem is complete; otherwise return an error through runtime.lastError.
-         * @return The `removeFile` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+         * Remove the downloaded file if it exists and the {@link DownloadItem} is complete; otherwise return an error through {@link runtime.lastError}.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 96.
          */
         export function removeFile(downloadId: number): Promise<void>;
+        export function removeFile(downloadId: number, callback: () => void): void;
+
         /**
-         * Remove the downloaded file if it exists and the DownloadItem is complete; otherwise return an error through runtime.lastError.
-         */
-        export function removeFile(downloadId: number, callback?: () => void): void;
-        /**
-         * Prompt the user to accept a dangerous download. Can only be called from a visible context (tab, window, or page/browser action popup). Does not automatically accept dangerous downloads. If the download is accepted, then an onChanged event will fire, otherwise nothing will happen. When all the data is fetched into a temporary file and either the download is not dangerous or the danger has been accepted, then the temporary file is renamed to the target filename, the |state| changes to 'complete', and onChanged fires.
-         * @param downloadId The identifier for the DownloadItem.
-         * @return The `acceptDanger` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+         * Prompt the user to accept a dangerous download. Can only be called from a visible context (tab, window, or page/browser action popup). Does not automatically accept dangerous downloads. If the download is accepted, then an {@link onChanged} event will fire, otherwise nothing will happen. When all the data is fetched into a temporary file and either the download is not dangerous or the danger has been accepted, then the temporary file is renamed to the target filename, the `state` changes to 'complete', and {@link onChanged} fires.
+         * @param downloadId The identifier for the {@link DownloadItem}.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 96.
          */
         export function acceptDanger(downloadId: number): Promise<void>;
-        /**
-         * Prompt the user to accept a dangerous download. Can only be called from a visible context (tab, window, or page/browser action popup). Does not automatically accept dangerous downloads. If the download is accepted, then an onChanged event will fire, otherwise nothing will happen. When all the data is fetched into a temporary file and either the download is not dangerous or the danger has been accepted, then the temporary file is renamed to the target filename, the |state| changes to 'complete', and onChanged fires.
-         * @param downloadId The identifier for the DownloadItem.
-         * @param callback Called when the danger prompt dialog closes.
-         */
         export function acceptDanger(downloadId: number, callback: () => void): void;
-        /** Initiate dragging the downloaded file to another application. Call in a javascript ondragstart handler. */
-        export function drag(downloadId: number): void;
-        /** Enable or disable the gray shelf at the bottom of every window associated with the current browser profile. The shelf will be disabled as long as at least one extension has disabled it. Enabling the shelf while at least one other extension has disabled it will return an error through runtime.lastError. Requires the "downloads.shelf" permission in addition to the "downloads" permission. */
-        export function setShelfEnabled(enabled: boolean): void;
+
         /**
-         * Change the download UI of every window associated with the current browser profile. As long as at least one extension has set UiOptions.enabled to false, the download UI will be hidden. Setting UiOptions.enabled to true while at least one other extension has disabled it will return an error through runtime.lastError. Requires the "downloads.ui" permission in addition to the "downloads" permission.
-         * @param options Encapsulate a change to the download UI.
+         * Enable or disable the gray shelf at the bottom of every window associated with the current browser profile. The shelf will be disabled as long as at least one extension has disabled it. Enabling the shelf while at least one other extension has disabled it will return an error through {@link runtime.lastError}. Requires the `"downloads.shelf"` permission in addition to the `"downloads"` permission.
+         * @deprecated since Chrome 117. Use {@link setUiOptions} instead.
+         */
+        export function setShelfEnabled(enabled: boolean): void;
+
+        /**
+         * Change the download UI of every window associated with the current browser profile. As long as at least one extension has set {@link UiOptions.enabled} to false, the download UI will be hidden. Setting {@link UiOptions.enabled} to true while at least one other extension has disabled it will return an error through {@link runtime.lastError}. Requires the `"downloads.ui"` permission in addition to the `"downloads"` permission.
          * @since Chrome 105
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 105.
          */
         export function setUiOptions(options: UiOptions): Promise<void>;
-        /**
-         * Change the download UI of every window associated with the current browser profile. As long as at least one extension has set UiOptions.enabled to false, the download UI will be hidden. Setting UiOptions.enabled to true while at least one other extension has disabled it will return an error through runtime.lastError. Requires the "downloads.ui" permission in addition to the "downloads" permission.
-         * @param options Encapsulate a change to the download UI.
-         * @param callback Called when the setUiOptions request is completed.
-         * @since Chrome 105
-         */
         export function setUiOptions(options: UiOptions, callback: () => void): void;
 
-        /** When any of a DownloadItem's properties except bytesReceived and estimatedEndTime changes, this event fires with the downloadId and an object containing the properties that changed. */
-        export var onChanged: DownloadChangedEvent;
-        /** This event fires with the DownloadItem object when a download begins. */
-        export var onCreated: DownloadCreatedEvent;
-        /** Fires with the downloadId when a download is erased from history. */
-        export var onErased: DownloadErasedEvent;
-        /** During the filename determination process, extensions will be given the opportunity to override the target DownloadItem.filename. Each extension may not register more than one listener for this event. Each listener must call suggest exactly once, either synchronously or asynchronously. If the listener calls suggest asynchronously, then it must return true. If the listener neither calls suggest synchronously nor returns true, then suggest will be called automatically. The DownloadItem will not complete until all listeners have called suggest. Listeners may call suggest without any arguments in order to allow the download to use downloadItem.filename for its filename, or pass a suggestion object to suggest in order to override the target filename. If more than one extension overrides the filename, then the last extension installed whose listener passes a suggestion object to suggest wins. In order to avoid confusion regarding which extension will win, users should not install extensions that may conflict. If the download is initiated by download and the target filename is known before the MIME type and tentative filename have been determined, pass filename to download instead. */
-        export var onDeterminingFilename: DownloadDeterminingFilenameEvent;
+        /** When any of a {@link DownloadItem}'s properties except `bytesReceived` and `estimatedEndTime` changes, this event fires with the `downloadId` and an object containing the properties that changed. */
+        export const onChanged: events.Event<(downloadDelta: DownloadDelta) => void>;
+
+        /** This event fires with the {@link DownloadItem} object when a download begins. */
+        export const onCreated: events.Event<(downloadItem: DownloadItem) => void>;
+
+        /** Fires with the `downloadId` when a download is erased from history. */
+        export const onErased: events.Event<(downloadId: number) => void>;
+
+        /** During the filename determination process, extensions will be given the opportunity to override the target {@link DownloadItem.filename}. Each extension may not register more than one listener for this event. Each listener must call `suggest` exactly once, either synchronously or asynchronously. If the listener calls `suggest` asynchronously, then it must return `true`. If the listener neither calls `suggest` synchronously nor returns `true`, then `suggest` will be called automatically. The {@link DownloadItem} will not complete until all listeners have called `suggest`. Listeners may call `suggest` without any arguments in order to allow the download to use `downloadItem.filename` for its filename, or pass a `suggestion` object to `suggest` in order to override the target filename. If more than one extension overrides the filename, then the last extension installed whose listener passes a `suggestion` object to `suggest` wins. In order to avoid confusion regarding which extension will win, users should not install extensions that may conflict. If the download is initiated by {@link download} and the target filename is known before the MIME type and tentative filename have been determined, pass `filename` to {@link download} instead. */
+        export const onDeterminingFilename: events.Event<
+            (downloadItem: DownloadItem, suggest: (suggestion?: FilenameSuggestion) => void) => void
+        >;
     }
 
     ////////////////////

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -3766,24 +3766,300 @@ async function testPageCapture() {
     await chrome.pageCapture.saveAsMHTML({ tabId: 0 }); // $ExpectType Blob | undefined
 }
 
-// https://developer.chrome.com/docs/extensions/reference/downloads
+// https://developer.chrome.com/docs/extensions/reference/api/downloads
 function testDownloads() {
-    chrome.downloads.search({}, (results) => {});
-    chrome.downloads.pause(1, () => {});
-    chrome.downloads.getFileIcon(1, (iconURL) => {});
-    chrome.downloads.getFileIcon(1, {}, (iconURL) => {});
-    chrome.downloads.resume(1, () => {});
-    chrome.downloads.cancel(1, () => {});
-    chrome.downloads.download({ url: "https://example.com" }, (downloadId) => {});
-    chrome.downloads.open(1);
-    chrome.downloads.show(1);
-    chrome.downloads.showDefaultFolder();
-    chrome.downloads.erase({}, (erasedIds) => {});
-    chrome.downloads.removeFile(1, () => {});
-    chrome.downloads.acceptDanger(1, () => {});
-    chrome.downloads.drag(1);
-    chrome.downloads.setShelfEnabled(true);
-    chrome.downloads.setUiOptions({ enabled: true }, () => {});
+    chrome.downloads.DangerType.ACCEPTED === "accepted";
+    chrome.downloads.DangerType.ACCOUNT_COMPROMISE === "accountCompromise";
+    chrome.downloads.DangerType.ALLOWLISTED_BY_POLICY === "allowlistedByPolicy";
+    chrome.downloads.DangerType.ASYNC_LOCAL_PASSWORD_SCANNING === "asyncLocalPasswordScanning";
+    chrome.downloads.DangerType.ASYNC_SCANNING === "asyncScanning";
+    chrome.downloads.DangerType.BLOCKED_SCAN_FAILED === "blockedScanFailed";
+    chrome.downloads.DangerType.BLOCKED_TOO_LARGE === "blockedTooLarge";
+    chrome.downloads.DangerType.CONTENT === "content";
+    chrome.downloads.DangerType.DEEP_SCANNED_FAILED === "deepScannedFailed";
+    chrome.downloads.DangerType.DEEP_SCANNED_OPENED_DANGEROUS === "deepScannedOpenedDangerous";
+    chrome.downloads.DangerType.DEEP_SCANNED_SAFE === "deepScannedSafe";
+    chrome.downloads.DangerType.FILE === "file";
+    chrome.downloads.DangerType.HOST === "host";
+    chrome.downloads.DangerType.PASSWORD_PROTECTED === "passwordProtected";
+    chrome.downloads.DangerType.PROMPT_FOR_LOCAL_PASSWORD_SCANNING === "promptForLocalPasswordScanning";
+    chrome.downloads.DangerType.PROMPT_FOR_SCANNING === "promptForScanning";
+    chrome.downloads.DangerType.SAFE === "safe";
+    chrome.downloads.DangerType.SENSITIVE_CONTENT_BLOCK === "sensitiveContentBlock";
+    chrome.downloads.DangerType.SENSITIVE_CONTENT_WARNING === "sensitiveContentWarning";
+    chrome.downloads.DangerType.UNCOMMON === "uncommon";
+    chrome.downloads.DangerType.UNWANTED === "unwanted";
+    chrome.downloads.DangerType.URL === "url";
+
+    chrome.downloads.FilenameConflictAction.OVERWRITE === "overwrite";
+    chrome.downloads.FilenameConflictAction.PROMPT === "prompt";
+    chrome.downloads.FilenameConflictAction.UNIQUIFY === "uniquify";
+
+    chrome.downloads.HttpMethod.GET === "GET";
+    chrome.downloads.HttpMethod.POST === "POST";
+
+    chrome.downloads.InterruptReason.CRASH === "CRASH";
+    chrome.downloads.InterruptReason.FILE_ACCESS_DENIED === "FILE_ACCESS_DENIED";
+    chrome.downloads.InterruptReason.FILE_BLOCKED === "FILE_BLOCKED";
+    chrome.downloads.InterruptReason.FILE_FAILED === "FILE_FAILED";
+    chrome.downloads.InterruptReason.FILE_HASH_MISMATCH === "FILE_HASH_MISMATCH";
+    chrome.downloads.InterruptReason.FILE_NAME_TOO_LONG === "FILE_NAME_TOO_LONG";
+    chrome.downloads.InterruptReason.FILE_NO_SPACE === "FILE_NO_SPACE";
+    chrome.downloads.InterruptReason.FILE_SAME_AS_SOURCE === "FILE_SAME_AS_SOURCE";
+    chrome.downloads.InterruptReason.FILE_SECURITY_CHECK_FAILED === "FILE_SECURITY_CHECK_FAILED";
+    chrome.downloads.InterruptReason.FILE_TOO_LARGE === "FILE_TOO_LARGE";
+    chrome.downloads.InterruptReason.FILE_TOO_SHORT === "FILE_TOO_SHORT";
+    chrome.downloads.InterruptReason.FILE_TRANSIENT_ERROR === "FILE_TRANSIENT_ERROR";
+    chrome.downloads.InterruptReason.FILE_VIRUS_INFECTED === "FILE_VIRUS_INFECTED";
+    chrome.downloads.InterruptReason.NETWORK_DISCONNECTED === "NETWORK_DISCONNECTED";
+    chrome.downloads.InterruptReason.NETWORK_FAILED === "NETWORK_FAILED";
+    chrome.downloads.InterruptReason.NETWORK_INVALID_REQUEST === "NETWORK_INVALID_REQUEST";
+    chrome.downloads.InterruptReason.NETWORK_SERVER_DOWN === "NETWORK_SERVER_DOWN";
+    chrome.downloads.InterruptReason.NETWORK_TIMEOUT === "NETWORK_TIMEOUT";
+    chrome.downloads.InterruptReason.SERVER_BAD_CONTENT === "SERVER_BAD_CONTENT";
+    chrome.downloads.InterruptReason.SERVER_CERT_PROBLEM === "SERVER_CERT_PROBLEM";
+    chrome.downloads.InterruptReason.SERVER_CONTENT_LENGTH_MISMATCH === "SERVER_CONTENT_LENGTH_MISMATCH";
+    chrome.downloads.InterruptReason.SERVER_CROSS_ORIGIN_REDIRECT === "SERVER_CROSS_ORIGIN_REDIRECT";
+    chrome.downloads.InterruptReason.SERVER_FAILED === "SERVER_FAILED";
+    chrome.downloads.InterruptReason.SERVER_FORBIDDEN === "SERVER_FORBIDDEN";
+    chrome.downloads.InterruptReason.SERVER_NO_RANGE === "SERVER_NO_RANGE";
+    chrome.downloads.InterruptReason.SERVER_UNAUTHORIZED === "SERVER_UNAUTHORIZED";
+    chrome.downloads.InterruptReason.SERVER_UNREACHABLE === "SERVER_UNREACHABLE";
+    chrome.downloads.InterruptReason.USER_CANCELED === "USER_CANCELED";
+    chrome.downloads.InterruptReason.USER_SHUTDOWN === "USER_SHUTDOWN";
+
+    chrome.downloads.State.COMPLETE === "complete";
+    chrome.downloads.State.INTERRUPTED === "interrupted";
+    chrome.downloads.State.IN_PROGRESS === "in_progress";
+
+    const downloadId = 1;
+
+    chrome.downloads.acceptDanger(downloadId); // $ExpectType Promise<void>
+    chrome.downloads.acceptDanger(downloadId, () => {}); // $ExpectType void
+    // @ts-expect-error
+    chrome.downloads.acceptDanger(downloadId, () => {}).then(() => {});
+
+    chrome.downloads.cancel(downloadId); // $ExpectType Promise<void>
+    chrome.downloads.cancel(downloadId, () => {}); // $ExpectType void
+    // @ts-expect-error
+    chrome.downloads.cancel(downloadId, () => {}).then(() => {});
+
+    const downloadOptions: chrome.downloads.DownloadOptions = {
+        body: "body",
+        conflictAction: "overwrite",
+        filename: "filename",
+        headers: [{
+            name: "Content-Type",
+            value: "application/json",
+        }],
+        method: "GET",
+        saveAs: true,
+        url: "https://example.com",
+    };
+
+    chrome.downloads.download(downloadOptions); // $ExpectType Promise<number>
+    chrome.downloads.download(downloadOptions, (downloadId) => { // $ExpectType void
+        downloadId; // $ExpectType number
+    });
+    // @ts-expect-error
+    chrome.downloads.download(downloadOptions, () => {}).then(() => {});
+
+    const downloadQuery: chrome.downloads.DownloadQuery = {
+        bytesReceived: 100,
+        danger: "safe",
+        endTime: "2025-05-30",
+        endedAfter: "2025-05-30",
+        endedBefore: "2025-05-30",
+        error: "CRASH",
+        exists: true,
+        fileSize: 100,
+        filename: "filename",
+        filenameRegex: "https://example.com/*",
+        finalUrl: "https://example.com",
+        finalUrlRegex: "https://example.com/*",
+        id: 1,
+        limit: 100,
+        mime: "application/json",
+        orderBy: ["startTime"],
+        paused: true,
+        query: ["https://example.com/*"],
+        startTime: "2025-05-30",
+        startedAfter: "2025-05-30",
+        startedBefore: "2025-05-30",
+        state: "complete",
+        totalBytes: 100,
+        url: "https://example.com",
+        urlRegex: "https://example.com/*",
+    };
+
+    chrome.downloads.erase(downloadQuery); // $ExpectType Promise<number[]>
+    chrome.downloads.erase(downloadQuery, (erasedIds) => { // $ExpectType void
+        erasedIds; // $ExpectType number[]
+    });
+    // @ts-expect-error
+    chrome.downloads.erase(downloadQuery, () => {}).then(() => {});
+
+    const getFileIconOptions: chrome.downloads.GetFileIconOptions = {
+        size: 32,
+    };
+
+    chrome.downloads.getFileIcon(downloadId); // $ExpectType Promise<string | undefined>
+    chrome.downloads.getFileIcon(downloadId, getFileIconOptions); // $ExpectType Promise<string | undefined>
+    chrome.downloads.getFileIcon(downloadId, (iconURL) => { // $ExpectType void
+        iconURL; // $ExpectType string | undefined
+    });
+    chrome.downloads.getFileIcon(downloadId, getFileIconOptions, (iconURL) => { // $ExpectType void
+        iconURL; // $ExpectType string | undefined
+    });
+    // @ts-expect-error
+    chrome.downloads.getFileIcon(downloadId, () => {}).then(() => {});
+
+    chrome.downloads.open(downloadId); // $ExpectType Promise<void>
+    chrome.downloads.open(downloadId, () => {}); // $ExpectType void
+    // @ts-expect-error
+    chrome.downloads.open(downloadId, () => {}).then(() => {});
+
+    chrome.downloads.pause(downloadId); // $ExpectType Promise<void>
+    chrome.downloads.pause(downloadId, () => {}); // $ExpectType void
+    // @ts-expect-error
+    chrome.downloads.pause(downloadId, () => {}).then(() => {});
+
+    chrome.downloads.removeFile(downloadId); // $ExpectType Promise<void>
+    chrome.downloads.removeFile(downloadId, () => {}); // $ExpectType void
+    // @ts-expect-error
+    chrome.downloads.removeFile(downloadId, () => {}).then(() => {});
+
+    chrome.downloads.resume(downloadId); // $ExpectType Promise<void>
+    chrome.downloads.resume(downloadId, () => {}); // $ExpectType void
+    // @ts-expect-error
+    chrome.downloads.resume(downloadId, () => {}).then(() => {});
+
+    chrome.downloads.search(downloadQuery); // $ExpectType Promise<DownloadItem[]>
+    chrome.downloads.search(downloadQuery, ([result]) => { // $ExpectType void
+        result.byExtensionId; // $ExpectType string | undefined
+        result.byExtensionName; // $ExpectType string | undefined
+        result.bytesReceived; // $ExpectType number
+        result.canResume; // $ExpectType boolean
+        result.danger; // $ExpectType "file" | "url" | "content" | "uncommon" | "host" | "unwanted" | "safe" | "accepted" | "allowlistedByPolicy" | "asyncScanning" | "asyncLocalPasswordScanning" | "passwordProtected" | "blockedTooLarge" | "sensitiveContentWarning" | "sensitiveContentBlock" | "deepScannedFailed" | "deepScannedSafe" | "deepScannedOpenedDangerous" | "promptForScanning" | "promptForLocalPasswordScanning" | "accountCompromise" | "blockedScanFailed"
+        result.endTime; // $ExpectType string | undefined
+        result.error; // $ExpectType "CRASH" | "FILE_ACCESS_DENIED" | "FILE_BLOCKED" | "FILE_FAILED" | "FILE_HASH_MISMATCH" | "FILE_NAME_TOO_LONG" | "FILE_NO_SPACE" | "FILE_SAME_AS_SOURCE" | "FILE_SECURITY_CHECK_FAILED" | "FILE_TOO_LARGE" | "FILE_TOO_SHORT" | "FILE_TRANSIENT_ERROR" | "FILE_VIRUS_INFECTED" | "NETWORK_DISCONNECTED" | "NETWORK_FAILED" | "NETWORK_INVALID_REQUEST" | "NETWORK_SERVER_DOWN" | "NETWORK_TIMEOUT" | "SERVER_BAD_CONTENT" | "SERVER_CERT_PROBLEM" | "SERVER_CONTENT_LENGTH_MISMATCH" | "SERVER_CROSS_ORIGIN_REDIRECT" | "SERVER_FAILED" | "SERVER_FORBIDDEN" | "SERVER_NO_RANGE" | "SERVER_UNAUTHORIZED" | "SERVER_UNREACHABLE" | "USER_CANCELED" | "USER_SHUTDOWN" | undefined
+        result.estimatedEndTime; // $ExpectType string | undefined
+        result.exists; // $ExpectType boolean
+        result.fileSize; // $ExpectType number
+        result.filename; // $ExpectType string
+        result.finalUrl; // $ExpectType string
+        result.id; // $ExpectType number
+        result.incognito; // $ExpectType boolean
+        result.mime; // $ExpectType string
+        result.paused; // $ExpectType boolean
+        result.referrer; // $ExpectType string
+        result.startTime; // $ExpectType string
+        result.state; // $ExpectType "complete" | "in_progress" | "interrupted"
+        result.url; // $ExpectType string
+    });
+    // @ts-expect-error
+    chrome.downloads.search(downloadQuery, () => {}).then(() => {});
+
+    chrome.downloads.setShelfEnabled(true); // $ExpectType void
+
+    const uiOptions: chrome.downloads.UiOptions = {
+        enabled: true,
+    };
+
+    chrome.downloads.setUiOptions(uiOptions); // $ExpectType Promise<void>
+    chrome.downloads.setUiOptions(uiOptions, () => {}); // $ExpectType void
+    // @ts-expect-error
+    chrome.downloads.setUiOptions(uiOptions, () => {}).then(() => {});
+
+    chrome.downloads.show(downloadId); // $ExpectType void
+
+    chrome.downloads.showDefaultFolder(); // $ExpectType void
+
+    chrome.downloads.onChanged.addListener((downloadDelta) => { // $ExpectType void
+        downloadDelta.canResume; // $ExpectType BooleanDelta | undefined
+        downloadDelta.danger; // $ExpectType StringDelta | undefined
+        downloadDelta.endTime; // $ExpectType StringDelta | undefined
+        downloadDelta.error; // $ExpectType StringDelta | undefined
+        downloadDelta.exists; // $ExpectType BooleanDelta | undefined
+        downloadDelta.fileSize; // $ExpectType DoubleDelta | undefined
+        downloadDelta.filename; // $ExpectType StringDelta | undefined
+        downloadDelta.finalUrl; // $ExpectType StringDelta | undefined
+        downloadDelta.id; // $ExpectType number
+        downloadDelta.mime; // $ExpectType StringDelta | undefined
+        downloadDelta.paused; // $ExpectType BooleanDelta | undefined
+        downloadDelta.startTime; // $ExpectType StringDelta | undefined
+        downloadDelta.state; // $ExpectType StringDelta | undefined
+        downloadDelta.totalBytes; // $ExpectType DoubleDelta | undefined
+        downloadDelta.url; // $ExpectType StringDelta | undefined
+    });
+    chrome.downloads.onChanged.removeListener((downloadDelta) => { // $ExpectType void
+        downloadDelta; // $ExpectType DownloadDelta
+    });
+    chrome.downloads.onChanged.hasListener((downloadDelta) => { // $ExpectType boolean
+        downloadDelta; // $ExpectType DownloadDelta
+    });
+    chrome.downloads.onChanged.hasListeners(); // $ExpectType boolean
+
+    chrome.downloads.onCreated.addListener((downloadItem) => { // $ExpectType void
+        downloadItem.byExtensionId; // $ExpectType string | undefined
+        downloadItem.byExtensionName; // $ExpectType string | undefined
+        downloadItem.bytesReceived; // $ExpectType number
+        downloadItem.canResume; // $ExpectType boolean
+        downloadItem.danger; // $ExpectType "file" | "url" | "content" | "uncommon" | "host" | "unwanted" | "safe" | "accepted" | "allowlistedByPolicy" | "asyncScanning" | "asyncLocalPasswordScanning" | "passwordProtected" | "blockedTooLarge" | "sensitiveContentWarning" | "sensitiveContentBlock" | "deepScannedFailed" | "deepScannedSafe" | "deepScannedOpenedDangerous" | "promptForScanning" | "promptForLocalPasswordScanning" | "accountCompromise" | "blockedScanFailed"
+        downloadItem.endTime; // $ExpectType string | undefined
+        downloadItem.error; // $ExpectType "CRASH" | "FILE_ACCESS_DENIED" | "FILE_BLOCKED" | "FILE_FAILED" | "FILE_HASH_MISMATCH" | "FILE_NAME_TOO_LONG" | "FILE_NO_SPACE" | "FILE_SAME_AS_SOURCE" | "FILE_SECURITY_CHECK_FAILED" | "FILE_TOO_LARGE" | "FILE_TOO_SHORT" | "FILE_TRANSIENT_ERROR" | "FILE_VIRUS_INFECTED" | "NETWORK_DISCONNECTED" | "NETWORK_FAILED" | "NETWORK_INVALID_REQUEST" | "NETWORK_SERVER_DOWN" | "NETWORK_TIMEOUT" | "SERVER_BAD_CONTENT" | "SERVER_CERT_PROBLEM" | "SERVER_CONTENT_LENGTH_MISMATCH" | "SERVER_CROSS_ORIGIN_REDIRECT" | "SERVER_FAILED" | "SERVER_FORBIDDEN" | "SERVER_NO_RANGE" | "SERVER_UNAUTHORIZED" | "SERVER_UNREACHABLE" | "USER_CANCELED" | "USER_SHUTDOWN" | undefined
+        downloadItem.estimatedEndTime; // $ExpectType string | undefined
+        downloadItem.exists; // $ExpectType boolean
+        downloadItem.fileSize; // $ExpectType number
+        downloadItem.filename; // $ExpectType string
+        downloadItem.finalUrl; // $ExpectType string
+        downloadItem.id; // $ExpectType number
+        downloadItem.incognito; // $ExpectType boolean
+        downloadItem.mime; // $ExpectType string
+        downloadItem.paused; // $ExpectType boolean
+        downloadItem.referrer; // $ExpectType string
+        downloadItem.startTime; // $ExpectType string
+        downloadItem.state; // $ExpectType "complete" | "in_progress" | "interrupted"
+        downloadItem.totalBytes; // $ExpectType number
+        downloadItem.url; // $ExpectType string
+    });
+    chrome.downloads.onCreated.removeListener((downloadItem) => { // $ExpectType void
+        downloadItem; // $ExpectType DownloadItem
+    });
+    chrome.downloads.onCreated.hasListener((downloadItem) => { // $ExpectType boolean
+        downloadItem; // $ExpectType DownloadItem
+    });
+    chrome.downloads.onCreated.hasListeners(); // $ExpectType boolean
+
+    const filenameSuggestion: chrome.downloads.FilenameSuggestion = {
+        filename: "filename",
+        conflictAction: "overwrite",
+    };
+
+    chrome.downloads.onDeterminingFilename.addListener((downloadItem, suggest) => { // $ExpectType void
+        downloadItem; // $ExpectType DownloadItem
+        suggest(filenameSuggestion); // $ExpectType void
+    });
+    chrome.downloads.onDeterminingFilename.removeListener((downloadItem, suggest) => { // $ExpectType void
+        downloadItem; // $ExpectType DownloadItem
+        suggest(filenameSuggestion); // $ExpectType void
+    });
+    chrome.downloads.onDeterminingFilename.hasListener((downloadItem, suggest) => { // $ExpectType boolean
+        downloadItem; // $ExpectType DownloadItem
+        suggest(filenameSuggestion); // $ExpectType void
+    });
+    chrome.downloads.onDeterminingFilename.hasListeners(); // $ExpectType boolean
+
+    chrome.downloads.onErased.addListener((downloadId) => { // $ExpectType void
+        downloadId; // $ExpectType number
+    });
+    chrome.downloads.onErased.removeListener((downloadId) => { // $ExpectType void
+        downloadId; // $ExpectType number
+    });
+    chrome.downloads.onErased.hasListener((downloadId) => { // $ExpectType boolean
+        downloadId; // $ExpectType number
+    });
+    chrome.downloads.onErased.hasListeners(); // $ExpectType boolean
 }
 
 // https://developer.chrome.com/docs/extensions/reference/downloads

--- a/types/naver-whale/index.d.ts
+++ b/types/naver-whale/index.d.ts
@@ -3,15 +3,6 @@
 declare interface Window {
     whale: typeof whale;
 }
-declare namespace chrome.downloads {
-    export interface StateType {
-        readonly COMPLETE: string;
-        readonly IN_PROGRESS: string;
-        readonly INTERRUPTED: string;
-    }
-    export const State: StateType;
-}
-
 declare namespace whale {
     /**
      * 지정한 주기 혹은 시간에 코드가 실행되도록 예약합니다


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/downloads
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes :
- Added `HTTPMethod` enum
- Converted the `DangerType` type to an enum.
- Converted the `InterruptReason` type to an enum.
- Renamed `DownloadState` to `State`
- Added more values for `State`
- Renamed `DownloadInterruptReason` to `InterruptReason`
- Renamed `DownloadFilenameSuggestion` to `FilenameSuggestion`
- Modified the type of the `conflictAction` key for `FilenameSuggestion`: `string | undefined` -> `FilenameConflictAction | undefined`
- Modified the type of the `danger` key for `DownloadQuery`: `string` -> `DangerType`
- Modified the type of the `error` key for `DownloadQuery`: `number` -> `InterruptReason`
- Modified the type of the `state` key for `DownloadQuery`: `string` -> `State`
- Added the missing keys for `DownloadQuery`: `finalUrl`, `finalUrlRegex`,
- Modified the callback type of `getFileIcon()` -> `string` -> `string | undefined`
- Modified `open()`: has now a callback
- Removed `drag()`: not documented 🚨
- Clean JSDoc
- The package `@types/naver-whale` no longer needs to override the `chrome` namespace 🚨

Runtime:
![image](https://github.com/user-attachments/assets/9bdaa4b3-0943-4bc6-925b-4d74bfdb8a05)
