### PR TITLE
fix(wtfnode): add fullStacks option to wtf.dump()

### DIFF
--- a/types/wtfnode/index.d.ts
+++ b/types/wtfnode/index.d.ts
@@ -1,4 +1,10 @@
-export function dump(): void;
+export interface DumpOptions {
+    /**
+     * Whether to include full stack traces in output, default false
+     */
+    fullStacks?: boolean;
+}
+export function dump(options?: DumpOptions): void;
 export function init(): void;
 export function setLogger(type: "info" | "warn" | "error", fn: (message?: any, ...optionalParams: any[]) => void): void;
 export function resetLoggers(): void;

--- a/types/wtfnode/package.json
+++ b/types/wtfnode/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/wtfnode",
-    "version": "0.7.9999",
+    "version": "0.10.9999",
     "projects": [
         "https://github.com/myndzi/wtfnode"
     ],

--- a/types/wtfnode/wtfnode-tests.ts
+++ b/types/wtfnode/wtfnode-tests.ts
@@ -7,4 +7,5 @@ wtf.setLogger("info", (message?: any, ...optionalParams: any[]) => console.info(
 wtf.setLogger("warn", (message?: any, ...optionalParams: any[]) => console.warn(message, ...optionalParams));
 wtf.setLogger("error", (message?: any, ...optionalParams: any[]) => console.error(message, ...optionalParams));
 wtf.dump();
+wtf.dump({ fullStacks: true });
 wtf.resetLoggers();


### PR DESCRIPTION
New option added in https://github.com/myndzi/wtfnode/pull/56 (released as 0.10.0).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/myndzi/wtfnode/pull/56
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
