### PR TITLE
[chrome] update devtools.inspectedWindows namespace

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2670,15 +2670,12 @@ declare namespace chrome {
         export interface Resource {
             /** The URL of the resource. */
             url: string;
-            /**
-             * Gets the content of the resource.
-             * @param callback A function that receives resource content when the request completes.
-             */
+            /** Gets the content of the resource. */
             getContent(
                 callback: (
-                    /** Content of the resource (potentially encoded) */
+                    /** Content of the resource (potentially encoded). */
                     content: string,
-                    /** Empty if content is not encoded, encoding name otherwise. Currently, only base64 is supported. */
+                    /** Empty if the content is not encoded, encoding name otherwise. Currently, only base64 is supported. */
                     encoding: string,
                 ) => void,
             ): void;
@@ -2686,33 +2683,24 @@ declare namespace chrome {
              * Sets the content of the resource.
              * @param content New content of the resource. Only resources with the text type are currently supported.
              * @param commit True if the user has finished editing the resource, and the new content of the resource should be persisted; false if this is a minor change sent in progress of the user editing the resource.
-             * @param callback A function called upon request completion.
              */
             setContent(
                 content: string,
                 commit: boolean,
                 callback?: (
-                    /**
-                     * Set to undefined if the resource content was set successfully; describes error otherwise.
-                     */
+                    /** Set to undefined if the resource content was set successfully; describes error otherwise. */
                     error?: object,
                 ) => void,
             ): void;
         }
 
         export interface ReloadOptions {
-            /** Optional. If specified, the string will override the value of the User-Agent HTTP header that's sent while loading the resources of the inspected page. The string will also override the value of the navigator.userAgent property that's returned to any scripts that are running within the inspected page.  */
+            /** If specified, the string will override the value of the `User-Agent` HTTP header that's sent while loading the resources of the inspected page. The string will also override the value of the `navigator.userAgent` property that's returned to any scripts that are running within the inspected page. */
             userAgent?: string | undefined;
-            /** Optional. When true, the loader will ignore the cache for all inspected page resources loaded before the load event is fired. The effect is similar to pressing Ctrl+Shift+R in the inspected window or within the Developer Tools window.  */
+            /** When true, the loader will bypass the cache for all inspected page resources loaded before the `load` event is fired. The effect is similar to pressing Ctrl+Shift+R in the inspected window or within the Developer Tools window. */
             ignoreCache?: boolean | undefined;
-            /** Optional. If specified, the script will be injected into every frame of the inspected page immediately upon load, before any of the frame's scripts. The script will not be injected after subsequent reloads—for example, if the user presses Ctrl+R.  */
+            /** If specified, the script will be injected into every frame of the inspected page immediately upon load, before any of the frame's scripts. The script will not be injected after subsequent reloads—for example, if the user presses Ctrl+R. */
             injectedScript?: string | undefined;
-            /**
-             * Optional.
-             * If specified, this script evaluates into a function that accepts three string arguments: the source to preprocess, the URL of the source, and a function name if the source is an DOM event handler. The preprocessorerScript function should return a string to be compiled by Chrome in place of the input source. In the case that the source is a DOM event handler, the returned source must compile to a single JS function.
-             * @deprecated Deprecated since Chrome 41. Please avoid using this parameter, it will be removed soon.
-             */
-            preprocessorScript?: string | undefined;
         }
 
         export interface EvaluationExceptionInfo {
@@ -2730,59 +2718,48 @@ declare namespace chrome {
             value: string;
         }
 
-        export interface ResourceAddedEvent extends chrome.events.Event<(resource: Resource) => void> {}
-
-        export interface ResourceContentCommittedEvent
-            extends chrome.events.Event<(resource: Resource, content: string) => void>
-        {}
-
-        /** The ID of the tab being inspected. This ID may be used with chrome.tabs.* API. */
-        export var tabId: number;
+        /** The ID of the tab being inspected. This ID may be used with {@link chrome.tabs} API. */
+        export const tabId: number;
 
         /** Reloads the inspected page. */
         export function reload(reloadOptions?: ReloadOptions): void;
+
         /**
-         * Evaluates a JavaScript expression in the context of the main frame of the inspected page. The expression must evaluate to a JSON-compliant object, otherwise an exception is thrown. The eval function can report either a DevTools-side error or a JavaScript exception that occurs during evaluation. In either case, the result parameter of the callback is undefined. In the case of a DevTools-side error, the isException parameter is non-null and has isError set to true and code set to an error code. In the case of a JavaScript error, isException is set to true and value is set to the string value of thrown object.
-         * @param expression An expression to evaluate.
-         * @param callback A function called when evaluation completes.
-         * Parameter result: The result of evaluation.
-         * Parameter exceptionInfo: An object providing details if an exception occurred while evaluating the expression.
-         */
-        export function eval<T>(
-            expression: string,
-            callback?: (result: T, exceptionInfo: EvaluationExceptionInfo) => void,
-        ): void;
-        /**
-         * Evaluates a JavaScript expression in the context of the main frame of the inspected page. The expression must evaluate to a JSON-compliant object, otherwise an exception is thrown. The eval function can report either a DevTools-side error or a JavaScript exception that occurs during evaluation. In either case, the result parameter of the callback is undefined. In the case of a DevTools-side error, the isException parameter is non-null and has isError set to true and code set to an error code. In the case of a JavaScript error, isException is set to true and value is set to the string value of thrown object.
+         * Evaluates a JavaScript expression in the context of the main frame of the inspected page. The expression must evaluate to a JSON-compliant object, otherwise an exception is thrown. The eval function can report either a DevTools-side error or a JavaScript exception that occurs during evaluation. In either case, the `result` parameter of the callback is `undefined`. In the case of a DevTools-side error, the `isException` parameter is non-null and has `isError` set to true and `code` set to an error code. In the case of a JavaScript error, `isException` is set to true and `value` is set to the string value of thrown object.
+         *
          * @param expression An expression to evaluate.
          * @param options The options parameter can contain one or more options.
          * @param callback A function called when evaluation completes.
-         * Parameter result: The result of evaluation.
-         * Parameter exceptionInfo: An object providing details if an exception occurred while evaluating the expression.
          */
-        export function eval<T>(
+        export function eval<T = { [key: string]: unknown }>(
             expression: string,
-            options?: EvalOptions,
             callback?: (result: T, exceptionInfo: EvaluationExceptionInfo) => void,
         ): void;
-        /**
-         * Retrieves the list of resources from the inspected page.
-         * @param callback A function that receives the list of resources when the request completes.
-         */
+        export function eval<T = { [key: string]: unknown }>(
+            expression: string,
+            options: EvalOptions | undefined,
+            callback?: (result: T, exceptionInfo: EvaluationExceptionInfo) => void,
+        ): void;
+
+        /** Retrieves the list of resources from the inspected page. */
         export function getResources(callback: (resources: Resource[]) => void): void;
 
         /** Fired when a new resource is added to the inspected page. */
-        export var onResourceAdded: ResourceAddedEvent;
+        export const onResourceAdded: events.Event<(resource: Resource) => void>;
+
         /** Fired when a new revision of the resource is committed (e.g. user saves an edited version of the resource in the Developer Tools). */
-        export var onResourceContentCommitted: ResourceContentCommittedEvent;
+        export const onResourceContentCommitted: events.Event<(resource: Resource, content: string) => void>;
 
         export interface EvalOptions {
             /** If specified, the expression is evaluated on the iframe whose URL matches the one specified. By default, the expression is evaluated in the top frame of the inspected page. */
             frameURL?: string | undefined;
-            /** Evaluate the expression in the context of the content script of the calling extension, provided that the content script is already injected into the inspected page. If not, the expression is not evaluated and the callback is invoked with the exception parameter set to an object that has the isError field set to true and the code field set to E_NOTFOUND. */
+            /** Evaluate the expression in the context of the content script of the calling extension, provided that the content script is already injected into the inspected page. If not, the expression is not evaluated and the callback is invoked with the exception parameter set to an object that has the `isError` field set to true and the `code` field set to `E_NOTFOUND`. */
             useContentScriptContext?: boolean | undefined;
-            /** Evaluate the expression in the context of a content script of an extension that matches the specified origin. If given, contextSecurityOrigin overrides the 'true' setting on userContentScriptContext. */
-            contextSecurityOrigin?: string | undefined;
+            /**
+             * Evaluate the expression in the context of a content script of an extension that matches the specified origin. If given, scriptExecutionContext overrides the 'true' setting on useContentScriptContext.
+             * @since Chrome 107
+             */
+            scriptExecutionContext?: string | undefined;
         }
     }
 

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1343,18 +1343,6 @@ function testDevtools() {
         console.log("harLog: ", harLog);
     });
 
-    chrome.devtools.inspectedWindow.eval("1+1", undefined, result => {
-        console.log(result);
-    });
-
-    chrome.devtools.inspectedWindow.reload();
-    chrome.devtools.inspectedWindow.reload({});
-    chrome.devtools.inspectedWindow.reload({
-        userAgent: "Best Browser",
-        ignoreCache: true,
-        injectedScript: "console.log(\"Hello World!\")",
-    });
-
     const view = chrome.devtools.recorder.createView("title", "replay.html"); // $ExpectType RecorderView
     checkChromeEvent(view.onHidden, () => void 0);
     checkChromeEvent(view.onShown, () => void 0);
@@ -1371,6 +1359,58 @@ function testDevtools() {
     chrome.devtools.panels.setOpenResourceHandler((resource, lineNumber) => { // $ExpectType void
         resource; // $ExpectType Resource
         lineNumber; // $ExpectType number
+    });
+}
+
+// https://developer.chrome.com/docs/extensions/reference/api/devtools/inspectedWindow
+function testDevtoolsInspectedWindow() {
+    const expression = "expression";
+
+    const evalOptions: chrome.devtools.inspectedWindow.EvalOptions = {
+        frameURL: "https://example.com",
+        scriptExecutionContext: "script",
+        useContentScriptContext: true,
+    };
+
+    chrome.devtools.inspectedWindow.eval(expression); // $ExpectType void
+    chrome.devtools.inspectedWindow.eval(expression, evalOptions); // $ExpectType void
+    chrome.devtools.inspectedWindow.eval(expression, evalOptions, (result, exceptionInfo) => { // $ExpectType void
+        result; // ExpectType object
+
+        exceptionInfo.code; // ExpectType string
+        exceptionInfo.description; // ExpectType string
+        exceptionInfo.details; // ExpectType unknown[]
+        exceptionInfo.isError; // ExpectType boolean
+        exceptionInfo.isException; // ExpectType boolean
+        exceptionInfo.value; // ExpectType string
+    });
+    chrome.devtools.inspectedWindow.eval(expression, (result) => { // $ExpectType void
+        result; // ExpectType object
+    });
+    chrome.devtools.inspectedWindow.eval<{ title: string }>(expression, evalOptions, (result) => { // $ExpectType void
+        result.title; // ExpectType string
+    });
+
+    chrome.devtools.inspectedWindow.getResources((resources) => { // $ExpectType void
+        resources; // ExpectType Resource[]
+    });
+
+    const reloadOptions: chrome.devtools.inspectedWindow.ReloadOptions = {
+        ignoreCache: true,
+        injectedScript: "script",
+        userAgent: "userAgent",
+    };
+
+    chrome.devtools.inspectedWindow.reload(); // $ExpectType void
+    chrome.devtools.inspectedWindow.reload(reloadOptions); // $ExpectType void
+
+    checkChromeEvent(chrome.devtools.inspectedWindow.onResourceAdded, (resource) => {
+        resource; // ExpectType Resource
+    });
+
+    checkChromeEvent(chrome.devtools.inspectedWindow.onResourceContentCommitted, (resource, content) => {
+        resource; // ExpectType Resource
+        content; // ExpectType string
     });
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/devtools/inspectedWindow
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes: 
- udpate `reload()`: 
  - remove `preprocessorScript` key in `options` param (deprecated since Chrome 41)
- update `eval()`
  - update default `T`, `unknow` -> `{ [key: string]: unknown }`
  - rename `contextSecurityOrigin` key  by `scriptExecutionContext` key in `options` param
 - add more tests
 - update JSDoc