### PR TITLE
fix(react-native-snap-carousel): move react-native to peerDependencie…

### DIFF
--- a/types/react-native-snap-carousel/package.json
+++ b/types/react-native-snap-carousel/package.json
@@ -6,7 +6,9 @@
         "https://github.com/archriss/react-native-snap-carousel"
     ],
     "dependencies": {
-        "@types/react": "*",
+        "@types/react": "*"
+    },
+    "peerDependencies": {
         "react-native": "*"
     },
     "devDependencies": {


### PR DESCRIPTION
`@types/react-native-snap-carousel` currently declares `"react-native": "*"` in **dependencies**. This can cause package managers to install a second React Native alongside the app’s pinned RN version, leading to resolution conflicts.

### Fix
Move `react-native` to **peerDependencies** and keep `@types/react` in **dependencies**. This relies on the app’s installed RN (which is always present in RN apps) and prevents duplicate installs. It also aligns with RN’s TypeScript setup where RN ships its own declarations.

### Change type
Packaging-only; no API changes to the declarations.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests] to reflect the change. (N/A — packaging-only; no type shape changes)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - React Native ships its own TypeScript types since 0.71, so projects already have RN types via `react-native`; the `@types` package should not pull a second RN via dependencies.
    - Upstream library: [meliorence/react-native-snap-carousel](https://github.com/meliorence/react-native-snap-carousel).
    - Current `@types/react-native-snap-carousel` lists `react-native` as a **dependency**, which can install a second RN when the app pins a different version.
