### PR TITLE
Move Chromecast SDK enums to const enum

### DIFF
--- a/types/chromecast-caf-receiver/.eslintrc.json
+++ b/types/chromecast-caf-receiver/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "@definitelytyped/no-const-enum": "off"
+    }
+}

--- a/types/chromecast-caf-receiver/cast.framework.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.d.ts
@@ -11,7 +11,7 @@ export import system = system;
 export import messages = messages;
 
 export as namespace framework;
-export enum LoggerLevel {
+export const enum LoggerLevel {
     DEBUG = 0,
     VERBOSE = 500,
     INFO = 800,
@@ -24,7 +24,7 @@ export enum LoggerLevel {
  * Content protection type.
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework#.ContentProtection
  */
-export enum ContentProtection {
+export const enum ContentProtection {
     NONE = "none",
     CLEARKEY = "clearkey",
     PLAYREADY = "playready",
@@ -997,7 +997,7 @@ export class NetworkRequestInfo {
  *
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework#.ShakaVariant
  */
-export enum ShakaVariant {
+export const enum ShakaVariant {
     /**
      * The standard, default build.
      */

--- a/types/chromecast-caf-receiver/cast.framework.events.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.events.d.ts
@@ -17,7 +17,7 @@ export as namespace events;
  * Player event types for @see{@link framework.PlayerManager}.
  * https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.events#.EventType
  */
-export enum EventType {
+export const enum EventType {
     ALL = "*",
     ABORT = "ABORT",
     CAN_PLAY = "CAN_PLAY",
@@ -97,7 +97,7 @@ export enum EventType {
     TRACKS_CHANGED = "TRACKS_CHANGED",
 }
 
-export enum DetailedErrorCode {
+export const enum DetailedErrorCode {
     MEDIA_UNKNOWN = 100,
     MEDIA_ABORTED = 101,
     MEDIA_DECODE = 102,
@@ -144,7 +144,7 @@ export enum DetailedErrorCode {
  * The error severity. Follows the same naming scheme and numbering as Shaka Player.
  * https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.events#.EventType
  */
-export enum ErrorSeverity {
+export const enum ErrorSeverity {
     RECOVERABLE = 1,
     CRITICAL = 2,
 }

--- a/types/chromecast-caf-receiver/cast.framework.messages.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.messages.d.ts
@@ -6,7 +6,7 @@ export as namespace messages;
  * Possible caption mimetype of text track.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.CaptionMimeType}
  */
-export enum CaptionMimeType {
+export const enum CaptionMimeType {
     CEA608 = "text/cea608",
     TTML = "application/ttml+xml",
     TTML_MP4 = "application/mp4",
@@ -17,7 +17,7 @@ export enum CaptionMimeType {
  * Commands supported by {@link framework.messages.MediaStatus.supportedMediaCommands}.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.Command}
  */
-export enum Command {
+export const enum Command {
     PAUSE = 1,
     SEEK = 2,
     STREAM_VOLUME = 4,
@@ -43,7 +43,7 @@ export enum Command {
  * Possible types of container metadata.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.ContainerType}
  */
-export enum ContainerType {
+export const enum ContainerType {
     GENERIC_CONTAINER = 0,
     AUDIOBOOK_CONTAINER = 1,
 }
@@ -52,7 +52,7 @@ export enum ContainerType {
  * Provides content filtering mode.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.ContentFilteringMode}
  */
-export enum ContentFilteringMode {
+export const enum ContentFilteringMode {
     FILTER_EXPLICIT = "FILTER_EXPLICIT",
 }
 
@@ -60,7 +60,7 @@ export enum ContentFilteringMode {
  * Represents media error message reasons.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.ErrorReason}
  */
-export enum ErrorReason {
+export const enum ErrorReason {
     APP_ERROR = "APP_ERROR",
     AUTHENTICATION_EXPIRED = "AUTHENTICATION_EXPIRED",
     CONCURRENT_STREAM_LIMIT = "CONCURRENT_STREAM_LIMIT",
@@ -86,7 +86,7 @@ export enum ErrorReason {
  * Represents media error message types.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.ErrorType}
  */
-export enum ErrorType {
+export const enum ErrorType {
     ERROR = "ERROR",
     INVALID_PLAYER_STATE = "INVALID_PLAYER_STATE",
     INVALID_REQUEST = "INVALID_REQUEST",
@@ -98,7 +98,7 @@ export enum ErrorType {
  * Extended player state information.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.ExtendedPlayerState}
  */
-export enum ExtendedPlayerState {
+export const enum ExtendedPlayerState {
     LOADING = "LOADING",
 }
 
@@ -106,7 +106,7 @@ export enum ExtendedPlayerState {
  * Focus states.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.FocusState}
  */
-export enum FocusState {
+export const enum FocusState {
     IN_FOCUS = "IN_FOCUS",
     NOT_IN_FOCUS = "NOT_IN_FOCUS",
 }
@@ -115,7 +115,7 @@ export enum FocusState {
  * The Get Status flag options determine the amount of data that must be included in the media status response.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.GetStatusOptions}
  */
-export enum GetStatusOptions {
+export const enum GetStatusOptions {
     NO_METADATA = 1,
     NO_QUEUE_ITEMS = 2,
 }
@@ -124,7 +124,7 @@ export enum GetStatusOptions {
  * Represents video High Dynamic Range (HDR) types.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.HdrType}
  */
-export enum HdrType {
+export const enum HdrType {
     DV = "dv",
     HDR = "hdr",
     SDR = "sdr",
@@ -134,7 +134,7 @@ export enum HdrType {
  * Format of an HLS audio segment.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages#.HlsSegmentFormat}
  */
-export enum HlsSegmentFormat {
+export const enum HlsSegmentFormat {
     AAC = "aac",
     AC3 = "ac3",
     E_AC3 = "e_ac3",
@@ -149,7 +149,7 @@ export enum HlsSegmentFormat {
  * Format of an HLS audio segment.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.HlsSegmentFormat}
  */
-export enum HlsVideoSegmentFormat {
+export const enum HlsVideoSegmentFormat {
     FMP4 = "fmp4",
     MPEG2_TS = "mpeg2_ts",
 }
@@ -158,7 +158,7 @@ export enum HlsVideoSegmentFormat {
  * The reason for the player to be in IDLE state.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.IdleReason}
  */
-export enum IdleReason {
+export const enum IdleReason {
     CANCELLED = "CANCELLED",
     ERROR = "ERROR",
     FINISHED = "FINISHED",
@@ -169,7 +169,7 @@ export enum IdleReason {
  * The media category.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.MediaCategory}
  */
-export enum MediaCategory {
+export const enum MediaCategory {
     AUDIO = "AUDIO",
     IMAGE = "IMAGE",
     VIDEO = "VIDEO",
@@ -179,7 +179,7 @@ export enum MediaCategory {
  * Represents media message types.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.MessageType}
  */
-export enum MessageType {
+export const enum MessageType {
     CLOUD_STATUS = "CLOUD_STATUS",
     CUSTOM_COMMAND = "CUSTOM_COMMAND",
     CUSTOM_STATE = "CUSTOM_STATE",
@@ -230,7 +230,7 @@ export enum MessageType {
  * Possible types of media metadata.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.MetadataType}
  */
-export enum MetadataType {
+export const enum MetadataType {
     GENERIC = 0,
     MOVIE = 1,
     TV_SHOW = 2,
@@ -243,7 +243,7 @@ export enum MetadataType {
  * String IDs used by {@link framework.PlayerManager#playString}
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages#.PlayStringId
  */
-export enum PlayStringId {
+export const enum PlayStringId {
     FREE_TRIAL_ABOUT_TO_EXPIRE = "FREE_TRIAL_ABOUT_TO_EXPIRE",
     PLAYING_ALTERNATE_MIX = "PLAYING_ALTERNATE_MIX",
     STREAM_HIJACKED = "STREAM_HIJACKED",
@@ -254,7 +254,7 @@ export enum PlayStringId {
  * Represents the player state.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.PlayerState}
  */
-export enum PlayerState {
+export const enum PlayerState {
     BUFFERING = "BUFFERING",
     IDLE = "IDLE",
     PAUSED = "PAUSED",
@@ -265,7 +265,7 @@ export enum PlayerState {
  * Queue change types used by QUEUE_CHANGE outgoing message.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.QueueChangeType}
  */
-export enum QueueChangeType {
+export const enum QueueChangeType {
     INSERT = "INSERT",
     ITEMS_CHANGE = "ITEMS_CHANGE",
     NO_CHANGE = "NO_CHANGE",
@@ -277,7 +277,7 @@ export enum QueueChangeType {
  * Types of media container/queue.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.QueueType}
  */
-export enum QueueType {
+export const enum QueueType {
     ALBUM = "ALBUM",
     AUDIOBOOK = "AUDIOBOOK",
     LIVE_TV = "LIVE_TV",
@@ -293,7 +293,7 @@ export enum QueueType {
  * Behavior of the queue when all items have been played.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.RepeatMode}
  */
-export enum RepeatMode {
+export const enum RepeatMode {
     REPEAT_ALL = "REPEAT_ALL",
     REPEAT_ALL_AND_SHUFFLE = "REPEAT_ALL_AND_SHUFFLE",
     REPEAT_OFF = "REPEAT_OFF",
@@ -304,7 +304,7 @@ export enum RepeatMode {
  * Represents the playback state after a SEEK request.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.SeekResumeState}
  */
-export enum SeekResumeState {
+export const enum SeekResumeState {
     PLAYBACK_PAUSE = "PLAYBACK_PAUSE",
     PLAYBACK_START = "PLAYBACK_START",
 }
@@ -313,7 +313,7 @@ export enum SeekResumeState {
  * The streaming protocol types.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.StreamingProtocolType}
  */
-export enum StreamingProtocolType {
+export const enum StreamingProtocolType {
     UNKNOWN = 0,
     MPEG_DASH = 1,
     HLS = 2,
@@ -324,7 +324,7 @@ export enum StreamingProtocolType {
  * Represents the stream types.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.StreamType}
  */
-export enum StreamType {
+export const enum StreamType {
     BUFFERED = "BUFFERED",
     LIVE = "LIVE",
     NONE = "NONE",
@@ -334,7 +334,7 @@ export enum StreamType {
  * Possible text track edge type.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.TextTrackEdgeType}
  */
-export enum TextTrackEdgeType {
+export const enum TextTrackEdgeType {
     DEPRESSED = "DEPRESSED",
     DROP_SHADOW = "DROP_SHADOW",
     NONE = "NONE",
@@ -346,7 +346,7 @@ export enum TextTrackEdgeType {
  * Text track font generic family.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.TextTrackFontGenericFamily}
  */
-export enum TextTrackFontGenericFamily {
+export const enum TextTrackFontGenericFamily {
     CASUAL = "CASUAL",
     CURSIVE = "CURSIVE",
     MONOSPACED_SANS_SERIF = "MONOSPACED_SANS_SERIF",
@@ -360,7 +360,7 @@ export enum TextTrackFontGenericFamily {
  * Possible text track font style.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.TextTrackFontStyle}
  */
-export enum TextTrackFontStyle {
+export const enum TextTrackFontStyle {
     BOLD = "BOLD",
     BOLD_ITALIC = "BOLD_ITALIC",
     ITALIC = "ITALIC",
@@ -371,7 +371,7 @@ export enum TextTrackFontStyle {
  * Possible text track type (follows the HTML5 text track type definitions).
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.TextTrackType}
  */
-export enum TextTrackType {
+export const enum TextTrackType {
     CAPTIONS = "CAPTIONS",
     CHAPTERS = "CHAPTERS",
     DESCRIPTIONS = "DESCRIPTIONS",
@@ -383,7 +383,7 @@ export enum TextTrackType {
  * Text track window type.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.TextTrackWindowType}
  */
-export enum TextTrackWindowType {
+export const enum TextTrackWindowType {
     NONE = "NONE",
     NORMAL = "NORMAL",
     ROUNDED_CORNERS = "ROUNDED_CORNERS",
@@ -393,7 +393,7 @@ export enum TextTrackWindowType {
  * Possible media track type.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.TrackType}
  */
-export enum TrackType {
+export const enum TrackType {
     AUDIO = "AUDIO",
     TEXT = "TEXT",
     VIDEO = "VIDEO",
@@ -403,7 +403,7 @@ export enum TrackType {
  * User actions.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.UserAction}
  */
-export enum UserAction {
+export const enum UserAction {
     DISLIKE = "DISLIKE",
     FLAG = "FLAG",
     FOLLOW = "FOLLOW",
@@ -416,7 +416,7 @@ export enum UserAction {
  * Context information for the user action.
  * [Documentation]{@link https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.messages#.UserActionContext}
  */
-export enum UserActionContext {
+export const enum UserActionContext {
     ALBUM = "ALBUM",
     ARTIST = "ARTIST",
     CHANNEL = "CHANNEL",

--- a/types/chromecast-caf-receiver/cast.framework.system.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.system.d.ts
@@ -4,7 +4,7 @@ export as namespace system;
  * System events dispatched by {@link framework.CastReceiverContext}.
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.system#.EventType
  */
-export enum EventType {
+export const enum EventType {
     ALLOW_GROUP_CHANGE = "allowgroupchange",
     /**
      * Fired when there is a system error.
@@ -61,7 +61,7 @@ export enum EventType {
  * Represents the current system state.
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.system#.SystemState
  */
-export enum SystemState {
+export const enum SystemState {
     /**
      * The application has not been requested to start yet.
      */
@@ -92,7 +92,7 @@ export enum SystemState {
  * Types of custom messages.
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.system#.MessageType
  */
-export enum MessageType {
+export const enum MessageType {
     /**
      * Messages are free-form strings. The application is responsible for encoding/decoding the information transmitted.
      */
@@ -108,7 +108,7 @@ export enum MessageType {
  * if the cast platform was unable to determine the state yet.
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.system#.StandbyState
  */
-export enum StandbyState {
+export const enum StandbyState {
     NOT_STANDBY = "notstandby",
     STANDBY = "standby",
     UNKNOWN = "unknown",
@@ -118,7 +118,7 @@ export enum StandbyState {
  * Represents the disconnect reason.
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.system#.DisconnectReason
  */
-export enum DisconnectReason {
+export const enum DisconnectReason {
     /**
      * There was a protocol error.
      */
@@ -141,7 +141,7 @@ export enum DisconnectReason {
  * Represent where the receiver was launched from.
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.system#.LaunchedFrom
  */
-export enum LaunchedFrom {
+export const enum LaunchedFrom {
     /**
      * App was launched by Cast V2 request.
      */
@@ -164,7 +164,7 @@ export enum LaunchedFrom {
  * Device capabilities.
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.system#.DeviceCapabilities
  */
-export enum DeviceCapabilities {
+export const enum DeviceCapabilities {
     APP_FOREGROUND = "app_foreground",
     /**
      * Audio Assistant support. For example, Google Home and Google Home Mini.
@@ -218,7 +218,7 @@ export enum DeviceCapabilities {
  * It may be UNKNOWN if the cast platform was unable to determine the state yet.
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.system#.VisibilityState
  */
-export enum VisibilityState {
+export const enum VisibilityState {
     NOT_VISIBLE = "notvisible",
     UNKNOWN = "unknown",
     VISIBLE = "visible",

--- a/types/chromecast-caf-receiver/cast.framework.ui.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.ui.d.ts
@@ -20,7 +20,7 @@ export type ContentType = "video" | "audio" | "image";
  * UI state of receiver application.
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.ui#.State
  */
-export enum State {
+export const enum State {
     LAUNCHING = "launching",
     IDLE = "idle",
     LOADING = "loading",
@@ -33,7 +33,7 @@ export enum State {
  * Player data changed event types.
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.ui#.PlayerDataEventType
  */
-export enum PlayerDataEventType {
+export const enum PlayerDataEventType {
     ACTIVE_TRACK_IDS_CHANGED = "activeTrackIdsChanged",
     ANY_CHANGE = "*",
     APPLICATION_DATA_CHANGED = "applicationDataChanged",
@@ -517,7 +517,7 @@ export class UiConfig {
  * Aspect ratio of all images in the media browse carousel.
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.ui#.BrowseImageAspectRatio
  */
-export enum BrowseImageAspectRatio {
+export const enum BrowseImageAspectRatio {
     /**
      * Square images.
      */
@@ -541,7 +541,7 @@ export enum BrowseImageAspectRatio {
  * available for the browse item.
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.ui#.BrowseImageType
  */
-export enum BrowseImageType {
+export const enum BrowseImageType {
     /**
      * A playlist that consists of songs by a specific
      * music artist or band, or radio seeded by an artist
@@ -627,7 +627,7 @@ export enum BrowseImageType {
  * Badge that will be displayed on top of the browse item image.
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.ui#.BrowseMediaBadge
  */
-export enum BrowseMediaBadge {
+export const enum BrowseMediaBadge {
     /**
      * LIVE indicator badge. Should be used if stream is a live
      * content.
@@ -639,7 +639,7 @@ export enum BrowseMediaBadge {
  * Predefined buttons for the Media Controls overlay
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.ui#.ControlsButton
  */
-export enum ControlsButton {
+export const enum ControlsButton {
     /**
      * Turn on/off closed captions.
      */
@@ -720,7 +720,7 @@ export enum ControlsButton {
  * Touch Controls interface.
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.ui#.ControlsSlot
  */
-export enum ControlsSlot {
+export const enum ControlsSlot {
     /**
      * Side left slot. Deprecated, use SLOT_SECONDARY_1 instead.
      *
@@ -774,7 +774,7 @@ export enum ControlsSlot {
  * Device display type.
  * @see https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.ui#.DisplayType
  */
-export enum DisplayType {
+export const enum DisplayType {
     TV = "tv",
     TOUCH = "touch",
 }


### PR DESCRIPTION
This allows Cast SDK messages to be crafted with compile-time constants in environments where the SDK is not importable at runtime.

-----

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
