### PR TITLE
node: `util.parseEnv()` returns string dictionary

### DIFF
--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -71,7 +71,10 @@ util.format();
 
 util.formatWithOptions({ colors: true }, "See object %O", { foo: 42 });
 
-util.parseEnv("HELLO=world\nHELLO=oh my\n");
+{
+    const dotenv = util.parseEnv("HELLO=world\nHELLO=oh my\n");
+    dotenv.HELLO; // $ExpectType string | undefined
+}
 
 console.log(util.styleText("red", "Error! Error!"));
 console.log(

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -1411,7 +1411,7 @@ declare module "util" {
      * @param content The raw contents of a `.env` file.
      * @since v20.12.0
      */
-    export function parseEnv(content: string): object;
+    export function parseEnv(content: string): NodeJS.Dict<string>;
     // https://nodejs.org/docs/latest/api/util.html#foreground-colors
     type ForegroundColors =
         | "black"

--- a/types/node/v20/test/util.ts
+++ b/types/node/v20/test/util.ts
@@ -62,7 +62,10 @@ util.format();
 
 util.formatWithOptions({ colors: true }, "See object %O", { foo: 42 });
 
-util.parseEnv("HELLO=world\nHELLO=oh my\n");
+{
+    const dotenv = util.parseEnv("HELLO=world\nHELLO=oh my\n");
+    dotenv.HELLO; // $ExpectType string | undefined
+}
 
 console.log(util.styleText("red", "Error! Error!"));
 console.log(

--- a/types/node/v20/util.d.ts
+++ b/types/node/v20/util.d.ts
@@ -1186,7 +1186,7 @@ declare module "util" {
      * @param content The raw contents of a `.env` file.
      * @since v20.12.0
      */
-    export function parseEnv(content: string): object;
+    export function parseEnv(content: string): NodeJS.Dict<string>;
     // https://nodejs.org/docs/latest/api/util.html#foreground-colors
     type ForegroundColors =
         | "black"


### PR DESCRIPTION
The properties of the object returned by the [Dotenv](https://github.com/nodejs/node/blob/main/src/node_dotenv.cc) parser in Node.js are guaranteed to be string values.

```ts
const dotenv = util.parseEnv(input);
if (dotenv.XYZ) {
  // assert: `dotenv.XYZ` is of type `string`
}
```