### PR TITLE
fb-watchman: Allow for optional callback argument for all commands, including unofficial ones

### DIFF
--- a/types/fb-watchman/fb-watchman-tests.ts
+++ b/types/fb-watchman/fb-watchman-tests.ts
@@ -211,3 +211,8 @@ client.on("subscription", (resp) => {
         }
     });
 });
+
+// All commands should accept a callback, including "unofficial" ones
+client.command(['watch-del', '/'], () => {});
+// .. and it's optional
+client.command(['watch-del-all']);

--- a/types/fb-watchman/fb-watchman-tests.ts
+++ b/types/fb-watchman/fb-watchman-tests.ts
@@ -213,6 +213,6 @@ client.on("subscription", (resp) => {
 });
 
 // All commands should accept a callback, including "unofficial" ones
-client.command(['watch-del', '/'], () => {});
+client.command(["watch-del", "/"], () => {});
 // .. and it's optional
-client.command(['watch-del-all']);
+client.command(["watch-del-all"]);

--- a/types/fb-watchman/index.d.ts
+++ b/types/fb-watchman/index.d.ts
@@ -383,6 +383,7 @@ export class Client extends EventEmitter {
             ),
             ...any[],
         ],
+        callback?: CommandCallback,
     ): void;
 
     /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test fb-watchman`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/watchman/docs/nodejs#clientcommandargs--done
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
