### PR TITLE
[luxon] fix: DateTime.fromSeconds can return DateTime<Invalid>

### DIFF
--- a/types/luxon/src/datetime.d.ts
+++ b/types/luxon/src/datetime.d.ts
@@ -718,7 +718,7 @@ export class DateTime<IsValid extends boolean = DefaultValidity> {
      * @param options.outputCalendar - the output calendar to set on the resulting DateTime instance
      * @param options.numberingSystem - the numbering system to set on the resulting DateTime instance
      */
-    static fromSeconds(seconds: number, options?: DateTimeJSOptions): DateTime<Valid>;
+    static fromSeconds(seconds: number, options?: DateTimeJSOptions): DateTimeMaybeValid;
 
     /**
      * Create a DateTime from a JavaScript object with keys like 'year' and 'hour' with reasonable defaults.

--- a/types/luxon/test/luxon-tests.module.ts
+++ b/types/luxon/test/luxon-tests.module.ts
@@ -542,7 +542,7 @@ DateTime.fromMillis();
 DateTime.fromMillis(1542674993410); // $ExpectType DateTime<true> | DateTime<false>
 // @ts-expect-error
 DateTime.fromSeconds();
-DateTime.fromSeconds(1542674993); // $ExpectType DateTime<true>
+DateTime.fromSeconds(1542674993); // $ExpectType DateTime<true> | DateTime<false>
 // @ts-expect-error
 DateTime.fromFormat();
 DateTime.fromFormat("May 25 1982", "LLLL dd yyyy"); // $ExpectType DateTime<true> | DateTime<false>


### PR DESCRIPTION
`DateTime.fromSeconds` returns invalid for `number` values such as `NaN` and `Infinity`.

Change return type from `DateTime<Valid>` to `DateTimeMaybeValid` to align with implementation and similar helpers such as `fromMillis`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/moment/luxon/blob/1337c7bdd64ff1546e43c606812f557f76c3e702/src/datetime.js#L744
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
