### PR TITLE
ltx: fix exports map, make compatible with TS 6.0

### DIFF
--- a/types/ltx/index.d.mts
+++ b/types/ltx/index.d.mts
@@ -1,1 +1,0 @@
-export * from "./src/ltx.js";

--- a/types/ltx/index.d.ts
+++ b/types/ltx/index.d.ts
@@ -1,1 +1,1 @@
-export * from "./lib/ltx";
+export * from "./lib/ltx.js";

--- a/types/ltx/ltx-tests.ts
+++ b/types/ltx/ltx-tests.ts
@@ -1,23 +1,23 @@
 /// <reference types="node" />
 
 import * as ltx from "ltx";
-import * as ltx2 from "ltx/src/ltx";
-import parsers from "ltx/src/parsers";
-import parsers2 = require("ltx/lib/parsers");
-import SaxLibxmljs from "ltx/src/parsers/libxmljs";
-import SaxLtx from "ltx/src/parsers/ltx";
-import SaxExpat from "ltx/src/parsers/node-expat";
-import SaxNodeXML from "ltx/src/parsers/node-xml";
-import SaxSaxjs from "ltx/src/parsers/sax-js";
-import SaxSaxesjs from "ltx/src/parsers/saxes";
-import SaxLibxmljs2 = require("ltx/lib/parsers/libxmljs");
-import SaxLtx2 = require("ltx/lib/parsers/ltx");
-import SaxExpat2 = require("ltx/lib/parsers/node-expat");
-import SaxNodeXML2 = require("ltx/lib/parsers/node-xml");
-import SaxSaxjs2 = require("ltx/lib/parsers/sax-js");
-import SaxSaxesjs2 = require("ltx/lib/parsers/saxes");
-import DOMElement from "ltx/src/DOMElement";
-import DOMElement2 = require("ltx/lib/DOMElement");
+import * as ltx2 from "ltx/src/ltx.js";
+import parsers from "ltx/src/parsers.js";
+import parsers2 = require("ltx/lib/parsers.js");
+import SaxLibxmljs from "ltx/src/parsers/libxmljs.js";
+import SaxLtx from "ltx/src/parsers/ltx.js";
+import SaxExpat from "ltx/src/parsers/node-expat.js";
+import SaxNodeXML from "ltx/src/parsers/node-xml.js";
+import SaxSaxjs from "ltx/src/parsers/sax-js.js";
+import SaxSaxesjs from "ltx/src/parsers/saxes.js";
+import SaxLibxmljs2 = require("ltx/lib/parsers/libxmljs.js");
+import SaxLtx2 = require("ltx/lib/parsers/ltx.js");
+import SaxExpat2 = require("ltx/lib/parsers/node-expat.js");
+import SaxNodeXML2 = require("ltx/lib/parsers/node-xml.js");
+import SaxSaxjs2 = require("ltx/lib/parsers/sax-js.js");
+import SaxSaxesjs2 = require("ltx/lib/parsers/saxes.js");
+import DOMElement from "ltx/src/DOMElement.js";
+import DOMElement2 = require("ltx/lib/DOMElement.js");
 
 // test type exports
 type Element = ltx.Element;

--- a/types/ltx/package.json
+++ b/types/ltx/package.json
@@ -2,16 +2,19 @@
     "private": true,
     "name": "@types/ltx",
     "version": "3.1.9999",
+    "type": "module",
     "projects": [
         "http://github.com/node-xmpp/ltx"
     ],
     "exports": {
         ".": {
             "types": {
-                "import": "./index.d.mts",
-                "default": "./index.d.ts"
+                "import": "./src/ltx.d.ts",
+                "default": "./lib/ltx.d.ts"
             }
-        }
+        },
+        "./src/*": "./src/*",
+        "./lib/*": "./lib/*"
     },
     "dependencies": {
         "@types/events": "*"

--- a/types/ltx/tsconfig.json
+++ b/types/ltx/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "node16",
         "lib": [
             "es6"
         ],


### PR DESCRIPTION
The exports map for the ltx npm package is
```json
  "exports": {
    ".": {
      "import": "./src/ltx.js",
      "require": "./lib/ltx.js"
    },
    "./src/*": "./src/*",
    "./lib/*": "./lib/*"
  }
```
which @types/ltx did not previously reflect; it was not possible to import a submodule under a resolution scheme that honours exports maps, which also meant that the tests failed under TS 6.0.

This does mean no more extensionless imports, but these would fail in the real world anyway due to the presence of the exports map.