### PR TITLE
[node] v24.3

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -3331,6 +3331,12 @@ declare module "fs" {
         persistent?: boolean | undefined;
         recursive?: boolean | undefined;
     }
+    export interface WatchOptionsWithBufferEncoding extends WatchOptions {
+        encoding: "buffer";
+    }
+    export interface WatchOptionsWithStringEncoding extends WatchOptions {
+        encoding?: BufferEncoding | undefined;
+    }
     export type WatchEventType = "rename" | "change";
     export type WatchListener<T> = (event: WatchEventType, filename: T | null) => void;
     export type StatsListener = (curr: Stats, prev: Stats) => void;
@@ -3357,44 +3363,20 @@ declare module "fs" {
      */
     export function watch(
         filename: PathLike,
-        options:
-            | (WatchOptions & {
-                encoding: "buffer";
-            })
-            | "buffer",
-        listener?: WatchListener<Buffer>,
-    ): FSWatcher;
-    /**
-     * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
-     * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
-     * @param options Either the encoding for the filename provided to the listener, or an object optionally specifying encoding, persistent, and recursive options.
-     * If `encoding` is not supplied, the default of `'utf8'` is used.
-     * If `persistent` is not supplied, the default of `true` is used.
-     * If `recursive` is not supplied, the default of `false` is used.
-     */
-    export function watch(
-        filename: PathLike,
-        options?: WatchOptions | BufferEncoding | null,
+        options?: WatchOptionsWithStringEncoding | BufferEncoding | null,
         listener?: WatchListener<string>,
     ): FSWatcher;
-    /**
-     * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
-     * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
-     * @param options Either the encoding for the filename provided to the listener, or an object optionally specifying encoding, persistent, and recursive options.
-     * If `encoding` is not supplied, the default of `'utf8'` is used.
-     * If `persistent` is not supplied, the default of `true` is used.
-     * If `recursive` is not supplied, the default of `false` is used.
-     */
     export function watch(
         filename: PathLike,
-        options: WatchOptions | string,
-        listener?: WatchListener<string | Buffer>,
+        options: WatchOptionsWithBufferEncoding | "buffer",
+        listener: WatchListener<Buffer>,
     ): FSWatcher;
-    /**
-     * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
-     * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
-     */
-    export function watch(filename: PathLike, listener?: WatchListener<string>): FSWatcher;
+    export function watch(
+        filename: PathLike,
+        options: WatchOptions | BufferEncoding | "buffer" | null,
+        listener: WatchListener<string | Buffer>,
+    ): FSWatcher;
+    export function watch(filename: PathLike, listener: WatchListener<string>): FSWatcher;
     /**
      * Test whether or not the given path exists by checking with the file system.
      * Then call the `callback` argument with either true or false:

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -323,15 +323,17 @@ declare module "fs" {
          */
         readSync(): Dirent | null;
         /**
-         * An alias for `dir.close()`.
+         * Calls `dir.close()` if the directory handle is open, and returns a promise that
+         * fulfills when disposal is complete.
+         * @since v24.1.0
+         */
+        [Symbol.asyncDispose](): Promise<void>;
+        /**
+         * Calls `dir.closeSync()` if the directory handle is open, and returns
+         * `undefined`.
          * @since v24.1.0
          */
         [Symbol.dispose](): void;
-        /**
-         * An alias for `dir.closeSync()`.
-         * @since v24.1.0
-         */
-        [Symbol.asyncDispose](): void;
     }
     /**
      * Class: fs.StatWatcher

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -40,7 +40,7 @@ declare module "fs/promises" {
         StatsFs,
         TimeLike,
         WatchEventType,
-        WatchOptions,
+        WatchOptions as _WatchOptions,
         WriteStream,
         WriteVResult,
     } from "node:fs";
@@ -1182,6 +1182,16 @@ declare module "fs/promises" {
      * @return Fulfills with an {fs.Dir}.
      */
     function opendir(path: PathLike, options?: OpenDirOptions): Promise<Dir>;
+    interface WatchOptions extends _WatchOptions {
+        maxQueue?: number | undefined;
+        overflow?: "ignore" | "throw" | undefined;
+    }
+    interface WatchOptionsWithBufferEncoding extends WatchOptions {
+        encoding: "buffer";
+    }
+    interface WatchOptionsWithStringEncoding extends WatchOptions {
+        encoding?: BufferEncoding | undefined;
+    }
     /**
      * Returns an async iterator that watches for changes on `filename`, where `filename`is either a file or a directory.
      *
@@ -1214,33 +1224,16 @@ declare module "fs/promises" {
      */
     function watch(
         filename: PathLike,
-        options:
-            | (WatchOptions & {
-                encoding: "buffer";
-            })
-            | "buffer",
-    ): AsyncIterable<FileChangeInfo<Buffer>>;
-    /**
-     * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
-     * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
-     * @param options Either the encoding for the filename provided to the listener, or an object optionally specifying encoding, persistent, and recursive options.
-     * If `encoding` is not supplied, the default of `'utf8'` is used.
-     * If `persistent` is not supplied, the default of `true` is used.
-     * If `recursive` is not supplied, the default of `false` is used.
-     */
-    function watch(filename: PathLike, options?: WatchOptions | BufferEncoding): AsyncIterable<FileChangeInfo<string>>;
-    /**
-     * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
-     * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
-     * @param options Either the encoding for the filename provided to the listener, or an object optionally specifying encoding, persistent, and recursive options.
-     * If `encoding` is not supplied, the default of `'utf8'` is used.
-     * If `persistent` is not supplied, the default of `true` is used.
-     * If `recursive` is not supplied, the default of `false` is used.
-     */
+        options?: WatchOptionsWithStringEncoding | BufferEncoding,
+    ): NodeJS.AsyncIterator<FileChangeInfo<string>>;
     function watch(
         filename: PathLike,
-        options: WatchOptions | string,
-    ): AsyncIterable<FileChangeInfo<string>> | AsyncIterable<FileChangeInfo<Buffer>>;
+        options: WatchOptionsWithBufferEncoding | "buffer",
+    ): NodeJS.AsyncIterator<FileChangeInfo<Buffer>>;
+    function watch(
+        filename: PathLike,
+        options: WatchOptions | BufferEncoding | "buffer",
+    ): NodeJS.AsyncIterator<FileChangeInfo<string | Buffer>>;
     /**
      * Asynchronously copies the entire directory structure from `src` to `dest`,
      * including subdirectories and files.

--- a/types/node/inspector.d.ts
+++ b/types/node/inspector.d.ts
@@ -1759,6 +1759,7 @@ declare module 'inspector' {
             url: string;
             method: string;
             headers: Headers;
+            hasPostData: boolean;
         }
         /**
          * HTTP response data.
@@ -1776,11 +1777,39 @@ declare module 'inspector' {
          */
         interface Headers {
         }
+        interface GetRequestPostDataParameterType {
+            /**
+             * Identifier of the network request to get content for.
+             */
+            requestId: RequestId;
+        }
+        interface GetResponseBodyParameterType {
+            /**
+             * Identifier of the network request to get content for.
+             */
+            requestId: RequestId;
+        }
         interface StreamResourceContentParameterType {
             /**
              * Identifier of the request to stream.
              */
             requestId: RequestId;
+        }
+        interface GetRequestPostDataReturnType {
+            /**
+             * Request body string, omitting files from multipart requests
+             */
+            postData: string;
+        }
+        interface GetResponseBodyReturnType {
+            /**
+             * Response body.
+             */
+            body: string;
+            /**
+             * True, if content was sent as base64.
+             */
+            base64Encoded: boolean;
         }
         interface StreamResourceContentReturnType {
             /**
@@ -2285,6 +2314,16 @@ declare module 'inspector' {
          * Enables network tracking, network events will now be delivered to the client.
          */
         post(method: 'Network.enable', callback?: (err: Error | null) => void): void;
+        /**
+         * Returns post data sent with the request. Returns an error when no data was sent with the request.
+         */
+        post(method: 'Network.getRequestPostData', params?: Network.GetRequestPostDataParameterType, callback?: (err: Error | null, params: Network.GetRequestPostDataReturnType) => void): void;
+        post(method: 'Network.getRequestPostData', callback?: (err: Error | null, params: Network.GetRequestPostDataReturnType) => void): void;
+        /**
+         * Returns content served for the given request.
+         */
+        post(method: 'Network.getResponseBody', params?: Network.GetResponseBodyParameterType, callback?: (err: Error | null, params: Network.GetResponseBodyReturnType) => void): void;
+        post(method: 'Network.getResponseBody', callback?: (err: Error | null, params: Network.GetResponseBodyReturnType) => void): void;
         /**
          * Enables streaming of the response for the given requestId.
          * If enabled, the dataReceived event contains the data that was received during streaming.
@@ -3062,9 +3101,18 @@ declare module 'inspector' {
          *
          * Broadcasts the `Network.dataReceived` event to connected frontends, or buffers the data if
          * `Network.streamResourceContent` command was not invoked for the given request yet.
+         *
+         * Also enables `Network.getResponseBody` command to retrieve the response data.
          * @since v24.2.0
          */
         function dataReceived(params: DataReceivedEventDataType): void;
+        /**
+         * This feature is only available with the `--experimental-network-inspection` flag enabled.
+         *
+         * Enables `Network.getRequestPostData` command to retrieve the request data.
+         * @since v24.3.0
+         */
+        function dataSent(params: unknown): void;
         /**
          * This feature is only available with the `--experimental-network-inspection` flag enabled.
          *
@@ -3450,6 +3498,14 @@ declare module 'inspector/promises' {
          * Enables network tracking, network events will now be delivered to the client.
          */
         post(method: 'Network.enable'): Promise<void>;
+        /**
+         * Returns post data sent with the request. Returns an error when no data was sent with the request.
+         */
+        post(method: 'Network.getRequestPostData', params?: Network.GetRequestPostDataParameterType): Promise<Network.GetRequestPostDataReturnType>;
+        /**
+         * Returns content served for the given request.
+         */
+        post(method: 'Network.getResponseBody', params?: Network.GetResponseBodyParameterType): Promise<Network.GetResponseBodyReturnType>;
         /**
          * Enables streaming of the response for the given requestId.
          * If enabled, the dataReceived event contains the data that was received during streaming.

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "24.2.9999",
+    "version": "24.3.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [

--- a/types/node/scripts/generate-inspector/inspector.d.ts.template
+++ b/types/node/scripts/generate-inspector/inspector.d.ts.template
@@ -171,9 +171,18 @@ declare module 'inspector' {
          *
          * Broadcasts the `Network.dataReceived` event to connected frontends, or buffers the data if
          * `Network.streamResourceContent` command was not invoked for the given request yet.
+         *
+         * Also enables `Network.getResponseBody` command to retrieve the response data.
          * @since v24.2.0
          */
         function dataReceived(params: DataReceivedEventDataType): void;
+        /**
+         * This feature is only available with the `--experimental-network-inspection` flag enabled.
+         *
+         * Enables `Network.getRequestPostData` command to retrieve the request data.
+         * @since v24.3.0
+         */
+        function dataSent(params: unknown): void;
         /**
          * This feature is only available with the `--experimental-network-inspection` flag enabled.
          *

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -918,11 +918,14 @@ const bigIntStatFs: bigint = bigStatFs.bfree;
 const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Math.random() > 0.5 });
 
 {
-    watchAsync("y33t"); // $ExpectType AsyncIterable<FileChangeInfo<string>>
-    watchAsync("y33t", "buffer"); // $ExpectType AsyncIterable<FileChangeInfo<Buffer>> || AsyncIterable<FileChangeInfo<Buffer<ArrayBufferLike>>>
-    watchAsync("y33t", { encoding: "buffer", signal: new AbortSignal() }); // $ExpectType AsyncIterable<FileChangeInfo<Buffer>> || AsyncIterable<FileChangeInfo<Buffer<ArrayBufferLike>>>
-
-    watchAsync("test", { persistent: true, recursive: true, encoding: "utf-8" }); // $ExpectType AsyncIterable<FileChangeInfo<string>>
+    // $ExpectType AsyncIterator<FileChangeInfo<string>, undefined, any>
+    watchAsync("y33t");
+    // $ExpectType AsyncIterator<FileChangeInfo<Buffer>, undefined, any> || AsyncIterator<FileChangeInfo<Buffer<ArrayBufferLike>>, undefined, any>
+    watchAsync("y33t", "buffer");
+    // $ExpectType AsyncIterator<FileChangeInfo<Buffer>, undefined, any> || AsyncIterator<FileChangeInfo<Buffer<ArrayBufferLike>>, undefined, any>
+    watchAsync("y33t", { encoding: "buffer", signal: new AbortSignal() });
+    // $ExpectType AsyncIterator<FileChangeInfo<string>, undefined, any>
+    watchAsync("test", { persistent: true, recursive: true, encoding: "utf-8", maxQueue: 2048, overflow: "ignore" });
 }
 
 {

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -810,6 +810,26 @@ test("mocks a module", (t) => {
     mock.restore();
 });
 
+test("mocks a property", (t) => {
+    const object = { foo: "bar" };
+    const mockedObject = t.mock.property(object, "foo");
+    // $ExpectType string
+    mockedObject.foo;
+
+    mockedObject.mock.mockImplementation("baz");
+    mockedObject.mock.mockImplementationOnce("bash", 5);
+
+    // $ExpectType number
+    mockedObject.mock.accessCount();
+
+    const access = mockedObject.mock.accesses[0];
+    // $ExpectType string
+    access.value;
+
+    mockedObject.mock.resetAccesses();
+    mockedObject.mock.restore();
+});
+
 // @ts-expect-error
 dot();
 // $ExpectType AsyncGenerator<"\n" | "." | "X", void, unknown> || AsyncGenerator<"\n" | "." | "X", void, any>

--- a/types/node/test/url.ts
+++ b/types/node/test/url.ts
@@ -192,6 +192,12 @@ import * as url from "node:url";
     path = url.fileURLToPath(new url.URL("file://test"));
     path = url.fileURLToPath(new url.URL("file://test"), { windows: false });
     path = url.fileURLToPath(new url.URL("file://test"), { windows: true });
+
+    let buffer: Buffer;
+    buffer = url.fileURLToPathBuffer("file://test");
+    buffer = url.fileURLToPathBuffer("file://test", { windows: true });
+    buffer = url.fileURLToPathBuffer(new url.URL("file://test"));
+    buffer = url.fileURLToPathBuffer(new url.URL("file://test"), { windows: true });
 }
 
 {

--- a/types/node/url.d.ts
+++ b/types/node/url.d.ts
@@ -316,6 +316,17 @@ declare module "url" {
      */
     function fileURLToPath(url: string | URL, options?: FileUrlToPathOptions): string;
     /**
+     * Like `url.fileURLToPath(...)` except that instead of returning a string
+     * representation of the path, a `Buffer` is returned. This conversion is
+     * helpful when the input URL contains percent-encoded segments that are
+     * not valid UTF-8 / Unicode sequences.
+     * @since v24.3.0
+     * @param url The file URL string or URL object to convert to a path.
+     * @returns The fully-resolved platform-specific Node.js file path
+     * as a `Buffer`.
+     */
+    function fileURLToPathBuffer(url: string | URL, options?: FileUrlToPathOptions): Buffer;
+    /**
      * This function ensures that `path` is resolved absolutely, and that the URL
      * control characters are correctly encoded when converting into a File URL.
      *


### PR DESCRIPTION
- **fs:** allow correct handling of burst in fs-events with AsyncIterator
- **fs:** make `Dir` disposers idempotent
- **inspector:** add protocol methods retrieving sent/received data
- **test_runner:** support object property mocking
- **url:** add fileURLToPathBuffer API

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V24.md#24.3.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
