### PR TITLE
fix(@types/plotly): Add number[][] support to marker.opacity

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1365,7 +1365,7 @@ export interface PlotData {
     "marker.symbol": MarkerSymbol | MarkerSymbol[];
     "marker.color": Color;
     "marker.colorscale": ColorScale | ColorScale[];
-    "marker.opacity": number | number[];
+    "marker.opacity": number | number[] | number[][];
     "marker.size": number | number[] | number[][];
     "marker.maxdisplayed": number;
     "marker.sizeref": number;

--- a/types/plotly.js/v2/index.d.ts
+++ b/types/plotly.js/v2/index.d.ts
@@ -1372,7 +1372,7 @@ export interface PlotData {
     "marker.symbol": MarkerSymbol | MarkerSymbol[];
     "marker.color": Color;
     "marker.colorscale": ColorScale | ColorScale[];
-    "marker.opacity": number | number[];
+    "marker.opacity": number | number[] | number[][];
     "marker.size": number | number[] | number[][];
     "marker.maxdisplayed": number;
     "marker.sizeref": number;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  
  [Plotly.js source code: restyle supports nested marker.opacity arrays](https://github.com/plotly/plotly.js/blob/v2.30.1/src/plot_api/plot_api.js#L1041-L1046)  
  The Plotly API accepts `marker.opacity` as `number | number[] | number[][]`, particularly when updating multiple traces simultaneously.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

### Description

This PR updates the type definition for `PlotData.marker.opacity` in `@types/plotly.js` to allow `number[][]` in addition to `number` and `number[]`. This is supported internally in Plotly.js's `Plotly.restyle()` API when providing per-point-per-trace opacity values across multiple traces.

```ts
Plotly.restyle(gd, { 'marker.opacity': [[0.5]] }, [0]); // Valid usage
```
### Reason

This change enables developers using @types/plotly.js to correctly type scenarios where marker.opacity values are nested arrays (e.g., updating multiple traces with varying per-point opacity). It reflects Plotly’s internal logic that flattens or applies inputVal[i] depending on the number of traces.

```js
val = Lib.isArrayOrTypedArray(inputVal) &&
      inputVal.length === traces.length ?
      inputVal[i] :
      inputVal;