### PR TITLE
[navermaps] Fix types - ReverseGeocodeResponse(Area, Land)

### DIFF
--- a/types/navermaps/index.d.ts
+++ b/types/navermaps/index.d.ts
@@ -2258,6 +2258,11 @@ declare namespace naver.maps {
             number1: string;
             number2: string;
             coords: Coords;
+            addition0: Addition;
+            addition1: Addition;
+            addition2: Addition;
+            addition3: Addition;
+            addition4: Addition;
         }
 
         interface Area {
@@ -2276,11 +2281,6 @@ declare namespace naver.maps {
             area2: Area;
             area3: Area;
             area4: Area;
-            addition0: Addition;
-            addition1: Addition;
-            addition2: Addition;
-            addition3: Addition;
-            addition4: Addition;
         }
 
         interface ResultItem {

--- a/types/navermaps/navermaps-tests.ts
+++ b/types/navermaps/navermaps-tests.ts
@@ -326,6 +326,7 @@ naver.maps.Service.reverseGeocode(
         results[0].code;
         results[0].region;
         results[0].land;
+        results[0].land.addition0;
 
         const v2Status = response.v2.status;
         v2Status.code;


### PR DESCRIPTION
This PR follows the ReverseGeocodeResponse documentation.
- https://navermaps.github.io/maps.js.ncp/docs/naver.maps.Service.html#toc29__anchor
- https://api.ncloud-docs.com/docs/application-maps-reversegeocoding#%EC%9D%91%EB%8B%B5-%EB%B0%94%EB%94%94

**The `additionN` property has been moved from under `Area` to under `Land`**

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

