### PR TITLE
Update `@id` keyword in JSON-LD. It cannot be an array

### DIFF
--- a/types/jsonld/index.d.ts
+++ b/types/jsonld/index.d.ts
@@ -129,10 +129,10 @@ export function flatten(
     input: JsonLdDocument,
     ctx: ContextDefinition | null,
     options: Options.Flatten,
-    callback: Callback<JsonLdObj>,
+    callback: Callback<JsonLdArray>,
 ): void;
-export function flatten(input: JsonLdDocument, ctx: ContextDefinition | null, callback: Callback<JsonLdObj>): void;
-export function flatten(input: JsonLdDocument, ctx?: ContextDefinition, options?: Options.Flatten): Promise<JsonLdObj>;
+export function flatten(input: JsonLdDocument, ctx: ContextDefinition | null, callback: Callback<JsonLdArray>): void;
+export function flatten(input: JsonLdDocument, ctx?: ContextDefinition, options?: Options.Flatten): Promise<JsonLdArray>;
 
 export function frame(input: JsonLdDocument, frame: Frame, options: Options.Frame, callback: Callback<JsonLdObj>): void;
 export function frame(input: JsonLdDocument, frame: Frame, callback: Callback<JsonLdObj>): void;

--- a/types/jsonld/jsonld.d.ts
+++ b/types/jsonld/jsonld.d.ts
@@ -219,7 +219,7 @@ type Keyword = {
     "@context": OrArray<null | string | ContextDefinition>;
     "@direction": "ltr" | "rtl" | null;
     "@graph": OrArray<ValueObject | NodeObject>;
-    "@id": OrArray<string>;
+    "@id": string;
     "@import": string;
     "@included": IncludedBlock;
     "@index": string;


### PR DESCRIPTION
Hmm this is complex. Currently the types conflate JSON-LD frames and JSON-LD nodes, which have different type constraints. My intention is to separate these out, because currently it implies that you can have `{"@id": ["#id", "#id2]}` which is not correct.

Separately, the `flatten()` return value is an array which you can see here: https://github.com/digitalbazaar/jsonld.js/blob/71656073c2abe14b2538215ec8592cd9548b7a35/lib/flatten.js#L28-L37

***

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://w3c.github.io/json-ld-syntax/#node-objects:~:text=If%20the%20node%20object%20contains%20the%20%40id%20key%2C%20its%20value%20MUST%20be%20an%20IRI%20reference%2C%20or%20a%20compact%20IRI%20(including%20blank%20node%20identifiers).%20See%203.3%20Node%20Identifiers%2C%204.1.5%20Compact%20IRIs%2C%20and%204.5.1%20Identifying%20Blank%20Nodes%20for%20further%20discussion%20on%20%40id%20values.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

