### PR TITLE
[sizzle] fix: add empty DOM global interfaces for non-DOM users

### DIFF
--- a/types/sizzle/index.d.ts
+++ b/types/sizzle/index.d.ts
@@ -4,13 +4,10 @@ declare const Sizzle: SizzleStatic;
 export = Sizzle;
 
 // For users who don't have "dom" types
-/* eslint-disable @typescript-eslint/no-empty-interface */
-declare global {
-    interface Document {}
-    interface DocumentFragment {}
-    interface Element {}
-}
-/* eslint-enable @typescript-eslint/no-empty-interface */
+// See: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/73082
+type Element = typeof globalThis extends { Element: { new(): infer T } } ? T : never;
+type Document = typeof globalThis extends { Document: { new(): infer T } } ? T : never;
+type DocumentFragment = typeof globalThis extends { DocumentFragment: { new(): infer T } } ? T : never;
 
 interface SizzleStatic {
     selectors: Sizzle.Selectors;

--- a/types/sizzle/index.d.ts
+++ b/types/sizzle/index.d.ts
@@ -3,6 +3,13 @@ export as namespace Sizzle;
 declare const Sizzle: SizzleStatic;
 export = Sizzle;
 
+// For users who don't have "dom" types
+/* eslint-disable @typescript-eslint/no-empty-interface */
+interface Document {}
+interface DocumentFragment {}
+interface Element {}
+/* eslint-enable @typescript-eslint/no-empty-interface */
+
 interface SizzleStatic {
     selectors: Sizzle.Selectors;
     <TArrayLike extends ArrayLike<Element>>(

--- a/types/sizzle/index.d.ts
+++ b/types/sizzle/index.d.ts
@@ -5,9 +5,11 @@ export = Sizzle;
 
 // For users who don't have "dom" types
 /* eslint-disable @typescript-eslint/no-empty-interface */
-interface Document {}
-interface DocumentFragment {}
-interface Element {}
+declare global {
+    interface Document {}
+    interface DocumentFragment {}
+    interface Element {}
+}
 /* eslint-enable @typescript-eslint/no-empty-interface */
 
 interface SizzleStatic {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] ~[Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.~ n/a
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/eslint/eslint/pull/19643#discussion_r2155194866
- [x] ~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.~ n/a

Fixes `@types/sizzle` to not cause errors when folks use it without `"dom"` in their types or `skipLibCheck` enabled. DOM types like `Document` and `Element` aren't available in that case, and these references cause type errors.

Some examples of similar fixes in the past:
* https://github.com/DefinitelyTyped/DefinitelyTyped/issues/23798
* https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24419

This particular one came out of https://github.com/eslint/eslint/pull/19643#discussion_r2155194866.