### PR TITLE
[imapflow] Fix doSTARTTLS typo in ImapFlow

### DIFF
--- a/types/imapflow/index.d.ts
+++ b/types/imapflow/index.d.ts
@@ -527,7 +527,7 @@ export interface ImapFlowOptions {
      * This may expose the connection to a downgrade attack.
      * @default undefined
      */
-    doSTARTTTLS?: boolean;
+    doSTARTTLS?: boolean;
 }
 
 export interface AppendResponseObject {


### PR DESCRIPTION
There is a typo in type annotation for `doSTARTTTLS` (extra `T`)

https://github.com/search?q=repo%3Apostalsys%2Fimapflow%20doSTARTTLS&type=code

```
132 | * @property {Boolean} [doSTARTTLS=undefined]
133 | *     Determines whether to upgrade the connection to TLS via STARTTLS:
135 | *         The connection fails if the server does not support STARTTLS or the upgrade fails.
136 | *         Note that `secure=true` combined with `doSTARTTLS=true` is invalid.
137 | *       - **false**: Never use STARTTLS, even if the server advertises support.
919 | if (this.options.doSTARTTLS === true) {
937 | if (this.options.doSTARTTLS === true && this.options.secure === true) {
938 | throw new Error('Misconfiguration: Cannot set both secure=true for TLS and doSTARTTLS=true for STARTTLS.');
946 | if (this.options.doSTARTTLS === false) {
```