### PR TITLE
[picomatch] fix `prepend` documentation

### DIFF
--- a/types/picomatch/lib/picomatch.d.ts
+++ b/types/picomatch/lib/picomatch.d.ts
@@ -186,7 +186,7 @@ declare namespace picomatch {
          */
         posixSlashes?: boolean | undefined;
         /**
-         * Convert all slashes in file paths to forward slashes. This does not convert slashes in the glob pattern itself
+         * String to prepend to the generated regex used for matching.
          */
         prepend?: boolean | undefined;
         /**


### PR DESCRIPTION
It looks like someone copypasted `posixSlashes`' documentation into the wrong place many years ago and no one ever noticed :eyes:

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.) (N/A)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. (N/A)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests). (N/A)

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/micromatch/picomatch?tab=readme-ov-file#picomatch-options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
