### PR TITLE
[chrome] update TabGroups namespace since chrome 137

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -12450,6 +12450,11 @@ declare namespace chrome {
             color: `${Color}`;
             /** The ID of the group. Group IDs are unique within a browser session. */
             id: number;
+            /**
+             * Whether the group is shared.
+             * @since Chrome 137
+             */
+            shared: boolean;
             /** The title of the group. */
             title?: string;
             /** The ID of the window that contains the group. */
@@ -12465,13 +12470,18 @@ declare namespace chrome {
 
         export interface QueryInfo {
             /** Whether the groups are collapsed. */
-            collapsed?: boolean;
+            collapsed?: boolean | undefined;
             /** The color of the groups. */
-            color?: `${Color}`;
+            color?: `${Color}` | undefined;
+            /**
+             * Whether the group is shared.
+             * @since Chrome 137
+             */
+            shared?: boolean | undefined;
             /** Match group titles against a pattern. */
-            title?: string;
+            title?: string | undefined;
             /** The ID of the parent window, or {@link windows.WINDOW_ID_CURRENT} for the current window. */
-            windowId?: number;
+            windowId?: number | undefined;
         }
 
         export interface UpdateProperties {

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -2816,7 +2816,12 @@ async function testTabGroup() {
 
     chrome.tabGroups.get(groupId); // $ExpectType Promise<TabGroup>
     chrome.tabGroups.get(groupId, (group) => { // $ExpectType void
-        group; // $ExpectType TabGroup
+        group.collapsed; // $ExpectType boolean
+        group.color; // $ExpectType "blue" | "cyan" | "green" | "grey" | "orange" | "pink" | "purple" | "red" | "yellow"
+        group.id; // $ExpectType number
+        group.shared; // $ExpectType boolean
+        group.title; // $ExpectType string | undefined
+        group.windowId; // $ExpectType number
     });
     // @ts-expect-error
     chrome.tabGroups.get(() => {}).then(() => {});
@@ -2835,6 +2840,7 @@ async function testTabGroup() {
 
     const queryInfo: chrome.tabGroups.QueryInfo = {
         collapsed: false,
+        shared: false,
         title: "Test",
     };
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/tabGroups#type-TabGroup
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Note : 
- Add `shared`
- Revert removed `| undefined` for `QueryInfo`

![image](https://github.com/user-attachments/assets/d2b99578-d05c-42e7-af37-392a2019a6f6)
