### PR TITLE
Update WebXR Depth to the 21 May 2025 draft

### DIFF
--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -1205,6 +1205,8 @@ type XRDepthType = "raw" | "smooth";
 interface XRDepthStateInit {
     usagePreference: XRDepthUsage[];
     dataFormatPreference: XRDepthDataFormat[];
+    depthTypeRequest?: XRDepthType[] | undefined;
+    matchDepthView?: boolean | undefined;
 }
 
 interface XRSessionInit {
@@ -1217,8 +1219,8 @@ interface XRSession {
     readonly depthType?: XRDepthType | undefined;
     readonly depthActive?: boolean | undefined;
 
-    pauseDepthSensing?: () => void;
-    resumeDepthSensing?: () => void;
+    pauseDepthSensing?: (() => void) | undefined;
+    resumeDepthSensing?: (() => void) | undefined;
 }
 
 interface XRDepthInformation {

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -1229,6 +1229,9 @@ interface XRDepthInformation {
 
     readonly normDepthBufferFromNormView: XRRigidTransform;
     readonly rawValueToMeters: number;
+
+    readonly transform?: XRRigidTransform | undefined;
+    readonly projectionMatrix?: Float32Array | undefined;
 }
 
 interface XRCPUDepthInformation extends XRDepthInformation {

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -1219,8 +1219,8 @@ interface XRSession {
     readonly depthType?: XRDepthType | undefined;
     readonly depthActive?: boolean | undefined;
 
-    pauseDepthSensing?: (() => void) | undefined;
-    resumeDepthSensing?: (() => void) | undefined;
+    readonly pauseDepthSensing?: (() => void) | undefined;
+    readonly resumeDepthSensing?: (() => void) | undefined;
 }
 
 interface XRDepthInformation {

--- a/types/webxr/index.d.ts
+++ b/types/webxr/index.d.ts
@@ -1200,6 +1200,8 @@ type XRDepthUsage = "cpu-optimized" | "gpu-optimized";
 
 type XRDepthDataFormat = "luminance-alpha" | "float32" | "unsigned-short";
 
+type XRDepthType = "raw" | "smooth";
+
 interface XRDepthStateInit {
     usagePreference: XRDepthUsage[];
     dataFormatPreference: XRDepthDataFormat[];
@@ -1212,6 +1214,11 @@ interface XRSessionInit {
 interface XRSession {
     readonly depthUsage?: XRDepthUsage | undefined;
     readonly depthDataFormat?: XRDepthDataFormat | undefined;
+    readonly depthType?: XRDepthType | undefined;
+    readonly depthActive?: boolean | undefined;
+
+    pauseDepthSensing?: () => void;
+    resumeDepthSensing?: () => void;
 }
 
 interface XRDepthInformation {

--- a/types/webxr/webxr-tests.ts
+++ b/types/webxr/webxr-tests.ts
@@ -259,6 +259,21 @@ function assertNever(value: never) {
     function useCpuDepthInformation(view: XRView, depthInformation: XRCPUDepthInformation) {
         const depthInMeters = depthInformation.getDepthInMeters(0.25, 0.75);
         console.log("Depth at normalized view coordinates (0.25, 0.75) is:", depthInMeters);
+
+        const projectionMatrix: Float32Array | undefined = depthInformation.projectionMatrix;
+        if (projectionMatrix) {
+            console.log("Depth projection matrix:", projectionMatrix);
+        }
+
+        const transformPosition: DOMPointReadOnly | undefined = depthInformation.transform?.position;
+        if (transformPosition) {
+            console.log("Depth transform position:", transformPosition);
+        }
+
+        const transformDirection: DOMPointReadOnly | undefined = depthInformation.transform?.orientation;
+        if (transformDirection) {
+            console.log("Depth transform direction:", transformDirection);
+        }
     }
 
     const glBinding = new XRWebGLBinding(session, ctx);

--- a/types/webxr/webxr-tests.ts
+++ b/types/webxr/webxr-tests.ts
@@ -228,7 +228,7 @@ function assertNever(value: never) {
             usagePreference: ["cpu-optimized", "gpu-optimized"],
             dataFormatPreference: ["luminance-alpha", "float32"],
             depthTypeRequest: ["raw", "smooth"],
-            matchDepthView: false
+            matchDepthView: false,
         },
     });
 

--- a/types/webxr/webxr-tests.ts
+++ b/types/webxr/webxr-tests.ts
@@ -222,6 +222,16 @@ function assertNever(value: never) {
         },
     });
 
+    const depthSensingSession2 = await navigator.xr!.requestSession("immersive-ar", {
+        requiredFeatures: ["depth-sensing"],
+        depthSensing: {
+            usagePreference: ["cpu-optimized", "gpu-optimized"],
+            dataFormatPreference: ["luminance-alpha", "float32"],
+            depthTypeRequest: ["raw", "smooth"],
+            matchDepthView: false
+        },
+    });
+
     function requestAnimationFrameCallback(t: number, frame: XRFrame) {
         session.requestAnimationFrame(requestAnimationFrameCallback);
 
@@ -232,6 +242,16 @@ function assertNever(value: never) {
                 if (depthInformation) {
                     useCpuDepthInformation(view, depthInformation);
                 }
+            }
+        }
+
+        if (session.depthActive) {
+            console.log("Depth type:", session.depthType);
+            if (session.pauseDepthSensing) {
+                session.pauseDepthSensing();
+            }
+            if (session.resumeDepthSensing) {
+                session.resumeDepthSensing();
             }
         }
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.w3.org/TR/webxr-depth-sensing-1/
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Changes:
1. Adds `type XRDepthType = "raw" | "smooth";`
2. Updates XRSession to optionally include: `depthType`, `depthActive`, `pauseDepthSensing`, and `resumeDepthSensing`.
3. Adds `depthTypeRequest` and `matchDepthView` to `XRDepthStateInit`.
4. Adds `transform` and `projectionMatrix` to `XRDepthInformation`.
