### PR TITLE
`dom-webcodecs`: Add `rotation` field to `VideoFrame` object

### DIFF
--- a/types/dom-webcodecs/webcodecs.generated.d.ts
+++ b/types/dom-webcodecs/webcodecs.generated.d.ts
@@ -426,6 +426,7 @@ interface VideoFrame {
     readonly format: VideoPixelFormat | null;
     readonly timestamp: number;
     readonly visibleRect: DOMRectReadOnly | null;
+    readonly rotation?: number;
     allocationSize(options?: VideoFrameCopyToOptions): number;
     clone(): VideoFrame;
     close(): void;


### PR DESCRIPTION
The global `VideoFrame` object in Chrome now includes `rotation`.  
Firefox and Safari don't support it yet, hence why I made it optional.

Link to spec: https://w3c.github.io/webcodecs/#dom-videoframe-rotation
Link to spec PR: https://github.com/w3c/webcodecs/issues/351

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
