### PR TITLE
fix(node-forge): update PrivateKey and PublicKey usage to better reflect library support

### DIFF
--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -475,7 +475,7 @@ declare module "node-forge" {
              * @param key the private key to sign with.
              * @param md the message digest object to use (defaults to forge.md.sha1).
              */
-            sign(key: pki.PrivateKey, md?: md.MessageDigest): void;
+            sign(key: pki.rsa.PrivateKey, md?: md.MessageDigest): void;
             /**
              * Attempts verify the signature on the passed certificate using this
              * certificate's public key.
@@ -570,7 +570,7 @@ declare module "node-forge" {
              * @param key the private key to sign with.
              * @param md the message digest object to use (defaults to forge.md.sha1).
              */
-            sign(key: pki.PrivateKey, md?: md.MessageDigest): void;
+            sign(key: pki.rsa.PrivateKey, md?: md.MessageDigest): void;
             /**
              * Attempts verify the signature on this csr using this
              * csr's public key.
@@ -764,23 +764,23 @@ declare module "node-forge" {
         /**
          * @description Encodes a private RSA key as an OpenSSH file
          */
-        function privateKeyToOpenSSH(privateKey: pki.PrivateKey, passphrase?: string): string;
+        function privateKeyToOpenSSH(privateKey: pki.rsa.PrivateKey, passphrase?: string): string;
 
         /**
          * @description Encodes (and optionally encrypts) a private RSA key as a Putty PPK file
          */
-        function privateKeyToPutty(privateKey: pki.PrivateKey, passphrase?: string, comment?: string): string;
+        function privateKeyToPutty(privateKey: pki.rsa.PrivateKey, passphrase?: string, comment?: string): string;
 
         /**
          * @description Encodes a public RSA key as an OpenSSH file
          */
-        function publicKeyToOpenSSH(publicKey: pki.PublicKey, comment?: string): string | pki.PEM;
+        function publicKeyToOpenSSH(publicKey: pki.rsa.PublicKey, comment?: string): string | pki.PEM;
 
         /**
          * @description Gets the SSH fingerprint for the given public key
          */
         function getPublicKeyFingerprint(
-            publicKey: pki.PublicKey,
+            publicKey: pki.rsa.PublicKey,
             options?: FingerprintOptions,
         ): util.ByteStringBuffer | Hex | string;
     }
@@ -966,7 +966,7 @@ declare module "node-forge" {
         interface Bag {
             type: string;
             attributes: any;
-            key?: pki.PrivateKey | undefined;
+            key?: pki.rsa.PrivateKey | undefined;
             cert?: pki.Certificate | undefined;
             asn1: asn1.Asn1;
         }
@@ -990,7 +990,7 @@ declare module "node-forge" {
         function pkcs12FromAsn1(obj: any, password?: string): Pkcs12Pfx;
 
         function toPkcs12Asn1(
-            key: pki.PrivateKey | null,
+            key: pki.rsa.PrivateKey | null,
             cert: pki.Certificate | pki.Certificate[],
             password: string | null,
             options?: {

--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -278,10 +278,6 @@ declare module "node-forge" {
         }
         var oids: oids;
 
-        interface MDSigner {
-            sign(md: md.MessageDigest): Bytes;
-        }
-
         namespace rsa {
             type EncryptionScheme = "RSAES-PKCS1-V1_5" | "RSA-OAEP" | "RAW" | "NONE" | null;
             type SignatureScheme = "RSASSA-PKCS1-V1_5" | pss.PSS | "NONE" | null;
@@ -476,10 +472,10 @@ declare module "node-forge" {
             /**
              * Signs this certificate using the given private key.
              *
-             * @param signer the signer used to sign this csr
+             * @param key the private key to sign with.
              * @param md the message digest object to use (defaults to forge.md.sha1).
              */
-            sign(signer: MDSigner, md?: md.MessageDigest): void;
+            sign(key: pki.PrivateKey, md?: md.MessageDigest): void;
             /**
              * Attempts verify the signature on the passed certificate using this
              * certificate's public key.
@@ -571,10 +567,10 @@ declare module "node-forge" {
             /**
              * Signs this csr using the given private key.
              *
-             * @param signer the signer used to sign this csr
+             * @param key the private key to sign with.
              * @param md the message digest object to use (defaults to forge.md.sha1).
              */
-            sign(signer: MDSigner, md?: md.MessageDigest): void;
+            sign(key: pki.PrivateKey, md?: md.MessageDigest): void;
             /**
              * Attempts verify the signature on this csr using this
              * csr's public key.

--- a/types/node-forge/node-forge-tests.ts
+++ b/types/node-forge/node-forge-tests.ts
@@ -30,7 +30,7 @@ let byteBufferString = forge.pki.pemToDer(privateKeyPem);
 let cert = forge.pki.createCertificate();
 cert.publicKey = keypair.publicKey;
 // explicitly cast as PrivateKey to ensure expected typings are accepted
-cert.sign(keypair.privateKey as forge.pki.PrivateKey);
+cert.sign(keypair.privateKey);
 forge.pki.certificateFromAsn1(forge.pki.certificateToAsn1(cert));
 let certPem = forge.pki.certificateToPem(cert);
 let csr = forge.pki.createCertificationRequest();
@@ -68,7 +68,7 @@ csr.addAttribute({
     name: "challengePassword",
     value: "password",
 });
-csr.sign(keypair.privateKey as forge.pki.PrivateKey);
+csr.sign(keypair.privateKey);
 csr.verify();
 csr.getAttribute({ name: "challengePassword" });
 csr.getAttribute({ name: "extensionRequest" }).extensions;

--- a/types/node-forge/node-forge-tests.ts
+++ b/types/node-forge/node-forge-tests.ts
@@ -29,7 +29,8 @@ let privateKeyFromAsn1 = forge.pki.privateKeyFromAsn1(privateKeyAsn1);
 let byteBufferString = forge.pki.pemToDer(privateKeyPem);
 let cert = forge.pki.createCertificate();
 cert.publicKey = keypair.publicKey;
-cert.sign(keypair.privateKey);
+// explicitly cast as PrivateKey to ensure expected typings are accepted
+cert.sign(keypair.privateKey as forge.pki.PrivateKey);
 forge.pki.certificateFromAsn1(forge.pki.certificateToAsn1(cert));
 let certPem = forge.pki.certificateToPem(cert);
 let csr = forge.pki.createCertificationRequest();
@@ -67,7 +68,7 @@ csr.addAttribute({
     name: "challengePassword",
     value: "password",
 });
-csr.sign(keypair.privateKey);
+csr.sign(keypair.privateKey as forge.pki.PrivateKey);
 csr.verify();
 csr.getAttribute({ name: "challengePassword" });
 csr.getAttribute({ name: "extensionRequest" }).extensions;


### PR DESCRIPTION
I've run through the type definitions to see where `pki.PrivateKey` and `pki.PublicKey` are being used and then cross referenced this with the upstream library to correctly narrow the typings down to `pki.rsa.PrivateKey` or `pki.rsa.PublicKey` where appropriate (which turns out to be most places).

~~Reverts DefinitelyTyped/DefinitelyTyped#73216~~

~~The change has broken the bone fide use case as per the library when providing a `pki.PrivateKey` the typescript parser now errors:~~

```
TS2345: Argument of type PrivateKey is not assignable to parameter of type MDSigner
   Property sign is missing in type Buffer<ArrayBufferLike> but required in type MDSigner
```

~~This library *may* be able to accept an argument that solely exists of an object with a sign function, but that is not the intended use of the function and is not the correct typing of the function. Anyone wishing to examine the internals of the function and make this assumption for themselves can use their own type coercion to achieve this instead of creating a synthetic type that doesn't exist in the library.~~

Please fill in this template.

 - [x] Use a meaningful title for the pull request. Include the name of the package modified.
 - [x] Test the change in your own code. (Compile and run.)
 - [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
 - [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
 - [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
 - [x] [Run pnpm test <package to test>](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<[url here](https://github.com/digitalbazaar/forge/blob/main/lib/x509.js#L1810-L1810)>>