### PR TITLE
Lock @types/minimatch deps to pre-deprecatation version

### DIFF
--- a/types/gulp-filter/package.json
+++ b/types/gulp-filter/package.json
@@ -6,7 +6,7 @@
         "https://github.com/sindresorhus/gulp-filter"
     ],
     "dependencies": {
-        "@types/minimatch": "*",
+        "@types/minimatch": "5",
         "@types/node": "*",
         "@types/vinyl": "*"
     },

--- a/types/gulp-filter/package.json
+++ b/types/gulp-filter/package.json
@@ -6,7 +6,7 @@
         "https://github.com/sindresorhus/gulp-filter"
     ],
     "dependencies": {
-        "@types/minimatch": "5",
+        "@types/minimatch": "<=5",
         "@types/node": "*",
         "@types/vinyl": "*"
     },

--- a/types/gulp-if/package.json
+++ b/types/gulp-if/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/gulp-match": "*",
-        "@types/minimatch": "*",
+        "@types/minimatch": "5",
         "@types/node": "*"
     },
     "devDependencies": {

--- a/types/gulp-if/package.json
+++ b/types/gulp-if/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/gulp-match": "*",
-        "@types/minimatch": "5",
+        "@types/minimatch": "<=5",
         "@types/node": "*"
     },
     "devDependencies": {

--- a/types/gulp-match/package.json
+++ b/types/gulp-match/package.json
@@ -6,7 +6,7 @@
         "https://github.com/robrich/gulp-match"
     ],
     "dependencies": {
-        "@types/minimatch": "5",
+        "@types/minimatch": "<=5",
         "@types/vinyl": "*"
     },
     "devDependencies": {

--- a/types/gulp-match/package.json
+++ b/types/gulp-match/package.json
@@ -6,7 +6,7 @@
         "https://github.com/robrich/gulp-match"
     ],
     "dependencies": {
-        "@types/minimatch": "*",
+        "@types/minimatch": "5",
         "@types/vinyl": "*"
     },
     "devDependencies": {


### PR DESCRIPTION
Which should fix CI on master. We *probably* need to add some kind of CI check on `notNeededPackages` updates to ensure this happens in those PRs instead of after them, since the tombstone deprecated package will make any deps within DT fail without locking their version range to pre-deprecation (or updated to use the actual package replacement).