### PR TITLE
fix(leaflet): add tileload and tileunload event typings to TileLayer

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1807,6 +1807,14 @@ export class TileLayer extends GridLayer {
     options: TileLayerOptions;
 }
 
+ interface Evented {
+    on(type: 'tileload', fn: (e: TileEvent) => void, context?: any): this;
+    on(type: 'tileunload', fn: (e: TileEvent) => void, context?: any): this;
+    on(type: string, fn: LeafletEventHandlerFn, context?: any): this;
+
+}
+
+
 export function tileLayer(urlTemplate: string, options?: TileLayerOptions): TileLayer;
 
 export namespace TileLayer {


### PR DESCRIPTION
Summary
This pull request adds missing type definitions for the tileload and tileunload events on the TileLayer class in the Leaflet type declarations.

These events are documented in the Leaflet official reference:
https://leafletjs.com/reference.html#tilelayer-tileload

Checklist
 A meaningful and descriptive title has been used for the pull request, indicating the affected package (leaflet).

 The changes have been tested locally using tsc --noEmit.

 The contribution follows the guidelines outlined in the DefinitelyTyped repository.

 Common mistakes have been reviewed and avoided.

 The command pnpm test leaflet was run (optional if pnpm is not available).

Context for the Change
 Documentation or source reference provided:
https://leafletjs.com/reference.html#tilelayer-tileload

 This pull request does not target a new Leaflet version; it adds typing's for existing event support that was previously untyped.

