### PR TITLE
Add `import.meta.main` for Node 22.18.0

### DIFF
--- a/types/node/v22/module.d.ts
+++ b/types/node/v22/module.d.ts
@@ -684,6 +684,30 @@ declare module "module" {
              * @returns The absolute URL string that the specifier would resolve to.
              */
             resolve(specifier: string, parent?: string | URL): string;
+            /**
+             * `true` when the current module is the entry point of the current process; `false` otherwise.
+             *
+             * Equivalent to `require.main === module` in CommonJS.
+             *
+             * Analogous to Python's `__name__ == "__main__"`.
+             *
+             * ```js
+             * export function foo() {
+             *   return 'Hello, world';
+             * }
+             *
+             * function main() {
+             *   const message = foo();
+             *   console.log(message);
+             * }
+             *
+             * if (import.meta.main) main();
+             * // `foo` can be imported from another module without possible side-effects from `main`
+             * ```
+             * @since v22.18.0
+             * @experimental
+             */
+            main: boolean;
         }
         namespace NodeJS {
             interface Module {

--- a/types/node/v22/package.json
+++ b/types/node/v22/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "22.17.9999",
+    "version": "22.18.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [


### PR DESCRIPTION
This simply copies the type from Node 24:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f3c4306d7f3b710b4087d2c1c0eb3a19973b516e/types/node/module.d.ts#L688-L711

But adjusting the @since tag. There are no tests for it, thus I don't think I need to add tests for this too.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v22.x/api/esm.html#importmetamain
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
