### PR TITLE
fix(node): export TestContextAssert interface

### DIFF
--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -1760,6 +1760,7 @@ declare module "node:test" {
         test,
         test as default,
         TestContext,
+        TestContextAssert,
         todo,
     };
 }

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -1045,6 +1045,13 @@ test("planning with streams", (t: TestContext, done) => {
 });
 
 // Test custom assertion functions.
+// extend the TestContextAssert interface so we have correct typing
+declare module "node:test" {
+    interface TestContextAssert {
+        isOdd(value: number): void;
+    }
+}
+
 {
     test.assert.register("isOdd", (n: number) => {
         assert.strictEqual(n % 2, 1);


### PR DESCRIPTION
The current behavior of these types makes it impossible to correctly type custom assertion methods that are registered in the test context. By exporting the TestContextAssert interface you can now do so. ~I also removed the misleading string index type so that `t.assert.anyRandomString()` stops being valid according to the types as I believe it is a far better idea to extend the interface with the real types of your own methods instead.~

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/test.html#assertregistername-fn
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

