### PR TITLE
[node-schedule] - Add `null` to `job.nextInvocation()` return

### DIFF
--- a/types/node-schedule/index.d.ts
+++ b/types/node-schedule/index.d.ts
@@ -68,7 +68,7 @@ export class Job extends EventEmitter {
     reschedule(spec: Spec): boolean;
 
     /** The Date on which this Job will be run next. */
-    nextInvocation(): Date;
+    nextInvocation(): null | Date;
 
     /** A list of all pending Invocations. */
     pendingInvocations: Invocation[];


### PR DESCRIPTION
According to the documentation:

> **job.nextInvocation()**
> This method returns a Date object for the planned next Invocation for this Job. If no invocation is planned the method returns `null`.

This pull request adds the `null` value to the return.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/node-schedule/node-schedule#jobnextinvocation>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.