### PR TITLE
@types/tabulator-tables paginationSize, setPageSize can accept "true" (i.e. "All)

### DIFF
--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -206,7 +206,7 @@ export interface OptionsPagination {
     paginationMode?: SortMode;
 
     /** Set the number of rows in each page. */
-    paginationSize?: number | undefined;
+    paginationSize?: number | true | undefined;
 
     /**
      * Setting this option to true will cause Tabulator to create a list of page size options, that are multiples of the current page size. In the example below, the list will have the values of 5, 10, 15 and 20.
@@ -3138,10 +3138,10 @@ declare class Tabulator {
     setPageToRow: (row: RowLookup) => Promise<void>;
 
     /** You can change the page size at any point by using the setPageSize function. (this setting will be ignored if using remote pagination with the page size set by the server) */
-    setPageSize: (size: number) => void;
+    setPageSize: (size: number | true) => void;
 
     /** To retrieve the number of rows allowed per page you can call the getPageSize function: */
-    getPageSize: () => number;
+    getPageSize: () => number | true;
 
     /** You can change to show the previous page using the previousPage function. */
     previousPage: () => Promise<void>;

--- a/types/tabulator-tables/tabulator-tables-tests.ts
+++ b/types/tabulator-tables/tabulator-tables-tests.ts
@@ -1312,6 +1312,44 @@ table = new Tabulator("#testPagination", {
     },
 });
 
+// Testing paginationSize to number and to "All"
+table = new Tabulator("#testPaginationSize", {
+    columns: [
+        {
+            field: "test_inline",
+            title: "Test inline",
+        },
+    ],
+    pagination: true,
+    paginationSize: true,
+});
+table = new Tabulator("#testPaginationSize", {
+    columns: [
+        {
+            field: "test_inline",
+            title: "Test inline",
+        },
+    ],
+    pagination: true,
+    paginationSize: 5,
+});
+
+// Testing setPageSize/getPageSize to number and to "All"
+table = new Tabulator("#testSetPagenSize", {
+    columns: [
+        {
+            field: "test_inline",
+            title: "Test inline",
+        },
+    ],
+    pagination: true,
+    paginationSize: 5,
+});
+table.setPageSize(10);
+table.setPageSize(true);
+// $ExpectType number | true
+table.getPageSize();
+
 // Testing data loader element
 table = new Tabulator("#testDataLoader", {
     data: [],


### PR DESCRIPTION
Tabulator accepts "true" as a page size to indicate "All."  @types/tabulator-tables was rejecting this.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/olifolkerd/tabulator/blob/7417849964e6329cc509cdc48b506edd98e69a09/src/js/modules/Page/Page.js#L557-L560
- [N/A] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

