### PR TITLE
jsonwebtoken - Tighten audience and issuer properties of VerifyOptions to disallow empty arrays

### DIFF
--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -56,12 +56,12 @@ export interface SignOptions {
 
 export interface VerifyOptions {
     algorithms?: Algorithm[] | undefined;
-    audience?: string | RegExp | Array<string | RegExp> | undefined;
+    audience?: string | RegExp | [string | RegExp, ...(string | RegExp)[]] | undefined;
     clockTimestamp?: number | undefined;
     clockTolerance?: number | undefined;
     /** return an object with the decoded `{ payload, header, signature }` instead of only the usual content of the payload. */
     complete?: boolean | undefined;
-    issuer?: string | string[] | undefined;
+    issuer?: string | [string, ...(string[])] | undefined;
     ignoreExpiration?: boolean | undefined;
     ignoreNotBefore?: boolean | undefined;
     jwtid?: string | undefined;

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -190,6 +190,12 @@ jwt.verify(token, cert, { audience: [/urn:f[o]{2}/, "urn:bar"] }, (err, decoded)
     // if audience mismatch, err == invalid audience
 });
 
+jwt.verify(token, cert, { audience: "audience" }); // ok - string
+jwt.verify(token, cert, { audience: /audience/ }); // ok - RegExp
+jwt.verify(token, cert, { audience: ["aud1", /aud2/] }); // ok - non-empty array with mixed string/RegExp
+// @ts-expect-error
+jwt.verify(token, cert, { audience: [] }); // error - empty array not allowed
+
 // verify issuer
 cert = fs.readFileSync("public.pem"); // get public key
 jwt.verify(token, cert, { audience: "urn:foo", issuer: "urn:issuer" }, (
@@ -198,6 +204,11 @@ jwt.verify(token, cert, { audience: "urn:foo", issuer: "urn:issuer" }, (
 ) => {
     // if issuer mismatch, err == invalid issuer
 });
+
+jwt.verify(token, cert, { issuer: "issuer" }); // ok - string
+jwt.verify(token, cert, { issuer: ["issuer1", "issuer2"] }); // ok - non-empty array
+// @ts-expect-error
+jwt.verify(token, cert, { issuer: [] }); // error - empty array not allowed
 
 // verify algorithm
 cert = fs.readFileSync("public.pem"); // get public key


### PR DESCRIPTION
Passing `audience: []` or `issuer: []` to `jwt.verify` will reject every token at runtime. An empty array means "must match one of zero values." This change updates the types to reflect that by requiring non-empty arrays.

This matches behavior in the upstream JS implementation here: https://github.com/auth0/node-jsonwebtoken/blob/master/verify.js#L194

The change doesn’t remove any valid usage. It just prevents specifying an empty array, which is effectively never valid.

Tests have been updated to confirm that `audience: []` or `issuer: []` in `VerifyOptions` now produces a type error. The migration is simple: remove the empty array or provide a correct value.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
