### PR TITLE
feat(node/crypto): completely factorize subtle.generateKey()

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -4338,17 +4338,48 @@ declare module "crypto" {
              * @since v15.0.0
              */
             generateKey(
-                algorithm: RsaHashedKeyGenParams | EcKeyGenParams,
+                algorithm: RsaHashedKeyGenParams & { name: "RSA-OAEP" },
                 extractable: boolean,
-                keyUsages: readonly KeyUsage[],
+                keyUsages: readonly ("encrypt" | "decrypt" | "wrapKey" | "unwrapKey")[],
             ): Promise<CryptoKeyPair>;
             generateKey(
-                algorithm: AesKeyGenParams | HmacKeyGenParams | Pbkdf2Params,
+                algorithm:
+                    | (RsaHashedKeyGenParams & { name: "RSA-PSS" | "RSASSA-PKCS1-v1_5" })
+                    | EcKeyGenParams
+                    | "Ed25519"
+                    | { name: "Ed25519" }
+                    | "Ed448"
+                    | { name: "Ed448" },
                 extractable: boolean,
-                keyUsages: readonly KeyUsage[],
+                keyUsages: readonly ("sign" | "verify")[],
+            ): Promise<CryptoKeyPair>;
+            generateKey(
+                algorithm:
+                    | "X25519"
+                    | { name: "X25519" }
+                    | "X448"
+                    | { name: "X448" },
+                extractable: boolean,
+                keyUsages: readonly ("deriveKey" | "deriveBits")[],
+            ): Promise<CryptoKeyPair>;
+            generateKey(
+                algorithm: AesKeyGenParams & { name: "AES-CBC" | "AES-CTR" | "AES-GCM" },
+                extractable: boolean,
+                keyUsages: readonly ("encrypt" | "decrypt" | "wrapKey" | "unwrapKey")[],
             ): Promise<CryptoKey>;
             generateKey(
-                algorithm: AlgorithmIdentifier,
+                algorithm: AesKeyGenParams & { name: "AES-KW" },
+                extractable: boolean,
+                keyUsages: readonly ("wrapKey" | "unwrapKey")[],
+            ): Promise<CryptoKey>;
+            generateKey(
+                algorithm: HmacKeyGenParams,
+                extractable: boolean,
+                keyUsages: readonly ("sign" | "verify")[],
+            ): Promise<CryptoKey>;
+            // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+            generateKey<T extends Algorithm>(
+                algorithm: string | T,
                 extractable: boolean,
                 keyUsages: KeyUsage[],
             ): Promise<CryptoKeyPair | CryptoKey>;

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -1661,14 +1661,6 @@ import { promisify } from "node:util";
     crypto.webcrypto.CryptoKey.toString();
     // @ts-expect-error
     new crypto.webcrypto.CryptoKey(); // Illegal constructor
-
-    crypto.webcrypto.subtle.generateKey({ name: "HMAC", hash: "SHA-1" }, true, ["sign", "decrypt", "deriveBits"]).then(
-        (out) => {
-            out.algorithm; // $ExpectType KeyAlgorithm
-            out.extractable; // $ExpectType boolean
-            out.usages; // $ExpectType KeyUsage[]
-        },
-    );
 }
 
 {
@@ -1702,7 +1694,88 @@ import { promisify } from "node:util";
     subtle.digest("SHA-384", buf); // $ExpectType Promise<ArrayBuffer>
     subtle.exportKey("jwk", key); // $ExpectType Promise<JsonWebKey>
     subtle.importKey("pkcs8", buf, { name: "RSA-PSS", hash: "SHA-1" }, false, []); // $ExpectType Promise<CryptoKey>
-    subtle.generateKey({ name: "ECDH", namedCurve: "P-256" }, false, ["deriveKey", "deriveBits"]); // $ExpectType Promise<CryptoKeyPair>
+
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        {
+            name: "RSA-OAEP",
+            modulusLength: 2048,
+            publicExponent: new Uint8Array([1, 0, 1]),
+            hash: "SHA-256",
+        },
+        true,
+        ["encrypt", "decrypt"],
+    );
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        {
+            name: Math.random() < 0.5 ? "RSA-PSS" : "RSASSA-PKCS1-v1_5",
+            modulusLength: 2048,
+            publicExponent: new Uint8Array([1, 0, 1]),
+            hash: "SHA-256",
+        },
+        false,
+        ["sign", "verify"],
+    );
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        Math.random() < 0.5 ? "Ed25519" : { name: "Ed25519" },
+        false,
+        ["sign", "verify"],
+    );
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        Math.random() < 0.5 ? "Ed448" : { name: "Ed448" },
+        false,
+        ["sign", "verify"],
+    );
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        Math.random() < 0.5 ? "X25519" : { name: "X25519" },
+        false,
+        ["deriveKey", "deriveBits"],
+    );
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        Math.random() < 0.5 ? "X448" : { name: "X448" },
+        false,
+        ["deriveKey", "deriveBits"],
+    );
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        { name: "ECDH", namedCurve: "P-256" },
+        false,
+        ["sign", "verify"],
+    );
+    // $ExpectType Promise<CryptoKey>;
+    subtle.generateKey(
+        {
+            name: Math.random() < 0.5 ? "AES-CBC" : Math.random() < 0.5 ? "AES-CTR" : "AES-GCM",
+            length: 2048,
+        },
+        true,
+        ["encrypt", "decrypt", "wrapKey", "unwrapKey"],
+    );
+    // $ExpectType Promise<CryptoKey>;
+    subtle.generateKey(
+        { name: "AES-KW", length: 2048 },
+        true,
+        ["wrapKey", "unwrapKey"],
+    );
+    // $ExpectType Promise<CryptoKey>;
+    subtle.generateKey(
+        { name: "HMAC", hash: "SHA-1" },
+        true,
+        ["sign", "verify"],
+    );
+    // Fallback
+    // $ExpectType Promise<CryptoKeyPair |CryptoKey>
+    subtle.generateKey(
+        { name: Math.random() < 0.5 ? "AES-KW" : "HMAC", length: 2048 },
+        true,
+        ["wrapKey", "unwrapKey"],
+    );
+
     subtle.sign({ name: "RSA-PSS", saltLength: 64 }, key, buf); // $ExpectType Promise<ArrayBuffer>
     subtle.unwrapKey(
         "raw",

--- a/types/node/test/globals-non-dom.ts
+++ b/types/node/test/globals-non-dom.ts
@@ -30,13 +30,8 @@
     crypto.getRandomValues(Buffer.alloc(8)); // $ExpectType Buffer || Buffer<ArrayBuffer>
     crypto.getRandomValues(new BigInt64Array(4)); // $ExpectType BigInt64Array || BigInt64Array<ArrayBuffer>
 
-    crypto.subtle.generateKey({ name: "HMAC", hash: "SHA-1" }, true, ["sign", "decrypt", "deriveBits"]).then(
-        (out) => {
-            out.algorithm; // $ExpectType KeyAlgorithm
-            out.extractable; // $ExpectType boolean
-            out.usages; // $ExpectType KeyUsage[]
-        },
-    );
+    // $ExpectType Promise<CryptoKey | CryptoKeyPair>
+    crypto.subtle.generateKey({ name: "HMAC", hash: "SHA-1" }, true, ["sign", "decrypt", "deriveBits"]);
 }
 
 {

--- a/types/node/v18/crypto.d.ts
+++ b/types/node/v18/crypto.d.ts
@@ -4334,17 +4334,48 @@ declare module "crypto" {
              * @since v15.0.0
              */
             generateKey(
-                algorithm: RsaHashedKeyGenParams | EcKeyGenParams,
+                algorithm: RsaHashedKeyGenParams & { name: "RSA-OAEP" },
                 extractable: boolean,
-                keyUsages: readonly KeyUsage[],
+                keyUsages: readonly ("encrypt" | "decrypt" | "wrapKey" | "unwrapKey")[],
             ): Promise<CryptoKeyPair>;
             generateKey(
-                algorithm: AesKeyGenParams | HmacKeyGenParams | Pbkdf2Params,
+                algorithm:
+                    | (RsaHashedKeyGenParams & { name: "RSA-PSS" | "RSASSA-PKCS1-v1_5" })
+                    | EcKeyGenParams
+                    | "Ed25519"
+                    | { name: "Ed25519" }
+                    | "Ed448"
+                    | { name: "Ed448" },
                 extractable: boolean,
-                keyUsages: readonly KeyUsage[],
+                keyUsages: readonly ("sign" | "verify")[],
+            ): Promise<CryptoKeyPair>;
+            generateKey(
+                algorithm:
+                    | "X25519"
+                    | { name: "X25519" }
+                    | "X448"
+                    | { name: "X448" },
+                extractable: boolean,
+                keyUsages: readonly ("deriveKey" | "deriveBits")[],
+            ): Promise<CryptoKeyPair>;
+            generateKey(
+                algorithm: AesKeyGenParams & { name: "AES-CBC" | "AES-CTR" | "AES-GCM" },
+                extractable: boolean,
+                keyUsages: readonly ("encrypt" | "decrypt" | "wrapKey" | "unwrapKey")[],
             ): Promise<CryptoKey>;
             generateKey(
-                algorithm: AlgorithmIdentifier,
+                algorithm: AesKeyGenParams & { name: "AES-KW" },
+                extractable: boolean,
+                keyUsages: readonly ("wrapKey" | "unwrapKey")[],
+            ): Promise<CryptoKey>;
+            generateKey(
+                algorithm: HmacKeyGenParams,
+                extractable: boolean,
+                keyUsages: readonly ("sign" | "verify")[],
+            ): Promise<CryptoKey>;
+            // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+            generateKey<T extends Algorithm>(
+                algorithm: string | T,
                 extractable: boolean,
                 keyUsages: KeyUsage[],
             ): Promise<CryptoKeyPair | CryptoKey>;

--- a/types/node/v18/test/crypto.ts
+++ b/types/node/v18/test/crypto.ts
@@ -1876,14 +1876,6 @@ import { promisify } from "node:util";
     crypto.webcrypto.CryptoKey.toString();
     // @ts-expect-error
     new crypto.webcrypto.CryptoKey(); // Illegal constructor
-
-    crypto.webcrypto.subtle.generateKey({ name: "HMAC", hash: "SHA-1" }, true, ["sign", "decrypt", "deriveBits"]).then(
-        (out) => {
-            out.algorithm; // $ExpectType KeyAlgorithm
-            out.extractable; // $ExpectType boolean
-            out.usages; // $ExpectType KeyUsage[]
-        },
-    );
 }
 
 {
@@ -1917,7 +1909,88 @@ import { promisify } from "node:util";
     subtle.digest("SHA-384", buf); // $ExpectType Promise<ArrayBuffer>
     subtle.exportKey("jwk", key); // $ExpectType Promise<JsonWebKey>
     subtle.importKey("pkcs8", buf, { name: "RSA-PSS", hash: "SHA-1" }, false, []); // $ExpectType Promise<CryptoKey>
-    subtle.generateKey({ name: "ECDH", namedCurve: "P-256" }, false, ["deriveKey", "deriveBits"]); // $ExpectType Promise<CryptoKeyPair>
+
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        {
+            name: "RSA-OAEP",
+            modulusLength: 2048,
+            publicExponent: new Uint8Array([1, 0, 1]),
+            hash: "SHA-256",
+        },
+        true,
+        ["encrypt", "decrypt"],
+    );
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        {
+            name: Math.random() < 0.5 ? "RSA-PSS" : "RSASSA-PKCS1-v1_5",
+            modulusLength: 2048,
+            publicExponent: new Uint8Array([1, 0, 1]),
+            hash: "SHA-256",
+        },
+        false,
+        ["sign", "verify"],
+    );
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        Math.random() < 0.5 ? "Ed25519" : { name: "Ed25519" },
+        false,
+        ["sign", "verify"],
+    );
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        Math.random() < 0.5 ? "Ed448" : { name: "Ed448" },
+        false,
+        ["sign", "verify"],
+    );
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        Math.random() < 0.5 ? "X25519" : { name: "X25519" },
+        false,
+        ["deriveKey", "deriveBits"],
+    );
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        Math.random() < 0.5 ? "X448" : { name: "X448" },
+        false,
+        ["deriveKey", "deriveBits"],
+    );
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        { name: "ECDH", namedCurve: "P-256" },
+        false,
+        ["sign", "verify"],
+    );
+    // $ExpectType Promise<CryptoKey>;
+    subtle.generateKey(
+        {
+            name: Math.random() < 0.5 ? "AES-CBC" : Math.random() < 0.5 ? "AES-CTR" : "AES-GCM",
+            length: 2048,
+        },
+        true,
+        ["encrypt", "decrypt", "wrapKey", "unwrapKey"],
+    );
+    // $ExpectType Promise<CryptoKey>;
+    subtle.generateKey(
+        { name: "AES-KW", length: 2048 },
+        true,
+        ["wrapKey", "unwrapKey"],
+    );
+    // $ExpectType Promise<CryptoKey>;
+    subtle.generateKey(
+        { name: "HMAC", hash: "SHA-1" },
+        true,
+        ["sign", "verify"],
+    );
+    // Fallback
+    // $ExpectType Promise<CryptoKeyPair |CryptoKey>
+    subtle.generateKey(
+        { name: Math.random() < 0.5 ? "AES-KW" : "HMAC", length: 2048 },
+        true,
+        ["wrapKey", "unwrapKey"],
+    );
+
     subtle.sign({ name: "RSA-PSS", saltLength: 64 }, key, buf); // $ExpectType Promise<ArrayBuffer>
     subtle.unwrapKey(
         "raw",

--- a/types/node/v20/crypto.d.ts
+++ b/types/node/v20/crypto.d.ts
@@ -4392,17 +4392,48 @@ declare module "crypto" {
              * @since v15.0.0
              */
             generateKey(
-                algorithm: RsaHashedKeyGenParams | EcKeyGenParams,
+                algorithm: RsaHashedKeyGenParams & { name: "RSA-OAEP" },
                 extractable: boolean,
-                keyUsages: readonly KeyUsage[],
+                keyUsages: readonly ("encrypt" | "decrypt" | "wrapKey" | "unwrapKey")[],
             ): Promise<CryptoKeyPair>;
             generateKey(
-                algorithm: AesKeyGenParams | HmacKeyGenParams | Pbkdf2Params,
+                algorithm:
+                    | (RsaHashedKeyGenParams & { name: "RSA-PSS" | "RSASSA-PKCS1-v1_5" })
+                    | EcKeyGenParams
+                    | "Ed25519"
+                    | { name: "Ed25519" }
+                    | "Ed448"
+                    | { name: "Ed448" },
                 extractable: boolean,
-                keyUsages: readonly KeyUsage[],
+                keyUsages: readonly ("sign" | "verify")[],
+            ): Promise<CryptoKeyPair>;
+            generateKey(
+                algorithm:
+                    | "X25519"
+                    | { name: "X25519" }
+                    | "X448"
+                    | { name: "X448" },
+                extractable: boolean,
+                keyUsages: readonly ("deriveKey" | "deriveBits")[],
+            ): Promise<CryptoKeyPair>;
+            generateKey(
+                algorithm: AesKeyGenParams & { name: "AES-CBC" | "AES-CTR" | "AES-GCM" },
+                extractable: boolean,
+                keyUsages: readonly ("encrypt" | "decrypt" | "wrapKey" | "unwrapKey")[],
             ): Promise<CryptoKey>;
             generateKey(
-                algorithm: AlgorithmIdentifier,
+                algorithm: AesKeyGenParams & { name: "AES-KW" },
+                extractable: boolean,
+                keyUsages: readonly ("wrapKey" | "unwrapKey")[],
+            ): Promise<CryptoKey>;
+            generateKey(
+                algorithm: HmacKeyGenParams,
+                extractable: boolean,
+                keyUsages: readonly ("sign" | "verify")[],
+            ): Promise<CryptoKey>;
+            // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+            generateKey<T extends Algorithm>(
+                algorithm: string | T,
                 extractable: boolean,
                 keyUsages: KeyUsage[],
             ): Promise<CryptoKeyPair | CryptoKey>;

--- a/types/node/v20/test/crypto.ts
+++ b/types/node/v20/test/crypto.ts
@@ -1869,14 +1869,6 @@ import { promisify } from "node:util";
     crypto.webcrypto.CryptoKey.toString();
     // @ts-expect-error
     new crypto.webcrypto.CryptoKey(); // Illegal constructor
-
-    crypto.webcrypto.subtle.generateKey({ name: "HMAC", hash: "SHA-1" }, true, ["sign", "decrypt", "deriveBits"]).then(
-        (out) => {
-            out.algorithm; // $ExpectType KeyAlgorithm
-            out.extractable; // $ExpectType boolean
-            out.usages; // $ExpectType KeyUsage[]
-        },
-    );
 }
 
 {
@@ -1910,7 +1902,88 @@ import { promisify } from "node:util";
     subtle.digest("SHA-384", buf); // $ExpectType Promise<ArrayBuffer>
     subtle.exportKey("jwk", key); // $ExpectType Promise<JsonWebKey>
     subtle.importKey("pkcs8", buf, { name: "RSA-PSS", hash: "SHA-1" }, false, []); // $ExpectType Promise<CryptoKey>
-    subtle.generateKey({ name: "ECDH", namedCurve: "P-256" }, false, ["deriveKey", "deriveBits"]); // $ExpectType Promise<CryptoKeyPair>
+
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        {
+            name: "RSA-OAEP",
+            modulusLength: 2048,
+            publicExponent: new Uint8Array([1, 0, 1]),
+            hash: "SHA-256",
+        },
+        true,
+        ["encrypt", "decrypt"],
+    );
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        {
+            name: Math.random() < 0.5 ? "RSA-PSS" : "RSASSA-PKCS1-v1_5",
+            modulusLength: 2048,
+            publicExponent: new Uint8Array([1, 0, 1]),
+            hash: "SHA-256",
+        },
+        false,
+        ["sign", "verify"],
+    );
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        Math.random() < 0.5 ? "Ed25519" : { name: "Ed25519" },
+        false,
+        ["sign", "verify"],
+    );
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        Math.random() < 0.5 ? "Ed448" : { name: "Ed448" },
+        false,
+        ["sign", "verify"],
+    );
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        Math.random() < 0.5 ? "X25519" : { name: "X25519" },
+        false,
+        ["deriveKey", "deriveBits"],
+    );
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        Math.random() < 0.5 ? "X448" : { name: "X448" },
+        false,
+        ["deriveKey", "deriveBits"],
+    );
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        { name: "ECDH", namedCurve: "P-256" },
+        false,
+        ["sign", "verify"],
+    );
+    // $ExpectType Promise<CryptoKey>;
+    subtle.generateKey(
+        {
+            name: Math.random() < 0.5 ? "AES-CBC" : Math.random() < 0.5 ? "AES-CTR" : "AES-GCM",
+            length: 2048,
+        },
+        true,
+        ["encrypt", "decrypt", "wrapKey", "unwrapKey"],
+    );
+    // $ExpectType Promise<CryptoKey>;
+    subtle.generateKey(
+        { name: "AES-KW", length: 2048 },
+        true,
+        ["wrapKey", "unwrapKey"],
+    );
+    // $ExpectType Promise<CryptoKey>;
+    subtle.generateKey(
+        { name: "HMAC", hash: "SHA-1" },
+        true,
+        ["sign", "verify"],
+    );
+    // Fallback
+    // $ExpectType Promise<CryptoKeyPair |CryptoKey>
+    subtle.generateKey(
+        { name: Math.random() < 0.5 ? "AES-KW" : "HMAC", length: 2048 },
+        true,
+        ["wrapKey", "unwrapKey"],
+    );
+
     subtle.sign({ name: "RSA-PSS", saltLength: 64 }, key, buf); // $ExpectType Promise<ArrayBuffer>
     subtle.unwrapKey(
         "raw",

--- a/types/node/v20/test/globals-non-dom.ts
+++ b/types/node/v20/test/globals-non-dom.ts
@@ -30,13 +30,8 @@
     crypto.getRandomValues(Buffer.alloc(8)); // $ExpectType Buffer || Buffer<ArrayBuffer>
     crypto.getRandomValues(new BigInt64Array(4)); // $ExpectType BigInt64Array || BigInt64Array<ArrayBuffer>
 
-    crypto.subtle.generateKey({ name: "HMAC", hash: "SHA-1" }, true, ["sign", "decrypt", "deriveBits"]).then(
-        (out) => {
-            out.algorithm; // $ExpectType KeyAlgorithm
-            out.extractable; // $ExpectType boolean
-            out.usages; // $ExpectType KeyUsage[]
-        },
-    );
+    // $ExpectType Promise<CryptoKey | CryptoKeyPair>
+    crypto.subtle.generateKey({ name: "HMAC", hash: "SHA-1" }, true, ["sign", "decrypt", "deriveBits"]);
 }
 
 {

--- a/types/node/v22/crypto.d.ts
+++ b/types/node/v22/crypto.d.ts
@@ -4331,17 +4331,48 @@ declare module "crypto" {
              * @since v15.0.0
              */
             generateKey(
-                algorithm: RsaHashedKeyGenParams | EcKeyGenParams,
+                algorithm: RsaHashedKeyGenParams & { name: "RSA-OAEP" },
                 extractable: boolean,
-                keyUsages: readonly KeyUsage[],
+                keyUsages: readonly ("encrypt" | "decrypt" | "wrapKey" | "unwrapKey")[],
             ): Promise<CryptoKeyPair>;
             generateKey(
-                algorithm: AesKeyGenParams | HmacKeyGenParams | Pbkdf2Params,
+                algorithm:
+                    | (RsaHashedKeyGenParams & { name: "RSA-PSS" | "RSASSA-PKCS1-v1_5" })
+                    | EcKeyGenParams
+                    | "Ed25519"
+                    | { name: "Ed25519" }
+                    | "Ed448"
+                    | { name: "Ed448" },
                 extractable: boolean,
-                keyUsages: readonly KeyUsage[],
+                keyUsages: readonly ("sign" | "verify")[],
+            ): Promise<CryptoKeyPair>;
+            generateKey(
+                algorithm:
+                    | "X25519"
+                    | { name: "X25519" }
+                    | "X448"
+                    | { name: "X448" },
+                extractable: boolean,
+                keyUsages: readonly ("deriveKey" | "deriveBits")[],
+            ): Promise<CryptoKeyPair>;
+            generateKey(
+                algorithm: AesKeyGenParams & { name: "AES-CBC" | "AES-CTR" | "AES-GCM" },
+                extractable: boolean,
+                keyUsages: readonly ("encrypt" | "decrypt" | "wrapKey" | "unwrapKey")[],
             ): Promise<CryptoKey>;
             generateKey(
-                algorithm: AlgorithmIdentifier,
+                algorithm: AesKeyGenParams & { name: "AES-KW" },
+                extractable: boolean,
+                keyUsages: readonly ("wrapKey" | "unwrapKey")[],
+            ): Promise<CryptoKey>;
+            generateKey(
+                algorithm: HmacKeyGenParams,
+                extractable: boolean,
+                keyUsages: readonly ("sign" | "verify")[],
+            ): Promise<CryptoKey>;
+            // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+            generateKey<T extends Algorithm>(
+                algorithm: string | T,
                 extractable: boolean,
                 keyUsages: KeyUsage[],
             ): Promise<CryptoKeyPair | CryptoKey>;

--- a/types/node/v22/test/crypto.ts
+++ b/types/node/v22/test/crypto.ts
@@ -1656,14 +1656,6 @@ import { promisify } from "node:util";
     crypto.webcrypto.CryptoKey.toString();
     // @ts-expect-error
     new crypto.webcrypto.CryptoKey(); // Illegal constructor
-
-    crypto.webcrypto.subtle.generateKey({ name: "HMAC", hash: "SHA-1" }, true, ["sign", "decrypt", "deriveBits"]).then(
-        (out) => {
-            out.algorithm; // $ExpectType KeyAlgorithm
-            out.extractable; // $ExpectType boolean
-            out.usages; // $ExpectType KeyUsage[]
-        },
-    );
 }
 
 {
@@ -1697,7 +1689,88 @@ import { promisify } from "node:util";
     subtle.digest("SHA-384", buf); // $ExpectType Promise<ArrayBuffer>
     subtle.exportKey("jwk", key); // $ExpectType Promise<JsonWebKey>
     subtle.importKey("pkcs8", buf, { name: "RSA-PSS", hash: "SHA-1" }, false, []); // $ExpectType Promise<CryptoKey>
-    subtle.generateKey({ name: "ECDH", namedCurve: "P-256" }, false, ["deriveKey", "deriveBits"]); // $ExpectType Promise<CryptoKeyPair>
+
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        {
+            name: "RSA-OAEP",
+            modulusLength: 2048,
+            publicExponent: new Uint8Array([1, 0, 1]),
+            hash: "SHA-256",
+        },
+        true,
+        ["encrypt", "decrypt"],
+    );
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        {
+            name: Math.random() < 0.5 ? "RSA-PSS" : "RSASSA-PKCS1-v1_5",
+            modulusLength: 2048,
+            publicExponent: new Uint8Array([1, 0, 1]),
+            hash: "SHA-256",
+        },
+        false,
+        ["sign", "verify"],
+    );
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        Math.random() < 0.5 ? "Ed25519" : { name: "Ed25519" },
+        false,
+        ["sign", "verify"],
+    );
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        Math.random() < 0.5 ? "Ed448" : { name: "Ed448" },
+        false,
+        ["sign", "verify"],
+    );
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        Math.random() < 0.5 ? "X25519" : { name: "X25519" },
+        false,
+        ["deriveKey", "deriveBits"],
+    );
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        Math.random() < 0.5 ? "X448" : { name: "X448" },
+        false,
+        ["deriveKey", "deriveBits"],
+    );
+    // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey(
+        { name: "ECDH", namedCurve: "P-256" },
+        false,
+        ["sign", "verify"],
+    );
+    // $ExpectType Promise<CryptoKey>;
+    subtle.generateKey(
+        {
+            name: Math.random() < 0.5 ? "AES-CBC" : Math.random() < 0.5 ? "AES-CTR" : "AES-GCM",
+            length: 2048,
+        },
+        true,
+        ["encrypt", "decrypt", "wrapKey", "unwrapKey"],
+    );
+    // $ExpectType Promise<CryptoKey>;
+    subtle.generateKey(
+        { name: "AES-KW", length: 2048 },
+        true,
+        ["wrapKey", "unwrapKey"],
+    );
+    // $ExpectType Promise<CryptoKey>;
+    subtle.generateKey(
+        { name: "HMAC", hash: "SHA-1" },
+        true,
+        ["sign", "verify"],
+    );
+    // Fallback
+    // $ExpectType Promise<CryptoKeyPair |CryptoKey>
+    subtle.generateKey(
+        { name: Math.random() < 0.5 ? "AES-KW" : "HMAC", length: 2048 },
+        true,
+        ["wrapKey", "unwrapKey"],
+    );
+
     subtle.sign({ name: "RSA-PSS", saltLength: 64 }, key, buf); // $ExpectType Promise<ArrayBuffer>
     subtle.unwrapKey(
         "raw",

--- a/types/node/v22/test/globals-non-dom.ts
+++ b/types/node/v22/test/globals-non-dom.ts
@@ -30,13 +30,8 @@
     crypto.getRandomValues(Buffer.alloc(8)); // $ExpectType Buffer || Buffer<ArrayBuffer>
     crypto.getRandomValues(new BigInt64Array(4)); // $ExpectType BigInt64Array || BigInt64Array<ArrayBuffer>
 
-    crypto.subtle.generateKey({ name: "HMAC", hash: "SHA-1" }, true, ["sign", "decrypt", "deriveBits"]).then(
-        (out) => {
-            out.algorithm; // $ExpectType KeyAlgorithm
-            out.extractable; // $ExpectType boolean
-            out.usages; // $ExpectType KeyUsage[]
-        },
-    );
+    // $ExpectType Promise<CryptoKey | CryptoKeyPair>
+    crypto.subtle.generateKey({ name: "HMAC", hash: "SHA-1" }, true, ["sign", "decrypt", "deriveBits"]);
 }
 
 {


### PR DESCRIPTION
Resolves discussion https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/72837.

This update is made according to https://nodejs.org/api/webcrypto.html#cryptokeyusages.

Potentially we can do this to other methods in the key-usages table, but let's see how reviewers think about this change, then we may perform the refactoring incrementally in subsequent PRs.

Fallback signature is also updated, in favor of matching richer shape of possible `Algorithm` object.
```ts
// eslint-disable-next-line @definitelytyped/no-unnecessary-generics
generateKey<T extends Algorithm>(
    algorithm: string | T,
    extractable: boolean,
    keyUsages: KeyUsage[],
): Promise<CryptoKeyPair | CryptoKey>;
```

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
