### PR TITLE
[chrome] fix conflict with chrome package

### DIFF
--- a/types/chrome/package.json
+++ b/types/chrome/package.json
@@ -2,6 +2,8 @@
     "private": true,
     "name": "@types/chrome",
     "version": "0.1.9999",
+    "nonNpm": "conflict",
+    "nonNpmDescription": "The complete reference to all APIs made available to Chrome Extensions",
     "projects": [
         "https://developer.chrome.com/docs/extensions"
     ],


### PR DESCRIPTION
`@types/chrome` package is not related to the [chrome](https://www.npmjs.com/package/chrome) package on npm. This PR removes that link to allow future version upgrades.

For now, this is not causing issues because the `@types/chrome` version is lower than the chrome package version

[readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#naming) :
> If you are adding typings for an npm package, create a directory with the same name. If the package you are adding typings for is not on npm, set "nonNpm": true in the package.json, and make sure the name you choose for it does not conflict with the name of a package on npm. (You can use npm info <my-package> to check for the existence of the <my-package> package.)
>
> In rare occasions, nonNpm may be set to "conflict", which incidates that there is a package on npm with the same name, but the types intentionally conflict with that package. This can be true for packages which define an environment like @types/node or for dummy packages like aws-lambda. Avoid using "conflict" where possible.

