### PR TITLE
[oracledb] Fix fetchInfo type

### DIFF
--- a/types/oracledb/index.d.ts
+++ b/types/oracledb/index.d.ts
@@ -2067,7 +2067,7 @@ declare namespace OracleDB {
             | Record<
                 string,
                 {
-                    type: number;
+                    type: DbType | number;
                 }
             >
             | undefined;


### PR DESCRIPTION
The number type was valid in version 5.

Currently, the parameter value can be either a DbType object returned by constants (oracledb.DB_TYPE_XXX_ or the number value 0 returned by oracledb.DEFAULT
