### PR TITLE
fix(fuzzy-finder): resolve attw by removing unneeded export map & dist/

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -137,7 +137,6 @@
         "frctl__fractal",
         "frecency",
         "fs-extra",
-        "fuzzy-finder",
         "geodesy",
         "get-folder-size",
         "github-label-sync",

--- a/types/fuzzy-finder/dist/fuzzy-finder.d.ts
+++ b/types/fuzzy-finder/dist/fuzzy-finder.d.ts
@@ -1,3 +1,0 @@
-import fuzzyFinder = require("../");
-
-export = fuzzyFinder;

--- a/types/fuzzy-finder/dist/fuzzy-finder.m.d.ts
+++ b/types/fuzzy-finder/dist/fuzzy-finder.m.d.ts
@@ -1,3 +1,0 @@
-import fuzzyFinder = require("../");
-
-export default fuzzyFinder;

--- a/types/fuzzy-finder/dist/fuzzy-finder.umd.d.ts
+++ b/types/fuzzy-finder/dist/fuzzy-finder.umd.d.ts
@@ -1,5 +1,0 @@
-import fuzzyFinder = require("../");
-
-export = fuzzyFinder;
-
-export as namespace fuzzyFinder;

--- a/types/fuzzy-finder/package.json
+++ b/types/fuzzy-finder/package.json
@@ -5,14 +5,6 @@
     "projects": [
         "https://github.com/tiaanduplessis/fuzzy-finder"
     ],
-    "exports": {
-        ".": {
-            "types": {
-                "import": "./dist/fuzzy-finder.m.d.ts",
-                "default": "./index.d.ts"
-            }
-        }
-    },
     "devDependencies": {
         "@types/fuzzy-finder": "workspace:."
     },

--- a/types/fuzzy-finder/test/fuzzy-finder-umd-tests.ts
+++ b/types/fuzzy-finder/test/fuzzy-finder-umd-tests.ts
@@ -1,1 +1,0 @@
-fuzzyFinder(); // $ExpectType string[]

--- a/types/fuzzy-finder/tsconfig.json
+++ b/types/fuzzy-finder/tsconfig.json
@@ -13,8 +13,6 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
-        "index.d.ts",
-        "test/fuzzy-finder-tests.ts",
-        "test/fuzzy-finder-umd-tests.ts"
+        "index.d.ts"
     ]
 }


### PR DESCRIPTION
The published `package.json` in https://www.npmjs.com/package/fuzzy-finder?activeTab=code does not specify any export map, hence `@type/` does not need to add any. 

Indeed, by removing export map & the extra `dist/` directory, attw test can pass already.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
