### PR TITLE
[fixed-data-table-2] Add missing getters: `gridAttributesGetter` and `rowAttributesGetter`

### DIFF
--- a/types/fixed-data-table-2/fixed-data-table-2-tests.tsx
+++ b/types/fixed-data-table-2/fixed-data-table-2-tests.tsx
@@ -2,7 +2,7 @@
  * The tests are based on tests from types/fixed-data-table
  */
 
-import { Cell, CellProps, Column, ColumnGroup, Plugins, Table } from "fixed-data-table-2";
+import { AttributesGetterReturn, Cell, CellProps, Column, ColumnGroup, Plugins, Table } from "fixed-data-table-2";
 import * as React from "react";
 
 // create your Table
@@ -325,5 +325,32 @@ class MyTable7 extends React.Component {
                 />
             </Table>
         );
+    }
+}
+
+// Attribute getters
+class MyTable8 extends React.Component {
+    render() {
+        return (
+            <Table
+                rowsCount={100}
+                rowHeight={50}
+                headerHeight={50}
+                width={1000}
+                height={500}
+                gridAttributesGetter={this.gridAttributesGetter}
+                rowAttributesGetter={this.rowAttributesGetter}
+            >
+                // add columns
+            </Table>
+        );
+    }
+
+    gridAttributesGetter(): AttributesGetterReturn {
+        return { className: "my-grid-class-name" };
+    }
+
+    rowAttributesGetter(index: number): AttributesGetterReturn {
+        return { className: "my-row-class-name", "data-row-index": index.toString() };
     }
 }

--- a/types/fixed-data-table-2/index.d.ts
+++ b/types/fixed-data-table-2/index.d.ts
@@ -29,6 +29,14 @@ export type ElementOrFunc<P> = string | React.ReactElement | ((props: P) => stri
 export type TableRowEventHandler = (event: React.SyntheticEvent<Table>, rowIndex: number) => void;
 
 /**
+ * Represents the return type for a function that provides HTML attributes for
+ * a component.
+ */
+export type AttributesGetterReturn =
+    & React.HTMLAttributes<HTMLElement>
+    & { [key: `data-${string}`]: string | undefined };
+
+/**
  * Data grid component with fixed or scrollable header and columns.
  *
  * The layout of the data table is as follows:
@@ -204,6 +212,12 @@ export interface TableProps extends React.ClassAttributes<Table> {
     rowExpanded?: ElementOrFunc<RowProps> | undefined;
 
     /**
+     * Callback that returns an object of html attributes to add to each row
+     * element.
+     */
+    rowAttributesGetter?: ((index: number) => AttributesGetterReturn) | undefined;
+
+    /**
      * To get any additional CSS classes that should be added to a row,
      * `rowClassNameGetter(index)` is called.
      */
@@ -214,6 +228,12 @@ export interface TableProps extends React.ClassAttributes<Table> {
      * returned value overrides `key` for the particular row.
      */
     rowKeyGetter?: ((index: number) => string) | undefined;
+
+    /**
+     * Callback that returns an object of html attributes to add to the grid
+     * element.
+     */
+    gridAttributesGetter?: (() => AttributesGetterReturn) | undefined;
 
     /**
      * Pixel height of the column group header.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - `gridAttributesGetter`: https://schrodinger.github.io/fixed-data-table-2/api-table.html#gridattributesgetter
  - `rowAttributesGetter`: https://schrodinger.github.io/fixed-data-table-2/api-table.html#rowattributesgetter