### PR TITLE
fix(oidc-provider): Provider ctx getter is not static

### DIFF
--- a/types/oidc-provider/index.d.ts
+++ b/types/oidc-provider/index.d.ts
@@ -1505,7 +1505,7 @@ export default class Provider extends Koa {
      */
     readonly app: Koa;
 
-    get ctx(): KoaContextWithOIDC | undefined;
+    static get ctx(): KoaContextWithOIDC | undefined;
 
     backchannelResult(
         request: BackchannelAuthenticationRequest | string,

--- a/types/oidc-provider/oidc-provider-tests.ts
+++ b/types/oidc-provider/oidc-provider-tests.ts
@@ -8,6 +8,8 @@ import * as oidc from "oidc-provider";
 
 oidc.errors.AccessDenied.name;
 
+Provider.ctx;
+
 new oidc.Provider("https://op.example.com");
 new Provider("https://op.example.com");
 


### PR DESCRIPTION
# Change:

This PR updates the recently added getter to the `Provider` class to be static, which aligns it with the [source code](https://github.com/panva/node-oidc-provider/blob/2e2b082c51980595b499110310937cdd2b9b65e6/lib/provider.js#L442).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [source code](https://github.com/panva/node-oidc-provider/blob/2e2b082c51980595b499110310937cdd2b9b65e6/lib/provider.js#L442)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
