### PR TITLE
fix: [@types/aws-cloudfront-function] adding Response.body for AWSCloudFrontFunction

### DIFF
--- a/types/aws-cloudfront-function/aws-cloudfront-function-tests.ts
+++ b/types/aws-cloudfront-function/aws-cloudfront-function-tests.ts
@@ -30,6 +30,13 @@ const cloudFrontFunctionResponseCookie: AWSCloudFrontFunction.ResponseCookie = {
     },
 };
 
+const responseBodyString: string = "Hello, World!";
+
+const responseBodyObject: AWSCloudFrontFunction.ResponseBody = {
+    data: "Hello",
+    encoding: "text",
+};
+
 const cloudFrontFunctionRequest: AWSCloudFrontFunction.Request = {
     method: "GET",
     uri: "/test",
@@ -43,6 +50,22 @@ const cloudFrontResponse: AWSCloudFrontFunction.Response = {
     statusDescription: "OK",
     headers: cloudFrontFunctionValue,
     cookies: cloudFrontFunctionResponseCookie,
+};
+
+const cloudFrontResponse2: AWSCloudFrontFunction.Response = {
+    statusCode: 200,
+    statusDescription: "OK",
+    headers: cloudFrontFunctionValue,
+    cookies: cloudFrontFunctionResponseCookie,
+    body: responseBodyString,
+};
+
+const cloudFrontResponse3: AWSCloudFrontFunction.Response = {
+    statusCode: 200,
+    statusDescription: "OK",
+    headers: cloudFrontFunctionValue,
+    cookies: cloudFrontFunctionResponseCookie,
+    body: responseBodyObject,
 };
 
 const cloudFrontFunctionViewer: AWSCloudFrontFunction.Viewer = {

--- a/types/aws-cloudfront-function/index.d.ts
+++ b/types/aws-cloudfront-function/index.d.ts
@@ -31,6 +31,12 @@ declare namespace AWSCloudFrontFunction {
         statusDescription?: string;
         headers?: ValueObject;
         cookies?: ResponseCookie;
+        body?: string | ResponseBody;
+    }
+
+    interface ResponseBody {
+        data: string;
+        encoding: "text" | "base64";
     }
 
     interface ValueObject {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-event-structure.html#functions-event-structure-response
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

