### PR TITLE
[node] v24.0 hotfix: URLPattern prototype

### DIFF
--- a/types/node/test/url.ts
+++ b/types/node/test/url.ts
@@ -224,7 +224,23 @@ import * as url from "node:url";
 }
 
 {
-    const urlPattern = new url.URLPattern("https://nodejs.org/docs/latest/api/*.html");
+    const urlPattern = new url.URLPattern("https://nodejs.org/docs/latest/api/*.html", { ignoreCase: false });
     urlPattern.exec("https://nodejs.org/docs/latest/api/dns.html");
     urlPattern.test("https://nodejs.org/docs/latest/api/dns.html");
+}
+
+{
+    const init: url.URLPatternInit = {
+        pathname: "../docs/latest/api/*.html",
+    };
+
+    const urlPattern = new url.URLPattern(init);
+    urlPattern.exec(init, "https://nodejs.org/about");
+    urlPattern.test(init, "https://nodejs.org/about");
+}
+
+{
+    const urlPattern = new url.URLPattern({});
+    urlPattern.exec();
+    urlPattern.test();
 }

--- a/types/node/url.d.ts
+++ b/types/node/url.d.ts
@@ -791,8 +791,17 @@ declare module "url" {
     class URLPattern {
         constructor(input: string | URLPatternInit, baseURL: string, options?: URLPatternOptions);
         constructor(input?: string | URLPatternInit, options?: URLPatternOptions);
-        exec(input: string | URLPatternInit, baseURL?: string): URLPatternResult | null;
-        test(input: string | URLPatternInit, baseURL?: string): boolean;
+        exec(input?: string | URLPatternInit, baseURL?: string): URLPatternResult | null;
+        readonly hasRegExpGroups: boolean;
+        readonly hash: string;
+        readonly hostname: string;
+        readonly password: string;
+        readonly pathname: string;
+        readonly port: string;
+        readonly protocol: string;
+        readonly search: string;
+        test(input?: string | URLPatternInit, baseURL?: string): boolean;
+        readonly username: string;
     }
     interface URLSearchParamsIterator<T> extends NodeJS.Iterator<T, NodeJS.BuiltinIteratorReturn, unknown> {
         [Symbol.iterator](): URLSearchParamsIterator<T>;


### PR DESCRIPTION
Some discrepancies between #72589 and the IDL: the prototype getters were missing, and the first argument to the test methods was not typed as optional.