### PR TITLE
[chrome] update events namespace

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2553,52 +2553,9 @@ declare namespace chrome {
      * Permissions: "declarativeContent"
      */
     export namespace declarativeContent {
-        export interface PageStateUrlDetails {
-            /** Optional. Matches if the host name of the URL contains a specified string. To test whether a host name component has a prefix 'foo', use hostContains: '.foo'. This matches 'www.foobar.com' and 'foo.com', because an implicit dot is added at the beginning of the host name. Similarly, hostContains can be used to match against component suffix ('foo.') and to exactly match against components ('.foo.'). Suffix- and exact-matching for the last components need to be done separately using hostSuffix, because no implicit dot is added at the end of the host name.  */
-            hostContains?: string | undefined;
-            /** Optional. Matches if the host name of the URL is equal to a specified string.  */
-            hostEquals?: string | undefined;
-            /** Optional. Matches if the host name of the URL starts with a specified string.  */
-            hostPrefix?: string | undefined;
-            /** Optional. Matches if the host name of the URL ends with a specified string.  */
-            hostSuffix?: string | undefined;
-            /** Optional. Matches if the path segment of the URL contains a specified string.  */
-            pathContains?: string | undefined;
-            /** Optional. Matches if the path segment of the URL is equal to a specified string.  */
-            pathEquals?: string | undefined;
-            /** Optional. Matches if the path segment of the URL starts with a specified string.  */
-            pathPrefix?: string | undefined;
-            /** Optional. Matches if the path segment of the URL ends with a specified string.  */
-            pathSuffix?: string | undefined;
-            /** Optional. Matches if the query segment of the URL contains a specified string.  */
-            queryContains?: string | undefined;
-            /** Optional. Matches if the query segment of the URL is equal to a specified string.  */
-            queryEquals?: string | undefined;
-            /** Optional. Matches if the query segment of the URL starts with a specified string.  */
-            queryPrefix?: string | undefined;
-            /** Optional. Matches if the query segment of the URL ends with a specified string.  */
-            querySuffix?: string | undefined;
-            /** Optional. Matches if the URL (without fragment identifier) contains a specified string. Port numbers are stripped from the URL if they match the default port number.  */
-            urlContains?: string | undefined;
-            /** Optional. Matches if the URL (without fragment identifier) is equal to a specified string. Port numbers are stripped from the URL if they match the default port number.  */
-            urlEquals?: string | undefined;
-            /** Optional. Matches if the URL (without fragment identifier) matches a specified regular expression. Port numbers are stripped from the URL if they match the default port number. The regular expressions use the RE2 syntax.  */
-            urlMatches?: string | undefined;
-            /** Optional. Matches if the URL without query segment and fragment identifier matches a specified regular expression. Port numbers are stripped from the URL if they match the default port number. The regular expressions use the RE2 syntax.  */
-            originAndPathMatches?: string | undefined;
-            /** Optional. Matches if the URL (without fragment identifier) starts with a specified string. Port numbers are stripped from the URL if they match the default port number.  */
-            urlPrefix?: string | undefined;
-            /** Optional. Matches if the URL (without fragment identifier) ends with a specified string. Port numbers are stripped from the URL if they match the default port number.  */
-            urlSuffix?: string | undefined;
-            /** Optional. Matches if the scheme of the URL is equal to any of the schemes specified in the array.  */
-            schemes?: string[] | undefined;
-            /** Optional. Matches if the port of the URL is contained in any of the specified port lists. For example [80, 443, [1000, 1200]] matches all requests on port 80, 443 and in the range 1000-1200.  */
-            ports?: Array<number | number[]> | undefined;
-        }
-
         export class PageStateMatcherProperties {
             /** Optional. Filters URLs for various criteria. See event filtering. All criteria are case sensitive.  */
-            pageUrl?: PageStateUrlDetails | undefined;
+            pageUrl?: events.UrlFilter | undefined;
             /** Optional. Matches if all of the CSS selectors in the array match displayed elements in a frame with the same origin as the page's main frame. All selectors in this array must be compound selectors to speed up matching. Note that listing hundreds of CSS selectors or CSS selectors that match hundreds of times per page can still slow down web sites.  */
             css?: string[] | undefined;
             /**
@@ -4406,53 +4363,50 @@ declare namespace chrome {
     export namespace events {
         /** Filters URLs for various criteria. See event filtering. All criteria are case sensitive. */
         export interface UrlFilter {
-            /** Optional. Matches if the scheme of the URL is equal to any of the schemes specified in the array.  */
+            /**
+             * Matches if the host part of the URL is an IP address and is contained in any of the CIDR blocks specified in the array.
+             * @since Chrome 123
+             */
+            cidrBlocks?: string[] | undefined;
+            /** Matches if the scheme of the URL is equal to any of the schemes specified in the array. */
             schemes?: string[] | undefined;
-            /**
-             * Optional.
-             * @since Chrome 23
-             * Matches if the URL (without fragment identifier) matches a specified regular expression. Port numbers are stripped from the URL if they match the default port number. The regular expressions use the RE2 syntax.
-             */
+            /** Matches if the URL (without fragment identifier) matches a specified regular expression. Port numbers are stripped from the URL if they match the default port number. The regular expressions use the RE2 syntax. */
             urlMatches?: string | undefined;
-            /** Optional. Matches if the path segment of the URL contains a specified string.  */
+            /** Matches if the path segment of the URL contains a specified string. */
             pathContains?: string | undefined;
-            /** Optional. Matches if the host name of the URL ends with a specified string.  */
+            /** Matches if the host name of the URL ends with a specified string. */
             hostSuffix?: string | undefined;
-            /** Optional. Matches if the host name of the URL starts with a specified string.  */
+            /** Matches if the host name of the URL starts with a specified string. */
             hostPrefix?: string | undefined;
-            /** Optional. Matches if the host name of the URL contains a specified string. To test whether a host name component has a prefix 'foo', use hostContains: '.foo'. This matches 'www.foobar.com' and 'foo.com', because an implicit dot is added at the beginning of the host name. Similarly, hostContains can be used to match against component suffix ('foo.') and to exactly match against components ('.foo.'). Suffix- and exact-matching for the last components need to be done separately using hostSuffix, because no implicit dot is added at the end of the host name.  */
+            /** Matches if the host name of the URL contains a specified string. To test whether a host name component has a prefix 'foo', use hostContains: '.foo'. This matches 'www.foobar.com' and 'foo.com', because an implicit dot is added at the beginning of the host name. Similarly, hostContains can be used to match against component suffix ('foo.') and to exactly match against components ('.foo.'). Suffix- and exact-matching for the last components need to be done separately using hostSuffix, because no implicit dot is added at the end of the host name. */
             hostContains?: string | undefined;
-            /** Optional. Matches if the URL (without fragment identifier) contains a specified string. Port numbers are stripped from the URL if they match the default port number.  */
+            /** Matches if the URL (without fragment identifier) contains a specified string. Port numbers are stripped from the URL if they match the default port number. */
             urlContains?: string | undefined;
-            /** Optional. Matches if the query segment of the URL ends with a specified string.  */
+            /** Matches if the query segment of the URL ends with a specified string. */
             querySuffix?: string | undefined;
-            /** Optional. Matches if the URL (without fragment identifier) starts with a specified string. Port numbers are stripped from the URL if they match the default port number.  */
+            /** Matches if the URL (without fragment identifier) starts with a specified string. Port numbers are stripped from the URL if they match the default port number. */
             urlPrefix?: string | undefined;
-            /** Optional. Matches if the host name of the URL is equal to a specified string.  */
+            /** Matches if the host name of the URL is equal to a specified string. */
             hostEquals?: string | undefined;
-            /** Optional. Matches if the URL (without fragment identifier) is equal to a specified string. Port numbers are stripped from the URL if they match the default port number.  */
+            /** Matches if the URL (without fragment identifier) is equal to a specified string. Port numbers are stripped from the URL if they match the default port number. */
             urlEquals?: string | undefined;
-            /** Optional. Matches if the query segment of the URL contains a specified string.  */
+            /** Matches if the query segment of the URL contains a specified string. */
             queryContains?: string | undefined;
-            /** Optional. Matches if the path segment of the URL starts with a specified string.  */
+            /** Matches if the path segment of the URL starts with a specified string. */
             pathPrefix?: string | undefined;
-            /** Optional. Matches if the path segment of the URL is equal to a specified string.  */
+            /** Matches if the path segment of the URL is equal to a specified string. */
             pathEquals?: string | undefined;
-            /** Optional. Matches if the path segment of the URL ends with a specified string.  */
+            /** Matches if the path segment of the URL ends with a specified string. */
             pathSuffix?: string | undefined;
-            /** Optional. Matches if the query segment of the URL is equal to a specified string.  */
+            /** Matches if the query segment of the URL is equal to a specified string. */
             queryEquals?: string | undefined;
-            /** Optional. Matches if the query segment of the URL starts with a specified string.  */
+            /** Matches if the query segment of the URL starts with a specified string. */
             queryPrefix?: string | undefined;
-            /** Optional. Matches if the URL (without fragment identifier) ends with a specified string. Port numbers are stripped from the URL if they match the default port number.  */
+            /** Matches if the URL (without fragment identifier) ends with a specified string. Port numbers are stripped from the URL if they match the default port number. */
             urlSuffix?: string | undefined;
-            /** Optional. Matches if the port of the URL is contained in any of the specified port lists. For example [80, 443, [1000, 1200]] matches all requests on port 80, 443 and in the range 1000-1200.  */
+            /** Matches if the port of the URL is contained in any of the specified port lists. For example `[80, 443, [1000, 1200]]` matches all requests on port 80, 443 and in the range 1000-1200. */
             ports?: Array<number | number[]> | undefined;
-            /**
-             * Optional.
-             * @since Chrome 28
-             * Matches if the URL without query segment and fragment identifier matches a specified regular expression. Port numbers are stripped from the URL if they match the default port number. The regular expressions use the RE2 syntax.
-             */
+            /** Matches if the URL without query segment and fragment identifier matches a specified regular expression. Port numbers are stripped from the URL if they match the default port number. The regular expressions use the RE2 syntax. */
             originAndPathMatches?: string | undefined;
         }
 
@@ -4462,43 +4416,33 @@ declare namespace chrome {
              * @param callback Called when an event occurs. The parameters of this function depend on the type of event.
              */
             addListener(callback: T): void;
-            /**
-             * Returns currently registered rules.
-             * @param callback Called with registered rules.
-             */
-            getRules(
-                callback: (
-                    /** Rules that were registered, the optional parameters are filled with values */
-                    rules: Rule[],
-                ) => void,
-            ): void;
+
             /**
              * Returns currently registered rules.
              * @param ruleIdentifiers If an array is passed, only rules with identifiers contained in this array are returned.
-             * @param callback Called with registered rules.
              */
             getRules(
-                ruleIdentifiers: string[],
-                callback: (
-                    /** Rules that were registered, the optional parameters are filled with values */
-                    rules: Rule[],
-                ) => void,
+                /** @param rules Rules that were registered, the optional parameters are filled with values */
+                callback: (rules: Rule[]) => void,
             ): void;
+            getRules(
+                ruleIdentifiers: string[],
+                /** @param rules Rules that were registered, the optional parameters are filled with values */
+                callback: (rules: Rule[]) => void,
+            ): void;
+
             /**
              * @param callback Listener whose registration status shall be tested.
+             * @returns True if _callback_ is registered to the event.
              */
             hasListener(callback: T): boolean;
+
             /**
              * Unregisters currently registered rules.
              * @param ruleIdentifiers If an array is passed, only rules with identifiers contained in this array are unregistered.
-             * @param callback Called when rules were unregistered.
              */
-            removeRules(ruleIdentifiers?: string[], callback?: () => void): void;
-            /**
-             * Unregisters currently registered rules.
-             * @param callback Called when rules were unregistered.
-             */
-            removeRules(callback?: () => void): void;
+            removeRules(ruleIdentifiers?: string[] | undefined, callback?: () => void): void;
+
             /**
              * Registers rules to handle events.
              * @param rules Rules to be registered. These do not replace previously registered rules.
@@ -4506,34 +4450,31 @@ declare namespace chrome {
              */
             addRules(
                 rules: Rule[],
-                callback?: (
-                    /** Rules that were registered, the optional parameters are filled with values */
-                    rules: Rule[],
-                ) => void,
+                /** @param rules Rules that were registered, the optional parameters are filled with values */
+                callback?: (rules: Rule[]) => void,
             ): void;
+
             /**
              * Deregisters an event listener callback from an event.
              * @param callback Listener that shall be unregistered.
              */
             removeListener(callback: T): void;
+
+            /** @returns True if any event listeners are registered to the event. */
             hasListeners(): boolean;
         }
 
         /** Description of a declarative rule for handling events. */
         export interface Rule {
-            /** Optional. Optional priority of this rule. Defaults to 100.  */
+            /** Optional priority of this rule. Defaults to 100. */
             priority?: number | undefined;
             /** List of conditions that can trigger the actions. */
             conditions: any[];
-            /** Optional. Optional identifier that allows referencing this rule.  */
+            /** Optional identifier that allows referencing this rule. */
             id?: string | undefined;
-            /** List of actions that are triggered if one of the condtions is fulfilled. */
+            /** List of actions that are triggered if one of the conditions is fulfilled. */
             actions: any[];
-            /**
-             * Optional.
-             * @since Chrome 28
-             * Tags can be used to annotate rules and perform operations on sets of rules.
-             */
+            /** Tags can be used to annotate rules and perform operations on sets of rules. */
             tags?: string[] | undefined;
         }
     }

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1,3 +1,18 @@
+/**
+ * Check all listeners for a Chrome event.
+ * @param event - The event to check.
+ * @param callback - The callback to check.
+ */
+const checkChromeEvent = <T extends chrome.events.Event<(...args: any) => void>>(
+    event: T,
+    callback: Parameters<T["addListener"]>[0],
+) => {
+    event.addListener(callback); // $ExpectType void
+    event.removeListener(callback); // $ExpectType void
+    event.hasListener(callback); // $ExpectType boolean
+    event.hasListeners(); // $ExpectType boolean
+};
+
 // https://developer.chrome.com/docs/extensions/reference/api/bookmarks
 function testBookmarks() {
     chrome.bookmarks.BookmarkTreeNodeUnmodifiable.MANAGED === "managed";


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://developer.chrome.com/docs/extensions/reference/api/events
  - https://developer.chrome.com/docs/extensions/reference/api/declarativeContent#type-PageStateMatcher
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes :
- clean JSDoc
- Replaced `PageStateUrlDetails ` by `events.UrlFilter` for `declarativeContent.PageStateMatcherProperties` (same type)
- Added `cidrBlocks` key for `events.Event`
- Added `checkChromeEvent` to simplify event testing, example before :
  ```ts
  chrome.notifications.onButtonClicked.addListener((notificationId, buttonIndex) => { // $ExpectType void
    notificationId; // $ExpectType string
    buttonIndex; // $ExpectType number
  });
  chrome.notifications.onButtonClicked.removeListener((notificationId, buttonIndex) => { // $ExpectType void
    notificationId; // $ExpectType string
    buttonIndex; // $ExpectType number
  });
  chrome.notifications.onButtonClicked.hasListener((notificationId, buttonIndex) => { // $ExpectType boolean
    notificationId; // $ExpectType string
    buttonIndex; // $ExpectType number
  });
  chrome.notifications.onButtonClicked.hasListeners(); // $ExpectType boolean
  ```
  
  Now : 
  ```ts
  const checkChromeEvent = <T extends chrome.events.Event<(...args: any) => void>>(
    event: T,
    callback: Parameters<T["addListener"]>[0],
  ) => {
    event.addListener(callback); // $ExpectType void
    event.removeListener(callback); // $ExpectType void
    event.hasListener(callback); // $ExpectType boolean
    event.hasListeners(); // $ExpectType boolean
  };
  
  checkChromeEvent(chrome.notifications.onButtonClicked, (notificationId, buttonIndex) => {
    notificationId; // $ExpectType string
    buttonIndex; // $ExpectType number
  })
  ```
