### PR TITLE
[rn-material-ui-textfield] Update types to be compatible with latest React Native types

### DIFF
--- a/types/rn-material-ui-textfield/index.d.ts
+++ b/types/rn-material-ui-textfield/index.d.ts
@@ -70,8 +70,6 @@ export interface TextFieldProps extends TextInputProps {
     renderLeftAccessory?(): React.JSX.Element;
     renderRightAccessory?(): React.JSX.Element;
     onChangeText?(text: string): void;
-    onFocus?(event: NativeSyntheticEvent<TextInputFocusEventData>): void;
-    onBlur?(event: NativeSyntheticEvent<TextInputChangeEventData>): void;
     inputRef?: React.RefObject<any> | undefined;
 }
 


### PR DESCRIPTION
Fixes 

```
/home/runner/work/DefinitelyTyped/DefinitelyTyped/types/rn-material-ui-textfield/index.d.ts
  40:18  error  TypeScript@5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 6.0 compile error: 
Interface 'TextFieldProps' incorrectly extends interface 'TextInputProps'.
  Types of property 'onBlur' are incompatible.
    Type '((event: NativeSyntheticEvent<TextInputChangeEventData>) => void) | undefined' is not assignable to type '((e: BlurEvent) => void) | undefined'.
      Type '(event: NativeSyntheticEvent<TextInputChangeEventData>) => void' is not assignable to type '(e: BlurEvent) => void'.
        Types of parameters 'event' and 'e' are incompatible.
          Type 'BlurEvent' is not assignable to type 'NativeSyntheticEvent<TextInputChangeEventData>'.
            Type 'TargetedEvent' is missing the following properties from type 'TextInputChangeEventData': eventCount, text  @definitelytyped/expect
```

-- https://github.com/DefinitelyTyped/DefinitelyTyped/actions/runs/17152961504/job/48663284202?pr=73404#step:11:703

The event handler is now typed on the host element