### PR TITLE
fix(intercept-stdout): hook param

### DIFF
--- a/types/intercept-stdout/index.d.ts
+++ b/types/intercept-stdout/index.d.ts
@@ -1,5 +1,7 @@
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-type hookFunction = (txt: string) => string | void;
+/// <reference types="node" />
+
+type Chunk = Parameters<NodeJS.Process["stdout"]["write"]>[0];
+type hookFunction = (chunk: Chunk) => Chunk;
 type unhookFunction = () => void;
 
 declare function intercept(

--- a/types/intercept-stdout/intercept-stdout-tests.ts
+++ b/types/intercept-stdout/intercept-stdout-tests.ts
@@ -1,7 +1,7 @@
 import intercept = require("intercept-stdout");
 
-const stdoutHook = (data: string) => {
-    return data;
+const stdoutHook = (chunk: string | Uint8Array) => {
+    return chunk;
 };
 
 const unhookIntercept = intercept(stdoutHook);

--- a/types/intercept-stdout/package.json
+++ b/types/intercept-stdout/package.json
@@ -5,6 +5,9 @@
     "projects": [
         "https://github.com/sfarthin/intercept-stdout"
     ],
+    "dependencies": {
+        "@types/node": "*"
+    },
     "devDependencies": {
         "@types/intercept-stdout": "workspace:."
     },


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://nodejs.org/api/process.html#processstdout
  - https://nodejs.org/api/net.html#class-netsocket → `Event: 'data'`
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

This fixes an error when `hookFunction` does not properly check the chunk type. Using `chunk.replace()` e.g. will fail whenever we encounter a buffer.
