### PR TITLE
[passport-http-bearer] make done callback `info.scope` property optional

### DIFF
--- a/types/passport-http-bearer/index.d.ts
+++ b/types/passport-http-bearer/index.d.ts
@@ -13,7 +13,7 @@ interface IStrategyOptions {
 }
 interface IVerifyOptions {
     message?: string | undefined;
-    scope: string | string[];
+    scope?: string | string[];
 }
 
 interface VerifyFunction {

--- a/types/passport-http-bearer/passport-http-bearer-tests.ts
+++ b/types/passport-http-bearer/passport-http-bearer-tests.ts
@@ -66,6 +66,31 @@ passport.use(
     }),
 );
 
+// Allow *not* passing `scope`, because is merely conventional.
+passport.use(
+    new httpBearer.Strategy(
+        (token: string, done: (error: unknown, user: unknown, options?: httpBearer.IVerifyOptions) => void) => {
+            done(null, {}, {/* no values is technically fine! */});
+            done(null, {}, { message: "so is just having a message" });
+        },
+    ),
+);
+
+// Allow arbitrary additional data on the `info` object
+interface ExtraOptions extends httpBearer.IVerifyOptions {
+    arbitraryData: string;
+}
+
+type ExtendedDoneFn = (error: unknown, user: unknown, options?: ExtraOptions) => void;
+
+passport.use(
+    new httpBearer.Strategy((token: string, done: ExtendedDoneFn) => {
+        done(null, {}, {
+            arbitraryData: "can go here",
+        });
+    }),
+);
+
 let app = express();
 app.post("/login", passport.authenticate("bearer", { failureRedirect: "/login" }), function(req, res) {
     res.redirect("/");


### PR DESCRIPTION
This allows end users to pass arbitrary data on this object, while still providing some hints about the “normal” pattern described (but not required!) by the docs. The implementation simply passes through the values on this object to be used by Passport as values on the `authInfo` object, without even inspecting them.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

    <https://www.passportjs.org/packages/passport-http-bearer/> reads:

    > Optional `info` can be passed, typically including associated scope, which will be set by Passport at `req.authInfo` to be used by later middleware for authorization and access control.

    <https://www.passportjs.org/concepts/authentication/http-bearer/> reads:

    > When invoking done, optional `info` can be passed, which will be set by Passport at `req.authInfo`. This is typically used to convey the scope of the token, and can be used when making access control checks.

    Note the phrasing: “typically” in both cases. Because Passport simply sets the info at `req.authInfo`, the `message` and `scope` are *common* but not required, and arbitrary *other* data may be passed instead or in addition to those.

- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.~~