### PR TITLE
[jquery.contextMenu] Correct argumet type of JQueryContextMenuOptions['position']

### DIFF
--- a/types/jquery.contextmenu/index.d.ts
+++ b/types/jquery.contextmenu/index.d.ts
@@ -7,7 +7,7 @@ interface JQueryContextMenuOptions {
     autoHide?: boolean | undefined;
     delay?: number | undefined;
     determinePosition?: ((menu: JQuery) => void) | undefined;
-    position?: ((opt: JQuery, x: number, y: number) => void) | undefined;
+    position?: ((opt: JQueryContextMenuOptions & { $menu: JQuery }, x: number, y: number) => void) | undefined;
     positionSubmenu?: ((menu: JQuery) => void) | undefined;
     zIndex?: number | undefined;
     animation?: {

--- a/types/jquery.contextmenu/jquery.contextmenu-tests.ts
+++ b/types/jquery.contextmenu/jquery.contextmenu-tests.ts
@@ -10,6 +10,19 @@ $(".some-selector").contextMenu({ x: 123, y: 123 });
 // Manually hide a contextMenu
 $(".some-selector").contextMenu("hide");
 
+// Register a contextMenu with option object
+$.contextMenu({
+    selector: ".some-selector",
+});
+
+// Register a contextMenu with position function
+$.contextMenu({
+    selector: ".some-selector",
+    position: function (opt, x, y) {
+        opt.$menu.css({ top: 123, left: 123 });
+    }
+});
+
 // Unregister contextMenu
 $.contextMenu("destroy", ".some-selector");
 


### PR DESCRIPTION
[The official documentation](https://swisnl.github.io/jQuery-contextMenu/docs.html#position) writes sample code as:
```js
$.contextMenu({
    selector: 'span.context-menu',
    position: function(opt, x, y){
        opt.$menu.css({top: 123, left: 123});
    } 
});
```
but current type here is written as if type of `opt` was equal to `$menu`.

Raw Code is here:
https://github.com/swisnl/jQuery-contextMenu/blob/e6bb11399e60df9342f84d4990683a87c10a881e/dist/jquery.contextMenu.js#L435C16-L435C58