### PR TITLE
[chrome] update windows namespace

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -13887,154 +13887,93 @@ declare namespace chrome {
      * Permissions: The chrome.windows API can be used without declaring any permission. However, the "tabs" permission is required in order to populate the url, title, and favIconUrl properties of Tab objects.
      */
     export namespace windows {
+        interface WindowsEvent<T extends (...args: any) => void> extends Omit<chrome.events.Event<T>, "addListener"> {
+            addListener(callback: T, filter?: {
+                windowTypes: `${WindowType}`[];
+            }): void;
+        }
+
         export interface Window {
-            /** Optional. Array of tabs.Tab objects representing the current tabs in the window. */
+            /** Array of {@link tabs.Tab} objects representing the current tabs in the window. */
             tabs?: chrome.tabs.Tab[] | undefined;
-            /** Optional. The offset of the window from the top edge of the screen in pixels. Under some circumstances a Window may not be assigned top property, for example when querying closed windows from the sessions API. */
+            /** The offset of the window from the top edge of the screen in pixels. In some circumstances a window may not be assigned a `top` property; for example, when querying closed windows from the {@link sessions} API. */
             top?: number | undefined;
-            /** Optional. The height of the window, including the frame, in pixels. Under some circumstances a Window may not be assigned height property, for example when querying closed windows from the sessions API. */
+            /** The height of the window, including the frame, in pixels. In some circumstances a window may not be assigned a `height` property, for example when querying closed windows from the {@link sessions} API. */
             height?: number | undefined;
-            /** Optional. The width of the window, including the frame, in pixels. Under some circumstances a Window may not be assigned width property, for example when querying closed windows from the sessions API. */
+            /** The width of the window, including the frame, in pixels. In some circumstances a window may not be assigned a `width` property; for example, when querying closed windows from the {@link sessions} API. */
             width?: number | undefined;
-            /**
-             * The state of this browser window.
-             * @since Chrome 17
-             */
-            state?: windowStateEnum | undefined;
+            /** The state of this browser window. */
+            state?: `${WindowState}` | undefined;
             /** Whether the window is currently the focused window. */
             focused: boolean;
-            /**
-             * Whether the window is set to be always on top.
-             * @since Chrome 19
-             */
+            /** Whether the window is set to be always on top. */
             alwaysOnTop: boolean;
             /** Whether the window is incognito. */
             incognito: boolean;
-            /**
-             * The type of browser window this is.
-             */
-            type?: windowTypeEnum | undefined;
-            /** Optional. The ID of the window. Window IDs are unique within a browser session. Under some circumstances a Window may not be assigned an ID, for example when querying windows using the sessions API, in which case a session ID may be present. */
+            /** The type of browser window this is. */
+            type?: `${WindowType}` | undefined;
+            /** The ID of the window. Window IDs are unique within a browser session. In some circumstances a window may not be assigned an `ID` property; for example, when querying windows using the {@link sessions} API, in which case a session ID may be present. */
             id?: number | undefined;
-            /** Optional. The offset of the window from the left edge of the screen in pixels. Under some circumstances a Window may not be assigned left property, for example when querying closed windows from the sessions API. */
+            /** The offset of the window from the left edge of the screen in pixels. In some circumstances a window may not be assigned a `left` property; for example, when querying closed windows from the {@link sessions} API. */
             left?: number | undefined;
-            /**
-             * Optional. The session ID used to uniquely identify a Window obtained from the sessions API.
-             * @since Chrome 31
-             */
+            /** The session ID used to uniquely identify a window, obtained from the {@link sessions} API. */
             sessionId?: string | undefined;
         }
 
+        /** @since Chrome 88 */
         export interface QueryOptions {
-            /**
-             * Optional.
-             * If true, the windows.Window object will have a tabs property that contains a list of the tabs.Tab objects.
-             * The Tab objects only contain the url, pendingUrl, title and favIconUrl properties if the extension's manifest file includes the "tabs" permission.
-             */
+            /** If true, the {@link windows.Window} object has a `tabs` property that contains a list of the {@link tabs.Tab} objects. The `Tab` objects only contain the `url`, `pendingUrl`, `title`, and `favIconUrl` properties if the extension's manifest file includes the `"tabs"` permission. */
             populate?: boolean | undefined;
-            /**
-             * If set, the Window returned is filtered based on its type. If unset, the default filter is set to ['normal', 'popup'].
-             */
-            windowTypes?: windowTypeEnum[] | undefined;
+            /** If set, the {@link windows.Window} returned is filtered based on its type. If unset, the default filter is set to `['normal', 'popup']`. */
+            windowTypes?: `${WindowType}`[] | undefined;
         }
 
         export interface CreateData {
-            /**
-             * Optional. The id of the tab for which you want to adopt to the new window.
-             * @since Chrome 10
-             */
+            /** The ID of the tab to add to the new window. */
             tabId?: number | undefined;
-            /**
-             * Optional.
-             * A URL or array of URLs to open as tabs in the window. Fully-qualified URLs must include a scheme (i.e. 'http://www.google.com', not 'www.google.com'). Relative URLs will be relative to the current page within the extension. Defaults to the New Tab Page.
-             */
+            /** A URL or array of URLs to open as tabs in the window. Fully-qualified URLs must include a scheme, e.g., 'http://www.google.com', not 'www.google.com'. Non-fully-qualified URLs are considered relative within the extension. Defaults to the New Tab Page. */
             url?: string | string[] | undefined;
-            /**
-             * Optional.
-             * The number of pixels to position the new window from the top edge of the screen. If not specified, the new window is offset naturally from the last focused window. This value is ignored for panels.
-             */
+            /** The number of pixels to position the new window from the top edge of the screen. If not specified, the new window is offset naturally from the last focused window. This value is ignored for panels. */
             top?: number | undefined;
-            /**
-             * Optional.
-             * The height in pixels of the new window, including the frame. If not specified defaults to a natural height.
-             */
+            /** The height in pixels of the new window, including the frame. If not specified, defaults to a natural height. */
             height?: number | undefined;
-            /**
-             * Optional.
-             * The width in pixels of the new window, including the frame. If not specified defaults to a natural width.
-             */
+            /** The width in pixels of the new window, including the frame. If not specified, defaults to a natural width. */
             width?: number | undefined;
-            /**
-             * Optional. If true, opens an active window. If false, opens an inactive window.
-             * @since Chrome 12
-             */
+            /** If `true`, opens an active window. If `false`, opens an inactive window. */
             focused?: boolean | undefined;
-            /** Optional. Whether the new window should be an incognito window. */
+            /** Whether the new window should be an incognito window. */
             incognito?: boolean | undefined;
-            /** Optional. Specifies what type of browser window to create. */
-            type?: createTypeEnum | undefined;
-            /**
-             * Optional.
-             * The number of pixels to position the new window from the left edge of the screen. If not specified, the new window is offset naturally from the last focused window. This value is ignored for panels.
-             */
+            /** Specifies what type of browser window to create. */
+            type?: `${CreateType}` | undefined;
+            /** The number of pixels to position the new window from the left edge of the screen. If not specified, the new window is offset naturally from the last focused window. This value is ignored for panels. */
             left?: number | undefined;
             /**
-             * Optional. The initial state of the window. The 'minimized', 'maximized' and 'fullscreen' states cannot be combined with 'left', 'top', 'width' or 'height'.
+             * The initial state of the window. The `minimized`, `maximized`, and `fullscreen` states cannot be combined with `left`, `top`, `width`, or `height`.
              * @since Chrome 44
              */
-            state?: windowStateEnum | undefined;
+            state?: `${WindowState}` | undefined;
             /**
-             * If true, the newly-created window's 'window.opener' is set to the caller and is in the same [unit of related browsing contexts](https://www.w3.org/TR/html51/browsers.html#unit-of-related-browsing-contexts) as the caller.
+             * If `true`, the newly-created window's 'window.opener' is set to the caller and is in the same [unit of related browsing contexts](https://www.w3.org/TR/html51/browsers.html#unit-of-related-browsing-contexts) as the caller.
              * @since Chrome 64
              */
             setSelfAsOpener?: boolean | undefined;
         }
 
         export interface UpdateInfo {
-            /** Optional. The offset from the top edge of the screen to move the window to in pixels. This value is ignored for panels. */
+            /** The offset from the top edge of the screen to move the window to in pixels. This value is ignored for panels. */
             top?: number | undefined;
-            /**
-             * Optional. If true, causes the window to be displayed in a manner that draws the user's attention to the window, without changing the focused window. The effect lasts until the user changes focus to the window. This option has no effect if the window already has focus. Set to false to cancel a previous draw attention request.
-             * @since Chrome 14
-             */
+            /** If `true`, causes the window to be displayed in a manner that draws the user's attention to the window, without changing the focused window. The effect lasts until the user changes focus to the window. This option has no effect if the window already has focus. Set to `false` to cancel a previous `drawAttention` request. */
             drawAttention?: boolean | undefined;
-            /** Optional. The height to resize the window to in pixels. This value is ignored for panels. */
+            /** The height to resize the window to in pixels. This value is ignored for panels. */
             height?: number | undefined;
-            /** Optional. The width to resize the window to in pixels. This value is ignored for panels. */
+            /** The width to resize the window to in pixels. This value is ignored for panels. */
             width?: number | undefined;
-            /**
-             * Optional. The new state of the window. The 'minimized', 'maximized' and 'fullscreen' states cannot be combined with 'left', 'top', 'width' or 'height'.
-             * @since Chrome 17
-             */
-            state?: windowStateEnum | undefined;
-            /**
-             * Optional. If true, brings the window to the front. If false, brings the next window in the z-order to the front.
-             * @since Chrome 8
-             */
+            /** The new state of the window. The 'minimized', 'maximized', and 'fullscreen' states cannot be combined with 'left', 'top', 'width', or 'height'. */
+            state?: `${WindowState}` | undefined;
+            /** If `true`, brings the window to the front; cannot be combined with the state 'minimized'. If `false`, brings the next window in the z-order to the front; cannot be combined with the state 'fullscreen' or 'maximized'. */
             focused?: boolean | undefined;
-            /** Optional. The offset from the left edge of the screen to move the window to in pixels. This value is ignored for panels. */
+            /** The offset from the left edge of the screen to move the window to in pixels. This value is ignored for panels. */
             left?: number | undefined;
-        }
-
-        export interface WindowEventFilter {
-            /**
-             * Conditions that the window's type being created must satisfy. By default it will satisfy ['app', 'normal', 'panel', 'popup'], with 'app' and 'panel' window types limited to the extension's own windows.
-             */
-            windowTypes: windowTypeEnum[];
-        }
-
-        export interface WindowIdEvent extends chrome.events.Event<(windowId: number) => void> {
-            addListener(
-                callback: (windowId: number) => void,
-                filters?: WindowEventFilter,
-            ): void;
-        }
-
-        export interface WindowReferenceEvent extends chrome.events.Event<(window: Window) => void> {
-            addListener(
-                callback: (window: Window) => void,
-                filters?: WindowEventFilter,
-            ): void;
         }
 
         /**
@@ -14042,179 +13981,137 @@ declare namespace chrome {
          * 'panel' is deprecated and is available only to existing whitelisted extensions on Chrome OS.
          * @since Chrome 44
          */
-        export type createTypeEnum = "normal" | "popup" | "panel";
+        export enum CreateType {
+            /** Specifies the window as a standard window. */
+            NORMAL = "normal",
+            /** Specifies the window as a popup window. */
+            POPUP = "popup",
+            /** @deprecated Specifies the window as a panel. */
+            PANEL = "panel",
+        }
 
         /**
-         * The state of this browser window.
-         * In some circumstances a window may not be assigned a state property; for example, when querying closed windows from the sessions API.
+         * The state of this browser window. In some circumstances a window may not be assigned a `state` property; for example, when querying closed windows from the {@link sessions} API.
          * @since Chrome 44
          */
-        export type windowStateEnum = "normal" | "minimized" | "maximized" | "fullscreen" | "locked-fullscreen";
+        export enum WindowState {
+            /** Normal window state (not minimized, maximized, or fullscreen). */
+            NORMAL = "normal",
+            /** Minimized window state. */
+            MINIMIZED = "minimized",
+            /** Maximized window state. */
+            MAXIMIZED = "maximized",
+            /** Fullscreen window state. */
+            FULLSCREEN = "fullscreen",
+            /** Locked fullscreen window state. This fullscreen state cannot be exited by user action and is available only to allowlisted extensions on Chrome OS. */
+            LOCKED_FULLSCREEN = "locked-fullscreen",
+        }
 
         /**
-         * The type of browser window this is.
-         * In some circumstances a window may not be assigned a type property; for example, when querying closed windows from the sessions API.
+         * The type of browser window this is. In some circumstances a window may not be assigned a `type` property; for example, when querying closed windows from the {@link sessions} API.
          * @since Chrome 44
          */
-        export type windowTypeEnum = "normal" | "popup" | "panel" | "app" | "devtools";
+        export enum WindowType {
+            /** A normal browser window. */
+            NORMAL = "normal",
+            /** A browser popup. */
+            POPUP = "popup",
+            /** @deprecated A Chrome App panel-style window. Extensions can only see their own panel windows. */
+            PANEL = "panel",
+            /** @deprecated A Chrome App window. Extensions can only see their app own windows. */
+            APP = "app",
+            /** A Developer Tools window. */
+            DEVTOOLS = "devtools",
+        }
+
+        /** The windowId value that represents the current window. */
+        export const WINDOW_ID_CURRENT: -2;
+
+        /** The windowId value that represents the absence of a Chrome browser window */
+        export const WINDOW_ID_NONE: -1;
 
         /**
-         * The windowId value that represents the current window.
-         * @since Chrome 18
-         */
-        export var WINDOW_ID_CURRENT: -2;
-        /**
-         * The windowId value that represents the absence of a chrome browser window.
-         * @since Chrome 6
-         */
-        export var WINDOW_ID_NONE: -1;
-
-        /** Gets details about a window. */
-        export function get(windowId: number, callback: (window: chrome.windows.Window) => void): void;
-        /**
          * Gets details about a window.
-         * @return The `get` method provides its result via callback or returned as a `Promise` (MV3 only).
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
          */
-        export function get(windowId: number): Promise<chrome.windows.Window>;
-        /**
-         * Gets details about a window.
-         * @since Chrome 18
-         */
+        export function get(windowId: number, queryOptions?: QueryOptions): Promise<Window>;
+        export function get(windowId: number, callback: (window: Window) => void): void;
         export function get(
             windowId: number,
-            queryOptions: QueryOptions,
-            callback: (window: chrome.windows.Window) => void,
+            queryOptions: QueryOptions | undefined,
+            callback: (window: Window) => void,
         ): void;
-        /**
-         * Gets details about a window.
-         * @since Chrome 18
-         * @return The `get` method provides its result via callback or returned as a `Promise` (MV3 only).
-         */
-        export function get(windowId: number, queryOptions: QueryOptions): Promise<chrome.windows.Window>;
-        /** Gets the current window. */
-        export function getCurrent(callback: (window: chrome.windows.Window) => void): void;
+
         /**
          * Gets the current window.
-         * @return The `getCurrent` method provides its result via callback or returned as a `Promise` (MV3 only).
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
          */
-        export function getCurrent(): Promise<chrome.windows.Window>;
+        export function getCurrent(queryOptions?: QueryOptions): Promise<Window>;
+        export function getCurrent(callback: (window: Window) => void): void;
+        export function getCurrent(queryOptions: QueryOptions | undefined, callback: (window: Window) => void): void;
+
         /**
-         * Gets the current window.
-         * @param QueryOptions
-         * @since Chrome 18
+         * Creates (opens) a new browser window with any optional sizing, position, or default URL provided.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
          */
-        export function getCurrent(queryOptions: QueryOptions, callback: (window: chrome.windows.Window) => void): void;
-        /**
-         * Gets the current window.
-         * @param QueryOptions
-         * @since Chrome 18
-         * @return The `getCurrent` method provides its result via callback or returned as a `Promise` (MV3 only).
-         */
-        export function getCurrent(queryOptions: QueryOptions): Promise<chrome.windows.Window>;
-        /**
-         * Creates (opens) a new browser with any optional sizing, position or default URL provided.
-         * @return The `create` method provides its result via callback or returned as a `Promise` (MV3 only). Contains details about the created window.
-         */
-        export function create(): Promise<chrome.windows.Window>;
-        /**
-         * Creates (opens) a new browser with any optional sizing, position or default URL provided.
-         * @param callback
-         * Optional parameter window: Contains details about the created window.
-         */
-        export function create(callback: (window?: chrome.windows.Window) => void): void;
-        /**
-         * Creates (opens) a new browser with any optional sizing, position or default URL provided.
-         * @param CreateData
-         * @return The `create` method provides its result via callback or returned as a `Promise` (MV3 only). Contains details about the created window.
-         */
-        export function create(createData: CreateData): Promise<chrome.windows.Window>;
-        /**
-         * Creates (opens) a new browser with any optional sizing, position or default URL provided.
-         * @param CreateData
-         * @param callback
-         * Optional parameter window: Contains details about the created window.
-         */
-        export function create(createData: CreateData, callback: (window?: chrome.windows.Window) => void): void;
+        export function create(createData?: CreateData): Promise<Window | undefined>;
+        export function create(callback: (window?: Window) => void): void;
+        export function create(createData: CreateData | undefined, callback: (window?: Window) => void): void;
+
         /**
          * Gets all windows.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
          */
-        export function getAll(callback: (windows: chrome.windows.Window[]) => void): void;
+        export function getAll(queryOptions?: QueryOptions): Promise<Window[]>;
+        export function getAll(callback: (windows: Window[]) => void): void;
+        export function getAll(queryOptions: QueryOptions | undefined, callback: (windows: Window[]) => void): void;
+
         /**
-         * Gets all windows.
-         * @return The `getAll` method provides its result via callback or returned as a `Promise` (MV3 only).
+         * Updates the properties of a window. Specify only the properties that to be changed; unspecified properties are unchanged.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
          */
-        export function getAll(): Promise<chrome.windows.Window[]>;
+        export function update(windowId: number, updateInfo: UpdateInfo): Promise<Window>;
+        export function update(windowId: number, updateInfo: UpdateInfo, callback: (window: Window) => void): void;
+
         /**
-         * Gets all windows.
-         * @since Chrome 18
-         */
-        export function getAll(queryOptions: QueryOptions, callback: (windows: chrome.windows.Window[]) => void): void;
-        /**
-         * Gets all windows.
-         * @since Chrome 18
-         * @return The `getAll` method provides its result via callback or returned as a `Promise` (MV3 only).
-         */
-        export function getAll(queryOptions: QueryOptions): Promise<chrome.windows.Window[]>;
-        /**
-         * Updates the properties of a window. Specify only the properties that you want to change; unspecified properties will be left unchanged.
-         * @return The `update` method provides its result via callback or returned as a `Promise` (MV3 only).
-         */
-        export function update(
-            windowId: number,
-            updateInfo: UpdateInfo,
-        ): Promise<chrome.windows.Window>;
-        /** Updates the properties of a window. Specify only the properties that you want to change; unspecified properties will be left unchanged. */
-        export function update(
-            windowId: number,
-            updateInfo: UpdateInfo,
-            callback: (window: chrome.windows.Window) => void,
-        ): void;
-        /**
-         * Removes (closes) a window, and all the tabs inside it
-         * @return The `remove` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+         * Removes (closes) a window and all the tabs inside it.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
          */
         export function remove(windowId: number): Promise<void>;
-        /** Removes (closes) a window, and all the tabs inside it. */
         export function remove(windowId: number, callback: () => void): void;
+
         /**
          * Gets the window that was most recently focused — typically the window 'on top'.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
          */
-        export function getLastFocused(callback: (window: chrome.windows.Window) => void): void;
-        /**
-         * Gets the window that was most recently focused — typically the window 'on top'.
-         * @return The `getLastFocused` method provides its result via callback or returned as a `Promise` (MV3 only).
-         */
-        export function getLastFocused(): Promise<chrome.windows.Window>;
-        /**
-         * Gets the window that was most recently focused — typically the window 'on top'.
-         * @since Chrome 18
-         */
+        export function getLastFocused(queryOptions?: QueryOptions): Promise<Window>;
+        export function getLastFocused(callback: (window: Window) => void): void;
         export function getLastFocused(
-            queryOptions: QueryOptions,
-            callback: (window: chrome.windows.Window) => void,
+            queryOptions: QueryOptions | undefined,
+            callback: (window: Window) => void,
         ): void;
-        /**
-         * Gets the window that was most recently focused — typically the window 'on top'.
-         * @since Chrome 18
-         * @return The `getLastFocused` method provides its result via callback or returned as a `Promise` (MV3 only).
-         */
-        export function getLastFocused(queryOptions: QueryOptions): Promise<chrome.windows.Window>;
 
         /** Fired when a window is removed (closed). */
-        export var onRemoved: WindowIdEvent;
+        export const onRemoved: WindowsEvent<(windowId: number) => void>;
+
         /** Fired when a window is created. */
-        export var onCreated: WindowReferenceEvent;
-        /**
-         * Fired when the currently focused window changes. Will be chrome.windows.WINDOW_ID_NONE if all chrome windows have lost focus.
-         * Note: On some Linux window managers, WINDOW_ID_NONE will always be sent immediately preceding a switch from one chrome window to another.
-         */
-        export var onFocusChanged: WindowIdEvent;
+        export const onCreated: WindowsEvent<(window: Window) => void>;
+
+        /** Fired when the currently focused window changes. Returns `chrome.windows.WINDOW_ID_NONE` if all Chrome windows have lost focus. **Note:** On some Linux window managers, `WINDOW_ID_NONE` is always sent immediately preceding a switch from one Chrome window to another. */
+        export const onFocusChanged: WindowsEvent<(windowId: number) => void>;
 
         /**
          * Fired when a window has been resized; this event is only dispatched when the new bounds are committed, and not for in-progress changes.
          * @since Chrome 86
          */
-        export var onBoundsChanged: WindowReferenceEvent;
+        export const onBoundsChanged: events.Event<(window: Window) => void>;
     }
 
     ////////////////////

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1087,22 +1087,6 @@ function testDeclarativeContent() {
     };
 }
 
-// https://developer.chrome.com/docs/extensions/reference/windows
-function testWindows() {
-    chrome.windows.onCreated.addListener(function(window) {
-        var windowResult: chrome.windows.Window = window;
-    }, { windowTypes: ["normal"] });
-    chrome.windows.onRemoved.addListener(function(windowId) {
-        var windowIdResult: number = windowId;
-    }, { windowTypes: ["normal"] });
-    chrome.windows.onBoundsChanged.addListener(function(window) {
-        var windowResult: chrome.windows.Window = window;
-    }, { windowTypes: ["normal"] });
-    chrome.windows.onFocusChanged.addListener(function(windowId) {
-        var windowIdResult: number = windowId;
-    }, { windowTypes: ["normal"] });
-}
-
 // https://developer.chrome.com/extensions/storage#type-StorageArea
 function testStorage() {
     interface StorageData {
@@ -2903,20 +2887,189 @@ async function testTabGroup() {
     chrome.tabGroups.onUpdated.hasListeners(); // $ExpectType boolean
 }
 
-// https://developer.chrome.com/docs/extensions/reference/windows
-async function testWindowsForPromise() {
-    await chrome.windows.get(0);
-    await chrome.windows.get(0, {});
-    await chrome.windows.getCurrent();
-    await chrome.windows.getCurrent({});
-    await chrome.windows.create();
-    await chrome.windows.create({});
-    await chrome.windows.getAll();
-    await chrome.windows.getAll({});
-    await chrome.windows.update(0, {});
-    await chrome.windows.remove(0);
-    await chrome.windows.getLastFocused();
-    await chrome.windows.getLastFocused({});
+// https://developer.chrome.com/docs/extensions/reference/api/windows
+function testWindows() {
+    chrome.windows.CreateType.NORMAL === "normal";
+    chrome.windows.CreateType.PANEL === "panel";
+    chrome.windows.CreateType.POPUP === "popup";
+
+    chrome.windows.WINDOW_ID_CURRENT === -2;
+    chrome.windows.WINDOW_ID_NONE === -1;
+
+    chrome.windows.WindowState.FULLSCREEN === "fullscreen";
+    chrome.windows.WindowState.LOCKED_FULLSCREEN === "locked-fullscreen";
+    chrome.windows.WindowState.MAXIMIZED === "maximized";
+    chrome.windows.WindowState.MINIMIZED === "minimized";
+    chrome.windows.WindowState.NORMAL === "normal";
+
+    chrome.windows.WindowType.APP === "app";
+    chrome.windows.WindowType.DEVTOOLS === "devtools";
+    chrome.windows.WindowType.NORMAL === "normal";
+    chrome.windows.WindowType.PANEL === "panel";
+    chrome.windows.WindowType.POPUP === "popup";
+
+    const createData: chrome.windows.CreateData = {
+        focused: true,
+        height: 100,
+        incognito: true,
+        left: 100,
+        setSelfAsOpener: true,
+        state: "maximized",
+        tabId: 0,
+        top: 100,
+        type: "normal",
+        url: "https://www.example.com",
+        width: 100,
+    };
+
+    chrome.windows.create(); // $ExpectType Promise<Window | undefined>
+    chrome.windows.create(createData); // $ExpectType Promise<Window | undefined>
+    chrome.windows.create((window) => { // $ExpectType void
+        window; // $ExpectType Window | undefined
+    });
+    chrome.windows.create(createData, (window) => { // $ExpectType void
+        window; // $ExpectType Window | undefined
+    });
+    // @ts-expect-error
+    chrome.windows.create(() => {}).then(() => {});
+
+    const windowId = 0;
+    const queryOptions: chrome.windows.QueryOptions = {
+        populate: true,
+        windowTypes: ["normal", chrome.windows.WindowType.POPUP],
+    };
+
+    chrome.windows.get(windowId); // $ExpectType Promise<Window>
+    chrome.windows.get(windowId, queryOptions); // $ExpectType Promise<Window>
+    chrome.windows.get(windowId, (window) => { // $ExpectType void
+        window; // $ExpectType Window
+    });
+    chrome.windows.get(windowId, queryOptions, (window) => { // $ExpectType void
+        window; // $ExpectType Window
+    });
+    // @ts-expect-error
+    chrome.windows.get(() => {}).then(() => {});
+
+    chrome.windows.getAll(); // $ExpectType Promise<Window[]>
+    chrome.windows.getAll(queryOptions); // $ExpectType Promise<Window[]>
+    chrome.windows.getAll((windows) => { // $ExpectType void
+        windows; // $ExpectType Window[]
+    });
+    chrome.windows.getAll(queryOptions, (windows) => { // $ExpectType void
+        windows; // $ExpectType Window[]
+    });
+    // @ts-expect-error
+    chrome.windows.getAll(() => {}).then(() => {});
+
+    chrome.windows.getCurrent(); // $ExpectType Promise<Window>
+    chrome.windows.getCurrent(queryOptions); // $ExpectType Promise<Window>
+    chrome.windows.getCurrent((window) => { // $ExpectType void
+        window; // $ExpectType Window
+    });
+    chrome.windows.getCurrent(queryOptions, (window) => { // $ExpectType void
+        window; // $ExpectType Window
+    });
+    // @ts-expect-error
+    chrome.windows.getCurrent(() => {}).then(() => {});
+
+    chrome.windows.getLastFocused(); // $ExpectType Promise<Window>
+    chrome.windows.getLastFocused(queryOptions); // $ExpectType Promise<Window>
+    chrome.windows.getLastFocused((window) => { // $ExpectType void
+        window; // $ExpectType Window
+    });
+    chrome.windows.getLastFocused(queryOptions, (window) => { // $ExpectType void
+        window; // $ExpectType Window
+    });
+    // @ts-expect-error
+    chrome.windows.getLastFocused(() => {}).then(() => {});
+
+    chrome.windows.remove(windowId); // $ExpectType Promise<void>
+    chrome.windows.remove(windowId, () => {}); // $ExpectType void
+    // @ts-expect-error
+    chrome.windows.remove(() => {}).then(() => {});
+
+    const updateInfo: chrome.windows.UpdateInfo = {
+        drawAttention: true,
+        focused: true,
+        height: 100,
+        left: 100,
+        state: "maximized",
+        top: 100,
+        width: 100,
+    };
+
+    chrome.windows.update(windowId, updateInfo); // $ExpectType Promise<Window>
+    chrome.windows.update(windowId, updateInfo, (window) => { // $ExpectType void
+        window; // $ExpectType Window
+    });
+    // @ts-expect-error
+    chrome.windows.update(() => {}).then(() => {});
+
+    chrome.windows.onBoundsChanged.addListener((window) => { // $ExpectType void
+        window.alwaysOnTop; // $ExpectType boolean
+        window.focused; // $ExpectType boolean
+        window.height; // $ExpectType number | undefined
+        window.id; // $ExpectType number | undefined
+        window.incognito; // $ExpectType boolean
+        window.left; // $ExpectType number | undefined
+        window.sessionId; // $ExpectType string | undefined
+        window.state; // $ExpectType "fullscreen" | "locked-fullscreen" | "maximized" | "minimized" | "normal" | undefined
+        window.tabs; // $ExpectType Tab[] | undefined
+        window.top; // $ExpectType number | undefined
+        window.type; // $ExpectType "app" | "devtools" | "normal" | "panel" | "popup" | undefined
+        window.width; // $ExpectType number | undefined
+    });
+    chrome.windows.onBoundsChanged.removeListener((window) => { // $ExpectType void
+        window; // $ExpectType Window
+    });
+    chrome.windows.onBoundsChanged.hasListener((window) => { // $ExpectType boolean
+        window; // $ExpectType Window
+    });
+    chrome.windows.onBoundsChanged.hasListeners(); // $ExpectType boolean
+
+    chrome.windows.onCreated.addListener((window) => { // $ExpectType void
+        window.alwaysOnTop; // $ExpectType boolean
+        window.focused; // $ExpectType boolean
+        window.height; // $ExpectType number | undefined
+        window.id; // $ExpectType number | undefined
+        window.incognito; // $ExpectType boolean
+        window.left; // $ExpectType number | undefined
+        window.sessionId; // $ExpectType string | undefined
+        window.state; // $ExpectType "fullscreen" | "locked-fullscreen" | "maximized" | "minimized" | "normal" | undefined
+        window.tabs; // $ExpectType Tab[] | undefined
+        window.top; // $ExpectType number | undefined
+        window.type; // $ExpectType "app" | "devtools" | "normal" | "panel" | "popup" | undefined
+        window.width; // $ExpectType number | undefined
+    }, { windowTypes: ["normal", chrome.windows.WindowType.POPUP] });
+    chrome.windows.onCreated.removeListener((window) => { // $ExpectType void
+        window; // $ExpectType Window
+    });
+    chrome.windows.onCreated.hasListener((window) => { // $ExpectType boolean
+        window; // $ExpectType Window
+    });
+    chrome.windows.onCreated.hasListeners(); // $ExpectType boolean
+
+    chrome.windows.onFocusChanged.addListener((windowId) => { // $ExpectType void
+        windowId; // $ExpectType number
+    }, { windowTypes: ["normal", chrome.windows.WindowType.POPUP] });
+    chrome.windows.onFocusChanged.removeListener((windowId) => { // $ExpectType void
+        windowId; // $ExpectType number
+    });
+    chrome.windows.onFocusChanged.hasListener((windowId) => { // $ExpectType boolean
+        windowId; // $ExpectType number
+    });
+    chrome.windows.onFocusChanged.hasListeners(); // $ExpectType boolean
+
+    chrome.windows.onRemoved.addListener((windowId) => { // $ExpectType void
+        windowId; // $ExpectType number
+    }, { windowTypes: ["normal", chrome.windows.WindowType.POPUP] });
+    chrome.windows.onRemoved.removeListener((windowId) => { // $ExpectType void
+        windowId; // $ExpectType number
+    });
+    chrome.windows.onRemoved.hasListener((windowId) => { // $ExpectType boolean
+        windowId; // $ExpectType number
+    });
+    chrome.windows.onRemoved.hasListeners(); // $ExpectType boolean
 }
 
 // https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/windows
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes :
- Converted the `CreateType` type to an enum (formerly: `createTypeEnum`)
- Converted the `WindowState` type to an enum (formerly: `windowStateEnum`)
- Converted the `WindowType` type to an enum (formerly: `windowTypeEnum`)
- Removed `filter` params for `onBoundsChanged` event
- Modified the callback type of `create()` -> `Promise<Windows>`-> `Promise<Windows | undefined>`
- Added mores tests
- Clean JSDoc

Runtime: 
![image](https://github.com/user-attachments/assets/0139600d-0d5c-4d2f-8dc1-620bfd4cb997)
