### PR TITLE
jsonwebtoken VerifyOptions.audience can be an array

### DIFF
--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -56,7 +56,7 @@ export interface SignOptions {
 
 export interface VerifyOptions {
     algorithms?: Algorithm[] | undefined;
-    audience?: string | RegExp | [string | RegExp, ...(string | RegExp)[]] | undefined;
+    audience?: string | RegExp | Array<string | RegExp> | undefined;
     clockTimestamp?: number | undefined;
     clockTolerance?: number | undefined;
     /** return an object with the decoded `{ payload, header, signature }` instead of only the usual content of the payload. */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [z] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

https://github.com/auth0/node-jsonwebtoken/blob/v9.0.2/verify.js#L194
```
if (options.audience) {
      const audiences = Array.isArray(options.audience) ? options.audience : [options.audience];
      const target = Array.isArray(payload.aud) ? payload.aud : [payload.aud];

      const match = target.some(function (targetAudience) {
        return audiences.some(function (audience) {
          return audience instanceof RegExp ? audience.test(targetAudience) : audience === targetAudience;
        });
      });
```