### PR TITLE
fix(react-virtualized): Made Grid `scrollToPosition` and `scrollToCell` params optional

### DIFF
--- a/types/react-virtualized/dist/es/Grid.d.ts
+++ b/types/react-virtualized/dist/es/Grid.d.ts
@@ -429,7 +429,7 @@ export class Grid extends PureComponent<GridProps, GridState> {
      * Scroll to the specified offset(s).
      * Useful for animating position changes.
      */
-    scrollToPosition(params?: { scrollLeft: number; scrollTop: number }): void;
+    scrollToPosition(params?: { scrollLeft?: number; scrollTop?: number }): void;
 }
 
 export default Grid;

--- a/types/react-virtualized/dist/es/Grid.d.ts
+++ b/types/react-virtualized/dist/es/Grid.d.ts
@@ -423,7 +423,7 @@ export class Grid extends PureComponent<GridProps, GridState> {
     /**
      * Ensure column and row are visible.
      */
-    scrollToCell(params: { columnIndex: number; rowIndex: number }): void;
+    scrollToCell(params: { columnIndex?: number; rowIndex?: number }): void;
 
     /**
      * Scroll to the specified offset(s).

--- a/types/react-virtualized/dist/es/Grid.d.ts
+++ b/types/react-virtualized/dist/es/Grid.d.ts
@@ -429,7 +429,7 @@ export class Grid extends PureComponent<GridProps, GridState> {
      * Scroll to the specified offset(s).
      * Useful for animating position changes.
      */
-    scrollToPosition(params?: { scrollLeft?: number; scrollTop?: number }): void;
+    scrollToPosition(params: { scrollLeft?: number; scrollTop?: number }): void;
 }
 
 export default Grid;

--- a/types/react-virtualized/react-virtualized-tests.tsx
+++ b/types/react-virtualized/react-virtualized-tests.tsx
@@ -27,7 +27,7 @@ export class ArrowKeyStepperExample extends PureComponent<any, any> {
         const { mode } = this.state;
 
         return (
-            <ArrowKeyStepper columnCount={'100'} mode={mode as "edges"} rowCount={100}>
+            <ArrowKeyStepper columnCount={100} mode={mode as "edges"} rowCount={100}>
                 {({ onSectionRendered, scrollToColumn, scrollToRow }) => (
                     <div>
                         <AutoSizer disableHeight>

--- a/types/react-virtualized/react-virtualized-tests.tsx
+++ b/types/react-virtualized/react-virtualized-tests.tsx
@@ -27,7 +27,7 @@ export class ArrowKeyStepperExample extends PureComponent<any, any> {
         const { mode } = this.state;
 
         return (
-            <ArrowKeyStepper columnCount={100} mode={mode as "edges"} rowCount={100}>
+            <ArrowKeyStepper columnCount={'100'} mode={mode as "edges"} rowCount={100}>
                 {({ onSectionRendered, scrollToColumn, scrollToRow }) => (
                     <div>
                         <AutoSizer disableHeight>


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bvaughn/react-virtualized/blob/c737715486f724586aee8870ebea1e9efb7b0bfe/source/Grid/Grid.js#L1413 (this method allows to scroll only a single direction)
