### PR TITLE
feat(jest): bump jest to v30

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3599,7 +3599,7 @@
 /types/jcof/                                            @MatyiFKBT
 /types/jconv/                                           @thany
 /types/jdataview/                                       @RReverser
-/types/jest/                                            @NoHomey @jwbay @asvetliakov @alexjoverm @epicallan @ikatyang @wsmd @JamieMason @douglasduteil @ahnpnl @UselessPickles @r3nya @hotell @sebald @andys8 @antoinebrault @gstamac @ExE-Boss @quassnoi @Belco90 @tonyhallett @ycmjason @pawfa @gerkindev @domdomegg @mrazauskas
+/types/jest/                                            @NoHomey @jwbay @asvetliakov @alexjoverm @epicallan @ikatyang @wsmd @JamieMason @douglasduteil @ahnpnl @UselessPickles @r3nya @hotell @sebald @andys8 @antoinebrault @gstamac @ExE-Boss @quassnoi @Belco90 @tonyhallett @ycmjason @pawfa @gerkindev @domdomegg
 /types/jest-axe/                                        @erbridge
 /types/jest-dev-server/                                 @ifiokjr @UziTech
 /types/jest-environment-puppeteer/                      @ifiokjr

--- a/types/jest-sinon/jest-sinon-tests.ts
+++ b/types/jest-sinon/jest-sinon-tests.ts
@@ -72,7 +72,7 @@ expect(fn).toBeCalledTimes(1);
 expect(fn).toHaveReturnedWith({});
 expect(fn).toReturnWith({});
 expect(fn).toHaveReturned();
-expect(fn).toReturn();
+expect(fn).toReturn({});
 expect(fn).toHaveAlwaysReturnedWith({});
 expect(fn).toAlwaysReturnWith({});
 

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -689,7 +689,7 @@ declare namespace jest {
          */
         <T = any>(actual: T): JestMatchers<T>;
         /**
-         * Matches anything but null or undefined. You can use it inside `toEqual` or `toBeCalledWith` instead
+         * Matches anything but null or undefined. You can use it inside `toEqual` or `toHaveBeenCalledWith` instead
          * of a literal value. For example, if you want to check that a mock function is called with a
          * non-null argument:
          *
@@ -698,13 +698,13 @@ declare namespace jest {
          * test('map calls its argument with a non-null argument', () => {
          *   const mock = jest.fn();
          *   [1].map(x => mock(x));
-         *   expect(mock).toBeCalledWith(expect.anything());
+         *   expect(mock).toHaveBeenCalledWith(expect.anything());
          * });
          */
         anything(): any;
         /**
          * Matches anything that was created with the given constructor.
-         * You can use it inside `toEqual` or `toBeCalledWith` instead of a literal value.
+         * You can use it inside `toEqual` or `toHaveBeenCalledWith` instead of a literal value.
          *
          * @example
          *
@@ -715,13 +715,13 @@ declare namespace jest {
          * test('randocall calls its callback with a number', () => {
          *   const mock = jest.fn();
          *   randocall(mock);
-         *   expect(mock).toBeCalledWith(expect.any(Number));
+         *   expect(mock).toHaveBeenCalledWith(expect.any(Number));
          * });
          */
         any(classType: any): any;
         /**
          * Matches any array made up entirely of elements in the provided array.
-         * You can use it inside `toEqual` or `toBeCalledWith` instead of a literal value.
+         * You can use it inside `toEqual` or `toHaveBeenCalledWith` instead of a literal value.
          *
          * Optionally, you can provide a type for the elements via a generic.
          */
@@ -800,46 +800,6 @@ declare namespace jest {
     // should be R extends void|Promise<void> but getting dtslint error
     interface Matchers<R, T = {}> {
         /**
-         * Ensures the last call to a mock function was provided specific args.
-         *
-         * Optionally, you can provide a type for the expected arguments via a generic.
-         * Note that the type must be either an array or a tuple.
-         *
-         * @deprecated in favor of `toHaveBeenLastCalledWith`
-         */
-        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        lastCalledWith<E extends any[]>(...args: E): R;
-        /**
-         * Ensure that the last call to a mock function has returned a specified value.
-         *
-         * Optionally, you can provide a type for the expected value via a generic.
-         * This is particularly useful for ensuring expected objects have the right structure.
-         *
-         * @deprecated in favor of `toHaveLastReturnedWith`
-         */
-        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        lastReturnedWith<E = any>(expected?: E): R;
-        /**
-         * Ensure that a mock function is called with specific arguments on an Nth call.
-         *
-         * Optionally, you can provide a type for the expected arguments via a generic.
-         * Note that the type must be either an array or a tuple.
-         *
-         * @deprecated in favor of `toHaveBeenNthCalledWith`
-         */
-        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        nthCalledWith<E extends any[]>(nthCall: number, ...params: E): R;
-        /**
-         * Ensure that the nth call to a mock function has returned a specified value.
-         *
-         * Optionally, you can provide a type for the expected value via a generic.
-         * This is particularly useful for ensuring expected objects have the right structure.
-         *
-         * @deprecated in favor of `toHaveNthReturnedWith`
-         */
-        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        nthReturnedWith<E = any>(n: number, expected?: E): R;
-        /**
          * Checks that a value is what you expect. It uses `Object.is` to check strict equality.
          * Don't use `toBe` with floating-point numbers.
          *
@@ -848,28 +808,6 @@ declare namespace jest {
          */
         // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
         toBe<E = any>(expected: E): R;
-        /**
-         * Ensures that a mock function is called.
-         *
-         * @deprecated in favor of `toHaveBeenCalled`
-         */
-        toBeCalled(): R;
-        /**
-         * Ensures that a mock function is called an exact number of times.
-         *
-         * @deprecated in favor of `toHaveBeenCalledTimes`
-         */
-        toBeCalledTimes(expected: number): R;
-        /**
-         * Ensure that a mock function is called with specific arguments.
-         *
-         * Optionally, you can provide a type for the expected arguments via a generic.
-         * Note that the type must be either an array or a tuple.
-         *
-         * @deprecated in favor of `toHaveBeenCalledWith`
-         */
-        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        toBeCalledWith<E extends any[]>(...args: E): R;
         /**
          * Using exact equality with floating point numbers is a bad idea.
          * Rounding means that intuitive things fail.
@@ -1099,28 +1037,6 @@ declare namespace jest {
          */
         toMatchInlineSnapshot(snapshot?: string): R;
         /**
-         * Ensure that a mock function has returned (as opposed to thrown) at least once.
-         *
-         * @deprecated in favor of `toHaveReturned`
-         */
-        toReturn(): R;
-        /**
-         * Ensure that a mock function has returned (as opposed to thrown) a specified number of times.
-         *
-         * @deprecated in favor of `toHaveReturnedTimes`
-         */
-        toReturnTimes(count: number): R;
-        /**
-         * Ensure that a mock function has returned a specified value at least once.
-         *
-         * Optionally, you can provide a type for the expected value via a generic.
-         * This is particularly useful for ensuring expected objects have the right structure.
-         *
-         * @deprecated in favor of `toHaveReturnedWith`
-         */
-        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        toReturnWith<E = any>(value?: E): R;
-        /**
          * Use to test that objects have the same types as well as structure.
          *
          * Optionally, you can provide a type for the expected value via a generic.
@@ -1132,12 +1048,6 @@ declare namespace jest {
          * Used to test that a function throws when it is called.
          */
         toThrow(error?: string | Constructable | RegExp | Error): R;
-        /**
-         * If you want to test that a specific error is thrown inside a function.
-         *
-         * @deprecated in favor of `toThrow`
-         */
-        toThrowError(error?: string | Constructable | RegExp | Error): R;
         /**
          * Used to test that a function throws a error matching the most recent snapshot when it is called.
          */

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -333,8 +333,9 @@ jest.autoMockOff()
     // @ts-expect-error
     .mock<{ animal: string }>("moduleName", () => ({ name: "tom" }))
     .resetModules()
+    .onGenerateMock(() => {})
     .isolateModules(() => {})
-    .retryTimes(3, { logErrorsBeforeRetry: true })
+    .retryTimes(3, { logErrorsBeforeRetry: true, waitBeforeRetry: 100, retryImmediately: true })
     .setMock("moduleName", {})
     .setMock<{}>("moduleName", {})
     .setMock<{ a: "b" }>("moduleName", { a: "b" })
@@ -348,6 +349,9 @@ jest.advanceTimersByTime(9001);
 
 // $ExpectType Promise<void>
 jest.advanceTimersByTimeAsync(9001);
+
+// $ExpectType void
+jest.advanceTimersToNextFrame();
 
 // $ExpectType void
 jest.advanceTimersToNextTimer();
@@ -578,9 +582,6 @@ mock9.mockImplementation((a: number) => Promise.resolve(a === 0));
 
 const createMockFromModule1: {} = jest.createMockFromModule("moduleName");
 const createMockFromModule2: { a: "b" } = jest.createMockFromModule<{ a: "b" }>("moduleName");
-
-const genMockModule1: {} = jest.genMockFromModule("moduleName");
-const genMockModule2: { a: "b" } = jest.genMockFromModule<{ a: "b" }>("moduleName");
 
 const isStringMock: boolean = jest.isMockFunction("foo");
 const isMockMock: boolean = jest.isMockFunction(mock1);
@@ -1158,32 +1159,26 @@ describe("", () => {
         // $ExpectType Promise<void>
         expect(Promise.resolve("")).resolves.toEqual("");
 
-        expect(jest.fn()).toHaveBeenLastCalledWith();
-        expect(jest.fn()).toHaveBeenLastCalledWith("jest");
-        expect(jest.fn()).toHaveBeenLastCalledWith({}, {});
+        expect(jest.fn()).toHaveReturned();
 
         expect(jest.fn()).toHaveReturnedWith("jest");
         expect(jest.fn()).toHaveReturnedWith({});
         expect(jest.fn()).toHaveReturnedWith();
 
-        expect(jest.fn()).toHaveBeenNthCalledWith(1, "jest");
-        expect(jest.fn()).toHaveBeenNthCalledWith(2, {});
+        expect(jest.fn()).toHaveReturnedTimes(0);
+        expect(jest.fn()).toHaveReturnedTimes(1);
 
         expect(jest.fn()).toHaveNthReturnedWith(1, "jest");
         expect(jest.fn()).toHaveNthReturnedWith(2, {});
         expect(jest.fn()).toHaveNthReturnedWith(3);
 
+        expect(jest.fn()).toHaveLastReturnedWith("jest");
+        expect(jest.fn()).toHaveLastReturnedWith({});
+        expect(jest.fn()).toHaveLastReturnedWith();
+
         expect({}).toBe({});
         expect([]).toBe([]);
         expect(10).toBe(10);
-
-        expect(jest.fn()).toHaveBeenCalled();
-
-        expect(jest.fn()).toHaveBeenCalledTimes(1);
-
-        expect(jest.fn()).toHaveBeenCalledWith();
-        expect(jest.fn()).toHaveBeenCalledWith("jest");
-        expect(jest.fn()).toHaveBeenCalledWith({}, {});
 
         // @ts-expect-error
         expect(jest.fn()).toBeCalledWith<[string, number]>(1, "two");
@@ -1239,9 +1234,6 @@ describe("", () => {
 
         expect(jest.fn()).toHaveBeenCalled();
 
-        expect(jest.fn()).toHaveBeenCalledTimes(0);
-        expect(jest.fn()).toHaveBeenCalledTimes(1);
-
         expect(jest.fn()).toHaveBeenCalledWith();
         expect(jest.fn()).toHaveBeenCalledWith("jest");
         expect(jest.fn()).toHaveBeenCalledWith({}, {});
@@ -1250,20 +1242,18 @@ describe("", () => {
         expect(jest.fn()).toHaveBeenCalledWith(1, "jest");
         expect(jest.fn()).toHaveBeenCalledWith(2, {}, {});
 
+        expect(jest.fn()).toHaveBeenCalledTimes(0);
+        expect(jest.fn()).toHaveBeenCalledTimes(1);
+
+        expect(jest.fn()).toHaveBeenNthCalledWith(1, "jest");
+        expect(jest.fn()).toHaveBeenNthCalledWith(2, {});
+
         expect(jest.fn()).toHaveBeenLastCalledWith();
         expect(jest.fn()).toHaveBeenLastCalledWith("jest");
         expect(jest.fn()).toHaveBeenLastCalledWith({}, {});
 
-        expect(jest.fn()).toHaveLastReturnedWith("jest");
-        expect(jest.fn()).toHaveLastReturnedWith({});
-        expect(jest.fn()).toHaveLastReturnedWith();
-
         expect([]).toHaveLength(0);
         expect("").toHaveLength(1);
-
-        expect(jest.fn()).toHaveNthReturnedWith(1, "jest");
-        expect(jest.fn()).toHaveNthReturnedWith(2, {});
-        expect(jest.fn()).toHaveNthReturnedWith(3);
 
         expect({}).toHaveProperty("property");
         expect({}).toHaveProperty("property", {});
@@ -1273,15 +1263,6 @@ describe("", () => {
         expect({}).toHaveProperty(["property", "deep"], {});
         expect({}).toHaveProperty(["property", "deep"] as const);
         expect({}).toHaveProperty(["property", "deep"] as const, {});
-
-        expect(jest.fn()).toHaveReturned();
-
-        expect(jest.fn()).toHaveReturnedTimes(0);
-        expect(jest.fn()).toHaveReturnedTimes(1);
-
-        expect(jest.fn()).toHaveReturnedWith("jest");
-        expect(jest.fn()).toHaveReturnedWith({});
-        expect(jest.fn()).toHaveReturnedWith();
 
         expect("").toMatch("");
         expect("").toMatch(/foo/);
@@ -1343,15 +1324,6 @@ describe("", () => {
             functionOne: expect.any(Function),
             bigIntegerOne: expect.any(BigInt),
         });
-
-        expect(jest.fn()).toHaveReturned();
-
-        expect(jest.fn()).toHaveReturnedTimes(0);
-        expect(jest.fn()).toHaveReturnedTimes(1);
-
-        expect(jest.fn()).toHaveReturnedWith("jest");
-        expect(jest.fn()).toHaveReturnedWith({});
-        expect(jest.fn()).toHaveReturnedWith();
 
         expect(true).toStrictEqual(false);
         expect({}).toStrictEqual({});
@@ -1418,6 +1390,10 @@ describe("", () => {
         expect({}).toBe(expect.arrayContaining(["a", "b"] as const));
         expect(["abc"]).toBe(expect.arrayContaining(["a", "b"] as const));
 
+        expect(["apple", "banana", "cherry"]).toEqual(
+            expect.arrayOf(expect.any(String)),
+        );
+
         expect.objectContaining({});
         expect.stringMatching("foo");
         expect.stringMatching(/foo/);
@@ -1440,6 +1416,9 @@ describe("", () => {
         expect({ bar: "baz" }).toEqual(expect.not.objectContaining({ foo: "bar" }));
         expect(["Alice", "Bob", "Eve"]).toEqual(expect.not.arrayContaining(["Samantha"]));
         expect(["Alice", "Bob", "Eve"]).toEqual(expect.not.arrayContaining(["Samantha"] as const));
+        expect(["apple", 123, "cherry"]).toEqual(
+            expect.not.arrayOf(expect.any(String)),
+        );
 
         /* Miscellaneous */
 

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -1158,32 +1158,32 @@ describe("", () => {
         // $ExpectType Promise<void>
         expect(Promise.resolve("")).resolves.toEqual("");
 
-        expect(jest.fn()).lastCalledWith();
-        expect(jest.fn()).lastCalledWith("jest");
-        expect(jest.fn()).lastCalledWith({}, {});
+        expect(jest.fn()).toHaveBeenLastCalledWith();
+        expect(jest.fn()).toHaveBeenLastCalledWith("jest");
+        expect(jest.fn()).toHaveBeenLastCalledWith({}, {});
 
-        expect(jest.fn()).lastReturnedWith("jest");
-        expect(jest.fn()).lastReturnedWith({});
-        expect(jest.fn()).lastReturnedWith();
+        expect(jest.fn()).toHaveReturnedWith("jest");
+        expect(jest.fn()).toHaveReturnedWith({});
+        expect(jest.fn()).toHaveReturnedWith();
 
-        expect(jest.fn()).nthCalledWith(1, "jest");
-        expect(jest.fn()).nthCalledWith(2, {});
+        expect(jest.fn()).toHaveBeenNthCalledWith(1, "jest");
+        expect(jest.fn()).toHaveBeenNthCalledWith(2, {});
 
-        expect(jest.fn()).nthReturnedWith(1, "jest");
-        expect(jest.fn()).nthReturnedWith(2, {});
-        expect(jest.fn()).nthReturnedWith(3);
+        expect(jest.fn()).toHaveNthReturnedWith(1, "jest");
+        expect(jest.fn()).toHaveNthReturnedWith(2, {});
+        expect(jest.fn()).toHaveNthReturnedWith(3);
 
         expect({}).toBe({});
         expect([]).toBe([]);
         expect(10).toBe(10);
 
-        expect(jest.fn()).toBeCalled();
+        expect(jest.fn()).toHaveBeenCalled();
 
-        expect(jest.fn()).toBeCalledTimes(1);
+        expect(jest.fn()).toHaveBeenCalledTimes(1);
 
-        expect(jest.fn()).toBeCalledWith();
-        expect(jest.fn()).toBeCalledWith("jest");
-        expect(jest.fn()).toBeCalledWith({}, {});
+        expect(jest.fn()).toHaveBeenCalledWith();
+        expect(jest.fn()).toHaveBeenCalledWith("jest");
+        expect(jest.fn()).toHaveBeenCalledWith({}, {});
 
         // @ts-expect-error
         expect(jest.fn()).toBeCalledWith<[string, number]>(1, "two");
@@ -1344,14 +1344,14 @@ describe("", () => {
             bigIntegerOne: expect.any(BigInt),
         });
 
-        expect(jest.fn()).toReturn();
+        expect(jest.fn()).toHaveReturned();
 
-        expect(jest.fn()).toReturnTimes(0);
-        expect(jest.fn()).toReturnTimes(1);
+        expect(jest.fn()).toHaveReturnedTimes(0);
+        expect(jest.fn()).toHaveReturnedTimes(1);
 
-        expect(jest.fn()).toReturnWith("jest");
-        expect(jest.fn()).toReturnWith({});
-        expect(jest.fn()).toReturnWith();
+        expect(jest.fn()).toHaveReturnedWith("jest");
+        expect(jest.fn()).toHaveReturnedWith({});
+        expect(jest.fn()).toHaveReturnedWith();
 
         expect(true).toStrictEqual(false);
         expect({}).toStrictEqual({});
@@ -2000,16 +2000,3 @@ test("import.meta.jest replaces the global jest in ESM", () => {
 
     importMetaJest.fn();
 });
-
-// these are deprecated and will be removed in Jest v30
-expect("abc").toBeCalled();
-expect("abc").toBeCalledTimes(0);
-expect("abc").toBeCalledWith();
-expect("abc").lastCalledWith();
-expect("abc").nthCalledWith(0);
-expect("abc").toReturn();
-expect("abc").toReturnTimes(0);
-expect("abc").toReturnWith();
-expect("abc").lastReturnedWith();
-expect("abc").nthReturnedWith(0);
-expect("abc").toThrowError();

--- a/types/jest/package.json
+++ b/types/jest/package.json
@@ -1,18 +1,13 @@
 {
     "private": true,
     "name": "@types/jest",
-    "version": "29.5.9999",
+    "version": "30.0.9999",
     "projects": [
         "https://jestjs.io/"
     ],
-    "exports": {
-        ".": {
-            "types": "./index.d.ts"
-        }
-    },
     "dependencies": {
-        "expect": "^29.0.0",
-        "pretty-format": "^29.0.0"
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
     },
     "devDependencies": {
         "@types/jest": "workspace:."

--- a/types/jest/package.json
+++ b/types/jest/package.json
@@ -112,10 +112,6 @@
         {
             "name": "Adam Jones",
             "githubUsername": "domdomegg"
-        },
-        {
-            "name": "Tom Mrazauskas",
-            "githubUsername": "mrazauskas"
         }
     ]
 }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <https://jestjs.io/docs/upgrading-to-jest30>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Deleted old typings for functions that were marked deprecated and are now completely removed in v30, bumped type dependencies & correct jsdoc references to non-deprecated functions