### PR TITLE
[node] add missing v23 APIs

### DIFF
--- a/types/node/dns.d.ts
+++ b/types/node/dns.d.ts
@@ -289,6 +289,15 @@ declare module "dns" {
     export interface AnySrvRecord extends SrvRecord {
         type: "SRV";
     }
+    export interface TlsaRecord {
+        certUsage: number;
+        selector: number;
+        match: number;
+        data: ArrayBuffer;
+    }
+    export interface AnyTlsaRecord extends TlsaRecord {
+        type: "TLSA";
+    }
     export interface AnyTxtRecord {
         type: "TXT";
         entries: string[];
@@ -315,6 +324,7 @@ declare module "dns" {
         | AnyPtrRecord
         | AnySoaRecord
         | AnySrvRecord
+        | AnyTlsaRecord
         | AnyTxtRecord;
     /**
      * Uses the DNS protocol to resolve a host name (e.g. `'nodejs.org'`) into an array
@@ -385,6 +395,11 @@ declare module "dns" {
     ): void;
     export function resolve(
         hostname: string,
+        rrtype: "TLSA",
+        callback: (err: NodeJS.ErrnoException | null, addresses: TlsaRecord[]) => void,
+    ): void;
+    export function resolve(
+        hostname: string,
         rrtype: "TXT",
         callback: (err: NodeJS.ErrnoException | null, addresses: string[][]) => void,
     ): void;
@@ -393,7 +408,15 @@ declare module "dns" {
         rrtype: string,
         callback: (
             err: NodeJS.ErrnoException | null,
-            addresses: string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | string[][] | AnyRecord[],
+            addresses:
+                | string[]
+                | MxRecord[]
+                | NaptrRecord[]
+                | SoaRecord
+                | SrvRecord[]
+                | TlsaRecord[]
+                | string[][]
+                | AnyRecord[],
         ) => void,
     ): void;
     export namespace resolve {
@@ -403,11 +426,14 @@ declare module "dns" {
         function __promisify__(hostname: string, rrtype: "NAPTR"): Promise<NaptrRecord[]>;
         function __promisify__(hostname: string, rrtype: "SOA"): Promise<SoaRecord>;
         function __promisify__(hostname: string, rrtype: "SRV"): Promise<SrvRecord[]>;
+        function __promisify__(hostname: string, rrtype: "TLSA"): Promise<TlsaRecord[]>;
         function __promisify__(hostname: string, rrtype: "TXT"): Promise<string[][]>;
         function __promisify__(
             hostname: string,
             rrtype: string,
-        ): Promise<string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | string[][] | AnyRecord[]>;
+        ): Promise<
+            string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | TlsaRecord[] | string[][] | AnyRecord[]
+        >;
     }
     /**
      * Uses the DNS protocol to resolve a IPv4 addresses (`A` records) for the `hostname`. The `addresses` argument passed to the `callback` function
@@ -608,6 +634,33 @@ declare module "dns" {
     ): void;
     export namespace resolveSrv {
         function __promisify__(hostname: string): Promise<SrvRecord[]>;
+    }
+    /**
+     * Uses the DNS protocol to resolve certificate associations (`TLSA` records) for
+     * the `hostname`. The `records` argument passed to the `callback` function is an
+     * array of objects with these properties:
+     *
+     * * `certUsage`
+     * * `selector`
+     * * `match`
+     * * `data`
+     *
+     * ```js
+     * {
+     *   certUsage: 3,
+     *   selector: 1,
+     *   match: 1,
+     *   data: [ArrayBuffer]
+     * }
+     * ```
+     * @since v23.9.0, v22.15.0
+     */
+    export function resolveTlsa(
+        hostname: string,
+        callback: (err: NodeJS.ErrnoException | null, addresses: TlsaRecord[]) => void,
+    ): void;
+    export namespace resolveTlsa {
+        function __promisify__(hostname: string): Promise<TlsaRecord[]>;
     }
     /**
      * Uses the DNS protocol to resolve text queries (`TXT` records) for the `hostname`. The `records` argument passed to the `callback` function is a
@@ -838,6 +891,7 @@ declare module "dns" {
         resolvePtr: typeof resolvePtr;
         resolveSoa: typeof resolveSoa;
         resolveSrv: typeof resolveSrv;
+        resolveTlsa: typeof resolveTlsa;
         resolveTxt: typeof resolveTxt;
         reverse: typeof reverse;
         /**

--- a/types/node/dns/promises.d.ts
+++ b/types/node/dns/promises.d.ts
@@ -20,6 +20,7 @@ declare module "dns/promises" {
         ResolveWithTtlOptions,
         SoaRecord,
         SrvRecord,
+        TlsaRecord,
     } from "node:dns";
     /**
      * Returns an array of IP address strings, formatted according to [RFC 5952](https://tools.ietf.org/html/rfc5952#section-6),
@@ -137,11 +138,14 @@ declare module "dns/promises" {
     function resolve(hostname: string, rrtype: "PTR"): Promise<string[]>;
     function resolve(hostname: string, rrtype: "SOA"): Promise<SoaRecord>;
     function resolve(hostname: string, rrtype: "SRV"): Promise<SrvRecord[]>;
+    function resolve(hostname: string, rrtype: "TLSA"): Promise<TlsaRecord[]>;
     function resolve(hostname: string, rrtype: "TXT"): Promise<string[][]>;
     function resolve(
         hostname: string,
         rrtype: string,
-    ): Promise<string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | string[][] | AnyRecord[]>;
+    ): Promise<
+        string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | TlsaRecord[] | string[][] | AnyRecord[]
+    >;
     /**
      * Uses the DNS protocol to resolve IPv4 addresses (`A` records) for the `hostname`. On success, the `Promise` is resolved with an array of IPv4
      * addresses (e.g. `['74.125.79.104', '74.125.79.105', '74.125.79.106']`).
@@ -292,6 +296,27 @@ declare module "dns/promises" {
      * @since v10.6.0
      */
     function resolveSrv(hostname: string): Promise<SrvRecord[]>;
+    /**
+     * Uses the DNS protocol to resolve certificate associations (`TLSA` records) for
+     * the `hostname`. On success, the `Promise` is resolved with an array of objectsAdd commentMore actions
+     * with these properties:
+     *
+     * * `certUsage`
+     * * `selector`
+     * * `match`
+     * * `data`
+     *
+     * ```js
+     * {
+     *   certUsage: 3,
+     *   selector: 1,
+     *   match: 1,
+     *   data: [ArrayBuffer]
+     * }
+     * ```
+     * @since v23.9.0, v22.15.0
+     */
+    function resolveTlsa(hostname: string): Promise<TlsaRecord[]>;
     /**
      * Uses the DNS protocol to resolve text queries (`TXT` records) for the `hostname`. On success, the `Promise` is resolved with a two-dimensional array
      * of the text records available for `hostname` (e.g.`[ ['v=spf1 ip4:0.0.0.0 ', '~all' ] ]`). Each sub-array contains TXT chunks of
@@ -450,6 +475,7 @@ declare module "dns/promises" {
         resolvePtr: typeof resolvePtr;
         resolveSoa: typeof resolveSoa;
         resolveSrv: typeof resolveSrv;
+        resolveTlsa: typeof resolveTlsa;
         resolveTxt: typeof resolveTxt;
         reverse: typeof reverse;
         /**

--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -485,6 +485,26 @@ declare module "module" {
                 context?: Partial<LoadHookContext>,
             ) => LoadFnOutput,
         ) => LoadFnOutput;
+        interface SourceMapsSupport {
+            /**
+             * If the source maps support is enabled
+             */
+            enabled: boolean;
+            /**
+             * If the support is enabled for files in `node_modules`.
+             */
+            nodeModules: boolean;
+            /**
+             * If the support is enabled for generated code from `eval` or `new Function`.
+             */
+            generatedCode: boolean;
+        }
+        /**
+         * This method returns whether the [Source Map v3](https://tc39.es/ecma426/) support for stack
+         * traces is enabled.
+         * @since v23.7.0, v22.14.0
+         */
+        function getSourceMapsSupport(): SourceMapsSupport;
         /**
          * `path` is the resolved path for the file for which a corresponding source map
          * should be fetched.
@@ -492,6 +512,33 @@ declare module "module" {
          * @return Returns `module.SourceMap` if a source map is found, `undefined` otherwise.
          */
         function findSourceMap(path: string): SourceMap | undefined;
+        interface SetSourceMapsSupportOptions {
+            /**
+             * If enabling the support for files in `node_modules`.
+             * @default false
+             */
+            nodeModules?: boolean | undefined;
+            /**
+             * If enabling the support for generated code from `eval` or `new Function`.
+             * @default false
+             */
+            generatedCode?: boolean | undefined;
+        }
+        /**
+         * This function enables or disables the [Source Map v3](https://tc39.es/ecma426/) support for
+         * stack traces.
+         *
+         * It provides same features as launching Node.js process with commandline options
+         * `--enable-source-maps`, with additional options to alter the support for files
+         * in `node_modules` or generated codes.
+         *
+         * Only source maps in JavaScript files that are loaded after source maps has been
+         * enabled will be parsed and loaded. Preferably, use the commandline options
+         * `--enable-source-maps` to avoid losing track of source maps of modules loaded
+         * before this API call.
+         * @since v23.7.0, v22.14.0
+         */
+        function setSourceMapsSupport(enabled: boolean, options?: SetSourceMapsSupportOptions): void;
         interface SourceMapConstructorOptions {
             /**
              * @since v21.0.0, v20.5.0

--- a/types/node/test/module.ts
+++ b/types/node/test/module.ts
@@ -92,8 +92,17 @@ Module.Module === Module;
     // $ExpectType SourceOrigin | {}
     sourceMap.findOrigin(1, 1);
 
+    // $ExpectType SourceMapsSupport
+    Module.getSourceMapsSupport();
+
     // $ExpectType SourceMap | undefined
     Module.findSourceMap("/path/to/file.js");
+
+    Module.setSourceMapsSupport(true);
+    Module.setSourceMapsSupport(true, {
+        generatedCode: true,
+        nodeModules: true,
+    });
 }
 
 // import.meta

--- a/types/node/test/v8.ts
+++ b/types/node/test/v8.ts
@@ -91,3 +91,5 @@ v8.deserialize(new DataView(new ArrayBuffer(1)));
 v8.deserialize(new ArrayBuffer(1));
 // @ts-expect-error String is not a valid deserialize parameter
 v8.deserialize("Hello World!");
+
+v8.isStringOneByteRepresentation("你好"); // $ExpectType boolean

--- a/types/node/v22/dns.d.ts
+++ b/types/node/v22/dns.d.ts
@@ -289,6 +289,15 @@ declare module "dns" {
     export interface AnySrvRecord extends SrvRecord {
         type: "SRV";
     }
+    export interface TlsaRecord {
+        certUsage: number;
+        selector: number;
+        match: number;
+        data: ArrayBuffer;
+    }
+    export interface AnyTlsaRecord extends TlsaRecord {
+        type: "TLSA";
+    }
     export interface AnyTxtRecord {
         type: "TXT";
         entries: string[];
@@ -315,6 +324,7 @@ declare module "dns" {
         | AnyPtrRecord
         | AnySoaRecord
         | AnySrvRecord
+        | AnyTlsaRecord
         | AnyTxtRecord;
     /**
      * Uses the DNS protocol to resolve a host name (e.g. `'nodejs.org'`) into an array
@@ -385,6 +395,11 @@ declare module "dns" {
     ): void;
     export function resolve(
         hostname: string,
+        rrtype: "TLSA",
+        callback: (err: NodeJS.ErrnoException | null, addresses: TlsaRecord[]) => void,
+    ): void;
+    export function resolve(
+        hostname: string,
         rrtype: "TXT",
         callback: (err: NodeJS.ErrnoException | null, addresses: string[][]) => void,
     ): void;
@@ -393,7 +408,15 @@ declare module "dns" {
         rrtype: string,
         callback: (
             err: NodeJS.ErrnoException | null,
-            addresses: string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | string[][] | AnyRecord[],
+            addresses:
+                | string[]
+                | MxRecord[]
+                | NaptrRecord[]
+                | SoaRecord
+                | SrvRecord[]
+                | TlsaRecord[]
+                | string[][]
+                | AnyRecord[],
         ) => void,
     ): void;
     export namespace resolve {
@@ -403,11 +426,14 @@ declare module "dns" {
         function __promisify__(hostname: string, rrtype: "NAPTR"): Promise<NaptrRecord[]>;
         function __promisify__(hostname: string, rrtype: "SOA"): Promise<SoaRecord>;
         function __promisify__(hostname: string, rrtype: "SRV"): Promise<SrvRecord[]>;
+        function __promisify__(hostname: string, rrtype: "TLSA"): Promise<TlsaRecord[]>;
         function __promisify__(hostname: string, rrtype: "TXT"): Promise<string[][]>;
         function __promisify__(
             hostname: string,
             rrtype: string,
-        ): Promise<string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | string[][] | AnyRecord[]>;
+        ): Promise<
+            string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | TlsaRecord[] | string[][] | AnyRecord[]
+        >;
     }
     /**
      * Uses the DNS protocol to resolve a IPv4 addresses (`A` records) for the `hostname`. The `addresses` argument passed to the `callback` function
@@ -608,6 +634,33 @@ declare module "dns" {
     ): void;
     export namespace resolveSrv {
         function __promisify__(hostname: string): Promise<SrvRecord[]>;
+    }
+    /**
+     * Uses the DNS protocol to resolve certificate associations (`TLSA` records) for
+     * the `hostname`. The `records` argument passed to the `callback` function is an
+     * array of objects with these properties:
+     *
+     * * `certUsage`
+     * * `selector`
+     * * `match`
+     * * `data`
+     *
+     * ```js
+     * {
+     *   certUsage: 3,
+     *   selector: 1,
+     *   match: 1,
+     *   data: [ArrayBuffer]
+     * }
+     * ```
+     * @since v22.15.0
+     */
+    export function resolveTlsa(
+        hostname: string,
+        callback: (err: NodeJS.ErrnoException | null, addresses: TlsaRecord[]) => void,
+    ): void;
+    export namespace resolveTlsa {
+        function __promisify__(hostname: string): Promise<TlsaRecord[]>;
     }
     /**
      * Uses the DNS protocol to resolve text queries (`TXT` records) for the `hostname`. The `records` argument passed to the `callback` function is a
@@ -838,6 +891,7 @@ declare module "dns" {
         resolvePtr: typeof resolvePtr;
         resolveSoa: typeof resolveSoa;
         resolveSrv: typeof resolveSrv;
+        resolveTlsa: typeof resolveTlsa;
         resolveTxt: typeof resolveTxt;
         reverse: typeof reverse;
         /**

--- a/types/node/v22/dns/promises.d.ts
+++ b/types/node/v22/dns/promises.d.ts
@@ -20,6 +20,7 @@ declare module "dns/promises" {
         ResolveWithTtlOptions,
         SoaRecord,
         SrvRecord,
+        TlsaRecord,
     } from "node:dns";
     /**
      * Returns an array of IP address strings, formatted according to [RFC 5952](https://tools.ietf.org/html/rfc5952#section-6),
@@ -137,11 +138,14 @@ declare module "dns/promises" {
     function resolve(hostname: string, rrtype: "PTR"): Promise<string[]>;
     function resolve(hostname: string, rrtype: "SOA"): Promise<SoaRecord>;
     function resolve(hostname: string, rrtype: "SRV"): Promise<SrvRecord[]>;
+    function resolve(hostname: string, rrtype: "TLSA"): Promise<TlsaRecord[]>;
     function resolve(hostname: string, rrtype: "TXT"): Promise<string[][]>;
     function resolve(
         hostname: string,
         rrtype: string,
-    ): Promise<string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | string[][] | AnyRecord[]>;
+    ): Promise<
+        string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | TlsaRecord[] | string[][] | AnyRecord[]
+    >;
     /**
      * Uses the DNS protocol to resolve IPv4 addresses (`A` records) for the `hostname`. On success, the `Promise` is resolved with an array of IPv4
      * addresses (e.g. `['74.125.79.104', '74.125.79.105', '74.125.79.106']`).
@@ -292,6 +296,27 @@ declare module "dns/promises" {
      * @since v10.6.0
      */
     function resolveSrv(hostname: string): Promise<SrvRecord[]>;
+    /**
+     * Uses the DNS protocol to resolve certificate associations (`TLSA` records) for
+     * the `hostname`. On success, the `Promise` is resolved with an array of objectsAdd commentMore actions
+     * with these properties:
+     *
+     * * `certUsage`
+     * * `selector`
+     * * `match`
+     * * `data`
+     *
+     * ```js
+     * {
+     *   certUsage: 3,
+     *   selector: 1,
+     *   match: 1,
+     *   data: [ArrayBuffer]
+     * }
+     * ```
+     * @since v22.15.0
+     */
+    function resolveTlsa(hostname: string): Promise<TlsaRecord[]>;
     /**
      * Uses the DNS protocol to resolve text queries (`TXT` records) for the `hostname`. On success, the `Promise` is resolved with a two-dimensional array
      * of the text records available for `hostname` (e.g.`[ ['v=spf1 ip4:0.0.0.0 ', '~all' ] ]`). Each sub-array contains TXT chunks of
@@ -450,6 +475,7 @@ declare module "dns/promises" {
         resolvePtr: typeof resolvePtr;
         resolveSoa: typeof resolveSoa;
         resolveSrv: typeof resolveSrv;
+        resolveTlsa: typeof resolveTlsa;
         resolveTxt: typeof resolveTxt;
         reverse: typeof reverse;
         /**

--- a/types/node/v22/module.d.ts
+++ b/types/node/v22/module.d.ts
@@ -484,6 +484,26 @@ declare module "module" {
                 context?: Partial<LoadHookContext>,
             ) => LoadFnOutput,
         ) => LoadFnOutput;
+        interface SourceMapsSupport {
+            /**
+             * If the source maps support is enabled
+             */
+            enabled: boolean;
+            /**
+             * If the support is enabled for files in `node_modules`.
+             */
+            nodeModules: boolean;
+            /**
+             * If the support is enabled for generated code from `eval` or `new Function`.
+             */
+            generatedCode: boolean;
+        }
+        /**
+         * This method returns whether the [Source Map v3](https://tc39.es/ecma426/) support for stack
+         * traces is enabled.
+         * @since v22.14.0
+         */
+        function getSourceMapsSupport(): SourceMapsSupport;
         /**
          * `path` is the resolved path for the file for which a corresponding source map
          * should be fetched.
@@ -491,6 +511,33 @@ declare module "module" {
          * @return Returns `module.SourceMap` if a source map is found, `undefined` otherwise.
          */
         function findSourceMap(path: string): SourceMap | undefined;
+        interface SetSourceMapsSupportOptions {
+            /**
+             * If enabling the support for files in `node_modules`.
+             * @default false
+             */
+            nodeModules?: boolean | undefined;
+            /**
+             * If enabling the support for generated code from `eval` or `new Function`.
+             * @default false
+             */
+            generatedCode?: boolean | undefined;
+        }
+        /**
+         * This function enables or disables the [Source Map v3](https://tc39.es/ecma426/) support for
+         * stack traces.
+         *
+         * It provides same features as launching Node.js process with commandline options
+         * `--enable-source-maps`, with additional options to alter the support for files
+         * in `node_modules` or generated codes.
+         *
+         * Only source maps in JavaScript files that are loaded after source maps has been
+         * enabled will be parsed and loaded. Preferably, use the commandline options
+         * `--enable-source-maps` to avoid losing track of source maps of modules loaded
+         * before this API call.
+         * @since v22.14.0
+         */
+        function setSourceMapsSupport(enabled: boolean, options?: SetSourceMapsSupportOptions): void;
         interface SourceMapConstructorOptions {
             /**
              * @since v21.0.0, v20.5.0

--- a/types/node/v22/test/module.ts
+++ b/types/node/v22/test/module.ts
@@ -92,8 +92,17 @@ Module.Module === Module;
     // $ExpectType SourceOrigin | {}
     sourceMap.findOrigin(1, 1);
 
+    // $ExpectType SourceMapsSupport
+    Module.getSourceMapsSupport();
+
     // $ExpectType SourceMap | undefined
     Module.findSourceMap("/path/to/file.js");
+
+    Module.setSourceMapsSupport(true);
+    Module.setSourceMapsSupport(true, {
+        generatedCode: true,
+        nodeModules: true,
+    });
 }
 
 // import.meta

--- a/types/node/v22/test/v8.ts
+++ b/types/node/v22/test/v8.ts
@@ -91,3 +91,5 @@ v8.deserialize(new DataView(new ArrayBuffer(1)));
 v8.deserialize(new ArrayBuffer(1));
 // @ts-expect-error String is not a valid deserialize parameter
 v8.deserialize("Hello World!");
+
+v8.isStringOneByteRepresentation("你好"); // $ExpectType boolean

--- a/types/node/v22/v8.d.ts
+++ b/types/node/v22/v8.d.ts
@@ -401,6 +401,39 @@ declare module "v8" {
      */
     function getHeapCodeStatistics(): HeapCodeStatistics;
     /**
+     * V8 only supports `Latin-1/ISO-8859-1` and `UTF16` as the underlying representation of a string.
+     * If the `content` uses `Latin-1/ISO-8859-1` as the underlying representation, this function will return true;
+     * otherwise, it returns false.
+     *
+     * If this method returns false, that does not mean that the string contains some characters not in `Latin-1/ISO-8859-1`.
+     * Sometimes a `Latin-1` string may also be represented as `UTF16`.
+     *
+     * ```js
+     * const { isStringOneByteRepresentation } = require('node:v8');
+     *
+     * const Encoding = {
+     *   latin1: 1,
+     *   utf16le: 2,
+     * };
+     * const buffer = Buffer.alloc(100);
+     * function writeString(input) {
+     *   if (isStringOneByteRepresentation(input)) {
+     *     buffer.writeUint8(Encoding.latin1);
+     *     buffer.writeUint32LE(input.length, 1);
+     *     buffer.write(input, 5, 'latin1');
+     *   } else {
+     *     buffer.writeUint8(Encoding.utf16le);
+     *     buffer.writeUint32LE(input.length * 2, 1);
+     *     buffer.write(input, 5, 'utf16le');
+     *   }
+     * }
+     * writeString('hello');
+     * writeString('你好');
+     * ```
+     * @since v22.15.0
+     */
+    function isStringOneByteRepresentation(content: string): boolean;
+    /**
      * @since v8.0.0
      */
     class Serializer {

--- a/types/node/v8.d.ts
+++ b/types/node/v8.d.ts
@@ -401,6 +401,39 @@ declare module "v8" {
      */
     function getHeapCodeStatistics(): HeapCodeStatistics;
     /**
+     * V8 only supports `Latin-1/ISO-8859-1` and `UTF16` as the underlying representation of a string.
+     * If the `content` uses `Latin-1/ISO-8859-1` as the underlying representation, this function will return true;
+     * otherwise, it returns false.
+     *
+     * If this method returns false, that does not mean that the string contains some characters not in `Latin-1/ISO-8859-1`.
+     * Sometimes a `Latin-1` string may also be represented as `UTF16`.
+     *
+     * ```js
+     * const { isStringOneByteRepresentation } = require('node:v8');
+     *
+     * const Encoding = {
+     *   latin1: 1,
+     *   utf16le: 2,
+     * };
+     * const buffer = Buffer.alloc(100);
+     * function writeString(input) {
+     *   if (isStringOneByteRepresentation(input)) {
+     *     buffer.writeUint8(Encoding.latin1);
+     *     buffer.writeUint32LE(input.length, 1);
+     *     buffer.write(input, 5, 'latin1');
+     *   } else {
+     *     buffer.writeUint8(Encoding.utf16le);
+     *     buffer.writeUint32LE(input.length * 2, 1);
+     *     buffer.write(input, 5, 'utf16le');
+     *   }
+     * }
+     * writeString('hello');
+     * writeString('你好');
+     * ```
+     * @since v23.10.0, v22.15.0
+     */
+    function isStringOneByteRepresentation(content: string): boolean;
+    /**
      * @since v8.0.0
      */
     class Serializer {


### PR DESCRIPTION
A number of v23 APIs were missed from #72589 due to also being backported to the latest v22.x releases and therefore being missed from the branch diffs.

These ideally need merging before the v24 branch starts to get package updates.