### PR TITLE
feat: types/validator add support for 'loose' for UUID version

### DIFF
--- a/types/validator/index.d.ts
+++ b/types/validator/index.d.ts
@@ -1258,6 +1258,7 @@ declare namespace validator {
         | "8"
         | "nil"
         | "max"
+        | "loose"
         | "all"
         | 1
         | 2


### PR DESCRIPTION
Add support for 'version' of UUID recently introduced in the `isUUID` from validator.js.

https://github.com/validatorjs/validator.js/blob/master/src/lib/isUUID.js#L15

This was added in the [PR](https://github.com/validatorjs/validator.js/pull/2553) of validator.js and released with version 13.15.15.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/validatorjs/validator.js/blob/master/src/lib/isUUID.js#L15
