### PR TITLE
fix(dockerode): improve types for `AuthConfig`, `Image.push`

### DIFF
--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -130,9 +130,10 @@ declare namespace Dockerode {
         get(callback: Callback<NodeJS.ReadableStream>): void;
         get(): Promise<NodeJS.ReadableStream>;
 
-        push(options: ImagePushOptions, callback: Callback<NodeJS.ReadableStream>): void;
-        push(callback: Callback<NodeJS.ReadableStream>): void;
+        push(options: ImagePushOptions, callback: Callback<NodeJS.ReadableStream>, auth?: AuthConfig): void;
+        push(callback: Callback<NodeJS.ReadableStream>, auth?: AuthConfig): void;
         push(options?: ImagePushOptions): Promise<NodeJS.ReadableStream>;
+        push(options?: ImagePushOptions, callback?: undefined, auth?: AuthConfig): Promise<NodeJS.ReadableStream>;
 
         tag(options: ImageTagOptions, callback: Callback<any>): void;
         tag(callback: Callback<any>): void;
@@ -1134,6 +1135,7 @@ declare namespace Dockerode {
         tag?: string | undefined;
         authconfig?: AuthConfig | undefined;
         abortSignal?: AbortSignal;
+        stream?: boolean | undefined;
     }
 
     interface ImageTagOptions {
@@ -1148,7 +1150,9 @@ declare namespace Dockerode {
         tag?: string;
     }
 
-    interface AuthConfig {
+    interface AuthConfigKey { key: string }
+    interface AuthConfigBase64 { base64: string }
+    interface AuthConfigObject {
         username?: string;
         password?: string;
         auth?: string;
@@ -1158,6 +1162,8 @@ declare namespace Dockerode {
         /** @deprecated */
         email?: string | undefined;
     }
+
+    type AuthConfig = AuthConfigKey | AuthConfigBase64 | AuthConfigObject;
 
     interface RegistryConfig {
         [registryAddress: string]: {

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -1150,8 +1150,12 @@ declare namespace Dockerode {
         tag?: string;
     }
 
-    interface AuthConfigKey { key: string }
-    interface AuthConfigBase64 { base64: string }
+    interface AuthConfigKey {
+        key: string;
+    }
+    interface AuthConfigBase64 {
+        base64: string;
+    }
     interface AuthConfigObject {
         username?: string;
         password?: string;


### PR DESCRIPTION
This PR updates types for the `dockerode` package, specifically, it fixes problems with incomplete `AuthConfig` type, incomplete args for `Image.push`, and missing `auth` for `Image.push`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
	- for the stream change, see https://github.com/apocas/dockerode/blob/master/lib/image.js#L167
	- for the authconfig change, see https://github.com/apocas/docker-modem/blob/master/lib/modem.js#L186-L189
	- lastly, for the Image push change, see the prototype https://github.com/apocas/dockerode/blob/master/lib/image.js#L163 and also check https://github.com/apocas/dockerode/blob/master/lib/image.js#L165 that assigns `opts` to `callback` if it's a function
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
