### PR TITLE
Update types to match actual library behavior in @types/screenshot-desktop

### DIFF
--- a/types/screenshot-desktop/index.d.ts
+++ b/types/screenshot-desktop/index.d.ts
@@ -3,26 +3,37 @@
 export = screenshotDesktop;
 
 declare function screenshotDesktop(
-    options?: { format?: screenshotDesktop.ImageFormat; screen?: screenshotDesktop.DisplayID },
-): Promise<Buffer>;
+    options?: screenshotDesktop.ScreenshotOptionsWithoutFilename,
+): Promise<NonSharedBuffer>;
 declare function screenshotDesktop(
-    options?: { filename: string; format?: screenshotDesktop.ImageFormat; screen?: screenshotDesktop.DisplayID },
+    options?: screenshotDesktop.ScreenshotOptionsWithFilename,
 ): Promise<string>;
 
 declare namespace screenshotDesktop {
-    type DisplayID = number;
+    interface ScreenshotOptions {
+        filename?: string;
+        format?: ImageFormat;
+        screen?: DisplayID;
+        linuxLibrary?: "scrot" | "imagemagick";
+    }
 
-    type ImageFormat =
-        | "bmp"
-        | "emf"
-        | "exif"
-        | "jpg"
-        | "jpeg"
-        | "gif"
-        | "png"
-        | "tiff"
-        | "wmf";
+    interface ScreenshotOptionsWithFilename extends ScreenshotOptions {
+        filename: string;
+    }
 
-    function listDisplays(): Promise<Array<{ id: DisplayID; name: string }>>;
-    function all(): Promise<Array<{ id: DisplayID; name: string }>>;
+    interface ScreenshotOptionsWithoutFilename extends ScreenshotOptions {
+        filename?: "";
+    }
+
+    interface Display {
+        id: number | string;
+        name: string;
+    }
+
+    type DisplayID = Display["id"];
+
+    type ImageFormat = "jpg" | "png";
+
+    function listDisplays(): Promise<Array<Display>>;
+    function all(): Promise<Array<NonSharedBuffer>>;
 }

--- a/types/screenshot-desktop/package.json
+++ b/types/screenshot-desktop/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/screenshot-desktop",
-    "version": "1.12.9999",
+    "version": "1.15.9999",
     "projects": [
         "https://github.com/bencevans/screenshot-desktop"
     ],

--- a/types/screenshot-desktop/screenshot-desktop-tests.ts
+++ b/types/screenshot-desktop/screenshot-desktop-tests.ts
@@ -1,35 +1,36 @@
 import screenshot = require("screenshot-desktop");
 
-screenshot().then((img) => {
-    // img: Buffer filled with jpg goodness
-    // ...
-}).catch((err) => {
-    // ...
-});
+// Buffer filled with jpg goodness
+// $ExpectType Promise<NonSharedBuffer> || Promise<Buffer>
+screenshot();
 
-screenshot({ format: "png" }).then((img) => {
-    // img: Buffer filled with png goodness
-    // ...
-}).catch((err) => {
-    // ...
-});
+// Buffer filled with png goodness
+// $ExpectType Promise<NonSharedBuffer> || Promise<Buffer>
+screenshot({ format: "png" });
 
-screenshot.listDisplays().then((displays) => {
-    // displays: [{ id, name }, { id, name }]
-    screenshot({ screen: displays[displays.length - 1].id })
-        .then((img) => {
-            // img: Buffer of screenshot of the last display
-        });
-});
+// Buffer when filename is empty
+// $ExpectType Promise<NonSharedBuffer> || Promise<Buffer>
+screenshot({ filename: "" });
 
-screenshot.all().then((imgs) => {
-    // imgs: an array of Buffers, one for each screen
-});
-
-screenshot({ filename: "shot.jpg" }).then((imgPath) => {
-    // imgPath: absolute path to screenshot
-    // created in current working directory named shot.png
-});
+// absolute path to screenshot
+// created in current working directory named shot.jpg
+// $ExpectType Promise<string>
+screenshot({ filename: "shot.jpg" });
 
 // absolute paths work too. so do pngs
-screenshot({ filename: "/Users/brian/Desktop/demo.png" });
+// $ExpectType Promise<string>
+screenshot({ filename: "/Users/$USER/Desktop/demo.png" });
+
+// an array of available displays
+// $ExpectType Promise<Display[]>
+screenshot.listDisplays();
+
+screenshot.listDisplays().then((displays) => {
+    // Buffer of screenshot of the last display
+    // $ExpectType Promise<NonSharedBuffer> || Promise<Buffer>
+    screenshot({ screen: displays[displays.length - 1].id });
+});
+
+// an array of Buffers or strings, one for each screen
+// $ExpectType Promise<NonSharedBuffer[]> || Promise<Buffer[]>
+screenshot.all();


### PR DESCRIPTION
This PR aims to accurately reflect the actual behavior of the screenshot-desktop library in its type definitions. The changes are organized into three main categories: bug fixes, cross-platform compatibility improvements, and common type definitions.

**Bug Fixes:**

Added the missing `linuxLibrary` property to the `options` parameter when calling the `screenshot(options)` function
Fixed the return type behavior based on the `filename` property in options. The function returns a `NonSharedBuffer` type when `filename` is an empty string, which was not properly reflected in the previous type definitions.

**Cross-Platform Compatibility:**

Updated the `ImageFormat` type, which previously included various formats beyond just `jpg` and `png` as a union type. However, not all listed formats work consistently across darwin, linux, and win32 platforms. According to the corresponding library's README, only `jpg` and `png` are assignable values for the `format` parameter, so the type definition has been updated to reflect this limitation.

Modified the `DisplayID` type to accurately reflect platform-specific behavior: `number` for darwin and `string` for linux and win32 platforms.

**Common Type Definitions:**

Added reusable type definitions such as `ScreenshotOptions` and `Display` to make it easier for TypeScript developers to reuse these types in their projects.

These changes ensure that the type definitions accurately represent the library's actual runtime behavior and provide better developer experience across different platforms.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bencevans/screenshot-desktop/commits/main/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.