### PR TITLE
node: v24.4

### DIFF
--- a/types/node/buffer.d.ts
+++ b/types/node/buffer.d.ts
@@ -139,7 +139,7 @@ declare module "buffer" {
         type?: string | undefined;
     }
     /**
-     * A [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) encapsulates immutable, raw data that can be safely shared across
+     * A `Blob` encapsulates immutable, raw data that can be safely shared across
      * multiple worker threads.
      * @since v15.7.0, v14.18.0
      */

--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -24,7 +24,7 @@
  * the parent Node.js process and the spawned subprocess. These pipes have
  * limited (and platform-specific) capacity. If the subprocess writes to
  * stdout in excess of that limit without the output being captured, the
- * subprocess blocks waiting for the pipe buffer to accept more data. This is
+ * subprocess blocks, waiting for the pipe buffer to accept more data. This is
  * identical to the behavior of pipes in the shell. Use the `{ stdio: 'ignore' }` option if the output will not be consumed.
  *
  * The command lookup is performed using the `options.env.PATH` environment

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -3363,11 +3363,36 @@ declare module "crypto" {
         options: { privateKey: KeyObject; publicKey: KeyObject },
         callback: (err: Error | null, secret: Buffer) => void,
     ): void;
+    interface OneShotDigestOptions {
+        /**
+         * Encoding used to encode the returned digest.
+         * @default 'hex'
+         */
+        outputEncoding?: BinaryToTextEncoding | "buffer" | undefined;
+        /**
+         * For XOF hash functions such as 'shake256', the outputLength option
+         * can be used to specify the desired output length in bytes.
+         */
+        outputLength?: number | undefined;
+    }
+    interface OneShotDigestOptionsWithStringEncoding extends OneShotDigestOptions {
+        outputEncoding?: BinaryToTextEncoding | undefined;
+    }
+    interface OneShotDigestOptionsWithBufferEncoding extends OneShotDigestOptions {
+        outputEncoding: "buffer";
+    }
     /**
-     * A utility for creating one-shot hash digests of data. It can be faster than the object-based `crypto.createHash()` when hashing a smaller amount of data
-     * (<= 5MB) that's readily available. If the data can be big or if it is streamed, it's still recommended to use `crypto.createHash()` instead. The `algorithm`
-     * is dependent on the available algorithms supported by the version of OpenSSL on the platform. Examples are `'sha256'`, `'sha512'`, etc. On recent releases
-     * of OpenSSL, `openssl list -digest-algorithms` will display the available digest algorithms.
+     * A utility for creating one-shot hash digests of data. It can be faster than
+     * the object-based `crypto.createHash()` when hashing a smaller amount of data
+     * (<= 5MB) that's readily available. If the data can be big or if it is streamed,
+     * it's still recommended to use `crypto.createHash()` instead.
+     *
+     * The `algorithm` is dependent on the available algorithms supported by the
+     * version of OpenSSL on the platform. Examples are `'sha256'`, `'sha512'`, etc.
+     * On recent releases of OpenSSL, `openssl list -digest-algorithms` will
+     * display the available digest algorithms.
+     *
+     * If `options` is a string, then it specifies the `outputEncoding`.
      *
      * Example:
      *
@@ -3387,16 +3412,25 @@ declare module "crypto" {
      * console.log(crypto.hash('sha1', Buffer.from(base64, 'base64'), 'buffer'));
      * ```
      * @since v21.7.0, v20.12.0
-     * @param data When `data` is a string, it will be encoded as UTF-8 before being hashed. If a different input encoding is desired for a string input, user
-     *             could encode the string into a `TypedArray` using either `TextEncoder` or `Buffer.from()` and passing the encoded `TypedArray` into this API instead.
-     * @param [outputEncoding='hex'] [Encoding](https://nodejs.org/docs/latest-v24.x/api/buffer.html#buffers-and-character-encodings) used to encode the returned digest.
+     * @param data When `data` is a string, it will be encoded as UTF-8 before being hashed. If a different
+     * input encoding is desired for a string input, user could encode the string
+     * into a `TypedArray` using either `TextEncoder` or `Buffer.from()` and passing
+     * the encoded `TypedArray` into this API instead.
      */
-    function hash(algorithm: string, data: BinaryLike, outputEncoding?: BinaryToTextEncoding): string;
-    function hash(algorithm: string, data: BinaryLike, outputEncoding: "buffer"): Buffer;
     function hash(
         algorithm: string,
         data: BinaryLike,
-        outputEncoding?: BinaryToTextEncoding | "buffer",
+        options?: OneShotDigestOptionsWithStringEncoding | BinaryToTextEncoding,
+    ): string;
+    function hash(
+        algorithm: string,
+        data: BinaryLike,
+        options: OneShotDigestOptionsWithBufferEncoding | "buffer",
+    ): Buffer;
+    function hash(
+        algorithm: string,
+        data: BinaryLike,
+        options: OneShotDigestOptions | BinaryToTextEncoding | "buffer",
     ): string | Buffer;
     type CipherMode = "cbc" | "ccm" | "cfb" | "ctr" | "ecb" | "gcm" | "ocb" | "ofb" | "stream" | "wrap" | "xts";
     interface CipherInfoOptions {

--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -1966,6 +1966,39 @@ declare module "fs" {
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
     export function mkdtempSync(prefix: string, options?: EncodingOption): string | Buffer;
+    export interface DisposableTempDir extends AsyncDisposable {
+        /**
+         * The path of the created directory.
+         */
+        path: string;
+        /**
+         * A function which removes the created directory.
+         */
+        remove(): Promise<void>;
+        /**
+         * The same as `remove`.
+         */
+        [Symbol.asyncDispose](): Promise<void>;
+    }
+    /**
+     * Returns a disposable object whose `path` property holds the created directory
+     * path. When the object is disposed, the directory and its contents will be
+     * removed if it still exists. If the directory cannot be deleted, disposal will
+     * throw an error. The object has a `remove()` method which will perform the same
+     * task.
+     *
+     * <!-- TODO: link MDN docs for disposables once https://github.com/mdn/content/pull/38027 lands -->
+     *
+     * For detailed information, see the documentation of `fs.mkdtemp()`.
+     *
+     * There is no callback-based version of this API because it is designed for use
+     * with the `using` syntax.
+     *
+     * The optional `options` argument can be a string specifying an encoding, or an
+     * object with an `encoding` property specifying the character encoding to use.
+     * @since v24.4.0
+     */
+    export function mkdtempDisposableSync(prefix: string, options?: EncodingOption): DisposableTempDir;
     /**
      * Reads the contents of a directory. The callback gets two arguments `(err, files)` where `files` is an array of the names of the files in the directory excluding `'.'` and `'..'`.
      *

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -20,6 +20,8 @@ declare module "fs/promises" {
         CopyOptions,
         Dir,
         Dirent,
+        DisposableTempDir,
+        EncodingOption,
         GlobOptions,
         GlobOptionsWithFileTypes,
         GlobOptionsWithoutFileTypes,
@@ -961,6 +963,26 @@ declare module "fs/promises" {
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
     function mkdtemp(prefix: string, options?: ObjectEncodingOptions | BufferEncoding | null): Promise<string | Buffer>;
+    /**
+     * The resulting Promise holds an async-disposable object whose `path` property
+     * holds the created directory path. When the object is disposed, the directory
+     * and its contents will be removed asynchronously if it still exists. If the
+     * directory cannot be deleted, disposal will throw an error. The object has an
+     * async `remove()` method which will perform the same task.
+     *
+     * Both this function and the disposal function on the resulting object are
+     * async, so it should be used with `await` + `await using` as in
+     * `await using dir = await fsPromises.mkdtempDisposable('prefix')`.
+     *
+     * <!-- TODO: link MDN docs for disposables once https://github.com/mdn/content/pull/38027 lands -->
+     *
+     * For detailed information, see the documentation of `fsPromises.mkdtemp()`.
+     *
+     * The optional `options` argument can be a string specifying an encoding, or an
+     * object with an `encoding` property specifying the character encoding to use.
+     * @since v24.4.0
+     */
+    function mkdtempDisposable(prefix: PathLike, options?: EncodingOption): Promise<DisposableTempDir>;
     /**
      * Asynchronously writes data to a file, replacing the file if it already exists. `data` can be a string, a buffer, an
      * [AsyncIterable](https://tc39.github.io/ecma262/#sec-asynciterable-interface), or an

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -2028,7 +2028,7 @@ declare module "http" {
      */
     const maxHeaderSize: number;
     /**
-     * A browser-compatible implementation of [WebSocket](https://nodejs.org/docs/latest/api/http.html#websocket).
+     * A browser-compatible implementation of `WebSocket`.
      * @since v22.5.0
      */
     const WebSocket: import("undici-types").WebSocket;

--- a/types/node/module.d.ts
+++ b/types/node/module.d.ts
@@ -359,6 +359,7 @@ declare module "module" {
         interface ImportAttributes extends NodeJS.Dict<string> {
             type?: string | undefined;
         }
+        type ImportPhase = "source" | "evaluation";
         type ModuleFormat =
             | "addon"
             | "builtin"

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "24.3.9999",
+    "version": "24.4.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -18,7 +18,7 @@
         }
     },
     "dependencies": {
-        "undici-types": "~7.10.0"
+        "undici-types": "~7.11.0"
     },
     "devDependencies": {
         "@types/node": "workspace:."

--- a/types/node/sqlite.d.ts
+++ b/types/node/sqlite.d.ts
@@ -97,6 +97,33 @@ declare module "node:sqlite" {
          * @default 0
          */
         timeout?: number | undefined;
+        /**
+         * If `true`, integer fields are read as JavaScript `BigInt` values. If `false`,
+         * integer fields are read as JavaScript numbers.
+         * @since v24.4.0
+         * @default false
+         */
+        readBigInts?: boolean | undefined;
+        /**
+         * If `true`, query results are returned as arrays instead of objects.
+         * @since v24.4.0
+         * @default false
+         */
+        returnArrays?: boolean | undefined;
+        /**
+         * If `true`, allows binding named parameters without the prefix
+         * character (e.g., `foo` instead of `:foo`).
+         * @since v24.4.40
+         * @default true
+         */
+        allowBareNamedParameters?: boolean | undefined;
+        /**
+         * If `true`, unknown named parameters are ignored when binding.
+         * If `false`, an exception is thrown for unknown named parameters.
+         * @since v24.4.40
+         * @default false
+         */
+        allowUnknownNamedParameters?: boolean | undefined;
     }
     interface CreateSessionOptions {
         /**

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -1100,8 +1100,16 @@ import { promisify } from "node:util";
 }
 
 {
+    // $ExpectType string
     crypto.hash("sha1", "Node.js");
+    // $ExpectType Buffer || Buffer<ArrayBufferLike>
     crypto.hash("sha1", Buffer.from("Tm9kZS5qcw==", "base64"), "buffer");
+    // $ExpectType string
+    crypto.hash("shake256", "Node.js", { outputLength: 256 });
+    // $ExpectType string
+    crypto.hash("shake256", Buffer.allocUnsafe(0), { outputEncoding: "base64" });
+    // $ExpectType Buffer || Buffer<ArrayBufferLike>
+    crypto.hash("shake256", "Node.js", { outputEncoding: "buffer", outputLength: 256 });
 }
 
 {

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -221,14 +221,36 @@ async function testPromisify() {
 
 {
     fs.mkdtemp("/tmp/foo-", (err, folder) => {
-        console.log(folder);
-        // Prints: /tmp/foo-itXde2
+        // $ExpectType string
+        folder;
+    });
+
+    // $ExpectType string
+    fs.mkdtempSync("/tmp/foo-");
+
+    fs.promises.mkdtemp("/tmp/foo-").then((result) => {
+        // $ExpectType string
+        result;
     });
 }
 
 {
-    let tempDir: string;
-    tempDir = fs.mkdtempSync("/tmp/foo-");
+    const disposable = fs.mkdtempDisposableSync("/tmp/foo-");
+    // $ExpectType string
+    disposable.path;
+    // $ExpectType Promise<void>
+    disposable.remove();
+    // $ExpectType Promise<void>
+    disposable[Symbol.asyncDispose]();
+
+    fs.promises.mkdtempDisposable("/tmp/foo-").then((result) => {
+        // $ExpectType string
+        result.path;
+        // $ExpectType Promise<void>
+        result.remove();
+        // $ExpectType Promise<void>
+        result[Symbol.asyncDispose]();
+    });
 }
 
 {

--- a/types/node/test/sqlite.ts
+++ b/types/node/test/sqlite.ts
@@ -69,6 +69,16 @@ import { TextEncoder } from "node:util";
 }
 
 {
+    new DatabaseSync(":memory:", {
+        timeout: 10_000,
+        readBigInts: true,
+        returnArrays: true,
+        allowBareNamedParameters: false,
+        allowUnknownNamedParameters: true,
+    });
+}
+
+{
     const database = new DatabaseSync(":memory:", { allowExtension: true });
     database.loadExtension("/path/to/extension.so");
     database.enableLoadExtension(false);

--- a/types/node/test/vm.ts
+++ b/types/node/test/vm.ts
@@ -158,6 +158,15 @@ import {
     });
 
     await bar.evaluate();
+
+    for (const request of bar.moduleRequests) {
+        // $ExpectType string
+        request.specifier;
+        // $ExpectType ImportAttributes
+        request.attributes;
+        // $ExpectType ImportPhase
+        request.phase;
+    }
 });
 
 (async () => {
@@ -178,7 +187,7 @@ import {
             specifier; // $ExpectType string
             referrer; // $ExpectType Script
             importAttributes; // $ExpectType ImportAttributes
-            phase; // $ExpectType "source" | "evaluation"
+            phase; // $ExpectType ImportPhase
 
             const module = new SyntheticModule(["bar"], () => {});
             return Math.random() < 1 ? module : new Promise(res => res(module));
@@ -195,7 +204,7 @@ import {
             specifier; // $ExpectType string
             referrer; // $ExpectType Script
             importAttributes; // $ExpectType ImportAttributes
-            phase; // $ExpectType "source" | "evaluation"
+            phase; // $ExpectType ImportPhase
 
             const module = new SyntheticModule(["bar"], () => {});
             return Math.random() < 1 ? module : new Promise(res => res(module));
@@ -211,7 +220,7 @@ import {
             specifier; // $ExpectType string
             referrer; // $ExpectType Script
             importAttributes; // $ExpectType ImportAttributes
-            phase; // $ExpectType "source" | "evaluation"
+            phase; // $ExpectType ImportPhase
 
             const module = new SyntheticModule(["bar"], () => {});
             return Math.random() < 1 ? module : new Promise(res => res(module));
@@ -227,7 +236,7 @@ import {
             specifier; // $ExpectType string
             referrer; // $ExpectType Script
             importAttributes; // $ExpectType ImportAttributes
-            phase; // $ExpectType "source" | "evaluation"
+            phase; // $ExpectType ImportPhase
 
             const module = new SyntheticModule(["bar"], () => {});
             return Math.random() < 1 ? module : new Promise(res => res(module));
@@ -243,7 +252,7 @@ import {
             specifier; // $ExpectType string
             referrer; // $ExpectType Function & { cachedData?: Buffer<ArrayBufferLike> | undefined; cachedDataProduced?: boolean | undefined; cachedDataRejected?: boolean | undefined; }
             importAttributes; // $ExpectType ImportAttributes
-            phase; // $ExpectType "source" | "evaluation"
+            phase; // $ExpectType ImportPhase
 
             const module = new SyntheticModule(["bar"], () => {});
             return Math.random() < 1 ? module : new Promise(res => res(module));
@@ -260,7 +269,7 @@ import {
             specifier; // $ExpectType string
             referrer; // $ExpectType SourceTextModule
             importAttributes; // $ExpectType ImportAttributes
-            phase; // $ExpectType "source" | "evaluation"
+            phase; // $ExpectType ImportPhase
 
             const module = new SyntheticModule(["bar"], () => {});
             return Math.random() < 1 ? module : new Promise(res => res(module));
@@ -279,7 +288,7 @@ import {
             specifier; // $ExpectType string
             referrer; // $ExpectType Context
             importAttributes; // $ExpectType ImportAttributes
-            phase; // $ExpectType "source" | "evaluation"
+            phase; // $ExpectType ImportPhase
 
             const module = new SyntheticModule(["bar"], () => {});
             return Math.random() < 1 ? module : new Promise(res => res(module));

--- a/types/node/test/wasi.ts
+++ b/types/node/test/wasi.ts
@@ -11,6 +11,7 @@ import { WASI } from "node:wasi";
         },
     });
     const importObject = wasi.getImportObject();
+    wasi.finalizeBindings(importObject);
     (async () => {
         // TODO: Global WebAssembly types are not currently declared.; uncomment below when added.
 

--- a/types/node/wasi.d.ts
+++ b/types/node/wasi.d.ts
@@ -121,6 +121,12 @@ declare module "wasi" {
          */
         version: "unstable" | "preview1";
     }
+    interface FinalizeBindingsOptions {
+        /**
+         * @default instance.exports.memory
+         */
+        memory?: object | undefined;
+    }
     /**
      * The `WASI` class provides the WASI system call API and additional convenience
      * methods for working with WASI-based applications. Each `WASI` instance
@@ -167,6 +173,21 @@ declare module "wasi" {
          * @since v14.6.0, v12.19.0
          */
         initialize(instance: object): void; // TODO: avoid DOM dependency until WASM moved to own lib.
+        /**
+         * Set up WASI host bindings to `instance` without calling `initialize()`
+         * or `start()`. This method is useful when the WASI module is instantiated in
+         * child threads for sharing the memory across threads.
+         *
+         * `finalizeBindings()` requires that either `instance` exports a
+         * [`WebAssembly.Memory`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory) named `memory` or user specify a
+         * [`WebAssembly.Memory`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory) object in `options.memory`. If the `memory` is invalid
+         * an exception is thrown.
+         *
+         * `start()` and `initialize()` will call `finalizeBindings()` internally.
+         * If `finalizeBindings()` is called more than once, an exception is thrown.
+         * @since v24.4.0
+         */
+        finalizeBindings(instance: object, options?: FinalizeBindingsOptions): void;
         /**
          * `wasiImport` is an object that implements the WASI system call API. This object
          * should be passed as the `wasi_snapshot_preview1` import during the instantiation


### PR DESCRIPTION
- **crypto:** support outputLength option in crypto.hash for XOF functions
- **deps:** update undici to 7.11.0
- **fs:** add disposable mkdtempSync
- **lib:** expose setupInstance method on WASI class
- **sqlite:** add support for readBigInts option in db connection level
- **vm:** expose import phase on SourceTextModule.moduleRequests

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V24.md#24.4.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
