### PR TITLE
fix(node/dns): add missing 'CAA' rrtype for sync & async resolve()

### DIFF
--- a/types/node/dns.d.ts
+++ b/types/node/dns.d.ts
@@ -250,6 +250,9 @@ declare module "dns" {
         contactemail?: string | undefined;
         contactphone?: string | undefined;
     }
+    export interface AnyCaaRecord extends CaaRecord {
+        type: "CAA";
+    }
     export interface MxRecord {
         priority: number;
         exchange: string;
@@ -317,6 +320,7 @@ declare module "dns" {
     export type AnyRecord =
         | AnyARecord
         | AnyAaaaRecord
+        | AnyCaaRecord
         | AnyCnameRecord
         | AnyMxRecord
         | AnyNaptrRecord
@@ -345,12 +349,7 @@ declare module "dns" {
     ): void;
     export function resolve(
         hostname: string,
-        rrtype: "A",
-        callback: (err: NodeJS.ErrnoException | null, addresses: string[]) => void,
-    ): void;
-    export function resolve(
-        hostname: string,
-        rrtype: "AAAA",
+        rrtype: "A" | "AAAA" | "CNAME" | "NS" | "PTR",
         callback: (err: NodeJS.ErrnoException | null, addresses: string[]) => void,
     ): void;
     export function resolve(
@@ -360,8 +359,8 @@ declare module "dns" {
     ): void;
     export function resolve(
         hostname: string,
-        rrtype: "CNAME",
-        callback: (err: NodeJS.ErrnoException | null, addresses: string[]) => void,
+        rrtype: "CAA",
+        callback: (err: NodeJS.ErrnoException | null, address: CaaRecord[]) => void,
     ): void;
     export function resolve(
         hostname: string,
@@ -372,16 +371,6 @@ declare module "dns" {
         hostname: string,
         rrtype: "NAPTR",
         callback: (err: NodeJS.ErrnoException | null, addresses: NaptrRecord[]) => void,
-    ): void;
-    export function resolve(
-        hostname: string,
-        rrtype: "NS",
-        callback: (err: NodeJS.ErrnoException | null, addresses: string[]) => void,
-    ): void;
-    export function resolve(
-        hostname: string,
-        rrtype: "PTR",
-        callback: (err: NodeJS.ErrnoException | null, addresses: string[]) => void,
     ): void;
     export function resolve(
         hostname: string,
@@ -410,6 +399,7 @@ declare module "dns" {
             err: NodeJS.ErrnoException | null,
             addresses:
                 | string[]
+                | CaaRecord[]
                 | MxRecord[]
                 | NaptrRecord[]
                 | SoaRecord
@@ -422,6 +412,7 @@ declare module "dns" {
     export namespace resolve {
         function __promisify__(hostname: string, rrtype?: "A" | "AAAA" | "CNAME" | "NS" | "PTR"): Promise<string[]>;
         function __promisify__(hostname: string, rrtype: "ANY"): Promise<AnyRecord[]>;
+        function __promisify__(hostname: string, rrtype: "CAA"): Promise<CaaRecord[]>;
         function __promisify__(hostname: string, rrtype: "MX"): Promise<MxRecord[]>;
         function __promisify__(hostname: string, rrtype: "NAPTR"): Promise<NaptrRecord[]>;
         function __promisify__(hostname: string, rrtype: "SOA"): Promise<SoaRecord>;
@@ -432,7 +423,15 @@ declare module "dns" {
             hostname: string,
             rrtype: string,
         ): Promise<
-            string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | TlsaRecord[] | string[][] | AnyRecord[]
+            | string[]
+            | CaaRecord[]
+            | MxRecord[]
+            | NaptrRecord[]
+            | SoaRecord
+            | SrvRecord[]
+            | TlsaRecord[]
+            | string[][]
+            | AnyRecord[]
         >;
     }
     /**

--- a/types/node/dns/promises.d.ts
+++ b/types/node/dns/promises.d.ts
@@ -127,24 +127,25 @@ declare module "dns/promises" {
      * @param [rrtype='A'] Resource record type.
      */
     function resolve(hostname: string): Promise<string[]>;
-    function resolve(hostname: string, rrtype: "A"): Promise<string[]>;
-    function resolve(hostname: string, rrtype: "AAAA"): Promise<string[]>;
+    function resolve(hostname: string, rrtype: "A" | "AAAA" | "CNAME" | "NS" | "PTR"): Promise<string[]>;
     function resolve(hostname: string, rrtype: "ANY"): Promise<AnyRecord[]>;
     function resolve(hostname: string, rrtype: "CAA"): Promise<CaaRecord[]>;
-    function resolve(hostname: string, rrtype: "CNAME"): Promise<string[]>;
     function resolve(hostname: string, rrtype: "MX"): Promise<MxRecord[]>;
     function resolve(hostname: string, rrtype: "NAPTR"): Promise<NaptrRecord[]>;
-    function resolve(hostname: string, rrtype: "NS"): Promise<string[]>;
-    function resolve(hostname: string, rrtype: "PTR"): Promise<string[]>;
     function resolve(hostname: string, rrtype: "SOA"): Promise<SoaRecord>;
     function resolve(hostname: string, rrtype: "SRV"): Promise<SrvRecord[]>;
     function resolve(hostname: string, rrtype: "TLSA"): Promise<TlsaRecord[]>;
     function resolve(hostname: string, rrtype: "TXT"): Promise<string[][]>;
-    function resolve(
-        hostname: string,
-        rrtype: string,
-    ): Promise<
-        string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | TlsaRecord[] | string[][] | AnyRecord[]
+    function resolve(hostname: string, rrtype: string): Promise<
+        | string[]
+        | CaaRecord[]
+        | MxRecord[]
+        | NaptrRecord[]
+        | SoaRecord
+        | SrvRecord[]
+        | TlsaRecord[]
+        | string[][]
+        | AnyRecord[]
     >;
     /**
      * Uses the DNS protocol to resolve IPv4 addresses (`A` records) for the `hostname`. On success, the `Promise` is resolved with an array of IPv4

--- a/types/node/test/dns.ts
+++ b/types/node/test/dns.ts
@@ -39,6 +39,7 @@ import {
     TIMEOUT,
     V4MAPPED,
 } from "node:dns";
+import { promisify } from "node:util";
 
 lookup("nodejs.org", (err, address, family) => {
     const _err: NodeJS.ErrnoException | null = err;
@@ -97,21 +98,130 @@ lookupService("127.0.0.1", 0, (err, hostname, service) => {
     const _service: string = service;
 });
 
-resolve("nodejs.org", (err, addresses) => {
-    const _addresses: string[] = addresses;
-});
-resolve("nodejs.org", "A", (err, addresses) => {
-    const _addresses: string[] = addresses;
-});
-resolve("nodejs.org", "AAAA", (err, addresses) => {
-    const _addresses: string[] = addresses;
-});
-resolve("nodejs.org", "ANY", (err, addresses) => {
-    const _addresses: AnyRecord[] = addresses;
-});
-resolve("nodejs.org", "MX", (err, addresses) => {
-    const _addresses: MxRecord[] = addresses;
-});
+{
+    const resolvePromisified = promisify(resolve);
+
+    resolve("nodejs.org", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType string[]
+        addresses;
+    });
+    // $ExpectType Promise<string[]>
+    resolvePromisified("nodejs.org");
+    // $ExpectType Promise<string[]>
+    promises.resolve("nodejs.org");
+
+    resolve("nodejs.org", "" as "A" | "AAAA" | "CNAME" | "NS" | "PTR", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType string[]
+        addresses;
+    });
+    // $ExpectType Promise<string[]>
+    resolvePromisified("nodejs.org", "" as "A" | "AAAA" | "CNAME" | "NS" | "PTR");
+    // $ExpectType Promise<string[]>
+    promises.resolve("nodejs.org", "" as "A" | "AAAA" | "CNAME" | "NS" | "PTR");
+
+    resolve("nodejs.org", "ANY", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType AnyRecord[]
+        addresses;
+    });
+    // $ExpectType Promise<AnyRecord[]>
+    resolvePromisified("nodejs.org", "ANY");
+    // $ExpectType Promise<AnyRecord[]>
+    promises.resolve("nodejs.org", "ANY");
+
+    resolve("nodejs.org", "CAA", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType CaaRecord[]
+        addresses;
+    });
+    // $ExpectType Promise<CaaRecord[]>
+    resolvePromisified("nodejs.org", "CAA");
+    // $ExpectType Promise<CaaRecord[]>
+    promises.resolve("nodejs.org", "CAA");
+
+    resolve("nodejs.org", "MX", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType MxRecord[]
+        addresses;
+    });
+    // $ExpectType Promise<MxRecord[]>
+    resolvePromisified("nodejs.org", "MX");
+    // $ExpectType Promise<MxRecord[]>
+    promises.resolve("nodejs.org", "MX");
+
+    resolve("nodejs.org", "NAPTR", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType NaptrRecord[]
+        addresses;
+    });
+    // $ExpectType Promise<NaptrRecord[]>
+    resolvePromisified("nodejs.org", "NAPTR");
+    // $ExpectType Promise<NaptrRecord[]>
+    promises.resolve("nodejs.org", "NAPTR");
+
+    resolve("nodejs.org", "SOA", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType SoaRecord
+        addresses;
+    });
+    // $ExpectType Promise<SoaRecord>
+    resolvePromisified("nodejs.org", "SOA");
+    // $ExpectType Promise<SoaRecord>
+    promises.resolve("nodejs.org", "SOA");
+
+    resolve("nodejs.org", "SRV", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType SrvRecord[]
+        addresses;
+    });
+    // $ExpectType Promise<SrvRecord[]>
+    resolvePromisified("nodejs.org", "SRV");
+    // $ExpectType Promise<SrvRecord[]>
+    promises.resolve("nodejs.org", "SRV");
+
+    resolve("nodejs.org", "TLSA", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType TlsaRecord[]
+        addresses;
+    });
+    // $ExpectType Promise<TlsaRecord[]>
+    resolvePromisified("nodejs.org", "TLSA");
+    // $ExpectType Promise<TlsaRecord[]>
+    promises.resolve("nodejs.org", "TLSA");
+
+    resolve("nodejs.org", "TXT", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType string[][]
+        addresses;
+    });
+    // $ExpectType Promise<string[][]>
+    resolvePromisified("nodejs.org", "TXT");
+    // $ExpectType Promise<string[][]>
+    promises.resolve("nodejs.org", "TXT");
+
+    resolve("nodejs.org", "unknown", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType string[] | SoaRecord | AnyRecord[] | CaaRecord[] | MxRecord[] | NaptrRecord[] | SrvRecord[] | TlsaRecord[] | string[][]
+        addresses;
+    });
+    // $ExpectType Promise<string[] | SoaRecord | AnyRecord[] | CaaRecord[] | MxRecord[] | NaptrRecord[] | SrvRecord[] | TlsaRecord[] | string[][]>
+    resolvePromisified("nodejs.org", "unknown");
+    // $ExpectType Promise<string[] | SoaRecord | AnyRecord[] | CaaRecord[] | MxRecord[] | NaptrRecord[] | SrvRecord[] | TlsaRecord[] | string[][]>
+    promises.resolve("nodejs.org", "unknown");
+}
 
 resolve4("nodejs.org", (err, addresses) => {
     const _addresses: string[] = addresses;

--- a/types/node/v18/dns.d.ts
+++ b/types/node/v18/dns.d.ts
@@ -240,6 +240,9 @@ declare module "dns" {
         contactemail?: string | undefined;
         contactphone?: string | undefined;
     }
+    export interface AnyCaaRecord extends CaaRecord {
+        type: "CAA";
+    }
     export interface MxRecord {
         priority: number;
         exchange: string;
@@ -298,6 +301,7 @@ declare module "dns" {
     export type AnyRecord =
         | AnyARecord
         | AnyAaaaRecord
+        | AnyCaaRecord
         | AnyCnameRecord
         | AnyMxRecord
         | AnyNaptrRecord
@@ -325,12 +329,7 @@ declare module "dns" {
     ): void;
     export function resolve(
         hostname: string,
-        rrtype: "A",
-        callback: (err: NodeJS.ErrnoException | null, addresses: string[]) => void,
-    ): void;
-    export function resolve(
-        hostname: string,
-        rrtype: "AAAA",
+        rrtype: "A" | "AAAA" | "CNAME" | "NS" | "PTR",
         callback: (err: NodeJS.ErrnoException | null, addresses: string[]) => void,
     ): void;
     export function resolve(
@@ -340,8 +339,8 @@ declare module "dns" {
     ): void;
     export function resolve(
         hostname: string,
-        rrtype: "CNAME",
-        callback: (err: NodeJS.ErrnoException | null, addresses: string[]) => void,
+        rrtype: "CAA",
+        callback: (err: NodeJS.ErrnoException | null, address: CaaRecord[]) => void,
     ): void;
     export function resolve(
         hostname: string,
@@ -352,16 +351,6 @@ declare module "dns" {
         hostname: string,
         rrtype: "NAPTR",
         callback: (err: NodeJS.ErrnoException | null, addresses: NaptrRecord[]) => void,
-    ): void;
-    export function resolve(
-        hostname: string,
-        rrtype: "NS",
-        callback: (err: NodeJS.ErrnoException | null, addresses: string[]) => void,
-    ): void;
-    export function resolve(
-        hostname: string,
-        rrtype: "PTR",
-        callback: (err: NodeJS.ErrnoException | null, addresses: string[]) => void,
     ): void;
     export function resolve(
         hostname: string,
@@ -383,12 +372,21 @@ declare module "dns" {
         rrtype: string,
         callback: (
             err: NodeJS.ErrnoException | null,
-            addresses: string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | string[][] | AnyRecord[],
+            addresses:
+                | string[]
+                | CaaRecord[]
+                | MxRecord[]
+                | NaptrRecord[]
+                | SoaRecord
+                | SrvRecord[]
+                | string[][]
+                | AnyRecord[],
         ) => void,
     ): void;
     export namespace resolve {
         function __promisify__(hostname: string, rrtype?: "A" | "AAAA" | "CNAME" | "NS" | "PTR"): Promise<string[]>;
         function __promisify__(hostname: string, rrtype: "ANY"): Promise<AnyRecord[]>;
+        function __promisify__(hostname: string, rrtype: "CAA"): Promise<CaaRecord[]>;
         function __promisify__(hostname: string, rrtype: "MX"): Promise<MxRecord[]>;
         function __promisify__(hostname: string, rrtype: "NAPTR"): Promise<NaptrRecord[]>;
         function __promisify__(hostname: string, rrtype: "SOA"): Promise<SoaRecord>;
@@ -397,7 +395,16 @@ declare module "dns" {
         function __promisify__(
             hostname: string,
             rrtype: string,
-        ): Promise<string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | string[][] | AnyRecord[]>;
+        ): Promise<
+            | string[]
+            | CaaRecord[]
+            | MxRecord[]
+            | NaptrRecord[]
+            | SoaRecord
+            | SrvRecord[]
+            | string[][]
+            | AnyRecord[]
+        >;
     }
     /**
      * Uses the DNS protocol to resolve a IPv4 addresses (`A` records) for the `hostname`. The `addresses` argument passed to the `callback` function

--- a/types/node/v18/dns/promises.d.ts
+++ b/types/node/v18/dns/promises.d.ts
@@ -126,22 +126,24 @@ declare module "dns/promises" {
      * @param [rrtype='A'] Resource record type.
      */
     function resolve(hostname: string): Promise<string[]>;
-    function resolve(hostname: string, rrtype: "A"): Promise<string[]>;
-    function resolve(hostname: string, rrtype: "AAAA"): Promise<string[]>;
+    function resolve(hostname: string, rrtype: "A" | "AAAA" | "CNAME" | "NS" | "PTR"): Promise<string[]>;
     function resolve(hostname: string, rrtype: "ANY"): Promise<AnyRecord[]>;
     function resolve(hostname: string, rrtype: "CAA"): Promise<CaaRecord[]>;
-    function resolve(hostname: string, rrtype: "CNAME"): Promise<string[]>;
     function resolve(hostname: string, rrtype: "MX"): Promise<MxRecord[]>;
     function resolve(hostname: string, rrtype: "NAPTR"): Promise<NaptrRecord[]>;
-    function resolve(hostname: string, rrtype: "NS"): Promise<string[]>;
-    function resolve(hostname: string, rrtype: "PTR"): Promise<string[]>;
     function resolve(hostname: string, rrtype: "SOA"): Promise<SoaRecord>;
     function resolve(hostname: string, rrtype: "SRV"): Promise<SrvRecord[]>;
     function resolve(hostname: string, rrtype: "TXT"): Promise<string[][]>;
-    function resolve(
-        hostname: string,
-        rrtype: string,
-    ): Promise<string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | string[][] | AnyRecord[]>;
+    function resolve(hostname: string, rrtype: string): Promise<
+        | string[]
+        | CaaRecord[]
+        | MxRecord[]
+        | NaptrRecord[]
+        | SoaRecord
+        | SrvRecord[]
+        | string[][]
+        | AnyRecord[]
+    >;
     /**
      * Uses the DNS protocol to resolve IPv4 addresses (`A` records) for the `hostname`. On success, the `Promise` is resolved with an array of IPv4
      * addresses (e.g. `['74.125.79.104', '74.125.79.105', '74.125.79.106']`).

--- a/types/node/v18/test/dns.ts
+++ b/types/node/v18/test/dns.ts
@@ -15,6 +15,7 @@ import {
     setDefaultResultOrder,
     V4MAPPED,
 } from "node:dns";
+import { promisify } from "node:util";
 
 lookup("nodejs.org", (err, address, family) => {
     const _err: NodeJS.ErrnoException | null = err;
@@ -73,21 +74,119 @@ lookupService("127.0.0.1", 0, (err, hostname, service) => {
     const _service: string = service;
 });
 
-resolve("nodejs.org", (err, addresses) => {
-    const _addresses: string[] = addresses;
-});
-resolve("nodejs.org", "A", (err, addresses) => {
-    const _addresses: string[] = addresses;
-});
-resolve("nodejs.org", "AAAA", (err, addresses) => {
-    const _addresses: string[] = addresses;
-});
-resolve("nodejs.org", "ANY", (err, addresses) => {
-    const _addresses: AnyRecord[] = addresses;
-});
-resolve("nodejs.org", "MX", (err, addresses) => {
-    const _addresses: MxRecord[] = addresses;
-});
+{
+    const resolvePromisified = promisify(resolve);
+
+    resolve("nodejs.org", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType string[]
+        addresses;
+    });
+    // $ExpectType Promise<string[]>
+    resolvePromisified("nodejs.org");
+    // $ExpectType Promise<string[]>
+    promises.resolve("nodejs.org");
+
+    resolve("nodejs.org", "" as "A" | "AAAA" | "CNAME" | "NS" | "PTR", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType string[]
+        addresses;
+    });
+    // $ExpectType Promise<string[]>
+    resolvePromisified("nodejs.org", "" as "A" | "AAAA" | "CNAME" | "NS" | "PTR");
+    // $ExpectType Promise<string[]>
+    promises.resolve("nodejs.org", "" as "A" | "AAAA" | "CNAME" | "NS" | "PTR");
+
+    resolve("nodejs.org", "ANY", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType AnyRecord[]
+        addresses;
+    });
+    // $ExpectType Promise<AnyRecord[]>
+    resolvePromisified("nodejs.org", "ANY");
+    // $ExpectType Promise<AnyRecord[]>
+    promises.resolve("nodejs.org", "ANY");
+
+    resolve("nodejs.org", "CAA", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType CaaRecord[]
+        addresses;
+    });
+    // $ExpectType Promise<CaaRecord[]>
+    resolvePromisified("nodejs.org", "CAA");
+    // $ExpectType Promise<CaaRecord[]>
+    promises.resolve("nodejs.org", "CAA");
+
+    resolve("nodejs.org", "MX", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType MxRecord[]
+        addresses;
+    });
+    // $ExpectType Promise<MxRecord[]>
+    resolvePromisified("nodejs.org", "MX");
+    // $ExpectType Promise<MxRecord[]>
+    promises.resolve("nodejs.org", "MX");
+
+    resolve("nodejs.org", "NAPTR", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType NaptrRecord[]
+        addresses;
+    });
+    // $ExpectType Promise<NaptrRecord[]>
+    resolvePromisified("nodejs.org", "NAPTR");
+    // $ExpectType Promise<NaptrRecord[]>
+    promises.resolve("nodejs.org", "NAPTR");
+
+    resolve("nodejs.org", "SOA", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType SoaRecord
+        addresses;
+    });
+    // $ExpectType Promise<SoaRecord>
+    resolvePromisified("nodejs.org", "SOA");
+    // $ExpectType Promise<SoaRecord>
+    promises.resolve("nodejs.org", "SOA");
+
+    resolve("nodejs.org", "SRV", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType SrvRecord[]
+        addresses;
+    });
+    // $ExpectType Promise<SrvRecord[]>
+    resolvePromisified("nodejs.org", "SRV");
+    // $ExpectType Promise<SrvRecord[]>
+    promises.resolve("nodejs.org", "SRV");
+
+    resolve("nodejs.org", "TXT", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType string[][]
+        addresses;
+    });
+    // $ExpectType Promise<string[][]>
+    resolvePromisified("nodejs.org", "TXT");
+    // $ExpectType Promise<string[][]>
+    promises.resolve("nodejs.org", "TXT");
+
+    resolve("nodejs.org", "unknown", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType string[] | SoaRecord | AnyRecord[] | CaaRecord[] | MxRecord[] | NaptrRecord[] | SrvRecord[] | string[][]
+        addresses;
+    });
+    // $ExpectType Promise<string[] | SoaRecord | AnyRecord[] | CaaRecord[] | MxRecord[] | NaptrRecord[] | SrvRecord[] | string[][]>
+    resolvePromisified("nodejs.org", "unknown");
+    // $ExpectType Promise<string[] | SoaRecord | AnyRecord[] | CaaRecord[] | MxRecord[] | NaptrRecord[] | SrvRecord[] | string[][]>
+    promises.resolve("nodejs.org", "unknown");
+}
 
 resolve4("nodejs.org", (err, addresses) => {
     const _addresses: string[] = addresses;

--- a/types/node/v20/dns.d.ts
+++ b/types/node/v20/dns.d.ts
@@ -249,6 +249,9 @@ declare module "dns" {
         contactemail?: string | undefined;
         contactphone?: string | undefined;
     }
+    export interface AnyCaaRecord extends CaaRecord {
+        type: "CAA";
+    }
     export interface MxRecord {
         priority: number;
         exchange: string;
@@ -307,6 +310,7 @@ declare module "dns" {
     export type AnyRecord =
         | AnyARecord
         | AnyAaaaRecord
+        | AnyCaaRecord
         | AnyCnameRecord
         | AnyMxRecord
         | AnyNaptrRecord
@@ -334,12 +338,7 @@ declare module "dns" {
     ): void;
     export function resolve(
         hostname: string,
-        rrtype: "A",
-        callback: (err: NodeJS.ErrnoException | null, addresses: string[]) => void,
-    ): void;
-    export function resolve(
-        hostname: string,
-        rrtype: "AAAA",
+        rrtype: "A" | "AAAA" | "CNAME" | "NS" | "PTR",
         callback: (err: NodeJS.ErrnoException | null, addresses: string[]) => void,
     ): void;
     export function resolve(
@@ -349,8 +348,8 @@ declare module "dns" {
     ): void;
     export function resolve(
         hostname: string,
-        rrtype: "CNAME",
-        callback: (err: NodeJS.ErrnoException | null, addresses: string[]) => void,
+        rrtype: "CAA",
+        callback: (err: NodeJS.ErrnoException | null, address: CaaRecord[]) => void,
     ): void;
     export function resolve(
         hostname: string,
@@ -361,16 +360,6 @@ declare module "dns" {
         hostname: string,
         rrtype: "NAPTR",
         callback: (err: NodeJS.ErrnoException | null, addresses: NaptrRecord[]) => void,
-    ): void;
-    export function resolve(
-        hostname: string,
-        rrtype: "NS",
-        callback: (err: NodeJS.ErrnoException | null, addresses: string[]) => void,
-    ): void;
-    export function resolve(
-        hostname: string,
-        rrtype: "PTR",
-        callback: (err: NodeJS.ErrnoException | null, addresses: string[]) => void,
     ): void;
     export function resolve(
         hostname: string,
@@ -392,12 +381,21 @@ declare module "dns" {
         rrtype: string,
         callback: (
             err: NodeJS.ErrnoException | null,
-            addresses: string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | string[][] | AnyRecord[],
+            addresses:
+                | string[]
+                | CaaRecord[]
+                | MxRecord[]
+                | NaptrRecord[]
+                | SoaRecord
+                | SrvRecord[]
+                | string[][]
+                | AnyRecord[],
         ) => void,
     ): void;
     export namespace resolve {
         function __promisify__(hostname: string, rrtype?: "A" | "AAAA" | "CNAME" | "NS" | "PTR"): Promise<string[]>;
         function __promisify__(hostname: string, rrtype: "ANY"): Promise<AnyRecord[]>;
+        function __promisify__(hostname: string, rrtype: "CAA"): Promise<CaaRecord[]>;
         function __promisify__(hostname: string, rrtype: "MX"): Promise<MxRecord[]>;
         function __promisify__(hostname: string, rrtype: "NAPTR"): Promise<NaptrRecord[]>;
         function __promisify__(hostname: string, rrtype: "SOA"): Promise<SoaRecord>;
@@ -406,7 +404,16 @@ declare module "dns" {
         function __promisify__(
             hostname: string,
             rrtype: string,
-        ): Promise<string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | string[][] | AnyRecord[]>;
+        ): Promise<
+            | string[]
+            | CaaRecord[]
+            | MxRecord[]
+            | NaptrRecord[]
+            | SoaRecord
+            | SrvRecord[]
+            | string[][]
+            | AnyRecord[]
+        >;
     }
     /**
      * Uses the DNS protocol to resolve a IPv4 addresses (`A` records) for the `hostname`. The `addresses` argument passed to the `callback` function

--- a/types/node/v20/dns/promises.d.ts
+++ b/types/node/v20/dns/promises.d.ts
@@ -126,22 +126,24 @@ declare module "dns/promises" {
      * @param [rrtype='A'] Resource record type.
      */
     function resolve(hostname: string): Promise<string[]>;
-    function resolve(hostname: string, rrtype: "A"): Promise<string[]>;
-    function resolve(hostname: string, rrtype: "AAAA"): Promise<string[]>;
+    function resolve(hostname: string, rrtype: "A" | "AAAA" | "CNAME" | "NS" | "PTR"): Promise<string[]>;
     function resolve(hostname: string, rrtype: "ANY"): Promise<AnyRecord[]>;
     function resolve(hostname: string, rrtype: "CAA"): Promise<CaaRecord[]>;
-    function resolve(hostname: string, rrtype: "CNAME"): Promise<string[]>;
     function resolve(hostname: string, rrtype: "MX"): Promise<MxRecord[]>;
     function resolve(hostname: string, rrtype: "NAPTR"): Promise<NaptrRecord[]>;
-    function resolve(hostname: string, rrtype: "NS"): Promise<string[]>;
-    function resolve(hostname: string, rrtype: "PTR"): Promise<string[]>;
     function resolve(hostname: string, rrtype: "SOA"): Promise<SoaRecord>;
     function resolve(hostname: string, rrtype: "SRV"): Promise<SrvRecord[]>;
     function resolve(hostname: string, rrtype: "TXT"): Promise<string[][]>;
-    function resolve(
-        hostname: string,
-        rrtype: string,
-    ): Promise<string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | string[][] | AnyRecord[]>;
+    function resolve(hostname: string, rrtype: string): Promise<
+        | string[]
+        | CaaRecord[]
+        | MxRecord[]
+        | NaptrRecord[]
+        | SoaRecord
+        | SrvRecord[]
+        | string[][]
+        | AnyRecord[]
+    >;
     /**
      * Uses the DNS protocol to resolve IPv4 addresses (`A` records) for the `hostname`. On success, the `Promise` is resolved with an array of IPv4
      * addresses (e.g. `['74.125.79.104', '74.125.79.105', '74.125.79.106']`).

--- a/types/node/v20/test/dns.ts
+++ b/types/node/v20/test/dns.ts
@@ -39,6 +39,7 @@ import {
     TIMEOUT,
     V4MAPPED,
 } from "node:dns";
+import { promisify } from "node:util";
 
 lookup("nodejs.org", (err, address, family) => {
     const _err: NodeJS.ErrnoException | null = err;
@@ -97,21 +98,119 @@ lookupService("127.0.0.1", 0, (err, hostname, service) => {
     const _service: string = service;
 });
 
-resolve("nodejs.org", (err, addresses) => {
-    const _addresses: string[] = addresses;
-});
-resolve("nodejs.org", "A", (err, addresses) => {
-    const _addresses: string[] = addresses;
-});
-resolve("nodejs.org", "AAAA", (err, addresses) => {
-    const _addresses: string[] = addresses;
-});
-resolve("nodejs.org", "ANY", (err, addresses) => {
-    const _addresses: AnyRecord[] = addresses;
-});
-resolve("nodejs.org", "MX", (err, addresses) => {
-    const _addresses: MxRecord[] = addresses;
-});
+{
+    const resolvePromisified = promisify(resolve);
+
+    resolve("nodejs.org", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType string[]
+        addresses;
+    });
+    // $ExpectType Promise<string[]>
+    resolvePromisified("nodejs.org");
+    // $ExpectType Promise<string[]>
+    promises.resolve("nodejs.org");
+
+    resolve("nodejs.org", "" as "A" | "AAAA" | "CNAME" | "NS" | "PTR", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType string[]
+        addresses;
+    });
+    // $ExpectType Promise<string[]>
+    resolvePromisified("nodejs.org", "" as "A" | "AAAA" | "CNAME" | "NS" | "PTR");
+    // $ExpectType Promise<string[]>
+    promises.resolve("nodejs.org", "" as "A" | "AAAA" | "CNAME" | "NS" | "PTR");
+
+    resolve("nodejs.org", "ANY", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType AnyRecord[]
+        addresses;
+    });
+    // $ExpectType Promise<AnyRecord[]>
+    resolvePromisified("nodejs.org", "ANY");
+    // $ExpectType Promise<AnyRecord[]>
+    promises.resolve("nodejs.org", "ANY");
+
+    resolve("nodejs.org", "CAA", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType CaaRecord[]
+        addresses;
+    });
+    // $ExpectType Promise<CaaRecord[]>
+    resolvePromisified("nodejs.org", "CAA");
+    // $ExpectType Promise<CaaRecord[]>
+    promises.resolve("nodejs.org", "CAA");
+
+    resolve("nodejs.org", "MX", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType MxRecord[]
+        addresses;
+    });
+    // $ExpectType Promise<MxRecord[]>
+    resolvePromisified("nodejs.org", "MX");
+    // $ExpectType Promise<MxRecord[]>
+    promises.resolve("nodejs.org", "MX");
+
+    resolve("nodejs.org", "NAPTR", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType NaptrRecord[]
+        addresses;
+    });
+    // $ExpectType Promise<NaptrRecord[]>
+    resolvePromisified("nodejs.org", "NAPTR");
+    // $ExpectType Promise<NaptrRecord[]>
+    promises.resolve("nodejs.org", "NAPTR");
+
+    resolve("nodejs.org", "SOA", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType SoaRecord
+        addresses;
+    });
+    // $ExpectType Promise<SoaRecord>
+    resolvePromisified("nodejs.org", "SOA");
+    // $ExpectType Promise<SoaRecord>
+    promises.resolve("nodejs.org", "SOA");
+
+    resolve("nodejs.org", "SRV", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType SrvRecord[]
+        addresses;
+    });
+    // $ExpectType Promise<SrvRecord[]>
+    resolvePromisified("nodejs.org", "SRV");
+    // $ExpectType Promise<SrvRecord[]>
+    promises.resolve("nodejs.org", "SRV");
+
+    resolve("nodejs.org", "TXT", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType string[][]
+        addresses;
+    });
+    // $ExpectType Promise<string[][]>
+    resolvePromisified("nodejs.org", "TXT");
+    // $ExpectType Promise<string[][]>
+    promises.resolve("nodejs.org", "TXT");
+
+    resolve("nodejs.org", "unknown", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType string[] | SoaRecord | AnyRecord[] | CaaRecord[] | MxRecord[] | NaptrRecord[] | SrvRecord[] | string[][]
+        addresses;
+    });
+    // $ExpectType Promise<string[] | SoaRecord | AnyRecord[] | CaaRecord[] | MxRecord[] | NaptrRecord[] | SrvRecord[] | string[][]>
+    resolvePromisified("nodejs.org", "unknown");
+    // $ExpectType Promise<string[] | SoaRecord | AnyRecord[] | CaaRecord[] | MxRecord[] | NaptrRecord[] | SrvRecord[] | string[][]>
+    promises.resolve("nodejs.org", "unknown");
+}
 
 resolve4("nodejs.org", (err, addresses) => {
     const _addresses: string[] = addresses;

--- a/types/node/v22/dns.d.ts
+++ b/types/node/v22/dns.d.ts
@@ -250,6 +250,9 @@ declare module "dns" {
         contactemail?: string | undefined;
         contactphone?: string | undefined;
     }
+    export interface AnyCaaRecord extends CaaRecord {
+        type: "CAA";
+    }
     export interface MxRecord {
         priority: number;
         exchange: string;
@@ -317,6 +320,7 @@ declare module "dns" {
     export type AnyRecord =
         | AnyARecord
         | AnyAaaaRecord
+        | AnyCaaRecord
         | AnyCnameRecord
         | AnyMxRecord
         | AnyNaptrRecord
@@ -345,12 +349,7 @@ declare module "dns" {
     ): void;
     export function resolve(
         hostname: string,
-        rrtype: "A",
-        callback: (err: NodeJS.ErrnoException | null, addresses: string[]) => void,
-    ): void;
-    export function resolve(
-        hostname: string,
-        rrtype: "AAAA",
+        rrtype: "A" | "AAAA" | "CNAME" | "NS" | "PTR",
         callback: (err: NodeJS.ErrnoException | null, addresses: string[]) => void,
     ): void;
     export function resolve(
@@ -360,8 +359,8 @@ declare module "dns" {
     ): void;
     export function resolve(
         hostname: string,
-        rrtype: "CNAME",
-        callback: (err: NodeJS.ErrnoException | null, addresses: string[]) => void,
+        rrtype: "CAA",
+        callback: (err: NodeJS.ErrnoException | null, address: CaaRecord[]) => void,
     ): void;
     export function resolve(
         hostname: string,
@@ -372,16 +371,6 @@ declare module "dns" {
         hostname: string,
         rrtype: "NAPTR",
         callback: (err: NodeJS.ErrnoException | null, addresses: NaptrRecord[]) => void,
-    ): void;
-    export function resolve(
-        hostname: string,
-        rrtype: "NS",
-        callback: (err: NodeJS.ErrnoException | null, addresses: string[]) => void,
-    ): void;
-    export function resolve(
-        hostname: string,
-        rrtype: "PTR",
-        callback: (err: NodeJS.ErrnoException | null, addresses: string[]) => void,
     ): void;
     export function resolve(
         hostname: string,
@@ -410,6 +399,7 @@ declare module "dns" {
             err: NodeJS.ErrnoException | null,
             addresses:
                 | string[]
+                | CaaRecord[]
                 | MxRecord[]
                 | NaptrRecord[]
                 | SoaRecord
@@ -422,6 +412,7 @@ declare module "dns" {
     export namespace resolve {
         function __promisify__(hostname: string, rrtype?: "A" | "AAAA" | "CNAME" | "NS" | "PTR"): Promise<string[]>;
         function __promisify__(hostname: string, rrtype: "ANY"): Promise<AnyRecord[]>;
+        function __promisify__(hostname: string, rrtype: "CAA"): Promise<CaaRecord[]>;
         function __promisify__(hostname: string, rrtype: "MX"): Promise<MxRecord[]>;
         function __promisify__(hostname: string, rrtype: "NAPTR"): Promise<NaptrRecord[]>;
         function __promisify__(hostname: string, rrtype: "SOA"): Promise<SoaRecord>;
@@ -432,7 +423,15 @@ declare module "dns" {
             hostname: string,
             rrtype: string,
         ): Promise<
-            string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | TlsaRecord[] | string[][] | AnyRecord[]
+            | string[]
+            | CaaRecord[]
+            | MxRecord[]
+            | NaptrRecord[]
+            | SoaRecord
+            | SrvRecord[]
+            | TlsaRecord[]
+            | string[][]
+            | AnyRecord[]
         >;
     }
     /**

--- a/types/node/v22/dns/promises.d.ts
+++ b/types/node/v22/dns/promises.d.ts
@@ -127,24 +127,25 @@ declare module "dns/promises" {
      * @param [rrtype='A'] Resource record type.
      */
     function resolve(hostname: string): Promise<string[]>;
-    function resolve(hostname: string, rrtype: "A"): Promise<string[]>;
-    function resolve(hostname: string, rrtype: "AAAA"): Promise<string[]>;
+    function resolve(hostname: string, rrtype: "A" | "AAAA" | "CNAME" | "NS" | "PTR"): Promise<string[]>;
     function resolve(hostname: string, rrtype: "ANY"): Promise<AnyRecord[]>;
     function resolve(hostname: string, rrtype: "CAA"): Promise<CaaRecord[]>;
-    function resolve(hostname: string, rrtype: "CNAME"): Promise<string[]>;
     function resolve(hostname: string, rrtype: "MX"): Promise<MxRecord[]>;
     function resolve(hostname: string, rrtype: "NAPTR"): Promise<NaptrRecord[]>;
-    function resolve(hostname: string, rrtype: "NS"): Promise<string[]>;
-    function resolve(hostname: string, rrtype: "PTR"): Promise<string[]>;
     function resolve(hostname: string, rrtype: "SOA"): Promise<SoaRecord>;
     function resolve(hostname: string, rrtype: "SRV"): Promise<SrvRecord[]>;
     function resolve(hostname: string, rrtype: "TLSA"): Promise<TlsaRecord[]>;
     function resolve(hostname: string, rrtype: "TXT"): Promise<string[][]>;
-    function resolve(
-        hostname: string,
-        rrtype: string,
-    ): Promise<
-        string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | TlsaRecord[] | string[][] | AnyRecord[]
+    function resolve(hostname: string, rrtype: string): Promise<
+        | string[]
+        | CaaRecord[]
+        | MxRecord[]
+        | NaptrRecord[]
+        | SoaRecord
+        | SrvRecord[]
+        | TlsaRecord[]
+        | string[][]
+        | AnyRecord[]
     >;
     /**
      * Uses the DNS protocol to resolve IPv4 addresses (`A` records) for the `hostname`. On success, the `Promise` is resolved with an array of IPv4

--- a/types/node/v22/test/dns.ts
+++ b/types/node/v22/test/dns.ts
@@ -39,6 +39,7 @@ import {
     TIMEOUT,
     V4MAPPED,
 } from "node:dns";
+import { promisify } from "node:util";
 
 lookup("nodejs.org", (err, address, family) => {
     const _err: NodeJS.ErrnoException | null = err;
@@ -97,21 +98,130 @@ lookupService("127.0.0.1", 0, (err, hostname, service) => {
     const _service: string = service;
 });
 
-resolve("nodejs.org", (err, addresses) => {
-    const _addresses: string[] = addresses;
-});
-resolve("nodejs.org", "A", (err, addresses) => {
-    const _addresses: string[] = addresses;
-});
-resolve("nodejs.org", "AAAA", (err, addresses) => {
-    const _addresses: string[] = addresses;
-});
-resolve("nodejs.org", "ANY", (err, addresses) => {
-    const _addresses: AnyRecord[] = addresses;
-});
-resolve("nodejs.org", "MX", (err, addresses) => {
-    const _addresses: MxRecord[] = addresses;
-});
+{
+    const resolvePromisified = promisify(resolve);
+
+    resolve("nodejs.org", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType string[]
+        addresses;
+    });
+    // $ExpectType Promise<string[]>
+    resolvePromisified("nodejs.org");
+    // $ExpectType Promise<string[]>
+    promises.resolve("nodejs.org");
+
+    resolve("nodejs.org", "" as "A" | "AAAA" | "CNAME" | "NS" | "PTR", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType string[]
+        addresses;
+    });
+    // $ExpectType Promise<string[]>
+    resolvePromisified("nodejs.org", "" as "A" | "AAAA" | "CNAME" | "NS" | "PTR");
+    // $ExpectType Promise<string[]>
+    promises.resolve("nodejs.org", "" as "A" | "AAAA" | "CNAME" | "NS" | "PTR");
+
+    resolve("nodejs.org", "ANY", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType AnyRecord[]
+        addresses;
+    });
+    // $ExpectType Promise<AnyRecord[]>
+    resolvePromisified("nodejs.org", "ANY");
+    // $ExpectType Promise<AnyRecord[]>
+    promises.resolve("nodejs.org", "ANY");
+
+    resolve("nodejs.org", "CAA", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType CaaRecord[]
+        addresses;
+    });
+    // $ExpectType Promise<CaaRecord[]>
+    resolvePromisified("nodejs.org", "CAA");
+    // $ExpectType Promise<CaaRecord[]>
+    promises.resolve("nodejs.org", "CAA");
+
+    resolve("nodejs.org", "MX", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType MxRecord[]
+        addresses;
+    });
+    // $ExpectType Promise<MxRecord[]>
+    resolvePromisified("nodejs.org", "MX");
+    // $ExpectType Promise<MxRecord[]>
+    promises.resolve("nodejs.org", "MX");
+
+    resolve("nodejs.org", "NAPTR", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType NaptrRecord[]
+        addresses;
+    });
+    // $ExpectType Promise<NaptrRecord[]>
+    resolvePromisified("nodejs.org", "NAPTR");
+    // $ExpectType Promise<NaptrRecord[]>
+    promises.resolve("nodejs.org", "NAPTR");
+
+    resolve("nodejs.org", "SOA", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType SoaRecord
+        addresses;
+    });
+    // $ExpectType Promise<SoaRecord>
+    resolvePromisified("nodejs.org", "SOA");
+    // $ExpectType Promise<SoaRecord>
+    promises.resolve("nodejs.org", "SOA");
+
+    resolve("nodejs.org", "SRV", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType SrvRecord[]
+        addresses;
+    });
+    // $ExpectType Promise<SrvRecord[]>
+    resolvePromisified("nodejs.org", "SRV");
+    // $ExpectType Promise<SrvRecord[]>
+    promises.resolve("nodejs.org", "SRV");
+
+    resolve("nodejs.org", "TLSA", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType TlsaRecord[]
+        addresses;
+    });
+    // $ExpectType Promise<TlsaRecord[]>
+    resolvePromisified("nodejs.org", "TLSA");
+    // $ExpectType Promise<TlsaRecord[]>
+    promises.resolve("nodejs.org", "TLSA");
+
+    resolve("nodejs.org", "TXT", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType string[][]
+        addresses;
+    });
+    // $ExpectType Promise<string[][]>
+    resolvePromisified("nodejs.org", "TXT");
+    // $ExpectType Promise<string[][]>
+    promises.resolve("nodejs.org", "TXT");
+
+    resolve("nodejs.org", "unknown", (err, addresses) => {
+        // $ExpectType ErrnoException | null
+        err;
+        // $ExpectType string[] | SoaRecord | AnyRecord[] | CaaRecord[] | MxRecord[] | NaptrRecord[] | SrvRecord[] | TlsaRecord[] | string[][]
+        addresses;
+    });
+    // $ExpectType Promise<string[] | SoaRecord | AnyRecord[] | CaaRecord[] | MxRecord[] | NaptrRecord[] | SrvRecord[] | TlsaRecord[] | string[][]>
+    resolvePromisified("nodejs.org", "unknown");
+    // $ExpectType Promise<string[] | SoaRecord | AnyRecord[] | CaaRecord[] | MxRecord[] | NaptrRecord[] | SrvRecord[] | TlsaRecord[] | string[][]>
+    promises.resolve("nodejs.org", "unknown");
+}
 
 resolve4("nodejs.org", (err, addresses) => {
     const _addresses: string[] = addresses;


### PR DESCRIPTION
For `resolve()`, see https://nodejs.org/api/dns.html#dnsresolvehostname-rrtype-callback, which indicates `'CAA'` can be used in `rrtype` for resolving CA authorization records.

Also, the `AnyTraits::Parse()` method in `cares_wrap.cc` in nodejs source code will "Parse CAA records" as the code comment suggests. Hence `CaaRecord[]` & `AnyCaaRecord` are introduced to the fallback signature as well.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
