### PR TITLE
[three-dat.gui] Remove instantiation of THREE.Material

### DIFF
--- a/types/three-dat.gui/three-dat.gui-tests.ts
+++ b/types/three-dat.gui/three-dat.gui-tests.ts
@@ -28,7 +28,7 @@ gui.open();
 }
 {
     // $ExpectType GUI
-    gui.addMaterial("", new THREE.Material());
+    gui.addMaterial("", new THREE.MeshStandardMaterial());
 }
 {
     // $ExpectType GUI


### PR DESCRIPTION
THREE.Material is an abstract class, and should therefore not be instantiated directly

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://threejs.org/docs/?q=mater#api/en/materials/Material
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
