### PR TITLE
[chrome] update Runtime namespace

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -8952,37 +8952,114 @@ declare namespace chrome {
      * Use the `chrome.runtime` API to retrieve the service worker, return details about the manifest, and listen for and respond to events in the extension lifecycle. You can also use this API to convert the relative path of URLs to fully-qualified URLs.
      */
     export namespace runtime {
-        /** This will be defined during an API method callback if there was an error */
-        export var lastError: LastError | undefined;
-        /** The ID of the extension/app. */
-        export var id: string;
+        /** Populated with an error message if calling an API function fails; otherwise undefined. This is only defined within the scope of that function's callback. If an error is produced, but `runtime.lastError` is not accessed within the callback, a message is logged to the console listing the API function that produced the error. API functions that return promises do not set this property. */
+        export const lastError: {
+            /** Details about the error which occurred.  */
+            message?: string;
+        } | undefined;
 
-        /** https://developer.chrome.com/docs/extensions/reference/api/runtime#type-PlatformOs */
-        export type PlatformOs = "mac" | "win" | "android" | "cros" | "linux" | "openbsd" | "fuchsia";
-        /** https://developer.chrome.com/docs/extensions/reference/api/runtime#type-PlatformArch */
-        export type PlatformArch = "arm" | "arm64" | "x86-32" | "x86-64" | "mips" | "mips64";
-        /** https://developer.chrome.com/docs/extensions/reference/api/runtime#type-PlatformNaclArch */
-        export type PlatformNaclArch = "arm" | "x86-32" | "x86-64" | "mips" | "mips64";
-        /** https://developer.chrome.com/docs/extensions/reference/api/runtime#type-ContextType */
+        /** The ID of the extension/app. */
+        export const id: string;
+
+        /**
+         * The operating system Chrome is running on.
+         * @since Chrome 44
+         */
+        export enum PlatformOs {
+            /** Specifies the MacOS operating system. */
+            MAC = "mac",
+            /** Specifies the Windows operating system. */
+            WIN = "win",
+            /** Specifies the Android operating system. */
+            ANDROID = "android",
+            /** Specifies the Chrome operating system. */
+            CROS = "cros",
+            /** Specifies the Linux operating system. */
+            LINUX = "linux",
+            /** Specifies the OpenBSD operating system. */
+            OPENBSD = "openbsd",
+            /** Specifies the Fuchsia operating system. */
+            FUCHSIA = "fuchsia",
+        }
+
+        /**
+         * The machine's processor architecture.
+         * @since Chrome 44
+         */
+        export enum PlatformArch {
+            /** Specifies the processer architecture as arm. */
+            ARM = "arm",
+            /** Specifies the processer architecture as arm64. */
+            ARM64 = "arm64",
+            /** Specifies the processer architecture as x86-32. */
+            X86_32 = "x86-32",
+            /** Specifies the processer architecture as x86-64. */
+            X86_64 = "x86-64",
+            /** Specifies the processer architecture as mips. */
+            MIPS = "mips",
+            /** Specifies the processer architecture as mips64. */
+            MIPS64 = "mips64",
+        }
+
+        /**
+         * The native client architecture. This may be different from arch on some platforms.
+         * @since Chrome 44
+         */
+        export enum PlatformNaclArch {
+            /** Specifies the native client architecture as arm. */
+            ARM = "arm",
+            /** Specifies the native client architecture as x86-32. */
+            X86_32 = "x86-32",
+            /** Specifies the native client architecture as x86-64. */
+            X86_64 = "x86-64",
+            /** Specifies the native client architecture as mips. */
+            MIPS = "mips",
+            /** Specifies the native client architecture as mips64. */
+            MIPS64 = "mips64",
+        }
+
+        /** @since Chrome 114 */
         export enum ContextType {
+            /** Specifies the context type as a tab */
             TAB = "TAB",
+            /** Specifies the context type as an extension popup window */
             POPUP = "POPUP",
+            /** Specifies the context type as a service worker. */
             BACKGROUND = "BACKGROUND",
+            /** Specifies the context type as an offscreen document. */
             OFFSCREEN_DOCUMENT = "OFFSCREEN_DOCUMENT",
+            /** Specifies the context type as a side panel. */
             SIDE_PANEL = "SIDE_PANEL",
+            /** Specifies the context type as developer tools. */
             DEVELOPER_TOOLS = "DEVELOPER_TOOLS",
         }
-        /** https://developer.chrome.com/docs/extensions/reference/api/runtime#type-OnInstalledReason */
+
+        /**
+         * The reason that this event is being dispatched.
+         * @since Chrome 44
+         */
         export enum OnInstalledReason {
+            /** Specifies the event reason as an installation. */
             INSTALL = "install",
+            /** Specifies the event reason as an extension update. */
             UPDATE = "update",
+            /** Specifies the event reason as a Chrome update. */
             CHROME_UPDATE = "chrome_update",
+            /** Specifies the event reason as an update to a shared module. */
             SHARED_MODULE_UPDATE = "shared_module_update",
         }
 
-        export interface LastError {
-            /** Optional. Details about the error which occurred.  */
-            message?: string | undefined;
+        /**
+         * The reason that the event is being dispatched. 'app_update' is used when the restart is needed because the application is updated to a newer version. 'os_update' is used when the restart is needed because the browser/OS is updated to a newer version. 'periodic' is used when the system runs for more than the permitted uptime set in the enterprise policy.
+         * @since Chrome 44
+         */
+        export enum OnRestartRequiredReason {
+            /** Specifies the event reason as an update to the app. */
+            APP_UPDATE = "app_update",
+            /** Specifies the event reason as an update to the operating system. */
+            OS_UPDATE = "os_update",
+            /** Specifies the event reason as a periodic restart of the app. */
+            PERIODIC = "periodic",
         }
 
         /**
@@ -8991,7 +9068,7 @@ declare namespace chrome {
          */
         export interface ContextFilter {
             contextIds?: string[] | undefined;
-            contextTypes?: ContextType[] | undefined;
+            contextTypes?: `${ContextType}`[] | undefined;
             documentIds?: string[] | undefined;
             documentOrigins?: string[] | undefined;
             documentUrls?: string[] | undefined;
@@ -9002,26 +9079,19 @@ declare namespace chrome {
         }
 
         export interface ConnectInfo {
+            /** Will be passed into onConnect for processes that are listening for the connection event. */
             name?: string | undefined;
+            /** Whether the TLS channel ID will be passed into onConnectExternal for processes that are listening for the connection event. */
             includeTlsChannelId?: boolean | undefined;
         }
 
         export interface InstalledDetails {
-            /**
-             * The reason that this event is being dispatched.
-             */
+            /** The reason that this event is being dispatched. */
             reason: `${OnInstalledReason}`;
-            /**
-             * Optional.
-             * Indicates the previous version of the extension, which has just been updated. This is present only if 'reason' is 'update'.
-             */
-            previousVersion?: string | undefined;
-            /**
-             * Optional.
-             * Indicates the ID of the imported shared module extension which updated. This is present only if 'reason' is 'shared_module_update'.
-             * @since Chrome 29
-             */
-            id?: string | undefined;
+            /** Indicates the previous version of the extension, which has just been updated. This is present only if 'reason' is 'update'. */
+            previousVersion?: string;
+            /** Indicates the ID of the imported shared module extension which updated. This is present only if 'reason' is 'shared_module_update'. */
+            id?: string;
         }
 
         /**
@@ -9032,29 +9102,20 @@ declare namespace chrome {
             /** A unique identifier for this context */
             contextId: string;
             /** The type of context this corresponds to. */
-            contextType: ContextType;
-            /**
-             * Optional.
-             * A UUID for the document associated with this context, or undefined if this context is hosted not in a document.
-             */
-            documentId?: string | undefined;
-            /**
-             * Optional.
-             * The origin of the document associated with this context, or undefined if the context is not hosted in a document.
-             */
-            documentOrigin?: string | undefined;
-            /**
-             * Optional.
-             * The URL of the document associated with this context, or undefined if the context is not hosted in a document.
-             */
-            documentUrl?: string | undefined;
-            /** The ID of the frame for this context, or -1 if this context is not hosted in a frame. */
+            contextType: `${ContextType}`;
+            /** A UUID for the document associated with this context, or undefined if this context is hosted not in a document.*/
+            documentId?: string;
+            /** The origin of the document associated with this context, or undefined if the context is not hosted in a document. */
+            documentOrigin?: string;
+            /** The URL of the document associated with this context, or undefined if the context is not hosted in a document. */
+            documentUrl?: string;
+            /** The ID of the frame for this context, or `-1` if this context is not hosted in a frame. */
             frameId: number;
             /** Whether the context is associated with an incognito profile. */
             incognito: boolean;
-            /** The ID of the tab for this context, or -1 if this context is not hosted in a tab. */
+            /** The ID of the tab for this context, or `-1` if this context is not hosted in a tab. */
             tabId: number;
-            /** The ID of the window for this context, or -1 if this context is not hosted in a window. */
+            /** The ID of the window for this context, or `-1` if this context is not hosted in a window. */
             windowId: number;
         }
 
@@ -9063,92 +9124,64 @@ declare namespace chrome {
             includeTlsChannelId?: boolean | undefined;
         }
 
-        /**
-         * An object containing information about the script context that sent a message or request.
-         * @since Chrome 26
-         */
+        /** An object containing information about the script context that sent a message or request */
         export interface MessageSender {
-            /** The ID of the extension or app that opened the connection, if any. */
-            id?: string | undefined;
-            /** The tabs.Tab which opened the connection, if any. This property will only be present when the connection was opened from a tab (including content scripts), and only if the receiver is an extension, not an app. */
-            tab?: chrome.tabs.Tab | undefined;
-            /** The name of the native application that opened the connection, if any.
+            /** The ID of the extension that opened the connection, if any. */
+            id?: string;
+            /** The {@link tabs.Tab} which opened the connection, if any. This property will **only** be present when the connection was opened from a tab (including content scripts), and **only** if the receiver is an extension, not an app. */
+            tab?: chrome.tabs.Tab;
+            /**
+             * The name of the native application that opened the connection, if any.
              * @since Chrome 74
              */
-            nativeApplication?: string | undefined;
-            /**
-             * The frame that opened the connection. 0 for top-level frames, positive for child frames. This will only be set when tab is set.
-             * @since Chrome 41
-             */
-            frameId?: number | undefined;
-            /**
-             * The URL of the page or frame that opened the connection. If the sender is in an iframe, it will be iframe's URL not the URL of the page which hosts it.
-             * @since Chrome 28
-             */
-            url?: string | undefined;
-            /**
-             * The TLS channel ID of the page or frame that opened the connection, if requested by the extension or app, and if available.
-             * @since Chrome 32
-             */
-            tlsChannelId?: string | undefined;
+            nativeApplication?: string;
+            /** The frame that opened the connection. 0 for top-level frames, positive for child frames. This will only be set when tab is set. */
+            frameId?: number;
+            /** The URL of the page or frame that opened the connection. If the sender is in an iframe, it will be iframe's URL not the URL of the page which hosts it. */
+            url?: string;
+            /** The TLS channel ID of the page or frame that opened the connection, if requested by the extension, and if available */
+            tlsChannelId?: string;
             /**
              * The origin of the page or frame that opened the connection. It can vary from the url property (e.g., about:blank) or can be opaque (e.g., sandboxed iframes). This is useful for identifying if the origin can be trusted if we can't immediately tell from the URL.
              * @since Chrome 80
              */
-            origin?: string | undefined;
+            origin?: string;
             /**
              * The lifecycle the document that opened the connection is in at the time the port was created. Note that the lifecycle state of the document may have changed since port creation.
              * @since Chrome 106
              */
-            documentLifecycle?: extensionTypes.DocumentLifecycle | undefined;
+            documentLifecycle?: extensionTypes.DocumentLifecycle;
             /**
              * A UUID of the document that opened the connection.
              * @since Chrome 106
              */
-            documentId?: string | undefined;
+            documentId?: string;
         }
 
-        /**
-         * An object containing information about the current platform.
-         * @since Chrome 36
-         */
+        /** An object containing information about the current platform. */
         export interface PlatformInfo {
-            /**
-             * The operating system chrome is running on.
-             */
-            os: PlatformOs;
-            /**
-             * The machine's processor architecture.
-             */
-            arch: PlatformArch;
-            /**
-             * The native client architecture. This may be different from arch on some platforms.
-             */
-            nacl_arch: PlatformNaclArch;
+            /** The operating system Chrome is running on. */
+            os: `${PlatformOs}`;
+            /** The machine's processor architecture. */
+            arch: `${PlatformArch}`;
+            /** The native client architecture. This may be different from arch on some platforms. */
+            nacl_arch: `${PlatformNaclArch}`;
         }
 
-        /**
-         * An object which allows two way communication with other pages.
-         * @since Chrome 26
-         */
+        /** An object which allows two way communication with other pages. */
         export interface Port {
+            /** Send a message to the other end of the port. If the port is disconnected, an error is thrown. */
             postMessage: (message: any) => void;
+            /** Immediately disconnect the port. Calling `disconnect()` on an already-disconnected port has no effect. When a port is disconnected, no new events will be dispatched to this port. */
             disconnect: () => void;
-            /**
-             * Optional.
-             * This property will only be present on ports passed to onConnect/onConnectExternal listeners.
-             */
-            sender?: MessageSender | undefined;
-            /** An object which allows the addition and removal of listeners for a Chrome event. */
-            onDisconnect: PortDisconnectEvent;
-            /** An object which allows the addition and removal of listeners for a Chrome event. */
-            onMessage: PortMessageEvent;
+            /** This property will **only** be present on ports passed to {@link runtime.onConnect onConnect} / {@link runtime.onConnectExternal onConnectExternal} / {@link runtime.onConnectExternal onConnectNative} listeners. */
+            sender?: MessageSender;
+            /** Fired when the port is disconnected from the other end(s). {@link runtime.lastError} may be set if the port was disconnected by an error. If the port is closed via {@link Port.disconnect disconnect}, then this event is _only_ fired on the other end. This event is fired at most once (see also Port lifetime). */
+            onDisconnect: events.Event<(port: Port) => void>;
+            /** This event is fired when {@link Port.postMessage postMessage} is called by the other end of the port. */
+            onMessage: events.Event<(message: any, port: Port) => void>;
+            /** The name of the port, as specified in the call to {@link runtime.connect}. */
             name: string;
-        }
-
-        export interface UpdateAvailableDetails {
-            /** The version number of the available update. */
-            version: string;
         }
 
         export interface UpdateCheckDetails {
@@ -9156,38 +9189,25 @@ declare namespace chrome {
             version: string;
         }
 
-        /** Result of the update check. */
-        export type RequestUpdateCheckStatus = "throttled" | "no_update" | "update_available";
-
-        /** Result of the update check. */
-        export interface RequestUpdateCheckResult {
-            /** The status of the update check. */
-            status: RequestUpdateCheckStatus;
-            /** The version of the available update. */
-            version: string;
+        /**
+         * Result of the update check.
+         * @since Chrome 44
+         */
+        export enum RequestUpdateCheckStatus {
+            /** Specifies that the status check has been throttled. This can occur after repeated checks within a short amount of time. */
+            THROTTLED = "throttled",
+            /** Specifies that there are no available updates to install. */
+            NO_UPDATE = "no_update",
+            /** Specifies that there is an available update to install. */
+            UPDATE_AVAILABLE = "update_available",
         }
 
-        export interface PortDisconnectEvent extends chrome.events.Event<(port: Port) => void> {}
-
-        export interface PortMessageEvent extends chrome.events.Event<(message: any, port: Port) => void> {}
-
-        export interface ExtensionMessageEvent extends
-            chrome.events.Event<
-                (message: any, sender: MessageSender, sendResponse: (response?: any) => void) => void
-            >
-        {}
-
-        export interface ExtensionConnectEvent extends chrome.events.Event<(port: Port) => void> {}
-
-        export interface RuntimeInstalledEvent extends chrome.events.Event<(details: InstalledDetails) => void> {}
-
-        export interface RuntimeEvent extends chrome.events.Event<() => void> {}
-
-        export interface RuntimeRestartRequiredEvent extends chrome.events.Event<(reason: string) => void> {}
-
-        export interface RuntimeUpdateAvailableEvent
-            extends chrome.events.Event<(details: UpdateAvailableDetails) => void>
-        {}
+        export interface RequestUpdateCheckResult {
+            /** Result of the update check. */
+            status: `${RequestUpdateCheckStatus}`;
+            /** If an update is available, this contains the version of the available update. */
+            version?: string;
+        }
 
         export interface ManifestIcons {
             [size: number]: string;
@@ -9564,282 +9584,225 @@ declare namespace chrome {
         export type Manifest = ManifestV2 | ManifestV3;
 
         /**
-         * Attempts to connect to connect listeners within an extension/app (such as the background page), or other extensions/apps. This is useful for content scripts connecting to their extension processes, inter-app/extension communication, and web messaging. Note that this does not connect to any listeners in a content script. Extensions may connect to content scripts embedded in tabs via tabs.connect.
-         * @since Chrome 26
+         * Attempts to connect listeners within an extension (such as the background page), or other extensions/apps. This is useful for content scripts connecting to their extension processes, inter-app/extension communication, and web messaging. Note that this does not connect to any listeners in a content script. Extensions may connect to content scripts embedded in tabs via {@link tabs.connect}.
+         *
+         * @param extensionId The ID of the extension to connect to. If omitted, a connection will be attempted with your own extension. Required if sending messages from a web page for web messaging.
+         * @returns Port through which messages can be sent and received. The port's {@link Port onDisconnect} event is fired if the extension does not exist.
          */
         export function connect(connectInfo?: ConnectInfo): Port;
+        export function connect(extensionId: string | undefined, connectInfo?: ConnectInfo): Port;
+
         /**
-         * Attempts to connect to connect listeners within an extension/app (such as the background page), or other extensions/apps. This is useful for content scripts connecting to their extension processes, inter-app/extension communication, and web messaging. Note that this does not connect to any listeners in a content script. Extensions may connect to content scripts embedded in tabs via tabs.connect.
-         * @since Chrome 26
-         * @param extensionId Optional.
-         * The ID of the extension or app to connect to. If omitted, a connection will be attempted with your own extension. Required if sending messages from a web page for web messaging.
-         */
-        export function connect(extensionId: string, connectInfo?: ConnectInfo): Port;
-        /**
-         * Connects to a native application in the host machine.
-         * @since Chrome 28
+         * Connects to a native application in the host machine. This method requires the `"nativeMessaging"` permission. See Native Messaging for more information.
          * @param application The name of the registered application to connect to.
          */
         export function connectNative(application: string): Port;
         /**
          * Retrieves the JavaScript 'window' object for the background page running inside the current extension/app. If the background page is an event page, the system will ensure it is loaded before calling the callback. If there is no background page, an error is set.
-         * @deprecated Removed since Chrome 133. Background pages do not exist in MV3 extensions.
+         *
+         * Foreground only
+         *
+         * Can return its result via Promise since Chrome 99.
+         * @deprecated since Chrome 133. Background pages do not exist in MV3 extensions.
          */
-        export function getBackgroundPage(): Promise<Window>;
-        /** Retrieves the JavaScript 'window' object for the background page running inside the current extension/app. If the background page is an event page, the system will ensure it is loaded before calling the callback. If there is no background page, an error is set. */
+        export function getBackgroundPage(): Promise<Window | undefined>;
         export function getBackgroundPage(callback: (backgroundPage?: Window) => void): void;
+
         /**
          * Fetches information about active contexts associated with this extension
-         * @since Chrome 116 MV3.
-         * @return Provides the matching context, if any via callback or returned as a `Promise` (MV3 only).
          * @param filter A filter to find matching contexts. A context matches if it matches all specified fields in the filter. Any unspecified field in the filter matches all contexts.
+         * @since Chrome 116 MV3.
          */
         export function getContexts(filter: ContextFilter): Promise<ExtensionContext[]>;
-        /**
-         * Fetches information about active contexts associated with this extension
-         * @since Chrome 116 MV3.
-         * @return Provides the matching context, if any via callback or returned as a `Promise` (MV3 only).
-         * @param filter A filter to find matching contexts. A context matches if it matches all specified fields in the filter. Any unspecified field in the filter matches all contexts.
-         * @param callback Called with results
-         */
         export function getContexts(filter: ContextFilter, callback: (contexts: ExtensionContext[]) => void): void;
+
         /**
          * Returns details about the app or extension from the manifest. The object returned is a serialization of the full manifest file.
          * @return The manifest details.
          */
         export function getManifest(): Manifest;
+
         /**
          * Returns a DirectoryEntry for the package directory.
-         * @since Chrome 29
+         *
+         * Foreground only
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 122.
          */
+        export function getPackageDirectoryEntry(): Promise<DirectoryEntry>;
         export function getPackageDirectoryEntry(callback: (directoryEntry: DirectoryEntry) => void): void;
+
         /**
          * Returns information about the current platform.
-         * @since Chrome 29
-         * @param callback Called with results
-         */
-        export function getPlatformInfo(callback: (platformInfo: PlatformInfo) => void): void;
-        /**
-         * Returns information about the current platform.
-         * @since Chrome 29
-         * @return The `getPlatformInfo` method provides its result via callback or returned as a `Promise` (MV3 only).
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 99.
          */
         export function getPlatformInfo(): Promise<PlatformInfo>;
+        export function getPlatformInfo(callback: (platformInfo: PlatformInfo) => void): void;
+
         /**
          * Converts a relative path within an app/extension install directory to a fully-qualified URL.
          * @param path A path to a resource within an app/extension expressed relative to its install directory.
+         * @returns The fully-qualified URL to the resource.
          */
         export function getURL(path: string): string;
-        /**
-         * Reloads the app or extension.
-         * @since Chrome 25
-         */
+
+        /** Reloads the app or extension. This method is not supported in kiosk mode. For kiosk mode, use {@link chrome.runtime.restart()} method. */
         export function reload(): void;
+
         /**
-         * Requests an update check for this app/extension.
-         * @since Chrome 109
-         * @return This only returns a Promise when the callback parameter is not specified, and with MV3.
+         * Requests an immediate update check be done for this app/extension.
+         *
+         * **Important**: Most extensions/apps should **not** use this method, since Chrome already does automatic checks every few hours, and you can listen for the {@link runtime.onUpdateAvailable} event without needing to call requestUpdateCheck.
+         *
+         * This method is only appropriate to call in very limited circumstances, such as if your extension talks to a backend service, and the backend service has determined that the client extension version is very far out of date and you'd like to prompt a user to update. Most other uses of requestUpdateCheck, such as calling it unconditionally based on a repeating timer, probably only serve to waste client, network, and server resources.
+         *
+         * Note: When called with a callback, instead of returning an object this function will return the two properties as separate arguments passed to the callback.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 109.
          */
         export function requestUpdateCheck(): Promise<RequestUpdateCheckResult>;
-        /**
-         * Requests an update check for this app/extension.
-         * @since Chrome 25
-         * @param callback
-         * Parameter status: Result of the update check. One of: "throttled", "no_update", or "update_available"
-         * Optional parameter details: If an update is available, this contains more information about the available update.
-         */
         export function requestUpdateCheck(
-            callback: (status: RequestUpdateCheckStatus, details?: UpdateCheckDetails) => void,
+            callback: (status: `${RequestUpdateCheckStatus}`, details?: { version: string }) => void,
         ): void;
-        /**
-         * Restart the ChromeOS device when the app runs in kiosk mode. Otherwise, it's no-op.
-         * @since Chrome 32
-         */
+
+        /** Restart the ChromeOS device when the app runs in kiosk mode. Otherwise, it's no-op. */
         export function restart(): void;
+
         /**
-         * Restart the ChromeOS device when the app runs in kiosk mode after the
-         * given seconds. If called again before the time ends, the reboot will
-         * be delayed. If called with a value of -1, the reboot will be
-         * cancelled. It's a no-op in non-kiosk mode. It's only allowed to be
-         * called repeatedly by the first extension to invoke this API.
+         * Restart the ChromeOS device when the app runs in kiosk mode after the given seconds. If called again before the time ends, the reboot will be delayed. If called with a value of `-1`, the reboot will be cancelled. It's a no-op in non-kiosk mode. It's only allowed to be called repeatedly by the first extension to invoke this API.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 99.
          * @since Chrome 53
-         * @param seconds
-         * @param callback
          */
-        export function restartAfterDelay(seconds: number, callback?: () => void): void;
+        export function restartAfterDelay(seconds: number): Promise<void>;
+        export function restartAfterDelay(seconds: number, callback: () => void): void;
+
         /**
-         * Sends a single message to event listeners within your extension/app or a different extension/app. Similar to runtime.connect but only sends a single message, with an optional response. If sending to your extension, the runtime.onMessage event will be fired in each page, or runtime.onMessageExternal, if a different extension. Note that extensions cannot send messages to content scripts using this method. To send messages to content scripts, use tabs.sendMessage.
-         * @since Chrome 26
-         * Parameter response: The JSON response object sent by the handler of the message. If an error occurs while connecting to the extension, the callback will be called with no arguments and runtime.lastError will be set to the error message.
+         * Sends a single message to event listeners within your extension or a different extension/app. Similar to {@link runtime.connect} but only sends a single message, with an optional response. If sending to your extension, the {@link runtime.onMessage} event will be fired in every frame of your extension (except for the sender's frame), or {@link runtime.onMessageExternal}, if a different extension. Note that extensions cannot send messages to content scripts using this method. To send messages to content scripts, use {@link tabs.sendMessage}.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 99.
+         * @param extensionId The ID of the extension to send the message to. If omitted, the message will be sent to your own extension/app. Required if sending messages from a web page for web messaging.
+         * @param message The message to send. This message should be a JSON-ifiable object.
          */
-        export function sendMessage<M = any, R = any>(message: M, responseCallback: (response: R) => void): void;
-        /**
-         * Sends a single message to event listeners within your extension/app or a different extension/app. Similar to runtime.connect but only sends a single message, with an optional response. If sending to your extension, the runtime.onMessage event will be fired in each page, or runtime.onMessageExternal, if a different extension. Note that extensions cannot send messages to content scripts using this method. To send messages to content scripts, use tabs.sendMessage.
-         * @since Chrome 32
-         * Parameter response: The JSON response object sent by the handler of the message. If an error occurs while connecting to the extension, the callback will be called with no arguments and runtime.lastError will be set to the error message.
-         */
+        export function sendMessage<M = any, R = any>(message: M, options?: MessageOptions): Promise<R>;
+        export function sendMessage<M = any, R = any>(message: M, callback: (response: R) => void): void;
         export function sendMessage<M = any, R = any>(
             message: M,
-            options: MessageOptions,
-            responseCallback: (response: R) => void,
+            options: MessageOptions | undefined,
+            callback: (response: R) => void,
         ): void;
-        /**
-         * Sends a single message to event listeners within your extension/app or a different extension/app. Similar to runtime.connect but only sends a single message, with an optional response. If sending to your extension, the runtime.onMessage event will be fired in each page, or runtime.onMessageExternal, if a different extension. Note that extensions cannot send messages to content scripts using this method. To send messages to content scripts, use tabs.sendMessage.
-         * @since Chrome 26
-         * @param extensionId The ID of the extension/app to send the message to. If omitted, the message will be sent to your own extension/app. Required if sending messages from a web page for web messaging.
-         * Parameter response: The JSON response object sent by the handler of the message. If an error occurs while connecting to the extension, the callback will be called with no arguments and runtime.lastError will be set to the error message.
-         */
         export function sendMessage<M = any, R = any>(
             extensionId: string | undefined | null,
             message: M,
-            responseCallback: (response: R) => void,
-        ): void;
-        /**
-         * Sends a single message to event listeners within your extension/app or a different extension/app. Similar to runtime.connect but only sends a single message, with an optional response. If sending to your extension, the runtime.onMessage event will be fired in each page, or runtime.onMessageExternal, if a different extension. Note that extensions cannot send messages to content scripts using this method. To send messages to content scripts, use tabs.sendMessage.
-         * @since Chrome 32
-         * @param extensionId The ID of the extension/app to send the message to. If omitted, the message will be sent to your own extension/app. Required if sending messages from a web page for web messaging.
-         * Parameter response: The JSON response object sent by the handler of the message. If an error occurs while connecting to the extension, the callback will be called with no arguments and runtime.lastError will be set to the error message.
-         */
-        export function sendMessage<Message = any, Response = any>(
-            extensionId: string | undefined | null,
-            message: Message,
-            options: MessageOptions,
-            responseCallback: (response: Response) => void,
-        ): void;
-        /**
-         * Sends a single message to event listeners within your extension/app or a different extension/app. Similar to runtime.connect but only sends a single message, with an optional response. If sending to your extension, the runtime.onMessage event will be fired in each page, or runtime.onMessageExternal, if a different extension. Note that extensions cannot send messages to content scripts using this method. To send messages to content scripts, use tabs.sendMessage.
-         * @since Chrome 26
-         */
-        export function sendMessage<M = any, R = any>(message: M): Promise<R>;
-        /**
-         * Sends a single message to event listeners within your extension/app or a different extension/app. Similar to runtime.connect but only sends a single message, with an optional response. If sending to your extension, the runtime.onMessage event will be fired in each page, or runtime.onMessageExternal, if a different extension. Note that extensions cannot send messages to content scripts using this method. To send messages to content scripts, use tabs.sendMessage.
-         * @since Chrome 32
-         */
-        export function sendMessage<M = any, R = any>(
-            message: M,
-            options: MessageOptions,
+            options?: MessageOptions,
         ): Promise<R>;
-        /**
-         * Sends a single message to event listeners within your extension/app or a different extension/app. Similar to runtime.connect but only sends a single message, with an optional response. If sending to your extension, the runtime.onMessage event will be fired in each page, or runtime.onMessageExternal, if a different extension. Note that extensions cannot send messages to content scripts using this method. To send messages to content scripts, use tabs.sendMessage.
-         * @since Chrome 26
-         * @param extensionId The ID of the extension/app to send the message to. If omitted, the message will be sent to your own extension/app. Required if sending messages from a web page for web messaging.
-         */
-        export function sendMessage<M = any, R = any>(extensionId: string | undefined | null, message: M): Promise<R>;
-        /**
-         * Sends a single message to event listeners within your extension/app or a different extension/app. Similar to runtime.connect but only sends a single message, with an optional response. If sending to your extension, the runtime.onMessage event will be fired in each page, or runtime.onMessageExternal, if a different extension. Note that extensions cannot send messages to content scripts using this method. To send messages to content scripts, use tabs.sendMessage.
-         * @since Chrome 32
-         * @param extensionId The ID of the extension/app to send the message to. If omitted, the message will be sent to your own extension/app. Required if sending messages from a web page for web messaging.
-         */
-        export function sendMessage<Message = any, Response = any>(
+        export function sendMessage<M = any, R = any>(
             extensionId: string | undefined | null,
-            message: Message,
-            options: MessageOptions,
-        ): Promise<Response>;
-        /**
-         * Send a single message to a native application.
-         * @since Chrome 28
-         * @param application The of the native messaging host.
-         * @param message The message that will be passed to the native messaging host.
-         * Parameter response: The response message sent by the native messaging host. If an error occurs while connecting to the native messaging host, the callback will be called with no arguments and runtime.lastError will be set to the error message.
-         */
-        export function sendNativeMessage(
-            application: string,
-            message: object,
-            responseCallback: (response: any) => void,
+            message: M,
+            callback: (response: R) => void,
         ): void;
+        export function sendMessage<M = any, R = any>(
+            extensionId: string | undefined | null,
+            message: M,
+            options: MessageOptions | undefined,
+            callback: (response: R) => void,
+        ): void;
+
         /**
-         * Send a single message to a native application.
-         * @since Chrome 28
-         * @param application The of the native messaging host.
+         * Send a single message to a native application. This method requires the `"nativeMessaging"` permission
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 99.
+         * @param application The name of the native messaging host.
          * @param message The message that will be passed to the native messaging host.
          */
+        export function sendNativeMessage(application: string, message: object): Promise<any>;
         export function sendNativeMessage(
             application: string,
             message: object,
-        ): Promise<any>;
+            callback: (response: any) => void,
+        ): void;
+
         /**
-         * Sets the URL to be visited upon uninstallation. This may be used to clean up server-side data, do analytics, and implement surveys. Maximum 255 characters.
-         * @since Chrome 41
-         * @param url Since Chrome 34.
-         * URL to be opened after the extension is uninstalled. This URL must have an http: or https: scheme. Set an empty string to not open a new tab upon uninstallation.
-         * @param callback Called when the uninstall URL is set. If the given URL is invalid, runtime.lastError will be set.
+         * Sets the URL to be visited upon uninstallation. This may be used to clean up server-side data, do analytics, and implement surveys. Maximum 1023 characters.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 99.
+         * @param url URL to be opened after the extension is uninstalled. This URL must have an http: or https: scheme. Set an empty string to not open a new tab upon uninstallation.
          */
-        export function setUninstallURL(url: string, callback?: () => void): void;
+        export function setUninstallURL(url: string): Promise<void>;
+        export function setUninstallURL(url: string, callback: () => void): void;
+
         /**
          * Open your Extension's options page, if possible.
+         *
          * The precise behavior may depend on your manifest's options_ui or options_page key, or what Chrome happens to support at the time. For example, the page may be opened in a new tab, within chrome://extensions, within an App, or it may just focus an open options page. It will never cause the caller page to reload.
-         * If your Extension does not declare an options page, or Chrome failed to create one for some other reason, the callback will set lastError.
-         * @since MV3
+         *
+         * If your Extension does not declare an options page, or Chrome failed to create one for some other reason, the callback will set {@link runtime.lastError lastError} .
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 99
          */
         export function openOptionsPage(): Promise<void>;
-        /**
-         * Open your Extension's options page, if possible.
-         * The precise behavior may depend on your manifest's options_ui or options_page key, or what Chrome happens to support at the time. For example, the page may be opened in a new tab, within chrome://extensions, within an App, or it may just focus an open options page. It will never cause the caller page to reload.
-         * If your Extension does not declare an options page, or Chrome failed to create one for some other reason, the callback will set lastError.
-         * @since Chrome 42
-         */
-        export function openOptionsPage(callback?: () => void): void;
+        export function openOptionsPage(callback: () => void): void;
+
+        /** Fired when a connection is made from either an extension process or a content script (by {@link runtime.connect}). */
+        export const onConnect: events.Event<(port: Port) => void>;
+
+        /** Fired when a connection is made from another extension (by {@link runtime.connect}), or from an externally connectable web site. */
+        export const onConnectExternal: events.Event<(port: Port) => void>;
 
         /**
-         * Fired when a connection is made from either an extension process or a content script.
-         * @since Chrome 26
+         * Fired when a connection is made from a native application. This event requires the `"nativeMessaging"` permission. It is only supported on Chrome OS.
+         * @since Chrome 76
          */
-        export var onConnect: ExtensionConnectEvent;
-        /**
-         * Fired when a connection is made from another extension.
-         * @since Chrome 26
-         */
-        export var onConnectExternal: ExtensionConnectEvent;
+        export const onConnectNative: events.Event<(port: Port) => void>;
+
         /** Sent to the event page just before it is unloaded. This gives the extension opportunity to do some clean up. Note that since the page is unloading, any asynchronous operations started while handling this event are not guaranteed to complete. If more activity for the event page occurs before it gets unloaded the onSuspendCanceled event will be sent and the page won't be unloaded. */
-        export var onSuspend: RuntimeEvent;
-        /**
-         * Fired when a profile that has this extension installed first starts up. This event is not fired when an incognito profile is started, even if this extension is operating in 'split' incognito mode.
-         * @since Chrome 23
-         */
-        export var onStartup: RuntimeEvent;
+        export const onSuspend: events.Event<() => void>;
+
+        /** Fired when a profile that has this extension installed first starts up. This event is not fired when an incognito profile is started, even if this extension is operating in 'split' incognito mode. */
+        export const onStartup: events.Event<() => void>;
+
         /** Fired when the extension is first installed, when the extension is updated to a new version, and when Chrome is updated to a new version. */
-        export var onInstalled: RuntimeInstalledEvent;
+        export const onInstalled: events.Event<(details: InstalledDetails) => void>;
+
         /** Sent after onSuspend to indicate that the app won't be unloaded after all. */
-        export var onSuspendCanceled: RuntimeEvent;
+        export const onSuspendCanceled: events.Event<() => void>;
+
+        /** Fired when a message is sent from either an extension process (by {@link runtime.sendMessage}) or a content script (by {@link tabs.sendMessage}). */
+        export const onMessage: events.Event<
+            (message: any, sender: MessageSender, sendResponse: (response?: any) => void) => void
+        >;
+
+        /** Fired when a message is sent from another extension (by {@link runtime.sendMessage}). Cannot be used in a content script. */
+        export const onMessageExternal: events.Event<
+            (message: any, sender: MessageSender, sendResponse: (response?: any) => void) => void
+        >;
+
+        /** Fired when an app or the device that it runs on needs to be restarted. The app should close all its windows at its earliest convenient time to let the restart to happen. If the app does nothing, a restart will be enforced after a 24-hour grace period has passed. Currently, this event is only fired for Chrome OS kiosk apps. */
+        export const onRestartRequired: events.Event<(reason: `${OnRestartRequiredReason}`) => void>;
+
+        /** Fired when an update is available, but isn't installed immediately because the app is currently running. If you do nothing, the update will be installed the next time the background page gets unloaded, if you want it to be installed sooner you can explicitly call chrome.runtime.reload(). If your extension is using a persistent background page, the background page of course never gets unloaded, so unless you call chrome.runtime.reload() manually in response to this event the update will not get installed until the next time Chrome itself restarts. If no handlers are listening for this event, and your extension has a persistent background page, it behaves as if chrome.runtime.reload() is called in response to this event. */
+        export const onUpdateAvailable: events.Event<(details: { version: string }) => void>;
+
         /**
-         * Fired when a message is sent from either an extension process or a content script.
-         * @since Chrome 26
-         */
-        export var onMessage: ExtensionMessageEvent;
-        /**
-         * Fired when a message is sent from another extension/app. Cannot be used in a content script.
-         * @since Chrome 26
-         */
-        export var onMessageExternal: ExtensionMessageEvent;
-        /**
-         * Fired when an app or the device that it runs on needs to be restarted. The app should close all its windows at its earliest convenient time to let the restart to happen. If the app does nothing, a restart will be enforced after a 24-hour grace period has passed. Currently, this event is only fired for Chrome OS kiosk apps.
-         * @since Chrome 29
-         */
-        export var onRestartRequired: RuntimeRestartRequiredEvent;
-        /**
-         * Fired when an update is available, but isn't installed immediately because the app is currently running. If you do nothing, the update will be installed the next time the background page gets unloaded, if you want it to be installed sooner you can explicitly call chrome.runtime.reload(). If your extension is using a persistent background page, the background page of course never gets unloaded, so unless you call chrome.runtime.reload() manually in response to this event the update will not get installed until the next time chrome itself restarts. If no handlers are listening for this event, and your extension has a persistent background page, it behaves as if chrome.runtime.reload() is called in response to this event.
-         * @since Chrome 25
-         */
-        export var onUpdateAvailable: RuntimeUpdateAvailableEvent;
-        /**
-         * @deprecated since Chrome 33. Please use chrome.runtime.onRestartRequired.
          * Fired when a Chrome update is available, but isn't installed immediately because a browser restart is required.
+         * @deprecated Please use {@link runtime.onRestartRequired}.
          */
-        export var onBrowserUpdateAvailable: RuntimeEvent;
+        export const onBrowserUpdateAvailable: events.Event<() => void>;
 
         /**
-         * @since chrome 115+
-         * @requires MV3+
-         * Listens for connections made from user scripts associated with this extension.
+         * Fired when a connection is made from a user script from this extension.
+         * @since chrome 115 MV3
          */
-        export var onUserScriptConnect: ExtensionConnectEvent;
+        export const onUserScriptConnect: events.Event<(port: Port) => void>;
 
         /**
-         * @since chrome 115+
-         * @requires MV3+
-         * Listens for messages sent from user scripts associated with this extension.
+         * Fired when a message is sent from a user script associated with the same extension.
+         * @since chrome 115, MV3
          */
-        export var onUserScriptMessage: ExtensionMessageEvent;
+        export const onUserScriptMessage: events.Event<
+            (message: any, sender: MessageSender, sendResponse: (response?: any) => void) => void
+        >;
     }
 
     ////////////////////

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -776,12 +776,342 @@ async function testTabInterface() {
     tab.sessionId; // $ExpectType string | undefined
 }
 
-// https://developer.chrome.com/extensions/runtime#method-openOptionsPage
-function testOptionsPage() {
-    chrome.runtime.openOptionsPage();
-    chrome.runtime.openOptionsPage(function() {
-        // Do a thing ...
+// https://developer.chrome.com/docs/extensions/reference/api/runtime
+function testRuntime() {
+    chrome.runtime.id; // $ExpectType string
+    chrome.runtime.lastError; // $ExpectType { message?: string | undefined } | undefined
+
+    chrome.runtime.ContextType.BACKGROUND === "BACKGROUND";
+    chrome.runtime.ContextType.DEVELOPER_TOOLS === "DEVELOPER_TOOLS";
+    chrome.runtime.ContextType.OFFSCREEN_DOCUMENT === "OFFSCREEN_DOCUMENT";
+    chrome.runtime.ContextType.POPUP === "POPUP";
+    chrome.runtime.ContextType.SIDE_PANEL === "SIDE_PANEL";
+    chrome.runtime.ContextType.TAB === "TAB";
+
+    chrome.runtime.OnInstalledReason.CHROME_UPDATE === "chrome_update";
+    chrome.runtime.OnInstalledReason.INSTALL === "install";
+    chrome.runtime.OnInstalledReason.SHARED_MODULE_UPDATE === "shared_module_update";
+    chrome.runtime.OnInstalledReason.UPDATE === "update";
+
+    chrome.runtime.OnRestartRequiredReason.APP_UPDATE === "app_update";
+    chrome.runtime.OnRestartRequiredReason.OS_UPDATE === "os_update";
+    chrome.runtime.OnRestartRequiredReason.PERIODIC === "periodic";
+
+    chrome.runtime.PlatformArch.ARM === "arm";
+    chrome.runtime.PlatformArch.ARM64 === "arm64";
+    chrome.runtime.PlatformArch.MIPS === "mips";
+    chrome.runtime.PlatformArch.MIPS64 === "mips64";
+    chrome.runtime.PlatformArch.X86_32 === "x86-32";
+    chrome.runtime.PlatformArch.X86_64 === "x86-64";
+
+    chrome.runtime.PlatformNaclArch.ARM === "arm";
+    chrome.runtime.PlatformNaclArch.MIPS === "mips";
+    chrome.runtime.PlatformNaclArch.MIPS64 === "mips64";
+    chrome.runtime.PlatformNaclArch.X86_32 === "x86-32";
+    chrome.runtime.PlatformNaclArch.X86_64 === "x86-64";
+
+    chrome.runtime.PlatformOs.ANDROID === "android";
+    chrome.runtime.PlatformOs.CROS === "cros";
+    chrome.runtime.PlatformOs.FUCHSIA === "fuchsia";
+    chrome.runtime.PlatformOs.LINUX === "linux";
+    chrome.runtime.PlatformOs.MAC === "mac";
+    chrome.runtime.PlatformOs.OPENBSD === "openbsd";
+    chrome.runtime.PlatformOs.WIN === "win";
+
+    chrome.runtime.RequestUpdateCheckStatus.NO_UPDATE === "no_update";
+    chrome.runtime.RequestUpdateCheckStatus.THROTTLED === "throttled";
+    chrome.runtime.RequestUpdateCheckStatus.UPDATE_AVAILABLE === "update_available";
+
+    const extensionId = "abcdefghijklmnopqrstuvwxyzabcdef";
+    const application = "com.example.app";
+
+    const connectInfo: chrome.runtime.ConnectInfo = {
+        includeTlsChannelId: true,
+        name: "test",
+    };
+
+    chrome.runtime.connect(); // $ExpectType Port
+    chrome.runtime.connect(extensionId); // $ExpectType Port
+    chrome.runtime.connect(connectInfo); // $ExpectType Port
+    chrome.runtime.connect(extensionId, connectInfo); // $ExpectType Port
+
+    chrome.runtime.connectNative(application); // $ExpectType Port
+
+    chrome.runtime.getBackgroundPage(); // $ExpectType Promise<Window | undefined>
+    chrome.runtime.getBackgroundPage((backgroundPage) => { // $ExpectType void
+        backgroundPage; // $ExpectType Window | undefined
     });
+    // @ts-expect-error
+    chrome.runtime.getBackgroundPage(() => {}).then(() => {});
+
+    const filter: chrome.runtime.ContextFilter = {
+        contextIds: ["id"],
+        contextTypes: ["TAB", chrome.runtime.ContextType.BACKGROUND],
+        documentIds: ["id"],
+        documentOrigins: ["https://example.com"],
+        documentUrls: ["https://example.com/file.html"],
+        frameIds: [1],
+        incognito: true,
+        tabIds: [1],
+        windowIds: [1],
+    };
+
+    chrome.runtime.getContexts(filter); // $ExpectType Promise<ExtensionContext[]>
+    chrome.runtime.getContexts(filter, (contexts) => { // $ExpectType void
+        contexts; // $ExpectType ExtensionContext[]
+    });
+    // @ts-expect-error
+    chrome.runtime.getContexts(() => {}).then(() => {});
+
+    chrome.runtime.getManifest(); // $ExpectType Manifest
+
+    chrome.runtime.getPackageDirectoryEntry(); // $ExpectType Promise<FileSystemDirectoryEntry>
+    chrome.runtime.getPackageDirectoryEntry((directoryEntry) => { // $ExpectType void
+        directoryEntry; // $ExpectType FileSystemDirectoryEntry
+    });
+    // @ts-expect-error
+    chrome.runtime.getPackageDirectoryEntry(() => {}).then(() => {});
+
+    chrome.runtime.getPlatformInfo(); // $ExpectType Promise<PlatformInfo>
+    chrome.runtime.getPlatformInfo((platformInfo) => { // $ExpectType void
+        platformInfo.arch; // $ExpectType "arm" | "arm64" | "x86-32" | "x86-64" | "mips" | "mips64"
+        platformInfo.nacl_arch; // $ExpectType "arm" | "mips" | "mips64" | "x86-32" | "x86-64"
+        platformInfo.os; // $ExpectType "android" | "cros" | "fuchsia" | "linux" | "mac" | "openbsd" | "win"
+    });
+    // @ts-expect-error
+    chrome.runtime.getPlatformInfo(() => {}).then(() => {});
+
+    chrome.runtime.getURL(""); // $ExpectType string
+
+    chrome.runtime.openOptionsPage(); // $ExpectType Promise<void>
+    chrome.runtime.openOptionsPage(() => {}); // $ExpectType void
+    // @ts-expect-error
+    chrome.runtime.openOptionsPage(() => {}).then(() => {});
+
+    chrome.runtime.reload(); // $ExpectType void
+
+    chrome.runtime.requestUpdateCheck(); // $ExpectType Promise<RequestUpdateCheckResult>
+    chrome.runtime.requestUpdateCheck((status, details) => { // $ExpectType void
+        status; // $ExpectType "throttled" | "no_update" | "update_available"
+        if (details) {
+            details.version; // $ExpectType string
+        }
+    });
+    // @ts-expect-error
+    chrome.runtime.requestUpdateCheck(() => {}).then(() => {});
+
+    chrome.runtime.restart(); // $ExpectType void
+
+    chrome.runtime.restartAfterDelay(10); // $ExpectType Promise<void>
+    chrome.runtime.restartAfterDelay(10, () => {}); // $ExpectType void
+    // @ts-expect-error
+    chrome.runtime.restartAfterDelay(10, () => {}).then(() => {});
+
+    const message = "Hello, world!";
+
+    const options: chrome.runtime.MessageOptions = {
+        includeTlsChannelId: true,
+    };
+
+    chrome.runtime.sendMessage(message); // $ExpectType Promise<any>
+    chrome.runtime.sendMessage(extensionId, message); // $ExpectType Promise<any>
+    chrome.runtime.sendMessage(extensionId, message, options); // $ExpectType Promise<any>
+    chrome.runtime.sendMessage(message, options); // $ExpectType Promise<any>
+    chrome.runtime.sendMessage<string, string>(message, options); // $ExpectType Promise<string>
+    chrome.runtime.sendMessage<number, number>(10, options); // $ExpectType Promise<number>
+    chrome.runtime.sendMessage(message, (response) => { // $ExpectType void
+        response; // $ExpectType any
+    });
+    chrome.runtime.sendMessage(extensionId, message, (response) => { // $ExpectType void
+        response; // $ExpectType any
+    });
+    chrome.runtime.sendMessage(extensionId, message, options, (response) => { // $ExpectType void
+        response; // $ExpectType any
+    });
+    chrome.runtime.sendMessage(message, options, (response) => { // $ExpectType void
+        response; // $ExpectType any
+    });
+    chrome.runtime.sendMessage<string, string>(message, options, (response) => { // $ExpectType void
+        response; // $ExpectType string
+    });
+    chrome.runtime.sendMessage<number, number>(10, options, (response) => { // $ExpectType void
+        response; // $ExpectType number
+    });
+    // @ts-expect-error
+    chrome.runtime.sendMessage(message, () => {}).then(() => {});
+
+    chrome.runtime.sendNativeMessage(application, {}); // $ExpectType Promise<any>
+    chrome.runtime.sendNativeMessage(application, {}, (response) => { // $ExpectType void
+        response; // $ExpectType any
+    });
+    // @ts-expect-error
+    chrome.runtime.sendNativeMessage(application, {}, () => {}).then(() => {});
+
+    const url = "https://example.com";
+
+    chrome.runtime.setUninstallURL(url); // $ExpectType Promise<void>
+    chrome.runtime.setUninstallURL(url, () => {}); // $ExpectType void
+    // @ts-expect-error
+    chrome.runtime.setUninstallURL(url, () => {}).then(() => {});
+
+    chrome.runtime.onBrowserUpdateAvailable.addListener(() => {}); // $ExpectType void
+    chrome.runtime.onBrowserUpdateAvailable.removeListener(() => {}); // $ExpectType void
+    chrome.runtime.onBrowserUpdateAvailable.hasListener(() => {}); // $ExpectType boolean
+    chrome.runtime.onBrowserUpdateAvailable.hasListeners(); // $ExpectType boolean
+
+    chrome.runtime.onConnect.addListener((port) => { // $ExpectType void
+        port.name; // $ExpectType string
+        port.onDisconnect; // $ExpectType Event<(port: Port) => void>
+        port.onMessage; // $ExpectType Event<(message: any, port: Port) => void>
+        port.sender; // $ExpectType MessageSender | undefined
+        port.disconnect(); // $ExpectType void
+        port.postMessage(""); // $ExpectType void
+    });
+    chrome.runtime.onConnect.removeListener((port) => { // $ExpectType void
+        port; // $ExpectType Port
+    });
+    chrome.runtime.onConnect.hasListener((port) => { // $ExpectType boolean
+        port; // $ExpectType Port
+    });
+    chrome.runtime.onConnect.hasListeners(); // $ExpectType boolean
+
+    chrome.runtime.onConnectExternal.addListener((port) => { // $ExpectType void
+        port; // $ExpectType Port
+    });
+    chrome.runtime.onConnectExternal.removeListener((port) => { // $ExpectType void
+        port; // $ExpectType Port
+    });
+    chrome.runtime.onConnectExternal.hasListener((port) => { // $ExpectType boolean
+        port; // $ExpectType Port
+    });
+    chrome.runtime.onConnectExternal.hasListeners(); // $ExpectType boolean
+
+    chrome.runtime.onConnectNative.addListener((port) => { // $ExpectType void
+        port; // $ExpectType Port
+    });
+    chrome.runtime.onConnectNative.removeListener((port) => { // $ExpectType void
+        port; // $ExpectType Port
+    });
+    chrome.runtime.onConnectNative.hasListener((port) => { // $ExpectType boolean
+        port; // $ExpectType Port
+    });
+    chrome.runtime.onConnectNative.hasListeners(); // $ExpectType boolean
+
+    chrome.runtime.onInstalled.addListener((details) => { // $ExpectType void
+        details.id; // $ExpectType string | undefined
+        details.previousVersion; // $ExpectType string | undefined
+        details.reason; // $ExpectType "install" | "update" | "chrome_update" | "shared_module_update"
+    });
+    chrome.runtime.onInstalled.removeListener((details) => { // $ExpectType void
+        details.id; // $ExpectType string | undefined
+        details.previousVersion; // $ExpectType string | undefined
+        details.reason; // $ExpectType "install" | "update" | "chrome_update" | "shared_module_update"
+    });
+    chrome.runtime.onInstalled.hasListener((details) => { // $ExpectType boolean
+        details.id; // $ExpectType string | undefined
+        details.previousVersion; // $ExpectType string | undefined
+        details.reason; // $ExpectType "install" | "update" | "chrome_update" | "shared_module_update"
+    });
+    chrome.runtime.onInstalled.hasListeners(); // $ExpectType boolean
+
+    chrome.runtime.onMessage.addListener((message, sender, sendResponse) => { // $ExpectType void
+        message; // $ExpectType any
+        sender; // $ExpectType MessageSender
+        sendResponse(); // $ExpectType void
+    });
+    chrome.runtime.onMessage.removeListener((message, sender, sendResponse) => { // $ExpectType void
+        message; // $ExpectType any
+        sender; // $ExpectType MessageSender
+        sendResponse(); // $ExpectType void
+    });
+    chrome.runtime.onMessage.hasListener((message, sender, sendResponse) => { // $ExpectType boolean
+        message; // $ExpectType any
+        sender; // $ExpectType MessageSender
+        sendResponse(); // $ExpectType void
+    });
+    chrome.runtime.onMessage.hasListeners(); // $ExpectType boolean
+
+    chrome.runtime.onMessageExternal.addListener((message, sender, sendResponse) => { // $ExpectType void
+        message; // $ExpectType any
+        sender; // $ExpectType MessageSender
+        sendResponse(); // $ExpectType void
+    });
+    chrome.runtime.onMessageExternal.removeListener((message, sender, sendResponse) => { // $ExpectType void
+        message; // $ExpectType any
+        sender; // $ExpectType MessageSender
+        sendResponse(); // $ExpectType void
+    });
+    chrome.runtime.onMessageExternal.hasListener((message, sender, sendResponse) => { // $ExpectType boolean
+        message; // $ExpectType any
+        sender; // $ExpectType MessageSender
+        sendResponse(); // $ExpectType void
+    });
+    chrome.runtime.onMessageExternal.hasListeners(); // $ExpectType boolean
+
+    chrome.runtime.onRestartRequired.addListener((reason) => { // $ExpectType void
+        reason; // $ExpectType "app_update" | "os_update" | "periodic"
+    });
+    chrome.runtime.onRestartRequired.removeListener((reason) => { // $ExpectType void
+        reason; // $ExpectType "app_update" | "os_update" | "periodic"
+    });
+    chrome.runtime.onRestartRequired.hasListener((reason) => { // $ExpectType boolean
+        reason; // $ExpectType "app_update" | "os_update" | "periodic"
+    });
+    chrome.runtime.onRestartRequired.hasListeners(); // $ExpectType boolean
+
+    chrome.runtime.onStartup.addListener(() => {}); // $ExpectType void
+    chrome.runtime.onStartup.removeListener(() => {}); // $ExpectType void
+    chrome.runtime.onStartup.hasListener(() => {}); // $ExpectType boolean
+    chrome.runtime.onStartup.hasListeners(); // $ExpectType boolean
+
+    chrome.runtime.onSuspend.addListener(() => {}); // $ExpectType void
+    chrome.runtime.onSuspend.removeListener(() => {}); // $ExpectType void
+    chrome.runtime.onSuspend.hasListener(() => {}); // $ExpectType boolean
+    chrome.runtime.onSuspend.hasListeners(); // $ExpectType boolean
+
+    chrome.runtime.onSuspendCanceled.addListener(() => {}); // $ExpectType void
+    chrome.runtime.onSuspendCanceled.removeListener(() => {}); // $ExpectType void
+    chrome.runtime.onSuspendCanceled.hasListener(() => {}); // $ExpectType boolean
+    chrome.runtime.onSuspendCanceled.hasListeners(); // $ExpectType boolean
+
+    chrome.runtime.onUpdateAvailable.addListener((details) => { // $ExpectType void
+        details.version; // $ExpectType string
+    });
+    chrome.runtime.onUpdateAvailable.removeListener((details) => { // $ExpectType void
+        details.version; // $ExpectType string
+    });
+    chrome.runtime.onUpdateAvailable.hasListener((details) => { // $ExpectType boolean
+        details.version; // $ExpectType string
+    });
+    chrome.runtime.onUpdateAvailable.hasListeners(); // $ExpectType boolean
+
+    chrome.runtime.onUserScriptConnect.addListener((port) => { // $ExpectType void
+        port; // $ExpectType Port
+    });
+    chrome.runtime.onUserScriptConnect.removeListener((port) => { // $ExpectType void
+        port; // $ExpectType Port
+    });
+    chrome.runtime.onUserScriptConnect.hasListener((port) => { // $ExpectType boolean
+        port; // $ExpectType Port
+    });
+    chrome.runtime.onUserScriptConnect.hasListeners(); // $ExpectType boolean
+
+    chrome.runtime.onUserScriptMessage.addListener((message, sender, sendResponse) => { // $ExpectType void
+        message; // $ExpectType any
+        sender; // $ExpectType MessageSender
+        sendResponse(); // $ExpectType void
+    });
+    chrome.runtime.onUserScriptMessage.removeListener((message, sender, sendResponse) => { // $ExpectType void
+        message; // $ExpectType any
+        sender; // $ExpectType MessageSender
+        sendResponse(); // $ExpectType void
+    });
+    chrome.runtime.onUserScriptMessage.hasListener((message, sender, sendResponse) => { // $ExpectType boolean
+        message; // $ExpectType any
+        sender; // $ExpectType MessageSender
+        sendResponse(); // $ExpectType void
+    });
+    chrome.runtime.onUserScriptMessage.hasListeners(); // $ExpectType boolean
 }
 
 function testGetManifest() {
@@ -891,53 +1221,6 @@ function testGetManifest() {
             },
         ],
     };
-}
-
-// https://developer.chrome.com/docs/extensions/reference/runtime/#method-restart
-function testRestart() {
-    chrome.runtime.restart();
-}
-
-// https://developer.chrome.com/docs/extensions/reference/runtime/#method-restartAfterDelay
-function testRestartAfterDelay() {
-    chrome.runtime.restartAfterDelay(10);
-    chrome.runtime.restartAfterDelay(10, () => {
-        console.log("This is a callback!");
-    });
-}
-
-async function testGetPlatformInfo() {
-    chrome.runtime.getPlatformInfo(platformInfo => {
-        platformInfo; // $ExpectType PlatformInfo
-
-        platformInfo.arch; // $ExpectType PlatformArch
-        platformInfo.nacl_arch; // $ExpectType PlatformNaclArch
-        platformInfo.os; // $ExpectType PlatformOs
-
-        // @ts-expect-error
-        platformInfo.arch = "invalid-arch";
-        // @ts-expect-error
-        platformInfo.nacl_arch = "invalid-nacl_arch";
-        // @ts-expect-error
-        platformInfo.os = "invalid-os";
-    });
-}
-
-async function testGetPlatformForPromise() {
-    chrome.runtime.getPlatformInfo().then(platformInfo => {
-        platformInfo; // $ExpectType PlatformInfo
-
-        platformInfo.arch; // $ExpectType PlatformArch
-        platformInfo.nacl_arch; // $ExpectType PlatformNaclArch
-        platformInfo.os; // $ExpectType PlatformOs
-
-        // @ts-expect-error
-        platformInfo.arch = "invalid-arch";
-        // @ts-expect-error
-        platformInfo.nacl_arch = "invalid-nacl_arch";
-        // @ts-expect-error
-        platformInfo.os = "invalid-os";
-    });
 }
 
 // https://developer.chrome.com/extensions/tabCapture#type-CaptureOptions
@@ -1404,43 +1687,6 @@ function testTtsEngine() {
         uninstallOptions; // $ExpectType LanguageUninstallOptions
     });
     chrome.ttsEngine.onUninstallLanguageRequest.hasListeners(); // $ExpectType boolean
-}
-
-chrome.runtime.onInstalled.addListener((details) => {
-    details; // $ExpectType InstalledDetails
-    details.previousVersion; // $ExpectType string | undefined
-    details.reason; // $ExpectType "install" | "update" | "chrome_update" | "shared_module_update"
-    details.id; // $ExpectType string | undefined
-    if (details.reason === "install") { // Accept string version of enum
-        return;
-    }
-
-    // @ts-expect-error
-    details.reason = "not-real-reason";
-});
-
-function testRuntimeOnMessageAddListener() {
-    // @ts-expect-error
-    chrome.runtime.onMessage.addListener();
-    // @ts-expect-error
-    chrome.runtime.onMessage.addListener((_1, _2, _3, _4) => {});
-
-    chrome.runtime.onMessage.addListener((_, sender) => {
-        console.log(
-            sender.documentId,
-            sender.documentLifecycle,
-            sender.frameId,
-            sender.id,
-            sender.nativeApplication,
-            sender.origin,
-            sender.tab,
-            sender.tlsChannelId,
-            sender.url,
-        );
-
-        // @ts-expect-error
-        console.log(sender.documentLifecycle === "invalid_value");
-    });
 }
 
 function testDevtools() {
@@ -3163,67 +3409,6 @@ function testStorageForPromise() {
     chrome.storage.sync.setAccessLevel({ accessLevel: chrome.storage.AccessLevel.TRUSTED_AND_UNTRUSTED_CONTEXTS }).then(
         () => {},
     );
-}
-
-// https://developer.chrome.com/docs/extensions/reference/api/runtime#method-getContexts
-function testRuntimeGetContexts() {
-    chrome.runtime.ContextType.TAB === "TAB";
-    chrome.runtime.ContextType.POPUP === "POPUP";
-    chrome.runtime.ContextType.BACKGROUND === "BACKGROUND";
-    chrome.runtime.ContextType.OFFSCREEN_DOCUMENT === "OFFSCREEN_DOCUMENT";
-    chrome.runtime.ContextType.SIDE_PANEL === "SIDE_PANEL";
-    chrome.runtime.ContextType.DEVELOPER_TOOLS === "DEVELOPER_TOOLS";
-
-    const options = { incognito: true, tabIds: [1, 2, 3] };
-
-    chrome.runtime.getContexts(options);
-}
-
-// https://developer.chrome.com/docs/extensions/reference/runtime/#method-sendMessage
-function testRuntimeSendMessage() {
-    const options = { includeTlsChannelId: true };
-
-    chrome.runtime.sendMessage("Hello World!").then(() => {});
-    chrome.runtime.sendMessage("Hello World!", console.log);
-    chrome.runtime.sendMessage<string>("Hello World!", console.log);
-    chrome.runtime.sendMessage<string, number>("Hello World!", console.log);
-    // @ts-expect-error
-    chrome.runtime.sendMessage<number>("Hello World!", console.log);
-    // @ts-expect-error
-    chrome.runtime.sendMessage<string, boolean>("Hello World!", (num: number) => alert(num + 1));
-    chrome.runtime.sendMessage("Hello World!", options).then(() => {});
-    chrome.runtime.sendMessage("Hello World!", options, console.log);
-    chrome.runtime.sendMessage<string>("Hello World!", options, console.log);
-    chrome.runtime.sendMessage<string, number>("Hello World!", options, console.log);
-    // @ts-expect-error
-    chrome.runtime.sendMessage<number>("Hello World!", options, console.log);
-    // @ts-expect-error
-    chrome.runtime.sendMessage<string, boolean>("Hello World!", options, (num: number) => alert(num + 1));
-
-    chrome.runtime.sendMessage("extension-id", "Hello World!").then(() => {});
-    chrome.runtime.sendMessage("extension-id", "Hello World!", console.log);
-    chrome.runtime.sendMessage<string>("extension-id", "Hello World!", console.log);
-    chrome.runtime.sendMessage<string, number>("extension-id", "Hello World!", console.log);
-    // @ts-expect-error
-    chrome.runtime.sendMessage<number>("extension-id", "Hello World!", console.log);
-    // @ts-expect-error
-    chrome.runtime.sendMessage<string, boolean>("extension-id", "Hello World!", (num: number) => alert(num + 1));
-    chrome.runtime.sendMessage("extension-id", "Hello World!", options).then(() => {});
-    chrome.runtime.sendMessage("extension-id", "Hello World!", options, console.log);
-    chrome.runtime.sendMessage<string>("extension-id", "Hello World!", options, console.log);
-    chrome.runtime.sendMessage<string, number>("extension-id", "Hello World!", options, console.log);
-    // @ts-expect-error
-    chrome.runtime.sendMessage<number>("extension-id", "Hello World!", console.log);
-    // @ts-expect-error
-    chrome.runtime.sendMessage<string, boolean>("extension-id", "Hello World!", (num: number) => alert(num + 1));
-
-    chrome.runtime.sendMessage(undefined, "Hello World!", console.log);
-    chrome.runtime.sendMessage(null, "Hello World!", console.log);
-}
-
-function testRuntimeSendNativeMessage() {
-    chrome.runtime.sendNativeMessage("application", {}).then(() => {});
-    chrome.runtime.sendNativeMessage("application", {}, (num: number) => alert(num + 1));
 }
 
 function testTabsSendRequest() {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  https://developer.chrome.com/docs/extensions/reference/api/runtime
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes :
- Added `OnRestartRequiredReason` enum
- Added `PlatformArch` enum
- Added `PlatformNaclArch` enum
- Added `PlatformOs` enum
- Added `RequestUpdateCheckStatus` enum
- Correction the return type of the `getBackgroundPage()` -> `Promise<Window>`-> `Promise<Window | undefined>`
- Not force use enums !
- Updated `restartAfterDelay()` -> Can be return a promise 
- Updated `setUninstallURL()` -> Can be return a promise 
- Added `onConnectNative` event
- Correction the return type of the `onRestartRequired` event -> `string` -> `OnRestartRequiredReason`
- Clean JSDoc
- Clean tests

Runtime : 
![image](https://github.com/user-attachments/assets/fe0bc76f-639b-47d9-9516-9ca43c8b1619)