### PR TITLE
[@types/node] `node:test` `describe`/`suite`/`test`/`it` and their variants don't return `Promise<void>` anymore.

### DIFF
--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -137,12 +137,11 @@ declare module "node:test" {
      * @param options Configuration options for the test.
      * @param fn The function under test. The first argument to this function is a {@link TestContext} object.
      * If the test uses callbacks, the callback function is passed as the second argument.
-     * @return Fulfilled with `undefined` once the test completes, or immediately if the test runs within a suite.
      */
-    function test(name?: string, fn?: TestFn): Promise<void>;
-    function test(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
-    function test(options?: TestOptions, fn?: TestFn): Promise<void>;
-    function test(fn?: TestFn): Promise<void>;
+    function test(name?: string, fn?: TestFn): void;
+    function test(name?: string, options?: TestOptions, fn?: TestFn): void;
+    function test(options?: TestOptions, fn?: TestFn): void;
+    function test(fn?: TestFn): void;
     namespace test {
         export {
             after,
@@ -168,73 +167,72 @@ declare module "node:test" {
      * Defaults to the `name` property of `fn`, or `'<anonymous>'` if `fn` does not have a name.
      * @param options Configuration options for the suite. This supports the same options as {@link test}.
      * @param fn The suite function declaring nested tests and suites. The first argument to this function is a {@link SuiteContext} object.
-     * @return Immediately fulfilled with `undefined`.
      * @since v20.13.0
      */
-    function suite(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
-    function suite(name?: string, fn?: SuiteFn): Promise<void>;
-    function suite(options?: TestOptions, fn?: SuiteFn): Promise<void>;
-    function suite(fn?: SuiteFn): Promise<void>;
+    function suite(name?: string, options?: TestOptions, fn?: SuiteFn): void;
+    function suite(name?: string, fn?: SuiteFn): void;
+    function suite(options?: TestOptions, fn?: SuiteFn): void;
+    function suite(fn?: SuiteFn): void;
     namespace suite {
         /**
          * Shorthand for skipping a suite. This is the same as calling {@link suite} with `options.skip` set to `true`.
          * @since v20.13.0
          */
-        function skip(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
-        function skip(name?: string, fn?: SuiteFn): Promise<void>;
-        function skip(options?: TestOptions, fn?: SuiteFn): Promise<void>;
-        function skip(fn?: SuiteFn): Promise<void>;
+        function skip(name?: string, options?: TestOptions, fn?: SuiteFn): void;
+        function skip(name?: string, fn?: SuiteFn): void;
+        function skip(options?: TestOptions, fn?: SuiteFn): void;
+        function skip(fn?: SuiteFn): void;
         /**
          * Shorthand for marking a suite as `TODO`. This is the same as calling {@link suite} with `options.todo` set to `true`.
          * @since v20.13.0
          */
-        function todo(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
-        function todo(name?: string, fn?: SuiteFn): Promise<void>;
-        function todo(options?: TestOptions, fn?: SuiteFn): Promise<void>;
-        function todo(fn?: SuiteFn): Promise<void>;
+        function todo(name?: string, options?: TestOptions, fn?: SuiteFn): void;
+        function todo(name?: string, fn?: SuiteFn): void;
+        function todo(options?: TestOptions, fn?: SuiteFn): void;
+        function todo(fn?: SuiteFn): void;
         /**
          * Shorthand for marking a suite as `only`. This is the same as calling {@link suite} with `options.only` set to `true`.
          * @since v20.13.0
          */
-        function only(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
-        function only(name?: string, fn?: SuiteFn): Promise<void>;
-        function only(options?: TestOptions, fn?: SuiteFn): Promise<void>;
-        function only(fn?: SuiteFn): Promise<void>;
+        function only(name?: string, options?: TestOptions, fn?: SuiteFn): void;
+        function only(name?: string, fn?: SuiteFn): void;
+        function only(options?: TestOptions, fn?: SuiteFn): void;
+        function only(fn?: SuiteFn): void;
     }
     /**
      * Alias for {@link suite}.
      *
      * The `describe()` function is imported from the `node:test` module.
      */
-    function describe(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
-    function describe(name?: string, fn?: SuiteFn): Promise<void>;
-    function describe(options?: TestOptions, fn?: SuiteFn): Promise<void>;
-    function describe(fn?: SuiteFn): Promise<void>;
+    function describe(name?: string, options?: TestOptions, fn?: SuiteFn): void;
+    function describe(name?: string, fn?: SuiteFn): void;
+    function describe(options?: TestOptions, fn?: SuiteFn): void;
+    function describe(fn?: SuiteFn): void;
     namespace describe {
         /**
          * Shorthand for skipping a suite. This is the same as calling {@link describe} with `options.skip` set to `true`.
          * @since v18.15.0
          */
-        function skip(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
-        function skip(name?: string, fn?: SuiteFn): Promise<void>;
-        function skip(options?: TestOptions, fn?: SuiteFn): Promise<void>;
-        function skip(fn?: SuiteFn): Promise<void>;
+        function skip(name?: string, options?: TestOptions, fn?: SuiteFn): void;
+        function skip(name?: string, fn?: SuiteFn): void;
+        function skip(options?: TestOptions, fn?: SuiteFn): void;
+        function skip(fn?: SuiteFn): void;
         /**
          * Shorthand for marking a suite as `TODO`. This is the same as calling {@link describe} with `options.todo` set to `true`.
          * @since v18.15.0
          */
-        function todo(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
-        function todo(name?: string, fn?: SuiteFn): Promise<void>;
-        function todo(options?: TestOptions, fn?: SuiteFn): Promise<void>;
-        function todo(fn?: SuiteFn): Promise<void>;
+        function todo(name?: string, options?: TestOptions, fn?: SuiteFn): void;
+        function todo(name?: string, fn?: SuiteFn): void;
+        function todo(options?: TestOptions, fn?: SuiteFn): void;
+        function todo(fn?: SuiteFn): void;
         /**
          * Shorthand for marking a suite as `only`. This is the same as calling {@link describe} with `options.only` set to `true`.
          * @since v18.15.0
          */
-        function only(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
-        function only(name?: string, fn?: SuiteFn): Promise<void>;
-        function only(options?: TestOptions, fn?: SuiteFn): Promise<void>;
-        function only(fn?: SuiteFn): Promise<void>;
+        function only(name?: string, options?: TestOptions, fn?: SuiteFn): void;
+        function only(name?: string, fn?: SuiteFn): void;
+        function only(options?: TestOptions, fn?: SuiteFn): void;
+        function only(fn?: SuiteFn): void;
     }
     /**
      * Alias for {@link test}.
@@ -242,58 +240,58 @@ declare module "node:test" {
      * The `it()` function is imported from the `node:test` module.
      * @since v18.6.0, v16.17.0
      */
-    function it(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
-    function it(name?: string, fn?: TestFn): Promise<void>;
-    function it(options?: TestOptions, fn?: TestFn): Promise<void>;
-    function it(fn?: TestFn): Promise<void>;
+    function it(name?: string, options?: TestOptions, fn?: TestFn): void;
+    function it(name?: string, fn?: TestFn): void;
+    function it(options?: TestOptions, fn?: TestFn): void;
+    function it(fn?: TestFn): void;
     namespace it {
         /**
          * Shorthand for skipping a test. This is the same as calling {@link it} with `options.skip` set to `true`.
          */
-        function skip(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
-        function skip(name?: string, fn?: TestFn): Promise<void>;
-        function skip(options?: TestOptions, fn?: TestFn): Promise<void>;
-        function skip(fn?: TestFn): Promise<void>;
+        function skip(name?: string, options?: TestOptions, fn?: TestFn): void;
+        function skip(name?: string, fn?: TestFn): void;
+        function skip(options?: TestOptions, fn?: TestFn): void;
+        function skip(fn?: TestFn): void;
         /**
          * Shorthand for marking a test as `TODO`. This is the same as calling {@link it} with `options.todo` set to `true`.
          */
-        function todo(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
-        function todo(name?: string, fn?: TestFn): Promise<void>;
-        function todo(options?: TestOptions, fn?: TestFn): Promise<void>;
-        function todo(fn?: TestFn): Promise<void>;
+        function todo(name?: string, options?: TestOptions, fn?: TestFn): void;
+        function todo(name?: string, fn?: TestFn): void;
+        function todo(options?: TestOptions, fn?: TestFn): void;
+        function todo(fn?: TestFn): void;
         /**
          * Shorthand for marking a test as `only`. This is the same as calling {@link it} with `options.only` set to `true`.
          * @since v18.15.0
          */
-        function only(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
-        function only(name?: string, fn?: TestFn): Promise<void>;
-        function only(options?: TestOptions, fn?: TestFn): Promise<void>;
-        function only(fn?: TestFn): Promise<void>;
+        function only(name?: string, options?: TestOptions, fn?: TestFn): void;
+        function only(name?: string, fn?: TestFn): void;
+        function only(options?: TestOptions, fn?: TestFn): void;
+        function only(fn?: TestFn): void;
     }
     /**
      * Shorthand for skipping a test. This is the same as calling {@link test} with `options.skip` set to `true`.
      * @since v20.2.0
      */
-    function skip(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
-    function skip(name?: string, fn?: TestFn): Promise<void>;
-    function skip(options?: TestOptions, fn?: TestFn): Promise<void>;
-    function skip(fn?: TestFn): Promise<void>;
+    function skip(name?: string, options?: TestOptions, fn?: TestFn): void;
+    function skip(name?: string, fn?: TestFn): void;
+    function skip(options?: TestOptions, fn?: TestFn): void;
+    function skip(fn?: TestFn): void;
     /**
      * Shorthand for marking a test as `TODO`. This is the same as calling {@link test} with `options.todo` set to `true`.
      * @since v20.2.0
      */
-    function todo(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
-    function todo(name?: string, fn?: TestFn): Promise<void>;
-    function todo(options?: TestOptions, fn?: TestFn): Promise<void>;
-    function todo(fn?: TestFn): Promise<void>;
+    function todo(name?: string, options?: TestOptions, fn?: TestFn): void;
+    function todo(name?: string, fn?: TestFn): void;
+    function todo(options?: TestOptions, fn?: TestFn): void;
+    function todo(fn?: TestFn): void;
     /**
      * Shorthand for marking a test as `only`. This is the same as calling {@link test} with `options.only` set to `true`.
      * @since v20.2.0
      */
-    function only(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
-    function only(name?: string, fn?: TestFn): Promise<void>;
-    function only(options?: TestOptions, fn?: TestFn): Promise<void>;
-    function only(fn?: TestFn): Promise<void>;
+    function only(name?: string, options?: TestOptions, fn?: TestFn): void;
+    function only(name?: string, fn?: TestFn): void;
+    function only(options?: TestOptions, fn?: TestFn): void;
+    function only(fn?: TestFn): void;
     /**
      * The type of a function passed to {@link test}. The first argument to this function is a {@link TestContext} object.
      * If the test uses callbacks, the callback function is passed as the second argument.
@@ -783,7 +781,6 @@ declare module "node:test" {
          * @param options Configuration options for the test.
          * @param fn The function under test. This first argument to this function is a {@link TestContext} object.
          * If the test uses callbacks, the callback function is passed as the second argument.
-         * @returns A {@link Promise} resolved with `undefined` once the test completes.
          */
         test: typeof test;
         /**
@@ -803,8 +800,8 @@ declare module "node:test" {
          */
         readonly mock: MockTracker;
     }
-    interface TestContextAssert extends
-        Pick<
+    interface TestContextAssert
+        extends Pick<
             typeof import("assert"),
             | "deepEqual"
             | "deepStrictEqual"
@@ -824,8 +821,7 @@ declare module "node:test" {
             | "rejects"
             | "strictEqual"
             | "throws"
-        >
-    {
+        > {
         /**
          * This function serializes `value` and writes it to the file specified by `path`.
          *
@@ -1184,7 +1180,7 @@ declare module "node:test" {
         fn<F extends Function = NoOpFunction, Implementation extends Function = F>(
             original?: F,
             implementation?: Implementation,
-            options?: MockFunctionOptions,
+            options?: MockFunctionOptions
         ): Mock<F | Implementation>;
         /**
          * This function is used to create a mock on an existing object method. The
@@ -1222,81 +1218,62 @@ declare module "node:test" {
          * @return The mocked method. The mocked method contains a special `mock` property, which is an instance of {@link MockFunctionContext}, and can be used for inspecting and changing the
          * behavior of the mocked method.
          */
-        method<
-            MockedObject extends object,
-            MethodName extends FunctionPropertyNames<MockedObject>,
-        >(
+        method<MockedObject extends object, MethodName extends FunctionPropertyNames<MockedObject>>(
             object: MockedObject,
             methodName: MethodName,
-            options?: MockFunctionOptions,
-        ): MockedObject[MethodName] extends Function ? Mock<MockedObject[MethodName]>
-            : never;
+            options?: MockFunctionOptions
+        ): MockedObject[MethodName] extends Function ? Mock<MockedObject[MethodName]> : never;
         method<
             MockedObject extends object,
             MethodName extends FunctionPropertyNames<MockedObject>,
-            Implementation extends Function,
+            Implementation extends Function
         >(
             object: MockedObject,
             methodName: MethodName,
             implementation: Implementation,
-            options?: MockFunctionOptions,
-        ): MockedObject[MethodName] extends Function ? Mock<MockedObject[MethodName] | Implementation>
-            : never;
+            options?: MockFunctionOptions
+        ): MockedObject[MethodName] extends Function ? Mock<MockedObject[MethodName] | Implementation> : never;
         method<MockedObject extends object>(
             object: MockedObject,
             methodName: keyof MockedObject,
-            options: MockMethodOptions,
+            options: MockMethodOptions
         ): Mock<Function>;
         method<MockedObject extends object>(
             object: MockedObject,
             methodName: keyof MockedObject,
             implementation: Function,
-            options: MockMethodOptions,
+            options: MockMethodOptions
         ): Mock<Function>;
 
         /**
          * This function is syntax sugar for `MockTracker.method` with `options.getter` set to `true`.
          * @since v19.3.0, v18.13.0
          */
-        getter<
-            MockedObject extends object,
-            MethodName extends keyof MockedObject,
-        >(
+        getter<MockedObject extends object, MethodName extends keyof MockedObject>(
             object: MockedObject,
             methodName: MethodName,
-            options?: MockFunctionOptions,
+            options?: MockFunctionOptions
         ): Mock<() => MockedObject[MethodName]>;
-        getter<
-            MockedObject extends object,
-            MethodName extends keyof MockedObject,
-            Implementation extends Function,
-        >(
+        getter<MockedObject extends object, MethodName extends keyof MockedObject, Implementation extends Function>(
             object: MockedObject,
             methodName: MethodName,
             implementation?: Implementation,
-            options?: MockFunctionOptions,
+            options?: MockFunctionOptions
         ): Mock<(() => MockedObject[MethodName]) | Implementation>;
         /**
          * This function is syntax sugar for `MockTracker.method` with `options.setter` set to `true`.
          * @since v19.3.0, v18.13.0
          */
-        setter<
-            MockedObject extends object,
-            MethodName extends keyof MockedObject,
-        >(
+        setter<MockedObject extends object, MethodName extends keyof MockedObject>(
             object: MockedObject,
             methodName: MethodName,
-            options?: MockFunctionOptions,
+            options?: MockFunctionOptions
         ): Mock<(value: MockedObject[MethodName]) => void>;
-        setter<
-            MockedObject extends object,
-            MethodName extends keyof MockedObject,
-            Implementation extends Function,
-        >(
+        setter<MockedObject extends object, MethodName extends keyof MockedObject, Implementation extends Function>(
             object: MockedObject,
             methodName: MethodName,
             implementation?: Implementation,
-            options?: MockFunctionOptions,
+            options?: MockFunctionOptions
         ): Mock<((value: MockedObject[MethodName]) => void) | Implementation>;
 
         /**
@@ -1368,12 +1345,16 @@ declare module "node:test" {
     const mock: MockTracker;
     interface MockFunctionCall<
         F extends Function,
-        ReturnType = F extends (...args: any) => infer T ? T
-            : F extends abstract new(...args: any) => infer T ? T
+        ReturnType = F extends (...args: any) => infer T
+            ? T
+            : F extends abstract new (...args: any) => infer T
+            ? T
             : unknown,
-        Args = F extends (...args: infer Y) => any ? Y
-            : F extends abstract new(...args: infer Y) => any ? Y
-            : unknown[],
+        Args = F extends (...args: infer Y) => any
+            ? Y
+            : F extends abstract new (...args: infer Y) => any
+            ? Y
+            : unknown[]
     > {
         /**
          * An array of the arguments passed to the mock function.
@@ -1397,7 +1378,7 @@ declare module "node:test" {
          * If the mocked function is a constructor, this field contains the class being constructed.
          * Otherwise this will be `undefined`.
          */
-        target: F extends abstract new(...args: any) => any ? F : undefined;
+        target: F extends abstract new (...args: any) => any ? F : undefined;
         /**
          * The mocked function's `this` value.
          */
@@ -2274,8 +2255,8 @@ declare module "node:test/reporters" {
         | { type: "test:watch:drained"; data: undefined };
     type TestEventGenerator = AsyncGenerator<TestEvent, void>;
 
-    interface ReporterConstructorWrapper<T extends new(...args: any[]) => Transform> {
-        new(...args: ConstructorParameters<T>): InstanceType<T>;
+    interface ReporterConstructorWrapper<T extends new (...args: any[]) => Transform> {
+        new (...args: ConstructorParameters<T>): InstanceType<T>;
         (...args: ConstructorParameters<T>): InstanceType<T>;
     }
 

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -67,13 +67,13 @@ run({
 // TestsStream should be a NodeJS.ReadableStream
 run().pipe(process.stdout);
 
-test("foo", t => {
+test("foo", (t) => {
     // $ExpectType TestContext
     t;
 });
 
 test("foo", (t) => {
-    // $ExpectType Promise<void>
+    // $ExpectType void
     t.test();
 });
 
@@ -100,7 +100,7 @@ test("options with booleans", {
 
 {
     const ret = test();
-    // $ExpectType Promise<void>
+    // $ExpectType void
     ret;
 }
 
@@ -115,7 +115,7 @@ test((t, cb) => {
 });
 
 // Test the context's methods/properties
-test(undefined, undefined, t => {
+test(undefined, undefined, (t) => {
     // $ExpectType void
     t.diagnostic("tap diagnostic");
     // $ExpectType void
@@ -129,22 +129,22 @@ test(undefined, undefined, t => {
     // $ExpectType void
     t.todo();
     // $ExpectType void
-    t.after(t => {
+    t.after((t) => {
         // $ExpectType TestContext
         t;
     });
     // $ExpectType void
-    t.afterEach(t => {
+    t.afterEach((t) => {
         // $ExpectType TestContext
         t;
     });
     // $ExpectType void
-    t.beforeEach(t => {
+    t.beforeEach((t) => {
         // $ExpectType TestContext
         t;
     });
     // $ExpectType void
-    t.before(t => {
+    t.before((t) => {
         // $ExpectType TestContext
         t;
     });
@@ -162,14 +162,14 @@ test(undefined, undefined, t => {
 });
 
 // Test the subtest approach.
-test(t => {
+test((t) => {
     // $ExpectType TestContext
     t;
-    const sub = t.test("sub", {}, t => {
+    const sub = t.test("sub", {}, (t) => {
         // $ExpectType TestContext
         t;
     });
-    // $ExpectType Promise<void>
+    // $ExpectType void
     sub;
 });
 
@@ -201,21 +201,19 @@ describe("foo", () => {
 
 describe("foo", () => {
     const d = describe();
-    // $ExpectType Promise<void>
+    // $ExpectType void
     d;
 });
 
 describe("foo", async () => {
     const d = describe();
-    // $ExpectType Promise<void>
-    d;
     // $ExpectType void
-    await d;
+    d;
 });
 
 {
     const ret = describe();
-    // $ExpectType Promise<void>
+    // $ExpectType void
     ret;
 }
 
@@ -349,7 +347,7 @@ it.only("only shorthand", {
 });
 
 // Test with suite context
-describe(s => {
+describe((s) => {
     // $ExpectType SuiteContext
     s;
     // $ExpectType string
@@ -375,13 +373,13 @@ describe(1, () => {});
 it(1, () => {});
 
 // suite() signatures
-// $ExpectType Promise<void>
+// $ExpectType void
 suite();
-// $ExpectType Promise<void>
+// $ExpectType void
 suite("foo");
-// $ExpectType Promise<void>
+// $ExpectType void
 suite("foo", () => {});
-// $ExpectType Promise<void>
+// $ExpectType void
 suite("foo", {
     concurrency: false,
     only: true,
@@ -390,22 +388,26 @@ suite("foo", {
     timeout: 30_000,
     todo: true,
 });
-// $ExpectType Promise<void>
-suite("foo", {
-    concurrency: 5,
-    todo: "foo",
-}, async () => {});
-// $ExpectType Promise<void>
+// $ExpectType void
+suite(
+    "foo",
+    {
+        concurrency: 5,
+        todo: "foo",
+    },
+    async () => {}
+);
+// $ExpectType void
 suite(() => {});
 
 // suite.skip() signatures
-// $ExpectType Promise<void>
+// $ExpectType void
 suite.skip();
-// $ExpectType Promise<void>
+// $ExpectType void
 suite.skip("foo");
-// $ExpectType Promise<void>
+// $ExpectType void
 suite.skip("foo", () => {});
-// $ExpectType Promise<void>
+// $ExpectType void
 suite.skip("foo", {
     concurrency: false,
     only: true,
@@ -413,22 +415,26 @@ suite.skip("foo", {
     timeout: 30_000,
     todo: true,
 });
-// $ExpectType Promise<void>
-suite.skip("foo", {
-    concurrency: 5,
-    todo: "foo",
-}, async () => {});
-// $ExpectType Promise<void>
+// $ExpectType void
+suite.skip(
+    "foo",
+    {
+        concurrency: 5,
+        todo: "foo",
+    },
+    async () => {}
+);
+// $ExpectType void
 suite.skip(() => {});
 
 // suite.todo() signatures
-// $ExpectType Promise<void>
+// $ExpectType void
 suite.todo();
-// $ExpectType Promise<void>
+// $ExpectType void
 suite.todo("foo");
-// $ExpectType Promise<void>
+// $ExpectType void
 suite.todo("foo", () => {});
-// $ExpectType Promise<void>
+// $ExpectType void
 suite.todo("foo", {
     concurrency: false,
     only: true,
@@ -436,22 +442,26 @@ suite.todo("foo", {
     skip: false,
     timeout: 30_000,
 });
-// $ExpectType Promise<void>
-suite.todo("foo", {
-    concurrency: 5,
-    timeout: Infinity,
-}, async () => {});
-// $ExpectType Promise<void>
+// $ExpectType void
+suite.todo(
+    "foo",
+    {
+        concurrency: 5,
+        timeout: Infinity,
+    },
+    async () => {}
+);
+// $ExpectType void
 suite.todo(() => {});
 
 // suite.only() signatures
-// $ExpectType Promise<void>
+// $ExpectType void
 suite.only();
-// $ExpectType Promise<void>
+// $ExpectType void
 suite.only("foo");
-// $ExpectType Promise<void>
+// $ExpectType void
 suite.only("foo", () => {});
-// $ExpectType Promise<void>
+// $ExpectType void
 suite.only("foo", {
     concurrency: false,
     signal: new AbortController().signal,
@@ -459,12 +469,16 @@ suite.only("foo", {
     timeout: 30_000,
     todo: true,
 });
-// $ExpectType Promise<void>
-suite.only("foo", {
-    concurrency: 5,
-    todo: "foo",
-}, async () => {});
-// $ExpectType Promise<void>
+// $ExpectType void
+suite.only(
+    "foo",
+    {
+        concurrency: 5,
+        todo: "foo",
+    },
+    async () => {}
+);
+// $ExpectType void
 suite.only(() => {});
 
 // SuiteContext
@@ -884,7 +898,7 @@ class TestReporter extends Transform {
                 callback(
                     null,
                     `${name}/${details.duration_ms}/${details.type}/${details.error}/
-                    ${nesting}/${testNumber}/${todo}/${skip}/${file}/${column}/${line}`,
+                    ${nesting}/${testNumber}/${todo}/${skip}/${file}/${column}/${line}`
                 );
                 break;
             }
@@ -913,7 +927,7 @@ class TestReporter extends Transform {
                 callback(
                     null,
                     `${name}/${details.duration_ms}/${details.type}/${details.error.cause}/
-                    ${nesting}/${testNumber}/${todo}/${skip}/${file}/${column}/${line}`,
+                    ${nesting}/${testNumber}/${todo}/${skip}/${file}/${column}/${line}`
                 );
                 break;
             }
@@ -922,7 +936,7 @@ class TestReporter extends Transform {
                 callback(
                     null,
                     `${name}/${details.duration_ms}/${details.type}/
-                    ${nesting}/${testNumber}/${todo}/${skip}/${file}/${column}/${line}`,
+                    ${nesting}/${testNumber}/${todo}/${skip}/${file}/${column}/${line}`
                 );
                 break;
             }
@@ -951,7 +965,7 @@ class TestReporter extends Transform {
                 callback(
                     null,
                     `${file ?? "<multiple>"}/${success}/${duration_ms}/
-                    ${counts.topLevel}/${counts.tests}/${counts.passed}`,
+                    ${counts.topLevel}/${counts.tests}/${counts.passed}`
                 );
                 break;
             }
@@ -1017,7 +1031,7 @@ const invalidTestContext = new TestContext();
 // @ts-expect-error Should not be able to instantiate a SuiteContext
 const invalidSuiteContext = new SuiteContext();
 
-test("check all assertion functions are re-exported", t => {
+test("check all assertion functions are re-exported", (t) => {
     type AssertModuleExports = keyof typeof import("assert");
     const keys: keyof { [K in keyof typeof t.assert as K extends AssertModuleExports ? K : never]: any } =
         {} as Exclude<AssertModuleExports, "AssertionError" | "CallTracker" | "strict">;
@@ -1057,24 +1071,24 @@ test("planning with streams", (t: TestContext, done) => {
             t.assert.isOdd(4);
         });
     });
-    test.assert.register("context", function() {
+    test.assert.register("context", function () {
         // $ExpectType TestContext
         this;
     });
 }
 
 // Test snapshot assertion.
-test(t => {
+test((t) => {
     // $ExpectType void
     t.assert.fileSnapshot({ value1: true, value2: false }, "./snapshots/snapshot.json");
     // $ExpectType void
     t.assert.fileSnapshot({ value3: "foo", value4: "bar" }, "./snapshots/snapshot.json", {
-        serializers: [value => JSON.stringify(value)],
+        serializers: [(value) => JSON.stringify(value)],
     });
     // $ExpectType void
     t.assert.snapshot({ value1: true, value2: false });
     // $ExpectType void
-    t.assert.snapshot({ value3: "foo", value4: "bar" }, { serializers: [value => JSON.stringify(value)] });
+    t.assert.snapshot({ value3: "foo", value4: "bar" }, { serializers: [(value) => JSON.stringify(value)] });
 });
 
 // Snapshot configuration


### PR DESCRIPTION
Hi,

This is my first PR into DefinitelyTyped. I hope I followed the instructions correctly. If not, please let me know.

This PR updates the definition of `@types/node`'s `node:test` module. I believe this update is important, as it reflects a change introduced in Node 24. On top of that, this tests allows you to enable [no-floating-promise](https://typescript-eslint.io/rules/no-floating-promises/) in `typescript-eslint` for your tests.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

This change was announced with the release of Node.js 24.0.0: https://nodejs.org/en/blog/release/v24.0.0
 
> [[1a2eb15bc6](https://github.com/nodejs/node/commit/1a2eb15bc6)] - (SEMVER-MAJOR) test_runner: remove promises returned by t.test() (Colin Ihrig) [#56664](https://github.com/nodejs/node/pull/56664)
> [[96718268fe](https://github.com/nodejs/node/commit/96718268fe)] - (SEMVER-MAJOR) test_runner: remove promises returned by test() (Colin Ihrig) [#56664](https://github.com/nodejs/node/pull/56664)
> [[aa3523ec22](https://github.com/nodejs/node/commit/aa3523ec22)] - (SEMVER-MAJOR) test_runner: automatically wait for subtests to finish (Colin Ihrig) [#56664](https://github.com/nodejs/node/pull/56664)

