### PR TITLE
`types/project-osrm__osrm`: Fixed typo, added RouteStep.driving_side; `types/osrm`: Mirrored type fixes

### DIFF
--- a/types/osrm/index.d.ts
+++ b/types/osrm/index.d.ts
@@ -142,7 +142,7 @@ declare namespace OSRM {
         | "uturn"
         | "sharp right"
         | "right"
-        | "slight rigth"
+        | "slight right"
         | "straight"
         | "slight left"
         | "left"
@@ -443,8 +443,8 @@ declare namespace OSRM {
      * https://github.com/Project-OSRM/node-osrm/blob/master/docs/api.md#match
      */
     interface MatchWaypoint extends Waypoint {
-        matchings_index: number[];
-        waypoint_index: number[];
+        matchings_index: number;
+        waypoint_index: number;
     }
 
     /**

--- a/types/osrm/osrm-tests.ts
+++ b/types/osrm/osrm-tests.ts
@@ -1,10 +1,6 @@
 import * as fs from "fs";
 import OSRM = require("osrm");
 
-// Access to Types from namespace
-const tile: OSRM.Tile = [0, 0, 0];
-const overview: OSRM.OverviewTypes = "full";
-
 // Version
 OSRM.version;
 
@@ -136,6 +132,18 @@ osrm.match({ coordinates, timestamps, exclude }, (err, response) => {
     if (err) throw err;
     console.log(response.tracepoints); // array of Waypoint objects
     console.log(response.matchings); // array of Route objects
+
+    response.tracepoints.forEach((tracepoint) => {
+        if (!tracepoint) {
+            return;
+        }
+
+        // $ExpectType number
+        tracepoint.matchings_index;
+
+        // $ExpectType number
+        tracepoint.waypoint_index;
+    });
 });
 
 osrm.match({ coordinates, timestamps, exclude }, { format: "object" }, (err, response) => {

--- a/types/project-osrm__osrm/index.d.ts
+++ b/types/project-osrm__osrm/index.d.ts
@@ -142,11 +142,14 @@ declare namespace OSRM {
         | "uturn"
         | "sharp right"
         | "right"
-        | "slight rigth"
+        | "slight right"
         | "straight"
         | "slight left"
         | "left"
         | "sharp left";
+    type DrivingSide =
+        | "left"
+        | "right";
 
     interface LineString {
         type: "LineString";
@@ -292,6 +295,10 @@ declare namespace OSRM {
          * The pronunciation hint of the rotary name. Optionally included, if the step is a rotary and a rotary pronunciation is available.
          */
         rotary_pronunciation: string;
+        /**
+         * The legal driving side at the location for this step. Either left or right.
+         */
+        driving_side: DrivingSide;
     }
 
     /**

--- a/types/project-osrm__osrm/project-osrm__osrm-tests.ts
+++ b/types/project-osrm__osrm/project-osrm__osrm-tests.ts
@@ -1,10 +1,5 @@
 import * as fs from "fs";
 import OSRM = require("@project-osrm/osrm");
-import assert from "assert";
-
-// Access to Types from namespace
-const tile: OSRM.Tile = [0, 0, 0];
-const overview: OSRM.OverviewTypes = "full";
 
 // Version
 OSRM.version;
@@ -54,6 +49,19 @@ osrm.route({ coordinates, exclude }, (err, result) => {
     if (err) throw err;
     console.log(result.waypoints); // array of Waypoint objects representing all waypoints in order
     console.log(result.routes); // array of Route objects ordered by descending recommendation rank
+
+    const [firstRoute] = result.routes;
+    const [firstLeg] = firstRoute.legs;
+    const [firstStep] = firstLeg.steps;
+
+    // $ExpectType Route
+    firstRoute;
+    // $ExpectType RouteLeg
+    firstLeg;
+    // $ExpectType RouteStep
+    firstStep;
+    // $ExpectType DrivingSide
+    firstStep.driving_side;
 });
 
 osrm.route({ coordinates }, { format: "object" }, (err, result) => {


### PR DESCRIPTION
`types/project-osrm__osrm`:
- fixed typo in <OSRM.Indication>, from `slight rigth` to `slight right`;
- added <RouteStep.driving_side> as `DrivingSide`;
- updated tests.


`types/osrm`:
- fixed typo in <OSRM.Indication>;
- mirrored types fix merged in PR #69909 (`MatchWaypoint.matchings_index` and `MatchWaypoint.waypoint_index` types);
- updated tests.


In `types/osrm`, I've only fixed the two important bugs (`OSRM.Indication` typo and `MatchWaypoint.matchings_index` and  
`MatchWaypoint.waypoint_index` type fixes from #69909) as there are many people still using this because of using the unscoped package `osrm`.

I was also wondering if there are plans to inform users to prefer `@project-osrm/osrm` and the associated types or if this is something that can even be in the scope of DefinitelyTyped.

Thank you

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - `OSRM.Indication` typo: https://github.com/Project-OSRM/osrm-backend/blob/master/docs/http.md#stepmaneuver-object
  - `RouteStep.driving_side`: https://github.com/Project-OSRM/osrm-backend/blob/master/docs/http.md#routestep-object
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
