### PR TITLE
Add copilot to Context

### DIFF
--- a/types/powerapps-component-framework/componentframework.d.ts
+++ b/types/powerapps-component-framework/componentframework.d.ts
@@ -790,6 +790,7 @@ declare namespace ComponentFramework {
          * Fluent v9 theming
          */
         fluentDesignLanguage?: FluentDesignState;
+        copilot: Copilot;
     }
 
     type IEventBag = Record<string, (params?: unknown) => void>;

--- a/types/powerapps-component-framework/powerapps-component-framework-tests.ts
+++ b/types/powerapps-component-framework/powerapps-component-framework-tests.ts
@@ -719,6 +719,6 @@ const mcsResponseTest: ComponentFramework.MCSResponse = {
 };
 
 const copilotTest: ComponentFramework.Copilot = {
-    executeEvent: (eventName: string, eventData?: any) => Promise.resolve([mcsResponseTest]),
+    executeEvent: (eventName: string, parameters: Record<string, unknown>) => Promise.resolve([mcsResponseTest]),
     executePrompt: (promptText: string) => Promise.resolve([mcsResponseTest]),
 };


### PR DESCRIPTION
Adding copilot to the Context interface. Validated locally by building and deploying a control. 