### PR TITLE
[pathfinding]Add missing options

### DIFF
--- a/types/pathfinding/index.d.ts
+++ b/types/pathfinding/index.d.ts
@@ -33,6 +33,8 @@ declare module "pathfinding" {
         interface FinderOptions extends Heuristic {
             diagonalMovement?: DiagonalMovement | undefined;
             weight?: number | undefined;
+            allowDiagonal?: boolean | undefined;
+            dontCrossCorners?: boolean | undefined;
         }
 
         interface IDAStarFinderOptions extends FinderOptions {

--- a/types/pathfinding/package.json
+++ b/types/pathfinding/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/pathfinding",
-    "version": "0.0.9999",
+    "version": "0.1.9999",
     "projects": [
         "https://github.com/qiao/PathFinding.js"
     ],

--- a/types/pathfinding/pathfinding-tests.ts
+++ b/types/pathfinding/pathfinding-tests.ts
@@ -11,10 +11,9 @@ var node = grid.getNodeAt(0, 0);
 
 var finder = new PF.AStarFinder();
 
-
 var finder = new PF.AStarFinder({
     allowDiagonal: true,
-    dontCrossCorners: true
+    dontCrossCorners: true,
 });
 
 var finder = new PF.AStarFinder({

--- a/types/pathfinding/pathfinding-tests.ts
+++ b/types/pathfinding/pathfinding-tests.ts
@@ -11,6 +11,12 @@ var node = grid.getNodeAt(0, 0);
 
 var finder = new PF.AStarFinder();
 
+
+var finder = new PF.AStarFinder({
+    allowDiagonal: true,
+    dontCrossCorners: true
+});
+
 var finder = new PF.AStarFinder({
     diagonalMovement: PF.DiagonalMovement.IfAtMostOneObstacle,
     heuristic: PF.Heuristic.chebyshev,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/qiao/PathFinding.js/blob/master/src/finders/AStarFinder.js#L22
https://github.com/qiao/PathFinding.js/blob/master/src/finders/IDAStarFinder.js#L36
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

The constructer for both AStarFinder, IDAStarFinder have the 2 options. So it added to the interface that both use. 