### PR TITLE
fix(@types/minimatch): add to notNeededPackages.json

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -4265,6 +4265,10 @@
             "libraryName": "mini-html-webpack-plugin",
             "asOfVersion": "3.0.0"
         },
+        "minimatch": {
+            "libraryName": "minimatch",
+            "asOfVersion": "6.0.0"
+        },
         "minimist-options": {
             "libraryName": "minimist-options",
             "asOfVersion": "4.0.1"


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] ~Test the change in your own code. (Compile and run.)~
- [x] ~[Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If removing a declaration:

- [x] ~If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)~
- [x] Delete the package's directory.
- [x] Add it to `notNeededPackages.json`.

The package directory doesn't exist, but [`@types/minimatch`](https://www.npmjs.com/package/@types/minimatch) isn't marked as deprecated. I think this -along with #73158- is the root confusion behind e.g. #68125 -> https://stackoverflow.com/questions/76012669/node-modules-minimatch-dist-cjs-index-has-no-exported-member-named-iminimatch/77810047#77810047.