### PR TITLE
Make `title` optional in `autoColumnsDefinitions` tabulator-tables

### DIFF
--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -719,8 +719,8 @@ export interface OptionsColumns {
     /** If you set the autoColumns option to true, every time data is loaded into the table through the data option or through the setData function, Tabulator will examine the first row of the data and build columns to match that data. */
     autoColumns?: boolean | undefined | "full";
     autoColumnsDefinitions?:
-        | ((columnDefinitions?: ColumnDefinition[]) => ColumnDefinition[])
-        | ColumnDefinition[]
+        | ((columnDefinitions?: ColumnDefinition[]) => Partial<ColumnDefinition>[])
+        | Partial<ColumnDefinition>[]
         | Record<string, Partial<ColumnDefinition>>
         | undefined;
 

--- a/types/tabulator-tables/tabulator-tables-tests.ts
+++ b/types/tabulator-tables/tabulator-tables-tests.ts
@@ -925,8 +925,8 @@ table = new Tabulator("#example-table", {
 
 new Tabulator("#example-table", {
     autoColumnsDefinitions: [
-        {field: "migration_up", formatter: "textarea" }
-    ]
+        { field: "migration_up", formatter: "textarea" },
+    ],
 });
 
 let colDefs: ColumnDefinition[] = [];

--- a/types/tabulator-tables/tabulator-tables-tests.ts
+++ b/types/tabulator-tables/tabulator-tables-tests.ts
@@ -923,6 +923,12 @@ table = new Tabulator("#example-table", {
     },
 });
 
+new Tabulator("#example-table", {
+    autoColumnsDefinitions: [
+        {field: "migration_up", formatter: "textarea" }
+    ]
+});
+
 let colDefs: ColumnDefinition[] = [];
 colDefs.push({
     field: "name",


### PR DESCRIPTION
This is perfectly valid as per the documentation

<img width="400" height="128" alt="image" src="https://github.com/user-attachments/assets/d6d8976c-13b0-4eaf-81bd-f273657a2763" />

But it is failing to type check now. This PR fixes that.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://tabulator.info/docs/6.3/columns#main-contents:~:text=%3B%0A%20%20%20%20%7D%2C%0A%7D)%3B-,Column%20Definition%20Array,-If%20you%20pass
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. N/A
