### PR TITLE
[googlepay] add buttonBorderType property to the ButtonOptions object

### DIFF
--- a/types/googlepay/googlepay-tests.ts
+++ b/types/googlepay/googlepay-tests.ts
@@ -155,6 +155,9 @@ function addGooglePayButton() {
     buttonOptions.buttonLocale = "qw";
     buttonOptions.buttonLocale = "zh";
 
+    buttonOptions.buttonBorderType = "default_border";
+    buttonOptions.buttonBorderType = "no_border";
+
     const client = getGooglePaymentsClient();
     const button = client.createButton(buttonOptions);
     document.appendChild(document.createElement("div").appendChild(button));

--- a/types/googlepay/index.d.ts
+++ b/types/googlepay/index.d.ts
@@ -1856,6 +1856,15 @@ declare namespace google.payments.api {
         buttonLocale?: string;
 
         /**
+         * Specifies the border types for the Google Pay button.
+         *
+         * If omitted, defaults to `default_border`.
+         *
+         * @default "default_border"
+         */
+        buttonBorderType?: ButtonBorderType | undefined;
+
+        /**
          * List of allowed payment methods.
          *
          * This is an optional field for filtering card info for dynamic
@@ -2153,6 +2162,21 @@ declare namespace google.payments.api {
         | "subscribe"
         | "long"
         | "short";
+
+    /**
+     * Supported border types for the Google Pay button.
+     *
+     * Options:
+     *
+     * - `no_border`:
+     *   "No border is displayed around the button.
+     *
+     * - `default_border`:
+     *   "A thin border is displayed around the button. (default).
+     */
+    type ButtonBorderType =
+        | "no_border"
+        | "default_border";
 
     /**
      * Supported methods for controlling the size of the Google Pay button.


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Google Pay ButtonOptions object reference](https://developers.google.com/pay/api/web/reference/request-objects#ButtonOptions:~:text=loadPaymentData()%20API%20call.-,buttonBorderType,-string)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

