### PR TITLE
[express-http-proxy] Update request options decorator param

### DIFF
--- a/types/express-http-proxy/express-http-proxy-tests.ts
+++ b/types/express-http-proxy/express-http-proxy-tests.ts
@@ -41,7 +41,7 @@ proxy("www.google.com", {
 
 proxy("www.google.com", {
     proxyReqOptDecorator(proxyReqOpts, srcReq) {
-        console.log(proxyReqOpts.headers, proxyReqOpts.method);
+        console.log(proxyReqOpts.headers, proxyReqOpts.method, proxyReqOpts.headers["user-agent"]);
         console.log(srcReq.url, srcReq.cookies);
         return proxyReqOpts;
     },

--- a/types/express-http-proxy/index.d.ts
+++ b/types/express-http-proxy/index.d.ts
@@ -19,7 +19,9 @@ declare namespace proxy {
         proxyReqPathResolver?: ((req: Request) => string | Promise<string>) | undefined;
         proxyReqOptDecorator?:
             | ((
-                proxyReqOpts: RequestOptions,
+                proxyReqOpts: Omit<RequestOptions, "headers"> & {
+                    headers: OutgoingHttpHeaders;
+                },
                 srcReq: Request,
             ) => RequestOptions | Promise<RequestOptions>)
             | undefined;


### PR DESCRIPTION
Set `headers` property in passed `proxyReqOpts` parameter to the dictionary form of `RequestOptions['headers']`, matching what is actually provided by `express-http-proxy`.

Rationale

1. PR #72617 changed the type of property `headers` in node's `http.ClientRequestArgs` interface from `OutgoingHttpHeaders | undefined` to `OutgoingHttpHeaders | readonly string[] | undefined`. As a result, all consumers of `headers` are now required to do cumbersome type narrowing to determine whether the value is an array or object (and [`Array.isArray()` does not help type narrow readonly arrays](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/73208#discussioncomment-13675598)).
1. In `express-http-proxy`, the `proxyReqOpts` parameter passed to option `proxyReqOptDecorator` includes a `header` property that [is an object](https://github.com/villadora/express-http-proxy/blob/b5d7dd011fa526699628c6fe3763e1d1ad9a9515/lib/requestOptions.js#L55) (i.e. it cannot be `undefined` or an array). While it is technically possible for the end user to [specify a legacy `headers` option](https://github.com/villadora/express-http-proxy/blob/b5d7dd011fa526699628c6fe3763e1d1ad9a9515/lib/resolveOptions.js#L61) when creating a proxy request handler, and this would supplement the headers import from the `Request` object, two things prevent the possibility of the end user passing `readonly string[]` headers:
   - The type definitions in this repository do not expose the legacy `headers` option in [`ProxyOptions`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/70305194cccca1d648922c0130eb62740b301fd9/types/express-http-proxy/index.d.ts#L5)
   - `express-http-proxy` [expects an object form of headers](https://github.com/villadora/express-http-proxy/blob/b5d7dd011fa526699628c6fe3763e1d1ad9a9515/lib/requestOptions.js#L61)
1. Type narrowing the `headers` property here simplifies uses of `headers` in the `proxyReqOptDecorator` function by allowing users to read and update the dictionary via `proxyReqOpts.headers.someProp` and `proxyReqOpts.headers.someProp = '...'`, respectively.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: < https://github.com/villadora/express-http-proxy/blob/b5d7dd011fa526699628c6fe3763e1d1ad9a9515/lib/requestOptions.js#L52-L83 >
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
