### PR TITLE
Update pako's array buffer types for TypeScript 5.9

### DIFF
--- a/types/pako/package.json
+++ b/types/pako/package.json
@@ -5,6 +5,14 @@
     "projects": [
         "https://github.com/nodeca/pako"
     ],
+    "types": "index",
+    "typesVersions": {
+        "<=5.8": {
+            "*": [
+                "ts5.8/*"
+            ]
+        }
+    },
     "devDependencies": {
         "@types/pako": "workspace:."
     },

--- a/types/pako/ts5.8/index.d.ts
+++ b/types/pako/ts5.8/index.d.ts
@@ -97,48 +97,48 @@ declare namespace Pako {
         hcrc?: boolean | undefined;
     }
 
-    type Data = Uint8Array<ArrayBuffer> | ArrayBuffer;
+    type Data = Uint8Array | ArrayBuffer;
 
     /**
      * Compress data with deflate algorithm and options.
      */
-    function deflate(data: Data | string, options?: DeflateFunctionOptions): Uint8Array<ArrayBuffer>;
+    function deflate(data: Data | string, options?: DeflateFunctionOptions): Uint8Array;
 
     /**
      * The same as deflate, but creates raw data, without wrapper (header and adler32 crc).
      */
-    function deflateRaw(data: Data | string, options?: DeflateFunctionOptions): Uint8Array<ArrayBuffer>;
+    function deflateRaw(data: Data | string, options?: DeflateFunctionOptions): Uint8Array;
 
     /**
      * The same as deflate, but create gzip wrapper instead of deflate one.
      */
-    function gzip(data: Data | string, options?: DeflateFunctionOptions): Uint8Array<ArrayBuffer>;
+    function gzip(data: Data | string, options?: DeflateFunctionOptions): Uint8Array;
 
     /**
      * Decompress data with inflate/ungzip and options. Autodetect format via wrapper header
      * by default. That's why we don't provide separate ungzip method.
      */
     function inflate(data: Data, options: InflateFunctionOptions & { to: "string" }): string;
-    function inflate(data: Data, options?: InflateFunctionOptions): Uint8Array<ArrayBuffer>;
+    function inflate(data: Data, options?: InflateFunctionOptions): Uint8Array;
 
     /**
      * The same as inflate, but creates raw data, without wrapper (header and adler32 crc).
      */
     function inflateRaw(data: Data, options: InflateFunctionOptions & { to: "string" }): string;
-    function inflateRaw(data: Data, options?: InflateFunctionOptions): Uint8Array<ArrayBuffer>;
+    function inflateRaw(data: Data, options?: InflateFunctionOptions): Uint8Array;
 
     /**
      * Just shortcut to inflate, because it autodetects format by header.content. Done for convenience.
      */
     function ungzip(data: Data, options: InflateFunctionOptions & { to: "string" }): string;
-    function ungzip(data: Data, options?: InflateFunctionOptions): Uint8Array<ArrayBuffer>;
+    function ungzip(data: Data, options?: InflateFunctionOptions): Uint8Array;
 
     // https://github.com/nodeca/pako/blob/893381abcafa10fa2081ce60dae7d4d8e873a658/lib/deflate.js
     class Deflate {
         constructor(options?: DeflateOptions);
         err: ReturnCodes;
         msg: string;
-        result: Uint8Array<ArrayBuffer>;
+        result: Uint8Array;
         onData(chunk: Data): void;
         onEnd(status: number): void;
         push(data: Data | string, mode?: FlushValues | boolean): boolean;
@@ -150,7 +150,7 @@ declare namespace Pako {
         header?: Header | undefined;
         err: ReturnCodes;
         msg: string;
-        result: Uint8Array<ArrayBuffer> | string;
+        result: Uint8Array | string;
         onData(chunk: Data): void;
         onEnd(status: number): void;
         push(data: Data, mode?: FlushValues | boolean): boolean;

--- a/types/pako/ts5.8/pako-tests.ts
+++ b/types/pako/ts5.8/pako-tests.ts
@@ -1,0 +1,52 @@
+import Pako = require("pako");
+
+declare function strictEqual<T>(actual: T, expected: T): void;
+
+const chunk1 = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+const chunk2 = new Uint8Array([10, 11, 12, 13, 14, 15, 16, 17, 18, 19]);
+const chunk3 = new Uint8Array([101, 111, 121, 131, 141, 151, 161, 171, 181, 191]);
+
+const deflate = new Pako.Deflate({ level: 3, strategy: Pako.constants.Z_HUFFMAN_ONLY });
+
+deflate.push(chunk1, false);
+deflate.push(chunk3, Pako.constants.Z_PARTIAL_FLUSH);
+deflate.push(chunk2, true); // true -> last chunk
+
+if (deflate.err !== Pako.constants.Z_OK) {
+    throw new Error(deflate.err.toString());
+}
+
+console.log(deflate.result);
+
+const arr: Uint8Array = Pako.deflate("1234");
+
+const data = "           ";
+
+const deflator = new Pako.Deflate({
+    gzip: true,
+    header: {
+        hcrc: true,
+        time: 1234567,
+        os: 15,
+        name: "test name",
+        comment: "test comment",
+        extra: [4, 5, 6],
+    },
+});
+deflator.push(data, true);
+
+const inflatorString = new Pako.Inflate({ to: "string" });
+inflatorString.push(deflator.result, true);
+const resultString: string = inflatorString.result as string;
+
+const inflatorUint8Array = new Pako.Inflate();
+inflatorUint8Array.push(deflator.result, true);
+const resultUint8Array: Uint8Array = inflatorUint8Array.result as Uint8Array;
+
+strictEqual(inflatorString.err, 0);
+strictEqual(inflatorString.result, data);
+
+const header = inflatorString.header;
+strictEqual(header?.time, 1234567);
+strictEqual(header?.os, 15);
+strictEqual(header?.name, "test name");

--- a/types/pako/ts5.8/tsconfig.json
+++ b/types/pako/ts5.8/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "module": "node16",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "pako-tests.ts"
+    ]
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-9.html#libdts-changes
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.


---

This makes the library compatible with TypeScript 5.9. I had to create separate versions in order to continue supporting versions of TypeScript where `Uint8Array` was not generic.
