### PR TITLE
[google-apps-script] Add `ScriptApp.requireScopes()` and `ScriptApp.requireAllScopes()`.

### DIFF
--- a/types/google-apps-script/google-apps-script.script.d.ts
+++ b/types/google-apps-script/google-apps-script.script.d.ts
@@ -146,6 +146,8 @@ declare namespace GoogleAppsScript {
             invalidateAuth(): void;
             newStateToken(): StateTokenBuilder;
             newTrigger(functionName: string): TriggerBuilder;
+            requireAllScopes(authMode: AuthMode): void;
+            requireScopes(authMode: AuthMode, oAuthScopes: string[]): void;
             /** @deprecated DO NOT USE */ getProjectKey(): string;
             /** @deprecated DO NOT USE */ getScriptTriggers(): Trigger[];
         }


### PR DESCRIPTION
This adds two missing methods in `ScriptApp` from Google Apps Script.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [ScriptApp.requireAllScopes()](https://developers.google.com/apps-script/reference/script/script-app#requireallscopesauthmode), [ScriptApp.requireScopes()](https://developers.google.com/apps-script/reference/script/script-app#requirescopesauthmode,-oauthscopes)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
