### PR TITLE
Allow OutputWriter to return promise in license-checker-webpack-plugin

### DIFF
--- a/types/license-checker-webpack-plugin/index.d.ts
+++ b/types/license-checker-webpack-plugin/index.d.ts
@@ -19,7 +19,7 @@ declare namespace LicenseCheckerWebpackPlugin {
         dependencies: Dependency[];
     }
 
-    type OutputWriter = (args: OutputWriterArgs) => string;
+    type OutputWriter = (args: OutputWriterArgs) => string | Promise<string>;
 
     interface Options {
         /**

--- a/types/license-checker-webpack-plugin/license-checker-webpack-plugin-tests.ts
+++ b/types/license-checker-webpack-plugin/license-checker-webpack-plugin-tests.ts
@@ -11,6 +11,7 @@ new LicenseCheckerWebpackPlugin({
         "querystring-es3@0.2.1": { licenseName: "MIT" },
     },
     emitError: true,
+    // $ExpectType string
     outputWriter: path.resolve(__dirname, "customTemplate.ejs"),
     outputFilename: "ThirdPartyNotices.txt",
 });
@@ -18,9 +19,18 @@ new LicenseCheckerWebpackPlugin({
 // $ExpectType LicenseCheckerWebpackPlugin
 new LicenseCheckerWebpackPlugin({
     filter: /.*/,
+    // $ExpectType ({ dependencies }: OutputWriterArgs) => string
     outputWriter: ({ dependencies }) => {
         dependencies; // $ExpectType Dependency[]
         return dependencies.map(d => `${d.name} - v${d.version} - ${d.author}\n${d.licenseName}`).join("\n");
+    },
+});
+
+// $ExpectType LicenseCheckerWebpackPlugin
+new LicenseCheckerWebpackPlugin({
+    // $ExpectType ({ dependencies }: OutputWriterArgs) => Promise<string>
+    outputWriter: async ({ dependencies }) => {
+        return dependencies.map(d => d.name).join("\n");
     },
 });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/microsoft/license-checker-webpack-plugin/blob/cdefc710375f3da72623fc110b1ed49b16dd7283/src/index.js#L30
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json` - N/A, the code has been this way since v0.0.7 per https://github.com/microsoft/license-checker-webpack-plugin/pull/6
