### PR TITLE
jasmine: do not map `expect(string)` to array-like matchers

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -112,6 +112,13 @@ declare function expect<T extends jasmine.Func>(spy: T | jasmine.Spy<T>): jasmin
 /**
  * Create an expectation for a spec.
  * @checkReturnValue see https://tsetse.info/check-return-value
+ * @param actual Actual computed value to test expectations against.
+ */
+declare function expect(actual: string): jasmine.Matchers<string>;
+
+/**
+ * Create an expectation for a spec.
+ * @checkReturnValue see https://tsetse.info/check-return-value
  * @param actual
  */
 declare function expect<T>(actual: ArrayLike<T>): jasmine.ArrayLikeMatchers<T>;

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -94,6 +94,11 @@ describe("Included matchers:", () => {
 
             expect(value).toBe(12);
         });
+
+        it("should not consider strings as array-like", () => {
+            // @ts-expect-error
+            expect("abc").toEqual(["a", "b", "c"]);
+        });
     });
 
     describe("The 'toEqual' matcher", () => {


### PR DESCRIPTION
Because strings are number-indexable and have a `length` property, the current signatures for `expect()` consider them to be array-like (ie. `string` to be equivalent to `string[]`), and map string arguments to array-like matchers. This doesn't match the behaviour of the library, and the difference is subtly observable.

I haven't backported this to EOL versions.

refs: microsoft/TypeScript#62083