### PR TITLE
[react-dates]: add constants

### DIFF
--- a/types/react-dates/constants.d.ts
+++ b/types/react-dates/constants.d.ts
@@ -40,4 +40,3 @@ export const FANG_HEIGHT_PX: 10;
 export const DEFAULT_VERTICAL_SPACING: 22;
 
 export const MODIFIER_KEY_NAMES: Set<"Shift" | "Control" | "Alt" | "Meta">;
-

--- a/types/react-dates/constants.d.ts
+++ b/types/react-dates/constants.d.ts
@@ -1,0 +1,43 @@
+// constants.js
+
+export const DISPLAY_FORMAT: "L";
+export const ISO_FORMAT: "YYYY-MM-DD";
+/**
+ * @deprecated Use `ISO_FORMAT` instead.
+ */
+export const ISO_MONTH_FORMAT: "YYYY-MM"; // from constants.js: delete this line of dead code on next breaking change
+
+export const START_DATE: "startDate";
+export const END_DATE: "endDate";
+
+export const HORIZONTAL_ORIENTATION: "horizontal";
+export const VERTICAL_ORIENTATION: "vertical";
+export const VERTICAL_SCROLLABLE: "verticalScrollable";
+
+export const NAV_POSITION_BOTTOM: "navPositionBottom";
+export const NAV_POSITION_TOP: "navPositionTop";
+
+export const ICON_BEFORE_POSITION: "before";
+export const ICON_AFTER_POSITION: "after";
+
+export const INFO_POSITION_TOP: "top";
+export const INFO_POSITION_BOTTOM: "bottom";
+export const INFO_POSITION_BEFORE: "before";
+export const INFO_POSITION_AFTER: "after";
+
+export const ANCHOR_LEFT: "left";
+export const ANCHOR_RIGHT: "right";
+
+export const OPEN_DOWN: "down";
+export const OPEN_UP: "up";
+
+export const DAY_SIZE: 39;
+export const BLOCKED_MODIFIER: "blocked";
+export const WEEKDAYS: [0, 1, 2, 3, 4, 5, 6];
+
+export const FANG_WIDTH_PX: 20;
+export const FANG_HEIGHT_PX: 10;
+export const DEFAULT_VERTICAL_SPACING: 22;
+
+export const MODIFIER_KEY_NAMES: Set<"Shift" | "Control" | "Alt" | "Meta">;
+

--- a/types/react-dates/constants.d.ts
+++ b/types/react-dates/constants.d.ts
@@ -3,7 +3,7 @@
 export const DISPLAY_FORMAT: "L";
 export const ISO_FORMAT: "YYYY-MM-DD";
 /**
- * @deprecated Use `ISO_FORMAT` instead.
+ * @deprecated Subject to be removed in the next breaking change.
  */
 export const ISO_MONTH_FORMAT: "YYYY-MM"; // from constants.js: delete this line of dead code on next breaking change
 

--- a/types/react-dates/index.d.ts
+++ b/types/react-dates/index.d.ts
@@ -28,7 +28,11 @@ export type RenderMonthProps =
 export type AnchorDirectionShape = typeof constants.ANCHOR_LEFT | typeof constants.ANCHOR_RIGHT;
 
 // shapes/CalendarInfoPositionShape.js
-export type CalendarInfoPositionShape = typeof constants.INFO_POSITION_TOP | typeof constants.INFO_POSITION_BOTTOM | typeof constants.INFO_POSITION_BEFORE | typeof constants.INFO_POSITION_AFTER;
+export type CalendarInfoPositionShape =
+    | typeof constants.INFO_POSITION_TOP
+    | typeof constants.INFO_POSITION_BOTTOM
+    | typeof constants.INFO_POSITION_BEFORE
+    | typeof constants.INFO_POSITION_AFTER;
 
 // shapes/NavPositionShape.js
 export type NavPositionShape = typeof constants.NAV_POSITION_TOP | typeof constants.NAV_POSITION_BOTTOM;
@@ -165,7 +169,10 @@ export type OpenDirectionShape = typeof constants.OPEN_DOWN | typeof constants.O
 export type OrientationShape = typeof constants.HORIZONTAL_ORIENTATION | typeof constants.VERTICAL_ORIENTATION;
 
 // shapes/ScrollableOrientationShape.js
-export type ScrollableOrientationShape = typeof constants.HORIZONTAL_ORIENTATION | typeof constants.VERTICAL_ORIENTATION | typeof constants.VERTICAL_SCROLLABLE;
+export type ScrollableOrientationShape =
+    | typeof constants.HORIZONTAL_ORIENTATION
+    | typeof constants.VERTICAL_ORIENTATION
+    | typeof constants.VERTICAL_SCROLLABLE;
 
 // shapes/SingleDatePickerShape.js
 export type SingleDatePickerShape = RenderMonthProps & {

--- a/types/react-dates/index.d.ts
+++ b/types/react-dates/index.d.ts
@@ -1,6 +1,7 @@
 import * as moment from "moment";
 import * as React from "react";
 import { Props as ReactOutsideClickHandlerProps } from "react-outside-click-handler";
+import * as constants from "./constants";
 
 // UTILITY TYPES
 export type RenderMonthProps =
@@ -24,13 +25,13 @@ export type RenderMonthProps =
 // SHAPES
 //
 // shapes/AnchorDirectionShape.js
-export type AnchorDirectionShape = "left" | "right";
+export type AnchorDirectionShape = typeof constants.ANCHOR_LEFT | typeof constants.ANCHOR_RIGHT;
 
 // shapes/CalendarInfoPositionShape.js
-export type CalendarInfoPositionShape = "top" | "bottom" | "before" | "after";
+export type CalendarInfoPositionShape = typeof constants.INFO_POSITION_TOP | typeof constants.INFO_POSITION_BOTTOM | typeof constants.INFO_POSITION_BEFORE | typeof constants.INFO_POSITION_AFTER;
 
 // shapes/NavPositionShape.js
-export type NavPositionShape = "navPositionTop" | "navPositionBottom";
+export type NavPositionShape = typeof constants.NAV_POSITION_TOP | typeof constants.NAV_POSITION_BOTTOM;
 
 // shapes/DateRangePickerShape.js
 export type DateRangePickerShape = RenderMonthProps & {
@@ -146,25 +147,25 @@ export const DateRangePickerShape: DateRangePickerShape;
 export type DayOfWeekShape = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
 // shapes/DisabledShape.js
-export type DisabledShape = boolean | "startDate" | "endDate";
+export type DisabledShape = boolean | typeof constants.START_DATE | typeof constants.END_DATE;
 
 // shapes/FocusedInputShape.js
-export type FocusedInputShape = "startDate" | "endDate";
+export type FocusedInputShape = typeof constants.START_DATE | typeof constants.END_DATE;
 
 // shapes/IconPositionShape.js
-export type IconPositionShape = "before" | "after";
+export type IconPositionShape = typeof constants.ICON_BEFORE_POSITION | typeof constants.ICON_AFTER_POSITION;
 
 // shapes/ModifiersShape.js
 export type ModifiersShape = Set<string>;
 
 // shapes/OpenDirectionShape.js
-export type OpenDirectionShape = "down" | "up";
+export type OpenDirectionShape = typeof constants.OPEN_DOWN | typeof constants.OPEN_UP;
 
 // shapes/OrientationShape.js
-export type OrientationShape = "horizontal" | "vertical";
+export type OrientationShape = typeof constants.HORIZONTAL_ORIENTATION | typeof constants.VERTICAL_ORIENTATION;
 
 // shapes/ScrollableOrientationShape.js
-export type ScrollableOrientationShape = "horizontal" | "vertical" | "verticalScrollable";
+export type ScrollableOrientationShape = typeof constants.HORIZONTAL_ORIENTATION | typeof constants.VERTICAL_ORIENTATION | typeof constants.VERTICAL_SCROLLABLE;
 
 // shapes/SingleDatePickerShape.js
 export type SingleDatePickerShape = RenderMonthProps & {

--- a/types/react-dates/package.json
+++ b/types/react-dates/package.json
@@ -7,8 +7,10 @@
     ],
     "dependencies": {
         "@types/react": "*",
-        "@types/react-outside-click-handler": "*",
-        "moment": "^2.26.0"
+        "@types/react-outside-click-handler": "*"
+    },
+    "peerDependencies": {
+        "moment": ">=2"
     },
     "devDependencies": {
         "@types/react-dates": "workspace:."

--- a/types/react-dates/react-dates-tests.tsx
+++ b/types/react-dates/react-dates-tests.tsx
@@ -5,6 +5,7 @@ import {
     CalendarDay,
     CalendarMonth,
     CalendarMonthGrid,
+    constants,
     DateRangePicker,
     DateRangePickerInput,
     DateRangePickerInputController,
@@ -742,3 +743,31 @@ const toLocalizedDateStringResultFromDate: string | null = toLocalizedDateString
 const toMomentObjectResult: moment.Moment | null = toMomentObject(moment());
 const toMomentObjectResultFromString: moment.Moment | null = toMomentObject("January 1, 2020", "dd.mm.yyyy");
 const toMomentObjectResultFromDate: moment.Moment | null = toMomentObject(new Date(), "dd.mm.yyyy");
+
+const constantsDisplayFormat: string = constants.DISPLAY_FORMAT;
+const constantsISOFormat: string = constants.ISO_FORMAT;
+const constantsISOFormatMonth: string = constants.ISO_MONTH_FORMAT;
+const constantsStartDate: string = constants.START_DATE;
+const constantsEndDate: string = constants.END_DATE;
+const constantsHorizontalOrientation: string = constants.HORIZONTAL_ORIENTATION;
+const constantsVerticalOrientation: string = constants.VERTICAL_ORIENTATION;
+const constantsVerticalScrollable: string = constants.VERTICAL_SCROLLABLE;
+const constantsNavPositionBottom: string = constants.NAV_POSITION_BOTTOM;
+const constantsNavPositionTop: string = constants.NAV_POSITION_TOP;
+const constantsIconBeforePosition: string = constants.ICON_BEFORE_POSITION;
+const constantsIconAfterPosition: string = constants.ICON_AFTER_POSITION;
+const constantsInfoPositionTop: string = constants.INFO_POSITION_TOP;
+const constantsInfoPositionBottom: string = constants.INFO_POSITION_BOTTOM;
+const constantsInfoPositionBefore: string = constants.INFO_POSITION_BEFORE;
+const constantsInfoPositionAfter: string = constants.INFO_POSITION_AFTER;
+const constantsAnchorLeft: string = constants.ANCHOR_LEFT;
+const constantsAnchorRight: string = constants.ANCHOR_RIGHT;
+const constantsOpenDown: string = constants.OPEN_DOWN;
+const constantsOpenUp: string = constants.OPEN_UP;
+const constantsDaySize: number = constants.DAY_SIZE;
+const constantsBlockedModifier: string = constants.BLOCKED_MODIFIER;
+const constantsWeekdays: number[] = constants.WEEKDAYS;
+const constantsFangWidthPx: number = constants.FANG_WIDTH_PX;
+const constantsFangHeightPx: number = constants.FANG_HEIGHT_PX;
+const constantsDefaultVerticalSpacing: number = constants.DEFAULT_VERTICAL_SPACING;
+const constantsModifierKeyNames: Set<string> = constants.MODIFIER_KEY_NAMES;

--- a/types/react-dates/react-dates-tests.tsx
+++ b/types/react-dates/react-dates-tests.tsx
@@ -5,7 +5,6 @@ import {
     CalendarDay,
     CalendarMonth,
     CalendarMonthGrid,
-    constants,
     DateRangePicker,
     DateRangePickerInput,
     DateRangePickerInputController,
@@ -23,6 +22,8 @@ import {
     toLocalizedDateString,
     toMomentObject,
 } from "react-dates";
+
+import * as constants from "react-dates/constants";
 
 const onlyRenderText: RenderMonthProps = {
     renderMonthText: month => month.format("MMMM"),


### PR DESCRIPTION
## CHANGES
- Added `constants` to `@types/react-dates`.
  Initial request: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/72925
- Moved `moment` dependency to `peerDeependencies` without the strict version. `react-dates` dependency: https://github.com/react-dates/react-dates/blob/master/package.json#L136.

## TESTS

```
import * as constants from "react-dates/constants";
```

<img width="1019" alt="image" src="https://github.com/user-attachments/assets/203b7679-34a2-4bfe-b6d8-325fc479b517" />
