### PR TITLE
chore(@types/node): refine https agent createConnection method types

### DIFF
--- a/types/node/https.d.ts
+++ b/types/node/https.d.ts
@@ -32,6 +32,11 @@ declare module "https" {
     class Agent extends http.Agent {
         constructor(options?: AgentOptions);
         options: AgentOptions;
+
+        createConnection(
+            options: tls.ConnectionOptions,
+            callback?: (err: Error | null, stream: Duplex) => void,
+        ): Duplex;
     }
     interface Server<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,

--- a/types/node/test/https.ts
+++ b/types/node/test/https.ts
@@ -56,6 +56,30 @@ import * as url from "node:url";
         checkServerIdentity: (host: string, cert: tls.DetailedPeerCertificate): Error | undefined => new Error("foo"),
     });
 
+    // agent
+
+    agent.getName({ host: "for", port: 1234, localAddress: "bar", family: 4 });
+
+    // ensure direct call and override
+    agent.createConnection({ port: 1234 });
+    agent.createConnection = function createConnection(options, callback) {
+        options.servername = "hello";
+        options.session = Buffer.from("world");
+        return tls.connect(options);
+    };
+
+    // ensure direct call and override
+    agent.keepSocketAlive(new stream.Duplex());
+    agent.keepSocketAlive = function keepSocketAlive(socket) {
+        socket.isPaused();
+    };
+
+    // ensure direct call and override
+    agent.reuseSocket(new stream.Duplex(), new http.ClientRequest(""));
+    agent.reuseSocket = function reuseSocket(socket, request) {
+        socket.isPaused();
+    };
+
     https.globalAgent.options.ca = [];
 
     {

--- a/types/node/v18/https.d.ts
+++ b/types/node/v18/https.d.ts
@@ -31,6 +31,11 @@ declare module "https" {
     class Agent extends http.Agent {
         constructor(options?: AgentOptions);
         options: AgentOptions;
+
+        createConnection(
+            options: tls.ConnectionOptions,
+            callback?: (err: Error | null, stream: Duplex) => void,
+        ): Duplex;
     }
     interface Server<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,

--- a/types/node/v18/test/https.ts
+++ b/types/node/v18/test/https.ts
@@ -56,6 +56,30 @@ import * as url from "node:url";
         checkServerIdentity: (host: string, cert: tls.PeerCertificate): Error | undefined => new Error("foo"),
     });
 
+    // agent
+
+    agent.getName({ host: "for", port: 1234, localAddress: "bar", family: 4 });
+
+    // ensure direct call and override
+    agent.createConnection({ port: 1234 });
+    agent.createConnection = function createConnection(options, callback) {
+        options.servername = "hello";
+        options.session = Buffer.from("world");
+        return tls.connect(options);
+    };
+
+    // ensure direct call and override
+    agent.keepSocketAlive(new stream.Duplex());
+    agent.keepSocketAlive = function keepSocketAlive(socket) {
+        socket.isPaused();
+    };
+
+    // ensure direct call and override
+    agent.reuseSocket(new stream.Duplex(), new http.ClientRequest(""));
+    agent.reuseSocket = function reuseSocket(socket, request) {
+        socket.isPaused();
+    };
+
     https.globalAgent.options.ca = [];
 
     {

--- a/types/node/v20/https.d.ts
+++ b/types/node/v20/https.d.ts
@@ -31,6 +31,11 @@ declare module "https" {
     class Agent extends http.Agent {
         constructor(options?: AgentOptions);
         options: AgentOptions;
+
+        createConnection(
+            options: tls.ConnectionOptions,
+            callback?: (err: Error | null, stream: Duplex) => void,
+        ): Duplex;
     }
     interface Server<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,

--- a/types/node/v20/test/https.ts
+++ b/types/node/v20/test/https.ts
@@ -56,6 +56,30 @@ import * as url from "node:url";
         checkServerIdentity: (host: string, cert: tls.PeerCertificate): Error | undefined => new Error("foo"),
     });
 
+    // agent
+
+    agent.getName({ host: "for", port: 1234, localAddress: "bar", family: 4 });
+
+    // ensure direct call and override
+    agent.createConnection({ port: 1234 });
+    agent.createConnection = function createConnection(options, callback) {
+        options.servername = "hello";
+        options.session = Buffer.from("world");
+        return tls.connect(options);
+    };
+
+    // ensure direct call and override
+    agent.keepSocketAlive(new stream.Duplex());
+    agent.keepSocketAlive = function keepSocketAlive(socket) {
+        socket.isPaused();
+    };
+
+    // ensure direct call and override
+    agent.reuseSocket(new stream.Duplex(), new http.ClientRequest(""));
+    agent.reuseSocket = function reuseSocket(socket, request) {
+        socket.isPaused();
+    };
+
     https.globalAgent.options.ca = [];
 
     {

--- a/types/node/v22/https.d.ts
+++ b/types/node/v22/https.d.ts
@@ -32,6 +32,11 @@ declare module "https" {
     class Agent extends http.Agent {
         constructor(options?: AgentOptions);
         options: AgentOptions;
+
+        createConnection(
+            options: tls.ConnectionOptions,
+            callback?: (err: Error | null, stream: Duplex) => void,
+        ): Duplex;
     }
     interface Server<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,

--- a/types/node/v22/test/https.ts
+++ b/types/node/v22/test/https.ts
@@ -58,6 +58,30 @@ import * as url from "node:url";
 
     https.globalAgent.options.ca = [];
 
+    // agent
+
+    agent.getName({ host: "for", port: 1234, localAddress: "bar", family: 4 });
+
+    // ensure direct call and override
+    agent.createConnection({ port: 1234 });
+    agent.createConnection = function createConnection(options, callback) {
+        options.servername = "hello";
+        options.session = Buffer.from("world");
+        return tls.connect(options);
+    };
+
+    // ensure direct call and override
+    agent.keepSocketAlive(new stream.Duplex());
+    agent.keepSocketAlive = function keepSocketAlive(socket) {
+        socket.isPaused();
+    };
+
+    // ensure direct call and override
+    agent.reuseSocket(new stream.Duplex(), new http.ClientRequest(""));
+    agent.reuseSocket = function reuseSocket(socket, request) {
+        socket.isPaused();
+    };
+
     {
         function reqListener(req: http.IncomingMessage, res: http.ServerResponse): void {}
 


### PR DESCRIPTION
Trying to solve https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/73168

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: `https` implementation of [`Agent.prototype.createConnection`](https://github.com/nodejs/node/blob/35d1511aaaf957acc2024c30c72a1fff9ca7ee21/lib/https.js#L173), uses `tls.connect()` so using `tls.connect()` types for this [type definition](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/tls.d.ts#L1090) as well.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
