### PR TITLE
[node/fs/promises] filehandle.read accepts bigint values as position since v21.0.0

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -2650,7 +2650,7 @@ declare module "fs" {
             buffer: TBuffer,
             offset: number,
             length: number,
-            position: number | null,
+            position: ReadPosition | null,
         ): Promise<{
             bytesRead: number;
             buffer: TBuffer;

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -29,6 +29,7 @@ declare module "fs/promises" {
         OpenDirOptions,
         OpenMode,
         PathLike,
+        ReadPosition,
         ReadStream,
         ReadVResult,
         RmDirOptions,
@@ -69,7 +70,7 @@ declare module "fs/promises" {
          * @default `buffer.byteLength`
          */
         length?: number | null;
-        position?: number | null;
+        position?: ReadPosition | null;
     }
     interface CreateReadStreamOptions extends Abortable {
         encoding?: BufferEncoding | null | undefined;
@@ -229,7 +230,7 @@ declare module "fs/promises" {
             buffer: T,
             offset?: number | null,
             length?: number | null,
-            position?: number | null,
+            position?: ReadPosition | null,
         ): Promise<FileReadResult<T>>;
         read<T extends NodeJS.ArrayBufferView = Buffer>(
             buffer: T,

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -130,6 +130,21 @@ import { CopyOptions, CopySyncOptions, cp, cpSync, glob, globSync } from "fs";
     // 2-param version using all-default options:
     fs.read(1, (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: NodeJS.ArrayBufferView) => {});
     fs.read(1, () => {});
+    // 6-param version with bigint valued position:
+    fs.read(
+        1,
+        new DataView(new ArrayBuffer(1)),
+        0,
+        1,
+        0n,
+        (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: DataView) => {},
+    );
+    // 3-param version with bigint valued position:
+    fs.read(
+        1,
+        { buffer: new DataView(new ArrayBuffer(1)), offset: 0, length: 1, position: 0n },
+        (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: DataView) => {},
+    );
 }
 
 {

--- a/types/node/v22/fs.d.ts
+++ b/types/node/v22/fs.d.ts
@@ -2656,7 +2656,7 @@ declare module "fs" {
             buffer: TBuffer,
             offset: number,
             length: number,
-            position: number | null,
+            position: ReadPosition | null,
         ): Promise<{
             bytesRead: number;
             buffer: TBuffer;

--- a/types/node/v22/fs/promises.d.ts
+++ b/types/node/v22/fs/promises.d.ts
@@ -29,6 +29,7 @@ declare module "fs/promises" {
         OpenDirOptions,
         OpenMode,
         PathLike,
+        ReadPosition,
         ReadStream,
         ReadVResult,
         RmDirOptions,
@@ -69,7 +70,7 @@ declare module "fs/promises" {
          * @default `buffer.byteLength`
          */
         length?: number | null;
-        position?: number | null;
+        position?: ReadPosition | null;
     }
     interface CreateReadStreamOptions extends Abortable {
         encoding?: BufferEncoding | null | undefined;
@@ -229,7 +230,7 @@ declare module "fs/promises" {
             buffer: T,
             offset?: number | null,
             length?: number | null,
-            position?: number | null,
+            position?: ReadPosition | null,
         ): Promise<FileReadResult<T>>;
         read<T extends NodeJS.ArrayBufferView = Buffer>(
             buffer: T,

--- a/types/node/v22/test/fs.ts
+++ b/types/node/v22/test/fs.ts
@@ -130,6 +130,21 @@ import { CopyOptions, CopySyncOptions, cp, cpSync, glob, globSync } from "fs";
     // 2-param version using all-default options:
     fs.read(1, (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: NodeJS.ArrayBufferView) => {});
     fs.read(1, () => {});
+    // 6-param version with bigint valued position:
+    fs.read(
+        1,
+        new DataView(new ArrayBuffer(1)),
+        0,
+        1,
+        0n,
+        (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: DataView) => {},
+    );
+    // 3-param version with bigint valued position:
+    fs.read(
+        1,
+        { buffer: new DataView(new ArrayBuffer(1)), offset: 0, length: 1, position: 0n },
+        (err: NodeJS.ErrnoException | null, bytesRead: number, buffer: DataView) => {},
+    );
 }
 
 {


### PR DESCRIPTION
# [node/fs/promises] `filehandle.read` accepts bigint values as `position` since Node v21.0.0

Refer to https://nodejs.org/api/fs.html#filehandlereadoptions.

The update had been made to the callback version of `node:fs` previously,
but the `node:fs/promises` API had not been updated.
