### PR TITLE
[chrome] fix WebRequestEvent return type

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -13772,14 +13772,15 @@ declare namespace chrome {
 
         /** Fired when a request is about to occur. */
         export const onBeforeRequest: WebRequestEvent<
-            (details: OnBeforeRequestDetails) => BlockingResponse | undefined,
+            // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+            (details: OnBeforeRequestDetails) => BlockingResponse | void,
             `${OnBeforeRequestOptions}`[]
         >;
 
         /** Fired before sending an HTTP request, once the request headers are available. This may occur after a TCP connection is made to the server, but before any HTTP data is sent. */
         export const onBeforeSendHeaders: WebRequestEvent<
             // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-            (details: OnBeforeSendHeadersDetails) => BlockingResponse | undefined,
+            (details: OnBeforeSendHeadersDetails) => BlockingResponse | void,
             `${OnBeforeSendHeadersOptions}`[]
         >;
 
@@ -13791,7 +13792,8 @@ declare namespace chrome {
 
         /** Fired when HTTP response headers of a request have been received. */
         export const onHeadersReceived: WebRequestEvent<
-            (details: OnHeadersReceivedDetails) => BlockingResponse | undefined,
+            // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+            (details: OnHeadersReceivedDetails) => BlockingResponse | void,
             `${OnHeadersReceivedOptions}`[]
         >;
 
@@ -13808,7 +13810,8 @@ declare namespace chrome {
                 details: OnAuthRequiredDetails,
                 /** @since Chrome 58 */
                 asyncCallback?: (response: BlockingResponse) => void,
-            ) => BlockingResponse | undefined,
+                // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+            ) => BlockingResponse | void,
             `${OnAuthRequiredOptions}`[]
         >;
         // export const onAuthRequired: WebAuthenticationChallengeEvent;

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -6060,8 +6060,12 @@ function testWebRequest() {
         details.type; // $ExpectType "main_frame" | "sub_frame" | "stylesheet" | "script" | "image" | "font" | "object" | "xmlhttprequest" | "ping" | "csp_report" | "media" | "websocket" | "webbundle" | "other";
         details.url; // $ExpectType string
 
-        if (!asyncCallback) return blockingResponse;
+        if (!asyncCallback) return;
         asyncCallback?.(blockingResponse); // $ExpectType void
+    }, ["responseHeaders", "asyncBlocking", "extraHeaders"]);
+
+    checkWebRequestEvent(chrome.webRequest.onAuthRequired, () => {
+        return blockingResponse;
     }, ["responseHeaders", "blocking", "asyncBlocking", "extraHeaders"]);
 
     checkWebRequestEvent(chrome.webRequest.onBeforeRedirect, (details) => {
@@ -6106,7 +6110,9 @@ function testWebRequest() {
         details.timeStamp; // $ExpectType number
         details.type; // $ExpectType "main_frame" | "sub_frame" | "stylesheet" | "script" | "image" | "font" | "object" | "xmlhttprequest" | "ping" | "csp_report" | "media" | "websocket" | "webbundle" | "other";
         details.url; // $ExpectType string
+    }, ["requestBody", "extraHeaders"]);
 
+    checkWebRequestEvent(chrome.webRequest.onBeforeRequest, () => {
         return blockingResponse;
     }, ["blocking", "requestBody", "extraHeaders"]);
 
@@ -6129,11 +6135,13 @@ function testWebRequest() {
             details.timeStamp; // $ExpectType number
             details.type; // $ExpectType "main_frame" | "sub_frame" | "stylesheet" | "script" | "image" | "font" | "object" | "xmlhttprequest" | "ping" | "csp_report" | "media" | "websocket" | "webbundle" | "other";
             details.url; // $ExpectType string
-
-            return blockingResponse;
         },
-        ["requestHeaders", "blocking", "extraHeaders"],
+        ["requestHeaders", "extraHeaders"],
     );
+
+    checkWebRequestEvent(chrome.webRequest.onBeforeSendHeaders, () => {
+        return blockingResponse;
+    }, ["blocking", "requestHeaders", "extraHeaders"]);
 
     checkWebRequestEvent(chrome.webRequest.onCompleted, (details) => {
         details.documentId; // $ExpectType string
@@ -6196,7 +6204,9 @@ function testWebRequest() {
         details.timeStamp; // $ExpectType number
         details.type; // $ExpectType "main_frame" | "sub_frame" | "stylesheet" | "script" | "image" | "font" | "object" | "xmlhttprequest" | "ping" | "csp_report" | "media" | "websocket" | "webbundle" | "other";
         details.url; // $ExpectType string
+    }, ["responseHeaders", "extraHeaders"]);
 
+    checkWebRequestEvent(chrome.webRequest.onHeadersReceived, () => {
         return blockingResponse;
     }, ["blocking", "responseHeaders", "extraHeaders"]);
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/webRequest#event-onBeforeRequest
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

I introduced an error in the typing of the events: `onAuthRequired`, `onBeforeRequest`, `onBeforeSendHeaders` and `onHeadersReceived`.

The documentation specifies this return type: `BlockingResponse | undefined`, but further down, it states:

> If "blocking" is specified in the "extraInfoSpec" parameter, the event listener should return an object of this type.

I am reverting the change to restore `BlockingResponse | void` (I wasn't able to improve the typing to avoid `@typescript-eslint/no-invalid-void-type`)