### PR TITLE
[xmpp__xml] do not use internal modules of ltx

### DIFF
--- a/types/xmpp__xml/index.d.ts
+++ b/types/xmpp__xml/index.d.ts
@@ -1,8 +1,6 @@
 export = xml;
 
 import * as ltx from "ltx";
-import * as escape from "ltx/lib/escape";
-import LtxParser = require("ltx/lib/parsers/ltx");
 
 declare function xml(...args: Parameters<typeof ltx.createElement>): ReturnType<typeof ltx.createElement>;
 
@@ -13,14 +11,14 @@ declare namespace xml {
     const Element: typeof ltx.Element;
     const createElement: typeof ltx.createElement;
 
-    const escapeXML: typeof escape.escapeXML;
-    const unescapeXML: typeof escape.unescapeXML;
-    const escapeXMLText: typeof escape.escapeXMLText;
-    const unescapeXMLText: typeof escape.unescapeXMLText;
+    const escapeXML: typeof ltx.escapeXML;
+    const unescapeXML: typeof ltx.unescapeXML;
+    const escapeXMLText: typeof ltx.escapeXMLText;
+    const unescapeXMLText: typeof ltx.unescapeXMLText;
 
     class Parser extends ltx.Parser {
         static readonly XMLError: typeof XMLError;
-        readonly parser: LtxParser;
+        readonly parser: ltx.Parser;
         root: Element | null;
         cursor: Element | null;
 

--- a/types/xmpp__xml/xmpp__xml-tests.ts
+++ b/types/xmpp__xml/xmpp__xml-tests.ts
@@ -14,7 +14,7 @@ xml.unescapeXMLText(""); // $ExpectType string
 xml.Parser.XMLError; // $ExpectType typeof XMLError
 const parser = new xml.Parser();
 const ltxParser: LtxParser = parser;
-parser.parser; // $ExpectType SaxLtx
+parser.parser; // $ExpectType Parser
 parser.root; // $ExpectType Element | null
 parser.cursor; // $ExpectType Element | null
 parser.onStartElement("el"); // $ExpectType void


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Not sure about why the change started to be necessary but seems related to the update of some version. But, anyway, the changes fix the problem and makes totally sense as there is no need to access module internals.