### PR TITLE
fix(react-dom): add `formState` option to SSR APIs

### DIFF
--- a/types/react-dom/server.d.ts
+++ b/types/react-dom/server.d.ts
@@ -22,7 +22,7 @@ declare global {
 }
 
 import { ReactNode } from "react";
-import { ErrorInfo } from "./client";
+import { ErrorInfo, ReactFormState } from "./client";
 
 export type BootstrapScriptDescriptor = {
     src: string;
@@ -42,6 +42,7 @@ export interface RenderToPipeableStreamOptions {
     onShellError?: (error: unknown) => void;
     onAllReady?: () => void;
     onError?: (error: unknown, errorInfo: ErrorInfo) => string | void;
+    formState?: ReactFormState | null;
 }
 
 export interface PipeableStream {
@@ -93,6 +94,7 @@ export interface RenderToReadableStreamOptions {
     progressiveChunkSize?: number;
     signal?: AbortSignal;
     onError?: (error: unknown, errorInfo: ErrorInfo) => string | void;
+    formState?: ReactFormState | null;
 }
 
 export interface ReactDOMServerReadableStream extends ReadableStream {

--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -222,7 +222,7 @@ function pipeableStreamDocumentedExample() {
             didError = true;
             console.error(err);
         },
-        formState: [1, "", "", 0] as unknown as ReactDOMClient.ReactFormState
+        formState: [1, "", "", 0] as unknown as ReactDOMClient.ReactFormState,
     });
 
     setTimeout(() => {
@@ -269,7 +269,7 @@ function pipeableStreamDocumentedStringExample() {
             didError = true;
             console.error(err);
         },
-        formState: [1, "", "", 0] as unknown as ReactDOMClient.ReactFormState
+        formState: [1, "", "", 0] as unknown as ReactDOMClient.ReactFormState,
     });
 
     setTimeout(() => {

--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -222,6 +222,7 @@ function pipeableStreamDocumentedExample() {
             didError = true;
             console.error(err);
         },
+        formState: [1, "", "", 0] as unknown as ReactDOMClient.ReactFormState
     });
 
     setTimeout(() => {
@@ -268,6 +269,7 @@ function pipeableStreamDocumentedStringExample() {
             didError = true;
             console.error(err);
         },
+        formState: [1, "", "", 0] as unknown as ReactDOMClient.ReactFormState
     });
 
     setTimeout(() => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react/blob/26e87b5f15d80fd4aaf9909f90de0857e54c1129/packages/react-dom/src/server/ReactDOMFizzServerNode.js#L83
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

I noticed the type is already available for `react-dom/client`'s `hydrateRoot` even though `formState` option is not listed in the documentation such as https://react.dev/reference/react-dom/client/hydrateRoot https://react.dev/reference/react-dom/server/renderToReadableStream. This aligns SSR APIs to also have the same type since this is commonly used for RSC integration. I've been always `@ts-ignore`-ing this option, but I thought I'd try a PR here to check with maintainers.