### PR TITLE
[pdfkit] Fixed CellOptions typings

### DIFF
--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -439,6 +439,11 @@ declare namespace PDFKit.Mixins {
         data: Array<Array<string | CellOptions>>;
     }
 
+    interface ExpandedAlign {
+        x?: "left" | "center" | "right" | "justify";
+        y?: "top" | "center" |  "bottom";
+    }
+
     interface CellOptions extends CellStyle {
         /** The value, will be cast to a string (null and undefined are not rendered but the cell is still outlined) */
         text?: string | undefined | null;
@@ -451,7 +456,7 @@ declare namespace PDFKit.Mixins {
         /** Font options for the cell */
         font?: any;
         /** The alignment of the cell text (default {x: 'left', y: 'top'}) */
-        align?: { x?: "right" | "left"; y?: "top" | "bottom" };
+        align?: "center" | ExpandedAlign;
         /** The text stroke (default 0) */
         textStroke?: number | boolean;
         /** Sets the text stroke color of the cells text (default black) */

--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -441,7 +441,7 @@ declare namespace PDFKit.Mixins {
 
     interface ExpandedAlign {
         x?: "left" | "center" | "right" | "justify";
-        y?: "top" | "center" |  "bottom";
+        y?: "top" | "center" | "bottom";
     }
 
     interface CellOptions extends CellStyle {

--- a/types/pdfkit/package.json
+++ b/types/pdfkit/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/pdfkit",
-    "version": "0.14.9999",
+    "version": "0.17.9999",
     "projects": [
         "http://pdfkit.org"
     ],

--- a/types/pdfkit/pdfkit-tests.ts
+++ b/types/pdfkit/pdfkit-tests.ts
@@ -436,6 +436,17 @@ doc.text("before")
     })
     .text("after");
 
+doc.table({
+  data: [
+    [
+      {
+        align: { x: 'center', y: 'bottom' },
+        text: 'test',
+      },
+    ],
+  ],
+});
+
 doc.text("Scale", { align: "justify" });
 
 doc.text("Baseline - string literal", { baseline: "alphabetic" });

--- a/types/pdfkit/pdfkit-tests.ts
+++ b/types/pdfkit/pdfkit-tests.ts
@@ -437,14 +437,14 @@ doc.text("before")
     .text("after");
 
 doc.table({
-  data: [
-    [
-      {
-        align: { x: 'center', y: 'bottom' },
-        text: 'test',
-      },
+    data: [
+        [
+            {
+                align: { x: "center", y: "bottom" },
+                text: "test",
+            },
+        ],
     ],
-  ],
 });
 
 doc.text("Scale", { align: "justify" });


### PR DESCRIPTION
Fixes the mentioned problem in this [discussion](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/73006)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/foliojs/pdfkit/blob/master/lib/table/utils.js#L65
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.