### PR TITLE
fix(culori): Allow passing mode as null when calling mapper

### DIFF
--- a/types/culori/src/map.d.ts
+++ b/types/culori/src/map.d.ts
@@ -29,6 +29,7 @@ declare function mapper(fn: MapFn<"rgb">, mode?: undefined, preserve_mode?: fals
 declare function mapper(fn: MapFn<"rgb">, mode: undefined, preserve_mode: true): ColorToSameColorMapper;
 declare function mapper<M extends Mode>(fn: MapFn<M>, mode: M, preserve_mode?: false): ColorToPredefinedColorMapper<M>;
 declare function mapper<M extends Mode>(fn: MapFn<M>, mode: M, preserve_mode: true): ColorToSameColorMapper;
+declare function mapper(fn: MapFn<Mode>, mode: null, preserve_mode?: false): ColorToSameColorMapper;
 
 declare function mapAlphaMultiply(v: number, ch: Channel, c: Color): number;
 

--- a/types/culori/test/mapper.test.ts
+++ b/types/culori/test/mapper.test.ts
@@ -46,3 +46,11 @@ mapper(
     undefined,
     true,
 );
+
+const halver = mapper(v => v / 2, null);
+
+// $ExpectType Rgb
+halver({ mode: "rgb", r: 0.5, b: 0.2, g: 0.1 });
+
+// $ExpectType Hsl
+halver({ h: 240, s: 1, l: 0.5, mode: "hsl", alpha: 0.5 });


### PR DESCRIPTION
According to the [culori documentation](https://culorijs.org/api/#mapper): "The mode parameter can be set to null, in which case the mapper will iterate through the channels in the color's original color space." Passing `null` to `mode` should now be allowed, and will cause the mapping function to return a color in the same mode that was passed in.

The `preserve_mode` parameter will have no effect if `mode` is `null`, although it is not an error to pass it in anyway.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [API Reference · culori](https://culorijs.org/api/#mapper)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. _Applies to the current version, not a new version_
