### PR TITLE
google-apps-script: Adding missing ScriptApp API requireAllScopes/requireScopes

### DIFF
--- a/types/google-apps-script/google-apps-script.script.d.ts
+++ b/types/google-apps-script/google-apps-script.script.d.ts
@@ -146,6 +146,8 @@ declare namespace GoogleAppsScript {
             invalidateAuth(): void;
             newStateToken(): StateTokenBuilder;
             newTrigger(functionName: string): TriggerBuilder;
+            requireAllScopes(authMode: AuthMode): void;
+            requireScopes(authMode: AuthMode, oAuthScopes: string[]): void;
             /** @deprecated DO NOT USE */ getProjectKey(): string;
             /** @deprecated DO NOT USE */ getScriptTriggers(): Trigger[];
         }

--- a/types/google-apps-script/test/google-apps-script-tests.ts
+++ b/types/google-apps-script/test/google-apps-script-tests.ts
@@ -53,6 +53,20 @@ const testCalendarAppEventType = (): void => {
     type == GoogleAppsScript.Calendar.EventType.STANDARD;
 };
 
+// ScriptApp
+// https://developers.google.com/apps-script/reference/script/script-app
+
+function testOAuthScopes() {
+    // https://developers.google.com/apps-script/reference/script/script-app#requireallscopesauthmode
+    ScriptApp.requireAllScopes(ScriptApp.AuthMode.FULL);
+
+    // https://developers.google.com/apps-script/reference/script/script-app#requirescopesauthmode,-oauthscopes
+    ScriptApp.requireScopes(ScriptApp.AuthMode.FULL, [
+        'https://www.googleapis.com/auth/documents',
+        'https://www.googleapis.com/auth/presentations',
+    ]);
+}
+
 // Advanced Services
 Slides.Presentations.Pages.getThumbnail("presentationId", "pageId");
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

https://developers.google.com/apps-script/reference/script/script-app#requireallscopesauthmode
https://developers.google.com/apps-script/reference/script/script-app#requirescopesauthmode,-oauthscopes


