### PR TITLE
[chrome] update fontSettings namespace

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -5400,212 +5400,382 @@ declare namespace chrome {
             fontId: string;
         }
 
-        export interface DefaultFontSizeDetails {
+        /** A CSS generic font family. */
+        export enum GenericFamily {
+            STANDARD = "standard",
+            SANSSERIF = "sansserif",
+            SERIF = "serif",
+            FIXED = "fixed",
+            CURSIVE = "cursive",
+            FANTASY = "fantasy",
+            MATH = "math",
+        }
+
+        export enum LevelOfControl {
+            /** Cannot be controlled by any extension */
+            NOT_CONTROLLABLE = "not_controllable",
+            /** Controlled by extensions with higher precedence */
+            CONTROLLED_BY_OTHER_EXTENSIONS = "controlled_by_other_extensions",
+            /** Can be controlled by this extension */
+            CONTROLLABLE_BY_THIS_EXTENSION = "controllable_by_this_extension",
+            /** Controlled by this extension */
+            CONTROLLED_BY_THIS_EXTENSION = "controlled_by_this_extension",
+        }
+
+        /** An ISO 15924 script code. The default, or global, script is represented by script code "Zyyy". */
+        export enum ScriptCode {
+            AFAK = "Afak",
+            ARAB = "Arab",
+            ARMI = "Armi",
+            ARMN = "Armn",
+            AVST = "Avst",
+            BALI = "Bali",
+            BAMU = "Bamu",
+            BASS = "Bass",
+            BATK = "Batk",
+            BENG = "Beng",
+            BLIS = "Blis",
+            BOPO = "Bopo",
+            BRAH = "Brah",
+            BRAI = "Brai",
+            BUGI = "Bugi",
+            BUHD = "Buhd",
+            CAKM = "Cakm",
+            CANS = "Cans",
+            CARI = "Cari",
+            CHAM = "Cham",
+            CHER = "Cher",
+            CIRT = "Cirt",
+            COPT = "Copt",
+            CPRT = "Cprt",
+            CYRL = "Cyrl",
+            CYRS = "Cyrs",
+            DEVA = "Deva",
+            DSRT = "Dsrt",
+            DUPL = "Dupl",
+            EGYD = "Egyd",
+            EGYH = "Egyh",
+            EGYP = "Egyp",
+            ELBA = "Elba",
+            ETHI = "Ethi",
+            GEOK = "Geok",
+            GEOR = "Geor",
+            GLAG = "Glag",
+            GOTH = "Goth",
+            GRAN = "Gran",
+            GREK = "Grek",
+            GUJR = "Gujr",
+            GURU = "Guru",
+            HANG = "Hang",
+            HANI = "Hani",
+            HANO = "Hano",
+            HANS = "Hans",
+            HANT = "Hant",
+            HEBR = "Hebr",
+            HLUW = "Hluw",
+            HMNG = "Hmng",
+            HUNG = "Hung",
+            INDS = "Inds",
+            ITAL = "Ital",
+            JAVA = "Java",
+            JPAN = "Jpan",
+            JURC = "Jurc",
+            KALI = "Kali",
+            KHAR = "Khar",
+            KHMR = "Khmr",
+            KHOJ = "Khoj",
+            KNDA = "Knda",
+            KPEL = "Kpel",
+            KTHI = "Kthi",
+            LANA = "Lana",
+            LAOO = "Laoo",
+            LATF = "Latf",
+            LATG = "Latg",
+            LATN = "Latn",
+            LEPC = "Lepc",
+            LIMB = "Limb",
+            LINA = "Lina",
+            LINB = "Linb",
+            LISU = "Lisu",
+            LOMA = "Loma",
+            LYCI = "Lyci",
+            LYDI = "Lydi",
+            MAND = "Mand",
+            MANI = "Mani",
+            MAYA = "Maya",
+            MEND = "Mend",
+            MERC = "Merc",
+            MERO = "Mero",
+            MLYM = "Mlym",
+            MONG = "Mong",
+            MOON = "Moon",
+            MROO = "Mroo",
+            MTEI = "Mtei",
+            MYMR = "Mymr",
+            NARB = "Narb",
+            NBAT = "Nbat",
+            NKGB = "Nkgb",
+            NKOO = "Nkoo",
+            NSHU = "Nshu",
+            OGAM = "Ogam",
+            OLCK = "Olck",
+            ORKH = "Orkh",
+            ORYA = "Orya",
+            OSMA = "Osma",
+            PALM = "Palm",
+            PERM = "Perm",
+            PHAG = "Phag",
+            PHLI = "Phli",
+            PHLP = "Phlp",
+            PHLV = "Phlv",
+            PHNX = "Phnx",
+            PLRD = "Plrd",
+            PRTI = "Prti",
+            RJNG = "Rjng",
+            RORO = "Roro",
+            RUNR = "Runr",
+            SAMR = "Samr",
+            SARA = "Sara",
+            SARB = "Sarb",
+            SAUR = "Saur",
+            SGNW = "Sgnw",
+            SHAW = "Shaw",
+            SHRD = "Shrd",
+            SIND = "Sind",
+            SINH = "Sinh",
+            SORA = "Sora",
+            SUND = "Sund",
+            SYLO = "Sylo",
+            SYRC = "Syrc",
+            SYRE = "Syre",
+            SYRJ = "Syrj",
+            SYRN = "Syrn",
+            TAGB = "Tagb",
+            TAKR = "Takr",
+            TALE = "Tale",
+            TALU = "Talu",
+            TAML = "Taml",
+            TANG = "Tang",
+            TAVT = "Tavt",
+            TELU = "Telu",
+            TENG = "Teng",
+            TFNG = "Tfng",
+            TGLG = "Tglg",
+            THAA = "Thaa",
+            THAI = "Thai",
+            TIBT = "Tibt",
+            TIRH = "Tirh",
+            UGAR = "Ugar",
+            VAII = "Vaii",
+            VISP = "Visp",
+            WARA = "Wara",
+            WOLE = "Wole",
+            XPEO = "Xpeo",
+            XSUX = "Xsux",
+            YIII = "Yiii",
+            ZMTH = "Zmth",
+            ZSYM = "Zsym",
+            ZYYY = "Zyyy",
+        }
+
+        export interface ClearFontDetails {
+            /** The generic font family for which the font should be cleared. */
+            genericFamily: `${GenericFamily}`;
+            /** The script for which the font should be cleared. If omitted, the global script font setting is cleared. */
+            script?: `${ScriptCode}` | undefined;
+        }
+
+        export interface GetFontDetails {
+            /** The generic font family for which the font should be retrieved. */
+            genericFamily: `${GenericFamily}`;
+            /** The script for which the font should be retrieved. If omitted, the font setting for the global script (script code "Zyyy") is retrieved. */
+            script?: `${ScriptCode}` | undefined;
+        }
+
+        export interface SetFontDetails {
+            /** The font ID. The empty string means to fallback to the global script font setting. */
+            fontId: string;
+            /** The generic font family for which the font should be set. */
+            genericFamily: `${GenericFamily}`;
+            /** The script code which the font should be set. If omitted, the font setting for the global script (script code "Zyyy") is set. */
+            script?: `${ScriptCode}` | undefined;
+        }
+
+        export interface FontChangedResult {
+            /** The generic font family for which the font setting has changed. */
+            genericFamily: `${GenericFamily}`;
+            /** The level of control this extension has over the setting. */
+            levelOfControl: `${LevelOfControl}`;
+            /** Optional. The script code for which the font setting has changed.  */
+            script?: `${ScriptCode}`;
+            /** The font ID. See the description in {@link getFont}. */
+            fontId: string;
+        }
+
+        export interface FontResult {
+            /** The level of control this extension has over the setting. */
+            levelOfControl: `${LevelOfControl}`;
+            /** The font ID. Rather than the literal font ID preference value, this may be the ID of the font that the system resolves the preference value to. So, `fontId` can differ from the font passed to {@link setFont}, if, for example, the font is not available on the system. The empty string signifies fallback to the global script font setting. */
+            fontId: string;
+        }
+
+        export interface FontSizeResult {
             /** The font size in pixels. */
             pixelSize: number;
-        }
-
-        export interface FontDetails {
-            /** The generic font family for the font. */
-            genericFamily:
-                | "cursive"
-                | "fantasy"
-                | "fixed"
-                | "sansserif"
-                | "serif"
-                | "standard";
-            /** Optional. The script for the font. If omitted, the global script font setting is affected.  */
-            script?: string | undefined;
-        }
-
-        export interface FullFontDetails {
-            /** The generic font family for which the font setting has changed. */
-            genericFamily: string;
             /** The level of control this extension has over the setting. */
-            levelOfControl: string;
-            /** Optional. The script code for which the font setting has changed.  */
-            script?: string | undefined;
-            /** The font ID. See the description in getFont. */
-            fontId: string;
-        }
-
-        export interface FontDetailsResult {
-            /** The level of control this extension has over the setting. */
-            levelOfControl: string;
-            /** The font ID. Rather than the literal font ID preference value, this may be the ID of the font that the system resolves the preference value to. So, fontId can differ from the font passed to setFont, if, for example, the font is not available on the system. The empty string signifies fallback to the global script font setting. */
-            fontId: string;
+            levelOfControl: `${LevelOfControl}`;
         }
 
         export interface FontSizeDetails {
             /** The font size in pixels. */
             pixelSize: number;
-            /** The level of control this extension has over the setting. */
-            levelOfControl: string;
         }
-
-        export interface SetFontSizeDetails {
-            /** The font size in pixels. */
-            pixelSize: number;
-        }
-
-        export interface SetFontDetails extends FontDetails {
-            /** The font ID. The empty string means to fallback to the global script font setting. */
-            fontId: string;
-        }
-
-        export interface DefaultFixedFontSizeChangedEvent
-            extends chrome.events.Event<(details: FontSizeDetails) => void>
-        {}
-
-        export interface DefaultFontSizeChangedEvent extends chrome.events.Event<(details: FontSizeDetails) => void> {}
-
-        export interface MinimumFontSizeChangedEvent extends chrome.events.Event<(details: FontSizeDetails) => void> {}
-
-        export interface FontChangedEvent extends chrome.events.Event<(details: FullFontDetails) => void> {}
 
         /**
          * Sets the default font size.
-         * @return The `setDefaultFontSize` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 96.
          */
-        export function setDefaultFontSize(details: DefaultFontSizeDetails): Promise<void>;
-        /**
-         * Sets the default font size.
-         */
-        export function setDefaultFontSize(details: DefaultFontSizeDetails, callback: () => void): void;
-        /**
-         * Gets the font for a given script and generic font family.
-         * @return The `getFont` method provides its result via callback or returned as a `Promise` (MV3 only).
-         */
-        export function getFont(details: FontDetails): Promise<FontDetailsResult>;
+        export function setDefaultFontSize(details: FontSizeDetails): Promise<void>;
+        export function setDefaultFontSize(details: FontSizeDetails, callback: () => void): void;
+
         /**
          * Gets the font for a given script and generic font family.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 96.
          */
-        export function getFont(details: FontDetails, callback: (details: FontDetailsResult) => void): void;
+        export function getFont(details: GetFontDetails): Promise<FontResult>;
+        export function getFont(details: GetFontDetails, callback: (details: FontResult) => void): void;
+
         /**
          * Gets the default font size.
          * @param details This parameter is currently unused.
-         * @return The `getDefaultFontSize` method provides its result via callback or returned as a `Promise` (MV3 only).
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 96.
          */
-        export function getDefaultFontSize(details?: unknown): Promise<FontSizeDetails>;
-        /**
-         * Gets the default font size.
-         * @param details This parameter is currently unused.
-         */
-        export function getDefaultFontSize(callback: (options: FontSizeDetails) => void): void;
-        export function getDefaultFontSize(details: unknown, callback: (options: FontSizeDetails) => void): void;
-        /**
-         * Gets the minimum font size.
-         * @param details This parameter is currently unused.
-         * @return The `getMinimumFontSize` method provides its result via callback or returned as a `Promise` (MV3 only).
-         */
-        export function getMinimumFontSize(details?: unknown): Promise<FontSizeDetails>;
+        export function getDefaultFontSize(details?: { [key: string]: unknown }): Promise<FontSizeResult>;
+        export function getDefaultFontSize(callback: (options: FontSizeResult) => void): void;
+        export function getDefaultFontSize(
+            details: { [key: string]: unknown } | undefined,
+            callback: (options: FontSizeResult) => void,
+        ): void;
+
         /**
          * Gets the minimum font size.
          * @param details This parameter is currently unused.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 96.
          */
-        export function getMinimumFontSize(callback: (options: FontSizeDetails) => void): void;
-        export function getMinimumFontSize(details: unknown, callback: (options: FontSizeDetails) => void): void;
+        export function getMinimumFontSize(details?: { [key: string]: unknown }): Promise<FontSizeResult>;
+        export function getMinimumFontSize(callback: (options: FontSizeResult) => void): void;
+        export function getMinimumFontSize(
+            details: { [key: string]: unknown } | undefined,
+            callback: (options: FontSizeResult) => void,
+        ): void;
+
         /**
          * Sets the minimum font size.
-         * @return The `setMinimumFontSize` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 96.
          */
-        export function setMinimumFontSize(details: SetFontSizeDetails): Promise<void>;
-        /**
-         * Sets the minimum font size.
-         */
-        export function setMinimumFontSize(details: SetFontSizeDetails, callback: () => void): void;
+        export function setMinimumFontSize(details: FontSizeDetails): Promise<void>;
+        export function setMinimumFontSize(details: FontSizeDetails, callback: () => void): void;
+
         /**
          * Gets the default size for fixed width fonts.
          * @param details This parameter is currently unused.
-         * @return The `getDefaultFixedFontSize` method provides its result via callback or returned as a `Promise` (MV3 only).
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 96.
          */
-        export function getDefaultFixedFontSize(details?: unknown): Promise<FontSizeDetails>;
-        /**
-         * Gets the default size for fixed width fonts.
-         * @param details This parameter is currently unused.
-         */
-        export function getDefaultFixedFontSize(callback: (details: FontSizeDetails) => void): void;
-        export function getDefaultFixedFontSize(details: unknown, callback: (details: FontSizeDetails) => void): void;
-        /**
-         * Clears the default font size set by this extension, if any.
-         * @param details This parameter is currently unused.
-         * @return The `clearDefaultFontSize` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
-         */
-        export function clearDefaultFontSize(details?: unknown): Promise<void>;
+        export function getDefaultFixedFontSize(details?: { [key: string]: unknown }): Promise<FontSizeResult>;
+        export function getDefaultFixedFontSize(callback: (details: FontSizeResult) => void): void;
+        export function getDefaultFixedFontSize(
+            details: { [key: string]: unknown } | undefined,
+            callback: (details: FontSizeResult) => void,
+        ): void;
+
         /**
          * Clears the default font size set by this extension, if any.
          * @param details This parameter is currently unused.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 96.
          */
+        export function clearDefaultFontSize(details?: { [key: string]: unknown }): Promise<void>;
         export function clearDefaultFontSize(callback: () => void): void;
-        export function clearDefaultFontSize(details: unknown, callback: () => void): void;
+        export function clearDefaultFontSize(
+            details: { [key: string]: unknown } | undefined,
+            callback: () => void,
+        ): void;
+
         /**
          * Sets the default size for fixed width fonts.
-         * @return The `setDefaultFixedFontSize` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 96.
          */
-        export function setDefaultFixedFontSize(details: SetFontSizeDetails): Promise<void>;
-        /**
-         * Sets the default size for fixed width fonts.
-         */
-        export function setDefaultFixedFontSize(details: SetFontSizeDetails, callback: () => void): void;
-        /**
-         * Clears the font set by this extension, if any.
-         * @return The `clearFont` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
-         */
-        export function clearFont(details: FontDetails): Promise<void>;
+        export function setDefaultFixedFontSize(details: FontSizeDetails): Promise<void>;
+        export function setDefaultFixedFontSize(details: FontSizeDetails, callback: () => void): void;
+
         /**
          * Clears the font set by this extension, if any.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 96.
          */
-        export function clearFont(details: FontDetails, callback: () => void): void;
+        export function clearFont(details: ClearFontDetails): Promise<void>;
+        export function clearFont(details: ClearFontDetails, callback: () => void): void;
+
         /**
          * Sets the font for a given script and generic font family.
-         * @return The `setFont` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 96.
          */
         export function setFont(details: SetFontDetails): Promise<void>;
-        /**
-         * Sets the font for a given script and generic font family.
-         */
         export function setFont(details: SetFontDetails, callback: () => void): void;
+
         /**
          * Clears the minimum font size set by this extension, if any.
          * @param details This parameter is currently unused.
-         * @return The `clearMinimumFontSize` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 96.
          */
-        export function clearMinimumFontSize(details?: unknown): Promise<void>;
-        /**
-         * Clears the minimum font size set by this extension, if any.
-         * @param details This parameter is currently unused.
-         */
+        export function clearMinimumFontSize(details?: { [key: string]: unknown }): Promise<void>;
         export function clearMinimumFontSize(callback: () => void): void;
-        export function clearMinimumFontSize(details: unknown, callback: () => void): void;
+        export function clearMinimumFontSize(
+            details: { [key: string]: unknown } | undefined,
+            callback: () => void,
+        ): void;
+
         /**
          * Gets a list of fonts on the system.
-         * @return The `getFontList` method provides its result via callback or returned as a `Promise` (MV3 only).
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 96.
          */
         export function getFontList(): Promise<FontName[]>;
-        /**
-         * Gets a list of fonts on the system.
-         */
         export function getFontList(callback: (results: FontName[]) => void): void;
+
         /**
          * Clears the default fixed font size set by this extension, if any.
          * @param details This parameter is currently unused.
-         * @return The `clearDefaultFixedFontSize` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 96.
          */
-        export function clearDefaultFixedFontSize(details: unknown): Promise<void>;
-        /**
-         * Clears the default fixed font size set by this extension, if any.
-         * @param details This parameter is currently unused.
-         */
-        export function clearDefaultFixedFontSize(details: unknown, callback: () => void): void;
+        export function clearDefaultFixedFontSize(details?: { [key: string]: unknown }): Promise<void>;
+        export function clearDefaultFixedFontSize(callback: () => void): void;
+        export function clearDefaultFixedFontSize(
+            details: { [key: string]: unknown } | undefined,
+            callback: () => void,
+        ): void;
 
         /** Fired when the default fixed font size setting changes. */
-        export var onDefaultFixedFontSizeChanged: DefaultFixedFontSizeChangedEvent;
+        export const onDefaultFixedFontSizeChanged: events.Event<(details: FontSizeResult) => void>;
+
         /** Fired when the default font size setting changes. */
-        export var onDefaultFontSizeChanged: DefaultFontSizeChangedEvent;
+        export const onDefaultFontSizeChanged: events.Event<(details: FontSizeResult) => void>;
+
         /** Fired when the minimum font size setting changes. */
-        export var onMinimumFontSizeChanged: MinimumFontSizeChangedEvent;
+        export const onMinimumFontSizeChanged: events.Event<(details: FontSizeResult) => void>;
+
         /** Fired when a font setting changes. */
-        export var onFontChanged: FontChangedEvent;
+        export const onFontChanged: events.Event<(details: FontChangedResult) => void>;
     }
 
     ////////////////////

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -4331,42 +4331,314 @@ async function testExtensionForPromise() {
     await chrome.extension.isAllowedIncognitoAccess();
 }
 
-// https://developer.chrome.com/docs/extensions/reference/fontSettings
+// https://developer.chrome.com/docs/extensions/reference/api/fontSettings
 function testFontSettings() {
-    chrome.fontSettings.setDefaultFontSize({ pixelSize: 1 }, () => {});
+    chrome.fontSettings.GenericFamily.CURSIVE === "cursive";
+    chrome.fontSettings.GenericFamily.FANTASY === "fantasy";
+    chrome.fontSettings.GenericFamily.FIXED === "fixed";
+    chrome.fontSettings.GenericFamily.MATH === "math";
+    chrome.fontSettings.GenericFamily.SANSSERIF === "sansserif";
+    chrome.fontSettings.GenericFamily.SERIF === "serif";
+    chrome.fontSettings.GenericFamily.STANDARD === "standard";
+
+    chrome.fontSettings.LevelOfControl.CONTROLLABLE_BY_THIS_EXTENSION === "controllable_by_this_extension";
+    chrome.fontSettings.LevelOfControl.CONTROLLED_BY_OTHER_EXTENSIONS === "controlled_by_other_extensions";
+    chrome.fontSettings.LevelOfControl.CONTROLLED_BY_THIS_EXTENSION === "controlled_by_this_extension";
+    chrome.fontSettings.LevelOfControl.NOT_CONTROLLABLE === "not_controllable";
+
+    chrome.fontSettings.ScriptCode.AFAK === "Afak";
+    chrome.fontSettings.ScriptCode.ARAB === "Arab";
+    chrome.fontSettings.ScriptCode.ARMI === "Armi";
+    chrome.fontSettings.ScriptCode.ARMN === "Armn";
+    chrome.fontSettings.ScriptCode.AVST === "Avst";
+    chrome.fontSettings.ScriptCode.BALI === "Bali";
+    chrome.fontSettings.ScriptCode.BAMU === "Bamu";
+    chrome.fontSettings.ScriptCode.BASS === "Bass";
+    chrome.fontSettings.ScriptCode.BATK === "Batk";
+    chrome.fontSettings.ScriptCode.BENG === "Beng";
+    chrome.fontSettings.ScriptCode.BLIS === "Blis";
+    chrome.fontSettings.ScriptCode.BOPO === "Bopo";
+    chrome.fontSettings.ScriptCode.BRAH === "Brah";
+    chrome.fontSettings.ScriptCode.BRAI === "Brai";
+    chrome.fontSettings.ScriptCode.BUGI === "Bugi";
+    chrome.fontSettings.ScriptCode.BUHD === "Buhd";
+    chrome.fontSettings.ScriptCode.CAKM === "Cakm";
+    chrome.fontSettings.ScriptCode.CANS === "Cans";
+    chrome.fontSettings.ScriptCode.CARI === "Cari";
+    chrome.fontSettings.ScriptCode.CHAM === "Cham";
+    chrome.fontSettings.ScriptCode.CHER === "Cher";
+    chrome.fontSettings.ScriptCode.CIRT === "Cirt";
+    chrome.fontSettings.ScriptCode.COPT === "Copt";
+    chrome.fontSettings.ScriptCode.CPRT === "Cprt";
+    chrome.fontSettings.ScriptCode.CYRL === "Cyrl";
+    chrome.fontSettings.ScriptCode.CYRS === "Cyrs";
+    chrome.fontSettings.ScriptCode.DEVA === "Deva";
+    chrome.fontSettings.ScriptCode.DSRT === "Dsrt";
+    chrome.fontSettings.ScriptCode.DUPL === "Dupl";
+    chrome.fontSettings.ScriptCode.EGYD === "Egyd";
+    chrome.fontSettings.ScriptCode.EGYH === "Egyh";
+    chrome.fontSettings.ScriptCode.EGYP === "Egyp";
+    chrome.fontSettings.ScriptCode.ELBA === "Elba";
+    chrome.fontSettings.ScriptCode.ETHI === "Ethi";
+    chrome.fontSettings.ScriptCode.GEOK === "Geok";
+    chrome.fontSettings.ScriptCode.GEOR === "Geor";
+    chrome.fontSettings.ScriptCode.GLAG === "Glag";
+    chrome.fontSettings.ScriptCode.GOTH === "Goth";
+    chrome.fontSettings.ScriptCode.GRAN === "Gran";
+    chrome.fontSettings.ScriptCode.GREK === "Grek";
+    chrome.fontSettings.ScriptCode.GUJR === "Gujr";
+    chrome.fontSettings.ScriptCode.GURU === "Guru";
+    chrome.fontSettings.ScriptCode.HANG === "Hang";
+    chrome.fontSettings.ScriptCode.HANI === "Hani";
+    chrome.fontSettings.ScriptCode.HANO === "Hano";
+    chrome.fontSettings.ScriptCode.HANS === "Hans";
+    chrome.fontSettings.ScriptCode.HANT === "Hant";
+    chrome.fontSettings.ScriptCode.HEBR === "Hebr";
+    chrome.fontSettings.ScriptCode.HLUW === "Hluw";
+    chrome.fontSettings.ScriptCode.HMNG === "Hmng";
+    chrome.fontSettings.ScriptCode.HUNG === "Hung";
+    chrome.fontSettings.ScriptCode.INDS === "Inds";
+    chrome.fontSettings.ScriptCode.ITAL === "Ital";
+    chrome.fontSettings.ScriptCode.JAVA === "Java";
+    chrome.fontSettings.ScriptCode.JPAN === "Jpan";
+    chrome.fontSettings.ScriptCode.JURC === "Jurc";
+    chrome.fontSettings.ScriptCode.KALI === "Kali";
+    chrome.fontSettings.ScriptCode.KHAR === "Khar";
+    chrome.fontSettings.ScriptCode.KHMR === "Khmr";
+    chrome.fontSettings.ScriptCode.KHOJ === "Khoj";
+    chrome.fontSettings.ScriptCode.KNDA === "Knda";
+    chrome.fontSettings.ScriptCode.KPEL === "Kpel";
+    chrome.fontSettings.ScriptCode.KTHI === "Kthi";
+    chrome.fontSettings.ScriptCode.LANA === "Lana";
+    chrome.fontSettings.ScriptCode.LAOO === "Laoo";
+    chrome.fontSettings.ScriptCode.LATF === "Latf";
+    chrome.fontSettings.ScriptCode.LATG === "Latg";
+    chrome.fontSettings.ScriptCode.LATN === "Latn";
+    chrome.fontSettings.ScriptCode.LEPC === "Lepc";
+    chrome.fontSettings.ScriptCode.LIMB === "Limb";
+    chrome.fontSettings.ScriptCode.LINA === "Lina";
+    chrome.fontSettings.ScriptCode.LINB === "Linb";
+    chrome.fontSettings.ScriptCode.LISU === "Lisu";
+    chrome.fontSettings.ScriptCode.LOMA === "Loma";
+    chrome.fontSettings.ScriptCode.LYCI === "Lyci";
+    chrome.fontSettings.ScriptCode.LYDI === "Lydi";
+    chrome.fontSettings.ScriptCode.MAND === "Mand";
+    chrome.fontSettings.ScriptCode.MANI === "Mani";
+    chrome.fontSettings.ScriptCode.MAYA === "Maya";
+    chrome.fontSettings.ScriptCode.MEND === "Mend";
+    chrome.fontSettings.ScriptCode.MERC === "Merc";
+    chrome.fontSettings.ScriptCode.MERO === "Mero";
+    chrome.fontSettings.ScriptCode.MLYM === "Mlym";
+    chrome.fontSettings.ScriptCode.MONG === "Mong";
+    chrome.fontSettings.ScriptCode.MOON === "Moon";
+    chrome.fontSettings.ScriptCode.MROO === "Mroo";
+    chrome.fontSettings.ScriptCode.MTEI === "Mtei";
+    chrome.fontSettings.ScriptCode.MYMR === "Mymr";
+    chrome.fontSettings.ScriptCode.NARB === "Narb";
+    chrome.fontSettings.ScriptCode.NBAT === "Nbat";
+    chrome.fontSettings.ScriptCode.NKGB === "Nkgb";
+    chrome.fontSettings.ScriptCode.NKOO === "Nkoo";
+    chrome.fontSettings.ScriptCode.NSHU === "Nshu";
+    chrome.fontSettings.ScriptCode.OGAM === "Ogam";
+    chrome.fontSettings.ScriptCode.OLCK === "Olck";
+    chrome.fontSettings.ScriptCode.ORKH === "Orkh";
+    chrome.fontSettings.ScriptCode.ORYA === "Orya";
+    chrome.fontSettings.ScriptCode.OSMA === "Osma";
+    chrome.fontSettings.ScriptCode.PALM === "Palm";
+    chrome.fontSettings.ScriptCode.PERM === "Perm";
+    chrome.fontSettings.ScriptCode.PHAG === "Phag";
+    chrome.fontSettings.ScriptCode.PHLI === "Phli";
+    chrome.fontSettings.ScriptCode.PHLP === "Phlp";
+    chrome.fontSettings.ScriptCode.PHLV === "Phlv";
+    chrome.fontSettings.ScriptCode.PHNX === "Phnx";
+    chrome.fontSettings.ScriptCode.PLRD === "Plrd";
+    chrome.fontSettings.ScriptCode.PRTI === "Prti";
+    chrome.fontSettings.ScriptCode.RJNG === "Rjng";
+    chrome.fontSettings.ScriptCode.RORO === "Roro";
+    chrome.fontSettings.ScriptCode.RUNR === "Runr";
+    chrome.fontSettings.ScriptCode.SAMR === "Samr";
+    chrome.fontSettings.ScriptCode.SARA === "Sara";
+    chrome.fontSettings.ScriptCode.SARB === "Sarb";
+    chrome.fontSettings.ScriptCode.SAUR === "Saur";
+    chrome.fontSettings.ScriptCode.SGNW === "Sgnw";
+    chrome.fontSettings.ScriptCode.SHAW === "Shaw";
+    chrome.fontSettings.ScriptCode.SHRD === "Shrd";
+    chrome.fontSettings.ScriptCode.SIND === "Sind";
+    chrome.fontSettings.ScriptCode.SINH === "Sinh";
+    chrome.fontSettings.ScriptCode.SORA === "Sora";
+    chrome.fontSettings.ScriptCode.SUND === "Sund";
+    chrome.fontSettings.ScriptCode.SYLO === "Sylo";
+    chrome.fontSettings.ScriptCode.SYRC === "Syrc";
+    chrome.fontSettings.ScriptCode.SYRE === "Syre";
+    chrome.fontSettings.ScriptCode.SYRJ === "Syrj";
+    chrome.fontSettings.ScriptCode.SYRN === "Syrn";
+    chrome.fontSettings.ScriptCode.TAGB === "Tagb";
+    chrome.fontSettings.ScriptCode.TAKR === "Takr";
+    chrome.fontSettings.ScriptCode.TALE === "Tale";
+    chrome.fontSettings.ScriptCode.TALU === "Talu";
+    chrome.fontSettings.ScriptCode.TAML === "Taml";
+    chrome.fontSettings.ScriptCode.TANG === "Tang";
+    chrome.fontSettings.ScriptCode.TAVT === "Tavt";
+    chrome.fontSettings.ScriptCode.TELU === "Telu";
+    chrome.fontSettings.ScriptCode.TENG === "Teng";
+    chrome.fontSettings.ScriptCode.TFNG === "Tfng";
+    chrome.fontSettings.ScriptCode.TGLG === "Tglg";
+    chrome.fontSettings.ScriptCode.THAA === "Thaa";
+    chrome.fontSettings.ScriptCode.THAI === "Thai";
+    chrome.fontSettings.ScriptCode.TIBT === "Tibt";
+    chrome.fontSettings.ScriptCode.TIRH === "Tirh";
+    chrome.fontSettings.ScriptCode.UGAR === "Ugar";
+    chrome.fontSettings.ScriptCode.VAII === "Vaii";
+    chrome.fontSettings.ScriptCode.VISP === "Visp";
+    chrome.fontSettings.ScriptCode.WARA === "Wara";
+    chrome.fontSettings.ScriptCode.WOLE === "Wole";
+    chrome.fontSettings.ScriptCode.XPEO === "Xpeo";
+    chrome.fontSettings.ScriptCode.XSUX === "Xsux";
+    chrome.fontSettings.ScriptCode.YIII === "Yiii";
+    chrome.fontSettings.ScriptCode.ZMTH === "Zmth";
+    chrome.fontSettings.ScriptCode.ZSYM === "Zsym";
+    chrome.fontSettings.ScriptCode.ZYYY === "Zyyy";
+
+    chrome.fontSettings.clearDefaultFixedFontSize(); // Expected Promise<void>
+    chrome.fontSettings.clearDefaultFontSize(() => void 0); // Expected void
+    chrome.fontSettings.clearDefaultFixedFontSize(); // Expected Promise<void>
+    chrome.fontSettings.clearDefaultFixedFontSize({}, () => void 0); // Expected void
+    // @ts-expect-error
+    chrome.fontSettings.clearDefaultFixedFontSize({}, () => {}).then(() => {});
+
+    chrome.fontSettings.clearDefaultFontSize(); // Expected Promise<void>
+    chrome.fontSettings.clearDefaultFontSize(() => void 0); // Expected void
+    chrome.fontSettings.clearDefaultFontSize({}); // Expected Promise<void>
+    chrome.fontSettings.clearDefaultFontSize({}, () => void 0); // Expected void
+    // @ts-expect-error
+    chrome.fontSettings.clearDefaultFontSize({}, () => {}).then(() => {});
+
+    const clearFontDetails: chrome.fontSettings.ClearFontDetails = {
+        genericFamily: "standard",
+        script: "Afak",
+    };
+
+    chrome.fontSettings.clearFont(clearFontDetails); // Expected Promise<void>
+    chrome.fontSettings.clearFont(clearFontDetails, () => void 0); // Expected void
+    // @ts-expect-error
+    chrome.fontSettings.clearFont(clearFontDetails, () => {}).then(() => {});
+
+    chrome.fontSettings.clearMinimumFontSize(); // Expected Promise<void>
+    chrome.fontSettings.clearMinimumFontSize(() => void 0); // Expected void
+    chrome.fontSettings.clearMinimumFontSize({}); // Expected Promise<void>
+    chrome.fontSettings.clearMinimumFontSize({}, () => void 0); // Expected void
+    // @ts-expect-error
+    chrome.fontSettings.clearMinimumFontSize(() => {}).then(() => {});
+
+    chrome.fontSettings.getDefaultFixedFontSize(); // Expected Promise<FontSizeResult>
+    chrome.fontSettings.getDefaultFixedFontSize((details) => { // Expected void
+        details.pixelSize; // Expected number
+        details.levelOfControl; // Expected LevelOfControl
+    });
+    chrome.fontSettings.getDefaultFixedFontSize({}); // Expected Promise<FontSizeResult>
+    chrome.fontSettings.getDefaultFixedFontSize({}, (details) => { // Expected void
+        details.pixelSize; // Expected number
+        details.levelOfControl; // Expected LevelOfControl
+    });
+    // @ts-expect-error
+    chrome.fontSettings.getDefaultFixedFontSize(() => {}).then(() => {});
+
+    chrome.fontSettings.getDefaultFontSize(); // Expected Promise<FontSizeResult>
+    chrome.fontSettings.getDefaultFontSize((details) => { // Expected void
+        details.pixelSize; // Expected number
+        details.levelOfControl; // Expected LevelOfControl
+    });
+    chrome.fontSettings.getDefaultFontSize({}); // Expected Promise<FontSizeResult>
+    chrome.fontSettings.getDefaultFontSize({}, (details) => { // Expected void
+        details.pixelSize; // Expected number
+        details.levelOfControl; // Expected LevelOfControl
+    });
+    // @ts-expect-error
+    chrome.fontSettings.getDefaultFontSize({}, () => {}).then(() => {});
+
+    const getFontDetails: chrome.fontSettings.GetFontDetails = {
+        genericFamily: "standard",
+        script: "Afak",
+    };
+
+    chrome.fontSettings.getFont(getFontDetails); // Expected Promise<GetFontResult>
+    chrome.fontSettings.getFont(getFontDetails, (details) => { // Expected void
+        details.fontId; // Expected string
+        details.levelOfControl; // Expected LevelOfControl
+    });
     // @ts-expect-error
     chrome.fontSettings.getFont({}, (details) => {});
-    // @ts-expect-error
-    chrome.fontSettings.getFont({ genericFamily: "" }, (details) => {});
-    chrome.fontSettings.getFont({ genericFamily: "cursive" }, (details) => {});
-    chrome.fontSettings.getDefaultFontSize({}, (options) => {});
-    chrome.fontSettings.getMinimumFontSize({}, (options) => {});
-    chrome.fontSettings.setMinimumFontSize({ pixelSize: 1 }, () => {});
-    chrome.fontSettings.getDefaultFixedFontSize({}, (details) => {});
-    chrome.fontSettings.clearDefaultFontSize({}, () => {});
-    chrome.fontSettings.setDefaultFixedFontSize({ pixelSize: 1 }, () => {});
-    chrome.fontSettings.clearFont({ genericFamily: "cursive" }, () => {});
-    chrome.fontSettings.setFont({ genericFamily: "cursive", fontId: "" }, () => {});
-    chrome.fontSettings.clearMinimumFontSize({}, () => {});
-    chrome.fontSettings.getFontList((results) => {});
-    chrome.fontSettings.clearDefaultFixedFontSize({}, () => {});
-}
 
-// https://developer.chrome.com/docs/extensions/reference/fontSettings
-async function testFontSettingsForPromise() {
-    await chrome.fontSettings.setDefaultFontSize({ pixelSize: 1 });
-    await chrome.fontSettings.getFont({ genericFamily: "cursive" });
-    await chrome.fontSettings.getDefaultFontSize({});
-    await chrome.fontSettings.getMinimumFontSize({});
-    await chrome.fontSettings.setMinimumFontSize({ pixelSize: 1 });
-    await chrome.fontSettings.getDefaultFixedFontSize({});
-    await chrome.fontSettings.clearDefaultFontSize({});
-    await chrome.fontSettings.setDefaultFixedFontSize({ pixelSize: 1 });
-    await chrome.fontSettings.clearFont({ genericFamily: "cursive" });
-    await chrome.fontSettings.setFont({ genericFamily: "cursive", fontId: "" });
-    await chrome.fontSettings.clearMinimumFontSize({});
-    await chrome.fontSettings.getFontList();
-    await chrome.fontSettings.clearDefaultFixedFontSize({});
+    chrome.fontSettings.getFontList(); // Expected Promise<FontName[]>
+    chrome.fontSettings.getFontList(([result]) => { // Expected void
+        result.fontId; // Expected string
+        result.displayName; // Expected string
+    });
+
+    chrome.fontSettings.getMinimumFontSize(); // Expected Promise<FontSizeResult>
+    chrome.fontSettings.getMinimumFontSize((details) => { // Expected void
+        details.pixelSize; // Expected number
+        details.levelOfControl; // Expected LevelOfControl
+    });
+    chrome.fontSettings.getMinimumFontSize({}); // Expected Promise<FontSizeResult>
+    chrome.fontSettings.getMinimumFontSize({}, (details) => { // Expected void
+        details.pixelSize; // Expected number
+        details.levelOfControl; // Expected LevelOfControl
+    });
+    // @ts-expect-error
+    chrome.fontSettings.getMinimumFontSize({}, () => {}).then(() => {});
+
+    const setFontSizeDetails: chrome.fontSettings.FontSizeDetails = {
+        pixelSize: 12,
+    };
+
+    chrome.fontSettings.setDefaultFixedFontSize(setFontSizeDetails); // Expected Promise<void>
+    chrome.fontSettings.setDefaultFixedFontSize(setFontSizeDetails, () => void 0); // Expected void
+    // @ts-expect-error
+    chrome.fontSettings.setDefaultFixedFontSize(() => {}).then(() => {});
+
+    chrome.fontSettings.setDefaultFontSize(setFontSizeDetails); // Expected Promise<void>
+    chrome.fontSettings.setDefaultFontSize(setFontSizeDetails, () => void 0); // Expected void
+    // @ts-expect-error
+    chrome.fontSettings.setDefaultFontSize(() => {}).then(() => {});
+
+    const setFontDetails: chrome.fontSettings.SetFontDetails = {
+        genericFamily: "standard",
+        script: "Afak",
+        fontId: "fontId",
+    };
+
+    chrome.fontSettings.setFont(setFontDetails); // Expected Promise<void>
+    chrome.fontSettings.setFont(setFontDetails, () => void 0); // Expected void
+    // @ts-expect-error
+    chrome.fontSettings.setFont(() => {}).then(() => {});
+
+    chrome.fontSettings.setMinimumFontSize(setFontSizeDetails); // Expected Promise<void>
+    chrome.fontSettings.setMinimumFontSize(setFontSizeDetails, () => void 0); // Expected void
+    // @ts-expect-error
+    chrome.fontSettings.setMinimumFontSize(() => {}).then(() => {});
+
+    checkChromeEvent(chrome.fontSettings.onDefaultFixedFontSizeChanged, (details) => {
+        details.pixelSize; // Expected number
+        details.levelOfControl; // Expected LevelOfControl
+    });
+
+    checkChromeEvent(chrome.fontSettings.onDefaultFontSizeChanged, (details) => {
+        details.pixelSize; // Expected number
+        details.levelOfControl; // Expected LevelOfControl
+    });
+
+    checkChromeEvent(chrome.fontSettings.onFontChanged, (details) => {
+        details.fontId; // Expected string
+        details.genericFamily; // Expected GenericFamily
+        details.levelOfControl; // Expected LevelOfControl
+        details.script; // Expected ScriptCode | undefined
+    });
+
+    checkChromeEvent(chrome.fontSettings.onMinimumFontSizeChanged, (details) => {
+        details.pixelSize; // Expected number
+        details.levelOfControl; // Expected LevelOfControl
+    });
 }
 
 // https://developer.chrome.com/docs/extensions/reference/api/gcm


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/mv2/reference/fontSettings
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes:
- replace all `details` with type `unknow` by `{ [key: string]: unknown }`
  <img width="1186" height="67" alt="image" src="https://github.com/user-attachments/assets/bd598f0e-8164-49e8-9e2c-cb84afa3d565" />
- update `clearDefaultFixedFontSize`, param `details` is optional
- rename <ins>unofficial</ins> types to avoid ambiguity:
  - `FontDetails` -> `GetFontDetails` or `ClearFontDetails` (no same JSDoc)
  - `FontDetailsResult` -> `FontResult`
  - `SetFontSizeDetails` - >`FontSizeDetails`
  - `DefaultFontSizeDetails` -> `FontSizeDetails`
  - `FontSizeDetails` -> `FontSizeResult`
  - `FullFontDetails` -> `FontChangedResult`
 
Runtime:
<img width="707" height="810" alt="image" src="https://github.com/user-attachments/assets/7c465ae5-a5c3-4fea-a9cd-fb9f3f6c1589" />
