### PR TITLE
Fix chrome alarms.get() return type

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -471,7 +471,7 @@ declare namespace chrome {
         /**
          * Retrieves details about the specified alarm.
          */
-        export function get(callback: (alarm: Alarm) => void): void;
+        export function get(callback: (alarm?: Alarm) => void): void;
         /**
          * Retrieves details about the specified alarm.
          * @return The `get` method provides its result via callback or returned as a `Promise` (MV3 only).
@@ -481,7 +481,7 @@ declare namespace chrome {
          * Retrieves details about the specified alarm.
          * @param name The name of the alarm to get. Defaults to the empty string.
          */
-        export function get(name: string, callback: (alarm: Alarm) => void): void;
+        export function get(name: string, callback: (alarm?: Alarm) => void): void;
         /**
          * Retrieves details about the specified alarm.
          * @param name The name of the alarm to get. Defaults to the empty string.

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -476,7 +476,7 @@ declare namespace chrome {
          * Retrieves details about the specified alarm.
          * @return The `get` method provides its result via callback or returned as a `Promise` (MV3 only).
          */
-        export function get(): Promise<Alarm>;
+        export function get(): Promise<Alarm | undefined>;
         /**
          * Retrieves details about the specified alarm.
          * @param name The name of the alarm to get. Defaults to the empty string.
@@ -487,7 +487,7 @@ declare namespace chrome {
          * @param name The name of the alarm to get. Defaults to the empty string.
          * @return The `get` method provides its result via callback or returned as a `Promise` (MV3 only).
          */
-        export function get(name: string): Promise<Alarm>;
+        export function get(name: string): Promise<Alarm | undefined>;
 
         /** Fired when an alarm has elapsed. Useful for event pages. */
         export var onAlarm: AlarmEvent;

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -2034,15 +2034,82 @@ async function testAction() {
 }
 
 // https://developer.chrome.com/docs/extensions/reference/alarms/
-async function testAlarmsForPromise() {
-    await chrome.alarms.getAll();
-    await chrome.alarms.create("name1", { when: Date.now() });
-    await chrome.alarms.create({ when: Date.now() });
-    await chrome.alarms.clearAll();
-    await chrome.alarms.clear();
-    await chrome.alarms.clear("name1");
-    await chrome.alarms.get();
-    await chrome.alarms.get("name1");
+async function testAlarms() {
+    const alarmCreateInfo: chrome.alarms.AlarmCreateInfo = {
+        delayInMinutes: 1,
+        periodInMinutes: 1,
+        when: 1,
+    };
+
+    chrome.alarms.create(alarmCreateInfo); // $ExpectType Promise<void>
+    chrome.alarms.create("name", alarmCreateInfo); // $ExpectType Promise<void>
+    chrome.alarms.create(alarmCreateInfo, () => {}); // $ExpectType void
+    chrome.alarms.create("name", alarmCreateInfo, () => {}); // $ExpectType void
+    // @ts-expect-error
+    chrome.alarms.create("name", alarmCreateInfo, () => {}).then(() => {});
+
+    chrome.alarms.getAll(); // $ExpectType Promise<Alarm[]>
+    chrome.alarms.getAll((alarms) => { // $ExpectType void
+        alarms[0].name; // $ExpectType string
+        alarms[0].periodInMinutes; // $ExpectType number | undefined
+        alarms[0].scheduledTime; // $ExpectType number
+    });
+    // @ts-expect-error
+    chrome.alarms.getAll(() => {}).then(() => {});
+
+    chrome.alarms.clearAll(); // $ExpectType Promise<boolean>
+    chrome.alarms.clearAll((wasCleared) => { // $ExpectType void
+        wasCleared; // $ExpectType boolean
+    });
+    // @ts-expect-error
+    chrome.alarms.clearAll(() => {}).then(() => {});
+
+    chrome.alarms.clear(); // $ExpectType Promise<boolean>
+    chrome.alarms.clear("name"); // $ExpectType Promise<boolean>
+    chrome.alarms.clear((wasCleared) => { // $ExpectType void
+        wasCleared; // $ExpectType boolean
+    });
+    chrome.alarms.clear("name", (wasCleared) => { // $ExpectType void
+        wasCleared; // $ExpectType boolean
+    });
+    // @ts-expect-error
+    chrome.alarms.clear("name", () => {}).then(() => {});
+
+    chrome.alarms.get(); // $ExpectType Promise<Alarm | undefined>
+    chrome.alarms.get("name"); // $ExpectType Promise<Alarm | undefined>
+    chrome.alarms.get((alarm) => { // $ExpectType void
+        if (alarm) {
+            alarm.name; // $ExpectType string
+            alarm.periodInMinutes; // $ExpectType number | undefined
+            alarm.scheduledTime; // $ExpectType number
+        }
+    });
+    chrome.alarms.get("name", (alarm) => { // $ExpectType void
+        if (alarm) {
+            alarm.name; // $ExpectType string
+            alarm.periodInMinutes; // $ExpectType number | undefined
+            alarm.scheduledTime; // $ExpectType number
+        }
+    });
+    // @ts-expect-error
+    chrome.alarms.get("name", () => {}).then(() => {});
+
+    chrome.alarms.onAlarm.addListener((alarm) => { // $ExpectType void
+        alarm.name; // $ExpectType string
+        alarm.periodInMinutes; // $ExpectType number | undefined
+        alarm.scheduledTime; // $ExpectType number
+    });
+    chrome.alarms.onAlarm.removeListener((alarm) => { // $ExpectType void
+        alarm.name; // $ExpectType string
+        alarm.periodInMinutes; // $ExpectType number | undefined
+        alarm.scheduledTime; // $ExpectType number
+    });
+    chrome.alarms.onAlarm.hasListener((alarm) => { // $ExpectType boolean
+        alarm.name; // $ExpectType string
+        alarm.periodInMinutes; // $ExpectType number | undefined
+        alarm.scheduledTime; // $ExpectType number
+    });
+    chrome.alarms.onAlarm.hasListeners(); // $ExpectType boolean
 }
 
 // https://developer.chrome.com/docs/extensions/reference/api/audio

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -2078,6 +2078,7 @@ async function testAlarms() {
     chrome.alarms.get(); // $ExpectType Promise<Alarm | undefined>
     chrome.alarms.get("name"); // $ExpectType Promise<Alarm | undefined>
     chrome.alarms.get((alarm) => { // $ExpectType void
+        alarm; // $ExpectType Alarm | undefined
         if (alarm) {
             alarm.name; // $ExpectType string
             alarm.periodInMinutes; // $ExpectType number | undefined
@@ -2085,6 +2086,7 @@ async function testAlarms() {
         }
     });
     chrome.alarms.get("name", (alarm) => { // $ExpectType void
+        alarm; // $ExpectType Alarm | undefined
         if (alarm) {
             alarm.name; // $ExpectType string
             alarm.periodInMinutes; // $ExpectType number | undefined


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://developer.chrome.com/docs/extensions/reference/api/alarms#method-get>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

Both the documentation from chrome and my personal testing in chrome extensions show that the return type for `alarms.get()` can be `undefined`.
