### PR TITLE
update imagemin-svgo to v11

### DIFF
--- a/types/gulp-imagemin/gulp-imagemin-tests.ts
+++ b/types/gulp-imagemin/gulp-imagemin-tests.ts
@@ -9,15 +9,15 @@ const plugins = [
         floatPrecision: 2,
         plugins: [
             {
-                name: 'preset-default',
+                name: "preset-default",
                 params: {
                     overrides: {
                         removeViewBox: false,
                         cleanupIds: {
-                            remove: true
-                        }
-                    }
-                }
+                            remove: true,
+                        },
+                    },
+                },
             },
         ],
     }),

--- a/types/gulp-imagemin/gulp-imagemin-tests.ts
+++ b/types/gulp-imagemin/gulp-imagemin-tests.ts
@@ -9,12 +9,15 @@ const plugins = [
         floatPrecision: 2,
         plugins: [
             {
-                name: "removeViewBox",
-                active: true,
-            },
-            {
-                name: "cleanupIDs",
-                active: false,
+                name: 'preset-default',
+                params: {
+                    overrides: {
+                        removeViewBox: false,
+                        cleanupIds: {
+                            remove: true
+                        }
+                    }
+                }
             },
         ],
     }),

--- a/types/imagemin-svgo/imagemin-svgo-tests.ts
+++ b/types/imagemin-svgo/imagemin-svgo-tests.ts
@@ -12,9 +12,11 @@ imagemin(["*.svg"], {
                     name: "preset-default",
                     params: {
                         overrides: {
-                            removeViewBox: false
+                            convertShapeToPath: {
+                                convertArcs: false
+                            }
                         }
-                    },
+                    }
                 },
             ],
             multipass: false,

--- a/types/imagemin-svgo/imagemin-svgo-tests.ts
+++ b/types/imagemin-svgo/imagemin-svgo-tests.ts
@@ -9,8 +9,12 @@ imagemin(["*.svg"], {
             floatPrecision: 2,
             plugins: [
                 {
-                    name: "removeViewBox",
-                    active: true,
+                    name: "preset-default",
+                    params: {
+                        overrides: {
+                            removeViewBox: false
+                        }
+                    },
                 },
             ],
             multipass: false,

--- a/types/imagemin-svgo/imagemin-svgo-tests.ts
+++ b/types/imagemin-svgo/imagemin-svgo-tests.ts
@@ -13,10 +13,10 @@ imagemin(["*.svg"], {
                     params: {
                         overrides: {
                             convertShapeToPath: {
-                                convertArcs: false
-                            }
-                        }
-                    }
+                                convertArcs: false,
+                            },
+                        },
+                    },
                 },
             ],
             multipass: false,

--- a/types/imagemin-svgo/index.d.ts
+++ b/types/imagemin-svgo/index.d.ts
@@ -1,12 +1,12 @@
 import { Plugin } from "imagemin";
-import { OptimizeOptions as SvgoOptions } from "svgo";
+import { Config as SvgoConfig } from "svgo";
 
 /**
  * SVGO imagemin plugin
  */
 declare function imageminSvgo(options?: Options): Plugin;
 
-export type Options = SvgoOptions & {
+export type Options = SvgoConfig & {
     /**
      * Pass over SVGs multiple times to ensure all optimizations are applied
      * @default true

--- a/types/imagemin-svgo/package.json
+++ b/types/imagemin-svgo/package.json
@@ -1,13 +1,13 @@
 {
     "private": true,
     "name": "@types/imagemin-svgo",
-    "version": "10.0.9999",
+    "version": "11.0.0",
     "projects": [
         "https://github.com/imagemin/imagemin-svgo#readme"
     ],
     "dependencies": {
         "@types/imagemin": "*",
-        "@types/svgo": "2"
+        "svgo": "3"
     },
     "devDependencies": {
         "@types/imagemin-svgo": "workspace:."

--- a/types/imagemin-svgo/package.json
+++ b/types/imagemin-svgo/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/imagemin-svgo",
-    "version": "11.0.0",
+    "version": "11.0.9999",
     "projects": [
         "https://github.com/imagemin/imagemin-svgo#readme"
     ],


### PR DESCRIPTION
svgo ships it's own types starting with v3, so we can use it directly

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/imagemin/imagemin-svgo/releases/tag/v11.0.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
