### PR TITLE
[@types/pdfkit] Further define table related properties

### DIFF
--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -427,7 +427,7 @@ declare namespace PDFKit.Mixins {
         /** Sets the text color of the cells text (default black) */
         textColor?: ColorValue;
         /** The border for the cell (default 1pt) */
-        border?: Sides<Wideness>;
+        border?: Sides<Wideness> | undefined;
         /** The border colors for the cell (default black) */
         borderColor?: Sides<ColorValue>;
         /** Set the background color of the cell */

--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -817,8 +817,8 @@ declare namespace PDFKit {
         pdfVersion?: "1.3" | "1.4" | "1.5" | "1.6" | "1.7" | "1.7ext3" | undefined;
         autoFirstPage?: boolean | undefined;
         size?: number[] | string | undefined;
-        margin?: number | undefined;
-        margins?: { top: number; left: number; bottom: number; right: number } | undefined;
+        margin?: PDFKit.Mixins.Size | undefined;
+        margins?: PDFKit.Mixins.ExpandedSides<PDFKit.Mixins.Size> | undefined;
         layout?: "portrait" | "landscape" | undefined;
         font?: string | undefined;
 
@@ -939,7 +939,7 @@ declare namespace PDFKit {
     interface PDFPage {
         size: string;
         layout: string;
-        margins: { top: number; left: number; bottom: number; right: number };
+        margins: PDFKit.Mixins.ExpandedSides<number>;
         width: number;
         height: number;
         document: PDFDocument;

--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -419,12 +419,26 @@ declare namespace PDFKit.Mixins {
     }
 
     interface CellStyle {
+        /** The text stroke (default 0) */
+        textStroke?: number | boolean;
+        /** Sets the text stroke color of the cells text (default black) */
+        textStrokeColor?: ColorValue;
+        /** Sets the text color of the cells text (default black) */
+        textColor?: ColorValue;
         /** The border for the cell (default 1pt) */
         border?: Sides<Wideness>;
         /** The border colors for the cell (default black) */
         borderColor?: Sides<ColorValue>;
         /** Set the background color of the cell */
         backgroundColor?: ColorValue;
+        /** The padding for the cell (default 0.25em) */
+        padding?: Sides<Wideness>;
+        /** The alignment of the cell text (default {x: 'left', y: 'top'}) */
+        align?: "center" | ExpandedAlign;
+        /** Sets any text options you wish to provide (such as rotation) */
+        textOptions?: TextOptions;
+        /** Whether to show the debug lines for the cell (default false) */
+        debug?: boolean;
     }
 
     interface TableOptions {
@@ -461,24 +475,10 @@ declare namespace PDFKit.Mixins {
         rowSpan?: number;
         /** How many columns this cell covers, follows the same logic as HTML colspan */
         colSpan?: number;
-        /** The padding for the cell (default 0.25em) */
-        padding?: Sides<Wideness>;
         /** Font options for the cell */
         font?: { src?: PDFFontSource; family?: string; size?: number; };
-        /** The alignment of the cell text (default {x: 'left', y: 'top'}) */
-        align?: "center" | ExpandedAlign;
-        /** The text stroke (default 0) */
-        textStroke?: number | boolean;
-        /** Sets the text stroke color of the cells text (default black) */
-        textStrokeColor?: ColorValue;
-        /** Sets the text color of the cells text (default black) */
-        textColor?: ColorValue;
         /** Sets the cell type (for accessibility) (default TD) */
         type?: 'TD' | 'TH';
-        /** Sets any text options you wish to provide (such as rotation) */
-        textOptions?: TextOptions;
-        /** Whether to show the debug lines for the cell (default false) */
-        debug?: boolean;
     }
 
     interface ColumnStyle extends CellStyle {

--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -344,6 +344,26 @@ declare namespace PDFKit.Mixins {
 
     type BoundingBox = [number, number, number, number];
 
+    type SizeUnits = 'em' | 'in' | 'px' | 'cm' | 'mm' | 'pc' | 'ex' | 'ch' | 'rem' | 'vw' | 'vmin' | 'vmax' | '%' | 'pt';
+
+    type Size = number | `${number}` | `${number}${SizeUnits}`;
+
+    type Wideness = Size | boolean;
+
+    type Sides<T> = T | [T, T] | [T, T, T, T] | SlightlyExpandedSides<T> | ExpandedSides<T>;
+
+    interface SlightlyExpandedSides<T> {
+        vertical: T;
+        horizontal: T;
+    }
+
+    interface ExpandedSides<T> {
+        top: T;
+        right: T;
+        bottom: T;
+        left: T;
+    }
+
     interface PDFColor {
         fillColor(color: ColorValue, opacity?: number): this;
         strokeColor(color: ColorValue, opacity?: number): this;
@@ -400,19 +420,9 @@ declare namespace PDFKit.Mixins {
 
     interface CellStyle {
         /** The border for the cell (default 1pt) */
-        border?: boolean | number | Array<boolean | number> | {
-            top?: number;
-            right?: number;
-            bottom?: number;
-            left?: number;
-        } | undefined;
+        border?: Sides<Wideness>;
         /** The border colors for the cell (default black) */
-        borderColor?: string | Array<string> | {
-            top?: ColorValue;
-            right?: ColorValue;
-            bottom?: ColorValue;
-            left?: ColorValue;
-        };
+        borderColor?: Sides<ColorValue>;
         /** Set the background color of the cell */
         backgroundColor?: ColorValue;
     }
@@ -452,9 +462,9 @@ declare namespace PDFKit.Mixins {
         /** How many columns this cell covers, follows the same logic as HTML colspan */
         colSpan?: number;
         /** The padding for the cell (default 0.25em) */
-        padding?: string;
+        padding?: Sides<Wideness>;
         /** Font options for the cell */
-        font?: any;
+        font?: { src?: PDFFontSource; family?: string; size?: number; };
         /** The alignment of the cell text (default {x: 'left', y: 'top'}) */
         align?: "center" | ExpandedAlign;
         /** The text stroke (default 0) */
@@ -464,7 +474,7 @@ declare namespace PDFKit.Mixins {
         /** Sets the text color of the cells text (default black) */
         textColor?: ColorValue;
         /** Sets the cell type (for accessibility) (default TD) */
-        type?: string;
+        type?: 'TD' | 'TH';
         /** Sets any text options you wish to provide (such as rotation) */
         textOptions?: TextOptions;
         /** Whether to show the debug lines for the cell (default false) */

--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -423,9 +423,9 @@ declare namespace PDFKit.Mixins {
         /** The maximum width the table can expand to (defaults to the remaining content width (offset from the tables position)) */
         maxWidth?: number;
         /** Column definitions of the table. (default auto) */
-        columnStyles?: number | Array<number | string> | CellStyle | ((row: number) => number | CellStyle | undefined);
+        columnStyles?: number | Array<number | string> | ColumnStyle | ((row: number) => number | ColumnStyle | undefined);
         /** Row definitions of the table. (default *) */
-        rowStyles?: number | Array<number | string> | CellStyle | ((row: number) => number | CellStyle | undefined);
+        rowStyles?: number | Array<number | string> | RowStyle | ((row: number) => number | RowStyle | undefined);
         /** Defaults to apply to every cell */
         defaultStyle?:
             & (number | Array<number | string> | CellStyle | ((row: number) => number | CellStyle | undefined))
@@ -471,7 +471,7 @@ declare namespace PDFKit.Mixins {
         debug?: boolean;
     }
 
-    interface ColumnOptions extends CellOptions {
+    interface ColumnStyle extends CellStyle {
         /** The width of the column (default *) */
         width?: string | number;
         /** The minimum width of the column (default 0) */
@@ -480,7 +480,7 @@ declare namespace PDFKit.Mixins {
         maxWidth?: string | number;
     }
 
-    interface RowOptions extends CellOptions {
+    interface RowBase {
         /** The height of the row (default auto) */
         height?: string | number;
         /** The minimum height of the row (default 0) */
@@ -488,6 +488,10 @@ declare namespace PDFKit.Mixins {
         /** The maximum height of the row (default Infinity) */
         maxHeight?: string | number;
     }
+
+    interface RowStyle extends CellStyle, RowBase { }
+
+    interface RowOptions extends CellOptions, RowBase { }
 
     interface PDFTableObject {
         /** Add a row of data (null and undefined are not rendered) */

--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -352,6 +352,8 @@ declare namespace PDFKit.Mixins {
 
     type Sides<T> = T | [T, T] | [T, T, T, T] | SlightlyExpandedSides<T> | ExpandedSides<T>;
 
+    type PartialSides<T> = T | [T, T] | [T, T, T, T] | Partial<SlightlyExpandedSides<T>> | Partial<ExpandedSides<T>>;
+
     interface SlightlyExpandedSides<T> {
         vertical: T;
         horizontal: T;
@@ -427,9 +429,9 @@ declare namespace PDFKit.Mixins {
         /** Sets the text color of the cells text (default black) */
         textColor?: ColorValue;
         /** The border for the cell (default 1pt) */
-        border?: Sides<Wideness> | undefined;
+        border?: PartialSides<Wideness> | undefined;
         /** The border colors for the cell (default black) */
-        borderColor?: Sides<ColorValue>;
+        borderColor?: PartialSides<ColorValue>;
         /** Set the background color of the cell */
         backgroundColor?: ColorValue;
         /** The padding for the cell (default 0.25em) */

--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -381,6 +381,7 @@ declare namespace PDFKit.Mixins {
         font(src: PDFFontSource, size?: number): this;
         font(src: PDFFontSource, family: string, size?: number): this;
         fontSize(size: number): this;
+        sizeToPoint(size: Size, defaultValue?: number, page?: PDFPage, percentageWidth?: number): number;
         currentLineHeight(includeGap?: boolean): number;
         /** Helpful method to give a font an alias, eg: `registerFont('bold', './Roboto.ttf')` */
         registerFont(

--- a/types/pdfkit/pdfkit-tests.ts
+++ b/types/pdfkit/pdfkit-tests.ts
@@ -560,6 +560,12 @@ doc.table({
     ],
 });
 
+doc.table({
+    data: [['col 1', 'col 2', 'col 3']],
+    rowStyles: { minHeight: 20 },
+    columnStyles: { maxWidth: 50 }
+});
+
 doc.text("Scale", { align: "justify" });
 
 doc.text("Baseline - string literal", { baseline: "alphabetic" });


### PR DESCRIPTION
Originally this pull request was just for extended types for columnStyles/rowStyles, however in my testing I've taken it a few steps further:

* Add additional types to define table related properties
* Move properties from `CellOptions` to `CellStyle` to allow further customization in `defaultStyle`
* Use new size/sides types to define margin properties
* Define the sizeToPoint function

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/foliojs/pdfkit/blob/d837a13569ccfac604e9ec42e420ebe55637a8cc/lib/table/utils.js#L263>>, <<https://pdfkit.org/docs/table.html#column_options>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
