### PR TITLE
fix(@types/plotly.js): include missing definitions in 'Font' interface

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1953,6 +1953,26 @@ export interface Font {
      * @default normal
      */
     weight: number;
+    /**
+     * Sets whether a font should be styled with a normal or italic face from its family.
+     * @default "normal"
+     */
+    style: "normal" | "italic";
+    /**
+     * Sets capitalization of text. Can be used to make text appear in all-uppercase, all-lowercase, or with each word capitalized.
+     * @default "normal"
+     */
+    textcase: "normal" | "word caps" | "upper" | "lower";
+    /**
+     * Sets the variant of the font.
+     * @default "normal"
+     */
+    variant: "normal" | "small-caps" | "all-small-caps" | "all-petite-caps" | "petite-caps" | "unicase";
+    /**
+     * Sets the kind of decoration line(s) with text, such as an "under", "over" or "through" as well as combinations e.g. "under+over".
+     * @default "none"
+     */
+    lineposition: "under" | "over" | "through" | "under+over" | "under+over+through" | "none";
 }
 
 export interface Edits {

--- a/types/plotly.js/test/index-tests.ts
+++ b/types/plotly.js/test/index-tests.ts
@@ -407,7 +407,7 @@ const config: Partial<Config> = {
         bgcolor: "#ffffff",
         bordercolor: "#444444",
         borderwidth: 1,
-        font: { size: 15 },
+        font: { size: 15, style: "italic" },
         groupclick: "togglegroup",
         grouptitlefont: { size: 15 },
         itemclick: "toggleothers",
@@ -498,7 +498,7 @@ const config: Partial<Config> = {
             colorbar: {
                 title: {
                     text: "Test",
-                    font: { size: 20, color: "#666" },
+                    font: { size: 20, color: "#666", textcase: "lower" },
                     side: "top",
                 },
                 orientation: "v",
@@ -574,7 +574,7 @@ const config: Partial<Config> = {
                     visible: true,
                     prefix: "Date:",
                     xanchor: "right",
-                    font: { size: 20, color: "#666" },
+                    font: { size: 20, color: "#666", variant: "all-small-caps" },
                 },
                 steps: [
                     {
@@ -726,6 +726,7 @@ const config: Partial<Config> = {
             text: "some new title",
             font: {
                 size: 1.2,
+                lineposition: "through",
             },
             x: 0.9,
             pad: {

--- a/types/plotly.js/v2/index.d.ts
+++ b/types/plotly.js/v2/index.d.ts
@@ -2003,6 +2003,26 @@ export interface Font {
      * @default normal
      */
     weight: number;
+    /**
+     * Sets whether a font should be styled with a normal or italic face from its family.
+     * @default "normal"
+     */
+    style: "normal" | "italic";
+    /**
+     * Sets capitalization of text. Can be used to make text appear in all-uppercase, all-lowercase, or with each word capitalized.
+     * @default "normal"
+     */
+    textcase: "normal" | "word caps" | "upper" | "lower";
+    /**
+     * Sets the variant of the font.
+     * @default "normal"
+     */
+    variant: "normal" | "small-caps" | "all-small-caps" | "all-petite-caps" | "petite-caps" | "unicase";
+    /**
+     * Sets the kind of decoration line(s) with text, such as an "under", "over" or "through" as well as combinations e.g. "under+over".
+     * @default "none"
+     */
+    lineposition: "under" | "over" | "through" | "under+over" | "under+over+through" | "none";
 }
 
 export interface Edits {

--- a/types/plotly.js/v2/test/index-tests.ts
+++ b/types/plotly.js/v2/test/index-tests.ts
@@ -428,7 +428,7 @@ const config: Partial<Config> = {
         bgcolor: "#ffffff",
         bordercolor: "#444444",
         borderwidth: 1,
-        font: { size: 15 },
+        font: { size: 15, style: "italic" },
         groupclick: "togglegroup",
         grouptitlefont: { size: 15 },
         itemclick: "toggleothers",
@@ -511,7 +511,7 @@ const config: Partial<Config> = {
             colorbar: {
                 title: {
                     text: "Test",
-                    font: { size: 20, color: "#666" },
+                    font: { size: 20, color: "#666", textcase: "lower" },
                     side: "top",
                 },
                 orientation: "v",
@@ -585,7 +585,7 @@ const config: Partial<Config> = {
                     visible: true,
                     prefix: "Date:",
                     xanchor: "right",
-                    font: { size: 20, color: "#666" },
+                    font: { size: 20, color: "#666", lineposition: "through" },
                 },
                 steps: [
                     {


### PR DESCRIPTION
Include style, textcase, variant and lineposition key definitions missing in the 'Font' interface.
Closes #73489

Derived from #73490 - I reopened the PR to use a different source branch instead

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://plotly.com/javascript/reference/layout/#layout-font
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. 
     - For this one I am not sure how to go forward. It seems like these options were already available in https://github.com/plotly/plotly.js/releases/tag/v2.32.0, so they should already be there...