### PR TITLE
Correct a few function types in dagre

### DIFF
--- a/types/dagre/dagre-tests.ts
+++ b/types/dagre/dagre-tests.ts
@@ -44,7 +44,7 @@ dagre.graphlib.alg.components(gDagre);
 dagre.graphlib.alg.dijkstra(gDagre, "a", edge => 5);
 dagre.graphlib.alg.dijkstraAll(gDagre);
 dagre.graphlib.alg.findCycles(gDagre);
-dagre.graphlib.alg.floydWarchall(gDagre);
+dagre.graphlib.alg.floydWarshall(gDagre);
 dagre.graphlib.alg.isAcyclic(gDagre);
 dagre.graphlib.alg.postorder(gDagre, "a");
 dagre.graphlib.alg.preorder(gDagre, ["b", "c"]);

--- a/types/dagre/index.d.ts
+++ b/types/dagre/index.d.ts
@@ -37,8 +37,8 @@ export namespace graphlib {
         setDefaultNodeLabel(callback: string | ((nodeId: string) => string | Label)): Graph<T>;
         setNode(name: string, label: string | Label): Graph<T>;
         setParent(childName: string, parentName: string): void;
-        sinks(): Array<Node<T>>;
-        sources(): Array<Node<T>>;
+        sinks(): string[];
+        sources(): string[];
         successors(name: string): Array<Node<T>> | undefined;
     }
 
@@ -49,10 +49,23 @@ export namespace graphlib {
 
     namespace alg {
         function components(graph: Graph): string[][];
-        function dijkstra(graph: Graph, source: string, weightFn?: WeightFn, edgeFn?: EdgeFn): any;
-        function dijkstraAll(graph: Graph, weightFn?: WeightFn, edgeFn?: EdgeFn): any;
+        function dijkstra(
+            graph: Graph,
+            source: string,
+            weightFn?: WeightFn,
+            edgeFn?: EdgeFn,
+        ): Record<string, { distance: number; predecessor?: string }>;
+        function dijkstraAll(
+            graph: Graph,
+            weightFn?: WeightFn,
+            edgeFn?: EdgeFn,
+        ): Record<string, Record<string, { distance: number; predecessor?: string }>>;
         function findCycles(graph: Graph): string[][];
-        function floydWarchall(graph: Graph, weightFn?: WeightFn, edgeFn?: EdgeFn): any;
+        function floydWarshall(
+            graph: Graph,
+            weightFn?: WeightFn,
+            edgeFn?: EdgeFn,
+        ): Record<string, Record<string, { distance: number; predecessor?: string }>>;
         function isAcyclic(graph: Graph): boolean;
         function postorder(graph: Graph, nodeNames: string | string[]): string[];
         function preorder(graph: Graph, nodeNames: string | string[]): string[];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [dagre re-exports graphlib](https://github.com/dagrejs/dagre/blob/master/index.js#L24).
  - [`sources`](https://github.com/dagrejs/graphlib/wiki/API-Reference#sources) and [`sinks`](https://github.com/dagrejs/graphlib/wiki/API-Reference#sinks) return the names of nodes, not full dagre `Node<T>`s, see graphlib's type definitions for [`sources`](https://github.com/dagrejs/graphlib/blob/master/index.d.ts#L415) and [`sinks`](https://github.com/dagrejs/graphlib/blob/master/index.d.ts#L423).
  - [`dijkstra`](https://github.com/dagrejs/graphlib/wiki/API-Reference#alg-dijkstra), [`dijkstraAll`](https://github.com/dagrejs/graphlib/wiki/API-Reference#alg-dijkstra-all), and [`floydWarshall`](https://github.com/dagrejs/graphlib/wiki/API-Reference#alg-floyd-warshall) (not `floydWar**c**hall`, as the existing types assert) all have example results in their docs.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
  - This corrects some mistakes for the existing library version.