### PR TITLE
Allow readonly array-param for pick* methods

### DIFF
--- a/types/chance/chance-tests.ts
+++ b/types/chance/chance-tests.ts
@@ -59,7 +59,7 @@ const chanceConstructedWithStringSeed = new Chance("test");
 const chanceConstructedWithMultipleParameters = new Chance("test", 1, 1.5);
 
 // Allow picking from readonly arrays
-const arr: readonly number[] = [1,2,3];
+const arr: readonly number[] = [1, 2, 3];
 chance.pickone(arr);
 const picked: number[] = chance.pickset(arr, 2);
 chance.shuffle(arr);

--- a/types/chance/chance-tests.ts
+++ b/types/chance/chance-tests.ts
@@ -58,6 +58,12 @@ const chanceCalledWithSeed100 = Chance();
 const chanceConstructedWithStringSeed = new Chance("test");
 const chanceConstructedWithMultipleParameters = new Chance("test", 1, 1.5);
 
+// Allow picking from readonly arrays
+const arr: readonly number[] = [1,2,3];
+chance.pickone(arr);
+const picked: number[] = chance.pickset(arr, 2);
+chance.shuffle(arr);
+
 // Test new added typed functions
 
 let letter = chance.letter();

--- a/types/chance/index.d.ts
+++ b/types/chance/index.d.ts
@@ -140,15 +140,15 @@ declare namespace Chance {
         /**
          * @deprecated Use pickone
          */
-        pick<T>(arr: T[]): T;
-        pickone<T>(arr: T[]): T;
+        pick<T>(arr: readonly T[]): T;
+        pickone<T>(arr: readonly T[]): T;
         /**
          * @deprecated Use pickset
          */
-        pick<T>(arr: T[], count: number): T[];
-        pickset<T>(arr: T[], count?: number): T[];
+        pick<T>(arr: readonly T[], count: number): T[];
+        pickset<T>(arr: readonly T[], count?: number): T[];
         set: Setter;
-        shuffle<T>(arr: T[]): T[];
+        shuffle<T>(arr: readonly T[]): T[];
 
         // Miscellaneous
         coin(): string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

Existing methods do not modify the passed in `arr` array param. As such, they can accept readonly arrays.
https://github.com/chancejs/chancejs/blob/bd69becf18edce68e140639400d10167c7173674/chance.js#L670

