### PR TITLE
Expose missing `NormalizationResolverField` in `@types/relay-runtime`

### DIFF
--- a/types/relay-runtime/lib/util/NormalizationNode.d.ts
+++ b/types/relay-runtime/lib/util/NormalizationNode.d.ts
@@ -161,6 +161,20 @@ export interface NormalizationTypeDiscriminator {
     readonly abstractKey: string;
 }
 
+type ResolverData =
+  | { readonly resolverModule?: ResolverModule }
+  | { readonly resolverReference?: ResolverReference }
+  | { readonly resolverInfo?: ResolverInfo };
+
+export type NormalizationResolverField = ResolverData & {
+    readonly kind: "RelayResolver";
+    readonly name: string;
+    readonly args?: readonly NormalizationArgument[] | null | undefined;
+    readonly fragment?: NormalizationInlineFragment | null | undefined;
+    readonly storageKey?: string | null | undefined;
+    readonly isOutputType: boolean;
+};
+
 export type NormalizationSelection =
     | NormalizationCondition
     | NormalizationClientComponent
@@ -174,7 +188,8 @@ export type NormalizationSelection =
     | NormalizationModuleImport
     | NormalizationStream
     | NormalizationActorChange
-    | NormalizationTypeDiscriminator;
+    | NormalizationTypeDiscriminator
+    | NormalizationResolverField;
 
 export interface NormalizationSplitOperation {
     readonly argumentDefinitions?: readonly NormalizationLocalArgumentDefinition[];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://github.com/facebook/relay/blob/dce1a2eaa7ec6fac103a2295d21f1df48aa8e3af/packages/relay-runtime/util/NormalizationNode.js#L180-L193)>> — equivalent Flow types in `relay-runtime`'s source code
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

