### PR TITLE
[@types/node] Add types for `Stream.Readable`

### DIFF
--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -65,22 +65,22 @@ declare module "stream" {
         /**
          * @since v0.9.4
          */
-        class Readable extends Stream implements NodeJS.ReadableStream {
+        class Readable<T = any> extends Stream implements NodeJS.ReadableStream {
             /**
              * A utility method for creating Readable Streams out of iterators.
              * @since v12.3.0, v10.17.0
              * @param iterable Object implementing the `Symbol.asyncIterator` or `Symbol.iterator` iterable protocol. Emits an 'error' event if a null value is passed.
              * @param options Options provided to `new stream.Readable([options])`. By default, `Readable.from()` will set `options.objectMode` to `true`, unless this is explicitly opted out by setting `options.objectMode` to `false`.
              */
-            static from(iterable: Iterable<any> | AsyncIterable<any>, options?: ReadableOptions): Readable;
+            static from<T = any>(iterable: Iterable<T> | AsyncIterable<T>, options?: ReadableOptions): Readable<T>;
             /**
              * A utility method for creating a `Readable` from a web `ReadableStream`.
              * @since v17.0.0
              */
-            static fromWeb(
+            static fromWeb<T = any>(
                 readableStream: streamWeb.ReadableStream,
                 options?: Pick<ReadableOptions, "encoding" | "highWaterMark" | "objectMode" | "signal">,
-            ): Readable;
+            ): Readable<T>;
             /**
              * A utility method for creating a web `ReadableStream` from a `Readable`.
              * @since v17.0.0
@@ -461,7 +461,7 @@ declare module "stream" {
              * @param fn a function to map over every chunk in the stream. Async or not.
              * @returns a stream mapped with the function *fn*.
              */
-            map(fn: (data: any, options?: Pick<ArrayOptions, "signal">) => any, options?: ArrayOptions): Readable;
+            map<U>(fn: (data: T, options?: Pick<ArrayOptions, "signal">) => U, options?: ArrayOptions): Readable<U>;
             /**
              * This method allows filtering the stream. For each chunk in the stream the *fn* function will be called
              * and if it returns a truthy value, the chunk will be passed to the result stream.
@@ -470,10 +470,18 @@ declare module "stream" {
              * @param fn a function to filter chunks from the stream. Async or not.
              * @returns a stream filtered with the predicate *fn*.
              */
-            filter(
-                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
+            filter<U extends T>(
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => data is U,
                 options?: ArrayOptions,
-            ): Readable;
+            ): Readable<U>;
+            filter<U>(
+                fn: (data: unknown, options?: Pick<ArrayOptions, "signal">) => data is U,
+                options?: ArrayOptions,
+            ): Readable<U>;
+            filter(
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
+                options?: ArrayOptions,
+            ): Readable<T>;
             /**
              * This method allows iterating a stream. For each chunk in the stream the *fn* function will be called.
              * If the *fn* function returns a promise - that promise will be `await`ed.
@@ -490,7 +498,7 @@ declare module "stream" {
              * @returns a promise for when the stream has finished.
              */
             forEach(
-                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => void | Promise<void>,
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => void | Promise<void>,
                 options?: ArrayOptions,
             ): Promise<void>;
             /**
@@ -501,7 +509,7 @@ declare module "stream" {
              * @since v17.5.0
              * @returns a promise containing an array with the contents of the stream.
              */
-            toArray(options?: Pick<ArrayOptions, "signal">): Promise<any[]>;
+            toArray(options?: Pick<ArrayOptions, "signal">): Promise<T[]>;
             /**
              * This method is similar to `Array.prototype.some` and calls *fn* on each chunk in the stream
              * until the awaited return value is `true` (or any truthy value). Once an *fn* call on a chunk
@@ -512,7 +520,7 @@ declare module "stream" {
              * @returns a promise evaluating to `true` if *fn* returned a truthy value for at least one of the chunks.
              */
             some(
-                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
                 options?: ArrayOptions,
             ): Promise<boolean>;
             /**
@@ -525,14 +533,18 @@ declare module "stream" {
              * @returns a promise evaluating to the first chunk for which *fn* evaluated with a truthy value,
              * or `undefined` if no element was found.
              */
-            find<T>(
-                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => data is T,
+            find<U extends T>(
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => data is U,
+                options?: ArrayOptions,
+            ): Promise<U | undefined>;
+            find<U>(
+                fn: (data: unknown, options?: Pick<ArrayOptions, "signal">) => data is U,
+                options?: ArrayOptions,
+            ): Promise<U | undefined>;
+            find(
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
                 options?: ArrayOptions,
             ): Promise<T | undefined>;
-            find(
-                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
-                options?: ArrayOptions,
-            ): Promise<any>;
             /**
              * This method is similar to `Array.prototype.every` and calls *fn* on each chunk in the stream
              * to check if all awaited return values are truthy value for *fn*. Once an *fn* call on a chunk
@@ -543,7 +555,7 @@ declare module "stream" {
              * @returns a promise evaluating to `true` if *fn* returned a truthy value for every one of the chunks.
              */
             every(
-                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
                 options?: ArrayOptions,
             ): Promise<boolean>;
             /**
@@ -556,28 +568,28 @@ declare module "stream" {
              * @param fn a function to map over every chunk in the stream. May be async. May be a stream or generator.
              * @returns a stream flat-mapped with the function *fn*.
              */
-            flatMap(fn: (data: any, options?: Pick<ArrayOptions, "signal">) => any, options?: ArrayOptions): Readable;
+            flatMap<U>(fn: (data: T, options?: Pick<ArrayOptions, "signal">) => U, options?: ArrayOptions): Readable<U>;
             /**
              * This method returns a new stream with the first *limit* chunks dropped from the start.
              * @since v17.5.0
              * @param limit the number of chunks to drop from the readable.
              * @returns a stream with *limit* chunks dropped from the start.
              */
-            drop(limit: number, options?: Pick<ArrayOptions, "signal">): Readable;
+            drop(limit: number, options?: Pick<ArrayOptions, "signal">): Readable<T>;
             /**
              * This method returns a new stream with the first *limit* chunks.
              * @since v17.5.0
              * @param limit the number of chunks to take from the readable.
              * @returns a stream with *limit* chunks taken.
              */
-            take(limit: number, options?: Pick<ArrayOptions, "signal">): Readable;
+            take(limit: number, options?: Pick<ArrayOptions, "signal">): Readable<T>;
             /**
              * This method returns a new stream with chunks of the underlying stream paired with a counter
              * in the form `[index, chunk]`. The first index value is `0` and it increases by 1 for each chunk produced.
              * @since v17.5.0
              * @returns a stream of indexed pairs.
              */
-            asIndexedPairs(options?: Pick<ArrayOptions, "signal">): Readable;
+            asIndexedPairs(options?: Pick<ArrayOptions, "signal">): Readable<T>;
             /**
              * This method calls *fn* on each chunk of the stream in order, passing it the result from the calculation
              * on the previous element. It returns a promise for the final value of the reduction.
@@ -592,16 +604,16 @@ declare module "stream" {
              * @param initial the initial value to use in the reduction.
              * @returns a promise for the final value of the reduction.
              */
-            reduce<T = any>(
-                fn: (previous: any, data: any, options?: Pick<ArrayOptions, "signal">) => T,
+            reduce<U = T>(
+                fn: (previous: U, data: T, options?: Pick<ArrayOptions, "signal">) => U,
                 initial?: undefined,
                 options?: Pick<ArrayOptions, "signal">,
-            ): Promise<T>;
-            reduce<T = any>(
-                fn: (previous: T, data: any, options?: Pick<ArrayOptions, "signal">) => T,
-                initial: T,
+            ): Promise<U>;
+            reduce<U = any>(
+                fn: (previous: U, data: T, options?: Pick<ArrayOptions, "signal">) => U,
+                initial: U,
                 options?: Pick<ArrayOptions, "signal">,
-            ): Promise<T>;
+            ): Promise<U>;
             _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
             /**
              * Destroy the stream. Optionally emit an `'error'` event, and emit a `'close'` event (unless `emitClose` is set to `false`). After this call, the readable

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -28,12 +28,12 @@ import { MessageChannel as NodeMC } from "node:worker_threads";
 function simplified_stream_ctor_test() {
     new Readable({
         construct(cb) {
-            // $ExpectType Readable
+            // $ExpectType Readable<any>
             this;
             cb();
         },
         read(size) {
-            // $ExpectType Readable
+            // $ExpectType Readable<any>
             this;
             // $ExpectType number
             size;
@@ -605,11 +605,14 @@ addAbortSignal(new AbortSignal(), new Readable());
 {
     const web = new ReadableStream();
 
-    // $ExpectType Readable
+    // $ExpectType Readable<any>
     Readable.fromWeb(web);
 
+    // $ExpectType Readable<number>
+    Readable.fromWeb<number>(web);
+
     // Handles subset of ReadableOptions param
-    // $ExpectType Readable
+    // $ExpectType Readable<any>
     Readable.fromWeb(web, { objectMode: true });
 
     // When the param includes unsupported ReadableOptions
@@ -675,7 +678,7 @@ addAbortSignal(new AbortSignal(), new Readable());
 }
 
 function testReadableReduce() {
-    const readable = Readable.from([]);
+    const readable = Readable.from([1, 2, 3]);
     // $ExpectType Promise<number>
     readable.reduce((prev, data) => prev * data);
     // $ExpectType Promise<number>
@@ -687,11 +690,42 @@ function testReadableReduce() {
 }
 
 function testReadableFind() {
-    const readable = Readable.from([]);
-    // $ExpectType Promise<any>
+    const readable = Readable.from([1]);
+    // $ExpectType Promise<number | undefined>
     readable.find(Boolean);
     // $ExpectType Promise<any[] | undefined>
     readable.find(Array.isArray);
+    // $ExpectType Promise<number | undefined>
+    readable.find(x => x > 2);
+}
+
+function testReadableMap() {
+    // $ExpectType Readable<number>
+    const readable = Readable.from([1, 2, 3]);
+    // $ExpectType Readable<string>
+    readable.map(i => i.toString());
+}
+
+function testReadableFilter() {
+    // $ExpectType Readable<number>
+    const readable = Readable.from([1, 2, 3]);
+    // $ExpectType Readable<number>
+    readable.filter(i => i > 2);
+}
+
+function testReadableMixedTypes() {
+    // $ExpectType Readable<string | number | boolean>
+    const readable = Readable.from(["a", 1, true]);
+
+    // $ExpectType Readable<number>
+    readable.filter(function(value): value is number {
+        return typeof value === "number";
+    });
+
+    // $ExpectType Readable<boolean>
+    readable.filter(function(value): value is boolean {
+        return typeof value === "boolean";
+    });
 }
 
 async function testReadableStream() {
@@ -788,10 +822,10 @@ async function testTransferringStreamWithPostMessage() {
     // checking the type definitions for the events on the Duplex class and subclasses
     const transform = new Transform();
     transform.on("pipe", (src) => {
-        // $ExpectType Readable
+        // $ExpectType Readable<any>
         src;
     }).once("unpipe", (src) => {
-        // $ExpectType Readable
+        // $ExpectType Readable<any>
         src;
     }).addListener("data", (chunk) => {
         // $ExpectType any

--- a/types/node/v18/stream.d.ts
+++ b/types/node/v18/stream.d.ts
@@ -61,20 +61,23 @@ declare module "stream" {
         /**
          * @since v0.9.4
          */
-        class Readable extends Stream implements NodeJS.ReadableStream {
+        class Readable<T = any> extends Stream implements NodeJS.ReadableStream {
             /**
              * A utility method for creating Readable Streams out of iterators.
+             * @since v12.3.0, v10.17.0
+             * @param iterable Object implementing the `Symbol.asyncIterator` or `Symbol.iterator` iterable protocol. Emits an 'error' event if a null value is passed.
+             * @param options Options provided to `new stream.Readable([options])`. By default, `Readable.from()` will set `options.objectMode` to `true`, unless this is explicitly opted out by setting `options.objectMode` to `false`.
              */
-            static from(iterable: Iterable<any> | AsyncIterable<any>, options?: ReadableOptions): Readable;
+            static from<T = any>(iterable: Iterable<T> | AsyncIterable<T>, options?: ReadableOptions): Readable<T>;
             /**
              * A utility method for creating a `Readable` from a web `ReadableStream`.
              * @since v17.0.0
              * @experimental
              */
-            static fromWeb(
+            static fromWeb<T = any>(
                 readableStream: streamWeb.ReadableStream,
                 options?: Pick<ReadableOptions, "encoding" | "highWaterMark" | "objectMode" | "signal">,
-            ): Readable;
+            ): Readable<T>;
             /**
              * Returns whether the stream has been read from or cancelled.
              * @since v16.8.0
@@ -457,7 +460,7 @@ declare module "stream" {
              * @param fn a function to map over every chunk in the stream. Async or not.
              * @returns a stream mapped with the function *fn*.
              */
-            map(fn: (data: any, options?: Pick<ArrayOptions, "signal">) => any, options?: ArrayOptions): Readable;
+            map<U>(fn: (data: T, options?: Pick<ArrayOptions, "signal">) => U, options?: ArrayOptions): Readable<U>;
             /**
              * This method allows filtering the stream. For each chunk in the stream the *fn* function will be called
              * and if it returns a truthy value, the chunk will be passed to the result stream.
@@ -466,10 +469,18 @@ declare module "stream" {
              * @param fn a function to filter chunks from the stream. Async or not.
              * @returns a stream filtered with the predicate *fn*.
              */
-            filter(
-                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
+            filter<U extends T>(
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => data is U,
                 options?: ArrayOptions,
-            ): Readable;
+            ): Readable<U>;
+            filter<U>(
+                fn: (data: unknown, options?: Pick<ArrayOptions, "signal">) => data is U,
+                options?: ArrayOptions,
+            ): Readable<U>;
+            filter(
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
+                options?: ArrayOptions,
+            ): Readable<T>;
             /**
              * This method allows iterating a stream. For each chunk in the stream the *fn* function will be called.
              * If the *fn* function returns a promise - that promise will be `await`ed.
@@ -486,7 +497,7 @@ declare module "stream" {
              * @returns a promise for when the stream has finished.
              */
             forEach(
-                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => void | Promise<void>,
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => void | Promise<void>,
                 options?: ArrayOptions,
             ): Promise<void>;
             /**
@@ -497,7 +508,7 @@ declare module "stream" {
              * @since v17.5.0
              * @returns a promise containing an array with the contents of the stream.
              */
-            toArray(options?: Pick<ArrayOptions, "signal">): Promise<any[]>;
+            toArray(options?: Pick<ArrayOptions, "signal">): Promise<T[]>;
             /**
              * This method is similar to `Array.prototype.some` and calls *fn* on each chunk in the stream
              * until the awaited return value is `true` (or any truthy value). Once an *fn* call on a chunk
@@ -508,7 +519,7 @@ declare module "stream" {
              * @returns a promise evaluating to `true` if *fn* returned a truthy value for at least one of the chunks.
              */
             some(
-                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
                 options?: ArrayOptions,
             ): Promise<boolean>;
             /**
@@ -521,14 +532,18 @@ declare module "stream" {
              * @returns a promise evaluating to the first chunk for which *fn* evaluated with a truthy value,
              * or `undefined` if no element was found.
              */
-            find<T>(
-                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => data is T,
+            find<U extends T>(
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => data is U,
+                options?: ArrayOptions,
+            ): Promise<U | undefined>;
+            find<U>(
+                fn: (data: unknown, options?: Pick<ArrayOptions, "signal">) => data is U,
+                options?: ArrayOptions,
+            ): Promise<U | undefined>;
+            find(
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
                 options?: ArrayOptions,
             ): Promise<T | undefined>;
-            find(
-                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
-                options?: ArrayOptions,
-            ): Promise<any>;
             /**
              * This method is similar to `Array.prototype.every` and calls *fn* on each chunk in the stream
              * to check if all awaited return values are truthy value for *fn*. Once an *fn* call on a chunk
@@ -539,7 +554,7 @@ declare module "stream" {
              * @returns a promise evaluating to `true` if *fn* returned a truthy value for every one of the chunks.
              */
             every(
-                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
                 options?: ArrayOptions,
             ): Promise<boolean>;
             /**
@@ -552,28 +567,28 @@ declare module "stream" {
              * @param fn a function to map over every chunk in the stream. May be async. May be a stream or generator.
              * @returns a stream flat-mapped with the function *fn*.
              */
-            flatMap(fn: (data: any, options?: Pick<ArrayOptions, "signal">) => any, options?: ArrayOptions): Readable;
+            flatMap<U>(fn: (data: T, options?: Pick<ArrayOptions, "signal">) => U, options?: ArrayOptions): Readable<U>;
             /**
              * This method returns a new stream with the first *limit* chunks dropped from the start.
              * @since v17.5.0
              * @param limit the number of chunks to drop from the readable.
              * @returns a stream with *limit* chunks dropped from the start.
              */
-            drop(limit: number, options?: Pick<ArrayOptions, "signal">): Readable;
+            drop(limit: number, options?: Pick<ArrayOptions, "signal">): Readable<T>;
             /**
              * This method returns a new stream with the first *limit* chunks.
              * @since v17.5.0
              * @param limit the number of chunks to take from the readable.
              * @returns a stream with *limit* chunks taken.
              */
-            take(limit: number, options?: Pick<ArrayOptions, "signal">): Readable;
+            take(limit: number, options?: Pick<ArrayOptions, "signal">): Readable<T>;
             /**
              * This method returns a new stream with chunks of the underlying stream paired with a counter
              * in the form `[index, chunk]`. The first index value is `0` and it increases by 1 for each chunk produced.
              * @since v17.5.0
              * @returns a stream of indexed pairs.
              */
-            asIndexedPairs(options?: Pick<ArrayOptions, "signal">): Readable;
+            asIndexedPairs(options?: Pick<ArrayOptions, "signal">): Readable<T>;
             /**
              * This method calls *fn* on each chunk of the stream in order, passing it the result from the calculation
              * on the previous element. It returns a promise for the final value of the reduction.
@@ -588,16 +603,16 @@ declare module "stream" {
              * @param initial the initial value to use in the reduction.
              * @returns a promise for the final value of the reduction.
              */
-            reduce<T = any>(
-                fn: (previous: any, data: any, options?: Pick<ArrayOptions, "signal">) => T,
+            reduce<U = T>(
+                fn: (previous: U, data: T, options?: Pick<ArrayOptions, "signal">) => U,
                 initial?: undefined,
                 options?: Pick<ArrayOptions, "signal">,
-            ): Promise<T>;
-            reduce<T = any>(
-                fn: (previous: T, data: any, options?: Pick<ArrayOptions, "signal">) => T,
-                initial: T,
+            ): Promise<U>;
+            reduce<U = any>(
+                fn: (previous: U, data: T, options?: Pick<ArrayOptions, "signal">) => U,
+                initial: U,
                 options?: Pick<ArrayOptions, "signal">,
-            ): Promise<T>;
+            ): Promise<U>;
             _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
             /**
              * Destroy the stream. Optionally emit an `'error'` event, and emit a `'close'`event (unless `emitClose` is set to `false`). After this call, the readable

--- a/types/node/v18/test/stream.ts
+++ b/types/node/v18/test/stream.ts
@@ -27,12 +27,12 @@ import { MessageChannel as NodeMC } from "node:worker_threads";
 function simplified_stream_ctor_test() {
     new Readable({
         construct(cb) {
-            // $ExpectType Readable
+            // $ExpectType Readable<any>
             this;
             cb();
         },
         read(size) {
-            // $ExpectType Readable
+            // $ExpectType Readable<any>
             this;
             // $ExpectType number
             size;
@@ -600,11 +600,14 @@ addAbortSignal(new AbortSignal(), new Readable());
 {
     const web = new ReadableStream();
 
-    // $ExpectType Readable
+    // $ExpectType Readable<any>
     Readable.fromWeb(web);
 
+    // $ExpectType Readable<number>
+    Readable.fromWeb<number>(web);
+
     // Handles subset of ReadableOptions param
-    // $ExpectType Readable
+    // $ExpectType Readable<any>
     Readable.fromWeb(web, { objectMode: true });
 
     // When the param includes unsupported ReadableOptions
@@ -708,10 +711,10 @@ async function testTransferringStreamWithPostMessage() {
     // checking the type definitions for the events on the Duplex class and subclasses
     const transform = new Transform();
     transform.on("pipe", (src) => {
-        // $ExpectType Readable
+        // $ExpectType Readable<any>
         src;
     }).once("unpipe", (src) => {
-        // $ExpectType Readable
+        // $ExpectType Readable<any>
         src;
     }).addListener("data", (chunk) => {
         // $ExpectType any

--- a/types/node/v20/stream.d.ts
+++ b/types/node/v20/stream.d.ts
@@ -65,23 +65,23 @@ declare module "stream" {
         /**
          * @since v0.9.4
          */
-        class Readable extends Stream implements NodeJS.ReadableStream {
+        class Readable<T = any> extends Stream implements NodeJS.ReadableStream {
             /**
              * A utility method for creating Readable Streams out of iterators.
              * @since v12.3.0, v10.17.0
              * @param iterable Object implementing the `Symbol.asyncIterator` or `Symbol.iterator` iterable protocol. Emits an 'error' event if a null value is passed.
              * @param options Options provided to `new stream.Readable([options])`. By default, `Readable.from()` will set `options.objectMode` to `true`, unless this is explicitly opted out by setting `options.objectMode` to `false`.
              */
-            static from(iterable: Iterable<any> | AsyncIterable<any>, options?: ReadableOptions): Readable;
+            static from<T = any>(iterable: Iterable<T> | AsyncIterable<T>, options?: ReadableOptions): Readable<T>;
             /**
              * A utility method for creating a `Readable` from a web `ReadableStream`.
              * @since v17.0.0
              * @experimental
              */
-            static fromWeb(
+            static fromWeb<T = any>(
                 readableStream: streamWeb.ReadableStream,
                 options?: Pick<ReadableOptions, "encoding" | "highWaterMark" | "objectMode" | "signal">,
-            ): Readable;
+            ): Readable<T>;
             /**
              * A utility method for creating a web `ReadableStream` from a `Readable`.
              * @since v17.0.0
@@ -465,7 +465,7 @@ declare module "stream" {
              * @param fn a function to map over every chunk in the stream. Async or not.
              * @returns a stream mapped with the function *fn*.
              */
-            map(fn: (data: any, options?: Pick<ArrayOptions, "signal">) => any, options?: ArrayOptions): Readable;
+            map<U>(fn: (data: T, options?: Pick<ArrayOptions, "signal">) => U, options?: ArrayOptions): Readable<U>;
             /**
              * This method allows filtering the stream. For each chunk in the stream the *fn* function will be called
              * and if it returns a truthy value, the chunk will be passed to the result stream.
@@ -474,10 +474,18 @@ declare module "stream" {
              * @param fn a function to filter chunks from the stream. Async or not.
              * @returns a stream filtered with the predicate *fn*.
              */
-            filter(
-                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
+            filter<U extends T>(
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => data is U,
                 options?: ArrayOptions,
-            ): Readable;
+            ): Readable<U>;
+            filter<U>(
+                fn: (data: unknown, options?: Pick<ArrayOptions, "signal">) => data is U,
+                options?: ArrayOptions,
+            ): Readable<U>;
+            filter(
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
+                options?: ArrayOptions,
+            ): Readable<T>;
             /**
              * This method allows iterating a stream. For each chunk in the stream the *fn* function will be called.
              * If the *fn* function returns a promise - that promise will be `await`ed.
@@ -494,7 +502,7 @@ declare module "stream" {
              * @returns a promise for when the stream has finished.
              */
             forEach(
-                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => void | Promise<void>,
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => void | Promise<void>,
                 options?: ArrayOptions,
             ): Promise<void>;
             /**
@@ -505,7 +513,7 @@ declare module "stream" {
              * @since v17.5.0
              * @returns a promise containing an array with the contents of the stream.
              */
-            toArray(options?: Pick<ArrayOptions, "signal">): Promise<any[]>;
+            toArray(options?: Pick<ArrayOptions, "signal">): Promise<T[]>;
             /**
              * This method is similar to `Array.prototype.some` and calls *fn* on each chunk in the stream
              * until the awaited return value is `true` (or any truthy value). Once an *fn* call on a chunk
@@ -516,7 +524,7 @@ declare module "stream" {
              * @returns a promise evaluating to `true` if *fn* returned a truthy value for at least one of the chunks.
              */
             some(
-                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
                 options?: ArrayOptions,
             ): Promise<boolean>;
             /**
@@ -529,14 +537,18 @@ declare module "stream" {
              * @returns a promise evaluating to the first chunk for which *fn* evaluated with a truthy value,
              * or `undefined` if no element was found.
              */
-            find<T>(
-                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => data is T,
+            find<U extends T>(
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => data is U,
+                options?: ArrayOptions,
+            ): Promise<U | undefined>;
+            find<U>(
+                fn: (data: unknown, options?: Pick<ArrayOptions, "signal">) => data is U,
+                options?: ArrayOptions,
+            ): Promise<U | undefined>;
+            find(
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
                 options?: ArrayOptions,
             ): Promise<T | undefined>;
-            find(
-                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
-                options?: ArrayOptions,
-            ): Promise<any>;
             /**
              * This method is similar to `Array.prototype.every` and calls *fn* on each chunk in the stream
              * to check if all awaited return values are truthy value for *fn*. Once an *fn* call on a chunk
@@ -547,7 +559,7 @@ declare module "stream" {
              * @returns a promise evaluating to `true` if *fn* returned a truthy value for every one of the chunks.
              */
             every(
-                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
                 options?: ArrayOptions,
             ): Promise<boolean>;
             /**
@@ -560,28 +572,28 @@ declare module "stream" {
              * @param fn a function to map over every chunk in the stream. May be async. May be a stream or generator.
              * @returns a stream flat-mapped with the function *fn*.
              */
-            flatMap(fn: (data: any, options?: Pick<ArrayOptions, "signal">) => any, options?: ArrayOptions): Readable;
+            flatMap<U>(fn: (data: T, options?: Pick<ArrayOptions, "signal">) => U, options?: ArrayOptions): Readable<U>;
             /**
              * This method returns a new stream with the first *limit* chunks dropped from the start.
              * @since v17.5.0
              * @param limit the number of chunks to drop from the readable.
              * @returns a stream with *limit* chunks dropped from the start.
              */
-            drop(limit: number, options?: Pick<ArrayOptions, "signal">): Readable;
+            drop(limit: number, options?: Pick<ArrayOptions, "signal">): Readable<T>;
             /**
              * This method returns a new stream with the first *limit* chunks.
              * @since v17.5.0
              * @param limit the number of chunks to take from the readable.
              * @returns a stream with *limit* chunks taken.
              */
-            take(limit: number, options?: Pick<ArrayOptions, "signal">): Readable;
+            take(limit: number, options?: Pick<ArrayOptions, "signal">): Readable<T>;
             /**
              * This method returns a new stream with chunks of the underlying stream paired with a counter
              * in the form `[index, chunk]`. The first index value is `0` and it increases by 1 for each chunk produced.
              * @since v17.5.0
              * @returns a stream of indexed pairs.
              */
-            asIndexedPairs(options?: Pick<ArrayOptions, "signal">): Readable;
+            asIndexedPairs(options?: Pick<ArrayOptions, "signal">): Readable<T>;
             /**
              * This method calls *fn* on each chunk of the stream in order, passing it the result from the calculation
              * on the previous element. It returns a promise for the final value of the reduction.
@@ -596,16 +608,16 @@ declare module "stream" {
              * @param initial the initial value to use in the reduction.
              * @returns a promise for the final value of the reduction.
              */
-            reduce<T = any>(
-                fn: (previous: any, data: any, options?: Pick<ArrayOptions, "signal">) => T,
+            reduce<U = T>(
+                fn: (previous: U, data: T, options?: Pick<ArrayOptions, "signal">) => U,
                 initial?: undefined,
                 options?: Pick<ArrayOptions, "signal">,
-            ): Promise<T>;
-            reduce<T = any>(
-                fn: (previous: T, data: any, options?: Pick<ArrayOptions, "signal">) => T,
-                initial: T,
+            ): Promise<U>;
+            reduce<U = any>(
+                fn: (previous: U, data: T, options?: Pick<ArrayOptions, "signal">) => U,
+                initial: U,
                 options?: Pick<ArrayOptions, "signal">,
-            ): Promise<T>;
+            ): Promise<U>;
             _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
             /**
              * Destroy the stream. Optionally emit an `'error'` event, and emit a `'close'` event (unless `emitClose` is set to `false`). After this call, the readable

--- a/types/node/v20/test/stream.ts
+++ b/types/node/v20/test/stream.ts
@@ -28,12 +28,12 @@ import { MessageChannel as NodeMC } from "node:worker_threads";
 function simplified_stream_ctor_test() {
     new Readable({
         construct(cb) {
-            // $ExpectType Readable
+            // $ExpectType Readable<any>
             this;
             cb();
         },
         read(size) {
-            // $ExpectType Readable
+            // $ExpectType Readable<any>
             this;
             // $ExpectType number
             size;
@@ -605,11 +605,14 @@ addAbortSignal(new AbortSignal(), new Readable());
 {
     const web = new ReadableStream();
 
-    // $ExpectType Readable
+    // $ExpectType Readable<any>
     Readable.fromWeb(web);
 
+    // $ExpectType Readable<number>
+    Readable.fromWeb<number>(web);
+
     // Handles subset of ReadableOptions param
-    // $ExpectType Readable
+    // $ExpectType Readable<any>
     Readable.fromWeb(web, { objectMode: true });
 
     // When the param includes unsupported ReadableOptions
@@ -675,7 +678,7 @@ addAbortSignal(new AbortSignal(), new Readable());
 }
 
 function testReadableReduce() {
-    const readable = Readable.from([]);
+    const readable = Readable.from([1, 2, 3]);
     // $ExpectType Promise<number>
     readable.reduce((prev, data) => prev * data);
     // $ExpectType Promise<number>
@@ -687,11 +690,27 @@ function testReadableReduce() {
 }
 
 function testReadableFind() {
-    const readable = Readable.from([]);
-    // $ExpectType Promise<any>
+    const readable = Readable.from([1]);
+    // $ExpectType Promise<number | undefined>
     readable.find(Boolean);
     // $ExpectType Promise<any[] | undefined>
     readable.find(Array.isArray);
+    // $ExpectType Promise<number | undefined>
+    readable.find(x => x > 2);
+}
+
+function testReadableMap() {
+    // $ExpectType Readable<number>
+    const readable = Readable.from([1, 2, 3]);
+    // $ExpectType Readable<string>
+    readable.map(i => i.toString());
+}
+
+function testReadableFilter() {
+    // $ExpectType Readable<number>
+    const readable = Readable.from([1, 2, 3]);
+    // $ExpectType Readable<number>
+    readable.filter(i => i > 2);
 }
 
 async function testReadableStream() {
@@ -788,10 +807,10 @@ async function testTransferringStreamWithPostMessage() {
     // checking the type definitions for the events on the Duplex class and subclasses
     const transform = new Transform();
     transform.on("pipe", (src) => {
-        // $ExpectType Readable
+        // $ExpectType Readable<any>
         src;
     }).once("unpipe", (src) => {
-        // $ExpectType Readable
+        // $ExpectType Readable<any>
         src;
     }).addListener("data", (chunk) => {
         // $ExpectType any

--- a/types/node/v22/stream.d.ts
+++ b/types/node/v22/stream.d.ts
@@ -65,23 +65,23 @@ declare module "stream" {
         /**
          * @since v0.9.4
          */
-        class Readable extends Stream implements NodeJS.ReadableStream {
+        class Readable<T = any> extends Stream implements NodeJS.ReadableStream {
             /**
              * A utility method for creating Readable Streams out of iterators.
              * @since v12.3.0, v10.17.0
              * @param iterable Object implementing the `Symbol.asyncIterator` or `Symbol.iterator` iterable protocol. Emits an 'error' event if a null value is passed.
              * @param options Options provided to `new stream.Readable([options])`. By default, `Readable.from()` will set `options.objectMode` to `true`, unless this is explicitly opted out by setting `options.objectMode` to `false`.
              */
-            static from(iterable: Iterable<any> | AsyncIterable<any>, options?: ReadableOptions): Readable;
+            static from<T = any>(iterable: Iterable<T> | AsyncIterable<T>, options?: ReadableOptions): Readable<T>;
             /**
              * A utility method for creating a `Readable` from a web `ReadableStream`.
              * @since v17.0.0
              * @experimental
              */
-            static fromWeb(
+            static fromWeb<T = any>(
                 readableStream: streamWeb.ReadableStream,
                 options?: Pick<ReadableOptions, "encoding" | "highWaterMark" | "objectMode" | "signal">,
-            ): Readable;
+            ): Readable<T>;
             /**
              * A utility method for creating a web `ReadableStream` from a `Readable`.
              * @since v17.0.0
@@ -465,7 +465,7 @@ declare module "stream" {
              * @param fn a function to map over every chunk in the stream. Async or not.
              * @returns a stream mapped with the function *fn*.
              */
-            map(fn: (data: any, options?: Pick<ArrayOptions, "signal">) => any, options?: ArrayOptions): Readable;
+            map<U>(fn: (data: T, options?: Pick<ArrayOptions, "signal">) => U, options?: ArrayOptions): Readable<U>;
             /**
              * This method allows filtering the stream. For each chunk in the stream the *fn* function will be called
              * and if it returns a truthy value, the chunk will be passed to the result stream.
@@ -474,10 +474,18 @@ declare module "stream" {
              * @param fn a function to filter chunks from the stream. Async or not.
              * @returns a stream filtered with the predicate *fn*.
              */
-            filter(
-                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
+            filter<U extends T>(
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => data is U,
                 options?: ArrayOptions,
-            ): Readable;
+            ): Readable<U>;
+            filter<U>(
+                fn: (data: unknown, options?: Pick<ArrayOptions, "signal">) => data is U,
+                options?: ArrayOptions,
+            ): Readable<U>;
+            filter(
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
+                options?: ArrayOptions,
+            ): Readable<T>;
             /**
              * This method allows iterating a stream. For each chunk in the stream the *fn* function will be called.
              * If the *fn* function returns a promise - that promise will be `await`ed.
@@ -494,7 +502,7 @@ declare module "stream" {
              * @returns a promise for when the stream has finished.
              */
             forEach(
-                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => void | Promise<void>,
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => void | Promise<void>,
                 options?: ArrayOptions,
             ): Promise<void>;
             /**
@@ -505,7 +513,7 @@ declare module "stream" {
              * @since v17.5.0
              * @returns a promise containing an array with the contents of the stream.
              */
-            toArray(options?: Pick<ArrayOptions, "signal">): Promise<any[]>;
+            toArray(options?: Pick<ArrayOptions, "signal">): Promise<T[]>;
             /**
              * This method is similar to `Array.prototype.some` and calls *fn* on each chunk in the stream
              * until the awaited return value is `true` (or any truthy value). Once an *fn* call on a chunk
@@ -516,7 +524,7 @@ declare module "stream" {
              * @returns a promise evaluating to `true` if *fn* returned a truthy value for at least one of the chunks.
              */
             some(
-                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
                 options?: ArrayOptions,
             ): Promise<boolean>;
             /**
@@ -529,14 +537,18 @@ declare module "stream" {
              * @returns a promise evaluating to the first chunk for which *fn* evaluated with a truthy value,
              * or `undefined` if no element was found.
              */
-            find<T>(
-                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => data is T,
+            find<U extends T>(
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => data is U,
+                options?: ArrayOptions,
+            ): Promise<U | undefined>;
+            find<U>(
+                fn: (data: unknown, options?: Pick<ArrayOptions, "signal">) => data is U,
+                options?: ArrayOptions,
+            ): Promise<U | undefined>;
+            find(
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
                 options?: ArrayOptions,
             ): Promise<T | undefined>;
-            find(
-                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
-                options?: ArrayOptions,
-            ): Promise<any>;
             /**
              * This method is similar to `Array.prototype.every` and calls *fn* on each chunk in the stream
              * to check if all awaited return values are truthy value for *fn*. Once an *fn* call on a chunk
@@ -547,7 +559,7 @@ declare module "stream" {
              * @returns a promise evaluating to `true` if *fn* returned a truthy value for every one of the chunks.
              */
             every(
-                fn: (data: any, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
+                fn: (data: T, options?: Pick<ArrayOptions, "signal">) => boolean | Promise<boolean>,
                 options?: ArrayOptions,
             ): Promise<boolean>;
             /**
@@ -560,28 +572,28 @@ declare module "stream" {
              * @param fn a function to map over every chunk in the stream. May be async. May be a stream or generator.
              * @returns a stream flat-mapped with the function *fn*.
              */
-            flatMap(fn: (data: any, options?: Pick<ArrayOptions, "signal">) => any, options?: ArrayOptions): Readable;
+            flatMap<U>(fn: (data: T, options?: Pick<ArrayOptions, "signal">) => U, options?: ArrayOptions): Readable<U>;
             /**
              * This method returns a new stream with the first *limit* chunks dropped from the start.
              * @since v17.5.0
              * @param limit the number of chunks to drop from the readable.
              * @returns a stream with *limit* chunks dropped from the start.
              */
-            drop(limit: number, options?: Pick<ArrayOptions, "signal">): Readable;
+            drop(limit: number, options?: Pick<ArrayOptions, "signal">): Readable<T>;
             /**
              * This method returns a new stream with the first *limit* chunks.
              * @since v17.5.0
              * @param limit the number of chunks to take from the readable.
              * @returns a stream with *limit* chunks taken.
              */
-            take(limit: number, options?: Pick<ArrayOptions, "signal">): Readable;
+            take(limit: number, options?: Pick<ArrayOptions, "signal">): Readable<T>;
             /**
              * This method returns a new stream with chunks of the underlying stream paired with a counter
              * in the form `[index, chunk]`. The first index value is `0` and it increases by 1 for each chunk produced.
              * @since v17.5.0
              * @returns a stream of indexed pairs.
              */
-            asIndexedPairs(options?: Pick<ArrayOptions, "signal">): Readable;
+            asIndexedPairs(options?: Pick<ArrayOptions, "signal">): Readable<T>;
             /**
              * This method calls *fn* on each chunk of the stream in order, passing it the result from the calculation
              * on the previous element. It returns a promise for the final value of the reduction.
@@ -596,16 +608,16 @@ declare module "stream" {
              * @param initial the initial value to use in the reduction.
              * @returns a promise for the final value of the reduction.
              */
-            reduce<T = any>(
-                fn: (previous: any, data: any, options?: Pick<ArrayOptions, "signal">) => T,
+            reduce<U = T>(
+                fn: (previous: U, data: T, options?: Pick<ArrayOptions, "signal">) => U,
                 initial?: undefined,
                 options?: Pick<ArrayOptions, "signal">,
-            ): Promise<T>;
-            reduce<T = any>(
-                fn: (previous: T, data: any, options?: Pick<ArrayOptions, "signal">) => T,
-                initial: T,
+            ): Promise<U>;
+            reduce<U = any>(
+                fn: (previous: U, data: T, options?: Pick<ArrayOptions, "signal">) => U,
+                initial: U,
                 options?: Pick<ArrayOptions, "signal">,
-            ): Promise<T>;
+            ): Promise<U>;
             _destroy(error: Error | null, callback: (error?: Error | null) => void): void;
             /**
              * Destroy the stream. Optionally emit an `'error'` event, and emit a `'close'` event (unless `emitClose` is set to `false`). After this call, the readable

--- a/types/node/v22/test/stream.ts
+++ b/types/node/v22/test/stream.ts
@@ -28,12 +28,12 @@ import { MessageChannel as NodeMC } from "node:worker_threads";
 function simplified_stream_ctor_test() {
     new Readable({
         construct(cb) {
-            // $ExpectType Readable
+            // $ExpectType Readable<any>
             this;
             cb();
         },
         read(size) {
-            // $ExpectType Readable
+            // $ExpectType Readable<any>
             this;
             // $ExpectType number
             size;
@@ -605,11 +605,14 @@ addAbortSignal(new AbortSignal(), new Readable());
 {
     const web = new ReadableStream();
 
-    // $ExpectType Readable
+    // $ExpectType Readable<any>
     Readable.fromWeb(web);
 
+    // $ExpectType Readable<number>
+    Readable.fromWeb<number>(web);
+
     // Handles subset of ReadableOptions param
-    // $ExpectType Readable
+    // $ExpectType Readable<any>
     Readable.fromWeb(web, { objectMode: true });
 
     // When the param includes unsupported ReadableOptions
@@ -675,7 +678,7 @@ addAbortSignal(new AbortSignal(), new Readable());
 }
 
 function testReadableReduce() {
-    const readable = Readable.from([]);
+    const readable = Readable.from([1, 2, 3]);
     // $ExpectType Promise<number>
     readable.reduce((prev, data) => prev * data);
     // $ExpectType Promise<number>
@@ -687,11 +690,27 @@ function testReadableReduce() {
 }
 
 function testReadableFind() {
-    const readable = Readable.from([]);
-    // $ExpectType Promise<any>
+    const readable = Readable.from([1]);
+    // $ExpectType Promise<number | undefined>
     readable.find(Boolean);
     // $ExpectType Promise<any[] | undefined>
     readable.find(Array.isArray);
+    // $ExpectType Promise<number | undefined>
+    readable.find(x => x > 2);
+}
+
+function testReadableMap() {
+    // $ExpectType Readable<number>
+    const readable = Readable.from([1, 2, 3]);
+    // $ExpectType Readable<string>
+    readable.map(i => i.toString());
+}
+
+function testReadableFilter() {
+    // $ExpectType Readable<number>
+    const readable = Readable.from([1, 2, 3]);
+    // $ExpectType Readable<number>
+    readable.filter(i => i > 2);
 }
 
 async function testReadableStream() {
@@ -788,10 +807,10 @@ async function testTransferringStreamWithPostMessage() {
     // checking the type definitions for the events on the Duplex class and subclasses
     const transform = new Transform();
     transform.on("pipe", (src) => {
-        // $ExpectType Readable
+        // $ExpectType Readable<any>
         src;
     }).once("unpipe", (src) => {
-        // $ExpectType Readable
+        // $ExpectType Readable<any>
         src;
     }).addListener("data", (chunk) => {
         // $ExpectType any


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/stream.html#readablemapfn-options
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

# What this does

In short, it provides chainable types to `Readable` for use with the `map`, `filter`, `reduce`, etc Array-like functions.  Before, writing something like this was fairly blind or required explicit type parameters:

```ts
const readable = await Readable.from([1, 2, 3]) // Type is Readable
  .map((x) => x * 2) // x is any - can I multiply x?
  .filter((x) => x > 2) // x is any - is > a valid operation here?
  .toArray(); // result is any[] - need to cast this
```

After this change, the same code is fully typed:

```ts
const readable = await Readable.from([1, 2, 3]) // Type is Readable<number>
  .map((x) => x * 2) // x is number
  .filter((x) => x > 2) // x is number
  .toArray(); // result is number[]
```

I've included changes for v18, v20, v22, and latest (v24).  Readable.map/filter/reduce/etc has been available since v17.5.0, v16.17.0 according to the the History section on [the Stream docs](https://nodejs.org/api/stream.html#readablemapfn-options).  I want to provide these types for users who haven't been able to upgrade to Node 24 yet.