### PR TITLE
[chrome] update tabs namespace

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -11501,11 +11501,108 @@ declare namespace chrome {
             groupId?: number | undefined;
         }
 
-        export interface TabRemoveInfo {
-            /** The window whose tab is closed */
+        export interface OnHighlightedInfo {
+            /** All highlighted tabs in the window. */
+            tabIds: number[];
+            /** The window whose tabs changed. */
             windowId: number;
+        }
+
+        export interface OnRemovedInfo {
             /** True when the tab was closed because its parent window was closed. */
             isWindowClosing: boolean;
+            /** The window whose tab is closed */
+            windowId: number;
+        }
+
+        export interface OnUpdatedInfo {
+            /** The tab's new audible state. */
+            audible?: boolean;
+            /**
+             * The tab's new auto-discardable state.
+             * @since Chrome 54
+             */
+            autoDiscardable?: boolean;
+            /**
+             * The tab's new discarded state.
+             * @since Chrome 54
+             */
+            discarded?: boolean;
+            /** The tab's new favicon URL. */
+            favIconUrl?: string;
+            /**
+             * The tab's new frozen state.
+             * @since Chrome 132
+             */
+            frozen?: boolean;
+            /**
+             * The tab's new group.
+             * @since Chrome 88
+             */
+            groupId?: number;
+            /**
+             * The tab's new muted state and the reason for the change.
+             * @since Chrome 46
+             */
+            mutedInfo?: MutedInfo;
+            /** The tab's new pinned state. */
+            pinned?: boolean;
+            /** The tab's loading status. */
+            status?: `${TabStatus}`;
+            /**
+             * The tab's new title.
+             * @since Chrome 48
+             */
+            title?: string;
+            /** The tab's URL if it has changed. */
+            url?: string;
+        }
+
+        export interface OnAttachedInfo {
+            newPosition: number;
+            newWindowId: number;
+        }
+
+        export interface OnMovedInfo {
+            fromIndex: number;
+            toIndex: number;
+            windowId: number;
+        }
+
+        export interface OnDetachedInfo {
+            oldPosition: number;
+            oldWindowId: number;
+        }
+
+        export interface OnActivatedInfo {
+            /** The ID of the tab that has become active. */
+            tabId: number;
+            /** The ID of the window the active tab changed inside of. */
+            windowId: number;
+        }
+
+        export interface OnSelectionChangedInfo {
+            /** The ID of the window the selected tab changed inside of. */
+            windowId: number;
+        }
+
+        export interface OnActiveChangedInfo {
+            /** The ID of the window the selected tab changed inside of. */
+            windowId: number;
+        }
+
+        export interface OnHighlightChangedInfo {
+            /** All highlighted tabs in the window. */
+            tabIds: number[];
+            /** The window whose tabs changed. */
+            windowId: number;
+        }
+
+        export interface OnZoomChangeInfo {
+            newZoomFactor: number;
+            oldZoomFactor: number;
+            tabId: number;
+            zoomSettings: ZoomSettings;
         }
 
         /**
@@ -11858,93 +11955,32 @@ declare namespace chrome {
 
         /** Fired when the highlighted or selected tabs in a window changes */
         export const onHighlighted: events.Event<
-            (highlightInfo: {
-                /** All highlighted tabs in the window. */
-                tabIds: number[];
-                /** The window whose tabs changed. */
-                windowId: number;
-            }) => void
+            (highlightInfo: OnHighlightedInfo) => void
         >;
 
         /** Fired when a tab is closed. */
         export const onRemoved: events.Event<
-            (tabId: number, removeInfo: {
-                /** True when the tab was closed because its parent window was closed. */
-                isWindowClosing: boolean;
-                /** The window whose tab is closed */
-                windowId: number;
-            }) => void
+            (tabId: number, removeInfo: OnRemovedInfo) => void
         >;
 
         /** Fired when a tab is updated. */
         export const onUpdated: events.Event<
-            (tabId: number, changeInfo: {
-                /** The tab's new audible state. */
-                audible?: boolean;
-                /**
-                 * The tab's new auto-discardable state.
-                 * @since Chrome 54
-                 */
-                autoDiscardable?: boolean;
-                /**
-                 * The tab's new discarded state.
-                 * @since Chrome 54
-                 */
-                discarded?: boolean;
-                /** The tab's new favicon URL. */
-                favIconUrl?: string;
-                /**
-                 * The tab's new frozen state.
-                 * @since Chrome 132
-                 */
-                frozen?: boolean;
-                /**
-                 * The tab's new group.
-                 * @since Chrome 88
-                 */
-                groupId?: number;
-                /**
-                 * The tab's new muted state and the reason for the change.
-                 * @since Chrome 46
-                 */
-                mutedInfo?: MutedInfo;
-                /** The tab's new pinned state. */
-                pinned?: boolean;
-                /** The tab's loading status. */
-                status?: `${TabStatus}`;
-                /**
-                 * The tab's new title.
-                 * @since Chrome 48
-                 */
-                title?: string;
-                /** The tab's URL if it has changed. */
-                url?: string;
-            }, tab: Tab) => void
+            (tabId: number, changeInfo: OnUpdatedInfo, tab: Tab) => void
         >;
 
         /** Fired when a tab is attached to a window, for example because it was moved between windows. */
         export const onAttached: events.Event<
-            (tabId: number, attachInfo: {
-                newPosition: number;
-                newWindowId: number;
-            }) => void
+            (tabId: number, attachInfo: OnAttachedInfo) => void
         >;
 
         /** Fired when a tab is moved within a window. Only one move event is fired, representing the tab the user directly moved. Move events are not fired for the other tabs that must move in response to the manually-moved tab. This event is not fired when a tab is moved between windows; for details, see {@link tabs.onDetached}. */
         export const onMoved: events.Event<
-            (tabId: number, moveInfo: {
-                fromIndex: number;
-                toIndex: number;
-                windowId: number;
-            }) => void
+            (tabId: number, moveInfo: OnMovedInfo) => void
         >;
 
         /** Fired when a tab is detached from a window; for example, because it was moved between windows. */
         export const onDetached: events.Event<
-            (tabId: number, detachInfo: {
-                oldPosition: number;
-                oldWindowId: number;
-            }) => void
+            (tabId: number, detachInfo: OnDetachedInfo) => void
         >;
 
         /** Fired when a tab is created. Note that the tab's URL and tab group membership may not be set at the time this event is fired, but you can listen to onUpdated events so as to be notified when a URL is set or the tab is added to a tab group. */
@@ -11952,16 +11988,13 @@ declare namespace chrome {
 
         /** Fires when the active tab in a window changes. Note that the tab's URL may not be set at the time this event fired, but you can listen to onUpdated events so as to be notified when a URL is set */
         export const onActivated: events.Event<
-            (activeInfo: {
-                /** The ID of the tab that has become active. */
-                tabId: number;
-                /** The ID of the window the active tab changed inside of. */
-                windowId: number;
-            }) => void
+            (activeInfo: OnActivatedInfo) => void
         >;
 
         /** Fired when a tab is replaced with another tab due to prerendering or instant */
-        export const onReplaced: events.Event<(addedTabId: number, removedTabId: number) => void>;
+        export const onReplaced: events.Event<
+            (addedTabId: number, removedTabId: number) => void
+        >;
 
         /**
          * Fires when the selected tab in a window changes.
@@ -11970,10 +12003,7 @@ declare namespace chrome {
          * @deprecated Please use {@link tabs.onActivated}.
          */
         export const onSelectionChanged: events.Event<
-            (tabId: number, selectInfo: {
-                /** The ID of the window the selected tab changed inside of. */
-                windowId: number;
-            }) => void
+            (tabId: number, selectInfo: OnSelectionChangedInfo) => void
         >;
 
         /**
@@ -11983,10 +12013,7 @@ declare namespace chrome {
          * @deprecated Please use {@link tabs.onActivated}.
          */
         export const onActiveChanged: events.Event<
-            (tabId: number, selectInfo: {
-                /** The ID of the window the selected tab changed inside of. */
-                windowId: number;
-            }) => void
+            (tabId: number, selectInfo: OnActiveChangedInfo) => void
         >;
 
         /**
@@ -11996,24 +12023,12 @@ declare namespace chrome {
          * @deprecated Please use {@link tabs.onHighlighted}.
          */
         export const onHighlightChanged: events.Event<
-            (
-                (selectInfo: {
-                    /** All highlighted tabs in the window. */
-                    tabIds: number[];
-                    /** The window whose tabs changed. */
-                    windowId: number;
-                }) => void
-            )
+            (selectInfo: OnHighlightChangedInfo) => void
         >;
 
         /** Fired when a tab is zoomed */
         export const onZoomChange: events.Event<
-            (ZoomChangeInfo: {
-                newZoomFactor: number;
-                oldZoomFactor: number;
-                tabId: number;
-                zoomSettings: ZoomSettings;
-            }) => void
+            (ZoomChangeInfo: OnZoomChangeInfo) => void
         >;
     }
 

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -11171,67 +11171,54 @@ declare namespace chrome {
      */
     export namespace tabs {
         /**
-         * Tab muted state and the reason for the last state change.
+         * The tab's muted state and the reason for the last state change.
          * @since Chrome 46
          */
         export interface MutedInfo {
-            /** Whether the tab is prevented from playing sound (but hasn't necessarily recently produced sound). Equivalent to whether the muted audio indicator is showing. */
+            /** Whether the tab is muted (prevented from playing sound). The tab may be muted even if it has not played or is not currently playing sound. Equivalent to whether the 'muted' audio indicator is showing. */
             muted: boolean;
-            /**
-             * Optional.
-             * The reason the tab was muted or unmuted. Not set if the tab's mute state has never been changed.
-             * "user": A user input action has set/overridden the muted state.
-             * "capture": Tab capture started, forcing a muted state change.
-             * "extension": An extension, identified by the extensionId field, set the muted state.
-             */
-            reason?: string | undefined;
-            /**
-             * Optional.
-             * The ID of the extension that changed the muted state. Not set if an extension was not the reason the muted state last changed.
-             */
+            /* The reason the tab was muted or unmuted. Not set if the tab's mute state has never been changed. */
+            reason?: `${MutedInfoReason}` | undefined;
+            /** The ID of the extension that changed the muted state. Not set if an extension was not the reason the muted state last changed. */
             extensionId?: string | undefined;
         }
 
+        /**
+         * An event that caused a muted state change.
+         * @since Chrome 46
+         */
+        export enum MutedInfoReason {
+            /** A user input action set the muted state. */
+            USER = "user",
+            /** Tab capture was started, forcing a muted state change. */
+            CAPTURE = "capture",
+            /** An extension set the muted state. */
+            EXTENSION = "extension",
+        }
+
         export interface Tab {
-            /**
-             * Optional.
-             * Either loading or complete.
-             */
-            status?: string | undefined;
+            /** The tab's loading status. */
+            status?: `${TabStatus}` | undefined;
             /** The zero-based index of the tab within its window. */
             index: number;
-            /**
-             * Optional.
-             * The ID of the tab that opened this tab, if any. This property is only present if the opener tab still exists.
-             * @since Chrome 18
-             */
+            /** The ID of the tab that opened this tab, if any. This property is only present if the opener tab still exists. */
             openerTabId?: number | undefined;
-            /** The title of the tab. This property is only present if the extension has the `tabs` permission or has host permissions for the page. */
+            /** The title of the tab. This property is only present if the extension has the `"tabs"` permission or has host permissions for the page. */
             title?: string | undefined;
-            /** The last committed URL of the main frame of the tab. This property is only present if the extension has the `tabs` permission or has host permissions for the page. May be an empty string if the tab has not yet committed. See also {@link Tab.pendingUrl}. */
+            /** The last committed URL of the main frame of the tab. This property is only present if the extension has the `"tabs"` permission or has host permissions for the page. May be an empty string if the tab has not yet committed. See also {@link Tab.pendingUrl}. */
             url?: string | undefined;
             /**
-             * The URL the tab is navigating to, before it has committed. This property is only present if the extension has the `tabs` permission or has host permissions for the page and there is a pending navigation.The URL the tab is navigating to, before it has committed.
-             * This property is only present if the extension's manifest includes the "tabs" permission and there is a pending navigation.
+             * The URL the tab is navigating to, before it has committed. This property is only present if the extension has the `"tabs"` permission or has host permissions for the page and there is a pending navigation.
              * @since Chrome 79
              */
             pendingUrl?: string | undefined;
-            /**
-             * Whether the tab is pinned.
-             * @since Chrome 9
-             */
+            /** Whether the tab is pinned. */
             pinned: boolean;
-            /**
-             * Whether the tab is highlighted.
-             * @since Chrome 16
-             */
+            /** Whether the tab is highlighted. */
             highlighted: boolean;
-            /** The ID of the window the tab is contained within. */
+            /** The ID of the window that contains the tab. */
             windowId: number;
-            /**
-             * Whether the tab is active in its window. (Does not necessarily mean the window is focused.)
-             * @since Chrome 16
-             */
+            /** Whether the tab is active in its window. Does not necessarily mean the window is focused. */
             active: boolean;
             /** The URL of the tab's favicon. This property is only present if the extension has the `tabs` permission or has host permissions for the page. It may also be an empty string if the tab is loading. */
             favIconUrl?: string | undefined;
@@ -11240,26 +11227,22 @@ declare namespace chrome {
              * @since Chrome 132
              */
             frozen: boolean;
-            /**
-             * Optional.
-             * The ID of the tab. Tab IDs are unique within a browser session. Under some circumstances a Tab may not be assigned an ID, for example when querying foreign tabs using the sessions API, in which case a session ID may be present. Tab ID can also be set to chrome.tabs.TAB_ID_NONE for apps and devtools windows.
-             */
+            /** The ID of the tab. Tab IDs are unique within a browser session. Under some circumstances a tab may not be assigned an ID; for example, when querying foreign tabs using the {@link sessions} API, in which case a session ID may be present. Tab ID can also be set to `chrome.tabs.TAB_ID_NONE` for apps and devtools windows. */
             id?: number | undefined;
             /** Whether the tab is in an incognito window. */
             incognito: boolean;
             /**
              * Whether the tab is selected.
-             * @deprecated since Chrome 33. Please use tabs.Tab.highlighted.
+             * @deprecated since Chrome 33. Please use {@link Tab.highlighted}.
              */
             selected: boolean;
             /**
-             * Optional.
-             * Whether the tab has produced sound over the past couple of seconds (but it might not be heard if also muted). Equivalent to whether the speaker audio indicator is showing.
+             * Whether the tab has produced sound over the past couple of seconds (but it might not be heard if also muted). Equivalent to whether the 'speaker audio' indicator is showing.
              * @since Chrome 45
              */
             audible?: boolean | undefined;
             /**
-             * Whether the tab is discarded. A discarded tab is one whose content has been unloaded from memory, but is still visible in the tab strip. Its content gets reloaded the next time it's activated.
+             * Whether the tab is discarded. A discarded tab is one whose content has been unloaded from memory, but is still visible in the tab strip. Its content is reloaded the next time it is activated.
              * @since Chrome 54
              */
             discarded: boolean;
@@ -11269,25 +11252,15 @@ declare namespace chrome {
              */
             autoDiscardable: boolean;
             /**
-             * Optional.
-             * Current tab muted state and the reason for the last state change.
+             * The tab's muted state and the reason for the last state change.
              * @since Chrome 46
              */
             mutedInfo?: MutedInfo | undefined;
-            /**
-             * Optional. The width of the tab in pixels.
-             * @since Chrome 31
-             */
+            /** The width of the tab in pixels. */
             width?: number | undefined;
-            /**
-             * Optional. The height of the tab in pixels.
-             * @since Chrome 31
-             */
+            /** The height of the tab in pixels. */
             height?: number | undefined;
-            /**
-             * Optional. The session ID used to uniquely identify a Tab obtained from the sessions API.
-             * @since Chrome 31
-             */
+            /** The session ID used to uniquely identify a tab obtained from the {@link sessions} API. */
             sessionId?: string | undefined;
             /**
              * The ID of the group that the tab belongs to.
@@ -11301,203 +11274,201 @@ declare namespace chrome {
             lastAccessed?: number | undefined;
         }
 
-        /**
-         * Defines how zoom changes in a tab are handled and at what scope.
-         * @since Chrome 38
-         */
+        /** The tab's loading status. */
+        export enum TabStatus {
+            UNLOADED = "unloaded",
+            LOADING = "loading",
+            COMPLETE = "complete",
+        }
+
+        /** The type of window. */
+        export enum WindowType {
+            NORMAL = "normal",
+            POPUP = "popup",
+            PANEL = "panel",
+            APP = "app",
+            DEVTOOLS = "devtools",
+        }
+
+        /** Defines how zoom changes in a tab are handled and at what scope. */
         export interface ZoomSettings {
+            /** Defines how zoom changes are handled, i.e., which entity is responsible for the actual scaling of the page; defaults to `automatic`. */
+            mode?: `${ZoomSettingsMode}` | undefined;
+            /** Defines whether zoom changes persist for the page's origin, or only take effect in this tab; defaults to `per-origin` when in `automatic` mode, and `per-tab` otherwise. */
+            scope?: `${ZoomSettingsScope}` | undefined;
             /**
-             * Optional.
-             * Defines how zoom changes are handled, i.e. which entity is responsible for the actual scaling of the page; defaults to "automatic".
-             * "automatic": Zoom changes are handled automatically by the browser.
-             * "manual": Overrides the automatic handling of zoom changes. The onZoomChange event will still be dispatched, and it is the responsibility of the extension to listen for this event and manually scale the page. This mode does not support per-origin zooming, and will thus ignore the scope zoom setting and assume per-tab.
-             * "disabled": Disables all zooming in the tab. The tab will revert to the default zoom level, and all attempted zoom changes will be ignored.
-             */
-            mode?: string | undefined;
-            /**
-             * Optional.
-             * Defines whether zoom changes will persist for the page's origin, or only take effect in this tab; defaults to per-origin when in automatic mode, and per-tab otherwise.
-             * "per-origin": Zoom changes will persist in the zoomed page's origin, i.e. all other tabs navigated to that same origin will be zoomed as well. Moreover, per-origin zoom changes are saved with the origin, meaning that when navigating to other pages in the same origin, they will all be zoomed to the same zoom factor. The per-origin scope is only available in the automatic mode.
-             * "per-tab": Zoom changes only take effect in this tab, and zoom changes in other tabs will not affect the zooming of this tab. Also, per-tab zoom changes are reset on navigation; navigating a tab will always load pages with their per-origin zoom factors.
-             */
-            scope?: string | undefined;
-            /**
-             * Optional.
-             * Used to return the default zoom level for the current tab in calls to tabs.getZoomSettings.
+             * Used to return the default zoom level for the current tab in calls to {@link tabs.getZoomSettings}.
              * @since Chrome 43
              */
             defaultZoomFactor?: number | undefined;
         }
 
+        /**
+         * Defines how zoom changes are handled, i.e., which entity is responsible for the actual scaling of the page; defaults to `automatic`.
+         * @since Chrome 44
+         */
+        export enum ZoomSettingsMode {
+            /** Zoom changes are handled automatically by the browser. */
+            AUTOMATIC = "automatic",
+            /** Overrides the automatic handling of zoom changes. The `onZoomChange` event will still be dispatched, and it is the extension's responsibility to listen for this event and manually scale the page. This mode does not support `per-origin` zooming, and thus ignores the `scope` zoom setting and assumes `per-tab`. */
+            MANUAL = "manual",
+            /** Disables all zooming in the tab. The tab reverts to the default zoom level, and all attempted zoom changes are ignored. */
+            DISABLED = "disabled",
+        }
+
+        /**
+         * Defines whether zoom changes persist for the page's origin, or only take effect in this tab; defaults to `per-origin` when in `automatic` mode, and `per-tab` otherwise.
+         * @since Chrome 44
+         */
+        export enum ZoomSettingsScope {
+            /** Zoom changes persist in the zoomed page's origin, i.e., all other tabs navigated to that same origin are zoomed as well. Moreover, `per-origin` zoom changes are saved with the origin, meaning that when navigating to other pages in the same origin, they are all zoomed to the same zoom factor. The `per-origin` scope is only available in the `automatic` mode. */
+            PER_ORIGIN = "per-origin",
+            /** Zoom changes only take effect in this tab, and zoom changes in other tabs do not affect the zooming of this tab. Also, `per-tab` zoom changes are reset on navigation; navigating a tab always loads pages with their `per-origin` zoom factors. */
+            PER_TAB = "per-tab",
+        }
+
+        /**
+         * The maximum number of times that {@link captureVisibleTab} can be called per second. {@link captureVisibleTab} is expensive and should not be called too often.
+         * @since Chrome 92
+         */
+        export const MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND = 2;
+
+        /**
+         * An ID that represents the absence of a browser tab.
+         * @since Chrome 46
+         */
+        export const TAB_ID_NONE = -1;
+
+        /**
+         * An index that represents the absence of a tab index in a tab_strip.
+         * @since Chrome 123
+         */
+        export const TAB_INDEX_NONE = -1;
+
         export interface CreateProperties {
-            /** Optional. The position the tab should take in the window. The provided value will be clamped to between zero and the number of tabs in the window. */
+            /** The position the tab should take in the window. The provided value is clamped to between zero and the number of tabs in the window. */
             index?: number | undefined;
-            /**
-             * Optional.
-             * The ID of the tab that opened this tab. If specified, the opener tab must be in the same window as the newly created tab.
-             * @since Chrome 18
-             */
+            /** The ID of the tab that opened this tab. If specified, the opener tab must be in the same window as the newly created tab. */
             openerTabId?: number | undefined;
-            /**
-             * Optional.
-             * The URL to navigate the tab to initially. Fully-qualified URLs must include a scheme (i.e. 'http://www.google.com', not 'www.google.com'). Relative URLs will be relative to the current page within the extension. Defaults to the New Tab Page.
-             */
+            /** The URL to initially navigate the tab to. Fully-qualified URLs must include a scheme (i.e., 'http://www.google.com', not 'www.google.com'). Relative URLs are relative to the current page within the extension. Defaults to the New Tab Page. */
             url?: string | undefined;
-            /**
-             * Optional. Whether the tab should be pinned. Defaults to false
-             * @since Chrome 9
-             */
+            /** Whether the tab should be pinned. Defaults to `false` */
             pinned?: boolean | undefined;
-            /** Optional. The window to create the new tab in. Defaults to the current window. */
+            /** The window in which to create the new tab. Defaults to the current window. */
             windowId?: number | undefined;
-            /**
-             * Optional.
-             * Whether the tab should become the active tab in the window. Does not affect whether the window is focused (see windows.update). Defaults to true.
-             * @since Chrome 16
-             */
+            /** Whether the tab should become the active tab in the window. Does not affect whether the window is focused (see {@link windows.update}). Defaults to `true`. */
             active?: boolean | undefined;
             /**
-             * Optional. Whether the tab should become the selected tab in the window. Defaults to true
-             * @deprecated since Chrome 33. Please use active.
+             * Whether the tab should become the selected tab in the window. Defaults to `true`
+             * @deprecated since Chrome 33. Please use {@link CreateProperties.active active}.
              */
             selected?: boolean | undefined;
         }
 
         export interface MoveProperties {
-            /** The position to move the window to. -1 will place the tab at the end of the window. */
+            /** The position to move the window to. Use `-1` to place the tab at the end of the window. */
             index: number;
-            /** Optional. Defaults to the window the tab is currently in. */
+            /** Defaults to the window the tab is currently in. */
             windowId?: number | undefined;
         }
 
         export interface UpdateProperties {
-            /**
-             * Optional. Whether the tab should be pinned.
-             * @since Chrome 9
-             */
+            /** Whether the tab should be pinned. */
             pinned?: boolean | undefined;
-            /**
-             * Optional. The ID of the tab that opened this tab. If specified, the opener tab must be in the same window as this tab.
-             * @since Chrome 18
-             */
+            /** The ID of the tab that opened this tab. If specified, the opener tab must be in the same window as this tab. */
             openerTabId?: number | undefined;
-            /** Optional. A URL to navigate the tab to. */
+            /** A URL to navigate the tab to. JavaScript URLs are not supported; use {@link scripting.executeScript} instead. */
             url?: string | undefined;
-            /**
-             * Optional. Adds or removes the tab from the current selection.
-             * @since Chrome 16
-             */
+            /** Adds or removes the tab from the current selection. */
             highlighted?: boolean | undefined;
-            /**
-             * Optional. Whether the tab should be active. Does not affect whether the window is focused (see windows.update).
-             * @since Chrome 16
-             */
+            /** Whether the tab should be active. Does not affect whether the window is focused (see {@link windows.update}).*/
             active?: boolean | undefined;
             /**
-             * Optional. Whether the tab should be selected.
-             * @deprecated since Chrome 33. Please use highlighted.
+             * Whether the tab should be selected.
+             * @deprecated since Chrome 33. Please use {@link highlighted}.
              */
             selected?: boolean | undefined;
             /**
-             * Optional. Whether the tab should be muted.
+             * Whether the tab should be muted.
              * @since Chrome 45
              */
             muted?: boolean | undefined;
             /**
-             * Optional. Whether the tab should be discarded automatically by the browser when resources are low.
+             * Whether the tab should be discarded automatically by the browser when resources are low.
              * @since Chrome 54
              */
             autoDiscardable?: boolean | undefined;
         }
 
         export interface ReloadProperties {
-            /** Optional. Whether using any local cache. Default is false. */
+            /** Whether to bypass local caching. Defaults to `false`. */
             bypassCache?: boolean | undefined;
         }
 
         export interface ConnectInfo {
-            /** Optional. Will be passed into onConnect for content scripts that are listening for the connection event. */
+            /** Is passed into onConnect for content scripts that are listening for the connection event. */
             name?: string | undefined;
-            /**
-             * Open a port to a specific frame identified by frameId instead of all frames in the tab.
-             * @since Chrome 41
-             */
+            /** Open a port to a specific frame identified by `frameId` instead of all frames in the tab. */
             frameId?: number | undefined;
             /**
-             * Optional. Open a port to a specific document identified by documentId instead of all frames in the tab.
+             * Open a port to a specific document identified by `documentId` instead of all frames in the tab.
              * @since Chrome 106
              */
             documentId?: string;
         }
 
         export interface MessageSendOptions {
-            /** Optional. Send a message to a specific frame identified by frameId instead of all frames in the tab. */
+            /** Send a message to a specific frame identified by `frameId` instead of all frames in the tab. */
             frameId?: number | undefined;
             /**
-             * Optional. Send a message to a specific document identified by documentId instead of all frames in the tab.
+             * Send a message to a specific document identified by `documentId` instead of all frames in the tab.
              * @since Chrome 106
              */
             documentId?: string;
         }
 
         export interface GroupOptions {
-            /** Optional. Configurations for creating a group. Cannot be used if groupId is already specified. */
+            /** Configurations for creating a group. Cannot be used if groupId is already specified. */
             createProperties?: {
-                /** Optional. The window of the new group. Defaults to the current window. */
+                /** The window of the new group. Defaults to the current window. */
                 windowId?: number | undefined;
             } | undefined;
-            /** Optional. The ID of the group to add the tabs to. If not specified, a new group will be created. */
+            /** The ID of the group to add the tabs to. If not specified, a new group will be created. */
             groupId?: number | undefined;
-            /** TOptional. he tab ID or list of tab IDs to add to the specified group. */
-            tabIds?: number | number[] | undefined;
+            /** The tab ID or list of tab IDs to add to the specified group. */
+            tabIds?: number | [number, ...number[]] | undefined;
         }
 
         export interface HighlightInfo {
             /** One or more tab indices to highlight. */
             tabs: number | number[];
-            /** Optional. The window that contains the tabs. */
+            /** The window that contains the tabs. */
             windowId?: number | undefined;
         }
 
         export interface QueryInfo {
-            /**
-             * Optional. Whether the tabs have completed loading.
-             * One of: "loading", or "complete"
-             */
-            status?: "loading" | "complete" | undefined;
-            /**
-             * Optional. Whether the tabs are in the last focused window.
-             * @since Chrome 19
-             */
+            /** The tab loading status. */
+            status?: `${TabStatus}` | undefined;
+            /** Whether the tabs are in the last focused window. */
             lastFocusedWindow?: boolean | undefined;
-            /** Optional. The ID of the parent window, or windows.WINDOW_ID_CURRENT for the current window. */
+            /** The ID of the parent window, or {@link windows.WINDOW_ID_CURRENT} for the current window. */
             windowId?: number | undefined;
-            /**
-             * Optional. The type of window the tabs are in.
-             * One of: "normal", "popup", "panel", "app", or "devtools"
-             */
-            windowType?: "normal" | "popup" | "panel" | "app" | "devtools" | undefined;
-            /** Optional. Whether the tabs are active in their windows. */
+            /** The type of window the tabs are in. */
+            windowType?: `${WindowType}` | undefined;
+            /** Whether the tabs are active in their windows. */
             active?: boolean | undefined;
-            /**
-             * Optional. The position of the tabs within their windows.
-             * @since Chrome 18
-             */
+            /** The position of the tabs within their windows. */
             index?: number | undefined;
-            /** Match page titles against a pattern. This property is ignored if the extension does not have the `tabs` permission or host permissions for the page. */
+            /** Match page titles against a pattern. This property is ignored if the extension does not have the `"tabs"` permission or host permissions for the page. */
             title?: string | undefined;
-            /** Match tabs against one or more URL patterns. Fragment identifiers are not matched. This property is ignored if the extension does not have the `tabs` permission or host permissions for the page. */
+            /** Match tabs against one or more URL patterns. Fragment identifiers are not matched. This property is ignored if the extension does not have the `"tabs"` permission or host permissions for the page. */
             url?: string | string[] | undefined;
-            /**
-             * Optional. Whether the tabs are in the current window.
-             * @since Chrome 19
-             */
+            /** Whether the tabs are in the current window. */
             currentWindow?: boolean | undefined;
-            /** Optional. Whether the tabs are highlighted. */
+            /** Whether the tabs are highlighted. */
             highlighted?: boolean | undefined;
             /**
-             * Optional.
-             * Whether the tabs are discarded. A discarded tab is one whose content has been unloaded from memory, but is still visible in the tab strip. Its content gets reloaded the next time it's activated.
+             * Whether the tabs are discarded. A discarded tab is one whose content has been unloaded from memory, but is still visible in the tab strip. Its content is reloaded the next time it is activated.
              * @since Chrome 54
              */
             discarded?: boolean | undefined;
@@ -11505,866 +11476,545 @@ declare namespace chrome {
              * Whether the tabs are frozen. A frozen tab cannot execute tasks, including event handlers or timers. It is visible in the tab strip and its content is loaded in memory. It is unfrozen on activation.
              * @since Chrome 132
              */
-            frozen?: boolean;
+            frozen?: boolean | undefined;
             /**
-             * Optional.
              * Whether the tabs can be discarded automatically by the browser when resources are low.
              * @since Chrome 54
              */
             autoDiscardable?: boolean | undefined;
-            /** Optional. Whether the tabs are pinned. */
+            /** Whether the tabs are pinned. */
             pinned?: boolean | undefined;
             /**
-             * Optional. Whether the tabs are audible.
+             * Whether the tabs are audible.
              * @since Chrome 45
              */
             audible?: boolean | undefined;
             /**
-             * Optional. Whether the tabs are muted.
+             * Whether the tabs are muted.
              * @since Chrome 45
              */
             muted?: boolean | undefined;
             /**
-             * Optional. The ID of the group that the tabs are in, or chrome.tabGroups.TAB_GROUP_ID_NONE for ungrouped tabs.
+             * The ID of the group that the tabs are in, or {@link chrome.tabGroups.TAB_GROUP_ID_NONE} for ungrouped tabs.
              * @since Chrome 88
              */
             groupId?: number | undefined;
-        }
-
-        export interface TabHighlightInfo {
-            windowId: number;
-            tabIds: number[];
         }
 
         export interface TabRemoveInfo {
-            /**
-             * The window whose tab is closed.
-             * @since Chrome 25
-             */
+            /** The window whose tab is closed */
             windowId: number;
-            /** True when the tab is being closed because its window is being closed. */
+            /** True when the tab was closed because its parent window was closed. */
             isWindowClosing: boolean;
         }
 
-        export interface TabAttachInfo {
-            newPosition: number;
-            newWindowId: number;
-        }
-
-        export interface TabChangeInfo {
-            /** Optional. The status of the tab. Can be either loading or complete. */
-            status?: string | undefined;
-            /**
-             * The tab's new pinned state.
-             * @since Chrome 9
-             */
-            pinned?: boolean | undefined;
-            /** Optional. The tab's URL if it has changed. */
-            url?: string | undefined;
-            /**
-             * The tab's new audible state.
-             * @since Chrome 45
-             */
-            audible?: boolean | undefined;
-            /**
-             * The tab's new discarded state.
-             * @since Chrome 54
-             */
-            discarded?: boolean | undefined;
-            /**
-             * The tab's new auto-discardable
-             * @since Chrome 54
-             */
-            autoDiscardable?: boolean | undefined;
-            /**
-             * The tab's new group.
-             * @since Chrome 88
-             */
-            groupId?: number | undefined;
-            /**
-             * The tab's new muted state and the reason for the change.
-             * @since Chrome 46
-             */
-            mutedInfo?: MutedInfo | undefined;
-            /**
-             * The tab's new favicon URL.
-             * @since Chrome 27
-             */
-            favIconUrl?: string | undefined;
-            /**
-             * The tab's new frozen state.
-             * @since Chrome 132
-             */
-            frozen?: boolean;
-            /**
-             * The tab's new title.
-             * @since Chrome 48
-             */
-            title?: string | undefined;
-        }
-
-        export interface TabMoveInfo {
-            toIndex: number;
-            windowId: number;
-            fromIndex: number;
-        }
-
-        export interface TabDetachInfo {
-            oldWindowId: number;
-            oldPosition: number;
-        }
-
-        export interface TabActiveInfo {
-            /** The ID of the tab that has become active. */
-            tabId: number;
-            /** The ID of the window the active tab changed inside of. */
-            windowId: number;
-        }
-
-        export interface TabWindowInfo {
-            /** The ID of the window of where the tab is located. */
-            windowId: number;
-        }
-
-        export interface ZoomChangeInfo {
-            tabId: number;
-            oldZoomFactor: number;
-            newZoomFactor: number;
-            zoomSettings: ZoomSettings;
-        }
-
-        export interface TabHighlightedEvent extends chrome.events.Event<(highlightInfo: TabHighlightInfo) => void> {}
-
-        export interface TabRemovedEvent
-            extends chrome.events.Event<(tabId: number, removeInfo: TabRemoveInfo) => void>
-        {}
-
-        export interface TabUpdatedEvent
-            extends chrome.events.Event<(tabId: number, changeInfo: TabChangeInfo, tab: Tab) => void>
-        {}
-
-        export interface TabAttachedEvent
-            extends chrome.events.Event<(tabId: number, attachInfo: TabAttachInfo) => void>
-        {}
-
-        export interface TabMovedEvent extends chrome.events.Event<(tabId: number, moveInfo: TabMoveInfo) => void> {}
-
-        export interface TabDetachedEvent
-            extends chrome.events.Event<(tabId: number, detachInfo: TabDetachInfo) => void>
-        {}
-
-        export interface TabCreatedEvent extends chrome.events.Event<(tab: Tab) => void> {}
-
-        export interface TabActivatedEvent extends chrome.events.Event<(activeInfo: TabActiveInfo) => void> {}
-
-        export interface TabReplacedEvent
-            extends chrome.events.Event<(addedTabId: number, removedTabId: number) => void>
-        {}
-
-        export interface TabSelectedEvent
-            extends chrome.events.Event<(tabId: number, selectInfo: TabWindowInfo) => void>
-        {}
-
-        export interface TabZoomChangeEvent extends chrome.events.Event<(ZoomChangeInfo: ZoomChangeInfo) => void> {}
-
         /**
          * Injects JavaScript code into a page. For details, see the programmatic injection section of the content scripts doc.
-         * @param details Details of the script or CSS to inject. Either the code or the file property must be set, but both may not be set at the same time.
-         * @return The `executeScript` method provides its result via callback or returned as a `Promise` (MV3 only). The result of the script in every injected frame.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         *
+         * MV2 only
+         * @param tabId The ID of the tab in which to run the script; defaults to the active tab of the current window.
+         * @param details Details of the script to run. Either the code or the file property must be set, but both may not be set at the same time
+         * @deprecated since Chrome 99. Replaced by {@link scripting.executeScript} in Manifest V3.
          */
-        export function executeScript(details: extensionTypes.InjectDetails): Promise<any[]>;
-        /**
-         * Injects JavaScript code into a page. For details, see the programmatic injection section of the content scripts doc.
-         * @param details Details of the script or CSS to inject. Either the code or the file property must be set, but both may not be set at the same time.
-         * @param callback Optional. Called after all the JavaScript has been executed.
-         * Parameter result: The result of the script in every injected frame.
-         */
-        export function executeScript(details: extensionTypes.InjectDetails, callback?: (result: any[]) => void): void;
-        /**
-         * Injects JavaScript code into a page. For details, see the programmatic injection section of the content scripts doc.
-         * @param tabId Optional. The ID of the tab in which to run the script; defaults to the active tab of the current window.
-         * @param details Details of the script or CSS to inject. Either the code or the file property must be set, but both may not be set at the same time.
-         * @return The `executeScript` method provides its result via callback or returned as a `Promise` (MV3 only). The result of the script in every injected frame.
-         */
-        export function executeScript(tabId: number, details: extensionTypes.InjectDetails): Promise<any[]>;
-        /**
-         * Injects JavaScript code into a page. For details, see the programmatic injection section of the content scripts doc.
-         * @param tabId Optional. The ID of the tab in which to run the script; defaults to the active tab of the current window.
-         * @param details Details of the script or CSS to inject. Either the code or the file property must be set, but both may not be set at the same time.
-         * @param callback Optional. Called after all the JavaScript has been executed.
-         * Parameter result: The result of the script in every injected frame.
-         */
+        export function executeScript(details: extensionTypes.InjectDetails): Promise<any[] | undefined>;
         export function executeScript(
-            tabId: number,
+            tabId: number | undefined,
             details: extensionTypes.InjectDetails,
-            callback?: (result: any[]) => void,
+        ): Promise<any[] | undefined>;
+        export function executeScript(details: extensionTypes.InjectDetails, callback: (result?: any[]) => void): void;
+        export function executeScript(
+            tabId: number | undefined,
+            details: extensionTypes.InjectDetails,
+            callback: (result?: any[]) => void,
         ): void;
-        /** Retrieves details about the specified tab. */
-        export function get(tabId: number, callback: (tab: Tab) => void): void;
+
         /**
-         * Retrieves details about the specified tab.
-         * @return The `get` method provides its result via callback or returned as a `Promise` (MV3 only).
+         * Retrieves details about the specified tab
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
          */
         export function get(tabId: number): Promise<Tab>;
+        export function get(tabId: number, callback: (tab: Tab) => void): void;
+
         /**
          * Gets details about all tabs in the specified window.
-         * @deprecated since Chrome 33. Please use tabs.query {windowId: windowId}.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         *
+         * MV2 only
+         * @deprecated Please use {@link tabs.query} `{windowId: windowId}`.
          */
-        export function getAllInWindow(callback: (tab: Tab) => void): void;
+        export function getAllInWindow(windowId?: number): Promise<Tab[]>;
+        export function getAllInWindow(callback: (tabs: Tab[]) => void): void;
+        export function getAllInWindow(windowId: number | undefined, callback: (tabs: Tab[]) => void): void;
+
         /**
-         * Gets details about all tabs in the specified window.
-         * @return The `getAllInWindow` method provides its result via callback or returned as a `Promise` (MV3 only).
-         * @deprecated since Chrome 33. Please use tabs.query {windowId: windowId}.
-         */
-        export function getAllInWindow(): Promise<Tab>;
-        /**
-         * Gets details about all tabs in the specified window.
-         * @deprecated since Chrome 33. Please use tabs.query {windowId: windowId}.
-         * @param windowId Optional. Defaults to the current window.
-         */
-        export function getAllInWindow(windowId: number, callback: (tab: Tab) => void): void;
-        /**
-         * Gets details about all tabs in the specified window.
-         * @deprecated since Chrome 33. Please use tabs.query {windowId: windowId}.
-         * @param windowId Optional. Defaults to the current window.
-         * @return The `getAllInWindow` method provides its result via callback or returned as a `Promise` (MV3 only).
-         */
-        export function getAllInWindow(windowId: number): Promise<Tab>;
-        /** Gets the tab that this script call is being made from. May be undefined if called from a non-tab context (for example: a background page or popup view). */
-        export function getCurrent(callback: (tab?: Tab) => void): void;
-        /**
-         * Gets the tab that this script call is being made from. May be undefined if called from a non-tab context (for example: a background page or popup view).
-         * @return The `getCurrent` method provides its result via callback or returned as a `Promise` (MV3 only).
+         * Gets the tab that this script call is being made from. Returns `undefined` if called from a non-tab context (for example, a background page or popup view).
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
          */
         export function getCurrent(): Promise<Tab | undefined>;
+        export function getCurrent(callback: (tab?: Tab) => void): void;
+
         /**
          * Gets the tab that is selected in the specified window.
-         * @deprecated since Chrome 33. Please use tabs.query {active: true}.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         *
+         * MV2 only
+         * @param windowId Defaults to the current window.
+         * @deprecated Please use {@link tabs.query} `{active: true}`.
          */
+        export function getSelected(windowId?: number): Promise<Tab>;
         export function getSelected(callback: (tab: Tab) => void): void;
-        /**
-         * Gets the tab that is selected in the specified window.
-         * @return The `getSelected` method provides its result via callback or returned as a `Promise` (MV3 only).
-         * @deprecated since Chrome 33. Please use tabs.query {active: true}.
-         */
-        export function getSelected(): Promise<Tab>;
-        /**
-         * Gets the tab that is selected in the specified window.
-         * @deprecated since Chrome 33. Please use tabs.query {active: true}.
-         * @param windowId Optional. Defaults to the current window.
-         */
-        export function getSelected(windowId: number, callback: (tab: Tab) => void): void;
-        /**
-         * Gets the tab that is selected in the specified window.
-         * @deprecated since Chrome 33. Please use tabs.query {active: true}.
-         * @param windowId Optional. Defaults to the current window.
-         * @return The `getSelected` method provides its result via callback or returned as a `Promise` (MV3 only).
-         */
-        export function getSelected(windowId: number): Promise<Tab>;
+        export function getSelected(windowId: number | undefined, callback: (tab: Tab) => void): void;
+
         /**
          * Creates a new tab.
-         * @return The `create` method provides its result via callback or returned as a `Promise` (MV3 only). Details about the created tab. Will contain the ID of the new tab.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
          */
         export function create(createProperties: CreateProperties): Promise<Tab>;
-        /**
-         * Creates a new tab.
-         * @param callback Optional.
-         * Parameter tab: Details about the created tab. Will contain the ID of the new tab.
-         */
         export function create(createProperties: CreateProperties, callback: (tab: Tab) => void): void;
+
         /**
          * Moves one or more tabs to a new position within its window, or to a new window. Note that tabs can only be moved to and from normal (window.type === "normal") windows.
-         * @param tabId The tab to move.
-         * @return The `move` method provides its result via callback or returned as a `Promise` (MV3 only). Details about the moved tab.
+         * @param tabId The tab ID to move.
+         * @param tabIds List of tab IDs to move.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
          */
         export function move(tabId: number, moveProperties: MoveProperties): Promise<Tab>;
-        /**
-         * Moves one or more tabs to a new position within its window, or to a new window. Note that tabs can only be moved to and from normal (window.type === "normal") windows.
-         * @param tabId The tab to move.
-         * @param callback Optional.
-         * Parameter tab: Details about the moved tab.
-         */
-        export function move(tabId: number, moveProperties: MoveProperties, callback: (tab: Tab) => void): void;
-        /**
-         * Moves one or more tabs to a new position within its window, or to a new window. Note that tabs can only be moved to and from normal (window.type === "normal") windows.
-         * @param tabIds The tabs to move.
-         * @return The `move` method provides its result via callback or returned as a `Promise` (MV3 only). Details about the moved tabs.
-         */
         export function move(tabIds: number[], moveProperties: MoveProperties): Promise<Tab[]>;
-        /**
-         * Moves one or more tabs to a new position within its window, or to a new window. Note that tabs can only be moved to and from normal (window.type === "normal") windows.
-         * @param tabIds The tabs to move.
-         * @param callback Optional.
-         * Parameter tabs: Details about the moved tabs.
-         */
+        export function move(tabId: number, moveProperties: MoveProperties, callback: (tab: Tab) => void): void;
         export function move(tabIds: number[], moveProperties: MoveProperties, callback: (tabs: Tab[]) => void): void;
+
         /**
-         * Modifies the properties of a tab. Properties that are not specified in updateProperties are not modified.
-         * @return The `update` method provides its result via callback or returned as a `Promise` (MV3 only). Details about the updated tab. The `url`, `pendingUrl`, `title` and `favIconUrl` properties are only included on the {@link tabs.Tab} object if the extension has the `tabs` permission or has host permissions for the page..
+         * Modifies the properties of a tab. Properties that are not specified in `updateProperties` are not modified.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         * @param tabId Defaults to the selected tab of the current window.
          */
         export function update(updateProperties: UpdateProperties): Promise<Tab | undefined>;
-        /**
-         * Modifies the properties of a tab. Properties that are not specified in updateProperties are not modified.
-         * @param callback Optional.
-         * Optional parameter tab: Details about the updated tab. The `url`, `pendingUrl`, `title` and `favIconUrl` properties are only included on the {@link tabs.Tab} object if the extension has the `tabs` permission or has host permissions for the page..
-         */
+        export function update(tabId: number | undefined, updateProperties: UpdateProperties): Promise<Tab | undefined>;
         export function update(updateProperties: UpdateProperties, callback: (tab?: Tab) => void): void;
+        export function update(
+            tabId: number | undefined,
+            updateProperties: UpdateProperties,
+            callback: (tab?: Tab) => void,
+        ): void;
+
         /**
-         * Modifies the properties of a tab. Properties that are not specified in updateProperties are not modified.
-         * @param tabId Defaults to the selected tab of the current window.
-         * @return The `update` method provides its result via callback or returned as a `Promise` (MV3 only). Details about the updated tab. The `url`, `pendingUrl`, `title` and `favIconUrl` properties are only included on the {@link tabs.Tab} object if the extension has the `tabs` permission or has host permissions for the page..
-         */
-        export function update(tabId: number, updateProperties: UpdateProperties): Promise<Tab | undefined>;
-        /**
-         * Modifies the properties of a tab. Properties that are not specified in updateProperties are not modified.
-         * @param tabId Defaults to the selected tab of the current window.
-         * @param callback Optional.
-         * Optional parameter tab: Details about the updated tab. The `url`, `pendingUrl`, `title` and `favIconUrl` properties are only included on the {@link tabs.Tab} object if the extension has the `tabs` permission or has host permissions for the page..
-         */
-        export function update(tabId: number, updateProperties: UpdateProperties, callback: (tab?: Tab) => void): void;
-        /**
-         * Closes a tab.
-         * @param tabId The tab to close.
-         * @return The `remove` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+         * Closes one or more tabs.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         * @param tabId The tab ID to close.
+         * @param tabIds List of tab IDs to close.
          */
         export function remove(tabId: number): Promise<void>;
-        /**
-         * Closes a tab.
-         * @param tabId The tab to close.
-         */
-        export function remove(tabId: number, callback: () => void): void;
-        /**
-         * Closes several tabs.
-         * @param tabIds The list of tabs to close.
-         * @return The `remove` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
-         */
         export function remove(tabIds: number[]): Promise<void>;
-        /**
-         * Closes several tabs.
-         * @param tabIds The list of tabs to close.
-         */
+        export function remove(tabId: number, callback: () => void): void;
         export function remove(tabIds: number[], callback: () => void): void;
+
         /**
-         * Captures the visible area of the currently active tab in the specified window. You must have <all_urls> permission to use this method.
-         * @param callback
-         * Parameter dataUrl: A data URL which encodes an image of the visible area of the captured tab. May be assigned to the 'src' property of an HTML Image element for display.
-         */
-        export function captureVisibleTab(callback: (dataUrl: string) => void): void;
-        /**
-         * Captures the visible area of the currently active tab in the specified window. You must have <all_urls> permission to use this method.
-         * @return The `captureVisibleTab` method provides its result via callback or returned as a `Promise` (MV3 only). A data URL which encodes an image of the visible area of the captured tab. May be assigned to the 'src' property of an HTML Image element for display.
+         * Captures the visible area of the currently active tab in the specified window. In order to call this method, the extension must have either the [<all\_urls>](https://developer.chrome.com/extensions/develop/concepts/declare-permissions) permission or the [activeTab](https://developer.chrome.com/docs/extensions/develop/concepts/activeTab) permission. In addition to sites that extensions can normally access, this method allows extensions to capture sensitive sites that are otherwise restricted, including chrome:-scheme pages, other extensions' pages, and data: URLs. These sensitive sites can only be captured with the activeTab permission. File URLs may be captured only if the extension has been granted file access.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         * @param windowId The target window. Defaults to the current window.
          */
         export function captureVisibleTab(): Promise<string>;
-        /**
-         * Captures the visible area of the currently active tab in the specified window. You must have <all_urls> permission to use this method.
-         * @param windowId Optional. The target window. Defaults to the current window.
-         * @param callback
-         * Parameter dataUrl: A data URL which encodes an image of the visible area of the captured tab. May be assigned to the 'src' property of an HTML Image element for display.
-         */
-        export function captureVisibleTab(windowId: number, callback: (dataUrl: string) => void): void;
-        /**
-         * Captures the visible area of the currently active tab in the specified window. You must have <all_urls> permission to use this method.
-         * @param windowId Optional. The target window. Defaults to the current window.
-         * @return The `captureVisibleTab` method provides its result via callback or returned as a `Promise` (MV3 only). A data URL which encodes an image of the visible area of the captured tab. May be assigned to the 'src' property of an HTML Image element for display.
-         */
         export function captureVisibleTab(windowId: number): Promise<string>;
-        /**
-         * Captures the visible area of the currently active tab in the specified window. You must have <all_urls> permission to use this method.
-         * @param options Optional. Details about the format and quality of an image.
-         * @return The `captureVisibleTab` method provides its result via callback or returned as a `Promise` (MV3 only). A data URL which encodes an image of the visible area of the captured tab. May be assigned to the 'src' property of an HTML Image element for display.
-         */
         export function captureVisibleTab(options: extensionTypes.ImageDetails): Promise<string>;
-        /**
-         * Captures the visible area of the currently active tab in the specified window. You must have <all_urls> permission to use this method.
-         * @param options Optional. Details about the format and quality of an image.
-         * @param callback
-         * Parameter dataUrl: A data URL which encodes an image of the visible area of the captured tab. May be assigned to the 'src' property of an HTML Image element for display.
-         */
+        export function captureVisibleTab(windowId: number, options: extensionTypes.ImageDetails): Promise<string>;
+        export function captureVisibleTab(callback: (dataUrl: string) => void): void;
+        export function captureVisibleTab(windowId: number, callback: (dataUrl: string) => void): void;
         export function captureVisibleTab(
             options: extensionTypes.ImageDetails,
             callback: (dataUrl: string) => void,
         ): void;
-        /**
-         * Captures the visible area of the currently active tab in the specified window. You must have <all_urls> permission to use this method.
-         * @param windowId Optional. The target window. Defaults to the current window.
-         * @param options Optional. Details about the format and quality of an image.
-         * @return The `captureVisibleTab` method provides its result via callback or returned as a `Promise` (MV3 only). A data URL which encodes an image of the visible area of the captured tab. May be assigned to the 'src' property of an HTML Image element for display.
-         */
-        export function captureVisibleTab(
-            windowId: number,
-            options: extensionTypes.ImageDetails,
-        ): Promise<string>;
-        /**
-         * Captures the visible area of the currently active tab in the specified window. You must have <all_urls> permission to use this method.
-         * @param windowId Optional. The target window. Defaults to the current window.
-         * @param options Optional. Details about the format and quality of an image.
-         * @param callback
-         * Parameter dataUrl: A data URL which encodes an image of the visible area of the captured tab. May be assigned to the 'src' property of an HTML Image element for display.
-         */
         export function captureVisibleTab(
             windowId: number,
             options: extensionTypes.ImageDetails,
             callback: (dataUrl: string) => void,
         ): void;
+
         /**
          * Reload a tab.
-         * @since Chrome 16
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
          * @param tabId The ID of the tab to reload; defaults to the selected tab of the current window.
-         * @return The `reload` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
-         */
-        export function reload(tabId: number): Promise<void>;
-        /**
-         * Reload a tab.
-         * @since Chrome 16
-         * @param tabId The ID of the tab to reload; defaults to the selected tab of the current window.
-         */
-        export function reload(tabId: number, callback?: () => void): void;
-        /**
-         * Reload the selected tab of the current window.
-         * @since Chrome 16
-         * @return The `reload` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
-         */
-        export function reload(reloadProperties: ReloadProperties): Promise<void>;
-        /**
-         * Reload the selected tab of the current window.
-         * @since Chrome 16
-         */
-        export function reload(reloadProperties: ReloadProperties, callback: () => void): void;
-        /**
-         * Reload the selected tab of the current window.
-         * @since Chrome 16
-         * @return The `reload` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
-         */
-        export function reload(tabId: number, reloadProperties: ReloadProperties): Promise<void>;
-        /**
-         * Reload the selected tab of the current window.
-         * @since Chrome 16
-         */
-        export function reload(tabId: number, reloadProperties: ReloadProperties, callback: () => void): void;
-        /**
-         * Reload the selected tab of the current window.
-         * @since Chrome 16
-         * @return The `reload` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
          */
         export function reload(): Promise<void>;
-        /**
-         * Reload the selected tab of the current window.
-         * @since Chrome 16
-         */
+        export function reload(tabId: number): Promise<void>;
+        export function reload(reloadProperties: ReloadProperties): Promise<void>;
+        export function reload(tabId: number, reloadProperties: ReloadProperties): Promise<void>;
         export function reload(callback: () => void): void;
+        export function reload(tabId: number | undefined, callback: () => void): void;
+        export function reload(reloadProperties: ReloadProperties | undefined, callback: () => void): void;
+        export function reload(
+            tabId: number | undefined,
+            reloadProperties: ReloadProperties | undefined,
+            callback: () => void,
+        ): void;
+
         /**
          * Duplicates a tab.
-         * @since Chrome 23
-         * @param tabId The ID of the tab which is to be duplicated.
-         * @return The `duplicate` method provides its result via callback or returned as a `Promise` (MV3 only).
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         * @param tabId The ID of the tab to duplicate.
          */
         export function duplicate(tabId: number): Promise<Tab | undefined>;
-        /**
-         * Duplicates a tab.
-         * @since Chrome 23
-         * @param tabId The ID of the tab which is to be duplicated.
-         * @param callback Optional.
-         * Optional parameter tab: Details about the duplicated tab. The `url`, `pendingUrl`, `title` and `favIconUrl` properties are only included on the {@link tabs.Tab} object if the extension has the `tabs` permission or has host permissions for the page.
-         */
         export function duplicate(tabId: number, callback: (tab?: Tab) => void): void;
+
         /**
-         * Sends a single message to the content script(s) in the specified tab, with an optional callback to run when a response is sent back. The runtime.onMessage event is fired in each content script running in the specified tab for the current extension.
-         * @since Chrome 20
+         * Sends a single message to the content script(s) in the specified tab, with an optional callback to run when a response is sent back. The {@link runtime.onMessage} event is fired in each content script running in the specified tab for the current extension.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 99.
          */
         export function sendMessage<M = any, R = any>(
             tabId: number,
             message: M,
-            responseCallback: (response: R) => void,
-        ): void;
-        /**
-         * Sends a single message to the content script(s) in the specified tab, with an optional callback to run when a response is sent back. The runtime.onMessage event is fired in each content script running in the specified tab for the current extension.
-         * @since Chrome 41
-         * @param responseCallback Optional.
-         * Parameter response: The JSON response object sent by the handler of the message. If an error occurs while connecting to the specified tab, the callback will be called with no arguments and runtime.lastError will be set to the error message.
-         */
-        export function sendMessage<M = any, R = any>(
-            tabId: number,
-            message: M,
-            options: MessageSendOptions,
-            responseCallback: (response: R) => void,
-        ): void;
-        /**
-         * Sends a single message to the content script(s) in the specified tab, with an optional callback to run when a response is sent back. The runtime.onMessage event is fired in each content script running in the specified tab for the current extension.
-         * @since Chrome 99
-         */
-        export function sendMessage<M = any, R = any>(tabId: number, message: M): Promise<R>;
-        /**
-         * Sends a single message to the content script(s) in the specified tab, with an optional callback to run when a response is sent back. The runtime.onMessage event is fired in each content script running in the specified tab for the current extension.
-         * @since Chrome 99
-         */
-        export function sendMessage<M = any, R = any>(
-            tabId: number,
-            message: M,
-            options: MessageSendOptions,
+            options?: MessageSendOptions,
         ): Promise<R>;
+        export function sendMessage<M = any, R = any>(
+            tabId: number,
+            message: M,
+            /** @since Chrome 99 */
+            callback: (response: R) => void,
+        ): void;
+        export function sendMessage<M = any, R = any>(
+            tabId: number,
+            message: M,
+            options: MessageSendOptions | undefined,
+            /** @since Chrome 99 */
+            callback: (response: R) => void,
+        ): void;
+
         /**
-         * Sends a single request to the content script(s) in the specified tab, with an optional callback to run when a response is sent back. The extension.onRequest event is fired in each content script running in the specified tab for the current extension.
-         * @deprecated since Chrome 33. Please use runtime.sendMessage.
-         * @param responseCallback Optional.
-         * Parameter response: The JSON response object sent by the handler of the request. If an error occurs while connecting to the specified tab, the callback will be called with no arguments and runtime.lastError will be set to the error message.
+         * Sends a single request to the content script(s) in the specified tab, with an optional callback to run when a response is sent back. The {@link extension.onRequest} event is fired in each content script running in the specified tab for the current extension.
+         *
+         * MV2 only
+         * @deprecated Please use {@link runtime.sendMessage}.
          */
         export function sendRequest<Request = any, Response = any>(
             tabId: number,
             request: Request,
-            responseCallback?: (response: Response) => void,
+        ): Promise<Response>;
+        export function sendRequest<Request = any, Response = any>(
+            tabId: number,
+            request: Request,
+            /** @since Chrome 99 */
+            callback?: (response: Response) => void,
         ): void;
-        /** Connects to the content script(s) in the specified tab. The runtime.onConnect event is fired in each content script running in the specified tab for the current extension. */
-        export function connect(tabId: number, connectInfo?: ConnectInfo): runtime.Port;
-        /**
-         * Injects CSS into a page. For details, see the programmatic injection section of the content scripts doc.
-         * @param details Details of the script or CSS to inject. Either the code or the file property must be set, but both may not be set at the same time.
-         * @return The `insertCSS` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
-         */
-        export function insertCSS(details: extensionTypes.InjectDetails): Promise<void>;
-        /**
-         * Injects CSS into a page. For details, see the programmatic injection section of the content scripts doc.
-         * @param details Details of the script or CSS to inject. Either the code or the file property must be set, but both may not be set at the same time.
-         * @param callback Optional. Called when all the CSS has been inserted.
-         */
-        export function insertCSS(details: extensionTypes.InjectDetails, callback: () => void): void;
-        /**
-         * Injects CSS into a page. For details, see the programmatic injection section of the content scripts doc.
-         * @param tabId Optional. The ID of the tab in which to insert the CSS; defaults to the active tab of the current window.
-         * @param details Details of the script or CSS to inject. Either the code or the file property must be set, but both may not be set at the same time.
-         * @return The `insertCSS` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
-         */
-        export function insertCSS(tabId: number, details: extensionTypes.InjectDetails): Promise<void>;
-        /**
-         * Injects CSS into a page. For details, see the programmatic injection section of the content scripts doc.
-         * @param tabId Optional. The ID of the tab in which to insert the CSS; defaults to the active tab of the current window.
-         * @param details Details of the script or CSS to inject. Either the code or the file property must be set, but both may not be set at the same time.
-         * @param callback Optional. Called when all the CSS has been inserted.
-         */
-        export function insertCSS(tabId: number, details: extensionTypes.InjectDetails, callback: () => void): void;
-        /**
-         * Highlights the given tabs.
-         * @since Chrome 16
-         * @return The `highlight` method provides its result via callback or returned as a `Promise` (MV3 only). Contains details about the window whose tabs were highlighted.
-         */
-        export function highlight(highlightInfo: HighlightInfo): Promise<chrome.windows.Window>;
-        /**
-         * Highlights the given tabs.
-         * @since Chrome 16
-         * @param callback Optional.
-         * Parameter window: Contains details about the window whose tabs were highlighted.
-         */
-        export function highlight(
-            highlightInfo: HighlightInfo,
-            callback: (window: chrome.windows.Window) => void,
-        ): void;
-        /**
-         * Gets all tabs that have the specified properties, or all tabs if no properties are specified.
-         * @since Chrome 16
-         */
-        export function query(queryInfo: QueryInfo, callback: (result: Tab[]) => void): void;
-        /**
-         * Gets all tabs that have the specified properties, or all tabs if no properties are specified.
-         * @since Chrome 16
-         * @return The `query` method provides its result via callback or returned as a `Promise` (MV3 only).
-         */
-        export function query(queryInfo: QueryInfo): Promise<Tab[]>;
-        /**
-         * Detects the primary language of the content in a tab.
-         * @param callback
-         * Parameter language: An ISO language code such as en or fr. For a complete list of languages supported by this method, see kLanguageInfoTable. The 2nd to 4th columns will be checked and the first non-NULL value will be returned except for Simplified Chinese for which zh-CN will be returned. For an unknown language, und will be returned.
-         */
-        export function detectLanguage(callback: (language: string) => void): void;
-        /**
-         * Detects the primary language of the content in a tab.
-         * @return The `detectLanguage` method provides its result via callback or returned as a `Promise` (MV3 only). An ISO language code such as en or fr. For a complete list of languages supported by this method, see kLanguageInfoTable. The 2nd to 4th columns will be checked and the first non-NULL value will be returned except for Simplified Chinese for which zh-CN will be returned. For an unknown language, und will be returned.
-         */
-        export function detectLanguage(): Promise<string>;
-        /**
-         * Detects the primary language of the content in a tab.
-         * @param tabId Optional. Defaults to the active tab of the current window.
-         * @param callback
-         * Parameter language: An ISO language code such as en or fr. For a complete list of languages supported by this method, see kLanguageInfoTable. The 2nd to 4th columns will be checked and the first non-NULL value will be returned except for Simplified Chinese for which zh-CN will be returned. For an unknown language, und will be returned.
-         */
-        export function detectLanguage(tabId: number, callback: (language: string) => void): void;
-        /**
-         * Detects the primary language of the content in a tab.
-         * @param tabId Optional. Defaults to the active tab of the current window.
-         * @return The `detectLanguage` method provides its result via callback or returned as a `Promise` (MV3 only). An ISO language code such as en or fr. For a complete list of languages supported by this method, see kLanguageInfoTable. The 2nd to 4th columns will be checked and the first non-NULL value will be returned except for Simplified Chinese for which zh-CN will be returned. For an unknown language, und will be returned.
-         */
-        export function detectLanguage(tabId: number): Promise<string>;
-        /**
-         * Zooms a specified tab.
-         * @since Chrome 42
-         * @param zoomFactor The new zoom factor. Use a value of 0 here to set the tab to its current default zoom factor. Values greater than zero specify a (possibly non-default) zoom factor for the tab.
-         * @return The `setZoom` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
-         */
-        export function setZoom(zoomFactor: number): Promise<void>;
-        /**
-         * Zooms a specified tab.
-         * @since Chrome 42
-         * @param zoomFactor The new zoom factor. Use a value of 0 here to set the tab to its current default zoom factor. Values greater than zero specify a (possibly non-default) zoom factor for the tab.
-         * @param callback Optional. Called after the zoom factor has been changed.
-         */
-        export function setZoom(zoomFactor: number, callback: () => void): void;
-        /**
-         * Zooms a specified tab.
-         * @since Chrome 42
-         * @param tabId Optional. The ID of the tab to zoom; defaults to the active tab of the current window.
-         * @param zoomFactor The new zoom factor. Use a value of 0 here to set the tab to its current default zoom factor. Values greater than zero specify a (possibly non-default) zoom factor for the tab.
-         * @return The `setZoom` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
-         */
-        export function setZoom(tabId: number, zoomFactor: number): Promise<void>;
-        /**
-         * Zooms a specified tab.
-         * @since Chrome 42
-         * @param tabId Optional. The ID of the tab to zoom; defaults to the active tab of the current window.
-         * @param zoomFactor The new zoom factor. Use a value of 0 here to set the tab to its current default zoom factor. Values greater than zero specify a (possibly non-default) zoom factor for the tab.
-         * @param callback Optional. Called after the zoom factor has been changed.
-         */
-        export function setZoom(tabId: number, zoomFactor: number, callback: () => void): void;
-        /**
-         * Gets the current zoom factor of a specified tab.
-         * @since Chrome 42
-         * @param callback Called with the tab's current zoom factor after it has been fetched.
-         * Parameter zoomFactor: The tab's current zoom factor.
-         */
-        export function getZoom(callback: (zoomFactor: number) => void): void;
-        /**
-         * Gets the current zoom factor of a specified tab.
-         * @since Chrome 42
-         * @return The `getZoom` method provides its result via callback or returned as a `Promise` (MV3 only). The tab's current zoom factor.
-         */
-        export function getZoom(): Promise<number>;
-        /**
-         * Gets the current zoom factor of a specified tab.
-         * @since Chrome 42
-         * @param tabId Optional. The ID of the tab to get the current zoom factor from; defaults to the active tab of the current window.
-         * @param callback Called with the tab's current zoom factor after it has been fetched.
-         * Parameter zoomFactor: The tab's current zoom factor.
-         */
-        export function getZoom(tabId: number, callback: (zoomFactor: number) => void): void;
-        /**
-         * Gets the current zoom factor of a specified tab.
-         * @since Chrome 42
-         * @param tabId Optional. The ID of the tab to get the current zoom factor from; defaults to the active tab of the current window.
-         * @return The `getZoom` method provides its result via callback or returned as a `Promise` (MV3 only). The tab's current zoom factor.
-         */
-        export function getZoom(tabId: number): Promise<number>;
-        /**
-         * Sets the zoom settings for a specified tab, which define how zoom changes are handled. These settings are reset to defaults upon navigating the tab.
-         * @since Chrome 42
-         * @param zoomSettings Defines how zoom changes are handled and at what scope.
-         * @return The `setZoomSettings` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
-         */
-        export function setZoomSettings(zoomSettings: ZoomSettings): Promise<void>;
-        /**
-         * Sets the zoom settings for a specified tab, which define how zoom changes are handled. These settings are reset to defaults upon navigating the tab.
-         * @since Chrome 42
-         * @param zoomSettings Defines how zoom changes are handled and at what scope.
-         * @param callback Optional. Called after the zoom settings have been changed.
-         */
-        export function setZoomSettings(zoomSettings: ZoomSettings, callback: () => void): void;
-        /**
-         * Sets the zoom settings for a specified tab, which define how zoom changes are handled. These settings are reset to defaults upon navigating the tab.
-         * @since Chrome 42
-         * @param tabId Optional. The ID of the tab to change the zoom settings for; defaults to the active tab of the current window.
-         * @param zoomSettings Defines how zoom changes are handled and at what scope.
-         * @return The `setZoomSettings` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
-         */
-        export function setZoomSettings(tabId: number, zoomSettings: ZoomSettings): Promise<void>;
-        /**
-         * Sets the zoom settings for a specified tab, which define how zoom changes are handled. These settings are reset to defaults upon navigating the tab.
-         * @since Chrome 42
-         * @param tabId Optional. The ID of the tab to change the zoom settings for; defaults to the active tab of the current window.
-         * @param zoomSettings Defines how zoom changes are handled and at what scope.
-         * @param callback Optional. Called after the zoom settings have been changed.
-         */
-        export function setZoomSettings(tabId: number, zoomSettings: ZoomSettings, callback: () => void): void;
-        /**
-         * Gets the current zoom settings of a specified tab.
-         * @since Chrome 42
-         * @param callback Called with the tab's current zoom settings.
-         * Parameter zoomSettings: The tab's current zoom settings.
-         */
-        export function getZoomSettings(callback: (zoomSettings: ZoomSettings) => void): void;
-        /**
-         * Gets the current zoom settings of a specified tab.
-         * @since Chrome 42
-         * @return The `getZoomSettings` method provides its result via callback or returned as a `Promise` (MV3 only). The tab's current zoom settings.
-         */
-        export function getZoomSettings(): Promise<ZoomSettings>;
-        /**
-         * Gets the current zoom settings of a specified tab.
-         * @since Chrome 42
-         * @param tabId Optional. The ID of the tab to get the current zoom settings from; defaults to the active tab of the current window.
-         * @param callback Called with the tab's current zoom settings.
-         * Parameter zoomSettings: The tab's current zoom settings.
-         */
-        export function getZoomSettings(tabId: number, callback: (zoomSettings: ZoomSettings) => void): void;
-        /**
-         * Gets the current zoom settings of a specified tab.
-         * @since Chrome 42
-         * @param tabId Optional. The ID of the tab to get the current zoom settings from; defaults to the active tab of the current window.
-         * @return The `getZoomSettings` method provides its result via callback or returned as a `Promise` (MV3 only). The tab's current zoom settings.
-         */
-        export function getZoomSettings(tabId: number): Promise<ZoomSettings>;
-        /**
-         * Discards a tab from memory. Discarded tabs are still visible on the tab strip and are reloaded when activated.
-         * @since Chrome 54
-         * @param tabId Optional. The ID of the tab to be discarded. If specified, the tab will be discarded unless it's active or already discarded. If omitted, the browser will discard the least important tab. This can fail if no discardable tabs exist.
-         * @return The `discard` method provides its result via callback or returned as a `Promise` (MV3 only).
-         */
-        export function discard(tabId?: number): Promise<Tab>;
-        /**
-         * Discards a tab from memory. Discarded tabs are still visible on the tab strip and are reloaded when activated.
-         * @since Chrome 54
-         * @param tabId Optional. The ID of the tab to be discarded. If specified, the tab will be discarded unless it's active or already discarded. If omitted, the browser will discard the least important tab. This can fail if no discardable tabs exist.
-         * @param callback Called after the operation is completed.
-         */
-        export function discard(callback: (tab: Tab) => void): void;
-        export function discard(tabId: number, callback: (tab: Tab) => void): void;
-        /**
-         * Go forward to the next page, if one is available.
-         * @since Chrome 72
-         * @return The `goForward` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
-         */
-        export function goForward(): Promise<void>;
-        /**
-         * Go forward to the next page, if one is available.
-         * @since Chrome 72
-         * @param callback Optional. Called after the operation is completed.
-         */
-        export function goForward(callback: () => void): void;
-        /**
-         * Go forward to the next page, if one is available.
-         * @since Chrome 72
-         * @param tabId Optional. The ID of the tab to navigate forward; defaults to the selected tab of the current window.
-         * @return The `goForward` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
-         */
-        export function goForward(tabId: number): Promise<void>;
-        /**
-         * Go forward to the next page, if one is available.
-         * @since Chrome 72
-         * @param tabId Optional. The ID of the tab to navigate forward; defaults to the selected tab of the current window.
-         * @param callback Optional. Called after the operation is completed.
-         */
-        export function goForward(tabId: number, callback: () => void): void;
-        /**
-         * Go back to the previous page, if one is available.
-         * @since Chrome 72
-         * @return The `goBack` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
-         */
-        export function goBack(): Promise<void>;
-        /**
-         * Go back to the previous page, if one is available.
-         * @since Chrome 72
-         * @param callback Optional. Called after the operation is completed.
-         */
-        export function goBack(callback: () => void): void;
-        /**
-         * Go back to the previous page, if one is available.
-         * @since Chrome 72
-         * @param tabId Optional. The ID of the tab to navigate back; defaults to the selected tab of the current window.
-         * @return The `goBack` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
-         */
-        export function goBack(tabId: number): Promise<void>;
-        /**
-         * Go back to the previous page, if one is available.
-         * @since Chrome 72
-         * @param tabId Optional. The ID of the tab to navigate back; defaults to the selected tab of the current window.
-         * @param callback Optional. Called after the operation is completed.
-         */
-        export function goBack(tabId: number, callback: () => void): void;
-        /**
-         * Adds one or more tabs to a specified group, or if no group is specified, adds the given tabs to a newly created group.
-         * @since Chrome 88
-         * @param options Configurations object
-         * @return The `group` method provides its result via callback or returned as a `Promise` (MV3 only).
-         */
-        export function group(options: GroupOptions): Promise<number>;
-        /**
-         * Adds one or more tabs to a specified group, or if no group is specified, adds the given tabs to a newly created group.
-         * @since Chrome 88
-         * @param options Configurations object
-         * @return The `group` method provides its result via callback or returned as a `Promise` (MV3 only).
-         */
-        export function group(options: GroupOptions): Promise<number>;
-        /**
-         * Adds one or more tabs to a specified group, or if no group is specified, adds the given tabs to a newly created group.
-         * @since Chrome 88
-         * @param options Configurations object
-         * @param callback Optional.
-         */
-        export function group(options: GroupOptions, callback: (groupId: number) => void): void;
-        /**
-         * Removes one or more tabs from their respective groups. If any groups become empty, they are deleted
-         * @since Chrome 88
-         * @param tabIds The tabs to ungroup.
-         * @return The `ungroup` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
-         */
-        export function ungroup(tabIds: number | number[]): Promise<void>;
-        /**
-         * Removes one or more tabs from their respective groups. If any groups become empty, they are deleted
-         * @since Chrome 88
-         * @param tabIds The tabs to ungroup.
-         * @param callback Optional. Called after the operation is completed.
-         */
-        export function ungroup(tabIds: number | number[], callback: () => void): void;
-        /**
-         * Fired when the highlighted or selected tabs in a window changes.
-         * @since Chrome 18
-         */
-        export var onHighlighted: TabHighlightedEvent;
-        /** Fired when a tab is closed. */
-        export var onRemoved: TabRemovedEvent;
-        /** Fired when a tab is updated. */
-        export var onUpdated: TabUpdatedEvent;
-        /** Fired when a tab is attached to a window, for example because it was moved between windows. */
-        export var onAttached: TabAttachedEvent;
-        /**
-         * Fired when a tab is moved within a window. Only one move event is fired, representing the tab the user directly moved. Move events are not fired for the other tabs that must move in response. This event is not fired when a tab is moved between windows. For that, see tabs.onDetached.
-         */
-        export var onMoved: TabMovedEvent;
-        /** Fired when a tab is detached from a window, for example because it is being moved between windows. */
-        export var onDetached: TabDetachedEvent;
-        /** Fired when a tab is created. Note that the tab's URL may not be set at the time this event fired, but you can listen to onUpdated events to be notified when a URL is set. */
-        export var onCreated: TabCreatedEvent;
-        /**
-         * Fires when the active tab in a window changes. Note that the tab's URL may not be set at the time this event fired, but you can listen to onUpdated events to be notified when a URL is set.
-         * @since Chrome 18
-         */
-        export var onActivated: TabActivatedEvent;
-        /**
-         * Fired when a tab is replaced with another tab due to prerendering or instant.
-         * @since Chrome 26
-         */
-        export var onReplaced: TabReplacedEvent;
-        /**
-         * @deprecated since Chrome 33. Please use tabs.onActivated.
-         * Fires when the selected tab in a window changes.
-         */
-        export var onSelectionChanged: TabSelectedEvent;
-        /**
-         * @deprecated since Chrome 33. Please use tabs.onActivated.
-         * Fires when the selected tab in a window changes. Note that the tab's URL may not be set at the time this event fired, but you can listen to tabs.onUpdated events to be notified when a URL is set.
-         */
-        export var onActiveChanged: TabSelectedEvent;
-        /**
-         * @deprecated since Chrome 33. Please use tabs.onHighlighted.
-         * Fired when the highlighted or selected tabs in a window changes.
-         */
-        export var onHighlightChanged: TabHighlightedEvent;
-        /**
-         * Fired when a tab is zoomed.
-         * @since Chrome 38
-         */
-        export var onZoomChange: TabZoomChangeEvent;
 
         /**
-         * An ID which represents the absence of a browser tab.
-         * @since Chrome 46
+         * Connects to the content script(s) in the specified tab. The {@link runtime.onConnect} event is fired in each content script running in the specified tab for the current extension.
+         * @returns A port that can be used to communicate with the content scripts running in the specified tab. The port's {@link runtime.Port} event is fired if the tab closes or does not exist.
          */
-        export var TAB_ID_NONE: -1;
+        export function connect(tabId: number, connectInfo?: ConnectInfo): runtime.Port;
+
+        /**
+         * Injects CSS into a page. Styles inserted with this method can be removed with {@link scripting.removeCSS}`. For details, see the programmatic injection section of the content scripts doc.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         *
+         * MV2 only
+         * @param tabId The ID of the tab in which to insert the CSS; defaults to the active tab of the current window.
+         * @param details Details of the CSS text to insert. Either the code or the file property must be set, but both may not be set at the same time.
+         * @deprecated since Chrome 99. Replaced by {@link scripting.insertCSS} in Manifest V3.
+         */
+        export function insertCSS(details: extensionTypes.InjectDetails): Promise<void>;
+        export function insertCSS(tabId: number | undefined, details: extensionTypes.InjectDetails): Promise<void>;
+        export function insertCSS(details: extensionTypes.InjectDetails, callback: () => void): void;
+        export function insertCSS(tabId: number | undefined, details: extensionTypes.InjectDetails): Promise<void>;
+        export function insertCSS(tabId: number, details: extensionTypes.InjectDetails, callback: () => void): void;
+
+        /**
+         * Highlights the given tabs and focuses on the first of group. Will appear to do nothing if the specified tab is currently active.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         */
+        export function highlight(highlightInfo: HighlightInfo): Promise<windows.Window>;
+        export function highlight(highlightInfo: HighlightInfo, callback: (window: windows.Window) => void): void;
+
+        /** Gets all tabs that have the specified properties, or all tabs if no properties are specified. */
+        export function query(queryInfo: QueryInfo): Promise<Tab[]>;
+        export function query(queryInfo: QueryInfo, callback: (result: Tab[]) => void): void;
+
+        /**
+         * Detects the primary language of the content in a tab.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         * @param tabId The ID of the tab to get the current zoom factor from; defaults to the active tab of the current window.
+         */
+        export function detectLanguage(tabId?: number): Promise<string>;
+        export function detectLanguage(callback: (language: string) => void): void;
+        export function detectLanguage(tabId: number | undefined, callback: (language: string) => void): void;
+
+        /**
+         * Zooms a specified tab.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         * @param tabId The ID of the tab to zoom; defaults to the active tab of the current window.
+         * @param zoomFactor The new zoom factor. A value of `0` sets the tab to its current default zoom factor. Values greater than 0 specify a (possibly non-default) zoom factor for the tab.
+         */
+        export function setZoom(zoomFactor: number): Promise<void>;
+        export function setZoom(tabId: number | undefined, zoomFactor: number): Promise<void>;
+        export function setZoom(zoomFactor: number, callback: () => void): void;
+        export function setZoom(tabId: number | undefined, zoomFactor: number, callback: () => void): void;
+
+        /**
+         * Gets the current zoom factor of a specified tab.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         * @param tabId The ID of the tab to get the current zoom factor from; defaults to the active tab of the current window.
+         */
+        export function getZoom(tabId?: number): Promise<number>;
+        export function getZoom(callback: (zoomFactor: number) => void): void;
+        export function getZoom(tabId: number | undefined, callback: (zoomFactor: number) => void): void;
+
+        /**
+         * Sets the zoom settings for a specified tab, which define how zoom changes are handled. These settings are reset to defaults upon navigating the tab.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         * @param tabId The ID of the tab to change the zoom settings for; defaults to the active tab of the current window.
+         * @param zoomSettings Defines how zoom changes are handled and at what scope.
+         */
+        export function setZoomSettings(zoomSettings: ZoomSettings): Promise<void>;
+        export function setZoomSettings(tabId: number | undefined, zoomSettings: ZoomSettings): Promise<void>;
+        export function setZoomSettings(zoomSettings: ZoomSettings, callback: () => void): void;
+        export function setZoomSettings(
+            tabId: number | undefined,
+            zoomSettings: ZoomSettings,
+            callback: () => void,
+        ): void;
+
+        /**
+         * Gets the current zoom settings of a specified tab.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         * @param tabId The ID of the tab to get the current zoom settings from; defaults to the active tab of the current window.
+         */
+        export function getZoomSettings(tabId?: number): Promise<ZoomSettings>;
+        export function getZoomSettings(callback: (zoomSettings: ZoomSettings) => void): void;
+        export function getZoomSettings(
+            tabId: number | undefined,
+            callback: (zoomSettings: ZoomSettings) => void,
+        ): void;
+
+        /**
+         * Discards a tab from memory. Discarded tabs are still visible on the tab strip and are reloaded when activated.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         * @param tabId The ID of the tab to be discarded. If specified, the tab is discarded unless it is active or already discarded. If omitted, the browser discards the least important tab. This can fail if no discardable tabs exist..
+         * @since Chrome 54
+         */
+        export function discard(tabId?: number): Promise<Tab | undefined>;
+        export function discard(callback: (tab?: Tab) => void): void;
+        export function discard(tabId: number | undefined, callback: (tab?: Tab) => void): void;
+
+        /**
+         * Go forward to the next page, if one is available.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         * @param tabId The ID of the tab to navigate forward; defaults to the selected tab of the current window.
+         * @since Chrome 72
+         */
+        export function goForward(tabId?: number): Promise<void>;
+        export function goForward(callback: () => void): void;
+        export function goForward(tabId: number | undefined, callback: () => void): void;
+
+        /**
+         * Go back to the previous page, if one is available.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         * @param tabId The ID of the tab to navigate back; defaults to the selected tab of the current window.
+         * @since Chrome 72
+         */
+        export function goBack(tabId?: number): Promise<void>;
+        export function goBack(callback: () => void): void;
+        export function goBack(tabId: number | undefined, callback: () => void): void;
+
+        /**
+         * Adds one or more tabs to a specified group, or if no group is specified, adds the given tabs to a newly created group.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         * @since Chrome 88
+         */
+        export function group(options: GroupOptions): Promise<number>;
+        export function group(options: GroupOptions, callback: (groupId: number) => void): void;
+
+        /**
+         * Removes one or more tabs from their respective groups. If any groups become empty, they are deleted
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         * @param tabIds The tab ID or list of tab IDs to remove from their respective groups.
+         * @since Chrome 88
+         */
+        export function ungroup(tabIds: number | [number, ...number[]]): Promise<void>;
+        export function ungroup(tabIds: number | [number, ...number[]], callback: () => void): void;
+
+        /** Fired when the highlighted or selected tabs in a window changes */
+        export const onHighlighted: events.Event<
+            (highlightInfo: {
+                /** All highlighted tabs in the window. */
+                tabIds: number[];
+                /** The window whose tabs changed. */
+                windowId: number;
+            }) => void
+        >;
+
+        /** Fired when a tab is closed. */
+        export const onRemoved: events.Event<
+            (tabId: number, removeInfo: {
+                /** True when the tab was closed because its parent window was closed. */
+                isWindowClosing: boolean;
+                /** The window whose tab is closed */
+                windowId: number;
+            }) => void
+        >;
+
+        /** Fired when a tab is updated. */
+        export const onUpdated: events.Event<
+            (tabId: number, changeInfo: {
+                /** The tab's new audible state. */
+                audible?: boolean;
+                /**
+                 * The tab's new auto-discardable state.
+                 * @since Chrome 54
+                 */
+                autoDiscardable?: boolean;
+                /**
+                 * The tab's new discarded state.
+                 * @since Chrome 54
+                 */
+                discarded?: boolean;
+                /** The tab's new favicon URL. */
+                favIconUrl?: string;
+                /**
+                 * The tab's new frozen state.
+                 * @since Chrome 132
+                 */
+                frozen?: boolean;
+                /**
+                 * The tab's new group.
+                 * @since Chrome 88
+                 */
+                groupId?: number;
+                /**
+                 * The tab's new muted state and the reason for the change.
+                 * @since Chrome 46
+                 */
+                mutedInfo?: MutedInfo;
+                /** The tab's new pinned state. */
+                pinned?: boolean;
+                /** The tab's loading status. */
+                status?: `${TabStatus}`;
+                /**
+                 * The tab's new title.
+                 * @since Chrome 48
+                 */
+                title?: string;
+                /** The tab's URL if it has changed. */
+                url?: string;
+            }, tab: Tab) => void
+        >;
+
+        /** Fired when a tab is attached to a window, for example because it was moved between windows. */
+        export const onAttached: events.Event<
+            (tabId: number, attachInfo: {
+                newPosition: number;
+                newWindowId: number;
+            }) => void
+        >;
+
+        /** Fired when a tab is moved within a window. Only one move event is fired, representing the tab the user directly moved. Move events are not fired for the other tabs that must move in response to the manually-moved tab. This event is not fired when a tab is moved between windows; for details, see {@link tabs.onDetached}. */
+        export const onMoved: events.Event<
+            (tabId: number, moveInfo: {
+                fromIndex: number;
+                toIndex: number;
+                windowId: number;
+            }) => void
+        >;
+
+        /** Fired when a tab is detached from a window; for example, because it was moved between windows. */
+        export const onDetached: events.Event<
+            (tabId: number, detachInfo: {
+                oldPosition: number;
+                oldWindowId: number;
+            }) => void
+        >;
+
+        /** Fired when a tab is created. Note that the tab's URL and tab group membership may not be set at the time this event is fired, but you can listen to onUpdated events so as to be notified when a URL is set or the tab is added to a tab group. */
+        export const onCreated: events.Event<(tab: Tab) => void>;
+
+        /** Fires when the active tab in a window changes. Note that the tab's URL may not be set at the time this event fired, but you can listen to onUpdated events so as to be notified when a URL is set */
+        export const onActivated: events.Event<
+            (activeInfo: {
+                /** The ID of the tab that has become active. */
+                tabId: number;
+                /** The ID of the window the active tab changed inside of. */
+                windowId: number;
+            }) => void
+        >;
+
+        /** Fired when a tab is replaced with another tab due to prerendering or instant */
+        export const onReplaced: events.Event<(addedTabId: number, removedTabId: number) => void>;
+
+        /**
+         * Fires when the selected tab in a window changes.
+         *
+         * MV2 only
+         * @deprecated Please use {@link tabs.onActivated}.
+         */
+        export const onSelectionChanged: events.Event<
+            (tabId: number, selectInfo: {
+                /** The ID of the window the selected tab changed inside of. */
+                windowId: number;
+            }) => void
+        >;
+
+        /**
+         * Fires when the selected tab in a window changes. Note that the tab's URL may not be set at the time this event fired, but you can listen to {@link tabs.onUpdated} events so as to be notified when a URL is set.
+         *
+         * MV2 only
+         * @deprecated Please use {@link tabs.onActivated}.
+         */
+        export const onActiveChanged: events.Event<
+            (tabId: number, selectInfo: {
+                /** The ID of the window the selected tab changed inside of. */
+                windowId: number;
+            }) => void
+        >;
+
+        /**
+         * Fired when the highlighted or selected tabs in a window changes.
+         *
+         * MV2 only
+         * @deprecated Please use {@link tabs.onHighlighted}.
+         */
+        export const onHighlightChanged: events.Event<
+            (
+                (selectInfo: {
+                    /** All highlighted tabs in the window. */
+                    tabIds: number[];
+                    /** The window whose tabs changed. */
+                    windowId: number;
+                }) => void
+            )
+        >;
+
+        /** Fired when a tab is zoomed */
+        export const onZoomChange: events.Event<
+            (ZoomChangeInfo: {
+                newZoomFactor: number;
+                oldZoomFactor: number;
+                tabId: number;
+                zoomSettings: ZoomSettings;
+            }) => void
+        >;
     }
 
     ////////////////////

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -2873,131 +2873,51 @@ async function testTabs() {
     // @ts-expect-error
     chrome.tabs.update(() => {}).then(() => {});
 
-    chrome.tabs.onActivated.addListener((activeInfo) => { // $ExpectType void
+    checkChromeEvent(chrome.tabs.onActivated, (activeInfo) => {
         activeInfo.tabId; // $ExpectType number
         activeInfo.windowId; // $ExpectType number
     });
-    chrome.tabs.onActivated.removeListener((activeInfo) => { // $ExpectType void
-        activeInfo.tabId; // $ExpectType number
-        activeInfo.windowId; // $ExpectType number
-    });
-    chrome.tabs.onActivated.hasListener((activeInfo) => { // $ExpectType boolean
-        activeInfo.tabId; // $ExpectType number
-        activeInfo.windowId; // $ExpectType number
-    });
-    chrome.tabs.onActivated.hasListeners(); // $ExpectType boolean
 
-    chrome.tabs.onAttached.addListener((tabId, attachInfo) => { // $ExpectType void
+    checkChromeEvent(chrome.tabs.onAttached, (tabId, attachInfo) => {
         tabId; // $ExpectType number
         attachInfo.newPosition; // $ExpectType number
         attachInfo.newWindowId; // $ExpectType number
     });
-    chrome.tabs.onAttached.removeListener((tabId, attachInfo) => { // $ExpectType void
-        tabId; // $ExpectType number
-        attachInfo.newPosition; // $ExpectType number
-        attachInfo.newWindowId; // $ExpectType number
-    });
-    chrome.tabs.onAttached.hasListener((tabId, attachInfo) => { // $ExpectType boolean
-        tabId; // $ExpectType number
-        attachInfo.newPosition; // $ExpectType number
-        attachInfo.newWindowId; // $ExpectType number
-    });
-    chrome.tabs.onAttached.hasListeners(); // $ExpectType boolean
 
-    chrome.tabs.onCreated.addListener((tab) => { // $ExpectType void
+    checkChromeEvent(chrome.tabs.onCreated, (tab) => {
         tab; // $ExpectType Tab
     });
-    chrome.tabs.onCreated.removeListener((tab) => { // $ExpectType void
-        tab; // $ExpectType Tab
-    });
-    chrome.tabs.onCreated.hasListener((tab) => { // $ExpectType boolean
-        tab; // $ExpectType Tab
-    });
-    chrome.tabs.onCreated.hasListeners(); // $ExpectType boolean
 
-    chrome.tabs.onDetached.addListener((tabId, detachInfo) => { // $ExpectType void
+    checkChromeEvent(chrome.tabs.onDetached, (tabId, detachInfo) => {
         tabId; // $ExpectType number
         detachInfo.oldPosition; // $ExpectType number
         detachInfo.oldWindowId; // $ExpectType number
     });
-    chrome.tabs.onDetached.removeListener((tabId, detachInfo) => { // $ExpectType void
-        tabId; // $ExpectType number
-        detachInfo.oldPosition; // $ExpectType number
-        detachInfo.oldWindowId; // $ExpectType number
-    });
-    chrome.tabs.onDetached.hasListener((tabId, detachInfo) => { // $ExpectType boolean
-        tabId; // $ExpectType number
-        detachInfo.oldPosition; // $ExpectType number
-        detachInfo.oldWindowId; // $ExpectType number
-    });
-    chrome.tabs.onDetached.hasListeners(); // $ExpectType boolean
 
-    chrome.tabs.onHighlighted.addListener((highlightInfo) => { // $ExpectType void
+    checkChromeEvent(chrome.tabs.onHighlighted, (highlightInfo) => {
         highlightInfo.tabIds; // $ExpectType number[]
         highlightInfo.windowId; // $ExpectType number
     });
-    chrome.tabs.onHighlighted.removeListener((highlightInfo) => { // $ExpectType void
-        highlightInfo.tabIds; // $ExpectType number[]
-        highlightInfo.windowId; // $ExpectType number
-    });
-    chrome.tabs.onHighlighted.hasListener((highlightInfo) => { // $ExpectType boolean
-        highlightInfo.tabIds; // $ExpectType number[]
-        highlightInfo.windowId; // $ExpectType number
-    });
-    chrome.tabs.onHighlighted.hasListeners(); // $ExpectType boolean
 
-    chrome.tabs.onMoved.addListener((tabId, moveInfo) => { // $ExpectType void
+    checkChromeEvent(chrome.tabs.onMoved, (tabId, moveInfo) => {
         tabId; // $ExpectType number
         moveInfo.fromIndex; // $ExpectType number
         moveInfo.toIndex; // $ExpectType number
         moveInfo.windowId; // $ExpectType number
     });
-    chrome.tabs.onMoved.removeListener((tabId, moveInfo) => { // $ExpectType void
-        tabId; // $ExpectType number
-        moveInfo.fromIndex; // $ExpectType number
-        moveInfo.toIndex; // $ExpectType number
-        moveInfo.windowId; // $ExpectType number
-    });
-    chrome.tabs.onMoved.hasListener((tabId, moveInfo) => { // $ExpectType boolean
-        tabId; // $ExpectType number
-        moveInfo.fromIndex; // $ExpectType number
-        moveInfo.toIndex; // $ExpectType number
-        moveInfo.windowId; // $ExpectType number
-    });
-    chrome.tabs.onMoved.hasListeners(); // $ExpectType boolean
 
-    chrome.tabs.onRemoved.addListener((tabId, removeInfo) => { // $ExpectType void
+    checkChromeEvent(chrome.tabs.onRemoved, (tabId, removeInfo) => {
         tabId; // $ExpectType number
         removeInfo.isWindowClosing; // $ExpectType boolean
         removeInfo.windowId; // $ExpectType number
     });
-    chrome.tabs.onRemoved.removeListener((tabId, removeInfo) => { // $ExpectType void
-        tabId; // $ExpectType number
-        removeInfo.isWindowClosing; // $ExpectType boolean
-        removeInfo.windowId; // $ExpectType number
-    });
-    chrome.tabs.onRemoved.hasListener((tabId, removeInfo) => { // $ExpectType boolean
-        tabId; // $ExpectType number
-        removeInfo.isWindowClosing; // $ExpectType boolean
-        removeInfo.windowId; // $ExpectType number
-    });
-    chrome.tabs.onRemoved.hasListeners(); // $ExpectType boolean
 
-    chrome.tabs.onReplaced.addListener((addedTabId, removedTabId) => { // $ExpectType void
+    checkChromeEvent(chrome.tabs.onReplaced, (addedTabId, removedTabId) => {
         addedTabId; // $ExpectType number
         removedTabId; // $ExpectType number
     });
-    chrome.tabs.onReplaced.removeListener((addedTabId, removedTabId) => { // $ExpectType void
-        addedTabId; // $ExpectType number
-        removedTabId; // $ExpectType number
-    });
-    chrome.tabs.onReplaced.hasListener((addedTabId, removedTabId) => { // $ExpectType boolean
-        addedTabId; // $ExpectType number
-        removedTabId; // $ExpectType number
-    });
-    chrome.tabs.onReplaced.hasListeners(); // $ExpectType boolean
 
-    chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => { // $ExpectType void
+    checkChromeEvent(chrome.tabs.onUpdated, (tabId, changeInfo, tab) => {
         tabId; // $ExpectType number
         changeInfo.audible; // $ExpectType boolean | undefined
         changeInfo.autoDiscardable; // $ExpectType boolean | undefined
@@ -3012,57 +2932,13 @@ async function testTabs() {
         changeInfo.url; // $ExpectType string | undefined
         tab; // $ExpectType Tab
     });
-    chrome.tabs.onUpdated.removeListener((tabId, changeInfo, tab) => { // $ExpectType void
-        tabId; // $ExpectType number
-        changeInfo.audible; // $ExpectType boolean | undefined
-        changeInfo.autoDiscardable; // $ExpectType boolean | undefined
-        changeInfo.discarded; // $ExpectType boolean | undefined
-        changeInfo.favIconUrl; // $ExpectType string | undefined
-        changeInfo.frozen; // $ExpectType boolean | undefined
-        changeInfo.groupId; // $ExpectType number | undefined
-        changeInfo.mutedInfo; // $ExpectType MutedInfo | undefined
-        changeInfo.pinned; // $ExpectType boolean | undefined
-        changeInfo.status; // $ExpectType "unloaded" | "loading" | "complete" | undefined
-        changeInfo.title; // $ExpectType string | undefined
-        changeInfo.url; // $ExpectType string | undefined
-        tab; // $ExpectType Tab
-    });
-    chrome.tabs.onUpdated.hasListener((tabId, changeInfo, tab) => { // $ExpectType boolean
-        tabId; // $ExpectType number
-        changeInfo.audible; // $ExpectType boolean | undefined
-        changeInfo.autoDiscardable; // $ExpectType boolean | undefined
-        changeInfo.discarded; // $ExpectType boolean | undefined
-        changeInfo.favIconUrl; // $ExpectType string | undefined
-        changeInfo.frozen; // $ExpectType boolean | undefined
-        changeInfo.groupId; // $ExpectType number | undefined
-        changeInfo.mutedInfo; // $ExpectType MutedInfo | undefined
-        changeInfo.pinned; // $ExpectType boolean | undefined
-        changeInfo.status; // $ExpectType "unloaded" | "loading" | "complete" | undefined
-        changeInfo.title; // $ExpectType string | undefined
-        changeInfo.url; // $ExpectType string | undefined
-        tab; // $ExpectType Tab
-    });
-    chrome.tabs.onUpdated.hasListeners(); // $ExpectType boolean
 
-    chrome.tabs.onZoomChange.addListener((zoomChangeInfo) => { // $ExpectType void
-        zoomChangeInfo.newZoomFactor; // $ExpectType number
-        zoomChangeInfo.oldZoomFactor; // $ExpectType number
-        zoomChangeInfo.tabId; // $ExpectType number
-        zoomChangeInfo.zoomSettings; // $ExpectType ZoomSettings
-    });
-    chrome.tabs.onZoomChange.removeListener((zoomChangeInfo) => { // $ExpectType void
+    checkChromeEvent(chrome.tabs.onZoomChange, (zoomChangeInfo) => {
         zoomChangeInfo.tabId; // $ExpectType number
         zoomChangeInfo.newZoomFactor; // $ExpectType number
         zoomChangeInfo.oldZoomFactor; // $ExpectType number
         zoomChangeInfo.zoomSettings; // $ExpectType ZoomSettings
     });
-    chrome.tabs.onZoomChange.hasListener((zoomChangeInfo) => { // $ExpectType boolean
-        zoomChangeInfo.newZoomFactor; // $ExpectType number
-        zoomChangeInfo.oldZoomFactor; // $ExpectType number
-        zoomChangeInfo.tabId; // $ExpectType number
-        zoomChangeInfo.zoomSettings; // $ExpectType ZoomSettings
-    });
-    chrome.tabs.onZoomChange.hasListeners(); // $ExpectType boolean
 
     const details: chrome.extensionTypes.InjectDetails = {
         allFrames: true,
@@ -3129,47 +3005,20 @@ async function testTabs() {
     // @ts-expect-error
     chrome.tabs.sendRequest(() => {}).then(() => {});
 
-    chrome.tabs.onActiveChanged.addListener((tabId, selectInfo) => { // $ExpectType void
+    checkChromeEvent(chrome.tabs.onActiveChanged, (tabId, selectInfo) => {
         tabId; // $ExpectType number
         selectInfo.windowId; // $ExpectType number
     });
-    chrome.tabs.onActiveChanged.removeListener((tabId, selectInfo) => { // $ExpectType void
-        tabId; // $ExpectType number
-        selectInfo.windowId; // $ExpectType number
-    });
-    chrome.tabs.onActiveChanged.hasListener((tabId, selectInfo) => { // $ExpectType boolean
-        tabId; // $ExpectType number
-        selectInfo.windowId; // $ExpectType number
-    });
-    chrome.tabs.onActiveChanged.hasListeners(); // $ExpectType boolean
 
-    chrome.tabs.onHighlightChanged.addListener((selectInfo) => { // $ExpectType void
+    checkChromeEvent(chrome.tabs.onHighlightChanged, (selectInfo) => {
         selectInfo.tabIds; // $ExpectType number[]
         selectInfo.windowId; // $ExpectType number
     });
-    chrome.tabs.onHighlightChanged.removeListener((selectInfo) => { // $ExpectType void
-        selectInfo.tabIds; // $ExpectType number[]
-        selectInfo.windowId; // $ExpectType number
-    });
-    chrome.tabs.onHighlightChanged.hasListener((selectInfo) => { // $ExpectType boolean
-        selectInfo.tabIds; // $ExpectType number[]
-        selectInfo.windowId; // $ExpectType number
-    });
-    chrome.tabs.onHighlightChanged.hasListeners(); // $ExpectType boolean
 
-    chrome.tabs.onSelectionChanged.addListener((tabId, selectInfo) => { // $ExpectType void
+    checkChromeEvent(chrome.tabs.onSelectionChanged, (tabId, selectInfo) => {
         tabId; // $ExpectType number
         selectInfo.windowId; // $ExpectType number
     });
-    chrome.tabs.onSelectionChanged.removeListener((tabId, selectInfo) => { // $ExpectType void
-        tabId; // $ExpectType number
-        selectInfo.windowId; // $ExpectType number
-    });
-    chrome.tabs.onSelectionChanged.hasListener((tabId, selectInfo) => { // $ExpectType boolean
-        tabId; // $ExpectType number
-        selectInfo.windowId; // $ExpectType number
-    });
-    chrome.tabs.onSelectionChanged.hasListeners(); // $ExpectType boolean
 }
 
 // https://developer.chrome.com/docs/extensions/reference/api/tabGroups

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -290,20 +290,6 @@ async function getAllFrames() {
     console.log("All frames (promise resolved):", frames);
 }
 
-// for chrome.tabs.InjectDetails.frameId
-function executeScriptFramed() {
-    const tabId = 123;
-    const frameId = 0;
-
-    const code = "alert('hi');";
-
-    chrome.tabs.executeScript({ frameId, code });
-    chrome.tabs.insertCSS({ frameId, code });
-
-    chrome.tabs.executeScript(tabId, { frameId, code });
-    chrome.tabs.insertCSS(tabId, { frameId, code });
-}
-
 // https://developer.chrome.com/docs/extensions/reference/api/proxy
 function proxySettings() {
     chrome.proxy.settings.get({ incognito: false }); // $ExpectType Promise<ChromeSettingGetResult<ProxyConfig>>
@@ -728,67 +714,6 @@ function testContentSettings() {
     chrome.contentSettings.unsandboxedPlugins.getResourceIdentifiers((resourceIdentifiers) => { // $ExpectType void
         resourceIdentifiers; // $ExpectType ResourceIdentifier[] | undefined
     });
-}
-
-// tabs: https://developer.chrome.com/extensions/tabs#
-async function testTabInterface() {
-    const options = { active: true, currentWindow: true, url: ["http://*/*", "https://*/*"] };
-
-    chrome.tabs.query(options, tabs => {
-        // $ExpectType Tab[]
-        tabs;
-
-        const [tab] = tabs;
-        tab.id; // $ExpectType number | undefined
-        tab.index; // $ExpectType number
-        tab.windowId; // $ExpectType number
-        tab.openerTabId; // $ExpectType number | undefined
-        tab.selected; // $ExpectType boolean
-        tab.highlighted; // $ExpectType boolean
-        tab.active; // $ExpectType boolean
-        tab.pinned; // $ExpectType boolean
-        tab.audible; // $ExpectType boolean | undefined
-        tab.discarded; // $ExpectType boolean
-        tab.autoDiscardable; // $ExpectType boolean
-        tab.groupId; // $ExpectType number
-        tab.mutedInfo; // $ExpectType MutedInfo | undefined
-        tab.url; // $ExpectType string | undefined
-        tab.pendingUrl; // $ExpectType string | undefined
-        tab.title; // $ExpectType string | undefined
-        tab.favIconUrl; // $ExpectType string | undefined
-        tab.status; // $ExpectType string | undefined
-        tab.incognito; // $ExpectType boolean
-        tab.width; // $ExpectType number | undefined
-        tab.height; // $ExpectType number | undefined
-        tab.sessionId; // $ExpectType string | undefined
-    });
-
-    // $ExpectType Tab[]
-    const tabs = await chrome.tabs.query(options);
-
-    const [tab] = tabs;
-    tab.id; // $ExpectType number | undefined
-    tab.index; // $ExpectType number
-    tab.windowId; // $ExpectType number
-    tab.openerTabId; // $ExpectType number | undefined
-    tab.selected; // $ExpectType boolean
-    tab.highlighted; // $ExpectType boolean
-    tab.active; // $ExpectType boolean
-    tab.pinned; // $ExpectType boolean
-    tab.audible; // $ExpectType boolean | undefined
-    tab.discarded; // $ExpectType boolean
-    tab.autoDiscardable; // $ExpectType boolean
-    tab.groupId; // $ExpectType number
-    tab.mutedInfo; // $ExpectType MutedInfo | undefined
-    tab.url; // $ExpectType string | undefined
-    tab.pendingUrl; // $ExpectType string | undefined
-    tab.title; // $ExpectType string | undefined
-    tab.favIconUrl; // $ExpectType string | undefined
-    tab.status; // $ExpectType string | undefined
-    tab.incognito; // $ExpectType boolean
-    tab.width; // $ExpectType number | undefined
-    tab.height; // $ExpectType number | undefined
-    tab.sessionId; // $ExpectType string | undefined
 }
 
 // https://developer.chrome.com/docs/extensions/reference/api/runtime
@@ -2619,6 +2544,33 @@ function testSystemLog() {
 
 // https://developer.chrome.com/docs/extensions/reference/api/tabs
 async function testTabs() {
+    chrome.tabs.MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND === 2;
+
+    chrome.tabs.MutedInfoReason.CAPTURE === "capture";
+    chrome.tabs.MutedInfoReason.EXTENSION === "extension";
+    chrome.tabs.MutedInfoReason.USER === "user";
+
+    chrome.tabs.TAB_ID_NONE === -1;
+
+    chrome.tabs.TAB_INDEX_NONE === -1;
+
+    chrome.tabs.TabStatus.COMPLETE === "complete";
+    chrome.tabs.TabStatus.LOADING === "loading";
+    chrome.tabs.TabStatus.UNLOADED === "unloaded";
+
+    chrome.tabs.WindowType.APP === "app";
+    chrome.tabs.WindowType.DEVTOOLS === "devtools";
+    chrome.tabs.WindowType.NORMAL === "normal";
+    chrome.tabs.WindowType.PANEL === "panel";
+    chrome.tabs.WindowType.POPUP === "popup";
+
+    chrome.tabs.ZoomSettingsMode.AUTOMATIC === "automatic";
+    chrome.tabs.ZoomSettingsMode.DISABLED === "disabled";
+    chrome.tabs.ZoomSettingsMode.MANUAL === "manual";
+
+    chrome.tabs.ZoomSettingsScope.PER_ORIGIN === "per-origin";
+    chrome.tabs.ZoomSettingsScope.PER_TAB === "per-tab";
+
     const tabId = 0;
     const windowId = 0;
     const groupId = 0;
@@ -2637,13 +2589,13 @@ async function testTabs() {
     chrome.tabs.captureVisibleTab((dataUrl) => {
         dataUrl; // $ExpectType string
     });
-    chrome.tabs.captureVisibleTab(windowId, (dataUrl) => {
+    chrome.tabs.captureVisibleTab(windowId, (dataUrl) => { // $ExpectType void
         dataUrl; // $ExpectType string
     });
-    chrome.tabs.captureVisibleTab(windowCaptureOptions, (dataUrl) => {
+    chrome.tabs.captureVisibleTab(windowCaptureOptions, (dataUrl) => { // $ExpectType void
         dataUrl; // $ExpectType string
     });
-    chrome.tabs.captureVisibleTab(windowId, windowCaptureOptions, (dataUrl) => {
+    chrome.tabs.captureVisibleTab(windowId, windowCaptureOptions, (dataUrl) => { // $ExpectType void
         dataUrl; // $ExpectType string
     });
     // @ts-expect-error
@@ -2660,11 +2612,17 @@ async function testTabs() {
     chrome.tabs.connect(tabId, connectInfo); // $ExpectType Port
 
     const createProperties: chrome.tabs.CreateProperties = {
+        active: true,
         index: 0,
+        openerTabId: tabId,
+        pinned: true,
+        selected: true,
+        url: "url",
+        windowId,
     };
 
     chrome.tabs.create(createProperties); // $ExpectType Promise<Tab>
-    chrome.tabs.create(createProperties, (tab) => {
+    chrome.tabs.create(createProperties, (tab) => { // $ExpectType void
         tab; // $ExpectType Tab
     });
     // @ts-expect-error
@@ -2672,7 +2630,7 @@ async function testTabs() {
 
     chrome.tabs.detectLanguage(); // $ExpectType Promise<string>
     chrome.tabs.detectLanguage(tabId); // $ExpectType Promise<string>
-    chrome.tabs.detectLanguage((language) => {
+    chrome.tabs.detectLanguage((language) => { // $ExpectType void
         language; // $ExpectType string
     });
     chrome.tabs.detectLanguage(tabId, (language) => {
@@ -2681,13 +2639,13 @@ async function testTabs() {
     // @ts-expect-error
     chrome.tabs.detectLanguage(() => {}).then(() => {});
 
-    chrome.tabs.discard(); // $ExpectType Promise<Tab>
-    chrome.tabs.discard(tabId); // $ExpectType Promise<Tab>
-    chrome.tabs.discard((tab) => {
-        tab; // $ExpectType Tab
+    chrome.tabs.discard(); // $ExpectType Promise<Tab | undefined>
+    chrome.tabs.discard(tabId); // $ExpectType Promise<Tab | undefined>
+    chrome.tabs.discard((tab) => { // $ExpectType void
+        tab; // $ExpectType Tab | undefined
     });
-    chrome.tabs.discard(tabId, (tab) => {
-        tab; // $ExpectType Tab
+    chrome.tabs.discard(tabId, (tab) => { // $ExpectType void
+        tab; // $ExpectType Tab | undefined
     });
     // @ts-expect-error
     chrome.tabs.discard(() => {}).then(() => {});
@@ -2700,14 +2658,14 @@ async function testTabs() {
     chrome.tabs.duplicate(() => {}).then(() => {});
 
     chrome.tabs.get(tabId); // $ExpectType Promise<Tab>
-    chrome.tabs.get(tabId, (tab) => {
+    chrome.tabs.get(tabId, (tab) => { // $ExpectType void
         tab; // $ExpectType Tab
     });
     // @ts-expect-error
     chrome.tabs.get(() => {}).then(() => {});
 
     chrome.tabs.getCurrent(); // $ExpectType Promise<Tab | undefined>
-    chrome.tabs.getCurrent((tab) => {
+    chrome.tabs.getCurrent((tab) => { // $ExpectType void
         tab; // $ExpectType Tab | undefined
     });
     // @ts-expect-error
@@ -2715,10 +2673,10 @@ async function testTabs() {
 
     chrome.tabs.getZoom(); // $ExpectType Promise<number>
     chrome.tabs.getZoom(tabId); // $ExpectType Promise<number>
-    chrome.tabs.getZoom((zoomFactor) => {
+    chrome.tabs.getZoom((zoomFactor) => { // $ExpectType void
         zoomFactor; // $ExpectType number
     });
-    chrome.tabs.getZoom(tabId, (zoomFactor) => {
+    chrome.tabs.getZoom(tabId, (zoomFactor) => { // $ExpectType void
         zoomFactor; // $ExpectType number
     });
     // @ts-expect-error
@@ -2726,10 +2684,10 @@ async function testTabs() {
 
     chrome.tabs.getZoomSettings(); // $ExpectType Promise<ZoomSettings>
     chrome.tabs.getZoomSettings(tabId); // $ExpectType Promise<ZoomSettings>
-    chrome.tabs.getZoomSettings((zoomSettings) => {
+    chrome.tabs.getZoomSettings((zoomSettings) => { // $ExpectType void
         zoomSettings; // $ExpectType ZoomSettings
     });
-    chrome.tabs.getZoomSettings(tabId, (zoomSettings) => {
+    chrome.tabs.getZoomSettings(tabId, (zoomSettings) => { // $ExpectType void
         zoomSettings; // $ExpectType ZoomSettings
     });
     // @ts-expect-error
@@ -2756,9 +2714,11 @@ async function testTabs() {
     };
 
     chrome.tabs.group(groupOptions); // $ExpectType Promise<number>
-    chrome.tabs.group(groupOptions, (groupId) => {
+    chrome.tabs.group(groupOptions, (groupId) => { // $ExpectType void
         groupId; // $ExpectType number
     });
+    // @ts-expect-error Value did not match any choice.
+    chrome.tabs.group({ tabIds: [] });
     // @ts-expect-error
     chrome.tabs.group(() => {}).then(() => {});
 
@@ -2768,7 +2728,7 @@ async function testTabs() {
     };
 
     chrome.tabs.highlight(highlightInfo); // $ExpectType Promise<Window>
-    chrome.tabs.highlight(highlightInfo, (window) => {
+    chrome.tabs.highlight(highlightInfo, (window) => { // $ExpectType void
         window; // $ExpectType Window
     });
     // @ts-expect-error
@@ -2781,7 +2741,7 @@ async function testTabs() {
 
     chrome.tabs.move(tabId, moveProperties); // $ExpectType Promise<Tab>
     chrome.tabs.move([tabId], moveProperties); // $ExpectType Promise<Tab[]>
-    chrome.tabs.move(tabId, moveProperties, (tab) => {
+    chrome.tabs.move(tabId, moveProperties, (tab) => { // $ExpectType void
         tab; // $ExpectType Tab
     });
     chrome.tabs.move([tabId], moveProperties, (tabs) => {
@@ -2811,7 +2771,7 @@ async function testTabs() {
     };
 
     chrome.tabs.query(queryInfo); // $ExpectType Promise<Tab[]>
-    chrome.tabs.query(queryInfo, (tabs) => {
+    chrome.tabs.query(queryInfo, (tabs) => { // $ExpectType void
         tabs; // $ExpectType Tab[]
     });
     // @ts-expect-error
@@ -2843,17 +2803,17 @@ async function testTabs() {
     chrome.tabs.sendMessage(tabId, message); // $ExpectType Promise<any>
     chrome.tabs.sendMessage(tabId, message, { frameId }); // $ExpectType Promise<any>
     chrome.tabs.sendMessage(tabId, message, { documentId }); // $ExpectType Promise<any>
-    chrome.tabs.sendMessage(tabId, message, (response) => {
+    chrome.tabs.sendMessage(tabId, message, (response) => { // $ExpectType void
         response; // $ExpectType any
     });
-    chrome.tabs.sendMessage(tabId, message, { frameId }, (response) => {
+    chrome.tabs.sendMessage(tabId, message, { frameId }, (response) => { // $ExpectType void
         response; // $ExpectType any
     });
-    chrome.tabs.sendMessage(tabId, message, { documentId }, (response) => {
+    chrome.tabs.sendMessage(tabId, message, { documentId }, (response) => { // $ExpectType void
         response; // $ExpectType any
     });
     chrome.tabs.sendMessage<string, number>(tabId, message); // $ExpectType Promise<number>
-    chrome.tabs.sendMessage<string, number>(tabId, message, (response) => {
+    chrome.tabs.sendMessage<string, number>(tabId, message, (response) => { // $ExpectType void
         response; // $ExpectType number
     });
     // @ts-expect-error message should be a number
@@ -2887,6 +2847,8 @@ async function testTabs() {
     chrome.tabs.ungroup([tabId]); // $ExpectType Promise<void>
     chrome.tabs.ungroup(tabId, () => {}); // $ExpectType void
     chrome.tabs.ungroup([tabId], () => {}); // $ExpectType void
+    // @ts-expect-error Value did not match any choice.
+    chrome.tabs.ungroup([]);
     // @ts-expect-error
     chrome.tabs.ungroup(() => {}).then(() => {});
 
@@ -2902,145 +2864,312 @@ async function testTabs() {
 
     chrome.tabs.update(updateProperties); // $ExpectType Promise<Tab | undefined>
     chrome.tabs.update(tabId, updateProperties); // $ExpectType Promise<Tab | undefined>
-    chrome.tabs.update(updateProperties, (tab) => {
+    chrome.tabs.update(updateProperties, (tab) => { // $ExpectType void
         tab; // $ExpectType Tab | undefined
     });
-    chrome.tabs.update(tabId, updateProperties, (tab) => {
+    chrome.tabs.update(tabId, updateProperties, (tab) => { // $ExpectType void
         tab; // $ExpectType Tab | undefined
     });
     // @ts-expect-error
     chrome.tabs.update(() => {}).then(() => {});
 
-    chrome.tabs.onActivated.addListener((activeInfo) => {
-        activeInfo; // $ExpectType TabActiveInfo
+    chrome.tabs.onActivated.addListener((activeInfo) => { // $ExpectType void
+        activeInfo.tabId; // $ExpectType number
+        activeInfo.windowId; // $ExpectType number
     });
-    chrome.tabs.onActivated.removeListener((activeInfo) => {
-        activeInfo; // $ExpectType TabActiveInfo
+    chrome.tabs.onActivated.removeListener((activeInfo) => { // $ExpectType void
+        activeInfo.tabId; // $ExpectType number
+        activeInfo.windowId; // $ExpectType number
     });
-    chrome.tabs.onActivated.hasListener((activeInfo) => {
-        activeInfo; // $ExpectType TabActiveInfo
+    chrome.tabs.onActivated.hasListener((activeInfo) => { // $ExpectType boolean
+        activeInfo.tabId; // $ExpectType number
+        activeInfo.windowId; // $ExpectType number
     });
     chrome.tabs.onActivated.hasListeners(); // $ExpectType boolean
 
-    chrome.tabs.onAttached.addListener((tabId, attachInfo) => {
+    chrome.tabs.onAttached.addListener((tabId, attachInfo) => { // $ExpectType void
         tabId; // $ExpectType number
-        attachInfo; // $ExpectType TabAttachInfo
+        attachInfo.newPosition; // $ExpectType number
+        attachInfo.newWindowId; // $ExpectType number
     });
-    chrome.tabs.onAttached.removeListener((tabId, attachInfo) => {
+    chrome.tabs.onAttached.removeListener((tabId, attachInfo) => { // $ExpectType void
         tabId; // $ExpectType number
-        attachInfo; // $ExpectType TabAttachInfo
+        attachInfo.newPosition; // $ExpectType number
+        attachInfo.newWindowId; // $ExpectType number
     });
-    chrome.tabs.onAttached.hasListener((tabId, attachInfo) => {
+    chrome.tabs.onAttached.hasListener((tabId, attachInfo) => { // $ExpectType boolean
         tabId; // $ExpectType number
-        attachInfo; // $ExpectType TabAttachInfo
+        attachInfo.newPosition; // $ExpectType number
+        attachInfo.newWindowId; // $ExpectType number
     });
     chrome.tabs.onAttached.hasListeners(); // $ExpectType boolean
 
-    chrome.tabs.onCreated.addListener((tab) => {
+    chrome.tabs.onCreated.addListener((tab) => { // $ExpectType void
         tab; // $ExpectType Tab
     });
-    chrome.tabs.onCreated.removeListener((tab) => {
+    chrome.tabs.onCreated.removeListener((tab) => { // $ExpectType void
         tab; // $ExpectType Tab
     });
-    chrome.tabs.onCreated.hasListener((tab) => {
+    chrome.tabs.onCreated.hasListener((tab) => { // $ExpectType boolean
         tab; // $ExpectType Tab
     });
     chrome.tabs.onCreated.hasListeners(); // $ExpectType boolean
 
-    chrome.tabs.onDetached.addListener((tabId, detachInfo) => {
+    chrome.tabs.onDetached.addListener((tabId, detachInfo) => { // $ExpectType void
         tabId; // $ExpectType number
-        detachInfo; // $ExpectType TabDetachInfo
+        detachInfo.oldPosition; // $ExpectType number
+        detachInfo.oldWindowId; // $ExpectType number
     });
-    chrome.tabs.onDetached.removeListener((tabId, detachInfo) => {
+    chrome.tabs.onDetached.removeListener((tabId, detachInfo) => { // $ExpectType void
         tabId; // $ExpectType number
-        detachInfo; // $ExpectType TabDetachInfo
+        detachInfo.oldPosition; // $ExpectType number
+        detachInfo.oldWindowId; // $ExpectType number
     });
-    chrome.tabs.onDetached.hasListener((tabId, detachInfo) => {
+    chrome.tabs.onDetached.hasListener((tabId, detachInfo) => { // $ExpectType boolean
         tabId; // $ExpectType number
-        detachInfo; // $ExpectType TabDetachInfo
+        detachInfo.oldPosition; // $ExpectType number
+        detachInfo.oldWindowId; // $ExpectType number
     });
     chrome.tabs.onDetached.hasListeners(); // $ExpectType boolean
 
-    chrome.tabs.onHighlighted.addListener((highlightInfo) => {
-        highlightInfo; // $ExpectType TabHighlightInfo
+    chrome.tabs.onHighlighted.addListener((highlightInfo) => { // $ExpectType void
+        highlightInfo.tabIds; // $ExpectType number[]
+        highlightInfo.windowId; // $ExpectType number
     });
-    chrome.tabs.onHighlighted.removeListener((highlightInfo) => {
-        highlightInfo; // $ExpectType TabHighlightInfo
+    chrome.tabs.onHighlighted.removeListener((highlightInfo) => { // $ExpectType void
+        highlightInfo.tabIds; // $ExpectType number[]
+        highlightInfo.windowId; // $ExpectType number
     });
-    chrome.tabs.onHighlighted.hasListener((highlightInfo) => {
-        highlightInfo; // $ExpectType TabHighlightInfo
+    chrome.tabs.onHighlighted.hasListener((highlightInfo) => { // $ExpectType boolean
+        highlightInfo.tabIds; // $ExpectType number[]
+        highlightInfo.windowId; // $ExpectType number
     });
     chrome.tabs.onHighlighted.hasListeners(); // $ExpectType boolean
 
-    chrome.tabs.onMoved.addListener((tabId, moveInfo) => {
+    chrome.tabs.onMoved.addListener((tabId, moveInfo) => { // $ExpectType void
         tabId; // $ExpectType number
-        moveInfo; // $ExpectType TabMoveInfo
+        moveInfo.fromIndex; // $ExpectType number
+        moveInfo.toIndex; // $ExpectType number
+        moveInfo.windowId; // $ExpectType number
     });
-    chrome.tabs.onMoved.removeListener((tabId, moveInfo) => {
+    chrome.tabs.onMoved.removeListener((tabId, moveInfo) => { // $ExpectType void
         tabId; // $ExpectType number
-        moveInfo; // $ExpectType TabMoveInfo
+        moveInfo.fromIndex; // $ExpectType number
+        moveInfo.toIndex; // $ExpectType number
+        moveInfo.windowId; // $ExpectType number
     });
-    chrome.tabs.onMoved.hasListener((tabId, moveInfo) => {
+    chrome.tabs.onMoved.hasListener((tabId, moveInfo) => { // $ExpectType boolean
         tabId; // $ExpectType number
-        moveInfo; // $ExpectType TabMoveInfo
+        moveInfo.fromIndex; // $ExpectType number
+        moveInfo.toIndex; // $ExpectType number
+        moveInfo.windowId; // $ExpectType number
     });
     chrome.tabs.onMoved.hasListeners(); // $ExpectType boolean
 
-    chrome.tabs.onRemoved.addListener((tabId, removeInfo) => {
+    chrome.tabs.onRemoved.addListener((tabId, removeInfo) => { // $ExpectType void
         tabId; // $ExpectType number
-        removeInfo; // $ExpectType TabRemoveInfo
+        removeInfo.isWindowClosing; // $ExpectType boolean
+        removeInfo.windowId; // $ExpectType number
     });
-    chrome.tabs.onRemoved.removeListener((tabId, removeInfo) => {
+    chrome.tabs.onRemoved.removeListener((tabId, removeInfo) => { // $ExpectType void
         tabId; // $ExpectType number
-        removeInfo; // $ExpectType TabRemoveInfo
+        removeInfo.isWindowClosing; // $ExpectType boolean
+        removeInfo.windowId; // $ExpectType number
     });
-    chrome.tabs.onRemoved.hasListener((tabId, removeInfo) => {
+    chrome.tabs.onRemoved.hasListener((tabId, removeInfo) => { // $ExpectType boolean
         tabId; // $ExpectType number
-        removeInfo; // $ExpectType TabRemoveInfo
+        removeInfo.isWindowClosing; // $ExpectType boolean
+        removeInfo.windowId; // $ExpectType number
     });
     chrome.tabs.onRemoved.hasListeners(); // $ExpectType boolean
 
-    chrome.tabs.onReplaced.addListener((addedTabId, removedTabId) => {
+    chrome.tabs.onReplaced.addListener((addedTabId, removedTabId) => { // $ExpectType void
         addedTabId; // $ExpectType number
         removedTabId; // $ExpectType number
     });
-    chrome.tabs.onReplaced.removeListener((addedTabId, removedTabId) => {
+    chrome.tabs.onReplaced.removeListener((addedTabId, removedTabId) => { // $ExpectType void
         addedTabId; // $ExpectType number
         removedTabId; // $ExpectType number
     });
-    chrome.tabs.onReplaced.hasListener((addedTabId, removedTabId) => {
+    chrome.tabs.onReplaced.hasListener((addedTabId, removedTabId) => { // $ExpectType boolean
         addedTabId; // $ExpectType number
         removedTabId; // $ExpectType number
     });
     chrome.tabs.onReplaced.hasListeners(); // $ExpectType boolean
 
-    chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+    chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => { // $ExpectType void
         tabId; // $ExpectType number
-        changeInfo; // $ExpectType TabChangeInfo
+        changeInfo.audible; // $ExpectType boolean | undefined
+        changeInfo.autoDiscardable; // $ExpectType boolean | undefined
+        changeInfo.discarded; // $ExpectType boolean | undefined
+        changeInfo.favIconUrl; // $ExpectType string | undefined
+        changeInfo.frozen; // $ExpectType boolean | undefined
+        changeInfo.groupId; // $ExpectType number | undefined
+        changeInfo.mutedInfo; // $ExpectType MutedInfo | undefined
+        changeInfo.pinned; // $ExpectType boolean | undefined
+        changeInfo.status; // $ExpectType "unloaded" | "loading" | "complete" | undefined
+        changeInfo.title; // $ExpectType string | undefined
+        changeInfo.url; // $ExpectType string | undefined
         tab; // $ExpectType Tab
     });
-    chrome.tabs.onUpdated.removeListener((tabId, changeInfo, tab) => {
+    chrome.tabs.onUpdated.removeListener((tabId, changeInfo, tab) => { // $ExpectType void
         tabId; // $ExpectType number
-        changeInfo; // $ExpectType TabChangeInfo
+        changeInfo.audible; // $ExpectType boolean | undefined
+        changeInfo.autoDiscardable; // $ExpectType boolean | undefined
+        changeInfo.discarded; // $ExpectType boolean | undefined
+        changeInfo.favIconUrl; // $ExpectType string | undefined
+        changeInfo.frozen; // $ExpectType boolean | undefined
+        changeInfo.groupId; // $ExpectType number | undefined
+        changeInfo.mutedInfo; // $ExpectType MutedInfo | undefined
+        changeInfo.pinned; // $ExpectType boolean | undefined
+        changeInfo.status; // $ExpectType "unloaded" | "loading" | "complete" | undefined
+        changeInfo.title; // $ExpectType string | undefined
+        changeInfo.url; // $ExpectType string | undefined
         tab; // $ExpectType Tab
     });
-    chrome.tabs.onUpdated.hasListener((tabId, changeInfo, tab) => {
+    chrome.tabs.onUpdated.hasListener((tabId, changeInfo, tab) => { // $ExpectType boolean
         tabId; // $ExpectType number
-        changeInfo; // $ExpectType TabChangeInfo
+        changeInfo.audible; // $ExpectType boolean | undefined
+        changeInfo.autoDiscardable; // $ExpectType boolean | undefined
+        changeInfo.discarded; // $ExpectType boolean | undefined
+        changeInfo.favIconUrl; // $ExpectType string | undefined
+        changeInfo.frozen; // $ExpectType boolean | undefined
+        changeInfo.groupId; // $ExpectType number | undefined
+        changeInfo.mutedInfo; // $ExpectType MutedInfo | undefined
+        changeInfo.pinned; // $ExpectType boolean | undefined
+        changeInfo.status; // $ExpectType "unloaded" | "loading" | "complete" | undefined
+        changeInfo.title; // $ExpectType string | undefined
+        changeInfo.url; // $ExpectType string | undefined
         tab; // $ExpectType Tab
     });
     chrome.tabs.onUpdated.hasListeners(); // $ExpectType boolean
 
-    chrome.tabs.onZoomChange.addListener((zoomChangeInfo) => {
-        zoomChangeInfo; // $ExpectType ZoomChangeInfo
+    chrome.tabs.onZoomChange.addListener((zoomChangeInfo) => { // $ExpectType void
+        zoomChangeInfo.newZoomFactor; // $ExpectType number
+        zoomChangeInfo.oldZoomFactor; // $ExpectType number
+        zoomChangeInfo.tabId; // $ExpectType number
+        zoomChangeInfo.zoomSettings; // $ExpectType ZoomSettings
     });
-    chrome.tabs.onZoomChange.removeListener((zoomChangeInfo) => {
-        zoomChangeInfo; // $ExpectType ZoomChangeInfo
+    chrome.tabs.onZoomChange.removeListener((zoomChangeInfo) => { // $ExpectType void
+        zoomChangeInfo.tabId; // $ExpectType number
+        zoomChangeInfo.newZoomFactor; // $ExpectType number
+        zoomChangeInfo.oldZoomFactor; // $ExpectType number
+        zoomChangeInfo.zoomSettings; // $ExpectType ZoomSettings
     });
-    chrome.tabs.onZoomChange.hasListener((zoomChangeInfo) => {
-        zoomChangeInfo; // $ExpectType ZoomChangeInfo
+    chrome.tabs.onZoomChange.hasListener((zoomChangeInfo) => { // $ExpectType boolean
+        zoomChangeInfo.newZoomFactor; // $ExpectType number
+        zoomChangeInfo.oldZoomFactor; // $ExpectType number
+        zoomChangeInfo.tabId; // $ExpectType number
+        zoomChangeInfo.zoomSettings; // $ExpectType ZoomSettings
     });
     chrome.tabs.onZoomChange.hasListeners(); // $ExpectType boolean
+
+    const details: chrome.extensionTypes.InjectDetails = {
+        allFrames: true,
+        code: "alert('hello world');",
+        cssOrigin: "author",
+        file: "file.js",
+        frameId,
+        matchAboutBlank: true,
+        runAt: "document_idle",
+    };
+
+    chrome.tabs.executeScript(details); // $ExpectType Promise<any[] | undefined>
+    chrome.tabs.executeScript(tabId, details); // $ExpectType Promise<any[] | undefined>
+    chrome.tabs.executeScript(details, (result) => { // $ExpectType void
+        result; // $ExpectType any[] | undefined
+    });
+    chrome.tabs.executeScript(tabId, details, (result) => { // $ExpectType void
+        result; // $ExpectType any[] | undefined
+    });
+    // @ts-expect-error
+    chrome.tabs.executeScript(() => {}).then(() => {});
+
+    chrome.tabs.getAllInWindow(); // $ExpectType Promise<Tab[]>
+    chrome.tabs.getAllInWindow(windowId); // $ExpectType Promise<Tab[]>
+    chrome.tabs.getAllInWindow((tabs) => { // $ExpectType void
+        tabs; // $ExpectType Tab[]
+    });
+    chrome.tabs.getAllInWindow(windowId, (tabs) => { // $ExpectType void
+        tabs; // $ExpectType Tab[]
+    });
+    // @ts-expect-error
+    chrome.tabs.getAllInWindow(() => {}).then(() => {});
+
+    chrome.tabs.getSelected(); // $ExpectType Promise<Tab>
+    chrome.tabs.getSelected(windowId); // $ExpectType Promise<Tab>
+    chrome.tabs.getSelected((tab) => { // $ExpectType void
+        tab; // $ExpectType Tab
+    });
+    chrome.tabs.getSelected(windowId, (tab) => { // $ExpectType void
+        tab; // $ExpectType Tab
+    });
+    // @ts-expect-error
+    chrome.tabs.getSelected(() => {}).then(() => {});
+
+    chrome.tabs.insertCSS(details); // $ExpectType Promise<void>
+    chrome.tabs.insertCSS(tabId, details); // $ExpectType Promise<void>
+    chrome.tabs.insertCSS(details, () => {}); // $ExpectType void
+    chrome.tabs.insertCSS(tabId, details, () => {}); // $ExpectType void
+    // @ts-expect-error
+    chrome.tabs.insertCSS(() => {}).then(() => {});
+
+    const request = "Hello World!";
+
+    chrome.tabs.sendRequest(tabId, request); // $ExpectType Promise<any>
+    chrome.tabs.sendRequest<string, string>(4, "Hello World!"); // $ExpectType Promise<string>
+    chrome.tabs.sendRequest<string, number>(5, "Hello World!"); // $ExpectType Promise<number>
+    chrome.tabs.sendRequest(tabId, request, (result) => { // $ExpectType void
+        result; // $ExpectType any
+    });
+    // @ts-expect-error
+    chrome.tabs.sendRequest<number>(6, "Hello World!", console.log);
+    // @ts-expect-error
+    chrome.tabs.sendRequest<string, string>(7, "Hello World!", (num: number) => alert(num + 1));
+    // @ts-expect-error
+    chrome.tabs.sendRequest(() => {}).then(() => {});
+
+    chrome.tabs.onActiveChanged.addListener((tabId, selectInfo) => { // $ExpectType void
+        tabId; // $ExpectType number
+        selectInfo.windowId; // $ExpectType number
+    });
+    chrome.tabs.onActiveChanged.removeListener((tabId, selectInfo) => { // $ExpectType void
+        tabId; // $ExpectType number
+        selectInfo.windowId; // $ExpectType number
+    });
+    chrome.tabs.onActiveChanged.hasListener((tabId, selectInfo) => { // $ExpectType boolean
+        tabId; // $ExpectType number
+        selectInfo.windowId; // $ExpectType number
+    });
+    chrome.tabs.onActiveChanged.hasListeners(); // $ExpectType boolean
+
+    chrome.tabs.onHighlightChanged.addListener((selectInfo) => { // $ExpectType void
+        selectInfo.tabIds; // $ExpectType number[]
+        selectInfo.windowId; // $ExpectType number
+    });
+    chrome.tabs.onHighlightChanged.removeListener((selectInfo) => { // $ExpectType void
+        selectInfo.tabIds; // $ExpectType number[]
+        selectInfo.windowId; // $ExpectType number
+    });
+    chrome.tabs.onHighlightChanged.hasListener((selectInfo) => { // $ExpectType boolean
+        selectInfo.tabIds; // $ExpectType number[]
+        selectInfo.windowId; // $ExpectType number
+    });
+    chrome.tabs.onHighlightChanged.hasListeners(); // $ExpectType boolean
+
+    chrome.tabs.onSelectionChanged.addListener((tabId, selectInfo) => { // $ExpectType void
+        tabId; // $ExpectType number
+        selectInfo.windowId; // $ExpectType number
+    });
+    chrome.tabs.onSelectionChanged.removeListener((tabId, selectInfo) => { // $ExpectType void
+        tabId; // $ExpectType number
+        selectInfo.windowId; // $ExpectType number
+    });
+    chrome.tabs.onSelectionChanged.hasListener((tabId, selectInfo) => { // $ExpectType boolean
+        tabId; // $ExpectType number
+        selectInfo.windowId; // $ExpectType number
+    });
+    chrome.tabs.onSelectionChanged.hasListeners(); // $ExpectType boolean
 }
 
 // https://developer.chrome.com/docs/extensions/reference/api/tabGroups
@@ -3583,18 +3712,6 @@ function testStorageForPromise() {
     chrome.storage.sync.setAccessLevel({ accessLevel: chrome.storage.AccessLevel.TRUSTED_AND_UNTRUSTED_CONTEXTS }).then(
         () => {},
     );
-}
-
-function testTabsSendRequest() {
-    chrome.tabs.sendRequest(1, "Hello World!");
-    chrome.tabs.sendRequest(2, "Hello World!", console.log);
-    chrome.tabs.sendRequest(3, "Hello World!", console.log);
-    chrome.tabs.sendRequest<string>(4, "Hello World!", console.log);
-    chrome.tabs.sendRequest<string, number>(5, "Hello World!", console.log);
-    // @ts-expect-error
-    chrome.tabs.sendRequest<number>(6, "Hello World!", console.log);
-    // @ts-expect-error
-    chrome.tabs.sendRequest<string, string>(7, "Hello World!", (num: number) => alert(num + 1));
 }
 
 function testExtensionSendRequest() {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://developer.chrome.com/docs/extensions/reference/api/tabs
  - https://developer.chrome.com/docs/extensions/mv2/reference/tabs
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes :
- Added `MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND` property
- Added `TAB_INDEX_NONE` property
- Added `MutedInfoReason` enum
- Added `TabStatus` enum
- Added `WindowType` enum
- Added `ZoomSettingsMode` enum
- Added `ZoomSettingsScope` enum
- Correction the return type of the `discard()` -> `Tab` -> `Tab | undefined` 
- Correction the `tabIds` type of the of `group()` and `ungroup()` -> `number | number[]` -> `number | [number, ...number[]]`  (Array can't be empty)
- Correction the return type of the `executeScript()` -> `any[]` -> `any[] | undefined`  (MV2)
- Correction the return type of the `getAllInWindow()` -> `Tab` -> `Tab[]`  (MV2)
- Updated `sendRequest()` -> Can be return a promise (MV2)
- Clean JSDoc (Remove internal interface of events)
- Updates tests

Runtime :
![image](https://github.com/user-attachments/assets/4552ef0a-19e1-48a5-9f60-30c2cb93b35c)





