### PR TITLE
[node] v24.2

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -3771,7 +3771,23 @@ declare module "crypto" {
          */
         checkIP(ip: string): string | undefined;
         /**
-         * Checks whether this certificate was issued by the given `otherCert`.
+         * Checks whether this certificate was potentially issued by the given `otherCert`
+         * by comparing the certificate metadata.
+         *
+         * This is useful for pruning a list of possible issuer certificates which have been
+         * selected using a more rudimentary filtering routine, i.e. just based on subject
+         * and issuer names.
+         *
+         * Finally, to verify that this certificate's signature was produced by a private key
+         * corresponding to `otherCert`'s public key use `x509.verify(publicKey)`
+         * with `otherCert`'s public key represented as a `KeyObject`
+         * like so
+         *
+         * ```js
+         * if (!x509.verify(otherCert.publicKey)) {
+         *   throw new Error('otherCert did not issue x509');
+         * }
+         * ```
          * @since v15.6.0
          */
         checkIssued(otherCert: X509Certificate): boolean;

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -325,13 +325,11 @@ declare module "fs" {
         /**
          * An alias for `dir.close()`.
          * @since v24.1.0
-         * @experimental
          */
         [Symbol.dispose](): void;
         /**
          * An alias for `dir.closeSync()`.
          * @since v24.1.0
-         * @experimental
          */
         [Symbol.asyncDispose](): void;
     }

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -474,8 +474,9 @@ declare module "fs/promises" {
          */
         close(): Promise<void>;
         /**
-         * An alias for {@link FileHandle.close()}.
-         * @since v20.4.0
+         * Calls `filehandle.close()` and returns a promise that fulfills when the
+         * filehandle is closed.
+         * @since v20.4.0, v18.8.0
          */
         [Symbol.asyncDispose](): Promise<void>;
     }

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -88,6 +88,9 @@ declare module "fs/promises" {
         highWaterMark?: number | undefined;
         flush?: boolean | undefined;
     }
+    interface ReadableWebStreamOptions {
+        autoClose?: boolean | undefined;
+    }
     // TODO: Add `EventEmitter` close
     interface FileHandle {
         /**
@@ -261,7 +264,7 @@ declare module "fs/promises" {
          * close the `FileHandle` automatically. User code must still call the`fileHandle.close()` method.
          * @since v17.0.0
          */
-        readableWebStream(): ReadableStream;
+        readableWebStream(options?: ReadableWebStreamOptions): ReadableStream;
         /**
          * Asynchronously reads the entire contents of a file.
          *

--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -1288,6 +1288,14 @@ declare module "http2" {
          * @default 100000
          */
         unknownProtocolTimeout?: number | undefined;
+        /**
+         * If `true`, it turns on strict leading
+         * and trailing whitespace validation for HTTP/2 header field names and values
+         * as per [RFC-9113](https://www.rfc-editor.org/rfc/rfc9113.html#section-8.2.1).
+         * @since v24.2.0
+         * @default true
+         */
+        strictFieldWhitespaceValidation?: boolean | undefined;
     }
     export interface ClientSessionOptions extends SessionOptions {
         /**

--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -32,18 +32,14 @@ declare module "http2" {
         ":scheme"?: string | undefined;
     }
     // Http2Stream
-    export interface StreamPriorityOptions {
-        exclusive?: boolean | undefined;
-        parent?: number | undefined;
-        weight?: number | undefined;
-        silent?: boolean | undefined;
-    }
     export interface StreamState {
         localWindowSize?: number | undefined;
         state?: number | undefined;
         localClose?: number | undefined;
         remoteClose?: number | undefined;
+        /** @deprecated */
         sumDependencyWeight?: number | undefined;
+        /** @deprecated */
         weight?: number | undefined;
     }
     export interface ServerStreamResponseOptions {
@@ -151,10 +147,9 @@ declare module "http2" {
          */
         close(code?: number, callback?: () => void): void;
         /**
-         * Updates the priority for this `Http2Stream` instance.
-         * @since v8.4.0
+         * @deprecated Priority signaling is no longer supported in Node.js.
          */
-        priority(options: StreamPriorityOptions): void;
+        priority(options: unknown): void;
         /**
          * ```js
          * import http2 from 'node:http2';
@@ -395,7 +390,7 @@ declare module "http2" {
         ): void;
         pushStream(
             headers: OutgoingHttpHeaders,
-            options?: StreamPriorityOptions,
+            options?: Pick<ClientSessionRequestOptions, "exclusive" | "parent">,
             callback?: (err: Error | null, pushStream: ServerHttp2Stream, headers: OutgoingHttpHeaders) => void,
         ): void;
         /**
@@ -629,7 +624,6 @@ declare module "http2" {
         endStream?: boolean | undefined;
         exclusive?: boolean | undefined;
         parent?: number | undefined;
-        weight?: number | undefined;
         waitForTrailers?: boolean | undefined;
         signal?: AbortSignal | undefined;
     }

--- a/types/node/inspector.d.ts
+++ b/types/node/inspector.d.ts
@@ -268,7 +268,7 @@ declare module 'inspector' {
             /**
              * Embedder-specific auxiliary data.
              */
-            auxData?: {} | undefined;
+            auxData?: object | undefined;
         }
         /**
          * Detailed information about exception (or error) that was thrown during script compilation or execution.
@@ -701,7 +701,7 @@ declare module 'inspector' {
         }
         interface InspectRequestedEventDataType {
             object: RemoteObject;
-            hints: {};
+            hints: object;
         }
     }
     namespace Debugger {
@@ -1173,7 +1173,7 @@ declare module 'inspector' {
             /**
              * Embedder-specific auxiliary data.
              */
-            executionContextAuxData?: {} | undefined;
+            executionContextAuxData?: object | undefined;
             /**
              * True, if this script is generated as a result of the live edit operation.
              * @experimental
@@ -1237,7 +1237,7 @@ declare module 'inspector' {
             /**
              * Embedder-specific auxiliary data.
              */
-            executionContextAuxData?: {} | undefined;
+            executionContextAuxData?: object | undefined;
             /**
              * URL of source map associated with script (if any).
              */
@@ -1282,7 +1282,7 @@ declare module 'inspector' {
             /**
              * Object containing break-specific auxiliary properties.
              */
-            data?: {} | undefined;
+            data?: object | undefined;
             /**
              * Hit breakpoints IDs
              */
@@ -1649,7 +1649,7 @@ declare module 'inspector' {
             categories: string[];
         }
         interface DataCollectedEventDataType {
-            value: Array<{}>;
+            value: object[];
         }
     }
     namespace NodeWorker {
@@ -1768,11 +1768,25 @@ declare module 'inspector' {
             status: number;
             statusText: string;
             headers: Headers;
+            mimeType: string;
+            charset: string;
         }
         /**
          * Request / response headers as keys / values of JSON object.
          */
         interface Headers {
+        }
+        interface StreamResourceContentParameterType {
+            /**
+             * Identifier of the request to stream.
+             */
+            requestId: RequestId;
+        }
+        interface StreamResourceContentReturnType {
+            /**
+             * Data that has been buffered until streaming is enabled.
+             */
+            bufferedData: string;
         }
         interface RequestWillBeSentEventDataType {
             /**
@@ -1841,6 +1855,29 @@ declare module 'inspector' {
              * Timestamp.
              */
             timestamp: MonotonicTime;
+        }
+        interface DataReceivedEventDataType {
+            /**
+             * Request identifier.
+             */
+            requestId: RequestId;
+            /**
+             * Timestamp.
+             */
+            timestamp: MonotonicTime;
+            /**
+             * Data chunk length.
+             */
+            dataLength: number;
+            /**
+             * Actual bytes received (might be less than dataLength for compressed encodings).
+             */
+            encodedDataLength: number;
+            /**
+             * Data that was received.
+             * @experimental
+             */
+            data?: string | undefined;
         }
     }
     namespace NodeRuntime {
@@ -2249,6 +2286,17 @@ declare module 'inspector' {
          */
         post(method: 'Network.enable', callback?: (err: Error | null) => void): void;
         /**
+         * Enables streaming of the response for the given requestId.
+         * If enabled, the dataReceived event contains the data that was received during streaming.
+         * @experimental
+         */
+        post(
+            method: 'Network.streamResourceContent',
+            params?: Network.StreamResourceContentParameterType,
+            callback?: (err: Error | null, params: Network.StreamResourceContentReturnType) => void
+        ): void;
+        post(method: 'Network.streamResourceContent', callback?: (err: Error | null, params: Network.StreamResourceContentReturnType) => void): void;
+        /**
          * Enable the NodeRuntime events except by `NodeRuntime.waitingForDisconnect`.
          */
         post(method: 'NodeRuntime.enable', callback?: (err: Error | null) => void): void;
@@ -2370,6 +2418,10 @@ declare module 'inspector' {
         addListener(event: 'Network.loadingFailed', listener: (message: InspectorNotification<Network.LoadingFailedEventDataType>) => void): this;
         addListener(event: 'Network.loadingFinished', listener: (message: InspectorNotification<Network.LoadingFinishedEventDataType>) => void): this;
         /**
+         * Fired when data chunk was received over the network.
+         */
+        addListener(event: 'Network.dataReceived', listener: (message: InspectorNotification<Network.DataReceivedEventDataType>) => void): this;
+        /**
          * This event is fired instead of `Runtime.executionContextDestroyed` when
          * enabled.
          * It is fired when the Node process finished all code execution and is
@@ -2414,6 +2466,7 @@ declare module 'inspector' {
         emit(event: 'Network.responseReceived', message: InspectorNotification<Network.ResponseReceivedEventDataType>): boolean;
         emit(event: 'Network.loadingFailed', message: InspectorNotification<Network.LoadingFailedEventDataType>): boolean;
         emit(event: 'Network.loadingFinished', message: InspectorNotification<Network.LoadingFinishedEventDataType>): boolean;
+        emit(event: 'Network.dataReceived', message: InspectorNotification<Network.DataReceivedEventDataType>): boolean;
         emit(event: 'NodeRuntime.waitingForDisconnect'): boolean;
         emit(event: 'NodeRuntime.waitingForDebugger'): boolean;
         emit(event: 'Target.targetCreated', message: InspectorNotification<Target.TargetCreatedEventDataType>): boolean;
@@ -2523,6 +2576,10 @@ declare module 'inspector' {
         on(event: 'Network.responseReceived', listener: (message: InspectorNotification<Network.ResponseReceivedEventDataType>) => void): this;
         on(event: 'Network.loadingFailed', listener: (message: InspectorNotification<Network.LoadingFailedEventDataType>) => void): this;
         on(event: 'Network.loadingFinished', listener: (message: InspectorNotification<Network.LoadingFinishedEventDataType>) => void): this;
+        /**
+         * Fired when data chunk was received over the network.
+         */
+        on(event: 'Network.dataReceived', listener: (message: InspectorNotification<Network.DataReceivedEventDataType>) => void): this;
         /**
          * This event is fired instead of `Runtime.executionContextDestroyed` when
          * enabled.
@@ -2643,6 +2700,10 @@ declare module 'inspector' {
         once(event: 'Network.loadingFailed', listener: (message: InspectorNotification<Network.LoadingFailedEventDataType>) => void): this;
         once(event: 'Network.loadingFinished', listener: (message: InspectorNotification<Network.LoadingFinishedEventDataType>) => void): this;
         /**
+         * Fired when data chunk was received over the network.
+         */
+        once(event: 'Network.dataReceived', listener: (message: InspectorNotification<Network.DataReceivedEventDataType>) => void): this;
+        /**
          * This event is fired instead of `Runtime.executionContextDestroyed` when
          * enabled.
          * It is fired when the Node process finished all code execution and is
@@ -2761,6 +2822,10 @@ declare module 'inspector' {
         prependListener(event: 'Network.responseReceived', listener: (message: InspectorNotification<Network.ResponseReceivedEventDataType>) => void): this;
         prependListener(event: 'Network.loadingFailed', listener: (message: InspectorNotification<Network.LoadingFailedEventDataType>) => void): this;
         prependListener(event: 'Network.loadingFinished', listener: (message: InspectorNotification<Network.LoadingFinishedEventDataType>) => void): this;
+        /**
+         * Fired when data chunk was received over the network.
+         */
+        prependListener(event: 'Network.dataReceived', listener: (message: InspectorNotification<Network.DataReceivedEventDataType>) => void): this;
         /**
          * This event is fired instead of `Runtime.executionContextDestroyed` when
          * enabled.
@@ -2881,6 +2946,10 @@ declare module 'inspector' {
         prependOnceListener(event: 'Network.loadingFailed', listener: (message: InspectorNotification<Network.LoadingFailedEventDataType>) => void): this;
         prependOnceListener(event: 'Network.loadingFinished', listener: (message: InspectorNotification<Network.LoadingFinishedEventDataType>) => void): this;
         /**
+         * Fired when data chunk was received over the network.
+         */
+        prependOnceListener(event: 'Network.dataReceived', listener: (message: InspectorNotification<Network.DataReceivedEventDataType>) => void): this;
+        /**
          * This event is fired instead of `Runtime.executionContextDestroyed` when
          * enabled.
          * It is fired when the Node process finished all code execution and is
@@ -2988,6 +3057,14 @@ declare module 'inspector' {
          * @since v22.6.0
          */
         function requestWillBeSent(params: RequestWillBeSentEventDataType): void;
+        /**
+         * This feature is only available with the `--experimental-network-inspection` flag enabled.
+         *
+         * Broadcasts the `Network.dataReceived` event to connected frontends, or buffers the data if
+         * `Network.streamResourceContent` command was not invoked for the given request yet.
+         * @since v24.2.0
+         */
+        function dataReceived(params: DataReceivedEventDataType): void;
         /**
          * This feature is only available with the `--experimental-network-inspection` flag enabled.
          *
@@ -3374,6 +3451,12 @@ declare module 'inspector/promises' {
          */
         post(method: 'Network.enable'): Promise<void>;
         /**
+         * Enables streaming of the response for the given requestId.
+         * If enabled, the dataReceived event contains the data that was received during streaming.
+         * @experimental
+         */
+        post(method: 'Network.streamResourceContent', params?: Network.StreamResourceContentParameterType): Promise<Network.StreamResourceContentReturnType>;
+        /**
          * Enable the NodeRuntime events except by `NodeRuntime.waitingForDisconnect`.
          */
         post(method: 'NodeRuntime.enable'): Promise<void>;
@@ -3493,6 +3576,10 @@ declare module 'inspector/promises' {
         addListener(event: 'Network.loadingFailed', listener: (message: InspectorNotification<Network.LoadingFailedEventDataType>) => void): this;
         addListener(event: 'Network.loadingFinished', listener: (message: InspectorNotification<Network.LoadingFinishedEventDataType>) => void): this;
         /**
+         * Fired when data chunk was received over the network.
+         */
+        addListener(event: 'Network.dataReceived', listener: (message: InspectorNotification<Network.DataReceivedEventDataType>) => void): this;
+        /**
          * This event is fired instead of `Runtime.executionContextDestroyed` when
          * enabled.
          * It is fired when the Node process finished all code execution and is
@@ -3537,6 +3624,7 @@ declare module 'inspector/promises' {
         emit(event: 'Network.responseReceived', message: InspectorNotification<Network.ResponseReceivedEventDataType>): boolean;
         emit(event: 'Network.loadingFailed', message: InspectorNotification<Network.LoadingFailedEventDataType>): boolean;
         emit(event: 'Network.loadingFinished', message: InspectorNotification<Network.LoadingFinishedEventDataType>): boolean;
+        emit(event: 'Network.dataReceived', message: InspectorNotification<Network.DataReceivedEventDataType>): boolean;
         emit(event: 'NodeRuntime.waitingForDisconnect'): boolean;
         emit(event: 'NodeRuntime.waitingForDebugger'): boolean;
         emit(event: 'Target.targetCreated', message: InspectorNotification<Target.TargetCreatedEventDataType>): boolean;
@@ -3646,6 +3734,10 @@ declare module 'inspector/promises' {
         on(event: 'Network.responseReceived', listener: (message: InspectorNotification<Network.ResponseReceivedEventDataType>) => void): this;
         on(event: 'Network.loadingFailed', listener: (message: InspectorNotification<Network.LoadingFailedEventDataType>) => void): this;
         on(event: 'Network.loadingFinished', listener: (message: InspectorNotification<Network.LoadingFinishedEventDataType>) => void): this;
+        /**
+         * Fired when data chunk was received over the network.
+         */
+        on(event: 'Network.dataReceived', listener: (message: InspectorNotification<Network.DataReceivedEventDataType>) => void): this;
         /**
          * This event is fired instead of `Runtime.executionContextDestroyed` when
          * enabled.
@@ -3766,6 +3858,10 @@ declare module 'inspector/promises' {
         once(event: 'Network.loadingFailed', listener: (message: InspectorNotification<Network.LoadingFailedEventDataType>) => void): this;
         once(event: 'Network.loadingFinished', listener: (message: InspectorNotification<Network.LoadingFinishedEventDataType>) => void): this;
         /**
+         * Fired when data chunk was received over the network.
+         */
+        once(event: 'Network.dataReceived', listener: (message: InspectorNotification<Network.DataReceivedEventDataType>) => void): this;
+        /**
          * This event is fired instead of `Runtime.executionContextDestroyed` when
          * enabled.
          * It is fired when the Node process finished all code execution and is
@@ -3885,6 +3981,10 @@ declare module 'inspector/promises' {
         prependListener(event: 'Network.loadingFailed', listener: (message: InspectorNotification<Network.LoadingFailedEventDataType>) => void): this;
         prependListener(event: 'Network.loadingFinished', listener: (message: InspectorNotification<Network.LoadingFinishedEventDataType>) => void): this;
         /**
+         * Fired when data chunk was received over the network.
+         */
+        prependListener(event: 'Network.dataReceived', listener: (message: InspectorNotification<Network.DataReceivedEventDataType>) => void): this;
+        /**
          * This event is fired instead of `Runtime.executionContextDestroyed` when
          * enabled.
          * It is fired when the Node process finished all code execution and is
@@ -4003,6 +4103,10 @@ declare module 'inspector/promises' {
         prependOnceListener(event: 'Network.responseReceived', listener: (message: InspectorNotification<Network.ResponseReceivedEventDataType>) => void): this;
         prependOnceListener(event: 'Network.loadingFailed', listener: (message: InspectorNotification<Network.LoadingFailedEventDataType>) => void): this;
         prependOnceListener(event: 'Network.loadingFinished', listener: (message: InspectorNotification<Network.LoadingFinishedEventDataType>) => void): this;
+        /**
+         * Fired when data chunk was received over the network.
+         */
+        prependOnceListener(event: 'Network.dataReceived', listener: (message: InspectorNotification<Network.DataReceivedEventDataType>) => void): this;
         /**
          * This event is fired instead of `Runtime.executionContextDestroyed` when
          * enabled.

--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -685,6 +685,30 @@ declare module "module" {
              * @returns The absolute URL string that the specifier would resolve to.
              */
             resolve(specifier: string, parent?: string | URL): string;
+            /**
+             * `true` when the current module is the entry point of the current process; `false` otherwise.
+             *
+             * Equivalent to `require.main === module` in CommonJS.
+             *
+             * Analogous to Python's `__name__ == "__main__"`.
+             *
+             * ```js
+             * export function foo() {
+             *   return 'Hello, world';
+             * }
+             *
+             * function main() {
+             *   const message = foo();
+             *   console.log(message);
+             * }
+             *
+             * if (import.meta.main) main();
+             * // `foo` can be imported from another module without possible side-effects from `main`
+             * ```
+             * @since v24.2.0
+             * @experimental
+             */
+            main: boolean;
         }
         namespace NodeJS {
             interface Module {

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -21,7 +21,7 @@
         }
     },
     "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~7.10.0"
     },
     "devDependencies": {
         "@types/node": "workspace:."

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "24.1.9999",
+    "version": "24.2.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [

--- a/types/node/perf_hooks.d.ts
+++ b/types/node/perf_hooks.d.ts
@@ -813,6 +813,20 @@ declare module "perf_hooks" {
          * @since v11.10.0
          */
         disable(): boolean;
+        /**
+         * Disables the update interval timer when the histogram is disposed.
+         *
+         * ```js
+         * const { monitorEventLoopDelay } = require('node:perf_hooks');
+         * {
+         *   using hist = monitorEventLoopDelay({ resolution: 20 });
+         *   hist.enable();
+         *   // The histogram will be disabled when the block is exited.
+         * }
+         * ```
+         * @since v24.2.0
+         */
+        [Symbol.dispose](): void;
     }
     interface RecordableHistogram extends Histogram {
         /**

--- a/types/node/repl.d.ts
+++ b/types/node/repl.d.ts
@@ -123,6 +123,12 @@ declare module "repl" {
          */
         action: REPLCommandAction;
     }
+    interface REPLServerSetupHistoryOptions {
+        filePath?: string | undefined;
+        size?: number | undefined;
+        removeHistoryDuplicates?: boolean | undefined;
+        onHistoryFileLoaded?: ((err: Error | null, repl: REPLServer) => void) | undefined;
+    }
     /**
      * Instances of `repl.REPLServer` are created using the {@link start} method
      * or directly using the JavaScript `new` keyword.
@@ -316,7 +322,11 @@ declare module "repl" {
          * @param historyPath the path to the history file
          * @param callback called when history writes are ready or upon error
          */
-        setupHistory(path: string, callback: (err: Error | null, repl: this) => void): void;
+        setupHistory(historyPath: string, callback: (err: Error | null, repl: this) => void): void;
+        setupHistory(
+            historyConfig?: REPLServerSetupHistoryOptions,
+            callback?: (err: Error | null, repl: this) => void,
+        ): void;
         /**
          * events.EventEmitter
          * 1. close - inherited from `readline.Interface`

--- a/types/node/scripts/generate-inspector/devtools-protocol-schema.ts
+++ b/types/node/scripts/generate-inspector/devtools-protocol-schema.ts
@@ -30,7 +30,7 @@ export interface ObjectReference {
 }
 
 export type TypeDefinition =
-    | BaseType<"any" | "integer" | "number" | "boolean">
+    | BaseType<"any" | "integer" | "number" | "boolean" | "binary">
     | StringType
     | ArrayType
     | ObjectDefinition;

--- a/types/node/scripts/generate-inspector/generate-substitute-args.ts
+++ b/types/node/scripts/generate-inspector/generate-substitute-args.ts
@@ -4,30 +4,29 @@ import { capitalize, createDocs, filterNull, hasElements, isObjectReference } fr
 
 const INDENT = "    ";
 
-// Turns a type into a type representing an array of that type
-const arrify = (typeString: string) => {
-    return typeString === "{}" ? `Array<${typeString}>` : `${typeString}[]`;
-};
-
 // Converts DevTools type to TS type
 const createTypeString = (type: schema.Field, domain?: string): string => {
-    return isObjectReference(type)
-        ? type.$ref
-        : type.type === "any"
-        ? "any"
-        : type.type === "integer"
-        ? "number"
-        : type.type === "number"
-        ? "number"
-        : type.type === "boolean"
-        ? "boolean"
-        : type.type === "string"
-        ? "string"
-        : type.type === "array"
-        ? arrify(createTypeString(type.items, domain))
-        : type.type === "object"
-        ? "{}"
-        : "never"; // 'never' has yet to be observed
+    if (isObjectReference(type)) {
+        return type.$ref;
+    }
+    switch (type.type) {
+        case "any":
+        case "number":
+        case "boolean":
+        case "string":
+        case "object":
+            return type.type;
+        case "integer":
+            return "number";
+        case "array":
+            return `${createTypeString(type.items, domain)}[]`;
+        case "binary":
+            // The V8 inspector provides these as base64-encoded strings.
+            return "string";
+        default:
+            console.warn(`Warning: unknown PDL type "${type["type"]}"`);
+            return "never";
+    }
 };
 
 // Helper for createInterface -- constructs a list of interface fields

--- a/types/node/scripts/generate-inspector/inspector.d.ts.template
+++ b/types/node/scripts/generate-inspector/inspector.d.ts.template
@@ -169,6 +169,14 @@ declare module 'inspector' {
         /**
          * This feature is only available with the `--experimental-network-inspection` flag enabled.
          *
+         * Broadcasts the `Network.dataReceived` event to connected frontends, or buffers the data if
+         * `Network.streamResourceContent` command was not invoked for the given request yet.
+         * @since v24.2.0
+         */
+        function dataReceived(params: DataReceivedEventDataType): void;
+        /**
+         * This feature is only available with the `--experimental-network-inspection` flag enabled.
+         *
          * Broadcasts the `Network.responseReceived` event to connected frontends. This event indicates that
          * HTTP response is available.
          * @since v22.6.0

--- a/types/node/sqlite.d.ts
+++ b/types/node/sqlite.d.ts
@@ -369,7 +369,6 @@ declare module "node:sqlite" {
          * Closes the database connection. If the database connection is already closed
          * then this is a no-op.
          * @since v22.15.0
-         * @experimental
          */
         [Symbol.dispose](): void;
     }

--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -616,6 +616,17 @@ declare module "stream" {
              */
             destroy(error?: Error): this;
             /**
+             * @returns `AsyncIterator` to fully consume the stream.
+             * @since v10.0.0
+             */
+            [Symbol.asyncIterator](): NodeJS.AsyncIterator<any>;
+            /**
+             * Calls `readable.destroy()` with an `AbortError` and returns
+             * a promise that fulfills when the stream is finished.
+             * @since v20.4.0
+             */
+            [Symbol.asyncDispose](): Promise<void>;
+            /**
              * Event emitter
              * The defined events on documents including:
              * 1. close
@@ -682,12 +693,6 @@ declare module "stream" {
             removeListener(event: "readable", listener: () => void): this;
             removeListener(event: "resume", listener: () => void): this;
             removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
-            [Symbol.asyncIterator](): NodeJS.AsyncIterator<any>;
-            /**
-             * Calls `readable.destroy()` with an `AbortError` and returns a promise that fulfills when the stream is finished.
-             * @since v20.4.0
-             */
-            [Symbol.asyncDispose](): Promise<void>;
         }
         interface WritableOptions<T extends Writable = Writable> extends StreamOptions<T> {
             decodeStrings?: boolean | undefined;
@@ -957,6 +962,12 @@ declare module "stream" {
              * @param error Optional, an error to emit with `'error'` event.
              */
             destroy(error?: Error): this;
+            /**
+             * Calls `writable.destroy()` with an `AbortError` and returns
+             * a promise that fulfills when the stream is finished.
+             * @since v22.4.0, v20.16.0
+             */
+            [Symbol.asyncDispose](): Promise<void>;
             /**
              * Event emitter
              * The defined events on documents including:

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -410,6 +410,7 @@ declare module "node:test" {
             addListener(event: "test:stdout", listener: (data: EventData.TestStdout) => void): this;
             addListener(event: "test:summary", listener: (data: EventData.TestSummary) => void): this;
             addListener(event: "test:watch:drained", listener: () => void): this;
+            addListener(event: "test:watch:restarted", listener: () => void): this;
             addListener(event: string, listener: (...args: any[]) => void): this;
             emit(event: "test:coverage", data: EventData.TestCoverage): boolean;
             emit(event: "test:complete", data: EventData.TestComplete): boolean;
@@ -424,6 +425,7 @@ declare module "node:test" {
             emit(event: "test:stdout", data: EventData.TestStdout): boolean;
             emit(event: "test:summary", data: EventData.TestSummary): boolean;
             emit(event: "test:watch:drained"): boolean;
+            emit(event: "test:watch:restarted"): boolean;
             emit(event: string | symbol, ...args: any[]): boolean;
             on(event: "test:coverage", listener: (data: EventData.TestCoverage) => void): this;
             on(event: "test:complete", listener: (data: EventData.TestComplete) => void): this;
@@ -438,6 +440,7 @@ declare module "node:test" {
             on(event: "test:stdout", listener: (data: EventData.TestStdout) => void): this;
             on(event: "test:summary", listener: (data: EventData.TestSummary) => void): this;
             on(event: "test:watch:drained", listener: () => void): this;
+            on(event: "test:watch:restarted", listener: () => void): this;
             on(event: string, listener: (...args: any[]) => void): this;
             once(event: "test:coverage", listener: (data: EventData.TestCoverage) => void): this;
             once(event: "test:complete", listener: (data: EventData.TestComplete) => void): this;
@@ -452,6 +455,7 @@ declare module "node:test" {
             once(event: "test:stdout", listener: (data: EventData.TestStdout) => void): this;
             once(event: "test:summary", listener: (data: EventData.TestSummary) => void): this;
             once(event: "test:watch:drained", listener: () => void): this;
+            once(event: "test:watch:restarted", listener: () => void): this;
             once(event: string, listener: (...args: any[]) => void): this;
             prependListener(event: "test:coverage", listener: (data: EventData.TestCoverage) => void): this;
             prependListener(event: "test:complete", listener: (data: EventData.TestComplete) => void): this;
@@ -466,6 +470,7 @@ declare module "node:test" {
             prependListener(event: "test:stdout", listener: (data: EventData.TestStdout) => void): this;
             prependListener(event: "test:summary", listener: (data: EventData.TestSummary) => void): this;
             prependListener(event: "test:watch:drained", listener: () => void): this;
+            prependListener(event: "test:watch:restarted", listener: () => void): this;
             prependListener(event: string, listener: (...args: any[]) => void): this;
             prependOnceListener(event: "test:coverage", listener: (data: EventData.TestCoverage) => void): this;
             prependOnceListener(event: "test:complete", listener: (data: EventData.TestComplete) => void): this;
@@ -480,6 +485,7 @@ declare module "node:test" {
             prependOnceListener(event: "test:stdout", listener: (data: EventData.TestStdout) => void): this;
             prependOnceListener(event: "test:summary", listener: (data: EventData.TestSummary) => void): this;
             prependOnceListener(event: "test:watch:drained", listener: () => void): this;
+            prependOnceListener(event: "test:watch:restarted", listener: () => void): this;
             prependOnceListener(event: string, listener: (...args: any[]) => void): this;
         }
         namespace EventData {
@@ -2168,7 +2174,8 @@ declare module "node:test/reporters" {
         | { type: "test:stderr"; data: EventData.TestStderr }
         | { type: "test:stdout"; data: EventData.TestStdout }
         | { type: "test:summary"; data: EventData.TestSummary }
-        | { type: "test:watch:drained"; data: undefined };
+        | { type: "test:watch:drained"; data: undefined }
+        | { type: "test:watch:restarted"; data: undefined };
     type TestEventGenerator = AsyncGenerator<TestEvent, void>;
 
     interface ReporterConstructorWrapper<T extends new(...args: any[]) => Transform> {

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -516,6 +516,14 @@ declare module "node:test" {
                  * The nesting level of the test.
                  */
                 nesting: number;
+                /**
+                 * The severity level of the diagnostic message.
+                 * Possible values are:
+                 * * `'info'`: Informational messages.
+                 * * `'warn'`: Warnings.
+                 * * `'error'`: Errors.
+                 */
+                level: "info" | "warn" | "error";
             }
             interface TestCoverage {
                 /**

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -626,6 +626,7 @@ async function testPromisify() {
     await handle.write(Buffer.from("hurr"), { position: 1 });
 
     handle.readableWebStream();
+    handle.readableWebStream({ autoClose: true });
 
     handle.readLines()[Symbol.asyncIterator](); // $ExpectType AsyncIterator<string, undefined, any>
 });

--- a/types/node/test/http2.ts
+++ b/types/node/test/http2.ts
@@ -265,6 +265,7 @@ import { URL } from "node:url";
         unknownProtocolTimeout: 100000,
         streamResetBurst: 1000,
         streamResetRate: 33,
+        strictFieldWhitespaceValidation: false,
     };
     const secureServerOptions: SecureServerOptions = { ...serverOptions, ca: "..." };
     const onRequestHandler = (request: Http2ServerRequest, response: Http2ServerResponse) => {
@@ -393,6 +394,7 @@ import { URL } from "node:url";
             return new Duplex();
         },
         protocol: "https:",
+        strictFieldWhitespaceValidation: false,
     };
     const secureClientSessionOptions: SecureClientSessionOptions = { ...clientSessionOptions, ca: "..." };
     const onConnectHandler = (session: Http2Session, socket: Socket) => {};
@@ -496,6 +498,7 @@ import { URL } from "node:url";
         unknownProtocolTimeout: 100000,
         streamResetBurst: 1000,
         streamResetRate: 33,
+        strictFieldWhitespaceValidation: false,
     };
 
     const http2Stream: Http2Stream = {} as any;

--- a/types/node/test/http2.ts
+++ b/types/node/test/http2.ts
@@ -96,7 +96,6 @@ import { URL } from "node:url";
         endStream: true,
         exclusive: true,
         parent: 0,
-        weight: 0,
         waitForTrailers: true,
         signal: new AbortController().signal,
     };
@@ -154,13 +153,6 @@ import { URL } from "node:url";
     const destroyed: boolean = http2Stream.destroyed;
     const id: number | undefined = http2Stream.id;
     const pending: boolean = http2Stream.pending;
-
-    http2Stream.priority({
-        exclusive: true,
-        parent: 0,
-        weight: 0,
-        silent: true,
-    });
 
     const sesh: Http2Session | undefined = http2Stream.session;
 

--- a/types/node/test/module.ts
+++ b/types/node/test/module.ts
@@ -115,6 +115,7 @@ Module.Module === Module;
     importmeta.resolve("local", "/parent"); // $ExpectType string
     importmeta.resolve("local", undefined); // $ExpectType string
     importmeta.resolve("local", new URL("https://parent.module")); // $ExpectType string
+    importmeta.main; // $ExpectType boolean
 }
 
 // Globals

--- a/types/node/test/repl.ts
+++ b/types/node/test/repl.ts
@@ -10,6 +10,12 @@ import { Context } from "node:vm";
 
     server.setupHistory("hurr/durr", (err, repl) => {
     });
+    server.setupHistory({
+        filePath: "/tmp/repl_history",
+        onHistoryFileLoaded(err, repl) {
+            repl; // $ExpectType REPLServer
+        },
+    });
 
     server = server.addListener("exit", () => {});
     server = server.addListener("reset", () => {});

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -884,8 +884,8 @@ class TestReporter extends Transform {
                 break;
             }
             case "test:diagnostic": {
-                const { file, column, line, message, nesting } = event.data;
-                callback(null, `${message}/${nesting}/${file}/${column}/${line}`);
+                const { file, column, line, message, nesting, level } = event.data;
+                callback(null, `${message}/${nesting}/${file}/${column}/${line}/${level}`);
                 break;
             }
             case "test:enqueue": {

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -944,6 +944,10 @@ class TestReporter extends Transform {
                 // event doesn't have any data
                 callback(null);
                 break;
+            case "test:watch:restarted":
+                // event doesn't have any data
+                callback(null);
+                break;
             default:
                 callback(null);
         }

--- a/types/node/timers.d.ts
+++ b/types/node/timers.d.ts
@@ -60,7 +60,6 @@ declare module "timers" {
                 /**
                  * Cancels the immediate. This is similar to calling `clearImmediate()`.
                  * @since v20.5.0, v18.18.0
-                 * @experimental
                  */
                 [Symbol.dispose](): void;
                 _onImmediate(...args: any[]): void;
@@ -141,7 +140,6 @@ declare module "timers" {
                 /**
                  * Cancels the timeout.
                  * @since v20.5.0, v18.18.0
-                 * @experimental
                  */
                 [Symbol.dispose](): void;
                 _onTimeout(...args: any[]): void;

--- a/types/node/url.d.ts
+++ b/types/node/url.d.ts
@@ -874,7 +874,7 @@ declare module "url" {
          * Returns an ES6 `Iterator` over each of the name-value pairs in the query.
          * Each item of the iterator is a JavaScript `Array`. The first item of the `Array` is the `name`, the second item of the `Array` is the `value`.
          *
-         * Alias for `urlSearchParams[@@iterator]()`.
+         * Alias for `urlSearchParams[Symbol.iterator]()`.
          */
         entries(): URLSearchParamsIterator<[string, string]>;
         /**

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -431,8 +431,8 @@ declare module "util" {
      * intended for debugging. The output of `util.inspect` may change at any time
      * and should not be depended upon programmatically. Additional `options` may be
      * passed that alter the result.
-     * `util.inspect()` will use the constructor's name and/or `@@toStringTag` to make
-     * an identifiable tag for an inspected value.
+     * `util.inspect()` will use the constructor's name and/or `Symbol.toStringTag`
+     * property to make an identifiable tag for an inspected value.
      *
      * ```js
      * class Foo {

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -2108,6 +2108,7 @@ declare module "util/types" {
      * console.log(myError instanceof Error); // true
      * ```
      * @since v10.0.0
+     * @deprecated The `util.types.isNativeError` API is deprecated. Please use `Error.isError` instead.
      */
     function isNativeError(object: unknown): object is Error;
     /**

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -1172,6 +1172,7 @@ declare module "util" {
         | "hidden"
         | "inverse"
         | "italic"
+        | "none"
         | "overlined"
         | "reset"
         | "strikethrough"
@@ -1227,6 +1228,8 @@ declare module "util" {
      *   util.styleText(['red', 'green'], 'text'), // green
      * );
      * ```
+     *
+     * The special format value `none` applies no additional styling to the text.
      *
      * The full list of formats can be found in [modifiers](https://nodejs.org/docs/latest-v24.x/api/util.html#modifiers).
      * @param format A text format or an Array of text formats defined in `util.inspect.colors`.

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -482,6 +482,18 @@ declare module "worker_threads" {
          * @since v24.0.0
          */
         getHeapStatistics(): Promise<HeapInfo>;
+        /**
+         * Calls `worker.terminate()` when the dispose scope is exited.
+         *
+         * ```js
+         * async function example() {
+         *   await using worker = new Worker('for (;;) {}', { eval: true });
+         *   // Worker is automatically terminate when the scope is exited.
+         * }
+         * ```
+         * @since v24.2.0
+         */
+        [Symbol.asyncDispose](): Promise<void>;
         addListener(event: "error", listener: (err: Error) => void): this;
         addListener(event: "exit", listener: (exitCode: number) => void): this;
         addListener(event: "message", listener: (value: any) => void): this;

--- a/types/node/zlib.d.ts
+++ b/types/node/zlib.d.ts
@@ -176,6 +176,10 @@ declare module "zlib" {
          * @default buffer.kMaxLength
          */
         maxOutputLength?: number | undefined;
+        /**
+         * If `true`, returns an object with `buffer` and `engine`.
+         */
+        info?: boolean | undefined;
     }
     interface Zlib {
         readonly bytesWritten: number;

--- a/types/node/zlib.d.ts
+++ b/types/node/zlib.d.ts
@@ -610,8 +610,6 @@ declare module "zlib" {
     const Z_FINISH: number;
     /** @deprecated Use `constants.Z_BLOCK` */
     const Z_BLOCK: number;
-    /** @deprecated Use `constants.Z_TREES` */
-    const Z_TREES: number;
     // Return codes for the compression/decompression functions.
     // Negative values are errors, positive values are used for special but normal events.
     /** @deprecated Use `constants.Z_OK` */

--- a/types/node/zlib.d.ts
+++ b/types/node/zlib.d.ts
@@ -147,6 +147,10 @@ declare module "zlib" {
          * @default buffer.kMaxLength
          */
         maxOutputLength?: number | undefined;
+        /**
+         * If `true`, returns an object with `buffer` and `engine`.
+         */
+        info?: boolean | undefined;
     }
     interface ZstdOptions {
         /**


### PR DESCRIPTION
- deps: update undici to 7.10.0
- doc: add missing options.info for BrotliOptions
- doc: add missing options.info for ZstdOptions
- doc: clarify x509.checkIssued only checks metadata
- doc: deprecate utilisNativeError in favor of ErrorisError
- doc: graduate Symbol.dispose/asyncDispose from experimental
- doc: remove remaining uses of `@@wellknown` syntax
- esm: implement import.meta.main
- fs: add autoClose option to FileHandle readableWebStream
- http2: remove support for priority signaling
- http2: add lenient flag for RFC-9113
- inspector: add protocol method Network.dataReceived
- perf_hooks: make event loop delay histogram disposable
- repl: extract and standardize history from both repl and interface
- test_runner: emit event when file changes in watch mode
- test_runner: add level parameter to reporter.diagnostic
- util: add 'none' style to styleText
- worker: make Worker async disposable
- zlib: remove mentions of unexposed Z_TREES constant

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V24.md#24.2.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

