### PR TITLE
types/w3c-web-usb: status properties are not undefined

### DIFF
--- a/types/w3c-web-usb/index.d.ts
+++ b/types/w3c-web-usb/index.d.ts
@@ -64,7 +64,7 @@ declare class USBAlternateInterface {
 declare class USBInTransferResult {
     constructor(status: USBTransferStatus, data?: DataView);
     readonly data?: DataView | undefined;
-    readonly status?: USBTransferStatus | undefined;
+    readonly status: USBTransferStatus;
 }
 
 declare class USBOutTransferResult {
@@ -76,7 +76,7 @@ declare class USBOutTransferResult {
 declare class USBIsochronousInTransferPacket {
     constructor(status: USBTransferStatus, data?: DataView);
     readonly data?: DataView | undefined;
-    readonly status?: USBTransferStatus | undefined;
+    readonly status: USBTransferStatus;
 }
 
 declare class USBIsochronousInTransferResult {

--- a/types/w3c-web-usb/w3c-web-usb-tests.ts
+++ b/types/w3c-web-usb/w3c-web-usb-tests.ts
@@ -114,3 +114,26 @@ function testNullVsUndefined(device: USBDevice) {
         }
     }
 }
+
+function testStatusIsNotUndefined(
+    r1: USBInTransferResult,
+    r2: USBOutTransferResult,
+    r3: USBIsochronousInTransferPacket,
+    r4: USBIsochronousOutTransferPacket,
+) {
+    if (r1.status !== "ok") {
+        r1.status.length;
+    }
+
+    if (r2.status !== "ok") {
+        r2.status.length;
+    }
+
+    if (r3.status !== "ok") {
+        r3.status.length;
+    }
+
+    if (r4.status !== "ok") {
+        r4.status.length;
+    }
+}


### PR DESCRIPTION
According to the spec, the status properties on `USBInTransferResult` and `USBIsochronousInTransferPacket` are not optional and will always be present.

- https://wicg.github.io/webusb/#usbintransferresult
- https://wicg.github.io/webusb/#usbisochronousintransferpacket

It is also logical that if the constructor argument cannot be undefined, then the property cannot be undefined.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
