### PR TITLE
Leaflet: fix return type for getting center of overlays

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1893,7 +1893,7 @@ export class ImageOverlay extends Layer {
     getBounds(): LatLngBounds;
 
     /** Get the center of the bounds this ImageOverlay covers */
-    getCenter(): Point;
+    getCenter(): LatLng;
 
     /** Get the img element that represents the ImageOverlay on the map */
     getElement(): HTMLImageElement | undefined;
@@ -1933,7 +1933,7 @@ export class SVGOverlay extends Layer {
     getBounds(): LatLngBounds;
 
     /** Get the center of the bounds this ImageOverlay covers */
-    getCenter(): Point;
+    getCenter(): LatLng;
 
     /** Get the img element that represents the SVGOverlay on the map */
     getElement(): SVGElement | undefined;
@@ -1989,7 +1989,7 @@ export class VideoOverlay extends Layer {
     getBounds(): LatLngBounds;
 
     /** Get the center of the bounds this ImageOverlay covers */
-    getCenter(): Point;
+    getCenter(): LatLng;
 
     /** Get the video element that represents the VideoOverlay on the map */
     getElement(): HTMLVideoElement | undefined;

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -88,6 +88,8 @@ const bottomRight = bounds.getBottomRight();
 
 bounds.isValid();
 
+point = bounds.getCenter();
+
 let points: L.Point[];
 points = L.LineUtil.simplify([point, point], 1);
 
@@ -435,7 +437,7 @@ imageOverlay.setBounds(imageOverlayBounds);
 imageOverlay.setZIndex(1);
 imageOverlayBounds = imageOverlay.getBounds();
 maybeHtml = imageOverlay.getElement();
-point = imageOverlay.getCenter();
+coordinates = imageOverlay.getCenter();
 imageOverlay = imageOverlay.setStyle({ opacity: 90 });
 
 // SVGOverlay
@@ -462,7 +464,7 @@ svgOverlay.setBounds(imageOverlayBounds);
 svgOverlay.setZIndex(1);
 svgOverlayBounds = svgOverlay.getBounds();
 const svgElement: SVGElement | undefined = svgOverlay.getElement();
-point = svgOverlay.getCenter();
+coordinates = svgOverlay.getCenter();
 svgOverlay = svgOverlay.setStyle({ opacity: 90 });
 
 // videoOverlay
@@ -493,7 +495,7 @@ videoOverlay.setBounds(imageOverlayBounds);
 videoOverlay.setZIndex(1);
 videoOverlayBounds = videoOverlay.getBounds();
 maybeHtml = videoOverlay.getElement();
-point = videoOverlay.getCenter();
+coordinates = videoOverlay.getCenter();
 videoOverlay = videoOverlay.setStyle(videoOverlayOptions);
 
 const eventHandler = () => {};


### PR DESCRIPTION
Method was introduced in [v. 1.8.0](https://web.archive.org/web/20220923053459/https://leafletjs.com/reference-1.8.0.html#imageoverlay) and the return type always should have been a LatLng instead of Point 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://leafletjs.com/reference.html#imageoverlay-getcenter
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
