### PR TITLE
fix(lodash): allow isMatchWith customizer to return any truthy/falsy value

### DIFF
--- a/types/lodash/common/lang.d.ts
+++ b/types/lodash/common/lang.d.ts
@@ -881,7 +881,7 @@ declare module "../index" {
         isMatch(source: object): PrimitiveChain<boolean>;
     }
 
-    type isMatchWithCustomizer = (value: any, other: any, indexOrKey: PropertyName, object: object, source: object) => boolean | undefined;
+    type isMatchWithCustomizer = (value: any, other: any, indexOrKey: PropertyName, object: object, source: object) => unknown;
     interface LoDashStatic {
         /**
          * This method is like `_.isMatch` except that it accepts `customizer` which

--- a/types/lodash/isMatchWith-tests.ts
+++ b/types/lodash/isMatchWith-tests.ts
@@ -1,0 +1,40 @@
+import { isMatchWith } from "lodash";
+
+/**
+ * Customizer returns a string (truthy value) — should compile and return boolean.
+ */
+const result1 = isMatchWith({ a: 1 }, { a: 1 }, () => "yes");
+// $ExpectType boolean
+
+/**
+ * Customizer returns 0 (falsy value) — should compile and return boolean.
+ */
+const result2 = isMatchWith({ a: 1 }, { a: 1 }, () => 0);
+// $ExpectType boolean
+
+/**
+ * Customizer returns null (falsy value) — should compile and return boolean.
+ */
+const result3 = isMatchWith({ a: 1 }, { a: 1 }, () => null);
+// $ExpectType boolean
+
+/**
+ * Invalid customizer: number instead of function.
+ * Should raise a type error since customizer must be a function.
+ */
+// @ts-expect-error
+isMatchWith({ a: 1 }, { a: 1 }, 123);
+
+/**
+ * Invalid customizer: object instead of function.
+ * Should raise a type error.
+ */
+// @ts-expect-error
+isMatchWith({ a: 1 }, { a: 1 }, {});
+
+/**
+ * Invalid customizer: string instead of function.
+ * Should raise a type error.
+ */
+// @ts-expect-error
+isMatchWith({ a: 1 }, { a: 1 }, "not a function");


### PR DESCRIPTION
Fixes: lodash/lodash#5991

The `isMatchWith` function in Lodash allows the customizer to return any value (e.g., strings, numbers, null), and determines the result based on the value’s truthiness or falsiness.

However, the existing type definition restricted the return type of the customizer to `boolean | undefined`, causing valid use cases to fail at compile time. This PR updates the customizer's return type to `unknown`, aligning it with Lodash’s real behavior.

This PR also includes type-level test cases to validate:

- Accepting truthy/falsy values like `'yes'`, `0`, `null`
- Rejecting non-function customizers like strings, numbers, or objects

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test lodash`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/lodash/lodash/blob/master/lodash.js#L10467
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
