### PR TITLE
Fix dependencies of @types/hoist-non-react-statics to avoid bundling pinned @types/react in node_modules

### DIFF
--- a/types/hoist-non-react-statics/package.json
+++ b/types/hoist-non-react-statics/package.json
@@ -6,12 +6,15 @@
         "https://github.com/mridgway/hoist-non-react-statics#readme"
     ],
     "dependencies": {
-        "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
     },
     "devDependencies": {
         "@types/hoist-non-react-statics": "workspace:.",
-        "@types/prop-types": "*"
+        "@types/prop-types": "*",
+        "@types/react": "*"
+    },
+    "peerDependencies": {
+         "@types/react": "*"
     },
     "owners": [
         {

--- a/types/hoist-non-react-statics/package.json
+++ b/types/hoist-non-react-statics/package.json
@@ -10,8 +10,7 @@
     },
     "devDependencies": {
         "@types/hoist-non-react-statics": "workspace:.",
-        "@types/prop-types": "*",
-        "@types/react": "*"
+        "@types/prop-types": "*"
     },
     "peerDependencies": {
          "@types/react": "*"

--- a/types/hoist-non-react-statics/package.json
+++ b/types/hoist-non-react-statics/package.json
@@ -13,7 +13,7 @@
         "@types/prop-types": "*"
     },
     "peerDependencies": {
-         "@types/react": "*"
+        "@types/react": "*"
     },
     "owners": [
         {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

None of the options apply:

- [x] This is for an existing package whose types are correct, but who incorrectly include a direct dependency on types that should be relied upon as a peer dependency. This creates problems when upgrading library versions.