### PR TITLE
fs-extra: fix mjs import test, update exports map, make compatible with TS 6.0

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -123,7 +123,6 @@
         "formol",
         "frctl__fractal",
         "frecency",
-        "fs-extra",
         "geodesy",
         "get-folder-size",
         "github-label-sync",

--- a/types/fs-extra/package.json
+++ b/types/fs-extra/package.json
@@ -10,9 +10,7 @@
             "types": "./index.d.ts"
         },
         "./esm": {
-            "types": {
-                "import": "./esm.d.mts"
-            }
+            "types": "./esm.d.mts"
         }
     },
     "dependencies": {

--- a/types/fs-extra/test/fs-extra-tests-module.mts
+++ b/types/fs-extra/test/fs-extra-tests-module.mts
@@ -1,4 +1,4 @@
-import * as fs from "fs-extra/esm.mjs";
+import * as fs from "fs-extra/esm";
 
 // test type exports
 type Types =

--- a/types/fs-extra/tsconfig.json
+++ b/types/fs-extra/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "node16",
         "lib": [
             "es6"
         ],
@@ -13,8 +13,9 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
+        "esm.d.mts",
         "index.d.ts",
         "test/fs-extra-tests.ts",
-        "test/fs-extra-tests-module.ts"
+        "test/fs-extra-tests-module.mts"
     ]
 }


### PR DESCRIPTION
The exports map for the fs-extra npm package is:
```json
  "exports": {
    ".": "./lib/index.js",
    "./esm": "./lib/esm.mjs"
  }
```
which this changeset now reflects.

In addition, the ESM test script attempted to import "esm.mjs", which doesn't appear as a package.json entrypoint, and therefore fails under a module scheme that honours exports maps; this currently causes errors under TS 6.0.