### PR TITLE
fix(react-dom): add environment-specific entrypoints

### DIFF
--- a/types/react-dom/package.json
+++ b/types/react-dom/package.json
@@ -28,22 +28,22 @@
         },
         "./server.browser": {
             "types": {
-                "default": "./server.d.ts"
+                "default": "./server.browser.d.ts"
             }
         },
         "./server.bun": {
             "types": {
-                "default": "./server.d.ts"
+                "default": "./server.bun.d.ts"
             }
         },
         "./server.edge": {
             "types": {
-                "default": "./server.d.ts"
+                "default": "./server.edge.d.ts"
             }
         },
         "./server.node": {
             "types": {
-                "default": "./server.d.ts"
+                "default": "./server.node.d.ts"
             }
         },
         "./static": {
@@ -53,17 +53,17 @@
         },
         "./static.browser": {
             "types": {
-                "default": "./static.d.ts"
+                "default": "./static.browser.d.ts"
             }
         },
         "./static.edge": {
             "types": {
-                "default": "./static.d.ts"
+                "default": "./static.edge.d.ts"
             }
         },
         "./static.node": {
             "types": {
-                "default": "./static.d.ts"
+                "default": "./static.node.d.ts"
             }
         },
         "./experimental": {

--- a/types/react-dom/package.json
+++ b/types/react-dom/package.json
@@ -21,12 +21,47 @@
                 "default": "./canary.d.ts"
             }
         },
-        "./server*": {
+        "./server": {
             "types": {
                 "default": "./server.d.ts"
             }
         },
-        "./static*": {
+        "./server.browser": {
+            "types": {
+                "default": "./server.d.ts"
+            }
+        },
+        "./server.bun": {
+            "types": {
+                "default": "./server.d.ts"
+            }
+        },
+        "./server.edge": {
+            "types": {
+                "default": "./server.d.ts"
+            }
+        },
+        "./server.node": {
+            "types": {
+                "default": "./server.d.ts"
+            }
+        },
+        "./static": {
+            "types": {
+                "default": "./static.d.ts"
+            }
+        },
+        "./static.browser": {
+            "types": {
+                "default": "./static.d.ts"
+            }
+        },
+        "./static.edge": {
+            "types": {
+                "default": "./static.d.ts"
+            }
+        },
+        "./static.node": {
             "types": {
                 "default": "./static.d.ts"
             }

--- a/types/react-dom/package.json
+++ b/types/react-dom/package.json
@@ -21,12 +21,12 @@
                 "default": "./canary.d.ts"
             }
         },
-        "./server": {
+        "./server*": {
             "types": {
                 "default": "./server.d.ts"
             }
         },
-        "./static": {
+        "./static*": {
             "types": {
                 "default": "./static.d.ts"
             }

--- a/types/react-dom/server.browser.d.ts
+++ b/types/react-dom/server.browser.d.ts
@@ -1,5 +1,1 @@
-export { 
-    renderToString, 
-    renderToStaticMarkup,
-    renderToReadableStream,
-} from "./server";
+export { renderToReadableStream, renderToStaticMarkup, renderToString } from "./server";

--- a/types/react-dom/server.browser.d.ts
+++ b/types/react-dom/server.browser.d.ts
@@ -1,0 +1,5 @@
+export { 
+    renderToString, 
+    renderToStaticMarkup,
+    renderToReadableStream,
+} from "./server";

--- a/types/react-dom/server.bun.d.ts
+++ b/types/react-dom/server.bun.d.ts
@@ -1,5 +1,1 @@
-export { 
-    renderToString, 
-    renderToStaticMarkup,
-    renderToReadableStream,
-} from "./server";
+export { renderToReadableStream, renderToStaticMarkup, renderToString } from "./server";

--- a/types/react-dom/server.bun.d.ts
+++ b/types/react-dom/server.bun.d.ts
@@ -1,0 +1,5 @@
+export { 
+    renderToString, 
+    renderToStaticMarkup,
+    renderToReadableStream,
+} from "./server";

--- a/types/react-dom/server.edge.d.ts
+++ b/types/react-dom/server.edge.d.ts
@@ -1,5 +1,1 @@
-export { 
-    renderToString, 
-    renderToStaticMarkup,
-    renderToReadableStream,
-} from "./server";
+export { renderToReadableStream, renderToStaticMarkup, renderToString } from "./server";

--- a/types/react-dom/server.edge.d.ts
+++ b/types/react-dom/server.edge.d.ts
@@ -1,0 +1,5 @@
+export { 
+    renderToString, 
+    renderToStaticMarkup,
+    renderToReadableStream,
+} from "./server";

--- a/types/react-dom/server.node.d.ts
+++ b/types/react-dom/server.node.d.ts
@@ -1,5 +1,1 @@
-export { 
-    renderToString, 
-    renderToStaticMarkup,
-    renderToPipeableStream,
-} from "./server";
+export { renderToPipeableStream, renderToStaticMarkup, renderToString } from "./server";

--- a/types/react-dom/server.node.d.ts
+++ b/types/react-dom/server.node.d.ts
@@ -1,0 +1,5 @@
+export { 
+    renderToString, 
+    renderToStaticMarkup,
+    renderToPipeableStream,
+} from "./server";

--- a/types/react-dom/static.browser.d.ts
+++ b/types/react-dom/static.browser.d.ts
@@ -1,0 +1,4 @@
+export {
+    prerender,
+    version,
+} from "./static";

--- a/types/react-dom/static.browser.d.ts
+++ b/types/react-dom/static.browser.d.ts
@@ -1,4 +1,1 @@
-export {
-    prerender,
-    version,
-} from "./static";
+export { prerender, version } from "./static";

--- a/types/react-dom/static.edge.d.ts
+++ b/types/react-dom/static.edge.d.ts
@@ -1,0 +1,4 @@
+export {
+    prerender,
+    version,
+} from "./static";

--- a/types/react-dom/static.edge.d.ts
+++ b/types/react-dom/static.edge.d.ts
@@ -1,4 +1,1 @@
-export {
-    prerender,
-    version,
-} from "./static";
+export { prerender, version } from "./static";

--- a/types/react-dom/static.node.d.ts
+++ b/types/react-dom/static.node.d.ts
@@ -1,0 +1,4 @@
+export {
+    prerenderToNodeStream,
+    version,
+} from "./static";

--- a/types/react-dom/static.node.d.ts
+++ b/types/react-dom/static.node.d.ts
@@ -1,4 +1,1 @@
-export {
-    prerenderToNodeStream,
-    version,
-} from "./static";
+export { prerenderToNodeStream, version } from "./static";


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Here is the `react-dom` source code: https://github.com/facebook/react/tree/main/packages/react-dom

As you can see, there are platform specific imports for `react-dom/server` and `react-dom/static`:
- `server.browser.js`
- `server.bun.js`
- `server.edge.js`
- `server.node.js`
- `static.browser.js`
- `static.edge.js`
- `static.node.js`

Currently these import paths do not have type declarations. It'd be nice to have them. i.e.

```ts
import { renderToReadableStream } from 'react-dom/server.edge'
```

This is for **19.1.0**. I'm not sure where to bump the version?