### PR TITLE
[node] Export the QueuingStrategy interface in stream/web

### DIFF
--- a/types/node/stream/web.d.ts
+++ b/types/node/stream/web.d.ts
@@ -6,6 +6,8 @@ type _CountQueuingStrategy = typeof globalThis extends { onmessage: any } ? {}
     : import("stream/web").CountQueuingStrategy;
 type _DecompressionStream = typeof globalThis extends { onmessage: any; ReportingObserver: any } ? {}
     : import("stream/web").DecompressionStream;
+type _QueuingStrategy<T = any> = typeof globalThis extends { onmessage: any } ? {}
+    : import("stream/web").QueuingStrategy<T>;
 type _ReadableByteStreamController = typeof globalThis extends { onmessage: any } ? {}
     : import("stream/web").ReadableByteStreamController;
 type _ReadableStream<R = any> = typeof globalThis extends { onmessage: any } ? {}
@@ -486,6 +488,8 @@ declare module "stream/web" {
                     new(format: "deflate" | "deflate-raw" | "gzip"): T;
                 }
             : typeof import("stream/web").DecompressionStream;
+
+        interface QueuingStrategy<T = any> extends _QueuingStrategy<T> {}
 
         interface ReadableByteStreamController extends _ReadableByteStreamController {}
         /**

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -828,3 +828,8 @@ async function testTransferringStreamWithPostMessage() {
     // $ExpectType void
     byobReader.releaseLock();
 }
+
+{
+    const strategy1: QueuingStrategy = new CountQueuingStrategy({ highWaterMark: 1 });
+    const strategy2: QueuingStrategy = new ByteLengthQueuingStrategy({ highWaterMark: 1 });
+}

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -828,8 +828,3 @@ async function testTransferringStreamWithPostMessage() {
     // $ExpectType void
     byobReader.releaseLock();
 }
-
-{
-    const strategy1: QueuingStrategy = new CountQueuingStrategy({ highWaterMark: 1 });
-    const strategy2: QueuingStrategy = new ByteLengthQueuingStrategy({ highWaterMark: 1 });
-}

--- a/types/node/v18/stream/web.d.ts
+++ b/types/node/v18/stream/web.d.ts
@@ -6,6 +6,8 @@ type _CountQueuingStrategy = typeof globalThis extends { onmessage: any } ? {}
     : import("stream/web").CountQueuingStrategy;
 type _DecompressionStream = typeof globalThis extends { onmessage: any; ReportingObserver: any } ? {}
     : import("stream/web").DecompressionStream;
+type _QueuingStrategy<T = any> = typeof globalThis extends { onmessage: any } ? {}
+    : import("stream/web").QueuingStrategy<T>;
 type _ReadableByteStreamController = typeof globalThis extends { onmessage: any } ? {}
     : import("stream/web").ReadableByteStreamController;
 type _ReadableStream<R = any> = typeof globalThis extends { onmessage: any } ? {}
@@ -456,6 +458,8 @@ declare module "stream/web" {
                     new(format: "deflate" | "deflate-raw" | "gzip"): T;
                 }
             : typeof import("stream/web").DecompressionStream;
+
+        interface QueuingStrategy<T = any> extends _QueuingStrategy<T> {}
 
         interface ReadableByteStreamController extends _ReadableByteStreamController {}
         var ReadableByteStreamController: typeof globalThis extends

--- a/types/node/v20/stream/web.d.ts
+++ b/types/node/v20/stream/web.d.ts
@@ -6,6 +6,8 @@ type _CountQueuingStrategy = typeof globalThis extends { onmessage: any } ? {}
     : import("stream/web").CountQueuingStrategy;
 type _DecompressionStream = typeof globalThis extends { onmessage: any; ReportingObserver: any } ? {}
     : import("stream/web").DecompressionStream;
+type _QueuingStrategy<T = any> = typeof globalThis extends { onmessage: any } ? {}
+    : import("stream/web").QueuingStrategy<T>;
 type _ReadableByteStreamController = typeof globalThis extends { onmessage: any } ? {}
     : import("stream/web").ReadableByteStreamController;
 type _ReadableStream<R = any> = typeof globalThis extends { onmessage: any } ? {}
@@ -462,6 +464,8 @@ declare module "stream/web" {
                     new(format: "deflate" | "deflate-raw" | "gzip"): T;
                 }
             : typeof import("stream/web").DecompressionStream;
+
+        interface QueuingStrategy<T = any> extends _QueuingStrategy<T> {}
 
         interface ReadableByteStreamController extends _ReadableByteStreamController {}
         var ReadableByteStreamController: typeof globalThis extends

--- a/types/node/v22/stream/web.d.ts
+++ b/types/node/v22/stream/web.d.ts
@@ -6,6 +6,8 @@ type _CountQueuingStrategy = typeof globalThis extends { onmessage: any } ? {}
     : import("stream/web").CountQueuingStrategy;
 type _DecompressionStream = typeof globalThis extends { onmessage: any; ReportingObserver: any } ? {}
     : import("stream/web").DecompressionStream;
+type _QueuingStrategy<T = any> = typeof globalThis extends { onmessage: any } ? {}
+    : import("stream/web").QueuingStrategy<T>;
 type _ReadableByteStreamController = typeof globalThis extends { onmessage: any } ? {}
     : import("stream/web").ReadableByteStreamController;
 type _ReadableStream<R = any> = typeof globalThis extends { onmessage: any } ? {}
@@ -486,6 +488,8 @@ declare module "stream/web" {
                     new(format: "deflate" | "deflate-raw" | "gzip"): T;
                 }
             : typeof import("stream/web").DecompressionStream;
+
+        interface QueuingStrategy<T = any> extends _QueuingStrategy<T> {}
 
         interface ReadableByteStreamController extends _ReadableByteStreamController {}
         /**


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v16.x/api/webstreams.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

This missing interface causes problems when using [Effect](https://effect.website/). Unless you build with `--skipLibCheck` or `--lib DOM` you get errors like this one:
```
node_modules/effect/dist/dts/Stream.d.ts:9045:29 - error TS2552: Cannot find name 'QueuingStrategy'. Did you mean 'CountQueuingStrategy'?

9045         readonly strategy?: QueuingStrategy<A> | undefined;
                                 ~~~~~~~~~~~~~~~

  node_modules/@types/node/stream/web.d.ts:467:13
    467         var CountQueuingStrategy: typeof globalThis extends { onmessage: any; CountQueuingStrategy: infer T } ? T
                    ~~~~~~~~~~~~~~~~~~~~
    'CountQueuingStrategy' is declared here.
```

I think it makes sense to make the `QueuingStrategy` interface available together with the implementations `ByteLengthQueuingStrategy` and `CountQueuingStrategy`.