### PR TITLE
[picomatch] remove `lookbehinds` option and fix documentation

### DIFF
--- a/types/picomatch/lib/picomatch.d.ts
+++ b/types/picomatch/lib/picomatch.d.ts
@@ -116,10 +116,6 @@ declare namespace picomatch {
          */
         literalBrackets?: boolean | undefined;
         /**
-         * Support regex positive and negative lookbehinds. Note that you must be using Node 8.1.10 or higher to enable regex lookbehinds.
-         */
-        lookbehinds?: boolean | undefined;
-        /**
          * Alias for `basename`
          */
         matchBase?: boolean | undefined;
@@ -132,7 +128,7 @@ declare namespace picomatch {
          */
         nobrace?: boolean | undefined;
         /**
-         * Disable brace matching, so that `{a,b}` and `{1..3}` would be treated as literal characters.
+         * Disable matching with regex brackets.
          */
         nobracket?: boolean | undefined;
         /**
@@ -182,7 +178,7 @@ declare namespace picomatch {
          */
         posix?: boolean | undefined;
         /**
-         * Convert all slashes in file paths to forward slashes. This does not convert slashes in the glob pattern itself
+         * Convert all slashes in file paths to forward slashes. This does not convert slashes in the glob pattern itself.
          */
         posixSlashes?: boolean | undefined;
         /**


### PR DESCRIPTION
Noticed right after #73282 that there is another entry with the wrong documentation, and that the `lookbehinds` option was removed from the documentation years ago in micromatch/picomatch#98 and removed as an option even more years ago. Also fixes a minor lack of trailing `.` mistake

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/micromatch/picomatch?tab=readme-ov-file#picomatch-options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
