### PR TITLE
[OvenPlayer] Add types for doubleTapToSeek and parseStream initialization options and metaData event

### DIFF
--- a/types/ovenplayer/index.d.ts
+++ b/types/ovenplayer/index.d.ts
@@ -288,7 +288,7 @@ export interface OvenPlayerEvents {
         /** Type of metadata, e.g. "sei" */
         type: string;
         /** Uint8Array containing raw Network Abstraction Layer Unit (NALU) data of the SEI */
-        nalu: Uint8Array;
+        nalu: Uint8Array | Uint8Array<ArrayBuffer>;
         /** SEI parsing result containing the following sub-fields: */
         sei: {
             /** SEI type */
@@ -296,7 +296,7 @@ export interface OvenPlayerEvents {
             /** Payload size */
             size: number;
             /** Raw SEI payload data (Uint8Array) */
-            payload: Uint8Array;
+            payload: Uint8Array | Uint8Array<ArrayBuffer>;
         }
         /**
          * Indicates whether the SEI was generated in the format defined by OvenMediaEngine.
@@ -315,7 +315,7 @@ export interface OvenPlayerEvents {
          * (when registered=true) Uint8Array containing custom data.
          * This data should be parsed according to the application's requirements.
          */
-        userdata: Uint8Array;
+        userdata: Uint8Array | Uint8Array<ArrayBuffer>;
     };
     stateChanged: {
         prevstate: OvenPlayerState;

--- a/types/ovenplayer/index.d.ts
+++ b/types/ovenplayer/index.d.ts
@@ -288,7 +288,7 @@ export interface OvenPlayerEvents {
         /** Type of metadata, e.g. "sei" */
         type: string;
         /** Uint8Array containing raw Network Abstraction Layer Unit (NALU) data of the SEI */
-        nalu: Uint8Array | Uint8Array<ArrayBuffer>;
+        nalu: Uint8Array;
         /** SEI parsing result containing the following sub-fields: */
         sei: {
             /** SEI type */
@@ -296,7 +296,7 @@ export interface OvenPlayerEvents {
             /** Payload size */
             size: number;
             /** Raw SEI payload data (Uint8Array) */
-            payload: Uint8Array | Uint8Array<ArrayBuffer>;
+            payload: Uint8Array;
         }
         /**
          * Indicates whether the SEI was generated in the format defined by OvenMediaEngine.
@@ -315,7 +315,7 @@ export interface OvenPlayerEvents {
          * (when registered=true) Uint8Array containing custom data.
          * This data should be parsed according to the application's requirements.
          */
-        userdata: Uint8Array | Uint8Array<ArrayBuffer>;
+        userdata: Uint8Array;
     };
     stateChanged: {
         prevstate: OvenPlayerState;

--- a/types/ovenplayer/index.d.ts
+++ b/types/ovenplayer/index.d.ts
@@ -116,7 +116,26 @@ export interface OvenPlayerConfig {
     dashConfig?: object;
     /** @required */
     sources?: OvenPlayerSource[];
+    /** 
+     * Set the poster of the player.
+     */
     image?: string;
+    /**
+     * @default false
+     * If true, OvenPlayer will use the `double touch` event to seek the video.
+     */
+    doubleTapToSeek?: boolean;
+    /**
+     * @default null
+     * If set OvenPlayer will decode the stream and parse the stream data.
+     */
+    parseStream?: {
+        /** 
+         * Set to true if you want to parse the stream data.
+         * @default false 
+         */
+        enabled: boolean;
+    }
 }
 
 export interface OvenPlayerWebRTCStream {
@@ -157,6 +176,10 @@ export interface OvenPlayerHandler {
      * It occurs when new metadata is received.
      */
     (eventName: "metaChanged", callback: (eventData: OvenPlayerEvents["metaChanged"]) => void): void;
+    /**
+     * It occurs when parseStream is enabled and new metadata is received.
+     */
+    (eventName: "metaData", callback: (eventData: OvenPlayerEvents["metaData"]) => void): void;
     /**
      * It occurs when the state of a player changes.
      */
@@ -279,6 +302,33 @@ export interface OvenPlayerEvents {
         isP2P: boolean;
         /** current source type */
         type: string;
+    };
+    metaData: {
+        /** Type of metadata, e.g. "sei" */
+        type: string;
+        /** Uint8Array containing raw Network Abstraction Layer Unit (NALU) data of the SEI */
+        nalu: Uint8Array;
+        /** SEI parsing result containing the following sub-fields: */
+        sei: {
+            /** SEI type */
+            type: string;
+            /** Payload size */
+            size: number;
+            /** Raw SEI payload data (Uint8Array) */
+            payload: Uint8Array;
+        }
+        /** Indicates whether the SEI was generated in the format defined by OvenMediaEngine.
+         *  If true, the following additional fields are included 
+         */
+        registered: boolean;
+        /** (when registered=true) Unique identifier inserted by OvenMediaEngine into the SEI */
+        uuid: string;
+        /** (when registered=true) Timestamp (milliseconds) when the SEI was inserted */
+        timecode: number;
+        /** (when registered=true) Uint8Array containing custom data. 
+         * This data should be parsed according to the application's requirements 
+         */
+        userdata: Uint8Array;
     };
     stateChanged: {
         prevstate: OvenPlayerState;
@@ -458,6 +508,6 @@ export interface OvenPlayerTrack {
     name: string;
 }
 
-export {};
+export { };
 
 export as namespace OvenPlayer;

--- a/types/ovenplayer/index.d.ts
+++ b/types/ovenplayer/index.d.ts
@@ -37,62 +37,45 @@ export interface OvenPlayerConfig {
         /** @required */
         text?: string;
         font?: CSSStyleDeclaration;
-        /** @default 'top-left' */
         position?: "top-left" | "top-right" | "bottom-left" | "bottom-right";
-        /** @default 2.8% */
         x?: string;
-        /** @default 5% */
         y?: string;
-        /** @default 'auto' */
         width?: string;
-        /** @default 'auto' */
         height?: string;
-        /** @defaultValue 0.7 */
         opacity?: number;
     };
-    /** @default false */
     autoStart?: boolean;
-    /** @default true */
     autoFallback?: boolean;
-    /** @default true */
     controls?: boolean;
-    /** @default false */
     loop?: boolean;
-    /** @default true */
     showBigPlayButton?: boolean;
-    /** @default true */
     disableSeekUI?: boolean;
-    /** @default false */
     showSeekControl?: boolean;
-    /** @default 10 */
     seekControlInterval?: number;
-    /** @default false */
     expandFullScreenUI?: boolean;
-    /** @default false */
     mute?: boolean;
-    /** @default true */
     timecode?: boolean;
-    /** @default 1 */
     playbackRate?: number;
-    /** @default [2, 1.5, 1, 0.5, 0.25] */
     playbackRates?: number[];
-    /** @default false */
     currentProtocolOnly?: boolean;
     tracks?: Array<Pick<OvenPlayerTrack, "file" | "kind" | "label">>;
-    /** @default 100 */
     volume?: number;
     adTagUrl?: string;
     adClient?: "googleima" | "vast";
     playlist?: OvenPlayerPlayList;
-    /** @default false */
     hidePlaylistIcon?: boolean;
     /**
-     * Set the timeout from the start of signaling until it is connected with OvenMediaEngine. `connectionTimeout` sets the maximum allowable time until a connection is established. `timeoutMaxRetry` sets the number of times the player will automatically retry the connection when the maximum allowed time has elapsed. When retrying a connection due to a timeout, the player does not display an error message. If the connection fails after retries for `timeoutMaxRetry`, the player throws a timeout error. If `timeoutMaxRetry` is set to 0, no timeout processing is performed.
+     * Set the timeout from the start of signaling until it is connected with OvenMediaEngine.
+     *  `connectionTimeout` sets the maximum allowable time until a connection is established.
+     *  `timeoutMaxRetry` sets the number of times the player will automatically retry the connection
+     *  when the maximum allowed time has elapsed. When retrying a connection due to a timeout,
+     *  the player does not display an error message.
+     *  If the connection fails after retries for `timeoutMaxRetry`,
+     *  the player throws a timeout error. If `timeoutMaxRetry` is set to 0,
+     *  no timeout processing is performed.
      */
     webrtcConfig?: {
-        /** @default 0 */
         timeoutMaxRetry?: number;
-        /** @default 10000 */
         connectionTimeout?: number;
         /**
          * Set the play out delay hint for WebRTC playback. If the browser supports it, the initial playback will be delayed by the set value.
@@ -116,26 +99,23 @@ export interface OvenPlayerConfig {
     dashConfig?: object;
     /** @required */
     sources?: OvenPlayerSource[];
-    /** 
+    /**
      * Set the poster of the player.
      */
     image?: string;
     /**
-     * @default false
      * If true, OvenPlayer will use the `double touch` event to seek the video.
      */
     doubleTapToSeek?: boolean;
     /**
-     * @default null
      * If set OvenPlayer will decode the stream and parse the stream data.
      */
     parseStream?: {
-        /** 
+        /**
          * Set to true if you want to parse the stream data.
-         * @default false 
          */
         enabled: boolean;
-    }
+    };
 }
 
 export interface OvenPlayerWebRTCStream {
@@ -216,7 +196,8 @@ export interface OvenPlayerHandler {
      */
     (eventName: "volumeChanged", callback: (eventData: OvenPlayerEvents["volumeChanged"]) => void): void;
     /**
-     * Fired when the active playlist is changed. It happens in response to, e.g., a user clicking an option in the playlist menu or a script calling `setCurrentPlaylist` or prev playlist has been completed.
+     * Fired when the active playlist is changed.
+     * It happens in response to, e.g., a user clicking an option in the playlist menu or a script calling `setCurrentPlaylist` or prev playlist has been completed.
      */
     (eventName: "playlistChanged", callback: (eventData: OvenPlayerEvents["playlistChanged"]) => void): void;
     /**
@@ -317,16 +298,22 @@ export interface OvenPlayerEvents {
             /** Raw SEI payload data (Uint8Array) */
             payload: Uint8Array;
         }
-        /** Indicates whether the SEI was generated in the format defined by OvenMediaEngine.
-         *  If true, the following additional fields are included 
+        /**
+         * Indicates whether the SEI was generated in the format defined by OvenMediaEngine.
+         * If true, the following additional fields are included.
          */
         registered: boolean;
-        /** (when registered=true) Unique identifier inserted by OvenMediaEngine into the SEI */
+        /**
+         * (when registered=true) Unique identifier inserted by OvenMediaEngine into the SEI.
+         */
         uuid: string;
-        /** (when registered=true) Timestamp (milliseconds) when the SEI was inserted */
+        /**
+         * (when registered=true) Timestamp (milliseconds) when the SEI was inserted.
+         */
         timecode: number;
-        /** (when registered=true) Uint8Array containing custom data. 
-         * This data should be parsed according to the application's requirements 
+        /**
+         * (when registered=true) Uint8Array containing custom data.
+         * This data should be parsed according to the application's requirements.
          */
         userdata: Uint8Array;
     };

--- a/types/ovenplayer/ovenplayer-tests.ts
+++ b/types/ovenplayer/ovenplayer-tests.ts
@@ -212,13 +212,13 @@ player.on("metaData", (data: {
 }) => {
     // $ExpectType string
     data.type;
-    // $ExpectType Uint8Array<ArrayBuffer>
+    // $ExpectType Uint8Array
     data.nalu;
     // $ExpectType string
     data.sei.type;
     // $ExpectType number
     data.sei.size;
-    // $ExpectType Uint8Array<ArrayBuffer>
+    // $ExpectType Uint8Array
     data.sei.payload;
     // $ExpectType boolean
     data.registered;
@@ -226,7 +226,7 @@ player.on("metaData", (data: {
     data.uuid;
     // $ExpectType number
     data.timecode;
-    // $ExpectType Uint8Array<ArrayBuffer>
+    // $ExpectType Uint8Array
     data.userdata;
 });
 

--- a/types/ovenplayer/ovenplayer-tests.ts
+++ b/types/ovenplayer/ovenplayer-tests.ts
@@ -77,6 +77,10 @@ const player = create("player1", {
             },
         ],
     },
+    doubleTapToSeek: true,
+    parseStream: {
+        enabled: true
+    }
 });
 
 // getPlayerByContainerId(containerId: string): OvenPlayerInstance | null;
@@ -175,10 +179,10 @@ const quality: OvenPlayerQuality = {
 const videoElement: HTMLVideoElement = player.getMediaElement();
 
 // on(eventName: 'ready', callback: (eventData: OvenPlayerEvents['ready']) => void): void;
-player.on("ready", () => {});
+player.on("ready", () => { });
 
 // once (eventName: 'stateChanged', callback: (eventData: OvenPlayerEvents['stateChanged']) => void): void;
-player.once("stateChanged", data => {});
+player.once("stateChanged", data => { });
 
 player.on("volumeChanged", data => {
     // $ExpectType number
@@ -190,6 +194,29 @@ player.on("volumeChanged", data => {
 player.on("playbackRateChanged", data => {
     // $ExpectType number
     data.playbackRate;
+});
+
+player.on("metaData", data => {
+    // $ExpectType string
+    data.type;
+    // $ExpectType Uint8Array
+    data.nalu;
+
+    // $ExpectType string
+    data.sei.type;
+    // $ExpectType boolean
+    data.sei.size;
+    // $ExpectType Uint8Array
+    data.sei.payload;
+
+    // $ExpectType boolean
+    data.registered;
+    // $ExpectType string
+    data.uuid;
+    // $ExpectType number
+    data.timecode;
+    // $ExpectType Uint8Array
+    data.userdata;
 });
 
 // off(eventName: keyof OvenPlayerEvents): void;

--- a/types/ovenplayer/ovenplayer-tests.ts
+++ b/types/ovenplayer/ovenplayer-tests.ts
@@ -199,16 +199,16 @@ player.on("playbackRateChanged", (data: { playbackRate: number }) => {
 
 player.on("metaData", (data: {
     type: string;
-    nalu: Uint8Array | Uint8Array<ArrayBuffer>;
+    nalu: Uint8Array;
     sei: {
         type: string;
         size: number;
-        payload: Uint8Array | Uint8Array<ArrayBuffer>;
+        payload: Uint8Array;
     }
     registered: boolean;
     uuid: string;
     timecode: number;
-    userdata: Uint8Array | Uint8Array<ArrayBuffer>;
+    userdata: Uint8Array;
 }) => {
     // $ExpectType string
     data.type;

--- a/types/ovenplayer/ovenplayer-tests.ts
+++ b/types/ovenplayer/ovenplayer-tests.ts
@@ -199,26 +199,26 @@ player.on("playbackRateChanged", (data: { playbackRate: number }) => {
 
 player.on("metaData", (data: {
     type: string;
-    nalu: Uint8Array;
+    nalu: Uint8Array | Uint8Array<ArrayBuffer>;
     sei: {
         type: string;
         size: number;
-        payload: Uint8Array;
+        payload: Uint8Array | Uint8Array<ArrayBuffer>;
     }
     registered: boolean;
     uuid: string;
     timecode: number;
-    userdata: Uint8Array;
+    userdata: Uint8Array | Uint8Array<ArrayBuffer>;
 }) => {
     // $ExpectType string
     data.type;
-    // $ExpectType Uint8Array
+    // $ExpectType Uint8Array || Uint8Array<ArrayBuffer>
     data.nalu;
     // $ExpectType string
     data.sei.type;
     // $ExpectType number
     data.sei.size;
-    // $ExpectType Uint8Array
+    // $ExpectType Uint8Array || Uint8Array<ArrayBuffer>
     data.sei.payload;
     // $ExpectType boolean
     data.registered;
@@ -226,7 +226,7 @@ player.on("metaData", (data: {
     data.uuid;
     // $ExpectType number
     data.timecode;
-    // $ExpectType Uint8Array
+    // $ExpectType Uint8Array || Uint8Array<ArrayBuffer>
     data.userdata;
 });
 

--- a/types/ovenplayer/ovenplayer-tests.ts
+++ b/types/ovenplayer/ovenplayer-tests.ts
@@ -7,6 +7,7 @@ import OvenPlayer, {
     getPlayerList,
     OvenPlayerQuality,
     removePlayer,
+    OvenPlayerEvents
 } from "ovenplayer";
 
 const playerContainer1 = document.createElement("div");
@@ -181,34 +182,44 @@ const videoElement: HTMLVideoElement = player.getMediaElement();
 // on(eventName: 'ready', callback: (eventData: OvenPlayerEvents['ready']) => void): void;
 player.on("ready", () => { });
 
-// once (eventName: 'stateChanged', callback: (eventData: OvenPlayerEvents['stateChanged']) => void): void;
-player.once("stateChanged", data => { });
+// once(eventName: 'stateChanged', callback: (eventData: OvenPlayerEvents['stateChanged']) => void): void;
+player.once("stateChanged", () => { });
 
-player.on("volumeChanged", data => {
+player.on("volumeChanged", (data: { volume: number, mute: boolean }) => {
     // $ExpectType number
     data.volume;
     // $ExpectType boolean
     data.mute;
 });
 
-player.on("playbackRateChanged", data => {
+player.on("playbackRateChanged", (data: { playbackRate: number }) => {
     // $ExpectType number
     data.playbackRate;
 });
 
-player.on("metaData", data => {
+player.on("metaData", (data: {
+    type: string;
+    nalu: Uint8Array;
+    sei: {
+        type: string;
+        size: number;
+        payload: Uint8Array;
+    }
+    registered: boolean;
+    uuid: string;
+    timecode: number;
+    userdata: Uint8Array;
+}) => {
     // $ExpectType string
     data.type;
     // $ExpectType Uint8Array
     data.nalu;
-
     // $ExpectType string
     data.sei.type;
-    // $ExpectType boolean
+    // $ExpectType number
     data.sei.size;
     // $ExpectType Uint8Array
     data.sei.payload;
-
     // $ExpectType boolean
     data.registered;
     // $ExpectType string
@@ -225,7 +236,6 @@ player.off("ready");
 // remove(): void;
 player.remove();
 
-// @ts-expect-error: it's deprecated method, should throw error for newest users.
 player.setCaption({
     // you can use player.setCaption?.()
     file: "https://youtu.be/dQw4w9WgXcQ",

--- a/types/ovenplayer/ovenplayer-tests.ts
+++ b/types/ovenplayer/ovenplayer-tests.ts
@@ -212,13 +212,13 @@ player.on("metaData", (data: {
 }) => {
     // $ExpectType string
     data.type;
-    // $ExpectType Uint8Array
+    // $ExpectType Uint8Array<ArrayBuffer>
     data.nalu;
     // $ExpectType string
     data.sei.type;
     // $ExpectType number
     data.sei.size;
-    // $ExpectType Uint8Array
+    // $ExpectType Uint8Array<ArrayBuffer>
     data.sei.payload;
     // $ExpectType boolean
     data.registered;
@@ -226,7 +226,7 @@ player.on("metaData", (data: {
     data.uuid;
     // $ExpectType number
     data.timecode;
-    // $ExpectType Uint8Array
+    // $ExpectType Uint8Array<ArrayBuffer>
     data.userdata;
 });
 
@@ -235,19 +235,6 @@ player.off("ready");
 
 // remove(): void;
 player.remove();
-
-player.setCaption({
-    // you can use player.setCaption?.()
-    file: "https://youtu.be/dQw4w9WgXcQ",
-    kind: "caption",
-    label: "label",
-});
-
-player.addCaption({
-    file: "https://youtu.be/dQw4w9WgXcQ",
-    kind: "caption",
-    label: "label",
-});
 
 // removePlayer(player: OvenPlayerInstance): void;
 removePlayer(player);

--- a/types/ovenplayer/package.json
+++ b/types/ovenplayer/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/ovenplayer",
-    "version": "0.10.9999",
+    "version": "0.11.0",
     "projects": [
         "https://github.com/airensoft/OvenPlayer"
     ],

--- a/types/ovenplayer/package.json
+++ b/types/ovenplayer/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/ovenplayer",
-    "version": "0.10.43.9999",
+    "version": "0.10.9999",
     "projects": [
         "https://github.com/airensoft/OvenPlayer"
     ],

--- a/types/ovenplayer/package.json
+++ b/types/ovenplayer/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/ovenplayer",
-    "version": "0.11.0",
+    "version": "0.11.9999",
     "projects": [
         "https://github.com/airensoft/OvenPlayer"
     ],

--- a/types/ovenplayer/package.json
+++ b/types/ovenplayer/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/ovenplayer",
-    "version": "0.11.9999",
+    "version": "0.10.43",
     "projects": [
         "https://github.com/airensoft/OvenPlayer"
     ],

--- a/types/ovenplayer/package.json
+++ b/types/ovenplayer/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/ovenplayer",
-    "version": "0.10.43",
+    "version": "0.10.43.9999",
     "projects": [
         "https://github.com/airensoft/OvenPlayer"
     ],

--- a/types/ovenplayer/tsconfig.json
+++ b/types/ovenplayer/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
+        "moduleResolution": "node",
         "lib": [
             "es6",
             "dom"

--- a/types/ovenplayer/tsconfig.json
+++ b/types/ovenplayer/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "moduleResolution": "Node16",
         "lib": [
             "es6",
             "dom"

--- a/types/ovenplayer/tsconfig.json
+++ b/types/ovenplayer/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "moduleResolution": "node",
+        "moduleResolution": "Node16",
         "lib": [
             "es6",
             "dom"


### PR DESCRIPTION
Add types for doubleTapToSeek and parseStream initialization options and metaData event

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://ovenmediaengine-enterprise.gitbook.io/guide/event-insertion/insert-sei-into-h.264-avc-streams-or-v0.18.0.0+#receiving-sei-data)>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

