### PR TITLE
feat(async): remove depreciated exports, add missing async func exports

### DIFF
--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -431,8 +431,13 @@ export function someLimit<T, E = Error>(
     arr: IterableCollection<T>,
     limit: number,
     iterator: AsyncBooleanIterator<T, E>,
-    callback?: AsyncBooleanResultCallback<E>,
+    callback: AsyncBooleanResultCallback<E>,
 ): void;
+export function someLimit<T, E = Error>(
+    arr: IterableCollection<T>,
+    limit: number,
+    iterator: AsyncBooleanIterator<T, E>,
+): Promise<boolean>;
 export const any: typeof some;
 export const anySeries: typeof someSeries;
 export const anyLimit: typeof someLimit;
@@ -576,16 +581,6 @@ export function doUntil<T, R, E = Error>(
     test: (/* ...results: T[], */ cb: AsyncBooleanResultCallback) => void,
 ): Promise<R>;
 
-export function during<E = Error>(
-    test: (testCallback: AsyncBooleanResultCallback<E>) => void,
-    fn: AsyncVoidFunction<E>,
-    callback: ErrorCallback<E>,
-): void;
-export function doDuring<E = Error>(
-    fn: AsyncVoidFunction<E>,
-    test: (testCallback: AsyncBooleanResultCallback<E>) => void,
-    callback: ErrorCallback<E>,
-): void;
 export function forever<E = Error>(next: (next: ErrorCallback<E>) => void, errBack: ErrorCallback<E>): void;
 export function waterfall<T>(tasks: Function[]): Promise<T>;
 export function waterfall<T, E = Error>(tasks: Function[], callback: AsyncResultCallback<T, E>): void;
@@ -615,7 +610,8 @@ export function auto<R extends Dictionary<any>, E = Error>(
     tasks: AsyncAutoTasks<R, E>,
     callback: AsyncResultCallback<R, E>,
 ): void;
-export function autoInject<E = Error>(tasks: any, callback?: AsyncResultCallback<any, E>): void;
+export function autoInject<E = Error>(tasks: any, callback: AsyncResultCallback<any, E>): void;
+export function autoInject(tasks: any): Promise<any>;
 
 export interface RetryOptions<E> {
     times?: number | undefined;
@@ -688,29 +684,46 @@ export function timesLimit<T, E = Error>(
 export function transform<T, R, E = Error>(
     arr: T[],
     iteratee: (acc: R[], item: T, key: number, callback: (error?: E) => void) => void,
-    callback?: AsyncResultArrayCallback<T, E>,
+    callback: AsyncResultArrayCallback<T, E>,
+): void;
+export function transform<T, R, E = Error>(
+    arr: T[],
+    iteratee: (acc: R[], item: T, key: number, callback: (error?: E) => void) => void,
+): Promise<Array<T | undefined>>;
+export function transform<T, R, E = Error>(
+    arr: T[],
+    acc: R[],
+    iteratee: (acc: R[], item: T, key: number, callback: (error?: E) => void) => void,
+    callback: AsyncResultArrayCallback<T, E>,
 ): void;
 export function transform<T, R, E = Error>(
     arr: T[],
     acc: R[],
     iteratee: (acc: R[], item: T, key: number, callback: (error?: E) => void) => void,
-    callback?: AsyncResultArrayCallback<T, E>,
-): void;
-
+): Promise<Array<T | undefined>>;
 export function transform<T, R, E = Error>(
     arr: { [key: string]: T },
     iteratee: (acc: { [key: string]: R }, item: T, key: string, callback: (error?: E) => void) => void,
-    callback?: AsyncResultObjectCallback<T, E>,
+    callback: AsyncResultObjectCallback<T, E>,
 ): void;
-
+export function transform<T, R, E = Error>(
+    arr: { [key: string]: T },
+    iteratee: (acc: { [key: string]: R }, item: T, key: string, callback: (error?: E) => void) => void,
+): Promise<Dictionary<T | undefined>>;
 export function transform<T, R, E = Error>(
     arr: { [key: string]: T },
     acc: { [key: string]: R },
     iteratee: (acc: { [key: string]: R }, item: T, key: string, callback: (error?: E) => void) => void,
-    callback?: AsyncResultObjectCallback<T, E>,
+    callback: AsyncResultObjectCallback<T, E>,
 ): void;
+export function transform<T, R, E = Error>(
+    arr: { [key: string]: T },
+    acc: { [key: string]: R },
+    iteratee: (acc: { [key: string]: R }, item: T, key: string, callback: (error?: E) => void) => void,
+): Promise<Dictionary<T | undefined>>;
 
 export function race<T, E = Error>(tasks: Array<AsyncFunction<T, E>>, callback: AsyncResultCallback<T, E>): void;
+export function race<T, E = Error>(tasks: Array<AsyncFunction<T, E>>): Promise<T>;
 
 export function tryEach<T, E = Error>(
     tasks: IterableCollection<AsyncFunction<T>>,

--- a/types/async/test/index.ts
+++ b/types/async/test/index.ts
@@ -96,14 +96,18 @@ promiseIterableString = async.sortBy(["file1", "file2", "file3"], (file, callbac
 });
 
 async.some(["file1", "file2", "file3"], funcStringCbErrBoolean, (err: Error, result: boolean) => {});
+promiseBoolean = async.some(["file1", "file2", "file3"], funcStringCbErrBoolean);
 async.someLimit(["file1", "file2", "file3"], 2, funcStringCbErrBoolean, (err: Error, result: boolean) => {});
+promiseBoolean = async.someLimit(["file1", "file2", "file3"], 2, funcStringCbErrBoolean);
 async.any(["file1", "file2", "file3"], funcStringCbErrBoolean, (err: Error, result: boolean) => {});
+promiseBoolean = async.any(["file1", "file2", "file3"], funcStringCbErrBoolean);
 
 async.every(["file1", "file2", "file3"], funcStringCbErrBoolean, (err: Error, result: boolean) => {});
 promiseBoolean = async.every(["file1", "file2", "file3"], funcStringCbErrBoolean);
 async.everyLimit(["file1", "file2", "file3"], 2, funcStringCbErrBoolean, (err: Error, result: boolean) => {});
 promiseBoolean = async.everyLimit(["file1", "file2", "file3"], 2, funcStringCbErrBoolean);
 async.all(["file1", "file2", "file3"], funcStringCbErrBoolean, (err: Error, result: boolean) => {});
+promiseBoolean = async.all(["file1", "file2", "file3"], funcStringCbErrBoolean);
 
 async.concat(["dir1", "dir2", "dir3"], fs.readdir, (err, files) => {}); // $ExpectType void
 async.concat<fs.PathLike, string>(["dir1", "dir2", "dir3"], fs.readdir); // $ExpectType Promise<string[]>
@@ -259,20 +263,6 @@ async.until(whileTest, whileFn, (err: Error) => {});
 async.doWhilst(whileFn, whileTest, (err: Error) => {});
 async.doUntil(whileFn, whileTest, (err: Error) => {});
 
-async.during(testCallback => {
-    testCallback(new Error(), false);
-}, callback => {
-    callback();
-}, error => {
-    console.log(error);
-});
-async.doDuring(callback => {
-    callback();
-}, testCallback => {
-    testCallback(new Error(), false);
-}, error => {
-    console.log(error);
-});
 async.forever(errBack => {
     errBack(new Error("Not going on forever."));
 }, error => {
@@ -1039,3 +1029,176 @@ const wrapped3 = async.timeout(myFunction3, 1000, { bar: "bar" });
 wrapped3((err: Error, data: any) => {
     console.log(`async.timeout 3 end ${data}`);
 });
+
+declare let autoInjectsTask: any;
+// $ExpectType void
+async.autoInject(autoInjectsTask, (error, result) => {
+    // $ExpectType Error | null | undefined
+    error;
+    // $ExpectType any
+    result;
+});
+// $ExpectType Promise<any>
+async.autoInject(autoInjectsTask);
+
+// $ExpectType void
+async.transform<string, number>(
+    [] as string[],
+    (acc, item, key, callback) => {
+        // $ExpectType number[]
+        acc;
+        // $ExpectType string
+        item;
+        // $ExpectType number
+        key;
+        // $ExpectType (error?: Error | undefined) => void
+        callback;
+    },
+    (error, result) => {
+        // $ExpectType Error | null | undefined
+        error;
+        // $ExpectType (string | undefined)[] | undefined
+        result;
+    },
+);
+// $ExpectType Promise<(string | undefined)[]>
+async.transform<string, number>(
+    [] as string[],
+    (acc, item, key, callback) => {
+        // $ExpectType number[]
+        acc;
+        // $ExpectType string
+        item;
+        // $ExpectType number
+        key;
+        // $ExpectType (error?: Error | undefined) => void
+        callback;
+    },
+);
+// $ExpectType void
+async.transform<string, number>(
+    [] as string[],
+    [] as number[],
+    (acc, item, key, callback) => {
+        // $ExpectType number[]
+        acc;
+        // $ExpectType string
+        item;
+        // $ExpectType number
+        key;
+        // $ExpectType (error?: Error | undefined) => void
+        callback;
+    },
+    (error, result) => {
+        // $ExpectType Error | null | undefined
+        error;
+        // $ExpectType (string | undefined)[] | undefined
+        result;
+    },
+);
+// $ExpectType Promise<(string | undefined)[]>
+async.transform<string, number>(
+    [] as string[],
+    [] as number[],
+    (acc, item, key, callback) => {
+        // $ExpectType number[]
+        acc;
+        // $ExpectType string
+        item;
+        // $ExpectType number
+        key;
+        // $ExpectType (error?: Error | undefined) => void
+        callback;
+    },
+);
+// $ExpectType void
+async.transform<string, number>(
+    { key: "value" },
+    (acc, item, key, callback) => {
+        // $ExpectType { [key: string]: number }
+        acc;
+        // $ExpectType string
+        item;
+        // $ExpectType string
+        key;
+        // $ExpectType (error?: Error | undefined) => void
+        callback;
+    },
+    (error, result) => {
+        // $ExpectType Error | undefined
+        error;
+        // $ExpectType Dictionary<string | undefined>
+        result;
+    },
+);
+// $ExpectType Promise<Dictionary<string | undefined>>
+async.transform<string, number>(
+    { key: "value" },
+    (acc, item, key, callback) => {
+        // $ExpectType { [key: string]: number }
+        acc;
+        // $ExpectType string
+        item;
+        // $ExpectType string
+        key;
+        // $ExpectType (error?: Error | undefined) => void
+        callback;
+    },
+);
+// $ExpectType void
+async.transform<string, number>(
+    { key: "value" },
+    { key: 1 },
+    (acc, item, key, callback) => {
+        // $ExpectType { [key: string]: number }
+        acc;
+        // $ExpectType string
+        item;
+        // $ExpectType string
+        key;
+        // $ExpectType (error?: Error | undefined) => void
+        callback;
+    },
+    (error, result) => {
+        // $ExpectType Error | undefined
+        error;
+        // $ExpectType Dictionary<string | undefined>
+        result;
+    },
+);
+// $ExpectType Promise<Dictionary<string | undefined>>
+async.transform<string, number>(
+    { key: "value" },
+    { key: 1 },
+    (acc, item, key, callback) => {
+        // $ExpectType { [key: string]: number }
+        acc;
+        // $ExpectType string
+        item;
+        // $ExpectType string
+        key;
+        // $ExpectType (error?: Error | undefined) => void
+        callback;
+    },
+);
+
+// $ExpectType void
+async.race<string>(
+    [(taskCallback) => {
+        // $ExpectType (err?: Error | null | undefined, result?: string | undefined) => void
+        taskCallback;
+    }],
+    (error, result) => {
+        // $ExpectType Error | null | undefined
+        error;
+        // $ExpectType string | undefined
+        result;
+    },
+);
+// $ExpectType Promise<string>
+async.race<string>(
+    [(taskCallback) => {
+        // $ExpectType (err?: Error | null | undefined, result?: string | undefined) => void
+        taskCallback;
+    }],
+);


### PR DESCRIPTION
Resolves https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/73166. Essentially replacing all existing `callback?` by adding corresponding es6 async overloads, as the [library doc](https://caolan.github.io/async/v3/docs.html) suggests.

Deprecated methods `during()` & `doDuring()` are removed too. See https://github.com/caolan/async/blob/master/CHANGELOG.md#breaking-changes.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
