### PR TITLE
[node] https: deconflict overridable Agent methods

### DIFF
--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -1591,7 +1591,7 @@ declare module "http" {
         createConnection(
             options: ClientRequestArgs,
             callback?: (err: Error | null, stream: stream.Duplex) => void,
-        ): stream.Duplex;
+        ): stream.Duplex | null | undefined;
         /**
          * Called when `socket` is detached from a request and could be persisted by the`Agent`. Default behavior is to:
          *

--- a/types/node/https.d.ts
+++ b/types/node/https.d.ts
@@ -32,6 +32,11 @@ declare module "https" {
     class Agent extends http.Agent {
         constructor(options?: AgentOptions);
         options: AgentOptions;
+        createConnection(
+            options: RequestOptions,
+            callback?: (err: Error | null, stream: Duplex) => void,
+        ): Duplex | null | undefined;
+        getName(options?: RequestOptions): string;
     }
     interface Server<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,

--- a/types/node/test/https.ts
+++ b/types/node/test/https.ts
@@ -19,6 +19,18 @@ import * as url from "node:url";
 
     agent = https.globalAgent;
 
+    class CustomAgent extends https.Agent {
+        createConnection(options: https.RequestOptions, callback?: (err: Error | null, socket: net.Socket) => void) {
+            const socket = new net.Socket(options);
+            callback?.(null, socket);
+            return socket;
+        }
+        getName(options: https.RequestOptions) {
+            return `${super.getName(options)}:${options?.ca}:${options?.cert}:${options?.key}`;
+        }
+    }
+    agent = new CustomAgent();
+
     let sockets: NodeJS.ReadOnlyDict<net.Socket[]> = agent.sockets;
     sockets = agent.freeSockets;
 

--- a/types/node/v18/http.d.ts
+++ b/types/node/v18/http.d.ts
@@ -1559,7 +1559,7 @@ declare module "http" {
         createConnection(
             options: ClientRequestArgs,
             callback?: (err: Error | null, stream: stream.Duplex) => void,
-        ): stream.Duplex;
+        ): stream.Duplex | null | undefined;
         /**
          * Called when `socket` is detached from a request and could be persisted by the`Agent`. Default behavior is to:
          *

--- a/types/node/v18/https.d.ts
+++ b/types/node/v18/https.d.ts
@@ -31,6 +31,11 @@ declare module "https" {
     class Agent extends http.Agent {
         constructor(options?: AgentOptions);
         options: AgentOptions;
+        createConnection(
+            options: RequestOptions,
+            callback?: (err: Error | null, stream: Duplex) => void,
+        ): Duplex | null | undefined;
+        getName(options?: RequestOptions): string;
     }
     interface Server<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,

--- a/types/node/v18/test/https.ts
+++ b/types/node/v18/test/https.ts
@@ -19,6 +19,18 @@ import * as url from "node:url";
 
     agent = https.globalAgent;
 
+    class CustomAgent extends https.Agent {
+        createConnection(options: https.RequestOptions, callback?: (err: Error | null, socket: net.Socket) => void) {
+            const socket = new net.Socket(options);
+            callback?.(null, socket);
+            return socket;
+        }
+        getName(options: https.RequestOptions) {
+            return `${super.getName(options)}:${options?.ca}:${options?.cert}:${options?.key}`;
+        }
+    }
+    agent = new CustomAgent();
+
     let sockets: NodeJS.ReadOnlyDict<net.Socket[]> = agent.sockets;
     sockets = agent.freeSockets;
 

--- a/types/node/v20/http.d.ts
+++ b/types/node/v20/http.d.ts
@@ -1589,7 +1589,7 @@ declare module "http" {
         createConnection(
             options: ClientRequestArgs,
             callback?: (err: Error | null, stream: stream.Duplex) => void,
-        ): stream.Duplex;
+        ): stream.Duplex | null | undefined;
         /**
          * Called when `socket` is detached from a request and could be persisted by the`Agent`. Default behavior is to:
          *

--- a/types/node/v20/https.d.ts
+++ b/types/node/v20/https.d.ts
@@ -31,6 +31,11 @@ declare module "https" {
     class Agent extends http.Agent {
         constructor(options?: AgentOptions);
         options: AgentOptions;
+        createConnection(
+            options: RequestOptions,
+            callback?: (err: Error | null, stream: Duplex) => void,
+        ): Duplex | null | undefined;
+        getName(options?: RequestOptions): string;
     }
     interface Server<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,

--- a/types/node/v20/test/https.ts
+++ b/types/node/v20/test/https.ts
@@ -19,6 +19,18 @@ import * as url from "node:url";
 
     agent = https.globalAgent;
 
+    class CustomAgent extends https.Agent {
+        createConnection(options: https.RequestOptions, callback?: (err: Error | null, socket: net.Socket) => void) {
+            const socket = new net.Socket(options);
+            callback?.(null, socket);
+            return socket;
+        }
+        getName(options: https.RequestOptions) {
+            return `${super.getName(options)}:${options?.ca}:${options?.cert}:${options?.key}`;
+        }
+    }
+    agent = new CustomAgent();
+
     let sockets: NodeJS.ReadOnlyDict<net.Socket[]> = agent.sockets;
     sockets = agent.freeSockets;
 

--- a/types/node/v22/http.d.ts
+++ b/types/node/v22/http.d.ts
@@ -1591,7 +1591,7 @@ declare module "http" {
         createConnection(
             options: ClientRequestArgs,
             callback?: (err: Error | null, stream: stream.Duplex) => void,
-        ): stream.Duplex;
+        ): stream.Duplex | null | undefined;
         /**
          * Called when `socket` is detached from a request and could be persisted by the`Agent`. Default behavior is to:
          *

--- a/types/node/v22/https.d.ts
+++ b/types/node/v22/https.d.ts
@@ -32,6 +32,11 @@ declare module "https" {
     class Agent extends http.Agent {
         constructor(options?: AgentOptions);
         options: AgentOptions;
+        createConnection(
+            options: RequestOptions,
+            callback?: (err: Error | null, stream: Duplex) => void,
+        ): Duplex | null | undefined;
+        getName(options?: RequestOptions): string;
     }
     interface Server<
         Request extends typeof http.IncomingMessage = typeof http.IncomingMessage,

--- a/types/node/v22/test/https.ts
+++ b/types/node/v22/test/https.ts
@@ -19,6 +19,18 @@ import * as url from "node:url";
 
     agent = https.globalAgent;
 
+    class CustomAgent extends https.Agent {
+        createConnection(options: https.RequestOptions, callback?: (err: Error | null, socket: net.Socket) => void) {
+            const socket = new net.Socket(options);
+            callback?.(null, socket);
+            return socket;
+        }
+        getName(options: https.RequestOptions) {
+            return `${super.getName(options)}:${options?.ca}:${options?.cert}:${options?.key}`;
+        }
+    }
+    agent = new CustomAgent();
+
     let sockets: NodeJS.ReadOnlyDict<net.Socket[]> = agent.sockets;
     sockets = agent.freeSockets;
 


### PR DESCRIPTION
Bringing the abandoned #73169 to the finish line.

Also ensures that `createConnection()` can return a nullish value, which matches the behaviour of the API as well as the existing callback type in `ClientRequestArgs`. (Addresses #73547.)

Follow-up to #73194.