### PR TITLE
fix(node): remove text/suite context union type for static suites

### DIFF
--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -1360,7 +1360,7 @@ declare module "node:test" {
          * @param fn The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
          */
-        function before(fn?: HookFn, options?: HookOptions): void;
+        function before(fn?: SuiteContextHookFn, options?: HookOptions): void;
         /**
          * This function creates a hook that runs after executing a suite.
          *
@@ -1376,7 +1376,7 @@ declare module "node:test" {
          * @param fn The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
          */
-        function after(fn?: HookFn, options?: HookOptions): void;
+        function after(fn?: SuiteContextHookFn, options?: HookOptions): void;
         /**
          * This function creates a hook that runs before each test in the current suite.
          *
@@ -1392,7 +1392,7 @@ declare module "node:test" {
          * @param fn The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
          */
-        function beforeEach(fn?: HookFn, options?: HookOptions): void;
+        function beforeEach(fn?: TestContextHookFn, options?: HookOptions): void;
         /**
          * This function creates a hook that runs after each test in the current suite.
          * The `afterEach()` hook is run even if the test fails.
@@ -1409,12 +1409,12 @@ declare module "node:test" {
          * @param fn The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
          */
-        function afterEach(fn?: HookFn, options?: HookOptions): void;
+        function afterEach(fn?: TestContextHookFn, options?: HookOptions): void;
         /**
          * The hook function. The first argument is the context in which the hook is called.
          * If the hook uses callbacks, the callback function is passed as the second argument.
          */
-        type HookFn = (c: TestContext | SuiteContext, done: (result?: any) => void) => any;
+        type SuiteContextHookFn = (c: SuiteContext, done: (result?: any) => void) => any;
         /**
          * The hook function. The first argument is a `TestContext` object.
          * If the hook uses callbacks, the callback function is passed as the second argument.

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -470,7 +470,7 @@ after(() => {});
 beforeEach(() => {});
 // - with callback
 before((c, cb) => {
-    // $ExpectType TestContext | SuiteContext
+    // $ExpectType SuiteContext
     c;
     // $ExpectType (result?: any) => void
     cb;
@@ -478,7 +478,7 @@ before((c, cb) => {
     cb({ x: "anything" });
 });
 beforeEach((c, cb) => {
-    // $ExpectType TestContext | SuiteContext
+    // $ExpectType TestContext
     c;
     // $ExpectType (result?: any) => void
     cb;
@@ -486,7 +486,7 @@ beforeEach((c, cb) => {
     cb({ x: "anything" });
 });
 after((c, cb) => {
-    // $ExpectType TestContext | SuiteContext
+    // $ExpectType SuiteContext
     c;
     // $ExpectType (result?: any) => void
     cb;
@@ -494,7 +494,7 @@ after((c, cb) => {
     cb({ x: "anything" });
 });
 afterEach((c, cb) => {
-    // $ExpectType TestContext | SuiteContext
+    // $ExpectType TestContext
     c;
     // $ExpectType (result?: any) => void
     cb;

--- a/types/node/v18/test.d.ts
+++ b/types/node/v18/test.d.ts
@@ -736,7 +736,7 @@ declare module "node:test" {
          * @param options Configuration options for the hook.
          * @since v18.8.0
          */
-        function before(fn?: HookFn, options?: HookOptions): void;
+        function before(fn?: SuiteContextHookFn, options?: HookOptions): void;
         /**
          * This function is used to create a hook running after running a suite.
          * @param fn The hook function. If the hook uses callbacks, the callback function is passed as
@@ -744,7 +744,7 @@ declare module "node:test" {
          * @param options Configuration options for the hook.
          * @since v18.8.0
          */
-        function after(fn?: HookFn, options?: HookOptions): void;
+        function after(fn?: SuiteContextHookFn, options?: HookOptions): void;
         /**
          * This function is used to create a hook running before each subtest of the current suite.
          * @param fn The hook function. If the hook uses callbacks, the callback function is passed as
@@ -752,7 +752,7 @@ declare module "node:test" {
          * @param options Configuration options for the hook.
          * @since v18.8.0
          */
-        function beforeEach(fn?: HookFn, options?: HookOptions): void;
+        function beforeEach(fn?: TestContextHookFn, options?: HookOptions): void;
         /**
          * This function is used to create a hook running after each subtest of the current test.
          * @param fn The hook function. If the hook uses callbacks, the callback function is passed as
@@ -760,12 +760,17 @@ declare module "node:test" {
          * @param options Configuration options for the hook.
          * @since v18.8.0
          */
-        function afterEach(fn?: HookFn, options?: HookOptions): void;
+        function afterEach(fn?: TestContextHookFn, options?: HookOptions): void;
         /**
          * The hook function. The first argument is the context in which the hook is called.
          * If the hook uses callbacks, the callback function is passed as the second argument.
          */
         type HookFn = (c: TestContext | SuiteContext, done: (result?: any) => void) => any;
+        /**
+         * The hook function. The first argument is the context in which the hook is called.
+         * If the hook uses callbacks, the callback function is passed as the second argument.
+         */
+        type SuiteContextHookFn = (c: SuiteContext, done: (result?: any) => void) => any;
         /**
          * The hook function. The first argument is a `TestContext` object.
          * If the hook uses callbacks, the callback function is passed as the second argument.

--- a/types/node/v18/test/test.ts
+++ b/types/node/v18/test/test.ts
@@ -231,7 +231,7 @@ after(() => {});
 beforeEach(() => {});
 // - with callback
 before((c, cb) => {
-    // $ExpectType TestContext | SuiteContext
+    // $ExpectType SuiteContext
     c;
     // $ExpectType (result?: any) => void
     cb;
@@ -239,7 +239,7 @@ before((c, cb) => {
     cb({ x: "anything" });
 });
 beforeEach((c, cb) => {
-    // $ExpectType TestContext | SuiteContext
+    // $ExpectType TestContext
     c;
     // $ExpectType (result?: any) => void
     cb;
@@ -247,7 +247,7 @@ beforeEach((c, cb) => {
     cb({ x: "anything" });
 });
 after((c, cb) => {
-    // $ExpectType TestContext | SuiteContext
+    // $ExpectType SuiteContext
     c;
     // $ExpectType (result?: any) => void
     cb;
@@ -255,7 +255,7 @@ after((c, cb) => {
     cb({ x: "anything" });
 });
 afterEach((c, cb) => {
-    // $ExpectType TestContext | SuiteContext
+    // $ExpectType TestContext
     c;
     // $ExpectType (result?: any) => void
     cb;

--- a/types/node/v20/test.d.ts
+++ b/types/node/v20/test.d.ts
@@ -1037,7 +1037,7 @@ declare module "node:test" {
          * @param fn The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
          */
-        function before(fn?: HookFn, options?: HookOptions): void;
+        function before(fn?: SuiteContextHookFn, options?: HookOptions): void;
         /**
          * This function creates a hook that runs after executing a suite.
          *
@@ -1053,7 +1053,7 @@ declare module "node:test" {
          * @param fn The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
          */
-        function after(fn?: HookFn, options?: HookOptions): void;
+        function after(fn?: SuiteContextHookFn, options?: HookOptions): void;
         /**
          * This function creates a hook that runs before each test in the current suite.
          *
@@ -1069,7 +1069,7 @@ declare module "node:test" {
          * @param fn The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
          */
-        function beforeEach(fn?: HookFn, options?: HookOptions): void;
+        function beforeEach(fn?: TestContextHookFn, options?: HookOptions): void;
         /**
          * This function creates a hook that runs after each test in the current suite.
          * The `afterEach()` hook is run even if the test fails.
@@ -1086,12 +1086,17 @@ declare module "node:test" {
          * @param fn The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
          */
-        function afterEach(fn?: HookFn, options?: HookOptions): void;
+        function afterEach(fn?: TestContextHookFn, options?: HookOptions): void;
         /**
          * The hook function. The first argument is the context in which the hook is called.
          * If the hook uses callbacks, the callback function is passed as the second argument.
          */
         type HookFn = (c: TestContext | SuiteContext, done: (result?: any) => void) => any;
+        /**
+         * The hook function. The first argument is the context in which the hook is called.
+         * If the hook uses callbacks, the callback function is passed as the second argument.
+         */
+        type SuiteContextHookFn = (c: SuiteContext, done: (result?: any) => void) => any;
         /**
          * The hook function. The first argument is a `TestContext` object.
          * If the hook uses callbacks, the callback function is passed as the second argument.

--- a/types/node/v20/test/test.ts
+++ b/types/node/v20/test/test.ts
@@ -452,7 +452,7 @@ after(() => {});
 beforeEach(() => {});
 // - with callback
 before((c, cb) => {
-    // $ExpectType TestContext | SuiteContext
+    // $ExpectType SuiteContext
     c;
     // $ExpectType (result?: any) => void
     cb;
@@ -460,7 +460,7 @@ before((c, cb) => {
     cb({ x: "anything" });
 });
 beforeEach((c, cb) => {
-    // $ExpectType TestContext | SuiteContext
+    // $ExpectType TestContext
     c;
     // $ExpectType (result?: any) => void
     cb;
@@ -468,7 +468,7 @@ beforeEach((c, cb) => {
     cb({ x: "anything" });
 });
 after((c, cb) => {
-    // $ExpectType TestContext | SuiteContext
+    // $ExpectType SuiteContext
     c;
     // $ExpectType (result?: any) => void
     cb;
@@ -476,7 +476,7 @@ after((c, cb) => {
     cb({ x: "anything" });
 });
 afterEach((c, cb) => {
-    // $ExpectType TestContext | SuiteContext
+    // $ExpectType TestContext
     c;
     // $ExpectType (result?: any) => void
     cb;

--- a/types/node/v22/test.d.ts
+++ b/types/node/v22/test.d.ts
@@ -1360,7 +1360,7 @@ declare module "node:test" {
          * @param fn The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
          */
-        function before(fn?: HookFn, options?: HookOptions): void;
+        function before(fn?: SuiteContextHookFn, options?: HookOptions): void;
         /**
          * This function creates a hook that runs after executing a suite.
          *
@@ -1376,7 +1376,7 @@ declare module "node:test" {
          * @param fn The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
          */
-        function after(fn?: HookFn, options?: HookOptions): void;
+        function after(fn?: SuiteContextHookFn, options?: HookOptions): void;
         /**
          * This function creates a hook that runs before each test in the current suite.
          *
@@ -1392,7 +1392,7 @@ declare module "node:test" {
          * @param fn The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
          */
-        function beforeEach(fn?: HookFn, options?: HookOptions): void;
+        function beforeEach(fn?: TestContextHookFn, options?: HookOptions): void;
         /**
          * This function creates a hook that runs after each test in the current suite.
          * The `afterEach()` hook is run even if the test fails.
@@ -1409,12 +1409,17 @@ declare module "node:test" {
          * @param fn The hook function. If the hook uses callbacks, the callback function is passed as the second argument.
          * @param options Configuration options for the hook.
          */
-        function afterEach(fn?: HookFn, options?: HookOptions): void;
+        function afterEach(fn?: TestContextHookFn, options?: HookOptions): void;
         /**
          * The hook function. The first argument is the context in which the hook is called.
          * If the hook uses callbacks, the callback function is passed as the second argument.
          */
         type HookFn = (c: TestContext | SuiteContext, done: (result?: any) => void) => any;
+        /**
+         * The hook function. The first argument is the context in which the hook is called.
+         * If the hook uses callbacks, the callback function is passed as the second argument.
+         */
+        type SuiteContextHookFn = (c: SuiteContext, done: (result?: any) => void) => any;
         /**
          * The hook function. The first argument is a `TestContext` object.
          * If the hook uses callbacks, the callback function is passed as the second argument.

--- a/types/node/v22/test/test.ts
+++ b/types/node/v22/test/test.ts
@@ -469,7 +469,7 @@ after(() => {});
 beforeEach(() => {});
 // - with callback
 before((c, cb) => {
-    // $ExpectType TestContext | SuiteContext
+    // $ExpectType SuiteContext
     c;
     // $ExpectType (result?: any) => void
     cb;
@@ -477,7 +477,7 @@ before((c, cb) => {
     cb({ x: "anything" });
 });
 beforeEach((c, cb) => {
-    // $ExpectType TestContext | SuiteContext
+    // $ExpectType TestContext
     c;
     // $ExpectType (result?: any) => void
     cb;
@@ -485,7 +485,7 @@ beforeEach((c, cb) => {
     cb({ x: "anything" });
 });
 after((c, cb) => {
-    // $ExpectType TestContext | SuiteContext
+    // $ExpectType SuiteContext
     c;
     // $ExpectType (result?: any) => void
     cb;
@@ -493,7 +493,7 @@ after((c, cb) => {
     cb({ x: "anything" });
 });
 afterEach((c, cb) => {
-    // $ExpectType TestContext | SuiteContext
+    // $ExpectType TestContext
     c;
     // $ExpectType (result?: any) => void
     cb;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:



- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/test.html#beforeeachfn-options
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

The docs are weird on this, unlike other test runners these contexts aren't shared and there is no 'parent' context either.
I used this test runner extensively over the last couple days and I can with reasonable confidence say that `beforeAll` is never called with a `SuiteContext` and `before` never called with a `TestContext`