### PR TITLE
cypress-dotenv, dotenv-defaults, dotenv-safe: constrain dotenv dependency, make compatible with TS 6.0

### DIFF
--- a/types/cypress-dotenv/package.json
+++ b/types/cypress-dotenv/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "dotenv": "^8.2.0"
+        "dotenv": ">=8.2.0 <8.5.0"
     },
     "devDependencies": {
         "@types/cypress-dotenv": "workspace:."

--- a/types/cypress-dotenv/tsconfig.json
+++ b/types/cypress-dotenv/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "node16",
         "lib": [
             "es6"
         ],

--- a/types/dotenv-defaults/package.json
+++ b/types/dotenv-defaults/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "dotenv": "^8.2.0"
+        "dotenv": ">=8.2.0 <8.5.0"
     },
     "devDependencies": {
         "@types/dotenv-defaults": "workspace:."

--- a/types/dotenv-defaults/tsconfig.json
+++ b/types/dotenv-defaults/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "node16",
         "lib": [
             "es6"
         ],

--- a/types/dotenv-safe/package.json
+++ b/types/dotenv-safe/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "dotenv": "^8.2.0"
+        "dotenv": ">=8.2.0 <8.5.0"
     },
     "devDependencies": {
         "@types/dotenv-safe": "workspace:."

--- a/types/dotenv-safe/tsconfig.json
+++ b/types/dotenv-safe/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "node16",
         "lib": [
             "es6"
         ],


### PR DESCRIPTION
The dotenv package on npm had broken types exports mapping in `>=8.5.0 <12.0.0`.

There are several DT packages that were depending on `^8.2.0` and therefore resolving an affected version, which breaks the DT package under a module scheme that honours exports maps. It also therefore causes failures in TS 6.0.

The cheapest way to get around this is to constrain the dependency versions for these specific packages.