### PR TITLE
[react] Restore Class Component constructor using Context

### DIFF
--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -5,7 +5,7 @@ declare namespace PropTypes {
     type ReactComponentLike =
         | string
         | ((props: any) => any)
-        | (new(props: any) => any);
+        | (new(props: any, context: any) => any);
 
     interface ReactElementLike {
         type: ReactComponentLike;

--- a/types/react-dual-listbox/react-dual-listbox-tests.tsx
+++ b/types/react-dual-listbox/react-dual-listbox-tests.tsx
@@ -91,18 +91,18 @@ const optionsChange = (selectedValues: Array<Option<string>>) => {};
 />;
 
 /** Filtering error examples. */
+// @ts-expect-error You can not use filter properties when `canFilter` is not `true`.
 <DualListBox
     options={flatOptions}
     filter={{
         available: flatOptions.map(o => o.value),
         selected: [],
     }}
-    // @ts-expect-error You can not use filter properties when `canFilter` is not `true`.
     onFilterChange={() => {}}
     filterPlaceholder={""}
-    // @ts-expect-error You can not use filter properties when `canFilter` is not `true`.
     filterCallback={(option: Option<string>) => true}
 />;
+// @ts-expect-error You can not use filter properties when `canFilter` is not `true`.
 <DualListBox
     options={flatOptions}
     canFilter={false}
@@ -110,10 +110,8 @@ const optionsChange = (selectedValues: Array<Option<string>>) => {};
         available: flatOptions.map(o => o.value),
         selected: [],
     }}
-    // @ts-expect-error You can not use filter properties when `canFilter` is not `true`.
     onFilterChange={() => {}}
     filterPlaceholder={""}
-    // @ts-expect-error You can not use filter properties when `canFilter` is not `true`.
     filterCallback={(option: Option<string>) => true}
 />;
 

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -135,7 +135,7 @@ declare namespace React {
             props: P,
         ) => ReactNode | Promise<ReactNode>)
         // constructor signature must match React.Component
-        | (new(props: P) => Component<any, any>);
+        | (new(props: P, context: any) => Component<any, any>);
 
     /**
      * Created by {@link createRef}, or {@link useRef} when passed `null`.
@@ -218,7 +218,7 @@ declare namespace React {
     type ElementRef<
         C extends
             | ForwardRefExoticComponent<any>
-            | { new(props: any): Component<any> }
+            | { new(props: any, context: any): Component<any> }
             | ((props: any) => ReactNode)
             | keyof JSX.IntrinsicElements,
     > = ComponentRef<C>;
@@ -928,7 +928,7 @@ declare namespace React {
         static propTypes?: any;
 
         /**
-         * If using the new style context, re-declare this in your class to be the
+         * If using React Context, re-declare this in your class to be the
          * `React.ContextType` of your `static contextType`.
          * Should be used with type annotation or static contextType.
          *
@@ -947,6 +947,14 @@ declare namespace React {
 
         // Keep in sync with constructor signature of JSXElementConstructor and ComponentClass.
         constructor(props: P);
+        /**
+         * @param props
+         * @param context value of the parent {@link https://react.dev/reference/react/Component#context Context} specified
+         * in `contextType`.
+         */
+        // TODO: Ideally we'd infer the constructor signatur from `contextType`.
+        // Might be hard to ship without breaking existing code.
+        constructor(props: P, context: any);
 
         // We MUST keep setState() as a unified signature because it allows proper checking of the method return type.
         // See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18365#issuecomment-351013257
@@ -1118,7 +1126,14 @@ declare namespace React {
      */
     interface ComponentClass<P = {}, S = ComponentState> extends StaticLifecycle<P, S> {
         // constructor signature must match React.Component
-        new(props: P): Component<P, S>;
+        new(
+            props: P,
+            /**
+             * Value of the parent {@link https://react.dev/reference/react/Component#context Context} specified
+             * in `contextType`.
+             */
+            context?: any,
+        ): Component<P, S>;
         /**
          * Ignored by React.
          * @deprecated Only kept in types for backwards compatibility. Will be removed in a future major release.
@@ -1158,7 +1173,7 @@ declare namespace React {
      */
     type ClassType<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>> =
         & C
-        & (new(props: P) => T);
+        & (new(props: P, context: any) => T);
 
     //
     // Component Specs and Lifecycle

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -129,12 +129,17 @@ declare const container: Element;
     }
 }
 
+const SomeContext = React.createContext<Context>({ someValue: "default" });
 class ModernComponent extends React.Component<Props, State, Snapshot> implements MyComponent {
     // deprecated. Kept for backwards compatibility.
     static propTypes = {};
 
-    contextType: React.Context<Context>;
-    context: Context = {};
+    static contextType = SomeContext;
+    context: Context;
+
+    constructor(props: Props, context: Context) {
+        super(props, context);
+    }
 
     state = {
         inputValue: this.context.someValue,
@@ -829,11 +834,9 @@ const propsWithoutRef: React.PropsWithoutRef<UnionProps> = {
     // @ts-expect-error -- legacy context was removed
     Wrapper = (props, legacyContext: { foo: number }) => null;
 
-    // @ts-expect-error -- legacy context was removed
     Wrapper = class Exact extends React.Component<ExactProps> {
-        constructor(props: ExactProps, legacyContext: { foo: number }) {
-            // @ts-expect-error -- legacy context was removed
-            super(props, legacyContext);
+        constructor(props: ExactProps, definitelyNotLegacyContext: { foo: number }) {
+            super(props, definitelyNotLegacyContext);
         }
     };
 

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -135,7 +135,7 @@ declare namespace React {
             props: P,
         ) => ReactElement<any, any> | null)
         // constructor signature must match React.Component
-        | (new(props: P) => Component<any, any>);
+        | (new(props: P, context: any) => Component<any, any>);
 
     /**
      * Created by {@link createRef}, or {@link useRef} when passed `null`.
@@ -218,7 +218,7 @@ declare namespace React {
     type ElementRef<
         C extends
             | ForwardRefExoticComponent<any>
-            | { new(props: any): Component<any> }
+            | { new(props: any, context: any): Component<any> }
             | ((props: any) => ReactElement | null)
             | keyof JSX.IntrinsicElements,
     > = ComponentRef<C>;
@@ -929,7 +929,7 @@ declare namespace React {
         static propTypes?: any;
 
         /**
-         * If using the new style context, re-declare this in your class to be the
+         * If using React Context, re-declare this in your class to be the
          * `React.ContextType` of your `static contextType`.
          * Should be used with type annotation or static contextType.
          *
@@ -948,6 +948,14 @@ declare namespace React {
 
         // Keep in sync with constructor signature of JSXElementConstructor and ComponentClass.
         constructor(props: P);
+        /**
+         * @param props
+         * @param context value of the parent {@link https://react.dev/reference/react/Component#context Context} specified
+         * in `contextType`.
+         */
+        // TODO: Ideally we'd infer the constructor signatur from `contextType`.
+        // Might be hard to ship without breaking existing code.
+        constructor(props: P, context: any);
 
         // We MUST keep setState() as a unified signature because it allows proper checking of the method return type.
         // See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18365#issuecomment-351013257
@@ -1117,7 +1125,13 @@ declare namespace React {
      */
     interface ComponentClass<P = {}, S = ComponentState> extends StaticLifecycle<P, S> {
         // constructor signature must match React.Component
-        new(props: P): Component<P, S>;
+        new(
+            props: P, /**
+             * Value of the parent {@link https://react.dev/reference/react/Component#context Context} specified
+             * in `contextType`.
+             */
+            context?: any,
+        ): Component<P, S>;
         /**
          * Ignored by React.
          * @deprecated Only kept in types for backwards compatibility. Will be removed in a future major release.
@@ -1157,7 +1171,7 @@ declare namespace React {
      */
     type ClassType<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>> =
         & C
-        & (new(props: P) => T);
+        & (new(props: P, context: any) => T);
 
     //
     // Component Specs and Lifecycle

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -129,12 +129,17 @@ declare const container: Element;
     }
 }
 
+const SomeContext = React.createContext<Context>({ someValue: "default" });
 class ModernComponent extends React.Component<Props, State, Snapshot> implements MyComponent {
     // deprecated. Kept for backwards compatibility.
     static propTypes = {};
 
-    contextType: React.Context<Context>;
-    context: Context = {};
+    static contextType = SomeContext;
+    context: Context;
+
+    constructor(props: Props, context: Context) {
+        super(props, context);
+    }
 
     state = {
         inputValue: this.context.someValue,
@@ -832,11 +837,9 @@ const propsWithoutRef: React.PropsWithoutRef<UnionProps> = {
     // @ts-expect-error -- legacy context was removed
     Wrapper = (props, legacyContext: { foo: number }) => null;
 
-    // @ts-expect-error -- legacy context was removed
     Wrapper = class Exact extends React.Component<ExactProps> {
-        constructor(props: ExactProps, legacyContext: { foo: number }) {
-            // @ts-expect-error -- legacy context was removed
-            super(props, legacyContext);
+        constructor(props: ExactProps, definitelyNotLegacyContext: { foo: number }) {
+            super(props, definitelyNotLegacyContext);
         }
     };
 


### PR DESCRIPTION
`constructor(props, context)` got [lumped in with legacy Context way back when](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/542f3c08a5eb3db0507a1d03272fa0c2bca9f551). I didn't double check when working on the 19 types so this got accidentally removed.

Resolves the type issue reported in https://github.com/reactjs/react.dev/issues/7832