### PR TITLE
[dockerode] Fix ConfigFrom type in NetworkCreateOptions

### DIFF
--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -483,7 +483,7 @@ declare namespace Dockerode {
         Attachable?: boolean | undefined;
         Ingress?: boolean | undefined;
         ConfigOnly?: boolean | undefined;
-        ConfigFrom?: { Network?: string } | undefined;
+        ConfigFrom?: { Network: string } | undefined;
         Options?: { [option: string]: string } | undefined;
         Labels?: { [label: string]: string } | undefined;
 


### PR DESCRIPTION
I set NetworkCreateOptions.ConfigFrom previously as `{ Network?: string } | undefined` in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/72881 which is incorrect, as `{ Network: undefined }` / `{}` is not a possible option to pass to NetworkCreateOptions.ConfigFrom. This change aligns the types of ConfigFrom in NetworkCreateOptions with NetworkInspectOptions which was already defined previously.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://github.com/moby/moby/blob/ed1406cb935d74d99a8aadfe553b8b763859ff64/api/types/swarm/network.go#L93
  - https://github.com/moby/moby/blob/ed1406cb935d74d99a8aadfe553b8b763859ff64/api/types/network/network.go#L145
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. (N/A)