### PR TITLE
[nodegit] Fix Reset return types

### DIFF
--- a/types/nodegit/nodegit-tests.ts
+++ b/types/nodegit/nodegit-tests.ts
@@ -205,6 +205,8 @@ Git.Rebase.init(repo, annotatedCommit, null, annotatedCommit, rebaseOptions).the
 });
 
 Git.Reset.reset(repo, commit, Git.Reset.TYPE.HARD, {}).catch(err => console.log(err));
+Git.Reset.default(repo, commit, []).catch(err => console.log(err));
+Git.Reset.fromAnnotated(repo, commit, Git.Reset.TYPE.HARD, {}).catch(err => console.log(err));
 
 Git.Cherrypick.cherrypick(repo, commit, {}).catch(err => console.log(err));
 

--- a/types/nodegit/reset.d.ts
+++ b/types/nodegit/reset.d.ts
@@ -37,5 +37,5 @@ export class Reset {
         commit: AnnotatedCommit,
         resetType: number,
         checkoutOpts: CheckoutOptions,
-    ): number;
+    ): Promise<number>;
 }


### PR DESCRIPTION
Fixes a missing promise on the return type of `Reset.fromAnnotated()`

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodegit/nodegit/blob/master/lib/reset.js#L44
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
