### PR TITLE
add callback to ServerResponse.writeProcessing

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -911,7 +911,7 @@ declare module "http" {
          * the request body should be sent.
          * @since v10.0.0
          */
-        writeProcessing(): void;
+        writeProcessing(callback?: () => void): void;
     }
     interface InformationEvent {
         statusCode: number;

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -269,6 +269,7 @@ import * as url from "node:url";
 
     // writeProcessing
     res.writeProcessing();
+    res.writeProcessing(() => { });
 
     // write string
     res.write("Part of my res.");

--- a/types/node/v18/http.d.ts
+++ b/types/node/v18/http.d.ts
@@ -901,7 +901,7 @@ declare module "http" {
          * the request body should be sent.
          * @since v10.0.0
          */
-        writeProcessing(): void;
+        writeProcessing(callback?: () => void): void;
     }
     interface InformationEvent {
         statusCode: number;

--- a/types/node/v18/test/http.ts
+++ b/types/node/v18/test/http.ts
@@ -263,6 +263,7 @@ import * as url from "node:url";
 
     // writeProcessing
     res.writeProcessing();
+    res.writeProcessing(() => { });
 
     // write string
     res.write("Part of my res.");

--- a/types/node/v20/http.d.ts
+++ b/types/node/v20/http.d.ts
@@ -909,7 +909,7 @@ declare module "http" {
          * the request body should be sent.
          * @since v10.0.0
          */
-        writeProcessing(): void;
+        writeProcessing(callback?: () => void): void;
     }
     interface InformationEvent {
         statusCode: number;

--- a/types/node/v20/test/http.ts
+++ b/types/node/v20/test/http.ts
@@ -264,6 +264,7 @@ import * as url from "node:url";
 
     // writeProcessing
     res.writeProcessing();
+    res.writeProcessing(() => { });
 
     // write string
     res.write("Part of my res.");

--- a/types/node/v22/http.d.ts
+++ b/types/node/v22/http.d.ts
@@ -911,7 +911,7 @@ declare module "http" {
          * the request body should be sent.
          * @since v10.0.0
          */
-        writeProcessing(): void;
+        writeProcessing(callback?: () => void): void;
     }
     interface InformationEvent {
         statusCode: number;

--- a/types/node/v22/test/http.ts
+++ b/types/node/v22/test/http.ts
@@ -269,6 +269,7 @@ import * as url from "node:url";
 
     // writeProcessing
     res.writeProcessing();
+    res.writeProcessing(() => { });
 
     // write string
     res.write("Part of my res.");


### PR DESCRIPTION
Adds the missing callback to writeProcessing. For the actual implementation take a look at https://github.com/nodejs/node/blob/main/lib/_http_server.js#L312