### PR TITLE
[chrome] update i18n namespace

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -5828,58 +5828,56 @@ declare namespace chrome {
      * Manifest: "default_locale"
      */
     export namespace i18n {
-        /** Holds detected ISO language code and its percentage in the input string */
         export interface DetectedLanguage {
-            /** An ISO language code such as 'en' or 'fr'.
-             * For a complete list of languages supported by this method, see  [kLanguageInfoTable]{@link https://src.chromium.org/viewvc/chrome/trunk/src/third_party/cld/languages/internal/languages.cc}.
-             * For an unknown language, 'und' will be returned, which means that [percentage] of the text is unknown to CLD */
             language: string;
-
             /** The percentage of the detected language */
             percentage: number;
         }
 
-        /** Holds detected language reliability and array of DetectedLanguage */
+        /** Holds detected language reliability and array of {@link DetectedLanguage} */
         export interface LanguageDetectionResult {
             /** CLD detected language reliability */
             isReliable: boolean;
-
             /** Array of detectedLanguage */
             languages: DetectedLanguage[];
         }
 
+        /** @since Chrome 79 */
+        export interface GetMessageOptions {
+            /** Escape `<` in translation to `&lt;`. This applies only to the message itself, not to the placeholders. Developers might want to use this if the translation is used in an HTML context. Closure Templates used with Closure Compiler generate this automatically. */
+            escapeLt?: boolean | undefined;
+        }
+
         /**
-         * Gets the accept-languages of the browser. This is different from the locale used by the browser; to get the locale, use i18n.getUILanguage.
-         * @return The `getAcceptLanguages` method provides its result via callback or returned as a `Promise` (MV3 only).
-         * @since MV3
+         * Gets the accept-languages of the browser. This is different from the locale used by the browser; to get the locale, use {@link i18n.getUILanguage}.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 99.
          */
         export function getAcceptLanguages(): Promise<string[]>;
-        /**
-         * Gets the accept-languages of the browser. This is different from the locale used by the browser; to get the locale, use i18n.getUILanguage.
-         * Parameter languages: Array of the accept languages of the browser, such as en-US,en,zh-CN
-         */
         export function getAcceptLanguages(callback: (languages: string[]) => void): void;
+
         /**
-         * Gets the localized string for the specified message. If the message is missing, this method returns an empty string (''). If the format of the getMessage() call is wrong — for example, messageName is not a string or the substitutions array has more than 9 elements — this method returns undefined.
-         * @param messageName The name of the message, as specified in the messages.json file.
-         * @param substitutions Optional. Up to 9 substitution strings, if the message requires any.
+         * Gets the localized string for the specified message. If the message is missing, this method returns an empty string (''). If the format of the `getMessage()` call is wrong — for example, messageName is not a string or the substitutions array has more than 9 elements — this method returns `undefined`.
+         * @param messageName The name of the message, as specified in the `messages.json` file.
+         * @param substitutions Up to 9 substitution strings, if the message requires any.
          */
-        export function getMessage(messageName: string, substitutions?: string | string[]): string;
-        /**
-         * Gets the browser UI language of the browser. This is different from i18n.getAcceptLanguages which returns the preferred user languages.
-         * @since Chrome 35
-         */
+        export function getMessage(messageName: string, substitutions?: string | Array<string | number>): string;
+        export function getMessage(
+            messageName: string,
+            substitutions: string | Array<string | number> | undefined,
+            options?: GetMessageOptions,
+        ): string;
+
+        /** Gets the browser UI language of the browser. This is different from {@link i18n.getAcceptLanguages} which returns the preferred user languages. */
         export function getUILanguage(): string;
 
         /** Detects the language of the provided text using CLD.
          * @param text User input string to be translated.
-         * @return The `detectLanguage` method provides its result via callback or returned as a `Promise` (MV3 only).
-         * @since MV3
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 99.
+         * @since Chrome 47
          */
         export function detectLanguage(text: string): Promise<LanguageDetectionResult>;
-        /** Detects the language of the provided text using CLD.
-         * @param text User input string to be translated.
-         */
         export function detectLanguage(text: string, callback: (result: LanguageDetectionResult) => void): void;
     }
 

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -4014,18 +4014,39 @@ async function testCommands() {
     });
 }
 
-// https://developer.chrome.com/docs/extensions/reference/i18n
+// https://developer.chrome.com/docs/extensions/reference/api/i18n
 function testI18n() {
-    chrome.i18n.getAcceptLanguages((languages) => {});
-    chrome.i18n.getMessage("dummy-id", "Hello World!");
-    chrome.i18n.getUILanguage();
-    chrome.i18n.detectLanguage("dummy-id", (result) => {});
-}
+    const text = "text";
+    chrome.i18n.detectLanguage(text); // ExpectType Promise<DetectLanguageResult>
+    chrome.i18n.detectLanguage(text, (result) => { // $ExpectType void
+        result.isReliable; // $ExpectType boolean
+        result.languages[0].language; // $ExpectType string
+        result.languages[0].percentage; // $ExpectType number
+    });
+    // @ts-expect-error
+    chrome.i18n.detectLanguage(text, () => {}).then(() => {});
 
-// https://developer.chrome.com/docs/extensions/reference/i18n
-async function testI18nForPromise() {
-    await chrome.i18n.getAcceptLanguages();
-    await chrome.i18n.detectLanguage("dummy-id");
+    chrome.i18n.getAcceptLanguages(); // $ExpectType Promise<string[]>
+    chrome.i18n.getAcceptLanguages(([language]) => {
+        language; // $ExpectType string
+    });
+    // @ts-expect-error
+    chrome.i18n.getAcceptLanguages(() => {}).then(() => {});
+
+    const messageName = "messageName";
+    const substitutions = ["hello", 10];
+
+    const options: chrome.i18n.GetMessageOptions = {
+        escapeLt: true,
+    };
+
+    chrome.i18n.getMessage(messageName); // $ExpectType string
+    chrome.i18n.getMessage(messageName, substitutions); // $ExpectType string
+    chrome.i18n.getMessage(messageName, substitutions, options); // $ExpectType string
+    // @ts-expect-error
+    chrome.i18n.getMessage(messageName, 10);
+
+    chrome.i18n.getUILanguage(); // $ExpectType string
 }
 
 async function testPageCapture() {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/i18n
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes:
- update `getMessage()`:
  - add `options` param (required `substitutions` param)
    <img width="548" height="150" alt="image" src="https://github.com/user-attachments/assets/1ec1db30-b6a5-44f7-99cb-7015b59330a0" />  
  - `substitutions` param can accept number (only in a array)
    <img width="438" height="197" alt="image" src="https://github.com/user-attachments/assets/6eb95d11-8266-4377-a29c-8ae249918db0" />  
- update jsdocs
- add tests