### PR TITLE
pin leaflet typings to current major.minor version to unblock the release of new leaflet typings

### DIFF
--- a/types/dynmap/package.json
+++ b/types/dynmap/package.json
@@ -10,7 +10,7 @@
     "dependencies": {
         "@types/jquery": "*",
         "@types/jquery-mousewheel": "*",
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/dynmap": "workspace:."

--- a/types/esri-leaflet-geocoder/package.json
+++ b/types/esri-leaflet-geocoder/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/esri-leaflet": "*",
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/esri-leaflet-geocoder": "workspace:."

--- a/types/esri-leaflet/package.json
+++ b/types/esri-leaflet/package.json
@@ -6,7 +6,7 @@
         "http://esri.github.io/esri-leaflet"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/esri-leaflet": "workspace:."

--- a/types/esri-leaflet/v2/package.json
+++ b/types/esri-leaflet/v2/package.json
@@ -6,7 +6,7 @@
         "http://esri.github.io/esri-leaflet"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/esri-leaflet": "workspace:."

--- a/types/iitc/package.json
+++ b/types/iitc/package.json
@@ -8,7 +8,7 @@
     "dependencies": {
         "@types/jquery": "*",
         "@types/jqueryui": "*",
-        "@types/leaflet": "*",
+        "@types/leaflet": "^1.9",
         "@types/spectrum": "*"
     },
     "devDependencies": {

--- a/types/leaflet-areaselect/package.json
+++ b/types/leaflet-areaselect/package.json
@@ -8,7 +8,7 @@
         "https://github.com/heyman/leaflet-areaselect"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet-areaselect": "workspace:."

--- a/types/leaflet-boundary-canvas/package.json
+++ b/types/leaflet-boundary-canvas/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/geojson": "*",
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet-boundary-canvas": "workspace:."

--- a/types/leaflet-contextmenu/package.json
+++ b/types/leaflet-contextmenu/package.json
@@ -6,7 +6,7 @@
         "https://github.com/aratcliffe/Leaflet.contextmenu"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet-contextmenu": "workspace:."

--- a/types/leaflet-curve/package.json
+++ b/types/leaflet-curve/package.json
@@ -6,7 +6,7 @@
         "https://github.com/onikiienko/Leaflet.curve"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet-curve": "workspace:."

--- a/types/leaflet-deepzoom/package.json
+++ b/types/leaflet-deepzoom/package.json
@@ -6,7 +6,7 @@
         "https://github.com/alfarisi/leaflet-deepzoom/"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet-deepzoom": "workspace:."

--- a/types/leaflet-draw/package.json
+++ b/types/leaflet-draw/package.json
@@ -6,7 +6,7 @@
         "https://github.com/Leaflet/Leaflet.draw"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet-draw": "workspace:."

--- a/types/leaflet-editable/package.json
+++ b/types/leaflet-editable/package.json
@@ -6,7 +6,7 @@
         "https://github.com/leaflet/leaflet.editable"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet-editable": "workspace:."

--- a/types/leaflet-freedraw/package.json
+++ b/types/leaflet-freedraw/package.json
@@ -6,7 +6,7 @@
         "https://github.com/Wildhoney/Leaflet.FreeDraw"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet-freedraw": "workspace:."

--- a/types/leaflet-freehandshapes/package.json
+++ b/types/leaflet-freehandshapes/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/geojson": "*",
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet-freehandshapes": "workspace:."

--- a/types/leaflet-fullscreen/package.json
+++ b/types/leaflet-fullscreen/package.json
@@ -6,7 +6,7 @@
         "https://github.com/Leaflet/Leaflet.fullscreen"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet-fullscreen": "workspace:."

--- a/types/leaflet-gpx/package.json
+++ b/types/leaflet-gpx/package.json
@@ -6,7 +6,7 @@
         "https://github.com/mpetazzoni/leaflet-gpx"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet-gpx": "workspace:."

--- a/types/leaflet-groupedlayercontrol/package.json
+++ b/types/leaflet-groupedlayercontrol/package.json
@@ -6,7 +6,7 @@
         "https://github.com/ismyrnow/leaflet-groupedlayercontrol"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet-groupedlayercontrol": "workspace:."

--- a/types/leaflet-imageoverlay-rotated/package.json
+++ b/types/leaflet-imageoverlay-rotated/package.json
@@ -6,7 +6,7 @@
         "https://github.com/IvanSanchez/Leaflet.ImageOverlay.Rotated"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet-imageoverlay-rotated": "workspace:."

--- a/types/leaflet-loading/package.json
+++ b/types/leaflet-loading/package.json
@@ -6,7 +6,7 @@
         "https://github.com/ebrelsford/Leaflet.loading"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet-loading": "workspace:."

--- a/types/leaflet-mouse-position/package.json
+++ b/types/leaflet-mouse-position/package.json
@@ -6,7 +6,7 @@
         "https://github.com/danwild/Leaflet.MousePosition"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet-mouse-position": "workspace:."

--- a/types/leaflet-pixi-overlay/package.json
+++ b/types/leaflet-pixi-overlay/package.json
@@ -9,7 +9,7 @@
         "pixi.js": "4.6 - 7"
     },
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet-pixi-overlay": "workspace:."

--- a/types/leaflet-polylinedecorator/package.json
+++ b/types/leaflet-polylinedecorator/package.json
@@ -6,7 +6,7 @@
         "https://github.com/bbecquet/Leaflet.PolylineDecorator#readme"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet-polylinedecorator": "workspace:."

--- a/types/leaflet-providers/package.json
+++ b/types/leaflet-providers/package.json
@@ -6,7 +6,7 @@
         "https://github.com/leaflet-extras/leaflet-providers#readme"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet-providers": "workspace:."

--- a/types/leaflet-rastercoords/package.json
+++ b/types/leaflet-rastercoords/package.json
@@ -6,7 +6,7 @@
         "https://github.com/commenthol/leaflet-rastercoords"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet-rastercoords": "workspace:."

--- a/types/leaflet-responsive-popup/package.json
+++ b/types/leaflet-responsive-popup/package.json
@@ -6,7 +6,7 @@
         "https://github.com/yafred/leaflet-responsive-popup"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet-responsive-popup": "workspace:."

--- a/types/leaflet-rotate/package.json
+++ b/types/leaflet-rotate/package.json
@@ -6,7 +6,7 @@
         "https://github.com//Raruto/leaflet-rotate"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet-rotate": "workspace:."

--- a/types/leaflet-rotatedmarker/package.json
+++ b/types/leaflet-rotatedmarker/package.json
@@ -6,7 +6,7 @@
         "https://github.com/bbecquet/Leaflet.RotatedMarker"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet-rotatedmarker": "workspace:."

--- a/types/leaflet-routing-machine/package.json
+++ b/types/leaflet-routing-machine/package.json
@@ -6,7 +6,7 @@
         "https://github.com/perliedman/leaflet-routing-machine#readme"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet-routing-machine": "workspace:."

--- a/types/leaflet-side-by-side/package.json
+++ b/types/leaflet-side-by-side/package.json
@@ -6,7 +6,7 @@
         "https://github.com/digidem/leaflet-side-by-side"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet-side-by-side": "workspace:."

--- a/types/leaflet-textpath/package.json
+++ b/types/leaflet-textpath/package.json
@@ -6,7 +6,7 @@
         "https://github.com/makinacorpus/Leaflet.TextPath"
     ],
     "dependencies": {
-        "@types/leaflet": "*",
+        "@types/leaflet": "^1.9",
         "@types/react": "*"
     },
     "devDependencies": {

--- a/types/leaflet.awesome-markers/package.json
+++ b/types/leaflet.awesome-markers/package.json
@@ -6,7 +6,7 @@
         "https://github.com/sigma-geosistemas/leaflet.awesome-markers"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet.awesome-markers": "workspace:."

--- a/types/leaflet.chinatmsproviders/package.json
+++ b/types/leaflet.chinatmsproviders/package.json
@@ -6,7 +6,7 @@
         "https://github.com/htoooth/Leaflet.ChineseTmsProviders"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet.chinatmsproviders": "workspace:."

--- a/types/leaflet.featuregroup.subgroup/package.json
+++ b/types/leaflet.featuregroup.subgroup/package.json
@@ -6,7 +6,7 @@
         "https://github.com/ghybs/Leaflet.FeatureGroup.SubGroup"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet.featuregroup.subgroup": "workspace:."

--- a/types/leaflet.fullscreen/package.json
+++ b/types/leaflet.fullscreen/package.json
@@ -6,7 +6,7 @@
         "https://github.com/brunob/leaflet.fullscreen"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet.fullscreen": "workspace:."

--- a/types/leaflet.gridlayer.googlemutant/package.json
+++ b/types/leaflet.gridlayer.googlemutant/package.json
@@ -6,7 +6,7 @@
         "https://gitlab.com/IvanSanchez/Leaflet.GridLayer.GoogleMutant#README"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet.gridlayer.googlemutant": "workspace:."

--- a/types/leaflet.heat/package.json
+++ b/types/leaflet.heat/package.json
@@ -6,7 +6,7 @@
         "https://github.com/Leaflet/Leaflet.heat"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet.heat": "workspace:."

--- a/types/leaflet.icon.glyph/package.json
+++ b/types/leaflet.icon.glyph/package.json
@@ -6,7 +6,7 @@
         "https://github.com/Leaflet/Leaflet.Icon.Glyph"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet.icon.glyph": "workspace:."

--- a/types/leaflet.locatecontrol/package.json
+++ b/types/leaflet.locatecontrol/package.json
@@ -6,7 +6,7 @@
         "https://github.com/domoritz/leaflet-locatecontrol"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet.locatecontrol": "workspace:."

--- a/types/leaflet.markercluster.layersupport/package.json
+++ b/types/leaflet.markercluster.layersupport/package.json
@@ -6,7 +6,7 @@
         "https://github.com/ghybs/Leaflet.MarkerCluster.LayerSupport"
     ],
     "dependencies": {
-        "@types/leaflet": "*",
+        "@types/leaflet": "^1.9",
         "@types/leaflet.markercluster": "*"
     },
     "devDependencies": {

--- a/types/leaflet.markercluster/package.json
+++ b/types/leaflet.markercluster/package.json
@@ -6,7 +6,7 @@
         "https://github.com/Leaflet/Leaflet.markercluster"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet.markercluster": "workspace:."

--- a/types/leaflet.pancontrol/package.json
+++ b/types/leaflet.pancontrol/package.json
@@ -6,7 +6,7 @@
         "https://github.com/kartena/Leaflet.Pancontrol"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet.pancontrol": "workspace:."

--- a/types/leaflet.pattern/package.json
+++ b/types/leaflet.pattern/package.json
@@ -6,7 +6,7 @@
         "https://github.com/pixelizedPeanut/Leaflet.pattern#leafletpattern"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet.pattern": "workspace:."

--- a/types/leaflet.pm/package.json
+++ b/types/leaflet.pm/package.json
@@ -7,7 +7,7 @@
         "https://leafletpm.now.sh"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet.pm": "workspace:."

--- a/types/leaflet.polylinemeasure/package.json
+++ b/types/leaflet.polylinemeasure/package.json
@@ -6,7 +6,7 @@
         "https://github.com/ppete2/Leaflet.PolylineMeasure#readme"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet.polylinemeasure": "workspace:."

--- a/types/leaflet.sync/package.json
+++ b/types/leaflet.sync/package.json
@@ -6,7 +6,7 @@
         "https://github.com/jieter/Leaflet.Sync"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet.sync": "workspace:."

--- a/types/leaflet.utm/package.json
+++ b/types/leaflet.utm/package.json
@@ -6,7 +6,7 @@
         "https://github.com/jjimenezshaw/Leaflet.UTM"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet.utm": "workspace:."

--- a/types/leaflet.vectorgrid/package.json
+++ b/types/leaflet.vectorgrid/package.json
@@ -8,7 +8,7 @@
     "dependencies": {
         "@types/geojson": "*",
         "@types/geojson-vt": "*",
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet.vectorgrid": "workspace:."

--- a/types/leaflet.wms/package.json
+++ b/types/leaflet.wms/package.json
@@ -6,7 +6,7 @@
         "https://github.com/heigeo/leaflet.wms"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/leaflet.wms": "workspace:."

--- a/types/mapbox-gl-leaflet/package.json
+++ b/types/mapbox-gl-leaflet/package.json
@@ -6,7 +6,7 @@
         "https://github.com/mapbox/mapbox-gl-leaflet"
     ],
     "dependencies": {
-        "@types/leaflet": "*"
+        "@types/leaflet": "^1.9"
     },
     "devDependencies": {
         "@types/mapbox-gl-leaflet": "workspace:."

--- a/types/proj4leaflet/package.json
+++ b/types/proj4leaflet/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/geojson": "*",
-        "@types/leaflet": "*",
+        "@types/leaflet": "^1.9",
         "proj4": "^2.19.0"
     },
     "devDependencies": {

--- a/types/svelte-leafletjs/package.json
+++ b/types/svelte-leafletjs/package.json
@@ -6,7 +6,7 @@
         "https://github.com/ngyewch/svelte-leaflet"
     ],
     "dependencies": {
-        "@types/leaflet": "*",
+        "@types/leaflet": "^1.9",
         "svelte": "^3.48.0"
     },
     "devDependencies": {


### PR DESCRIPTION
## TL;DR

[Leaflet](https://leafletjs.com) needs new typings for an upcoming major release. Other typings that depend on it must be pinned to the existing (1.9) version to unblock the CI tests.

## Background

[Leaflet](https://leafletjs.com) is planning to release [a new version](https://leafletjs.com/2025/05/18/leaflet-2.0.0-alpha.html). This release includes breaking changes and following [Semantic Versioning](https://semver.org/), this means a major version increment.

Consequently, new typings will be needed and some great people are [already working](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/73485) on it.

## Problem Statement

Several (50+) of other typings have a dependency to `"@types/leaflet"`. Unfortunately, this dependency is expressed without considering that major versions may change in the future and these typings simply use `"@types/leaflet": "*"` in their `package.json`. When we release new (incompatible) typings the CI tests will for these "child" typings will immediately use these new typings during CI tests. This will fail unless all of them adapt to the new typings, making it really difficult to ever merge new leaflet typings. See [this discussion](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/73485#issuecomment-3210859277) for details.

## Proposed Solution

1. Leaflet typings will conserve the existing typings as [described here](https://github.com/DefinitelyTyped/DefinitelyTyped?tab=readme-ov-file#if-a-library-is-updated-to-a-new-major-version-with-breaking-changes-how-should-i-update-its-type-declaration-package). Existing "child" typings will still work with 1.9 typings. 
2. This PR pins the leaflet typings for all child-typings to `"@types/leaflet": "^1.9"`. This avoids using the new (incompatible) typings during CI tests and will thus mitigate the blocking situation.

I thank you all for your cooperation and hope this can be resolved quickly.