### PR TITLE
node: v22.18

### DIFF
--- a/types/node/v22/buffer.d.ts
+++ b/types/node/v22/buffer.d.ts
@@ -139,7 +139,7 @@ declare module "buffer" {
         type?: string | undefined;
     }
     /**
-     * A [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) encapsulates immutable, raw data that can be safely shared across
+     * A `Blob` encapsulates immutable, raw data that can be safely shared across
      * multiple worker threads.
      * @since v15.7.0, v14.18.0
      */

--- a/types/node/v22/child_process.d.ts
+++ b/types/node/v22/child_process.d.ts
@@ -24,7 +24,7 @@
  * the parent Node.js process and the spawned subprocess. These pipes have
  * limited (and platform-specific) capacity. If the subprocess writes to
  * stdout in excess of that limit without the output being captured, the
- * subprocess blocks waiting for the pipe buffer to accept more data. This is
+ * subprocess blocks, waiting for the pipe buffer to accept more data. This is
  * identical to the behavior of pipes in the shell. Use the `{ stdio: 'ignore' }` option if the output will not be consumed.
  *
  * The command lookup is performed using the `options.env.PATH` environment

--- a/types/node/v22/fs.d.ts
+++ b/types/node/v22/fs.d.ts
@@ -3340,6 +3340,12 @@ declare module "fs" {
         persistent?: boolean | undefined;
         recursive?: boolean | undefined;
     }
+    export interface WatchOptionsWithBufferEncoding extends WatchOptions {
+        encoding: "buffer";
+    }
+    export interface WatchOptionsWithStringEncoding extends WatchOptions {
+        encoding?: BufferEncoding | undefined;
+    }
     export type WatchEventType = "rename" | "change";
     export type WatchListener<T> = (event: WatchEventType, filename: T | null) => void;
     export type StatsListener = (curr: Stats, prev: Stats) => void;
@@ -3366,44 +3372,20 @@ declare module "fs" {
      */
     export function watch(
         filename: PathLike,
-        options:
-            | (WatchOptions & {
-                encoding: "buffer";
-            })
-            | "buffer",
-        listener?: WatchListener<Buffer>,
-    ): FSWatcher;
-    /**
-     * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
-     * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
-     * @param options Either the encoding for the filename provided to the listener, or an object optionally specifying encoding, persistent, and recursive options.
-     * If `encoding` is not supplied, the default of `'utf8'` is used.
-     * If `persistent` is not supplied, the default of `true` is used.
-     * If `recursive` is not supplied, the default of `false` is used.
-     */
-    export function watch(
-        filename: PathLike,
-        options?: WatchOptions | BufferEncoding | null,
+        options?: WatchOptionsWithStringEncoding | BufferEncoding | null,
         listener?: WatchListener<string>,
     ): FSWatcher;
-    /**
-     * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
-     * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
-     * @param options Either the encoding for the filename provided to the listener, or an object optionally specifying encoding, persistent, and recursive options.
-     * If `encoding` is not supplied, the default of `'utf8'` is used.
-     * If `persistent` is not supplied, the default of `true` is used.
-     * If `recursive` is not supplied, the default of `false` is used.
-     */
     export function watch(
         filename: PathLike,
-        options: WatchOptions | string,
-        listener?: WatchListener<string | Buffer>,
+        options: WatchOptionsWithBufferEncoding | "buffer",
+        listener: WatchListener<Buffer>,
     ): FSWatcher;
-    /**
-     * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
-     * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
-     */
-    export function watch(filename: PathLike, listener?: WatchListener<string>): FSWatcher;
+    export function watch(
+        filename: PathLike,
+        options: WatchOptions | BufferEncoding | "buffer" | null,
+        listener: WatchListener<string | Buffer>,
+    ): FSWatcher;
+    export function watch(filename: PathLike, listener: WatchListener<string>): FSWatcher;
     /**
      * Test whether or not the given path exists by checking with the file system.
      * Then call the `callback` argument with either true or false:

--- a/types/node/v22/fs.d.ts
+++ b/types/node/v22/fs.d.ts
@@ -329,14 +329,15 @@ declare module "fs" {
          */
         readSync(): Dirent | null;
         /**
-         * Calls `dir.close()` and returns a promise that fulfills when the
-         * dir is closed.
+         * Calls `dir.close()` if the directory handle is open, and returns a promise that
+         * fulfills when disposal is complete.
          * @since v22.17.0
          * @experimental
          */
         [Symbol.asyncDispose](): Promise<void>;
         /**
-         * Calls `dir.closeSync()` and returns `undefined`.
+         * Calls `dir.closeSync()` if the directory handle is open, and returns
+         * `undefined`.
          * @since v22.17.0
          * @experimental
          */

--- a/types/node/v22/fs/promises.d.ts
+++ b/types/node/v22/fs/promises.d.ts
@@ -40,7 +40,7 @@ declare module "fs/promises" {
         StatsFs,
         TimeLike,
         WatchEventType,
-        WatchOptions,
+        WatchOptions as _WatchOptions,
         WriteStream,
         WriteVResult,
     } from "node:fs";
@@ -1182,6 +1182,16 @@ declare module "fs/promises" {
      * @return Fulfills with an {fs.Dir}.
      */
     function opendir(path: PathLike, options?: OpenDirOptions): Promise<Dir>;
+    interface WatchOptions extends _WatchOptions {
+        maxQueue?: number | undefined;
+        overflow?: "ignore" | "throw" | undefined;
+    }
+    interface WatchOptionsWithBufferEncoding extends WatchOptions {
+        encoding: "buffer";
+    }
+    interface WatchOptionsWithStringEncoding extends WatchOptions {
+        encoding?: BufferEncoding | undefined;
+    }
     /**
      * Returns an async iterator that watches for changes on `filename`, where `filename`is either a file or a directory.
      *
@@ -1214,33 +1224,16 @@ declare module "fs/promises" {
      */
     function watch(
         filename: PathLike,
-        options:
-            | (WatchOptions & {
-                encoding: "buffer";
-            })
-            | "buffer",
-    ): AsyncIterable<FileChangeInfo<Buffer>>;
-    /**
-     * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
-     * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
-     * @param options Either the encoding for the filename provided to the listener, or an object optionally specifying encoding, persistent, and recursive options.
-     * If `encoding` is not supplied, the default of `'utf8'` is used.
-     * If `persistent` is not supplied, the default of `true` is used.
-     * If `recursive` is not supplied, the default of `false` is used.
-     */
-    function watch(filename: PathLike, options?: WatchOptions | BufferEncoding): AsyncIterable<FileChangeInfo<string>>;
-    /**
-     * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
-     * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
-     * @param options Either the encoding for the filename provided to the listener, or an object optionally specifying encoding, persistent, and recursive options.
-     * If `encoding` is not supplied, the default of `'utf8'` is used.
-     * If `persistent` is not supplied, the default of `true` is used.
-     * If `recursive` is not supplied, the default of `false` is used.
-     */
+        options?: WatchOptionsWithStringEncoding | BufferEncoding,
+    ): NodeJS.AsyncIterator<FileChangeInfo<string>>;
     function watch(
         filename: PathLike,
-        options: WatchOptions | string,
-    ): AsyncIterable<FileChangeInfo<string>> | AsyncIterable<FileChangeInfo<Buffer>>;
+        options: WatchOptionsWithBufferEncoding | "buffer",
+    ): NodeJS.AsyncIterator<FileChangeInfo<Buffer>>;
+    function watch(
+        filename: PathLike,
+        options: WatchOptions | BufferEncoding | "buffer",
+    ): NodeJS.AsyncIterator<FileChangeInfo<string | Buffer>>;
     /**
      * Asynchronously copies the entire directory structure from `src` to `dest`,
      * including subdirectories and files.

--- a/types/node/v22/http.d.ts
+++ b/types/node/v22/http.d.ts
@@ -2028,7 +2028,7 @@ declare module "http" {
      */
     const maxHeaderSize: number;
     /**
-     * A browser-compatible implementation of [WebSocket](https://nodejs.org/docs/latest/api/http.html#websocket).
+     * A browser-compatible implementation of `WebSocket`.
      * @since v22.5.0
      */
     const WebSocket: import("undici-types").WebSocket;

--- a/types/node/v22/inspector.d.ts
+++ b/types/node/v22/inspector.d.ts
@@ -268,7 +268,7 @@ declare module 'inspector' {
             /**
              * Embedder-specific auxiliary data.
              */
-            auxData?: {} | undefined;
+            auxData?: object | undefined;
         }
         /**
          * Detailed information about exception (or error) that was thrown during script compilation or execution.
@@ -701,7 +701,7 @@ declare module 'inspector' {
         }
         interface InspectRequestedEventDataType {
             object: RemoteObject;
-            hints: {};
+            hints: object;
         }
     }
     namespace Debugger {
@@ -1173,7 +1173,7 @@ declare module 'inspector' {
             /**
              * Embedder-specific auxiliary data.
              */
-            executionContextAuxData?: {} | undefined;
+            executionContextAuxData?: object | undefined;
             /**
              * True, if this script is generated as a result of the live edit operation.
              * @experimental
@@ -1237,7 +1237,7 @@ declare module 'inspector' {
             /**
              * Embedder-specific auxiliary data.
              */
-            executionContextAuxData?: {} | undefined;
+            executionContextAuxData?: object | undefined;
             /**
              * URL of source map associated with script (if any).
              */
@@ -1282,7 +1282,7 @@ declare module 'inspector' {
             /**
              * Object containing break-specific auxiliary properties.
              */
-            data?: {} | undefined;
+            data?: object | undefined;
             /**
              * Hit breakpoints IDs
              */
@@ -1649,7 +1649,7 @@ declare module 'inspector' {
             categories: string[];
         }
         interface DataCollectedEventDataType {
-            value: Array<{}>;
+            value: object[];
         }
     }
     namespace NodeWorker {
@@ -1759,6 +1759,7 @@ declare module 'inspector' {
             url: string;
             method: string;
             headers: Headers;
+            hasPostData: boolean;
         }
         /**
          * HTTP response data.
@@ -1776,17 +1777,45 @@ declare module 'inspector' {
          */
         interface Headers {
         }
+        interface GetRequestPostDataParameterType {
+            /**
+             * Identifier of the network request to get content for.
+             */
+            requestId: RequestId;
+        }
+        interface GetResponseBodyParameterType {
+            /**
+             * Identifier of the network request to get content for.
+             */
+            requestId: RequestId;
+        }
         interface StreamResourceContentParameterType {
             /**
              * Identifier of the request to stream.
              */
             requestId: RequestId;
         }
+        interface GetRequestPostDataReturnType {
+            /**
+             * Request body string, omitting files from multipart requests
+             */
+            postData: string;
+        }
+        interface GetResponseBodyReturnType {
+            /**
+             * Response body.
+             */
+            body: string;
+            /**
+             * True, if content was sent as base64.
+             */
+            base64Encoded: boolean;
+        }
         interface StreamResourceContentReturnType {
             /**
              * Data that has been buffered until streaming is enabled.
              */
-            bufferedData: never;
+            bufferedData: string;
         }
         interface RequestWillBeSentEventDataType {
             /**
@@ -1877,7 +1906,7 @@ declare module 'inspector' {
              * Data that was received.
              * @experimental
              */
-            data?: never | undefined;
+            data?: string | undefined;
         }
     }
     namespace NodeRuntime {
@@ -2285,6 +2314,16 @@ declare module 'inspector' {
          * Enables network tracking, network events will now be delivered to the client.
          */
         post(method: 'Network.enable', callback?: (err: Error | null) => void): void;
+        /**
+         * Returns post data sent with the request. Returns an error when no data was sent with the request.
+         */
+        post(method: 'Network.getRequestPostData', params?: Network.GetRequestPostDataParameterType, callback?: (err: Error | null, params: Network.GetRequestPostDataReturnType) => void): void;
+        post(method: 'Network.getRequestPostData', callback?: (err: Error | null, params: Network.GetRequestPostDataReturnType) => void): void;
+        /**
+         * Returns content served for the given request.
+         */
+        post(method: 'Network.getResponseBody', params?: Network.GetResponseBodyParameterType, callback?: (err: Error | null, params: Network.GetResponseBodyReturnType) => void): void;
+        post(method: 'Network.getResponseBody', callback?: (err: Error | null, params: Network.GetResponseBodyReturnType) => void): void;
         /**
          * Enables streaming of the response for the given requestId.
          * If enabled, the dataReceived event contains the data that was received during streaming.
@@ -3052,19 +3091,28 @@ declare module 'inspector' {
         /**
          * This feature is only available with the `--experimental-network-inspection` flag enabled.
          *
+         * Broadcasts the `Network.requestWillBeSent` event to connected frontends. This event indicates that
+         * the application is about to send an HTTP request.
+         * @since v22.6.0
+         */
+        function requestWillBeSent(params: RequestWillBeSentEventDataType): void;
+        /**
+         * This feature is only available with the `--experimental-network-inspection` flag enabled.
+         *
          * Broadcasts the `Network.dataReceived` event to connected frontends, or buffers the data if
          * `Network.streamResourceContent` command was not invoked for the given request yet.
+         *
+         * Also enables `Network.getResponseBody` command to retrieve the response data.
          * @since v22.17.0
          */
         function dataReceived(params: DataReceivedEventDataType): void;
         /**
          * This feature is only available with the `--experimental-network-inspection` flag enabled.
          *
-         * Broadcasts the `Network.requestWillBeSent` event to connected frontends. This event indicates that
-         * the application is about to send an HTTP request.
-         * @since v22.6.0
+         * Enables `Network.getRequestPostData` command to retrieve the request data.
+         * @since v22.18.0
          */
-        function requestWillBeSent(params: RequestWillBeSentEventDataType): void;
+        function dataSent(params: unknown): void;
         /**
          * This feature is only available with the `--experimental-network-inspection` flag enabled.
          *
@@ -3450,6 +3498,14 @@ declare module 'inspector/promises' {
          * Enables network tracking, network events will now be delivered to the client.
          */
         post(method: 'Network.enable'): Promise<void>;
+        /**
+         * Returns post data sent with the request. Returns an error when no data was sent with the request.
+         */
+        post(method: 'Network.getRequestPostData', params?: Network.GetRequestPostDataParameterType): Promise<Network.GetRequestPostDataReturnType>;
+        /**
+         * Returns content served for the given request.
+         */
+        post(method: 'Network.getResponseBody', params?: Network.GetResponseBodyParameterType): Promise<Network.GetResponseBodyReturnType>;
         /**
          * Enables streaming of the response for the given requestId.
          * If enabled, the dataReceived event contains the data that was received during streaming.

--- a/types/node/v22/module.d.ts
+++ b/types/node/v22/module.d.ts
@@ -684,6 +684,30 @@ declare module "module" {
              * @returns The absolute URL string that the specifier would resolve to.
              */
             resolve(specifier: string, parent?: string | URL): string;
+            /**
+             * `true` when the current module is the entry point of the current process; `false` otherwise.
+             *
+             * Equivalent to `require.main === module` in CommonJS.
+             *
+             * Analogous to Python's `__name__ == "__main__"`.
+             *
+             * ```js
+             * export function foo() {
+             *   return 'Hello, world';
+             * }
+             *
+             * function main() {
+             *   const message = foo();
+             *   console.log(message);
+             * }
+             *
+             * if (import.meta.main) main();
+             * // `foo` can be imported from another module without possible side-effects from `main`
+             * ```
+             * @since v22.18.0
+             * @experimental
+             */
+            main: boolean;
         }
         namespace NodeJS {
             interface Module {

--- a/types/node/v22/package.json
+++ b/types/node/v22/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "22.17.9999",
+    "version": "22.18.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [

--- a/types/node/v22/process.d.ts
+++ b/types/node/v22/process.d.ts
@@ -231,8 +231,9 @@ declare module "process" {
                  */
                 readonly tls_sni: boolean;
                 /**
-                 * A value that is `"strip"` if Node.js is run with `--experimental-strip-types`,
-                 * `"transform"` if Node.js is run with `--experimental-transform-types`, and `false` otherwise.
+                 * A value that is `"strip"` by default,
+                 * `"transform"` if Node.js is run with `--experimental-transform-types`, and `false` if
+                 * Node.js is run with `--no-experimental-strip-types`.
                  * @since v22.10.0
                  */
                 readonly typescript: "strip" | "transform" | false;

--- a/types/node/v22/sqlite.d.ts
+++ b/types/node/v22/sqlite.d.ts
@@ -89,6 +89,14 @@ declare module "node:sqlite" {
          * @default false
          */
         allowExtension?: boolean | undefined;
+        /**
+         * The [busy timeout](https://sqlite.org/c3ref/busy_timeout.html) in milliseconds. This is the maximum amount of
+         * time that SQLite will wait for a database lock to be released before
+         * returning an error.
+         * @since v22.16.0
+         * @default 0
+         */
+        timeout?: number | undefined;
     }
     interface CreateSessionOptions {
         /**

--- a/types/node/v22/sqlite.d.ts
+++ b/types/node/v22/sqlite.d.ts
@@ -97,6 +97,33 @@ declare module "node:sqlite" {
          * @default 0
          */
         timeout?: number | undefined;
+        /**
+         * If `true`, integer fields are read as JavaScript `BigInt` values. If `false`,
+         * integer fields are read as JavaScript numbers.
+         * @since v22.18.0
+         * @default false
+         */
+        readBigInts?: boolean | undefined;
+        /**
+         * If `true`, query results are returned as arrays instead of objects.
+         * @since v22.18.0
+         * @default false
+         */
+        returnArrays?: boolean | undefined;
+        /**
+         * If `true`, allows binding named parameters without the prefix
+         * character (e.g., `foo` instead of `:foo`).
+         * @since v22.18.0
+         * @default true
+         */
+        allowBareNamedParameters?: boolean | undefined;
+        /**
+         * If `true`, unknown named parameters are ignored when binding.
+         * If `false`, an exception is thrown for unknown named parameters.
+         * @since v22.18.0
+         * @default false
+         */
+        allowUnknownNamedParameters?: boolean | undefined;
     }
     interface CreateSessionOptions {
         /**

--- a/types/node/v22/test/fs.ts
+++ b/types/node/v22/test/fs.ts
@@ -919,11 +919,14 @@ const bigIntStatFs: bigint = bigStatFs.bfree;
 const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Math.random() > 0.5 });
 
 {
-    watchAsync("y33t"); // $ExpectType AsyncIterable<FileChangeInfo<string>>
-    watchAsync("y33t", "buffer"); // $ExpectType AsyncIterable<FileChangeInfo<Buffer>> || AsyncIterable<FileChangeInfo<Buffer<ArrayBufferLike>>>
-    watchAsync("y33t", { encoding: "buffer", signal: new AbortSignal() }); // $ExpectType AsyncIterable<FileChangeInfo<Buffer>> || AsyncIterable<FileChangeInfo<Buffer<ArrayBufferLike>>>
-
-    watchAsync("test", { persistent: true, recursive: true, encoding: "utf-8" }); // $ExpectType AsyncIterable<FileChangeInfo<string>>
+    // $ExpectType AsyncIterator<FileChangeInfo<string>, any, any>
+    watchAsync("y33t");
+    // $ExpectType AsyncIterator<FileChangeInfo<Buffer>, any, any> || AsyncIterator<FileChangeInfo<Buffer<ArrayBufferLike>>, any, any>
+    watchAsync("y33t", "buffer");
+    // $ExpectType AsyncIterator<FileChangeInfo<Buffer>, any, any> || AsyncIterator<FileChangeInfo<Buffer<ArrayBufferLike>>, any, any>
+    watchAsync("y33t", { encoding: "buffer", signal: new AbortSignal() });
+    // $ExpectType AsyncIterator<FileChangeInfo<string>, any, any>
+    watchAsync("test", { persistent: true, recursive: true, encoding: "utf-8", maxQueue: 2048, overflow: "ignore" });
 }
 
 {

--- a/types/node/v22/test/module.ts
+++ b/types/node/v22/test/module.ts
@@ -115,6 +115,7 @@ Module.Module === Module;
     importmeta.resolve("local", "/parent"); // $ExpectType string
     importmeta.resolve("local", undefined); // $ExpectType string
     importmeta.resolve("local", new URL("https://parent.module")); // $ExpectType string
+    importmeta.main; // $ExpectType boolean
 }
 
 // Globals

--- a/types/node/v22/test/sqlite.ts
+++ b/types/node/v22/test/sqlite.ts
@@ -69,6 +69,16 @@ import { TextEncoder } from "node:util";
 }
 
 {
+    new DatabaseSync(":memory:", {
+        timeout: 10_000,
+        readBigInts: true,
+        returnArrays: true,
+        allowBareNamedParameters: false,
+        allowUnknownNamedParameters: true,
+    });
+}
+
+{
     const database = new DatabaseSync(":memory:", { allowExtension: true });
     database.loadExtension("/path/to/extension.so");
     database.enableLoadExtension(false);

--- a/types/node/v22/test/url.ts
+++ b/types/node/v22/test/url.ts
@@ -192,6 +192,12 @@ import * as url from "node:url";
     path = url.fileURLToPath(new url.URL("file://test"));
     path = url.fileURLToPath(new url.URL("file://test"), { windows: false });
     path = url.fileURLToPath(new url.URL("file://test"), { windows: true });
+
+    let buffer: Buffer;
+    buffer = url.fileURLToPathBuffer("file://test");
+    buffer = url.fileURLToPathBuffer("file://test", { windows: true });
+    buffer = url.fileURLToPathBuffer(new url.URL("file://test"));
+    buffer = url.fileURLToPathBuffer(new url.URL("file://test"), { windows: true });
 }
 
 {

--- a/types/node/v22/url.d.ts
+++ b/types/node/v22/url.d.ts
@@ -316,6 +316,17 @@ declare module "url" {
      */
     function fileURLToPath(url: string | URL, options?: FileUrlToPathOptions): string;
     /**
+     * Like `url.fileURLToPath(...)` except that instead of returning a string
+     * representation of the path, a `Buffer` is returned. This conversion is
+     * helpful when the input URL contains percent-encoded segments that are
+     * not valid UTF-8 / Unicode sequences.
+     * @since v22.18.0
+     * @param url The file URL string or URL object to convert to a path.
+     * @returns The fully-resolved platform-specific Node.js file path
+     * as a `Buffer`.
+     */
+    function fileURLToPathBuffer(url: string | URL, options?: FileUrlToPathOptions): Buffer;
+    /**
      * This function ensures that `path` is resolved absolutely, and that the URL
      * control characters are correctly encoded when converting into a File URL.
      *

--- a/types/node/v22/worker_threads.d.ts
+++ b/types/node/v22/worker_threads.d.ts
@@ -481,6 +481,18 @@ declare module "worker_threads" {
          * @since v22.16.0
          */
         getHeapStatistics(): Promise<HeapInfo>;
+        /**
+         * Calls `worker.terminate()` when the dispose scope is exited.
+         *
+         * ```js
+         * async function example() {
+         *   await using worker = new Worker('for (;;) {}', { eval: true });
+         *   // Worker is automatically terminate when the scope is exited.
+         * }
+         * ```
+         * @since v22.18.0
+         */
+        [Symbol.asyncDispose](): Promise<void>;
         addListener(event: "error", listener: (err: Error) => void): this;
         addListener(event: "exit", listener: (exitCode: number) => void): this;
         addListener(event: "message", listener: (value: any) => void): this;


### PR DESCRIPTION
- **esm:** implement import.meta.main
- **fs:** allow correct handling of burst in fs-events with AsyncIterator
- **fs:** make `Dir` disposers idempotent
- **inspector:** add protocol methods retrieving sent/received data
- **module:** unflag --experimental-strip-types
- **sqlite:** add timeout options to DatabaseSync
- **sqlite:** add support for readBigInts option in db connection level
- **url:** add fileURLToPathBuffer API
- **worker:** make Worker async disposable

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V22.md#22.18.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
