### PR TITLE
feat(qunit): add types for module.if

### DIFF
--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -445,11 +445,14 @@ declare global {
         beforeEach(fn: (assert: Assert) => void | Promise<void>): void;
     }
 
-    type moduleFunc1 = (name: string, hooks?: Hooks, nested?: (hooks: NestedHooks) => void) => void;
-    type moduleFunc2 = (name: string, nested?: (hooks: NestedHooks) => void) => void;
-    type ModuleOnly = { only: moduleFunc1 & moduleFunc2 };
-    type ModuleSkip = { skip: moduleFunc1 & moduleFunc2 };
-    type ModuleTodo = { todo: moduleFunc1 & moduleFunc2 };
+    type moduleFunctionWithOptions = (name: string, options?: Hooks, nested?: (hooks: NestedHooks) => void) => void;
+    type moduleFunction = (name: string, nested?: (hooks: NestedHooks) => void) => void;
+    type conditionalModuleFunctionWithOptions = (name: string, condition: boolean, options?: Hooks, nested?: (hooks: NestedHooks) => void) => void;
+    type conditionalModuleFunction = (name: string, condition: boolean, nested?: (hooks: NestedHooks) => void) => void;
+    type ModuleOnly = { only: moduleFunction & moduleFunctionWithOptions };
+    type ModuleSkip = { skip: moduleFunction & moduleFunctionWithOptions };
+    type ModuleIf = { if: conditionalModuleFunction & conditionalModuleFunctionWithOptions };
+    type ModuleTodo = { todo: moduleFunction & moduleFunctionWithOptions };
 
     namespace QUnit {
         interface BeginDetails {
@@ -739,7 +742,7 @@ declare global {
          * @param hookds Callbacks to run during test execution
          * @param nested A callback with grouped tests and nested modules to run under the current module label
          */
-        module: moduleFunc1 & moduleFunc2 & ModuleOnly & ModuleSkip & ModuleTodo;
+        module: moduleFunction & moduleFunctionWithOptions & ModuleOnly & ModuleSkip & ModuleIf & ModuleTodo;
 
         /**
          * Register a callback to fire whenever a module ends.

--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -447,7 +447,12 @@ declare global {
 
     type moduleFunctionWithOptions = (name: string, options?: Hooks, nested?: (hooks: NestedHooks) => void) => void;
     type moduleFunction = (name: string, nested?: (hooks: NestedHooks) => void) => void;
-    type conditionalModuleFunctionWithOptions = (name: string, condition: boolean, options?: Hooks, nested?: (hooks: NestedHooks) => void) => void;
+    type conditionalModuleFunctionWithOptions = (
+        name: string,
+        condition: boolean,
+        options?: Hooks,
+        nested?: (hooks: NestedHooks) => void,
+    ) => void;
     type conditionalModuleFunction = (name: string, condition: boolean, nested?: (hooks: NestedHooks) => void) => void;
     type ModuleOnly = { only: moduleFunction & moduleFunctionWithOptions };
     type ModuleSkip = { skip: moduleFunction & moduleFunctionWithOptions };

--- a/types/qunit/test/global-test.ts
+++ b/types/qunit/test/global-test.ts
@@ -241,7 +241,7 @@ QUnit.module.if("Conditional module", true, function(hooks) {
 
     QUnit.test("call hooks", function(assert) {
         assert.expect(2);
-    })
+    });
 
     QUnit.module.if("nested conditional module", true, {
         // This will run after the parent module's beforeEach hook
@@ -257,7 +257,7 @@ QUnit.module.if("Conditional module", true, function(hooks) {
     QUnit.test("call nested hooks", function(assert) {
         assert.expect(4);
     });
-})
+});
 
 QUnit.module.only("exclusive module", function(hooks) {
     hooks.beforeEach(function(assert) {

--- a/types/qunit/test/global-test.ts
+++ b/types/qunit/test/global-test.ts
@@ -172,6 +172,93 @@ QUnit.module("grouped tests argument hooks", function(hooks) {
     });
 });
 
+QUnit.module.todo("unfinished module", function(hooks) {
+    hooks.beforeEach(function(assert) {
+        assert.ok(true, "beforeEach called");
+    });
+
+    hooks.afterEach(function(assert) {
+        assert.ok(true, "afterEach called");
+    });
+
+    QUnit.test("call hooks", function(assert) {
+        assert.expect(2);
+    });
+
+    QUnit.module.todo("nested unfinished module", {
+        // This will run after the parent module's beforeEach hook
+        beforeEach: assert => {
+            assert.ok(true, "nested beforeEach called");
+        },
+        // This will run before the parent module's afterEach
+        afterEach: assert => {
+            assert.ok(true, "nested afterEach called");
+        },
+    });
+
+    QUnit.test("call nested hooks", function(assert) {
+        assert.expect(4);
+    });
+});
+
+QUnit.module.skip("skipped module", function(hooks) {
+    hooks.beforeEach(function(assert) {
+        assert.ok(true, "beforeEach called");
+    });
+
+    hooks.afterEach(function(assert) {
+        assert.ok(true, "afterEach called");
+    });
+
+    QUnit.test("call hooks", function(assert) {
+        assert.expect(2);
+    });
+
+    QUnit.module.skip("nested skipped module", {
+        // This will run after the parent module's beforeEach hook
+        beforeEach: assert => {
+            assert.ok(true, "nested beforeEach called");
+        },
+        // This will run before the parent module's afterEach
+        afterEach: assert => {
+            assert.ok(true, "nested afterEach called");
+        },
+    });
+
+    QUnit.test("call nested hooks", function(assert) {
+        assert.expect(4);
+    });
+});
+
+QUnit.module.if("Conditional module", true, function(hooks) {
+    hooks.beforeEach(function(assert) {
+        assert.ok(true, "beforeEach called");
+    });
+
+    hooks.afterEach(function(assert) {
+        assert.ok(true, "afterEach called");
+    });
+
+    QUnit.test("call hooks", function(assert) {
+        assert.expect(2);
+    })
+
+    QUnit.module.if("nested conditional module", true, {
+        // This will run after the parent module's beforeEach hook
+        beforeEach: assert => {
+            assert.ok(true, "nested beforeEach called");
+        },
+        // This will run before the parent module's afterEach
+        afterEach: assert => {
+            assert.ok(true, "nested afterEach called");
+        },
+    });
+
+    QUnit.test("call nested hooks", function(assert) {
+        assert.expect(4);
+    });
+})
+
 QUnit.module.only("exclusive module", function(hooks) {
     hooks.beforeEach(function(assert) {
         assert.ok(true, "beforeEach called");

--- a/types/qunit/test/module-test.ts
+++ b/types/qunit/test/module-test.ts
@@ -33,7 +33,175 @@ QUnit.module("basic tests for importing QUnit", function(hooks) {
         assert.ok(true, "this is called if true");
     });
 
-    QUnit.module("skip", function() {
+    QUnit.module("nested", function() {
+        QUnit.test.each("each with string array example", ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "string value");
+        });
+
+        QUnit.test.each("each with string object example", { case1: "foo", case2: "bar" }, function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "string value");
+        });
+
+        QUnit.test.each("each with number array example", [1, 2], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, 3);
+        });
+
+        QUnit.test.each("each with number object example", { case1: 1, case2: 2 }, function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, 3);
+        });
+
+        QUnit.test.if.each("if.each with string array example", true, ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "foo");
+        });
+
+        QUnit.test.skip.each("skip.each with string array example", ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "foo");
+        });
+
+        QUnit.test.todo.each("todo.each with string array example", ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "foo");
+        });
+
+        QUnit.test.only.each("only.each with string array example", ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "foo");
+        });
+    });
+
+    QUnit.module.if("conditional", true, function() {
+        QUnit.test.each("each with string array example", ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "string value");
+        });
+
+        QUnit.test.each("each with string object example", { case1: "foo", case2: "bar" }, function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "string value");
+        });
+
+        QUnit.test.each("each with number array example", [1, 2], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, 3);
+        });
+
+        QUnit.test.each("each with number object example", { case1: 1, case2: 2 }, function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, 3);
+        });
+
+        QUnit.test.if.each("if.each with string array example", true, ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "foo");
+        });
+
+        QUnit.test.skip.each("skip.each with string array example", ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "foo");
+        });
+
+        QUnit.test.todo.each("todo.each with string array example", ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "foo");
+        });
+
+        QUnit.test.only.each("only.each with string array example", ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "foo");
+        });
+    });
+
+    QUnit.module.only("exclusive", function() {
+        QUnit.test.each("each with string array example", ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "string value");
+        });
+
+        QUnit.test.each("each with string object example", { case1: "foo", case2: "bar" }, function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "string value");
+        });
+
+        QUnit.test.each("each with number array example", [1, 2], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, 3);
+        });
+
+        QUnit.test.each("each with number object example", { case1: 1, case2: 2 }, function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, 3);
+        });
+
+        QUnit.test.if.each("if.each with string array example", true, ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "foo");
+        });
+
+        QUnit.test.skip.each("skip.each with string array example", ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "foo");
+        });
+
+        QUnit.test.todo.each("todo.each with string array example", ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "foo");
+        });
+
+        QUnit.test.only.each("only.each with string array example", ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "foo");
+        });
+    });
+
+    QUnit.module.skip("skip", function() {
+        QUnit.test.each("each with string array example", ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "string value");
+        });
+
+        QUnit.test.each("each with string object example", { case1: "foo", case2: "bar" }, function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "string value");
+        });
+
+        QUnit.test.each("each with number array example", [1, 2], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, 3);
+        });
+
+        QUnit.test.each("each with number object example", { case1: 1, case2: 2 }, function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, 3);
+        });
+
+        QUnit.test.if.each("if.each with string array example", true, ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "foo");
+        });
+
+        QUnit.test.skip.each("skip.each with string array example", ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "foo");
+        });
+
+        QUnit.test.todo.each("todo.each with string array example", ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "foo");
+        });
+
+        QUnit.test.only.each("only.each with string array example", ["foo", "bar"], function(assert, data) {
+            assert.expect(3);
+            assert.strictEqual(data, "foo");
+        });
+    });
+
+    QUnit.module.todo("nested", function() {
         QUnit.test.each("each with string array example", ["foo", "bar"], function(assert, data) {
             assert.expect(3);
             assert.strictEqual(data, "string value");


### PR DESCRIPTION
This PR adds in the missing types for `module.if`.
The (not exported) names for the module union have also been updated to have a more descriptive name.

While writing the tests, I also noticed some cases missing for `Qunit.module.todo` and `Qunit.module.skip`, these have been added as well.

---

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://qunitjs.com/api/QUnit/module/
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.