### PR TITLE
fix(semver): Add missing third parameter ‎`throwErrors` to parse

### DIFF
--- a/types/semver/functions/parse.d.ts
+++ b/types/semver/functions/parse.d.ts
@@ -5,9 +5,9 @@ import semver = require("../index");
  * Return the parsed version as a SemVer object, or null if it's not valid.
  */
 declare function parse(
-  version: string | SemVer | null | undefined,
-  optionsOrLoose?: boolean | semver.Options,
-  throwErrors?: boolean
+    version: string | SemVer | null | undefined,
+    optionsOrLoose?: boolean | semver.Options,
+    throwErrors?: boolean,
 ): SemVer | null;
 
 export = parse;

--- a/types/semver/functions/parse.d.ts
+++ b/types/semver/functions/parse.d.ts
@@ -5,8 +5,9 @@ import semver = require("../index");
  * Return the parsed version as a SemVer object, or null if it's not valid.
  */
 declare function parse(
-    version: string | SemVer | null | undefined,
-    optionsOrLoose?: boolean | semver.Options,
+  version: string | SemVer | null | undefined,
+  optionsOrLoose?: boolean | semver.Options,
+  throwErrors?: boolean
 ): SemVer | null;
 
 export = parse;

--- a/types/semver/semver-tests.ts
+++ b/types/semver/semver-tests.ts
@@ -37,6 +37,14 @@ import Range = require("semver/classes/range");
 
 // functions for working with versions
 import semverParse = require("semver/functions/parse");
+semverParse("1.2.3", true, false); // $ExpectType SemVer | null
+semverParse("1.2.3", { loose: true }, true); // $ExpectType SemVer | null
+semverParse("1.2.3", undefined, true); // $ExpectType SemVer | null
+semverParse("1.2.3", undefined, false); // $ExpectType SemVer | null
+semverParse("1.2.3", false, false); // $ExpectType SemVer | null
+// @ts-expect-error
+semverParse("1.2.3", false, "notABoolean");
+
 import semverValid = require("semver/functions/valid");
 import semverClean = require("semver/functions/clean");
 import semverInc = require("semver/functions/inc");


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [parse.js](https://github.com/npm/node-semver/blob/fcafb61ed566ff8ccf24818dd94b76738f037aa4/functions/parse.js)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
