### PR TITLE
[@types/progressbar.js] Allow using ProgressBar types in type annotations

### DIFF
--- a/types/progressbar.js/index.d.ts
+++ b/types/progressbar.js/index.d.ts
@@ -20,6 +20,12 @@ declare const main: {
 
 declare namespace main {
     type SvgSelector = SVGPathElement | string;
+    type Line = Line;
+    type Circle = Circle;
+    type SemiCircle = SemiCircle;
+    type Square = Square;
+    type Path = Path;
+    type Shape = Shape;
 
     type StepFunction = (
         state: {


### PR DESCRIPTION
This is needed because otherwise things like this won't work (in this simple example the type annotation isn't needed, but in more complicated cases it is):

```typescript
//Should work, but gives TS2749 "'ProgressBar.Line' refers to a value, but is being used as a type here" without this pull request.
const result: ProgressBar.Line = new ProgressBar.Line(document.body, {});
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

N/A

If changing an existing definition:

- [x Provide a URL to documentation or source code which provides context for the suggested changes: Not applicable, this change only fixes a bug when using type annotations.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

N/A