### PR TITLE
[d3-dispatch] Implement type-safe events

### DIFF
--- a/types/d3-dispatch/d3-dispatch-tests.ts
+++ b/types/d3-dispatch/d3-dispatch-tests.ts
@@ -8,6 +8,33 @@
 
 import * as d3Dispatch from "d3-dispatch";
 
+// Utils --------------------------------------------
+
+let extractTests: [
+    // $ExpectType 'a'
+    d3Dispatch.Dispatch.ExtractEventNames<"a">,
+    // $ExpectType 'a'
+    d3Dispatch.Dispatch.ExtractEventNames<"a.1">,
+    // $ExpectType 'a' | 'b'
+    d3Dispatch.Dispatch.ExtractEventNames<"a b">,
+    // $ExpectType 'a' | 'b' | 'c'
+    d3Dispatch.Dispatch.ExtractEventNames<"a b c">,
+    // $ExpectType 'a' | 'b'
+    d3Dispatch.Dispatch.ExtractEventNames<"a.1 b">,
+    // $ExpectType 'a' | 'b'
+    d3Dispatch.Dispatch.ExtractEventNames<"a.1 b.2">,
+    // $ExpectType 'a' | 'b'
+    d3Dispatch.Dispatch.ExtractEventNames<"a b.2">,
+    // $ExpectType 'a'
+    d3Dispatch.Dispatch.ExtractEventNames<"a ">,
+    // $ExpectType 'a'
+    d3Dispatch.Dispatch.ExtractEventNames<" a">,
+    // $ExpectType 'a'
+    d3Dispatch.Dispatch.ExtractEventNames<" a ">,
+    // $ExpectType 'a' | 'b'
+    d3Dispatch.Dispatch.ExtractEventNames<" a   b ">,
+];
+
 // Preparation --------------------------------------------
 
 interface Datum {
@@ -19,8 +46,6 @@ interface ContextObject {
     about: string;
 }
 
-let dispatch: d3Dispatch.Dispatch<HTMLElement>;
-let dispatch2: d3Dispatch.Dispatch<ContextObject>;
 let callback: (this: HTMLElement, ...args: any[]) => void;
 let callbackOrUndef: ((this: HTMLElement, ...args: any[]) => void) | undefined;
 let undef: undefined;
@@ -28,15 +53,26 @@ let undef: undefined;
 // Signature Tests ----------------------------------------
 
 // create new dispatch object
-dispatch = d3Dispatch.dispatch("foo", "bar");
-dispatch2 = d3Dispatch.dispatch("start", "end");
+const dispatch = d3Dispatch.dispatch<HTMLElement, {
+    foo: [d?: Datum, i?: number];
+    bar: [];
+}>("foo", "bar");
 
-function cbFn(this: HTMLElement, d: Datum, i: number) {
+// $ExpectType Dispatch<HTMLElement, { foo: [d?: Datum | undefined, i?: number | undefined]; bar: [] }>
+dispatch;
+
+// in this example, the type-arguments are inferred
+const dispatch2 = d3Dispatch.dispatch("start", "end");
+
+// $ExpectType Dispatch<object, Record<"start" | "end", any[]>>
+dispatch2;
+
+function cbFn(this: HTMLElement, d?: Datum, i?: number) {
     console.log(this.baseURI ? this.baseURI : "nada");
     console.log(d ? d.a : "nada");
 }
 
-function cbFn2(this: SVGElement, d: Datum, i: number) {
+function cbFn2(this: SVGElement, d?: Datum, i?: number) {
     console.log(this.baseURI ? this.baseURI : "nada");
     console.log(d ? d.a : "nada");
 }
@@ -44,6 +80,9 @@ function cbFn2(this: SVGElement, d: Datum, i: number) {
 dispatch.on("foo", cbFn);
 // @ts-expect-error
 dispatch.on("foo", cbFn2); // test fails as 'this' context type is mismatched between dispatch and callback function
+
+// @ts-expect-error -- test fails since there are 3 arguments, but only 2 in the defintion
+dispatch.on("foo", (a, b, c) => {});
 
 callback = dispatch.on("bar")!;
 callbackOrUndef = dispatch.on("bar");
@@ -60,6 +99,8 @@ dispatch2.call("start", { about: "I am a context object" }, "I am an argument");
 
 dispatch.apply("bar");
 dispatch.apply("bar", document.body);
+dispatch.apply("bar", document.body, []);
+// @ts-expect-error -- `bar` expected 0 arguments
 dispatch.apply("bar", document.body, [{ a: 3, b: "test" }, 1]);
 
 dispatch.on("bar", null);
@@ -68,3 +109,166 @@ dispatch.on("bar", null);
 const copy: d3Dispatch.Dispatch<HTMLElement> = dispatch.copy();
 // @ts-expect-error
 const copy2: d3Dispatch.Dispatch<SVGElement> = dispatch.copy(); // test fails type mismatch of underlying event target
+
+const abc = d3Dispatch.dispatch("a", "b", "c");
+// valid cases:
+abc.on("a", null);
+abc.on("b", null);
+abc.on("a.1", null);
+abc.on("b.b", null);
+abc.on("a b", null);
+abc.on("a.1 b", null);
+abc.on("a.1 b.1", null);
+abc.on("a b.2", null);
+abc.on(" a", null);
+abc.on("a ", null);
+abc.call("a");
+abc.apply("a");
+
+// invalid, but no error. the arguments are just `never`:
+abc.on(" ", (...args) => {
+    // $ExpectType never
+    args;
+});
+
+// invalid cases:
+// @ts-expect-error -- d isn't defined
+abc.on("d", null);
+// @ts-expect-error -- d isn't defined
+abc.on("d.a", null);
+// @ts-expect-error -- d isn't defined
+abc.on("d e", null);
+// @ts-expect-error -- d isn't defined
+abc.on("d e.a", null);
+// @ts-expect-error -- e isn't defined
+abc.on("a e c", null);
+// @ts-expect-error -- e isn't defined
+abc.on("a e c.1", null);
+// @ts-expect-error -- nothing before and after period
+abc.on(".", null);
+// @ts-expect-error -- d isn't defined
+abc.call("d");
+// @ts-expect-error -- empty string
+abc.call("");
+// @ts-expect-error -- d isn't defined
+abc.apply("d");
+// @ts-expect-error -- empty string before period
+abc.on("a.2 b .", null);
+// @ts-expect-error -- empty string before period
+abc.on("a.2 b .3", null);
+// @ts-expect-error -- empty string
+abc.apply("");
+
+// this one has no event map, but we still infer the event names
+// and validate if an invalid event is passed to .apply() or .call()
+const inferred = d3Dispatch.dispatch("a", "b", "c");
+
+inferred.on("a", (...args) => {
+    // $ExpectType any[]
+    args;
+});
+inferred.on("b", (...args) => {
+    // $ExpectType any[]
+    args;
+});
+inferred.on("b.1", (...args) => {
+    // $ExpectType any[]
+    args;
+});
+inferred.on("c", (...args) => {
+    // $ExpectType any[]
+    args;
+});
+// @ts-expect-error -- event name is not defined
+inferred.on("invalid", () => {});
+inferred.on("a b", (...args) => {
+    // $ExpectType any[]
+    args;
+});
+inferred.on("a.1 b.2", (...args) => {
+    // $ExpectType any[]
+    args;
+});
+// @ts-expect-error -- e is not valid
+inferred.on("a.1 b.2 e", (...args) => {});
+inferred.call("a");
+inferred.call("a", window);
+inferred.call("a", window, 1, 2);
+inferred.apply("a");
+inferred.apply("a", window, []);
+inferred.apply("a", window, [1, 2]);
+
+// @ts-expect-error -- event does not exist
+inferred.call("d");
+// @ts-expect-error -- event does not exist
+inferred.call("");
+// @ts-expect-error -- event does not exist
+inferred.apply("d");
+// @ts-expect-error -- event does not exist
+inferred.apply("");
+
+interface EventMap {
+    // eslint-disable-next-line @definitelytyped/no-single-element-tuple-type -- intentional
+    a: [number];
+    b: [];
+    c: [string, boolean];
+}
+const explicit = d3Dispatch.dispatch<ContextObject, EventMap>("a", "b", "c");
+
+// @ts-expect-error -- type-arguments must match runtime-arguments
+d3Dispatch.dispatch<ContextObject, EventMap>("a", "b", "c", "d");
+// @ts-expect-error -- type-arguments must match runtime-arguments
+d3Dispatch.dispatch<ContextObject, EventMap>("a", "b", "d");
+
+explicit.on("a", function(...args) {
+    // $ExpectType [number]
+    args;
+    // $ExpectType ContextObject
+    this;
+});
+explicit.on("b", (...args) => {
+    // $ExpectType []
+    args;
+});
+explicit.on("b.1", (...args) => {
+    // $ExpectType []
+    args;
+});
+explicit.on("c", (...args) => {
+    // $ExpectType [string, boolean]
+    args;
+});
+// @ts-expect-error -- event name is not defined
+explicit.on("invalid", () => {});
+explicit.on("a b", (...args) => {
+    // union of `a` and `b`'s types
+    // $ExpectType [number] | []
+    args;
+});
+explicit.on("a.1 b.2", (...args) => {
+    // union of `a` and `b`'s types
+    // $ExpectType [number] | []
+    args;
+});
+// @ts-expect-error -- e is not valid
+explicit.on("a.1 b.2 e", (...args) => {});
+
+explicit.apply("a", this, [123]);
+explicit.apply("b", this, []);
+explicit.apply("c", this, ["", true]);
+// @ts-expect-error -- event does not exist
+inferred.apply("d");
+// @ts-expect-error -- invalid arguments
+explicit.apply("a", this, []);
+// @ts-expect-error -- invalid arguments
+explicit.apply("b", this, [1]);
+
+explicit.call("a", this, 123);
+explicit.call("b", this);
+explicit.call("c", this, "", true);
+// @ts-expect-error -- event does not exist
+inferred.call("d");
+// @ts-expect-error -- invalid arguments
+explicit.call("a", this);
+// @ts-expect-error -- invalid arguments
+explicit.call("b", this, 1);

--- a/types/d3-dispatch/index.d.ts
+++ b/types/d3-dispatch/index.d.ts
@@ -1,6 +1,27 @@
 // Last module patch version validated against: 3.0.1
 
-export interface Dispatch<T extends object> {
+export namespace Dispatch {
+    /** given a string like `a.1 b c.2`, it returns a union like `'a' | 'b' | 'c'` */
+    type ExtractEventNames<Input extends string> = Input extends "" ? never
+        : Input extends `${infer A} ${infer B}` // multiple events
+            ? ExtractEventNames<A> | ExtractEventNames<B>
+        : Input extends `${infer A}.${string}` // single event with a name
+            ? A
+        : Input; // single event with no name
+
+    /** helper function, maps over a union type */
+    type MapUnion<K extends keyof T, T> = K extends any ? T[K] : never;
+
+    /**
+     * defines all the events that can be emitted.
+     * Each property is the arguments for that event.
+     */
+    interface GenericEventMap {
+        [eventName: string]: any[];
+    }
+}
+
+export interface Dispatch<This extends object, EventMap extends Dispatch.GenericEventMap = Dispatch.GenericEventMap> {
     /**
      * Like `function.apply`, invokes each registered callback for the specified type,
      * passing the callback the specified arguments, with `that` as the `this` context.
@@ -10,7 +31,7 @@ export interface Dispatch<T extends object> {
      * @param args Additional arguments to be passed to the callback.
      * @throws "unknown type" on unknown event type.
      */
-    apply(type: string, that?: T, args?: any[]): void;
+    apply<U extends keyof EventMap>(type: U, that?: This, args?: EventMap[U]): void;
 
     /**
      * Like `function.call`, invokes each registered callback for the specified type,
@@ -22,19 +43,24 @@ export interface Dispatch<T extends object> {
      * @param args Additional arguments to be passed to the callback.
      * @throws "unknown type" on unknown event type.
      */
-    call(type: string, that?: T, ...args: any[]): void;
+    call<U extends keyof EventMap>(type: U, that?: This, ...args: EventMap[U]): void;
 
     /**
      * Returns a copy of this dispatch object.
      * Changes to this dispatch do not affect the returned copy and vice versa.
      */
-    copy(): Dispatch<T>;
+    copy(): Dispatch<This, EventMap>;
 
     /**
      * Returns the callback for the specified typenames, if any.
      * If multiple typenames are specified, the first matching callback is returned.
      */
-    on(typenames: string): ((this: T, ...args: any[]) => void) | undefined;
+    on<Source extends string>(
+        typenames: Source,
+    ): Dispatch.ExtractEventNames<Source> extends keyof EventMap
+        ? ((this: This, ...args: Dispatch.MapUnion<Dispatch.ExtractEventNames<Source>, EventMap>) => void) | undefined
+        : never;
+
     /**
      * Adds or removes the callback for the specified typenames.
      * If a callback function is specified, it is registered for the specified (fully-qualified) typenames.
@@ -44,7 +70,12 @@ export interface Dispatch<T extends object> {
      * To specify multiple typenames, separate typenames with spaces, such as start end or start.foo start.bar.
      * To remove all callbacks for a given name foo, say dispatch.on(".foo", null).
      */
-    on(typenames: string, callback: null | ((this: T, ...args: any[]) => void)): this;
+    on<Source extends string>(
+        typenames: Source,
+        callback: Dispatch.ExtractEventNames<Source> extends keyof EventMap
+            ? ((this: This, ...args: Dispatch.MapUnion<Dispatch.ExtractEventNames<Source>, EventMap>) => void) | null
+            : never,
+    ): this;
 }
 
 /**
@@ -53,5 +84,11 @@ export interface Dispatch<T extends object> {
  * @param types The event types.
  * @throws "illegal type" on empty string or duplicated event types.
  */
-// eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-export function dispatch<T extends object>(...types: string[]): Dispatch<T>;
+/* eslint-disable @definitelytyped/no-unnecessary-generics */
+export function dispatch<
+    This extends object,
+    EventMap extends Record<EventNames, any[]>,
+    const EventNames extends keyof any = keyof EventMap,
+>(
+    ...types: EventNames[]
+): Dispatch<This, EventMap>;

--- a/types/d3-dispatch/index.d.ts
+++ b/types/d3-dispatch/index.d.ts
@@ -1,5 +1,8 @@
 // Last module patch version validated against: 3.0.1
 
+/** helper function, maps over a union type */
+type MapUnion<K extends keyof T, T> = K extends any ? T[K] : never;
+
 export namespace Dispatch {
     /** given a string like `a.1 b c.2`, it returns a union like `'a' | 'b' | 'c'` */
     type ExtractEventNames<Input extends string> = Input extends "" ? never
@@ -8,9 +11,6 @@ export namespace Dispatch {
         : Input extends `${infer A}.${string}` // single event with a name
             ? A
         : Input; // single event with no name
-
-    /** helper function, maps over a union type */
-    type MapUnion<K extends keyof T, T> = K extends any ? T[K] : never;
 
     /**
      * defines all the events that can be emitted.
@@ -58,7 +58,7 @@ export interface Dispatch<This extends object, EventMap extends Dispatch.Generic
     on<Source extends string>(
         typenames: Source,
     ): Dispatch.ExtractEventNames<Source> extends keyof EventMap
-        ? ((this: This, ...args: Dispatch.MapUnion<Dispatch.ExtractEventNames<Source>, EventMap>) => void) | undefined
+        ? ((this: This, ...args: MapUnion<Dispatch.ExtractEventNames<Source>, EventMap>) => void) | undefined
         : never;
 
     /**
@@ -73,7 +73,7 @@ export interface Dispatch<This extends object, EventMap extends Dispatch.Generic
     on<Source extends string>(
         typenames: Source,
         callback: Dispatch.ExtractEventNames<Source> extends keyof EventMap
-            ? ((this: This, ...args: Dispatch.MapUnion<Dispatch.ExtractEventNames<Source>, EventMap>) => void) | null
+            ? ((this: This, ...args: MapUnion<Dispatch.ExtractEventNames<Source>, EventMap>) => void) | null
             : never,
     ): this;
 }
@@ -92,3 +92,5 @@ export function dispatch<
 >(
     ...types: EventNames[]
 ): Dispatch<This, EventMap>;
+
+export {};

--- a/types/d3-dispatch/package.json
+++ b/types/d3-dispatch/package.json
@@ -29,6 +29,10 @@
         {
             "name": "Nathan Bierema",
             "githubUsername": "Methuselah96"
+        },
+        {
+            "name": "Kyle Hensel",
+            "githubUsername": "k-yle"
         }
     ]
 }


### PR DESCRIPTION
This library currently has very basic types; all event names are `string` and all function arguments are `any`, which is pretty unhelpful.

With a little bit of type-gymnastics, we can get type-safe event names and event arguments. 

There are two cases:

* If you provide no type-arguments, you get type-safety for event names only, but not event arguments (still an improvement over the status quo):
  ```js
  dispatch("onClick", "onScroll");
  ```
* If you provide a type-argument, then you get type-safety for event names *and* event arguments:
  ```ts
  interface EventMap {
    onClick: [MouseEvent];
    onScroll: [WheelEvent];
  }
  dispatch<HTMLDivElement, EventMap>("onClick", "onScroll");
  ```

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: *the library's runtime logic has not changed.* Docs [are here](https://d3js.org/d3-dispatch) anyway.
- [x] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.~~

