### PR TITLE
[node] prune codeowners

### DIFF
--- a/types/node/package.json
+++ b/types/node/package.json
@@ -36,10 +36,6 @@
             "githubUsername": "jkomyno"
         },
         {
-            "name": "Alvis HT Tang",
-            "githubUsername": "alvis"
-        },
-        {
             "name": "Andrew Makarov",
             "githubUsername": "r3nya"
         },
@@ -48,44 +44,8 @@
             "githubUsername": "btoueg"
         },
         {
-            "name": "Chigozirim C.",
-            "githubUsername": "smac89"
-        },
-        {
             "name": "David Junger",
             "githubUsername": "touffy"
-        },
-        {
-            "name": "Deividas Bakanas",
-            "githubUsername": "DeividasBakanas"
-        },
-        {
-            "name": "Eugene Y. Q. Shen",
-            "githubUsername": "eyqs"
-        },
-        {
-            "name": "Hannes Magnusson",
-            "githubUsername": "Hannes-Magnusson-CK"
-        },
-        {
-            "name": "Huw",
-            "githubUsername": "hoo29"
-        },
-        {
-            "name": "Kelvin Jin",
-            "githubUsername": "kjin"
-        },
-        {
-            "name": "Klaus Meinhardt",
-            "githubUsername": "ajafff"
-        },
-        {
-            "name": "Lishude",
-            "githubUsername": "islishude"
-        },
-        {
-            "name": "Mariusz Wiktorczyk",
-            "githubUsername": "mwiktorczyk"
         },
         {
             "name": "Mohsen Azimi",
@@ -96,36 +56,12 @@
             "githubUsername": "galkin"
         },
         {
-            "name": "Parambir Singh",
-            "githubUsername": "parambirs"
-        },
-        {
             "name": "Sebastian Silbermann",
             "githubUsername": "eps1lon"
         },
         {
-            "name": "Thomas den Hollander",
-            "githubUsername": "ThomasdenH"
-        },
-        {
             "name": "Wilco Bakker",
             "githubUsername": "WilcoBakker"
-        },
-        {
-            "name": "wwwy3y3",
-            "githubUsername": "wwwy3y3"
-        },
-        {
-            "name": "Samuel Ainsworth",
-            "githubUsername": "samuela"
-        },
-        {
-            "name": "Kyle Uehlein",
-            "githubUsername": "kuehlein"
-        },
-        {
-            "name": "Thanik Bhongbhibhat",
-            "githubUsername": "bhongy"
         },
         {
             "name": "Marcin Kopacz",

--- a/types/node/v18/package.json
+++ b/types/node/v18/package.json
@@ -30,10 +30,6 @@
             "githubUsername": "jkomyno"
         },
         {
-            "name": "Alvis HT Tang",
-            "githubUsername": "alvis"
-        },
-        {
             "name": "Andrew Makarov",
             "githubUsername": "r3nya"
         },
@@ -42,44 +38,8 @@
             "githubUsername": "btoueg"
         },
         {
-            "name": "Chigozirim C.",
-            "githubUsername": "smac89"
-        },
-        {
             "name": "David Junger",
             "githubUsername": "touffy"
-        },
-        {
-            "name": "Deividas Bakanas",
-            "githubUsername": "DeividasBakanas"
-        },
-        {
-            "name": "Eugene Y. Q. Shen",
-            "githubUsername": "eyqs"
-        },
-        {
-            "name": "Hannes Magnusson",
-            "githubUsername": "Hannes-Magnusson-CK"
-        },
-        {
-            "name": "Huw",
-            "githubUsername": "hoo29"
-        },
-        {
-            "name": "Kelvin Jin",
-            "githubUsername": "kjin"
-        },
-        {
-            "name": "Klaus Meinhardt",
-            "githubUsername": "ajafff"
-        },
-        {
-            "name": "Lishude",
-            "githubUsername": "islishude"
-        },
-        {
-            "name": "Mariusz Wiktorczyk",
-            "githubUsername": "mwiktorczyk"
         },
         {
             "name": "Mohsen Azimi",
@@ -90,10 +50,6 @@
             "githubUsername": "galkin"
         },
         {
-            "name": "Parambir Singh",
-            "githubUsername": "parambirs"
-        },
-        {
             "name": "Sebastian Silbermann",
             "githubUsername": "eps1lon"
         },
@@ -102,28 +58,8 @@
             "githubUsername": "SimonSchick"
         },
         {
-            "name": "Thomas den Hollander",
-            "githubUsername": "ThomasdenH"
-        },
-        {
             "name": "Wilco Bakker",
             "githubUsername": "WilcoBakker"
-        },
-        {
-            "name": "wwwy3y3",
-            "githubUsername": "wwwy3y3"
-        },
-        {
-            "name": "Samuel Ainsworth",
-            "githubUsername": "samuela"
-        },
-        {
-            "name": "Kyle Uehlein",
-            "githubUsername": "kuehlein"
-        },
-        {
-            "name": "Thanik Bhongbhibhat",
-            "githubUsername": "bhongy"
         },
         {
             "name": "Marcin Kopacz",

--- a/types/node/v20/package.json
+++ b/types/node/v20/package.json
@@ -30,10 +30,6 @@
             "githubUsername": "jkomyno"
         },
         {
-            "name": "Alvis HT Tang",
-            "githubUsername": "alvis"
-        },
-        {
             "name": "Andrew Makarov",
             "githubUsername": "r3nya"
         },
@@ -42,44 +38,8 @@
             "githubUsername": "btoueg"
         },
         {
-            "name": "Chigozirim C.",
-            "githubUsername": "smac89"
-        },
-        {
             "name": "David Junger",
             "githubUsername": "touffy"
-        },
-        {
-            "name": "Deividas Bakanas",
-            "githubUsername": "DeividasBakanas"
-        },
-        {
-            "name": "Eugene Y. Q. Shen",
-            "githubUsername": "eyqs"
-        },
-        {
-            "name": "Hannes Magnusson",
-            "githubUsername": "Hannes-Magnusson-CK"
-        },
-        {
-            "name": "Huw",
-            "githubUsername": "hoo29"
-        },
-        {
-            "name": "Kelvin Jin",
-            "githubUsername": "kjin"
-        },
-        {
-            "name": "Klaus Meinhardt",
-            "githubUsername": "ajafff"
-        },
-        {
-            "name": "Lishude",
-            "githubUsername": "islishude"
-        },
-        {
-            "name": "Mariusz Wiktorczyk",
-            "githubUsername": "mwiktorczyk"
         },
         {
             "name": "Mohsen Azimi",
@@ -90,36 +50,12 @@
             "githubUsername": "galkin"
         },
         {
-            "name": "Parambir Singh",
-            "githubUsername": "parambirs"
-        },
-        {
             "name": "Sebastian Silbermann",
             "githubUsername": "eps1lon"
         },
         {
-            "name": "Thomas den Hollander",
-            "githubUsername": "ThomasdenH"
-        },
-        {
             "name": "Wilco Bakker",
             "githubUsername": "WilcoBakker"
-        },
-        {
-            "name": "wwwy3y3",
-            "githubUsername": "wwwy3y3"
-        },
-        {
-            "name": "Samuel Ainsworth",
-            "githubUsername": "samuela"
-        },
-        {
-            "name": "Kyle Uehlein",
-            "githubUsername": "kuehlein"
-        },
-        {
-            "name": "Thanik Bhongbhibhat",
-            "githubUsername": "bhongy"
         },
         {
             "name": "Marcin Kopacz",

--- a/types/node/v22/package.json
+++ b/types/node/v22/package.json
@@ -30,10 +30,6 @@
             "githubUsername": "jkomyno"
         },
         {
-            "name": "Alvis HT Tang",
-            "githubUsername": "alvis"
-        },
-        {
             "name": "Andrew Makarov",
             "githubUsername": "r3nya"
         },
@@ -42,44 +38,8 @@
             "githubUsername": "btoueg"
         },
         {
-            "name": "Chigozirim C.",
-            "githubUsername": "smac89"
-        },
-        {
             "name": "David Junger",
             "githubUsername": "touffy"
-        },
-        {
-            "name": "Deividas Bakanas",
-            "githubUsername": "DeividasBakanas"
-        },
-        {
-            "name": "Eugene Y. Q. Shen",
-            "githubUsername": "eyqs"
-        },
-        {
-            "name": "Hannes Magnusson",
-            "githubUsername": "Hannes-Magnusson-CK"
-        },
-        {
-            "name": "Huw",
-            "githubUsername": "hoo29"
-        },
-        {
-            "name": "Kelvin Jin",
-            "githubUsername": "kjin"
-        },
-        {
-            "name": "Klaus Meinhardt",
-            "githubUsername": "ajafff"
-        },
-        {
-            "name": "Lishude",
-            "githubUsername": "islishude"
-        },
-        {
-            "name": "Mariusz Wiktorczyk",
-            "githubUsername": "mwiktorczyk"
         },
         {
             "name": "Mohsen Azimi",
@@ -90,36 +50,12 @@
             "githubUsername": "galkin"
         },
         {
-            "name": "Parambir Singh",
-            "githubUsername": "parambirs"
-        },
-        {
             "name": "Sebastian Silbermann",
             "githubUsername": "eps1lon"
         },
         {
-            "name": "Thomas den Hollander",
-            "githubUsername": "ThomasdenH"
-        },
-        {
             "name": "Wilco Bakker",
             "githubUsername": "WilcoBakker"
-        },
-        {
-            "name": "wwwy3y3",
-            "githubUsername": "wwwy3y3"
-        },
-        {
-            "name": "Samuel Ainsworth",
-            "githubUsername": "samuela"
-        },
-        {
-            "name": "Kyle Uehlein",
-            "githubUsername": "kuehlein"
-        },
-        {
-            "name": "Thanik Bhongbhibhat",
-            "githubUsername": "bhongy"
         },
         {
             "name": "Marcin Kopacz",


### PR DESCRIPTION
The @types/node codeowners list has grown incredibly long over the years, with the majority of its number inactive. This is neither useful for DT contributors nor maintainers.

This removes all listed codeowners who have not opened, reviewed or commented on @types/node issues/PRs in five or more years, which seem fairly uncontroversial criteria.

Will leave this open for a while – if anyone listed would prefer not to be removed, then drop a comment.