### PR TITLE
fix(async-retry): make bail return type never

### DIFF
--- a/types/async-retry/async-retry-tests.ts
+++ b/types/async-retry/async-retry-tests.ts
@@ -12,13 +12,13 @@ retry(() => Promise.resolve(1)); // $ExpectType Promise<number>
 
 // $ExpectType Promise<void>
 retry((bail, attempt) => {
-    bail; // $ExpectType (e: unknown) => void
+    bail; // $ExpectType (e: unknown) => never
     attempt; // $ExpectType number
 });
 
 // $ExpectType Promise<void>
 retry<void, Error>((bail, attempt) => { // eslint-disable-line @typescript-eslint/no-invalid-void-type
-    bail; // $ExpectType (e: Error) => void
+    bail; // $ExpectType (e: Error) => never
     attempt; // $ExpectType number
 });
 
@@ -62,3 +62,6 @@ retry(() => "hello", {
         return 42;
     },
 });
+
+// $ExpectType Promise<string>
+retry<string>((bail) => bail(new Error('bye')))

--- a/types/async-retry/async-retry-tests.ts
+++ b/types/async-retry/async-retry-tests.ts
@@ -64,4 +64,4 @@ retry(() => "hello", {
 });
 
 // $ExpectType Promise<string>
-retry<string>((bail) => bail(new Error('bye')))
+retry<string>((bail) => bail(new Error("bye")));

--- a/types/async-retry/index.d.ts
+++ b/types/async-retry/index.d.ts
@@ -49,7 +49,7 @@ declare namespace AsyncRetry {
      * @param bail A function you can invoke to abort the retrying (bail).
      * @param attempt The attempt number. The absolute first attempt (before any retries) is `1`.
      */
-    type RetryFunction<TRet, TErr = unknown> = (bail: (e: TErr) => void, attempt: number) => TRet | Promise<TRet>;
+    type RetryFunction<TRet, TErr = unknown> = (bail: (e: TErr) => never, attempt: number) => TRet | Promise<TRet>;
 }
 
 export = AsyncRetry;


### PR DESCRIPTION
Looking at the
[implementation](https://github.com/vercel/async-retry/blob/main/lib/index.js#L21-L23), you can see that bail rejects the overall run promise, which should be treated as never rather than void as a return type. Otherwise, using bail will always result in an unexpected type.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/vercel/async-retry/blob/main/lib/index.js#L21-L23
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
