### PR TITLE
node/buffer: Enhance Buffer.fill Type Definitions with Overload Variants for Encoding Parameter Flexibility

### DIFF
--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -1701,6 +1701,8 @@ declare module "buffer" {
              * @return A reference to `buf`.
              */
             fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, offset?: number, encoding?: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, encoding?: BufferEncoding): this;
             /**
              * If `value` is:
              *

--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -1700,9 +1700,10 @@ declare module "buffer" {
              * @param [encoding='utf8'] The encoding for `value` if `value` is a string.
              * @return A reference to `buf`.
              */
-            fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
-            fill(value: string | Uint8Array | number, offset: number, encoding: BufferEncoding): this;
-            fill(value: string | Uint8Array | number, encoding: BufferEncoding): this;
+            fill(value: Uint8Array | number, offset?: number, end?: number): this;
+            fill(value: string, offset?: number, end?: number, encoding?: BufferEncoding): this;
+            fill(value: string, offset: number, encoding: BufferEncoding): this;
+            fill(value: string, encoding: BufferEncoding): this;
             /**
              * If `value` is:
              *

--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -1701,8 +1701,8 @@ declare module "buffer" {
              * @return A reference to `buf`.
              */
             fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
-            fill(value: string | Uint8Array | number, offset: number, encoding: BufferEncoding): this;
-            fill(value: string | Uint8Array | number, encoding: BufferEncoding): this;
+            fill(value: string, offset: number, encoding: BufferEncoding): this;
+            fill(value: string, encoding: BufferEncoding): this;
             /**
              * If `value` is:
              *

--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -1700,10 +1700,9 @@ declare module "buffer" {
              * @param [encoding='utf8'] The encoding for `value` if `value` is a string.
              * @return A reference to `buf`.
              */
-            fill(value: Uint8Array | number, offset?: number, end?: number): this;
-            fill(value: string, offset?: number, end?: number, encoding?: BufferEncoding): this;
-            fill(value: string, offset: number, encoding: BufferEncoding): this;
-            fill(value: string, encoding: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, offset: number, encoding: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, encoding: BufferEncoding): this;
             /**
              * If `value` is:
              *

--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -1701,8 +1701,8 @@ declare module "buffer" {
              * @return A reference to `buf`.
              */
             fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
-            fill(value: string, offset: number, encoding: BufferEncoding): this;
-            fill(value: string, encoding: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, offset: number, encoding: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, encoding: BufferEncoding): this;
             /**
              * If `value` is:
              *

--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -1701,8 +1701,8 @@ declare module "buffer" {
              * @return A reference to `buf`.
              */
             fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
-            fill(value: string | Uint8Array | number, offset?: number, encoding?: BufferEncoding): this;
-            fill(value: string | Uint8Array | number, encoding?: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, offset: number, encoding: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, encoding: BufferEncoding): this;
             /**
              * If `value` is:
              *

--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -367,10 +367,11 @@ result = b.write("asd", 123, 123, "hex");
 
 {
     const buf = Buffer.allocUnsafe(5);
-    buf.fill("a");
-    buf.fill("aazz", "hex");
-    buf.fill("aazz", 1, "hex");
-    buf.fill("aazz", 1, 2, "hex");
+    let result: Buffer;
+    result = buf.fill("a");
+    result = buf.fill("aazz", "hex");
+    result = buf.fill("aazz", 1, "hex");
+    result = buf.fill("aazz", 1, 2, "hex");
 }
 
 (async () => {

--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -243,9 +243,6 @@ result = b.write("asd", "hex");
 result = b.write("asd", 123, "hex");
 result = b.write("asd", 123, 123, "hex");
 
-// fill returns the input buffer.
-b.fill("a").fill("b");
-
 {
     const buffer = new Buffer("123");
     let index: number;

--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -197,7 +197,7 @@ const result2 = Buffer.concat([utf8Buffer, base64Buffer] as readonly Uint8Array[
     const buf: Buffer = Buffer.allocUnsafeSlow(10);
 }
 
-// Class Method byteLenght
+// Class Method byteLength
 {
     let len: number;
     len = Buffer.byteLength("foo");
@@ -366,6 +366,14 @@ b.fill("a").fill("b");
     b = a.readBigUint64LE(123);
     b = a.readBigUInt64BE(123);
     b = a.readBigUint64BE(123);
+}
+
+{
+    const buf = Buffer.allocUnsafe(5);
+    buf.fill("a");
+    buf.fill("aazz", "hex");
+    buf.fill("aazz", 1, "hex");
+    buf.fill("aazz", 1, 2, "hex");
 }
 
 (async () => {

--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -372,6 +372,17 @@ result = b.write("asd", 123, 123, "hex");
     result = buf.fill("aazz", "hex");
     result = buf.fill("aazz", 1, "hex");
     result = buf.fill("aazz", 1, 2, "hex");
+
+    result = buf.fill(1);
+    result = buf.fill(1234, "hex");
+    result = buf.fill(1234, 1, "hex");
+    result = buf.fill(1234, 1, 2, "hex");
+
+    const target = Buffer.allocUnsafe(0);
+    result = buf.fill(target);
+    result = buf.fill(target, "hex");
+    result = buf.fill(target, 1, "hex");
+    result = buf.fill(target, 1, 2, "hex");
 }
 
 (async () => {

--- a/types/node/test/buffer.ts
+++ b/types/node/test/buffer.ts
@@ -373,16 +373,14 @@ result = b.write("asd", 123, 123, "hex");
     result = buf.fill("aazz", 1, "hex");
     result = buf.fill("aazz", 1, 2, "hex");
 
-    result = buf.fill(1);
-    result = buf.fill(1234, "hex");
-    result = buf.fill(1234, 1, "hex");
-    result = buf.fill(1234, 1, 2, "hex");
+    result = buf.fill(1234);
+    result = buf.fill(1234, 1);
+    result = buf.fill(1234, 1, 2);
 
     const target = Buffer.allocUnsafe(0);
     result = buf.fill(target);
-    result = buf.fill(target, "hex");
-    result = buf.fill(target, 1, "hex");
-    result = buf.fill(target, 1, 2, "hex");
+    result = buf.fill(target, 1);
+    result = buf.fill(target, 1, 2);
 }
 
 (async () => {

--- a/types/node/v18/buffer.d.ts
+++ b/types/node/v18/buffer.d.ts
@@ -1680,8 +1680,8 @@ declare module "buffer" {
              * @return A reference to `buf`.
              */
             fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
-            fill(value: string, offset: number, encoding: BufferEncoding): this;
-            fill(value: string, encoding: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, offset: number, encoding: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, encoding: BufferEncoding): this;
             /**
              * If `value` is:
              *

--- a/types/node/v18/buffer.d.ts
+++ b/types/node/v18/buffer.d.ts
@@ -1679,9 +1679,10 @@ declare module "buffer" {
              * @param [encoding='utf8'] The encoding for `value` if `value` is a string.
              * @return A reference to `buf`.
              */
-            fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
-            fill(value: string | Uint8Array | number, offset: number, encoding: BufferEncoding): this;
-            fill(value: string | Uint8Array | number, encoding: BufferEncoding): this;
+            fill(value: Uint8Array | number, offset?: number, end?: number): this;
+            fill(value: string, offset?: number, end?: number, encoding?: BufferEncoding): this;
+            fill(value: string, offset: number, encoding: BufferEncoding): this;
+            fill(value: string, encoding: BufferEncoding): this;
             /**
              * If `value` is:
              *

--- a/types/node/v18/buffer.d.ts
+++ b/types/node/v18/buffer.d.ts
@@ -1680,6 +1680,8 @@ declare module "buffer" {
              * @return A reference to `buf`.
              */
             fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, offset?: number, encoding?: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, encoding?: BufferEncoding): this;
             /**
              * If `value` is:
              *

--- a/types/node/v18/buffer.d.ts
+++ b/types/node/v18/buffer.d.ts
@@ -1679,10 +1679,9 @@ declare module "buffer" {
              * @param [encoding='utf8'] The encoding for `value` if `value` is a string.
              * @return A reference to `buf`.
              */
-            fill(value: Uint8Array | number, offset?: number, end?: number): this;
-            fill(value: string, offset?: number, end?: number, encoding?: BufferEncoding): this;
-            fill(value: string, offset: number, encoding: BufferEncoding): this;
-            fill(value: string, encoding: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, offset: number, encoding: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, encoding: BufferEncoding): this;
             /**
              * If `value` is:
              *

--- a/types/node/v18/buffer.d.ts
+++ b/types/node/v18/buffer.d.ts
@@ -1680,8 +1680,8 @@ declare module "buffer" {
              * @return A reference to `buf`.
              */
             fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
-            fill(value: string | Uint8Array | number, offset: number, encoding: BufferEncoding): this;
-            fill(value: string | Uint8Array | number, encoding: BufferEncoding): this;
+            fill(value: string, offset: number, encoding: BufferEncoding): this;
+            fill(value: string, encoding: BufferEncoding): this;
             /**
              * If `value` is:
              *

--- a/types/node/v18/buffer.d.ts
+++ b/types/node/v18/buffer.d.ts
@@ -1680,8 +1680,8 @@ declare module "buffer" {
              * @return A reference to `buf`.
              */
             fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
-            fill(value: string | Uint8Array | number, offset?: number, encoding?: BufferEncoding): this;
-            fill(value: string | Uint8Array | number, encoding?: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, offset: number, encoding: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, encoding: BufferEncoding): this;
             /**
              * If `value` is:
              *

--- a/types/node/v18/test/buffer.ts
+++ b/types/node/v18/test/buffer.ts
@@ -365,16 +365,14 @@ result = b.write("asd", 123, 123, "hex");
     result = buf.fill("aazz", 1, "hex");
     result = buf.fill("aazz", 1, 2, "hex");
 
-    result = buf.fill(1);
-    result = buf.fill(1234, "hex");
-    result = buf.fill(1234, 1, "hex");
-    result = buf.fill(1234, 1, 2, "hex");
+    result = buf.fill(1234);
+    result = buf.fill(1234, 1);
+    result = buf.fill(1234, 1, 2);
 
     const target = Buffer.allocUnsafe(0);
     result = buf.fill(target);
-    result = buf.fill(target, "hex");
-    result = buf.fill(target, 1, "hex");
-    result = buf.fill(target, 1, 2, "hex");
+    result = buf.fill(target, 1);
+    result = buf.fill(target, 1, 2);
 }
 
 (async () => {

--- a/types/node/v18/test/buffer.ts
+++ b/types/node/v18/test/buffer.ts
@@ -242,9 +242,6 @@ result = b.write("asd", "hex");
 result = b.write("asd", 123, "hex");
 result = b.write("asd", 123, 123, "hex");
 
-// fill returns the input buffer.
-b.fill("a").fill("b");
-
 {
     const buffer = new Buffer("123");
     let index: number;
@@ -358,6 +355,26 @@ b.fill("a").fill("b");
     b = a.readBigUint64LE(123);
     b = a.readBigUInt64BE(123);
     b = a.readBigUint64BE(123);
+}
+
+{
+    const buf = Buffer.allocUnsafe(5);
+    let result: Buffer;
+    result = buf.fill("a");
+    result = buf.fill("aazz", "hex");
+    result = buf.fill("aazz", 1, "hex");
+    result = buf.fill("aazz", 1, 2, "hex");
+
+    result = buf.fill(1);
+    result = buf.fill(1234, "hex");
+    result = buf.fill(1234, 1, "hex");
+    result = buf.fill(1234, 1, 2, "hex");
+
+    const target = Buffer.allocUnsafe(0);
+    result = buf.fill(target);
+    result = buf.fill(target, "hex");
+    result = buf.fill(target, 1, "hex");
+    result = buf.fill(target, 1, 2, "hex");
 }
 
 (async () => {

--- a/types/node/v20/buffer.d.ts
+++ b/types/node/v20/buffer.d.ts
@@ -1703,8 +1703,8 @@ declare module "buffer" {
              * @return A reference to `buf`.
              */
             fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
-            fill(value: string | Uint8Array | number, offset?: number, encoding?: BufferEncoding): this;
-            fill(value: string | Uint8Array | number, encoding?: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, offset: number, encoding: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, encoding: BufferEncoding): this;
             /**
              * If `value` is:
              *

--- a/types/node/v20/buffer.d.ts
+++ b/types/node/v20/buffer.d.ts
@@ -1703,8 +1703,8 @@ declare module "buffer" {
              * @return A reference to `buf`.
              */
             fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
-            fill(value: string | Uint8Array | number, offset: number, encoding: BufferEncoding): this;
-            fill(value: string | Uint8Array | number, encoding: BufferEncoding): this;
+            fill(value: string, offset: number, encoding: BufferEncoding): this;
+            fill(value: string, encoding: BufferEncoding): this;
             /**
              * If `value` is:
              *

--- a/types/node/v20/buffer.d.ts
+++ b/types/node/v20/buffer.d.ts
@@ -1702,9 +1702,10 @@ declare module "buffer" {
              * @param [encoding='utf8'] The encoding for `value` if `value` is a string.
              * @return A reference to `buf`.
              */
-            fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
-            fill(value: string | Uint8Array | number, offset: number, encoding: BufferEncoding): this;
-            fill(value: string | Uint8Array | number, encoding: BufferEncoding): this;
+            fill(value: Uint8Array | number, offset?: number, end?: number): this;
+            fill(value: string, offset?: number, end?: number, encoding?: BufferEncoding): this;
+            fill(value: string, offset: number, encoding: BufferEncoding): this;
+            fill(value: string, encoding: BufferEncoding): this;
             /**
              * If `value` is:
              *

--- a/types/node/v20/buffer.d.ts
+++ b/types/node/v20/buffer.d.ts
@@ -1703,8 +1703,8 @@ declare module "buffer" {
              * @return A reference to `buf`.
              */
             fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
-            fill(value: string, offset: number, encoding: BufferEncoding): this;
-            fill(value: string, encoding: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, offset: number, encoding: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, encoding: BufferEncoding): this;
             /**
              * If `value` is:
              *

--- a/types/node/v20/buffer.d.ts
+++ b/types/node/v20/buffer.d.ts
@@ -1703,6 +1703,8 @@ declare module "buffer" {
              * @return A reference to `buf`.
              */
             fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, offset?: number, encoding?: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, encoding?: BufferEncoding): this;
             /**
              * If `value` is:
              *

--- a/types/node/v20/buffer.d.ts
+++ b/types/node/v20/buffer.d.ts
@@ -1702,10 +1702,9 @@ declare module "buffer" {
              * @param [encoding='utf8'] The encoding for `value` if `value` is a string.
              * @return A reference to `buf`.
              */
-            fill(value: Uint8Array | number, offset?: number, end?: number): this;
-            fill(value: string, offset?: number, end?: number, encoding?: BufferEncoding): this;
-            fill(value: string, offset: number, encoding: BufferEncoding): this;
-            fill(value: string, encoding: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, offset: number, encoding: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, encoding: BufferEncoding): this;
             /**
              * If `value` is:
              *

--- a/types/node/v20/test/buffer.ts
+++ b/types/node/v20/test/buffer.ts
@@ -243,9 +243,6 @@ result = b.write("asd", "hex");
 result = b.write("asd", 123, "hex");
 result = b.write("asd", 123, 123, "hex");
 
-// fill returns the input buffer.
-b.fill("a").fill("b");
-
 {
     const buffer = new Buffer("123");
     let index: number;
@@ -366,6 +363,26 @@ b.fill("a").fill("b");
     b = a.readBigUint64LE(123);
     b = a.readBigUInt64BE(123);
     b = a.readBigUint64BE(123);
+}
+
+{
+    const buf = Buffer.allocUnsafe(5);
+    let result: Buffer;
+    result = buf.fill("a");
+    result = buf.fill("aazz", "hex");
+    result = buf.fill("aazz", 1, "hex");
+    result = buf.fill("aazz", 1, 2, "hex");
+
+    result = buf.fill(1);
+    result = buf.fill(1234, "hex");
+    result = buf.fill(1234, 1, "hex");
+    result = buf.fill(1234, 1, 2, "hex");
+
+    const target = Buffer.allocUnsafe(0);
+    result = buf.fill(target);
+    result = buf.fill(target, "hex");
+    result = buf.fill(target, 1, "hex");
+    result = buf.fill(target, 1, 2, "hex");
 }
 
 (async () => {

--- a/types/node/v20/test/buffer.ts
+++ b/types/node/v20/test/buffer.ts
@@ -373,16 +373,14 @@ result = b.write("asd", 123, 123, "hex");
     result = buf.fill("aazz", 1, "hex");
     result = buf.fill("aazz", 1, 2, "hex");
 
-    result = buf.fill(1);
-    result = buf.fill(1234, "hex");
-    result = buf.fill(1234, 1, "hex");
-    result = buf.fill(1234, 1, 2, "hex");
+    result = buf.fill(1234);
+    result = buf.fill(1234, 1);
+    result = buf.fill(1234, 1, 2);
 
     const target = Buffer.allocUnsafe(0);
     result = buf.fill(target);
-    result = buf.fill(target, "hex");
-    result = buf.fill(target, 1, "hex");
-    result = buf.fill(target, 1, 2, "hex");
+    result = buf.fill(target, 1);
+    result = buf.fill(target, 1, 2);
 }
 
 (async () => {

--- a/types/node/v22/buffer.d.ts
+++ b/types/node/v22/buffer.d.ts
@@ -1701,9 +1701,10 @@ declare module "buffer" {
              * @param [encoding='utf8'] The encoding for `value` if `value` is a string.
              * @return A reference to `buf`.
              */
-            fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
-            fill(value: string | Uint8Array | number, offset: number, encoding: BufferEncoding): this;
-            fill(value: string | Uint8Array | number, encoding: BufferEncoding): this;
+            fill(value: Uint8Array | number, offset?: number, end?: number): this;
+            fill(value: string, offset?: number, end?: number, encoding?: BufferEncoding): this;
+            fill(value: string, offset: number, encoding: BufferEncoding): this;
+            fill(value: string, encoding: BufferEncoding): this;
             /**
              * If `value` is:
              *

--- a/types/node/v22/buffer.d.ts
+++ b/types/node/v22/buffer.d.ts
@@ -1702,8 +1702,8 @@ declare module "buffer" {
              * @return A reference to `buf`.
              */
             fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
-            fill(value: string | Uint8Array | number, offset: number, encoding: BufferEncoding): this;
-            fill(value: string | Uint8Array | number, encoding: BufferEncoding): this;
+            fill(value: string, offset: number, encoding: BufferEncoding): this;
+            fill(value: string, encoding: BufferEncoding): this;
             /**
              * If `value` is:
              *

--- a/types/node/v22/buffer.d.ts
+++ b/types/node/v22/buffer.d.ts
@@ -1702,8 +1702,8 @@ declare module "buffer" {
              * @return A reference to `buf`.
              */
             fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
-            fill(value: string, offset: number, encoding: BufferEncoding): this;
-            fill(value: string, encoding: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, offset: number, encoding: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, encoding: BufferEncoding): this;
             /**
              * If `value` is:
              *

--- a/types/node/v22/buffer.d.ts
+++ b/types/node/v22/buffer.d.ts
@@ -1701,10 +1701,9 @@ declare module "buffer" {
              * @param [encoding='utf8'] The encoding for `value` if `value` is a string.
              * @return A reference to `buf`.
              */
-            fill(value: Uint8Array | number, offset?: number, end?: number): this;
-            fill(value: string, offset?: number, end?: number, encoding?: BufferEncoding): this;
-            fill(value: string, offset: number, encoding: BufferEncoding): this;
-            fill(value: string, encoding: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, offset: number, encoding: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, encoding: BufferEncoding): this;
             /**
              * If `value` is:
              *

--- a/types/node/v22/buffer.d.ts
+++ b/types/node/v22/buffer.d.ts
@@ -1702,8 +1702,8 @@ declare module "buffer" {
              * @return A reference to `buf`.
              */
             fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
-            fill(value: string | Uint8Array | number, offset?: number, encoding?: BufferEncoding): this;
-            fill(value: string | Uint8Array | number, encoding?: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, offset: number, encoding: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, encoding: BufferEncoding): this;
             /**
              * If `value` is:
              *

--- a/types/node/v22/buffer.d.ts
+++ b/types/node/v22/buffer.d.ts
@@ -1702,6 +1702,8 @@ declare module "buffer" {
              * @return A reference to `buf`.
              */
             fill(value: string | Uint8Array | number, offset?: number, end?: number, encoding?: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, offset?: number, encoding?: BufferEncoding): this;
+            fill(value: string | Uint8Array | number, encoding?: BufferEncoding): this;
             /**
              * If `value` is:
              *

--- a/types/node/v22/test/buffer.ts
+++ b/types/node/v22/test/buffer.ts
@@ -243,9 +243,6 @@ result = b.write("asd", "hex");
 result = b.write("asd", 123, "hex");
 result = b.write("asd", 123, 123, "hex");
 
-// fill returns the input buffer.
-b.fill("a").fill("b");
-
 {
     const buffer = new Buffer("123");
     let index: number;
@@ -366,6 +363,26 @@ b.fill("a").fill("b");
     b = a.readBigUint64LE(123);
     b = a.readBigUInt64BE(123);
     b = a.readBigUint64BE(123);
+}
+
+{
+    const buf = Buffer.allocUnsafe(5);
+    let result: Buffer;
+    result = buf.fill("a");
+    result = buf.fill("aazz", "hex");
+    result = buf.fill("aazz", 1, "hex");
+    result = buf.fill("aazz", 1, 2, "hex");
+
+    result = buf.fill(1);
+    result = buf.fill(1234, "hex");
+    result = buf.fill(1234, 1, "hex");
+    result = buf.fill(1234, 1, 2, "hex");
+
+    const target = Buffer.allocUnsafe(0);
+    result = buf.fill(target);
+    result = buf.fill(target, "hex");
+    result = buf.fill(target, 1, "hex");
+    result = buf.fill(target, 1, 2, "hex");
 }
 
 (async () => {

--- a/types/node/v22/test/buffer.ts
+++ b/types/node/v22/test/buffer.ts
@@ -373,16 +373,14 @@ result = b.write("asd", 123, 123, "hex");
     result = buf.fill("aazz", 1, "hex");
     result = buf.fill("aazz", 1, 2, "hex");
 
-    result = buf.fill(1);
-    result = buf.fill(1234, "hex");
-    result = buf.fill(1234, 1, "hex");
-    result = buf.fill(1234, 1, 2, "hex");
+    result = buf.fill(1234);
+    result = buf.fill(1234, 1);
+    result = buf.fill(1234, 1, 2);
 
     const target = Buffer.allocUnsafe(0);
     result = buf.fill(target);
-    result = buf.fill(target, "hex");
-    result = buf.fill(target, 1, "hex");
-    result = buf.fill(target, 1, 2, "hex");
+    result = buf.fill(target, 1);
+    result = buf.fill(target, 1, 2);
 }
 
 (async () => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v24.x/api/buffer.html#buffillvalue-offset-end-encoding
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
