### PR TITLE
[chrome] update scripting namespace

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -9802,11 +9802,22 @@ declare namespace chrome {
      * @since Chrome 88, MV3
      */
     export namespace scripting {
-        /* The CSS style origin for a style change. */
-        export type StyleOrigin = "AUTHOR" | "USER";
+        /** The origin for a style change. See style origins for more info. */
+        export enum StyleOrigin {
+            AUTHOR = "AUTHOR",
+            USER = "USER",
+        }
 
-        /* The JavaScript world for a script to execute within. */
-        export type ExecutionWorld = "ISOLATED" | "MAIN";
+        /**
+         * The JavaScript world for a script to execute within.
+         * @since Chrome 95
+         */
+        export enum ExecutionWorld {
+            /** Specifies the isolated world, which is the execution environment unique to this extension. */
+            ISOLATED = "ISOLATED",
+            /** Specifies the main world of the DOM, which is the execution environment shared with the host page's JavaScript. */
+            MAIN = "MAIN",
+        }
 
         export interface InjectionResult<T extends any = any> {
             /**
@@ -9819,100 +9830,162 @@ declare namespace chrome {
              * @since Chrome 90
              */
             frameId: number;
-            /* The result of the script execution. */
-            result?: T | undefined;
+            /** The result of the script execution. */
+            result?: T;
         }
 
-        export interface InjectionTarget {
-            /* Whether the script should inject into all frames within the tab. Defaults to false. This must not be true if frameIds is specified. */
-            allFrames?: boolean | undefined;
-            /**
-             * The IDs of specific documentIds to inject into. This must not be set if frameIds is set.
-             * @since Chrome 106
-             */
-            documentIds?: string[] | undefined;
-            /* The IDs of specific frames to inject into. */
-            frameIds?: number[] | undefined;
-            /* The ID of the tab into which to inject. */
-            tabId: number;
-        }
+        export type InjectionTarget =
+            & {
+                /** The ID of the tab into which to inject. */
+                tabId: number;
+            }
+            & (
+                | {
+                    /** Whether the script should inject into all frames within the tab. Defaults to false. This must not be true if `frameIds` or `documentIds` is specified. */
+                    allFrames?: boolean | undefined;
+                    /**
+                     * The IDs of specific documentIds to inject into. This must not be set if `frameIds` is set.
+                     * @since Chrome 106
+                     */
+                    documentIds?: never | undefined;
+                    /** The IDs of specific frames to inject into. */
+                    frameIds?: never | undefined;
+                }
+                | {
+                    /** Whether the script should inject into all frames within the tab. Defaults to false. This must not be true if `frameIds` or `documentIds` is specified. */
+                    allFrames?: false | undefined;
+                    /**
+                     * The IDs of specific documentIds to inject into. This must not be set if `frameIds` is set.
+                     * @since Chrome 106
+                     */
+                    documentIds?: never | undefined;
+                    /** The IDs of specific frames to inject into. */
+                    frameIds: number[] | undefined;
+                }
+                | {
+                    /** Whether the script should inject into all frames within the tab. Defaults to false. This must not be true if `frameIds` or `documentIds` is specified. */
+                    allFrames?: false | undefined;
+                    /**
+                     * The IDs of specific documentIds to inject into. This must not be set if `frameIds` is set.
+                     * @since Chrome 106
+                     */
+                    documentIds?: string[] | undefined;
+                    /** The IDs of specific frames to inject into. */
+                    frameIds?: never | undefined;
+                }
+            );
 
-        export interface CSSInjection {
-            /* A string containing the CSS to inject. Exactly one of files and css must be specified. */
-            css?: string | undefined;
-            /* The path of the CSS files to inject, relative to the extension's root directory. NOTE: Currently a maximum of one file is supported. Exactly one of files and css must be specified. */
-            files?: string[] | undefined;
-            /* The style origin for the injection. Defaults to 'AUTHOR'. */
-            origin?: StyleOrigin | undefined;
-            /* Details specifying the target into which to insert the CSS. */
-            target: InjectionTarget;
-        }
+        export type CSSInjection =
+            & {
+                /** The style origin for the injection. Defaults to `'AUTHOR'`. */
+                origin?: `${StyleOrigin}` | undefined;
+                /** Details specifying the target into which to insert the CSS. */
+                target: InjectionTarget;
+            }
+            & (
+                | {
+                    /** A string containing the CSS to inject. Exactly one of `files` and `css` must be specified. */
+                    css: string;
+                    /** The path of the CSS files to inject, relative to the extension's root directory. Exactly one of `files` and `css` must be specified. */
+                    files?: never | undefined;
+                }
+                | {
+                    /** A string containing the CSS to inject. Exactly one of `files` and `css` must be specified. */
+                    css?: never | undefined;
+                    /** The path of the CSS files to inject, relative to the extension's root directory. Exactly one of `files` and `css` must be specified. */
+                    files: string[];
+                }
+            );
 
         export type ScriptInjection<Args extends any[], Result> =
             & {
-                /* Details specifying the target into which to inject the script. */
+                /** Details specifying the target into which to inject the script. */
                 target: InjectionTarget;
-                /* The JavaScript world for a script to execute within. */
-                world?: ExecutionWorld;
-                /* Whether the injection should be triggered in the target as soon as possible. Note that this is not a guarantee that injection will occur prior to page load, as the page may have already loaded by the time the script reaches the target. */
+                /** The JavaScript "world" to run the script in. Defaults to `ISOLATED`. */
+                world?: `${ExecutionWorld}`;
+                /**
+                 * Whether the injection should be triggered in the target as soon as possible. Note that this is not a guarantee that injection will occur prior to page load, as the page may have already loaded by the time the script reaches the target.
+                 * @since Chrome 102
+                 */
                 injectImmediately?: boolean;
             }
             & (
                 | {
-                    /* The path of the JS files to inject, relative to the extension's root directory. NOTE: Currently a maximum of one file is supported. Exactly one of files and function must be specified. */
+                    /** A JavaScript function to inject. This function will be serialized, and then deserialized for injection. This means that any bound parameters and execution context will be lost. Exactly one of `files` or `func` must be specified. */
+                    func?: never | undefined;
+                    /** The path of the JS or CSS files to inject, relative to the extension's root directory. Exactly one of files or func must be specified. */
                     files: string[];
                 }
                 | ({
-                    /* A JavaScript function to inject. This function will be serialized, and then deserialized for injection. This means that any bound parameters and execution context will be lost. Exactly one of files and function must be specified. */
+                    /** A JavaScript function to inject. This function will be serialized, and then deserialized for injection. This means that any bound parameters and execution context will be lost. Exactly one of `files` or `func` must be specified. */
                     func: () => Result;
+                    /** The path of the JS or CSS files to inject, relative to the extension's root directory. Exactly one of files or func must be specified. */
+                    files?: never | undefined;
                 } | {
-                    /* A JavaScript function to inject. This function will be serialized, and then deserialized for injection. This means that any bound parameters and execution context will be lost. Exactly one of files and function must be specified. */
-                    func: (...args: Args) => Result;
-                    /* The arguments to carry into a provided function. This is only valid if the func parameter is specified. These arguments must be JSON-serializable. */
+                    /** The arguments to pass to the provided function. This is only valid if the `func` parameter is specified. These arguments must be JSON-serializable. */
                     args: Args;
+                    /** A JavaScript function to inject. This function will be serialized, and then deserialized for injection. This means that any bound parameters and execution context will be lost. Exactly one of `files` or `func` must be specified. */
+                    func: (...args: Args) => Result;
+                    /** The path of the JS or CSS files to inject, relative to the extension's root directory. Exactly one of files or func must be specified. */
+                    files?: never | undefined;
                 })
             );
 
         type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
 
-        interface RegisteredContentScript {
-            id: string;
-            allFrames?: boolean;
-            matchOriginAsFallback?: boolean;
-            css?: string[];
-            excludeMatches?: string[];
-            js?: string[];
-            matches?: string[];
-            persistAcrossSessions?: boolean;
-            runAt?: extensionTypes.RunAt;
-            world?: ExecutionWorld;
-        }
+        /** @since Chrome 96 */
+        type RegisteredContentScript =
+            & {
+                /** The id of the content script, specified in the API call. Must not start with a '_' as it's reserved as a prefix for generated script IDs. */
+                id: string;
+                /** If specified true, it will inject into all frames, even if the frame is not the top-most frame in the tab. Each frame is checked independently for URL requirements; it will not inject into child frames if the URL requirements are not met. Defaults to false, meaning that only the top frame is matched. */
+                allFrames?: boolean | undefined;
+                /** Excludes pages that this content script would otherwise be injected into. See Match Patterns for more details on the syntax of these strings. */
+                excludeMatches?: string[] | undefined;
+                /**
+                 * Indicates whether the script can be injected into frames where the URL contains an unsupported scheme; specifically: about:, data:, blob:, or filesystem:. In these cases, the URL's origin is checked to determine if the script should be injected. If the origin is `null` (as is the case for data: URLs) then the used origin is either the frame that created the current frame or the frame that initiated the navigation to this frame. Note that this may not be the parent frame.
+                 * @since Chrome 119
+                 */
+                matchOriginAsFallback?: boolean | undefined;
+                /** Specifies which pages this content script will be injected into. See Match Patterns for more details on the syntax of these strings. Must be specified for {@link registerContentScripts}. */
+                matches?: string[] | undefined;
+                /** Specifies if this content script will persist into future sessions. The default is true. */
+                persistAcrossSessions?: boolean | undefined;
+                /** Specifies when JavaScript files are injected into the web page. The preferred and default value is `document_idle`. */
+                runAt?: extensionTypes.RunAt | undefined;
+                /** The JavaScript "world" to run the script in. Defaults to `ISOLATED`. */
+                world?: `${ExecutionWorld}` | undefined;
+            }
+            & (
+                | {
+                    /** The list of JavaScript files to be injected into matching pages. These are injected in the order they appear in this array. */
+                    js: string[];
+                    /** The list of CSS files to be injected into matching pages. These are injected in the order they appear in this array, before any DOM is constructed or displayed for the page. */
+                    css?: string[] | undefined;
+                }
+                | {
+                    /** The list of JavaScript files to be injected into matching pages. These are injected in the order they appear in this array. */
+                    js?: string[] | undefined;
+                    /** The list of CSS files to be injected into matching pages. These are injected in the order they appear in this array, before any DOM is constructed or displayed for the page. */
+                    css: string[];
+                }
+            );
 
-        interface ContentScriptFilter {
-            ids?: string[];
-            css?: string;
-            files?: string[];
-            origin?: StyleOrigin;
-            target?: InjectionTarget;
+        /** @since Chrome 96 */
+        export interface ContentScriptFilter {
+            /** If specified, {@link getRegisteredContentScripts} will only return scripts with an id specified in this list. */
+            ids?: string[] | undefined;
         }
 
         /**
-         * Injects a script into a target context. The script will be run at document_end.
-         * @param injection
-         * The details of the script which to inject.
-         * @return The `executeScript` method provides its result via callback or returned as a `Promise` (MV3 only). The resulting array contains the result of execution for each frame where the injection succeeded.
+         * Injects a script into a target context. By default, the script will be run at `document_idle`, or immediately if the page has already loaded. If the `injectImmediately` property is set, the script will inject without waiting, even if the page has not finished loading. If the script evaluates to a promise, the browser will wait for the promise to settle and return the resulting value.
+         *
+         * Can return its result via Promise since Chrome 90.
+         * @param injection The details of the script which to inject.
          */
         export function executeScript<Args extends any[], Result>(
             injection: ScriptInjection<Args, Result>,
         ): Promise<Array<InjectionResult<Awaited<Result>>>>;
-
-        /**
-         * Injects a script into a target context. The script will be run at document_end.
-         * @param injection
-         * The details of the script which to inject.
-         * @param callback
-         * Invoked upon completion of the injection. The resulting array contains the result of execution for each frame where the injection succeeded.
-         */
         export function executeScript<Args extends any[], Result>(
             injection: ScriptInjection<Args, Result>,
             callback: (results: Array<InjectionResult<Awaited<Result>>>) => void,
@@ -9920,102 +9993,56 @@ declare namespace chrome {
 
         /**
          * Inserts a CSS stylesheet into a target context. If multiple frames are specified, unsuccessful injections are ignored.
-         * @param injection
-         * The details of the styles to insert.
-         * @return The `insertCSS` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+         *
+         * Can return its result via Promise since Chrome 90.
+         * @param injection The details of the styles to insert.
          */
         export function insertCSS(injection: CSSInjection): Promise<void>;
-
-        /**
-         * Inserts a CSS stylesheet into a target context. If multiple frames are specified, unsuccessful injections are ignored.
-         * @param injection
-         * The details of the styles to insert.
-         * @param callback
-         * Invoked upon completion of the injection.
-         */
         export function insertCSS(injection: CSSInjection, callback: () => void): void;
 
         /**
          * Removes a CSS stylesheet that was previously inserted by this extension from a target context.
-         * @param injection
-         * The details of the styles to remove.
-         * Note that the css, files, and origin properties must exactly match the stylesheet inserted through `insertCSS`.
-         * Attempting to remove a non-existent stylesheet is a no-op.
-         * @return This only returns a Promise when the callback parameter is not specified, and with MV3.
+         * @param injection The details of the styles to remove. Note that the `css`, `files`, and `origin` properties must exactly match the stylesheet inserted through {@link insertCSS}. Attempting to remove a non-existent stylesheet is a no-op.
          * @since Chrome 90
          */
         export function removeCSS(injection: CSSInjection): Promise<void>;
-
-        /**
-         * Removes a CSS stylesheet that was previously inserted by this extension from a target context.
-         * @param injection
-         * The details of the styles to remove.
-         * Note that the css, files, and origin properties must exactly match the stylesheet inserted through `insertCSS`.
-         * Attempting to remove a non-existent stylesheet is a no-op.
-         * @param callback
-         * Invoked upon completion of the removal.
-         * @since Chrome 90
-         */
         export function removeCSS(injection: CSSInjection, callback: () => void): void;
 
         /**
-         * Registers one or more content scripts.
-         * @param scripts
+         * Registers one or more content scripts for this extension
+         * @param scripts Contains a list of scripts to be registered. If there are errors during script parsing/file validation, or if the IDs specified already exist, then no scripts are registered.
+         * @since Chrome 96
          */
         export function registerContentScripts(scripts: RegisteredContentScript[]): Promise<void>;
-
-        /**
-         * Registers one or more content scripts.
-         * @param scripts
-         * @param callback
-         */
         export function registerContentScripts(scripts: RegisteredContentScript[], callback: () => void): void;
 
         /**
-         * Unregister one or more content scripts.
-         * @param filter
-         * @param callback
+         * Unregisters content scripts for this extension.
+         * @param filter If specified, only unregisters dynamic content scripts which match the filter. Otherwise, all of the extension's dynamic content scripts are unregistered.
+         * @since Chrome 96
          */
         export function unregisterContentScripts(filter?: ContentScriptFilter): Promise<void>;
-
-        /**
-         * Unregister one or more content scripts.
-         * @param filter
-         * @param callback
-         */
         export function unregisterContentScripts(callback: () => void): void;
-        export function unregisterContentScripts(filter: ContentScriptFilter, callback: () => void): void;
+        export function unregisterContentScripts(filter: ContentScriptFilter | undefined, callback: () => void): void;
 
         /**
-         * Returns all the content scripts registered with scripting.registerContentScripts()
-         * or a subset of the registered scripts when using a filter.
-         * @param filter
+         * Returns all dynamically registered content scripts for this extension that match the given filter.
+         * @param filter An object to filter the extension's dynamically registered scripts.
+         * @since Chrome 96
          */
         export function getRegisteredContentScripts(filter?: ContentScriptFilter): Promise<RegisteredContentScript[]>;
-
-        /**
-         * Returns all the content scripts registered with scripting.registerContentScripts()
-         * or a subset of the registered scripts when using a filter.
-         * @param filter
-         * @param callback
-         */
         export function getRegisteredContentScripts(callback: (scripts: RegisteredContentScript[]) => void): void;
         export function getRegisteredContentScripts(
-            filter: ContentScriptFilter,
+            filter: ContentScriptFilter | undefined,
             callback: (scripts: RegisteredContentScript[]) => void,
         ): void;
 
         /**
-         * Updates one or more content scripts.
-         * @param scripts
+         * Updates one or more content scripts for this extension.
+         * @param scripts Contains a list of scripts to be updated. A property is only updated for the existing script if it is specified in this object. If there are errors during script parsing/file validation, or if the IDs specified do not correspond to a fully registered script, then no scripts are updated.
+         * @since Chrome 96
          */
         export function updateContentScripts(scripts: RegisteredContentScript[]): Promise<void>;
-
-        /**
-         * Updates one or more content scripts.
-         * @param scripts
-         * @param callback
-         */
         export function updateContentScripts(scripts: RegisteredContentScript[], callback: () => void): void;
     }
 

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -2403,91 +2403,145 @@ async function testManagementForPromise() {
     await chrome.management.generateAppForLink("url1", "title1");
 }
 
-// https://developer.chrome.com/docs/extensions/reference/scripting
-async function testScriptingForPromise() {
-    // @ts-expect-error
-    await chrome.scripting.executeScript({ target: { tabId: 0 } });
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, func: () => {} });
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, func: function() {} });
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, func: () => {}, args: [] });
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, func: function() {}, args: [] });
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, func: (str: string) => {}, args: [""] });
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, func: (str: string, n: number) => {}, args: ["", 0] });
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, func: () => {} }); // $ExpectType InjectionResult<void>[]
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, func: () => 0 }); // $ExpectType InjectionResult<number>[]
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, func: () => "" }); // $ExpectType InjectionResult<string>[]
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, func: (str: string, n: number) => {}, args: ["", 0] }); // $ExpectType InjectionResult<void>[]
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, func: (str: string, n: number) => 0, args: ["", 0] }); // $ExpectType InjectionResult<number>[]
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, func: (str: string, n: number) => "", args: ["", 0] }); // $ExpectType InjectionResult<string>[]
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, func: async () => {} }); // $ExpectType InjectionResult<void>[]
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, func: async () => 0 }); // $ExpectType InjectionResult<number>[]
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, func: async () => "" }); // $ExpectType InjectionResult<string>[]
-    // $ExpectType InjectionResult<void>[]
-    await chrome.scripting.executeScript({
-        target: { tabId: 0 },
-        func: async (str: string, n: number) => {},
-        args: ["", 0],
-    });
-    // $ExpectType InjectionResult<number>[]
-    await chrome.scripting.executeScript({
-        target: { tabId: 0 },
-        func: async (str: string, n: number) => 0,
-        args: ["", 0],
-    });
-    // $ExpectType InjectionResult<string>[]
-    await chrome.scripting.executeScript({
-        target: { tabId: 0 },
-        func: async (str: string, n: number) => "",
-        args: ["", 0],
-    });
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, world: "ISOLATED", func: () => {} });
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, injectImmediately: true, func: () => {} }); // $ExpectType InjectionResult<void>[]
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, injectImmediately: false, func: () => {} }); // $ExpectType InjectionResult<void>[]
-    // @ts-expect-error
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, world: "not-real-world", func: () => {} });
-    // @ts-expect-error
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, func: (str: string, n: number) => {}, args: [0, ""] });
-    // @ts-expect-error
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, func: (str: string) => {}, args: [0] });
-    // @ts-expect-error
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, func: () => {}, args: [""] });
-    // @ts-expect-error
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, func: (name: string) => {}, args: [] });
-    // @ts-expect-error
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, func: () => {}, args: {} });
-    await chrome.scripting.executeScript({ target: { tabId: 0 }, files: ["script.js"] }); // $ExpectType InjectionResult<unknown>[]
+// https://developer.chrome.com/docs/extensions/reference/api/scripting
+async function testScripting() {
+    chrome.scripting.ExecutionWorld.ISOLATED === "ISOLATED";
+    chrome.scripting.ExecutionWorld.MAIN === "MAIN";
 
-    await chrome.scripting.insertCSS({ target: { tabId: 0 } });
+    chrome.scripting.StyleOrigin.AUTHOR === "AUTHOR";
+    chrome.scripting.StyleOrigin.USER === "USER";
 
-    await chrome.scripting.removeCSS({ target: { tabId: 0 } });
+    const target: chrome.scripting.InjectionTarget = {
+        tabId: 0,
+    };
 
-    await chrome.scripting.registerContentScripts([
-        { id: "id1", js: ["script1.js"] },
-        { id: "id2", js: ["script2.js"], runAt: "document_start", allFrames: true, world: "ISOLATED" },
-        {
-            id: "id3",
-            css: ["style1.css"],
-            excludeMatches: ["*://*.example.com/*"],
-            runAt: "document_end",
-            allFrames: true,
-            world: "MAIN",
+    chrome.scripting.executeScript({ target, func: () => {} }); // $ExpectType Promise<InjectionResult<void>[]>
+    chrome.scripting.executeScript({ target, func: () => {}, args: [] }); // $ExpectType Promise<InjectionResult<void>[]>
+    chrome.scripting.executeScript({ target, func: (str: string) => {}, args: [""] }); // $ExpectType Promise<InjectionResult<void>[]>
+    chrome.scripting.executeScript({ target, func: (str: string, n: number) => {}, args: ["", 0] }); // $ExpectType Promise<InjectionResult<void>[]>
+    chrome.scripting.executeScript({ target, func: () => {} }); // $ExpectType Promise<InjectionResult<void>[]>
+    chrome.scripting.executeScript({ target, func: () => 0 }); // $ExpectType Promise<InjectionResult<number>[]>
+    chrome.scripting.executeScript({ target, func: () => "" }); // $ExpectType Promise<InjectionResult<string>[]>
+    chrome.scripting.executeScript({ target, func: (str: string, n: number) => {}, args: ["", 0] }); // $ExpectType Promise<InjectionResult<void>[]>
+    chrome.scripting.executeScript({ target, func: (str: string, n: number) => 0, args: ["", 0] }); // $ExpectType Promise<InjectionResult<number>[]>
+    chrome.scripting.executeScript({ target, func: (str: string, n: number) => "", args: ["", 0] }); // $ExpectType Promise<InjectionResult<string>[]>
+    chrome.scripting.executeScript({ target, func: async () => {} }); // $ExpectType Promise<InjectionResult<void>[]>
+    chrome.scripting.executeScript({ target, func: async () => 0 }); // $ExpectType Promise<InjectionResult<number>[]>
+    chrome.scripting.executeScript({ target, func: async () => "" }); // $ExpectType Promise<InjectionResult<string>[]>
+    chrome.scripting.executeScript({ target, func: async (str: string, n: number) => {}, args: ["", 0] }); // $ExpectType Promise<InjectionResult<void>[]>
+    chrome.scripting.executeScript({ target, func: async (str: string, n: number) => 0, args: ["", 0] }); // $ExpectType Promise<InjectionResult<number>[]>
+    chrome.scripting.executeScript({ target, func: async (str: string, n: number) => "", args: ["", 0] }); // $ExpectType Promise<InjectionResult<string>[]>
+    chrome.scripting.executeScript({ target, world: "ISOLATED", injectImmediately: true, func: () => {} }); // $ExpectType Promise<InjectionResult<void>[]>
+    chrome.scripting.executeScript( // $ExpectType void
+        { target, world: "ISOLATED", injectImmediately: true, func: () => {} },
+        (results) => {
+            results; // $ExpectType InjectionResult<void>[]
         },
-    ]);
-    await chrome.scripting.updateContentScripts([
-        { id: "id1", js: ["script1.js"] },
-        { id: "id2", js: ["script2.js"], runAt: "document_start", allFrames: true, world: "ISOLATED" },
-        {
-            id: "id3",
-            css: ["style1.css"],
-            excludeMatches: ["*://*.example.com/*"],
-            runAt: "document_end",
-            allFrames: true,
-            world: "MAIN",
-        },
-    ]);
-    await chrome.scripting.unregisterContentScripts({ ids: ["id1", "id2"] });
-    await chrome.scripting.unregisterContentScripts({ files: ["script1.js", "style1.css"] });
-    await chrome.scripting.getRegisteredContentScripts();
+    );
+    chrome.scripting.executeScript({ target, files: ["script.js"] }); // $ExpectType Promise<InjectionResult<unknown>[]
+    chrome.scripting.executeScript({ target, files: ["script.js"] }, (results) => { // $ExpectType void
+        results; // $ExpectType InjectionResult<unknown>[]
+    });
+    // @ts-expect-error Exactly one of 'func' and 'files' must be specified.
+    chrome.scripting.executeScript({ target });
+    // @ts-expect-error Exactly one of 'func' and 'files' must be specified.
+    chrome.scripting.executeScript({ target, func: () => {}, files: [] });
+    // @ts-expect-error 'args' may not be used with file injections.
+    chrome.scripting.executeScript({ target, files: [], args: [] });
+    // @ts-expect-error Cannot specify both 'frameIds' and 'documentIds'.
+    chrome.scripting.executeScript({ target: { tabId: 0, frameIds: [], documentIds: [] }, func: () => {} });
+    chrome.scripting.executeScript({
+        // @ts-expect-error Cannot specify 'allFrames' if either 'frameIds' or 'documentIds' is specified.
+        target: { tabId: 0, allFrames: true, frameIds: [], documentIds: [] },
+        func: () => {},
+    });
+    // @ts-expect-error
+    chrome.scripting.executeScript({ target, func: (str: string, n: number) => {}, args: [0, ""] });
+    // @ts-expect-error
+    chrome.scripting.executeScript({ target, func: (str: string) => {}, args: [0] });
+    // @ts-expect-error
+    chrome.scripting.executeScript({ target, func: () => {}, args: [""] });
+    // @ts-expect-error
+    chrome.scripting.executeScript({ target, func: (name: string) => {}, args: [] });
+    // @ts-expect-error
+    chrome.scripting.executeScript({ target, func: () => {}, args: {} });
+
+    const contentScriptFilter: chrome.scripting.ContentScriptFilter = {
+        ids: ["id1", "id2"],
+    };
+
+    const registeredContentScript: chrome.scripting.RegisteredContentScript = {
+        allFrames: true,
+        css: ["style.css"],
+        excludeMatches: [],
+        id: "id",
+        js: ["script.js"],
+        matchOriginAsFallback: true,
+        matches: ["*://*.example.com/*"],
+        persistAcrossSessions: true,
+        runAt: "document_start",
+        world: "ISOLATED",
+    };
+
+    chrome.scripting.getRegisteredContentScripts(); // $ExpectType Promise<RegisteredContentScript[]>
+    chrome.scripting.getRegisteredContentScripts(contentScriptFilter); // $ExpectType Promise<RegisteredContentScript[]>
+    chrome.scripting.getRegisteredContentScripts((scripts) => { // $ExpectType void
+        scripts; // $ExpectType RegisteredContentScript[]
+    });
+    chrome.scripting.getRegisteredContentScripts(contentScriptFilter, (scripts) => { // $ExpectType void
+        scripts; // $ExpectType RegisteredContentScript[]
+    });
+    // @ts-expect-error
+    chrome.scripting.getRegisteredContentScripts(() => {}).then(() => {});
+
+    chrome.scripting.insertCSS({ target, css: "styles" }); // $ExpectType Promise<void>
+    chrome.scripting.insertCSS({ target, files: ["styles.css"] }); // $ExpectType Promise<void>
+    chrome.scripting.insertCSS({ target, css: "styles" }, () => {}); // $ExpectType void
+    chrome.scripting.insertCSS({ target, files: ["styles.css"] }, () => {}); // $ExpectType void
+    // @ts-expect-error Exactly one of 'css' and 'files' must be specified.
+    chrome.scripting.insertCSS({ target });
+    // @ts-expect-error Exactly one of 'css' and 'files' must be specified.
+    chrome.scripting.insertCSS({ target, css: "styles", files: [] });
+    // @ts-expect-error Cannot specify both 'frameIds' and 'documentIds'.
+    chrome.scripting.insertCSS({ target: { tabId: 0, frameIds: [], documentIds: [] }, css: "styles" });
+    // @ts-expect-error Cannot specify 'allFrames' if either 'frameIds' or 'documentIds' is specified.
+    chrome.scripting.insertCSS({ target: { tabId: 0, allFrames: true, frameIds: [], documentIds: [] }, css: "styles" });
+    // @ts-expect-error
+    chrome.scripting.insertCSS({ target }, () => {}).then(() => {});
+
+    chrome.scripting.registerContentScripts([registeredContentScript]); // $ExpectType Promise<void>
+    chrome.scripting.registerContentScripts([registeredContentScript], () => {}); // $ExpectType void
+    // @ts-expect-error must specify at least one js or css file.
+    chrome.scripting.registerContentScripts([{ id: "id", matches: ["*://*.example.com/*"] }], () => {});
+    // @ts-expect-error
+    chrome.scripting.registerContentScripts([], () => {}).then(() => {});
+
+    chrome.scripting.removeCSS({ target, css: "styles" }); // $ExpectType Promise<void>
+    chrome.scripting.removeCSS({ target, files: ["styles.css"] }); // $ExpectType Promise<void>
+    chrome.scripting.removeCSS({ target, css: "styles" }, () => {}); // $ExpectType void
+    chrome.scripting.removeCSS({ target, files: ["styles.css"] }, () => {}); // $ExpectType void
+    // @ts-expect-error Exactly one of 'css' and 'files' must be specified.
+    chrome.scripting.removeCSS({ target });
+    // @ts-expect-error Exactly one of 'css' and 'files' must be specified.
+    chrome.scripting.removeCSS({ target, css: "styles", files: [] });
+    // @ts-expect-error Cannot specify both 'frameIds' and 'documentIds'.
+    chrome.scripting.removeCSS({ target: { tabId: 0, frameIds: [], documentIds: [] }, css: "styles" });
+    // @ts-expect-error Cannot specify 'allFrames' if either 'frameIds' or 'documentIds' is specified.
+    chrome.scripting.removeCSS({ target: { tabId: 0, allFrames: true, frameIds: [], documentIds: [] }, css: "styles" });
+    // @ts-expect-error
+    chrome.scripting.removeCSS({ target }, () => {}).then(() => {});
+
+    chrome.scripting.unregisterContentScripts(); // $ExpectType Promise<void>
+    chrome.scripting.unregisterContentScripts(contentScriptFilter); // $ExpectType Promise<void>
+    chrome.scripting.unregisterContentScripts(() => {}); // $ExpectType void
+    chrome.scripting.unregisterContentScripts(contentScriptFilter, () => {}); // $ExpectType void
+    // @ts-expect-error
+    chrome.scripting.unregisterContentScripts(() => {}).then(() => {});
+
+    chrome.scripting.updateContentScripts([registeredContentScript]); // $ExpectType Promise<void>
+    chrome.scripting.updateContentScripts([registeredContentScript], () => {}); // $ExpectType void
+    // @ts-expect-error
+    chrome.scripting.updateContentScripts([], () => {}).then(() => {});
 }
 
 // https://developer.chrome.com/docs/extensions/reference/system_cpu


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/scripting
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes : 
- Added `ExecutionWorld` and `StyleOrigin` enums
- Restriction of the injections type of `executeScript()`: 🚨
  > Exactly one of 'func' and 'files' must be specified
  
  ![image](https://github.com/user-attachments/assets/fbc85d96-4ad9-4e57-9b67-cbbf61449b4f)
  
  > 'args' may not be used with file injections.
  
  ![image](https://github.com/user-attachments/assets/4d6c8919-db7c-451c-a1ee-7bff6d3987c3)
- Restriction of the injections type of `insertCSS()` and `removeCSS()`: 🚨
  > Exactly one of 'css' and 'files' must be specified.  
  
  ![image](https://github.com/user-attachments/assets/ad610ab3-b594-4849-bbfd-9aa3f3769233)
- Restriction of the target type of `insertCSS()`, `removeCSS()` and `executeScript()`: 🚨
  > Cannot specify 'allFrames' if either 'frameIds' or 'documentIds' is specified.
  
  ![image](https://github.com/user-attachments/assets/e505fccc-d173-4b48-ac7e-0123950d2895)
  > Cannot specify both 'frameIds' and 'documentIds'.
  
  ![image](https://github.com/user-attachments/assets/2d000fe0-a3bf-4b3d-9be6-e120441b486a)
- Restriction of the ContentScriptFilter type of `getRegisteredContentScripts()`: 🚨
  > Script with ID 'id' must specify at least one js or css file.
 
  ![image](https://github.com/user-attachments/assets/3da3c59d-bb85-48c6-8a05-de4496c15dd7)
- Added `matchOriginAsFallback` key for `RegisteredContentScript`
- Removed many wrong keys for `ContentScriptFilter` 🚨
  ![image](https://github.com/user-attachments/assets/fb8180ac-1d5e-41a4-a01e-d386b5dec274)

- Add more tests
- Clean JSDoc

Runtime : 
![image](https://github.com/user-attachments/assets/bf1ceae1-d8f3-44b2-b965-97516ac4904f)
