### PR TITLE
[dom-chromium-ai] add types for Proofreader API

### DIFF
--- a/types/dom-chromium-ai/dom-chromium-ai-tests.ts
+++ b/types/dom-chromium-ai/dom-chromium-ai-tests.ts
@@ -437,11 +437,11 @@ async function topLevel() {
     const proofreaderResult: ProofreadResult = await proofreader.proofread("foo");
     console.log(proofreaderResult);
 
-    for await (
-        const chunk of proofreader.proofreadStreaming("foo")
-    ) {
-        console.log(chunk);
-    }
+    // for await (
+    //     const chunk of proofreader.proofreadStreaming("foo")
+    // ) {
+    //     console.log(chunk);
+    // }
 
     console.log(
         proofreader.expectedInputLanguages,

--- a/types/dom-chromium-ai/dom-chromium-ai-tests.ts
+++ b/types/dom-chromium-ai/dom-chromium-ai-tests.ts
@@ -410,4 +410,45 @@ async function topLevel() {
     console.log(languageDetectorResult.confidence);
 
     languageDetector.destroy();
+
+    // Proofreader
+
+    const proofreader = await Proofreader.create({
+        includeCorrectionTypes: true,
+        includeCorrectionExplanations: true,
+        correctionExplanationLanguage: "de",
+        expectedInputLanguages: ["de"],
+        signal: (new AbortController()).signal,
+        monitor(m: CreateMonitor) {
+            m.addEventListener("downloadprogress", (e) => {
+                console.log(e.loaded, e.total);
+            });
+        },
+    });
+
+    const proofreaderAvailability1: Availability = await Proofreader.availability();
+    console.log(proofreaderAvailability1);
+
+    const proofreaderAvailability2: Availability = await Proofreader.availability({
+        expectedInputLanguages: ["de"],
+    });
+    console.log(proofreaderAvailability2);
+
+    const proofreaderResult: ProofreadResult = await proofreader.proofread("foo");
+    console.log(proofreaderResult);
+
+    for await (
+        const chunk of proofreader.proofreadStreaming("foo")
+    ) {
+        console.log(chunk);
+    }
+
+    console.log(
+        proofreader.expectedInputLanguages,
+        proofreader.correctionExplanationLanguage,
+        proofreader.includeCorrectionExplanations,
+        proofreader.includeCorrectionTypes,
+    );
+
+    proofreader.destroy();
 }

--- a/types/dom-chromium-ai/index.d.ts
+++ b/types/dom-chromium-ai/index.d.ts
@@ -398,7 +398,7 @@ declare abstract class Proofreader implements DestroyableModel {
     static availability(options?: ProofreaderCreateCoreOptions): Promise<Availability>;
 
     proofread(input: string): Promise<ProofreadResult>;
-    proofreadStreaming(input: string): ReadableStream<ProofreadResult>;
+    // proofreadStreaming(input: string): ReadableStream<unknown>;
 
     readonly includeCorrectionTypes: boolean;
     readonly includeCorrectionExplanations: boolean;

--- a/types/dom-chromium-ai/index.d.ts
+++ b/types/dom-chromium-ai/index.d.ts
@@ -421,8 +421,8 @@ interface ProofreaderCreateOptions extends ProofreaderCreateCoreOptions {
 }
 
 interface ProofreadResult {
-    correctedInput?: string;
-    corrections?: ProofreadCorrection[];
+    correctedInput: string;
+    corrections: ProofreadCorrection[];
 }
 
 interface ProofreadCorrection {

--- a/types/dom-chromium-ai/index.d.ts
+++ b/types/dom-chromium-ai/index.d.ts
@@ -389,3 +389,48 @@ interface LanguageDetectionResult {
     detectedLanguage?: string;
     confidence?: number;
 }
+
+// Proofreader API
+// https://github.com/webmachinelearning/proofreader-api?tab=readme-ov-file#full-api-surface-in-web-idl
+
+declare abstract class Proofreader implements DestroyableModel {
+    static create(options?: ProofreaderCreateOptions): Promise<Proofreader>;
+    static availability(options?: ProofreaderCreateCoreOptions): Promise<Availability>;
+
+    proofread(input: string): Promise<ProofreadResult>;
+    proofreadStreaming(input: string): ReadableStream<ProofreadResult>;
+
+    readonly includeCorrectionTypes: boolean;
+    readonly includeCorrectionExplanations: boolean;
+    readonly correctionExplanationLanguage?: string;
+    readonly expectedInputLanguages: ReadonlyArray<string>;
+
+    destroy(): void;
+}
+
+interface ProofreaderCreateCoreOptions {
+    includeCorrectionTypes?: boolean;
+    includeCorrectionExplanations?: boolean;
+    correctionExplanationLanguage?: string;
+    expectedInputLanguages?: string[];
+}
+
+interface ProofreaderCreateOptions extends ProofreaderCreateCoreOptions {
+    signal?: AbortSignal;
+    monitor?: CreateMonitorCallback;
+}
+
+interface ProofreadResult {
+    correctedInput?: string;
+    corrections?: ProofreadCorrection[];
+}
+
+interface ProofreadCorrection {
+    startIndex: number;
+    endIndex: number;
+    correction: string;
+    type?: CorrectionType;
+    explanation?: string;
+}
+
+type CorrectionType = "spelling" | "punctuation" | "capitalization" | "preposition" | "missing-words" | "grammar";


### PR DESCRIPTION
**Todo:**

- [x] What type does `proofreadStreaming()` return? https://github.com/webmachinelearning/proofreader-api/issues/11

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webmachinelearning/proofreader-api
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Cc @tomayac