### PR TITLE
ltx: fix exports map, make compatible with TS 6.0

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -168,6 +168,7 @@
         "kss",
         "leveldown",
         "locutus",
+        "ltx",
         "mapbox__mapbox-sdk",
         "mapboxgl-spiderifier",
         "marv",

--- a/types/ltx/index.d.mts
+++ b/types/ltx/index.d.mts
@@ -1,1 +1,0 @@
-export * from "./src/ltx.js";

--- a/types/ltx/index.d.ts
+++ b/types/ltx/index.d.ts
@@ -1,1 +1,1 @@
-export * from "./lib/ltx";
+export * from "./lib/ltx.js";

--- a/types/ltx/lib/DOMElement.d.ts
+++ b/types/ltx/lib/DOMElement.d.ts
@@ -1,3 +1,3 @@
-import DOMElement from "../src/DOMElement";
+import DOMElement from "../src/DOMElement.js";
 
 export = DOMElement;

--- a/types/ltx/lib/Element.d.ts
+++ b/types/ltx/lib/Element.d.ts
@@ -1,3 +1,3 @@
-import Element from "../src/Element";
+import Element from "../src/Element.js";
 
 export = Element;

--- a/types/ltx/lib/JSONify.d.ts
+++ b/types/ltx/lib/JSONify.d.ts
@@ -1,3 +1,3 @@
-import JSONify from "../src/JSONify";
+import JSONify from "../src/JSONify.js";
 
 export = JSONify;

--- a/types/ltx/lib/Parser.d.ts
+++ b/types/ltx/lib/Parser.d.ts
@@ -1,3 +1,3 @@
-import Parser from "../src/Parser";
+import Parser from "../src/Parser.js";
 
 export = Parser;

--- a/types/ltx/lib/clone.d.ts
+++ b/types/ltx/lib/clone.d.ts
@@ -1,3 +1,3 @@
-import clone from "../src/clone";
+import clone from "../src/clone.js";
 
 export = clone;

--- a/types/ltx/lib/createElement.d.ts
+++ b/types/ltx/lib/createElement.d.ts
@@ -1,3 +1,3 @@
-import createElement from "../src/createElement";
+import createElement from "../src/createElement.js";
 
 export = createElement;

--- a/types/ltx/lib/equal.d.ts
+++ b/types/ltx/lib/equal.d.ts
@@ -1,4 +1,4 @@
-import equal from "../src/equal";
+import equal from "../src/equal.js";
 
 export default equal;
-export * from "../src/equal";
+export * from "../src/equal.js";

--- a/types/ltx/lib/escape.d.ts
+++ b/types/ltx/lib/escape.d.ts
@@ -1,1 +1,1 @@
-export * from "../src/escape";
+export * from "../src/escape.js";

--- a/types/ltx/lib/is.d.ts
+++ b/types/ltx/lib/is.d.ts
@@ -1,1 +1,1 @@
-export * from "../src/is";
+export * from "../src/is.js";

--- a/types/ltx/lib/ltx.d.ts
+++ b/types/ltx/lib/ltx.d.ts
@@ -1,18 +1,18 @@
-import parse = require("./parse");
-import Parser = require("./Parser");
-import { ParserOptions } from "../src/Parser";
-import { escapeXML, escapeXMLText, unescapeXML, unescapeXMLText } from "./escape";
-import Element = require("./Element");
-import { Node } from "../src/Element";
-import equal, { attrsEqual, childrenEqual, nameEqual } from "./equal";
-import createElement = require("./createElement");
-import tag = require("./tag");
-import tagString = require("./tagString");
-import { isElement, isNode, isText } from "./is";
-import clone = require("./clone");
-import stringify = require("./stringify");
-import JSONify = require("./JSONify");
-import { ElementJson } from "../src/JSONify";
+import parse = require("./parse.js");
+import Parser = require("./Parser.js");
+import { ParserOptions } from "../src/Parser.js";
+import { escapeXML, escapeXMLText, unescapeXML, unescapeXMLText } from "./escape.js";
+import Element = require("./Element.js");
+import { Node } from "../src/Element.js";
+import equal, { attrsEqual, childrenEqual, nameEqual } from "./equal.js";
+import createElement = require("./createElement.js");
+import tag = require("./tag.js");
+import tagString = require("./tagString.js");
+import { isElement, isNode, isText } from "./is.js";
+import clone = require("./clone.js");
+import stringify = require("./stringify.js");
+import JSONify = require("./JSONify.js");
+import { ElementJson } from "../src/JSONify.js";
 
 export {
     attrsEqual,

--- a/types/ltx/lib/parse.d.ts
+++ b/types/ltx/lib/parse.d.ts
@@ -1,3 +1,3 @@
-import parse from "../src/parse";
+import parse from "../src/parse.js";
 
 export = parse;

--- a/types/ltx/lib/parsers.d.ts
+++ b/types/ltx/lib/parsers.d.ts
@@ -1,3 +1,3 @@
-import parsers from "../src/parsers";
+import parsers from "../src/parsers.js";
 
 export = parsers;

--- a/types/ltx/lib/parsers/libxmljs.d.ts
+++ b/types/ltx/lib/parsers/libxmljs.d.ts
@@ -1,3 +1,3 @@
-import SaxLibxmljs from "../../src/parsers/libxmljs";
+import SaxLibxmljs from "../../src/parsers/libxmljs.js";
 
 export = SaxLibxmljs;

--- a/types/ltx/lib/parsers/ltx.d.ts
+++ b/types/ltx/lib/parsers/ltx.d.ts
@@ -1,3 +1,3 @@
-import SaxLtx from "../../src/parsers/ltx";
+import SaxLtx from "../../src/parsers/ltx.js";
 
 export = SaxLtx;

--- a/types/ltx/lib/parsers/node-expat.d.ts
+++ b/types/ltx/lib/parsers/node-expat.d.ts
@@ -1,3 +1,3 @@
-import SaxExpat from "../../src/parsers/node-expat";
+import SaxExpat from "../../src/parsers/node-expat.js";
 
 export = SaxExpat;

--- a/types/ltx/lib/parsers/node-xml.d.ts
+++ b/types/ltx/lib/parsers/node-xml.d.ts
@@ -1,3 +1,3 @@
-import SaxNodeXML from "../../src/parsers/node-xml";
+import SaxNodeXML from "../../src/parsers/node-xml.js";
 
 export = SaxNodeXML;

--- a/types/ltx/lib/parsers/sax-js.d.ts
+++ b/types/ltx/lib/parsers/sax-js.d.ts
@@ -1,3 +1,3 @@
-import SaxSaxjs from "../../src/parsers/sax-js";
+import SaxSaxjs from "../../src/parsers/sax-js.js";
 
 export = SaxSaxjs;

--- a/types/ltx/lib/parsers/saxes.d.ts
+++ b/types/ltx/lib/parsers/saxes.d.ts
@@ -1,3 +1,3 @@
-import SaxSaxesjs from "../../src/parsers/saxes";
+import SaxSaxesjs from "../../src/parsers/saxes.js";
 
 export = SaxSaxesjs;

--- a/types/ltx/lib/stringify.d.ts
+++ b/types/ltx/lib/stringify.d.ts
@@ -1,3 +1,3 @@
-import stringify from "../src/stringify";
+import stringify from "../src/stringify.js";
 
 export = stringify;

--- a/types/ltx/lib/tag.d.ts
+++ b/types/ltx/lib/tag.d.ts
@@ -1,3 +1,3 @@
-import tag from "../src/tag";
+import tag from "../src/tag.js";
 
 export = tag;

--- a/types/ltx/lib/tagString.d.ts
+++ b/types/ltx/lib/tagString.d.ts
@@ -1,3 +1,3 @@
-import tagString from "../src/tagString";
+import tagString from "../src/tagString.js";
 
 export = tagString;

--- a/types/ltx/ltx-tests.ts
+++ b/types/ltx/ltx-tests.ts
@@ -1,23 +1,23 @@
 /// <reference types="node" />
 
 import * as ltx from "ltx";
-import * as ltx2 from "ltx/src/ltx";
-import parsers from "ltx/src/parsers";
-import parsers2 = require("ltx/lib/parsers");
-import SaxLibxmljs from "ltx/src/parsers/libxmljs";
-import SaxLtx from "ltx/src/parsers/ltx";
-import SaxExpat from "ltx/src/parsers/node-expat";
-import SaxNodeXML from "ltx/src/parsers/node-xml";
-import SaxSaxjs from "ltx/src/parsers/sax-js";
-import SaxSaxesjs from "ltx/src/parsers/saxes";
-import SaxLibxmljs2 = require("ltx/lib/parsers/libxmljs");
-import SaxLtx2 = require("ltx/lib/parsers/ltx");
-import SaxExpat2 = require("ltx/lib/parsers/node-expat");
-import SaxNodeXML2 = require("ltx/lib/parsers/node-xml");
-import SaxSaxjs2 = require("ltx/lib/parsers/sax-js");
-import SaxSaxesjs2 = require("ltx/lib/parsers/saxes");
-import DOMElement from "ltx/src/DOMElement";
-import DOMElement2 = require("ltx/lib/DOMElement");
+import * as ltx2 from "ltx/src/ltx.js";
+import parsers from "ltx/src/parsers.js";
+import parsers2 = require("ltx/lib/parsers.js");
+import SaxLibxmljs from "ltx/src/parsers/libxmljs.js";
+import SaxLtx from "ltx/src/parsers/ltx.js";
+import SaxExpat from "ltx/src/parsers/node-expat.js";
+import SaxNodeXML from "ltx/src/parsers/node-xml.js";
+import SaxSaxjs from "ltx/src/parsers/sax-js.js";
+import SaxSaxesjs from "ltx/src/parsers/saxes.js";
+import SaxLibxmljs2 = require("ltx/lib/parsers/libxmljs.js");
+import SaxLtx2 = require("ltx/lib/parsers/ltx.js");
+import SaxExpat2 = require("ltx/lib/parsers/node-expat.js");
+import SaxNodeXML2 = require("ltx/lib/parsers/node-xml.js");
+import SaxSaxjs2 = require("ltx/lib/parsers/sax-js.js");
+import SaxSaxesjs2 = require("ltx/lib/parsers/saxes.js");
+import DOMElement from "ltx/src/DOMElement.js";
+import DOMElement2 = require("ltx/lib/DOMElement.js");
 
 // test type exports
 type Element = ltx.Element;

--- a/types/ltx/package.json
+++ b/types/ltx/package.json
@@ -8,10 +8,12 @@
     "exports": {
         ".": {
             "types": {
-                "import": "./index.d.mts",
-                "default": "./index.d.ts"
+                "import": "./src/ltx.d.ts",
+                "require": "./lib/ltx.d.ts"
             }
-        }
+        },
+        "./src/*": "./src/*",
+        "./lib/*": "./lib/*"
     },
     "dependencies": {
         "@types/events": "*"

--- a/types/ltx/src/DOMElement.d.ts
+++ b/types/ltx/src/DOMElement.d.ts
@@ -1,4 +1,4 @@
-import Element, { Node } from "./Element";
+import Element, { Node } from "./Element.js";
 
 export default class DOMElement extends Element {
     static createElement(name: string, attrs?: string | { [attrName: string]: any }, ...children: Node[]): DOMElement;

--- a/types/ltx/src/JSONify.d.ts
+++ b/types/ltx/src/JSONify.d.ts
@@ -1,4 +1,4 @@
-import Element, { Node } from "./Element";
+import Element, { Node } from "./Element.js";
 
 export default function JSONify<TNode extends Node>(el: TNode): TNode extends Element ? ElementJson : TNode;
 

--- a/types/ltx/src/Parser.d.ts
+++ b/types/ltx/src/Parser.d.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "events";
-import Element from "./Element";
+import Element from "./Element.js";
 
 export default class Parser extends EventEmitter {
     static DefaultParser: typeof Parser;

--- a/types/ltx/src/clone.d.ts
+++ b/types/ltx/src/clone.d.ts
@@ -1,3 +1,3 @@
-import { Node } from "./Element";
+import { Node } from "./Element.js";
 
 export default function clone<T extends Node>(el: T): T;

--- a/types/ltx/src/createElement.d.ts
+++ b/types/ltx/src/createElement.d.ts
@@ -1,4 +1,4 @@
-import Element, { Node } from "./Element";
+import Element, { Node } from "./Element.js";
 
 export default function createElement(
     name: string,

--- a/types/ltx/src/equal.d.ts
+++ b/types/ltx/src/equal.d.ts
@@ -1,4 +1,4 @@
-import Element from "./Element";
+import Element from "./Element.js";
 
 export function nameEqual(a: Element, b: Element): boolean;
 export function attrsEqual(a: Element, b: Element): boolean;

--- a/types/ltx/src/is.d.ts
+++ b/types/ltx/src/is.d.ts
@@ -1,4 +1,4 @@
-import Element, { Node } from "./Element";
+import Element, { Node } from "./Element.js";
 
 export function isNode(el: any): el is Node;
 export function isElement(el: any): el is Element;

--- a/types/ltx/src/ltx.d.ts
+++ b/types/ltx/src/ltx.d.ts
@@ -1,15 +1,15 @@
-import clone from "./clone";
-import createElement from "./createElement";
-import Element, { Node } from "./Element";
-import equal, { attrsEqual, childrenEqual, nameEqual } from "./equal";
-import { escapeXML, escapeXMLText, unescapeXML, unescapeXMLText } from "./escape";
-import { isElement, isNode, isText } from "./is";
-import JSONify, { ElementJson } from "./JSONify";
-import parse from "./parse";
-import Parser, { ParserOptions } from "./Parser";
-import stringify from "./stringify";
-import tag from "./tag";
-import tagString from "./tagString";
+import clone from "./clone.js";
+import createElement from "./createElement.js";
+import Element, { Node } from "./Element.js";
+import equal, { attrsEqual, childrenEqual, nameEqual } from "./equal.js";
+import { escapeXML, escapeXMLText, unescapeXML, unescapeXMLText } from "./escape.js";
+import { isElement, isNode, isText } from "./is.js";
+import JSONify, { ElementJson } from "./JSONify.js";
+import parse from "./parse.js";
+import Parser, { ParserOptions } from "./Parser.js";
+import stringify from "./stringify.js";
+import tag from "./tag.js";
+import tagString from "./tagString.js";
 
 export {
     attrsEqual,

--- a/types/ltx/src/parse.d.ts
+++ b/types/ltx/src/parse.d.ts
@@ -1,4 +1,4 @@
-import Element from "./Element";
-import Parser, { ParserOptions } from "./Parser";
+import Element from "./Element.js";
+import Parser, { ParserOptions } from "./Parser.js";
 
 export default function parse(data: string, options?: ParserOptions | typeof Parser): Element;

--- a/types/ltx/src/parsers.d.ts
+++ b/types/ltx/src/parsers.d.ts
@@ -1,4 +1,4 @@
-import Parser from "./Parser";
+import Parser from "./Parser.js";
 
 declare const parsers: Array<typeof Parser>;
 

--- a/types/ltx/src/parsers/libxmljs.d.ts
+++ b/types/ltx/src/parsers/libxmljs.d.ts
@@ -1,3 +1,3 @@
-import Parser from "../Parser";
+import Parser from "../Parser.js";
 
 export default class SaxLibxmljs extends Parser {}

--- a/types/ltx/src/parsers/ltx.d.ts
+++ b/types/ltx/src/parsers/ltx.d.ts
@@ -1,3 +1,3 @@
-import Parser from "../Parser";
+import Parser from "../Parser.js";
 
 export default class SaxLtx extends Parser {}

--- a/types/ltx/src/parsers/node-expat.d.ts
+++ b/types/ltx/src/parsers/node-expat.d.ts
@@ -1,3 +1,3 @@
-import Parser from "../Parser";
+import Parser from "../Parser.js";
 
 export default class SaxExpat extends Parser {}

--- a/types/ltx/src/parsers/node-xml.d.ts
+++ b/types/ltx/src/parsers/node-xml.d.ts
@@ -1,3 +1,3 @@
-import Parser from "../Parser";
+import Parser from "../Parser.js";
 
 export default class SaxNodeXML extends Parser {}

--- a/types/ltx/src/parsers/sax-js.d.ts
+++ b/types/ltx/src/parsers/sax-js.d.ts
@@ -1,3 +1,3 @@
-import Parser from "../Parser";
+import Parser from "../Parser.js";
 
 export default class SaxSaxjs extends Parser {}

--- a/types/ltx/src/parsers/saxes.d.ts
+++ b/types/ltx/src/parsers/saxes.d.ts
@@ -1,3 +1,3 @@
-import Parser from "../Parser";
+import Parser from "../Parser.js";
 
 export default class SaxSaxesjs extends Parser {}

--- a/types/ltx/src/stringify.d.ts
+++ b/types/ltx/src/stringify.d.ts
@@ -1,3 +1,3 @@
-import Element from "./Element";
+import Element from "./Element.js";
 
 export default function stringify(el: Element, indent?: number, level?: number): string;

--- a/types/ltx/src/tag.d.ts
+++ b/types/ltx/src/tag.d.ts
@@ -1,4 +1,4 @@
-import Element from "./Element";
-import tagString from "./tagString";
+import Element from "./Element.js";
+import tagString from "./tagString.js";
 
 export default function tag(...args: Parameters<typeof tagString>): Element;

--- a/types/ltx/tsconfig.json
+++ b/types/ltx/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "node16",
         "lib": [
             "es6"
         ],


### PR DESCRIPTION
The exports map for the ltx npm package is
```json
  "exports": {
    ".": {
      "import": "./src/ltx.js",
      "require": "./lib/ltx.js"
    },
    "./src/*": "./src/*",
    "./lib/*": "./lib/*"
  }
```
which @types/ltx did not previously reflect; it was not possible to import a submodule under a resolution scheme that honours exports maps, which also meant that the tests failed under TS 6.0.

This change does mean no more extensionless imports, but these would fail in the real world anyway due to the presence of the exports map.

attw does complain that the CJS and ESM entrypoints both have .js (and therefore .d.ts) extensions. Since this reflects the real-world package behaviour, it seems legitimate to ignore this error.