### PR TITLE
Fix heic-decode types

### DIFF
--- a/types/heic-decode/index.d.ts
+++ b/types/heic-decode/index.d.ts
@@ -5,7 +5,7 @@ interface HasBuffer {
 interface DecodedImage {
     width: number;
     height: number;
-    data: ArrayBuffer;
+    data: Uint8ClampedArray;
 }
 
 interface Decodable {


### PR DESCRIPTION
This PR fixes the return type of `heic-decode` decode function, according to the documentation over at: https://github.com/catdad-experiments/heic-decode

```javascript
  const {
    width,  // integer width of the image
    height, // integer height of the image
    data    // Uint8ClampedArray containing pixel data
  } = await decode({ buffer });
```

This has also been confirmed locally.

### Template

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.


