### PR TITLE
[chrome] update declarativeContent namespace

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2450,45 +2450,70 @@ declare namespace chrome {
      * Permissions: "declarativeContent"
      */
     export namespace declarativeContent {
-        export class PageStateMatcherProperties {
-            /** Optional. Filters URLs for various criteria. See event filtering. All criteria are case sensitive.  */
+        interface PageStateMatcherProperties {
+            /** Matches if the conditions of the `UrlFilter` are fulfilled for the top-level URL of the page. */
             pageUrl?: events.UrlFilter | undefined;
-            /** Optional. Matches if all of the CSS selectors in the array match displayed elements in a frame with the same origin as the page's main frame. All selectors in this array must be compound selectors to speed up matching. Note that listing hundreds of CSS selectors or CSS selectors that match hundreds of times per page can still slow down web sites.  */
+            /** Matches if all of the CSS selectors in the array match displayed elements in a frame with the same origin as the page's main frame. All selectors in this array must be compound selectors to speed up matching. Note: Listing hundreds of CSS selectors or listing CSS selectors that match hundreds of times per page can slow down web sites. */
             css?: string[] | undefined;
             /**
-             * Optional.
-             * @since Chrome 45
              * Matches if the bookmarked state of the page is equal to the specified value. Requires the bookmarks permission.
+             * @since Chrome 45
              */
             isBookmarked?: boolean | undefined;
         }
 
-        /** Matches the state of a web page by various criteria. */
+        /** Matches the state of a web page based on various criteria. */
         export class PageStateMatcher {
-            constructor(options: PageStateMatcherProperties);
+            constructor(arg: PageStateMatcherProperties);
+        }
+
+        export interface RequestContentScriptProperties {
+            /** Whether the content script runs in all frames of the matching page, or in only the top frame. Default is `false`. */
+            allFrames?: boolean | undefined;
+
+            /** Names of CSS files to be injected as a part of the content script. */
+            css?: string[] | undefined;
+
+            /** Names of JavaScript files to be injected as a part of the content script. */
+            js?: string[] | undefined;
+
+            /** Whether to insert the content script on `about:blank` and `about:srcdoc`. Default is `false`. */
+            matchAboutBlank?: boolean | undefined;
+        }
+
+        /** Declarative event action that injects a content script. */
+        export class RequestContentScript {
+            constructor(arg: RequestContentScriptProperties);
         }
 
         /**
-         * Declarative event action that enables the extension's action while the corresponding conditions are met.
-         * Manifest v3.
+         * A declarative event action that sets the extension's toolbar {@link action} to an enabled state while the corresponding conditions are met. This action can be used without host permissions. If the extension has the `activeTab` permission, clicking the page action grants access to the active tab.
+         *
+         * On pages where the conditions are not met the extension's toolbar action will be grey-scale, and clicking it will open the context menu, instead of triggering the action.
+         * @since MV3
          */
         export class ShowAction {}
 
         /**
-         * Declarative event action that shows the extension's page action while the corresponding conditions are met.
-         * Manifest v2.
+         * A declarative event action that sets the extension's {@link pageAction} to an enabled state while the corresponding conditions are met. This action can be used without host permissions, but the extension must have a page action. If the extension has the `activeTab` permission, clicking the page action grants access to the active tab.
+         *
+         * On pages where the conditions are not met the extension's toolbar action will be grey-scale, and clicking it will open the context menu, instead of triggering the action.
+         *
+         * MV2 only
          */
         export class ShowPageAction {}
 
-        /** Declarative event action that changes the icon of the page action while the corresponding conditions are met. */
+        /**
+         * Declarative event action that sets the n-dip square icon for the extension's {@link pageAction} or {@link browserAction} while the corresponding conditions are met. This action can be used without host permissions, but the extension must have a page or browser action.
+         *
+         * Exactly one of `imageData` or `path` must be specified. Both are dictionaries mapping a number of pixels to an image representation. The image representation in `imageData` is an `ImageData` object; for example, from a `canvas` element, while the image representation in `path` is the path to an image file relative to the extension's manifest. If `scale` screen pixels fit into a device-independent pixel, the `scale * n` icon is used. If that scale is missing, another image is resized to the required size.
+         */
         export class SetIcon {
             constructor(options?: { imageData?: ImageData | { [size: string]: ImageData } | undefined });
         }
 
-        /** Provides the Declarative Event API consisting of addRules, removeRules, and getRules. */
-        export interface PageChangedEvent extends chrome.events.Event<() => void> {}
-
-        export var onPageChanged: PageChangedEvent;
+        /** Provides the Declarative Event API consisting of {@link events.Event.addRules addRules}, {@link events.Event.removeRules removeRules}, and {@link events.Event.getRules getRules}. */
+        export const onPageChanged: events.Event<() => void>;
     }
 
     ////////////////////
@@ -4331,7 +4356,8 @@ declare namespace chrome {
              * Unregisters currently registered rules.
              * @param ruleIdentifiers If an array is passed, only rules with identifiers contained in this array are unregistered.
              */
-            removeRules(ruleIdentifiers?: string[] | undefined, callback?: () => void): void;
+            removeRules(ruleIdentifiers: string[] | undefined, callback?: () => void): void;
+            removeRules(callback?: () => void): void;
 
             /**
              * Registers rules to handle events.

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1071,24 +1071,79 @@ function testDebugger() {
     });
 }
 
-// https://developer.chrome.com/extensions/declarativeContent
+// https://developer.chrome.com/docs/extensions/reference/api/declarativeContent
 function testDeclarativeContent() {
-    const activeIcon: ImageData = new ImageData(32, 32);
+    const pageStateMatcherProperties: chrome.declarativeContent.PageStateMatcherProperties = {
+        css: [""],
+        isBookmarked: true,
+        pageUrl: {
+            cidrBlocks: [""],
+            hostContains: "",
+            hostEquals: "",
+            hostPrefix: "",
+            hostSuffix: "",
+            originAndPathMatches: "",
+            pathContains: "",
+            pathEquals: "",
+            pathPrefix: "",
+            pathSuffix: "",
+            ports: [1],
+            queryContains: "",
+            queryEquals: "",
+            queryPrefix: "",
+            querySuffix: "",
+            schemes: ["https"],
+            urlContains: "",
+            urlEquals: "",
+            urlMatches: "",
+            urlPrefix: "",
+            urlSuffix: "",
+        },
+    };
+
+    const condition = new chrome.declarativeContent.PageStateMatcher(pageStateMatcherProperties); // ExpectType PageStateMatcher
+
+    const requestContentScriptProperties: chrome.declarativeContent.RequestContentScriptProperties = {
+        allFrames: true,
+        css: [""],
+        js: [""],
+        matchAboutBlank: true,
+    };
+
+    new chrome.declarativeContent.RequestContentScript(requestContentScriptProperties); // ExpectType RequestContentScript
+
+    const imageData = new ImageData(32, 32);
+
+    new chrome.declarativeContent.SetIcon({ imageData }); // ExpectType SetIcon
+
+    const action = new chrome.declarativeContent.ShowAction(); // ExpectType ShowAction
+
+    new chrome.declarativeContent.ShowPageAction(); // ExpectType ShowPageAction
 
     const rule: chrome.events.Rule = {
-        conditions: [
-            new chrome.declarativeContent.PageStateMatcher({
-                pageUrl: {
-                    hostContains: "test.com",
-                },
-            }),
-        ],
-        actions: [
-            new chrome.declarativeContent.SetIcon({
-                imageData: activeIcon,
-            }),
-        ],
+        conditions: [condition],
+        actions: [action],
     };
+
+    chrome.declarativeContent.onPageChanged.addRules([rule]); // $ExpectType void
+    chrome.declarativeContent.onPageChanged.addRules([rule], ([rule]) => { // $ExpectType void
+        rule; // $ExpectType Rule
+    });
+
+    chrome.declarativeContent.onPageChanged.getRules(([rule]) => { // $ExpectType void
+        rule; // $ExpectType Rule
+    });
+
+    chrome.declarativeContent.onPageChanged.getRules(([rule]) => { // $ExpectType void
+        rule; // $ExpectType Rule
+    });
+    chrome.declarativeContent.onPageChanged.getRules(["identifier"], ([rule]) => { // $ExpectType void
+        rule; // $ExpectType Rule
+    });
+
+    chrome.declarativeContent.onPageChanged.removeRules(); // $ExpectType void
+    chrome.declarativeContent.onPageChanged.removeRules(() => void 0); // $ExpectType void
+    chrome.declarativeContent.onPageChanged.removeRules(["identifier"], () => void 0); // $ExpectType void
 }
 
 // https://developer.chrome.com/extensions/storage#type-StorageArea


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/declarativeContent#rules
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes:
- convert `PageStateMatcherProperties`: class -> interface
- add `RequestContentScript` class
- `removeRules` can just have `callback` param
- add tests
- update JSDocs

Runtime:
<img width="970" height="297" alt="image" src="https://github.com/user-attachments/assets/f46668a0-c3b4-42ab-8b36-4d7dcde682f7" />
