### PR TITLE
w3c-web-usb: fix nullable types

### DIFF
--- a/types/w3c-web-usb/index.d.ts
+++ b/types/w3c-web-usb/index.d.ts
@@ -39,7 +39,7 @@ interface USBConnectionEventInit extends EventInit {
 
 declare class USBConfiguration {
     readonly configurationValue: number;
-    readonly configurationName?: string | undefined;
+    readonly configurationName: string | null;
     readonly interfaces: USBInterface[];
 }
 
@@ -57,7 +57,7 @@ declare class USBAlternateInterface {
     readonly interfaceClass: number;
     readonly interfaceSubclass: number;
     readonly interfaceProtocol: number;
-    readonly interfaceName?: string | undefined;
+    readonly interfaceName: string | null;
     readonly endpoints: USBEndpoint[];
 }
 
@@ -140,10 +140,10 @@ declare class USBDevice {
     readonly deviceVersionMajor: number;
     readonly deviceVersionMinor: number;
     readonly deviceVersionSubminor: number;
-    readonly manufacturerName?: string | undefined;
-    readonly productName?: string | undefined;
-    readonly serialNumber?: string | undefined;
-    readonly configuration?: USBConfiguration | undefined;
+    readonly manufacturerName: string | null;
+    readonly productName: string | null;
+    readonly serialNumber: string | null;
+    readonly configuration: USBConfiguration | null;
     readonly configurations: USBConfiguration[];
     readonly opened: boolean;
     open(): Promise<void>;

--- a/types/w3c-web-usb/w3c-web-usb-tests.ts
+++ b/types/w3c-web-usb/w3c-web-usb-tests.ts
@@ -87,3 +87,30 @@ async function handleConnectedDevice(device: USBDevice) {
         }
     }
 }
+
+function testNullVsUndefined(device: USBDevice) {
+    // There are certain properties that are nullable, meaning they return null
+    // rather than undefined. These constructs test that this is the case.
+
+    if (device.manufacturerName !== null) {
+        device.manufacturerName.length;
+    }
+
+    if (device.productName !== null) {
+        device.productName.length;
+    }
+
+    if (device.serialNumber !== null) {
+        device.serialNumber.length;
+    }
+
+    if (device.configuration !== null) {
+        if (device.configuration.configurationName !== null) {
+            device.configuration.configurationName.length;
+        }
+
+        if (device.configuration.interfaces[0].alternate.interfaceName !== null) {
+            device.configuration.interfaces[0].alternate.interfaceName.length;
+        }
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://wicg.github.io/webusb/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Additional context:

The first commit fixes errors that were already present when running `pnpm test w3c-web-usb`. This was needed to be able to actually run tests for the main commit.

The main commit fixes some incorrect types that were observed. According to the WebUSB spec (link above), some properties are nullable, meaning the value can only be `null` and never `undefined`. We have also confirmed at runtime in a web browser that these properties do indeed return `null`.