### PR TITLE
Add `chai` type definitions for is[Not]{Array,Object,Function,String,Number} 

### DIFF
--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -1188,8 +1188,10 @@ suite("assert", () => {
     });
 
     test("isObject", () => {
+        const x: unknown = {};
+        assert.isObject(x);
         // $ExpectType object
-        assert.isObject({});
+        const y = x;
         assert.isObject(new Foo());
         assert.isObject(true);
         assert.isObject(Foo);
@@ -1328,10 +1330,11 @@ suite("assert", () => {
     });
 
     test("isFunction", () => {
-        const func = () => {
+        const func: unknown = () => {
         };
-        // $ExpectType Function
         assert.isFunction(func);
+        // $ExpectType Function
+        const y = func;
         assert.isFunction({});
     });
 
@@ -1342,8 +1345,10 @@ suite("assert", () => {
     });
 
     test("isArray", () => {
+        const x: unknown = [];
+        assert.isArray(x);
         // $ExpectType unknown[]
-        assert.isArray([]);
+        const y = x;
         assert.isArray(new Array<any>());
         assert.isArray({});
     });
@@ -1355,7 +1360,10 @@ suite("assert", () => {
     });
 
     test("isString", () => {
+        const x: unknown = "Foo";
+        assert.isString(x);
         // $ExpectType string
+        const y = x;
         assert.isString("Foo");
         // tslint:disable-next-line:no-construct
         assert.isString(new String("foo"));
@@ -2163,14 +2171,12 @@ suite("narrowing", () => {
 
     test("isTrue", () => {
         const x = foobar<true | number>();
-        // $ExpectType true
         assert.isTrue(x);
         const y: true = x;
     });
 
     test("isFalse", () => {
         const x = foobar<false | number>();
-        // $ExpectType false
         assert.isFalse(x);
         const y: false = x;
     });

--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -1188,6 +1188,7 @@ suite("assert", () => {
     });
 
     test("isObject", () => {
+        // $ExpectType object
         assert.isObject({});
         assert.isObject(new Foo());
         assert.isObject(true);
@@ -1329,6 +1330,7 @@ suite("assert", () => {
     test("isFunction", () => {
         const func = () => {
         };
+        // $ExpectType Function
         assert.isFunction(func);
         assert.isFunction({});
     });
@@ -1340,6 +1342,7 @@ suite("assert", () => {
     });
 
     test("isArray", () => {
+        // $ExpectType unknown[]
         assert.isArray([]);
         assert.isArray(new Array<any>());
         assert.isArray({});
@@ -1352,6 +1355,7 @@ suite("assert", () => {
     });
 
     test("isString", () => {
+        // $ExpectType string
         assert.isString("Foo");
         // tslint:disable-next-line:no-construct
         assert.isString(new String("foo"));
@@ -2159,12 +2163,14 @@ suite("narrowing", () => {
 
     test("isTrue", () => {
         const x = foobar<true | number>();
+        // $ExpectType true
         assert.isTrue(x);
         const y: true = x;
     });
 
     test("isFalse", () => {
         const x = foobar<false | number>();
+        // $ExpectType false
         assert.isFalse(x);
         const y: false = x;
     });

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -1186,7 +1186,7 @@ declare global {
             propertyVal<T, V>(object: T, property: string, /* keyof T */ value: V, message?: string): asserts object is T & { [property: string]: V };
 
             /**
-             * Asserts that object has a property named by property with value given by value.
+             * Asserts that object does not have a property named by property with value given by value.
              *
              * T   Type of object.
              * V   Type of value.

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -702,7 +702,7 @@ declare global {
              * @param value   Actual value.
              * @param message   Message to display on error.
              */
-            isFunction(value: unknown, message?: string): value is Function;
+            isFunction(value: unknown, message?: string): asserts value is Function;
 
             /**
              * Asserts that value is not a function.
@@ -711,7 +711,7 @@ declare global {
              * @param value   Actual value.
              * @param message   Message to display on error.
              */
-            isNotFunction(value: unknown, message?: string): value is Exclude<unknown, Function>;
+            isNotFunction(value: unknown, message?: string): asserts value is Exclude<unknown, Function>;
 
             /**
              * Asserts that value is an object of type 'Object'
@@ -796,7 +796,7 @@ declare global {
              * @param value    Actual value
              * @param message   Message to display on error.
              */
-            isFinite<T>(value: T, message?: string): void;
+            isFinite<T>(value: T, message?: string): asserts value is Exclude<T, number>;
 
             /**
              * Asserts that value is a boolean.
@@ -1139,7 +1139,7 @@ declare global {
              * @param property   Potential contained property of object.
              * @param message   Message to display on error.
              */
-            property<T>(object: T, property: string, /* keyof T */ message?: string): asserts object is T & { [property]: unknown };
+            property<T>(object: T, property: string, /* keyof T */ message?: string): asserts object is T & { [property: string]: unknown };
 
             /**
              * Asserts that object does not have a property named by property.
@@ -1149,7 +1149,7 @@ declare global {
              * @param property   Potential contained property of object.
              * @param message   Message to display on error.
              */
-            notProperty<T>(object: T, property: string, /* keyof T */ message?: string): asserts object is Exclude<T, { [property]: unknown }>;
+            notProperty<T>(object: T, property: string, /* keyof T */ message?: string): asserts object is Exclude<T, { [property: string]: unknown }>;
 
             /**
              * Asserts that object has a property named by property, which can be a string
@@ -1183,7 +1183,7 @@ declare global {
              * @param value   Potential expected property value.
              * @param message   Message to display on error.
              */
-            propertyVal<T, V>(object: T, property: string, /* keyof T */ value: V, message?: string): asserts object is T & { [property]: V };
+            propertyVal<T, V>(object: T, property: string, /* keyof T */ value: V, message?: string): asserts object is T & { [property: string]: V };
 
             /**
              * Asserts that object has a property named by property with value given by value.
@@ -1195,7 +1195,7 @@ declare global {
              * @param value   Potential expected property value.
              * @param message   Message to display on error.
              */
-            notPropertyVal<T, V>(object: T, property: string, /* keyof T */ value: V, message?: string): asserts object is Exclude<T, { [property]: V }>;
+            notPropertyVal<T, V>(object: T, property: string, /* keyof T */ value: V, message?: string): asserts object is Exclude<T, { [property: string]: V }>;
 
             /**
              * Asserts that object has a property named by property, which can be a string

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -702,7 +702,7 @@ declare global {
              * @param value   Actual value.
              * @param message   Message to display on error.
              */
-            isFunction<T>(value: T, message?: string): void;
+            isFunction(value: unknown, message?: string): value is Function;
 
             /**
              * Asserts that value is not a function.
@@ -711,7 +711,7 @@ declare global {
              * @param value   Actual value.
              * @param message   Message to display on error.
              */
-            isNotFunction<T>(value: T, message?: string): void;
+            isNotFunction(value: unknown, message?: string): value is Exclude<unknown, Function>;
 
             /**
              * Asserts that value is an object of type 'Object'

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -796,7 +796,7 @@ declare global {
              * @param value    Actual value
              * @param message   Message to display on error.
              */
-            isFinite<T>(value: T, message?: string): asserts value is Exclude<T, number>;
+            isFinite(value: unknown, message?: string): asserts value is number;
 
             /**
              * Asserts that value is a boolean.

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -1139,7 +1139,11 @@ declare global {
              * @param property   Potential contained property of object.
              * @param message   Message to display on error.
              */
-            property<T>(object: T, property: string, /* keyof T */ message?: string): asserts object is T & { [property: string]: unknown };
+            property<T>(
+                object: T,
+                property: string,
+                /* keyof T */ message?: string,
+            ): asserts object is T & { [property: string]: unknown };
 
             /**
              * Asserts that object does not have a property named by property.
@@ -1149,7 +1153,11 @@ declare global {
              * @param property   Potential contained property of object.
              * @param message   Message to display on error.
              */
-            notProperty<T>(object: T, property: string, /* keyof T */ message?: string): asserts object is Exclude<T, { [property: string]: unknown }>;
+            notProperty<T>(
+                object: T,
+                property: string,
+                /* keyof T */ message?: string,
+            ): asserts object is Exclude<T, { [property: string]: unknown }>;
 
             /**
              * Asserts that object has a property named by property, which can be a string
@@ -1183,7 +1191,12 @@ declare global {
              * @param value   Potential expected property value.
              * @param message   Message to display on error.
              */
-            propertyVal<T, V>(object: T, property: string, /* keyof T */ value: V, message?: string): asserts object is T & { [property: string]: V };
+            propertyVal<T, V>(
+                object: T,
+                property: string,
+                /* keyof T */ value: V,
+                message?: string,
+            ): asserts object is T & { [property: string]: V };
 
             /**
              * Asserts that object does not have a property named by property with value given by value.
@@ -1195,7 +1208,12 @@ declare global {
              * @param value   Potential expected property value.
              * @param message   Message to display on error.
              */
-            notPropertyVal<T, V>(object: T, property: string, /* keyof T */ value: V, message?: string): asserts object is Exclude<T, { [property: string]: V }>;
+            notPropertyVal<T, V>(
+                object: T,
+                property: string,
+                /* keyof T */ value: V,
+                message?: string,
+            ): asserts object is Exclude<T, { [property: string]: V }>;
 
             /**
              * Asserts that object has a property named by property, which can be a string

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -722,7 +722,7 @@ declare global {
              * @param message   Message to display on error.
              * @remarks The assertion does not match subclassed objects.
              */
-            isObject<T>(value: T, message?: string): void;
+            isObject(value: unknown, message?: string): asserts value is object;
 
             /**
              * Asserts that value is not an object of type 'Object'
@@ -732,7 +732,7 @@ declare global {
              * @param value   Actual value.
              * @param message   Message to display on error.
              */
-            isNotObject<T>(value: T, message?: string): void;
+            isNotObject(value: unknown, message?: string): asserts value is Exclude<unknown, object>;
 
             /**
              * Asserts that value is an array.
@@ -741,7 +741,7 @@ declare global {
              * @param value   Actual value.
              * @param message   Message to display on error.
              */
-            isArray<T>(value: T, message?: string): void;
+            isArray(value: unknown, message?: string): asserts value is unknown[];
 
             /**
              * Asserts that value is not an array.
@@ -750,7 +750,7 @@ declare global {
              * @param value   Actual value.
              * @param message   Message to display on error.
              */
-            isNotArray<T>(value: T, message?: string): void;
+            isNotArray(value: unknown, message?: string): asserts value is Exclude<unknown, unknown[]>;
 
             /**
              * Asserts that value is a string.
@@ -759,7 +759,7 @@ declare global {
              * @param value   Actual value.
              * @param message   Message to display on error.
              */
-            isString<T>(value: T, message?: string): void;
+            isString(value: unknown, message?: string): asserts value is string;
 
             /**
              * Asserts that value is not a string.
@@ -768,7 +768,7 @@ declare global {
              * @param value   Actual value.
              * @param message   Message to display on error.
              */
-            isNotString<T>(value: T, message?: string): void;
+            isNotString(value: unknown, message?: string): asserts value is Exclude<unknown, string>;
 
             /**
              * Asserts that value is a number.
@@ -777,7 +777,7 @@ declare global {
              * @param value   Actual value.
              * @param message   Message to display on error.
              */
-            isNumber<T>(value: T, message?: string): void;
+            isNumber(value: unknown, message?: string): asserts value is number;
 
             /**
              * Asserts that value is not a number.
@@ -786,7 +786,7 @@ declare global {
              * @param value   Actual value.
              * @param message   Message to display on error.
              */
-            isNotNumber<T>(value: T, message?: string): void;
+            isNotNumber(value: unknown, message?: string): asserts value is Exclude<unknown, number>;
 
             /**
              * Asserts that value is a finite number.
@@ -805,7 +805,7 @@ declare global {
              * @param value   Actual value.
              * @param message   Message to display on error.
              */
-            isBoolean<T>(value: T, message?: string): void;
+            isBoolean(value: unknown, message?: string): asserts value is boolean;
 
             /**
              * Asserts that value is not a boolean.
@@ -814,7 +814,7 @@ declare global {
              * @param value   Actual value.
              * @param message   Message to display on error.
              */
-            isNotBoolean<T>(value: T, message?: string): void;
+            isNotBoolean(value: unknown, message?: string): asserts value is Exclude<unknown, boolean>;
 
             /**
              * Asserts that value's type is name, as determined by Object.prototype.toString.
@@ -1139,7 +1139,7 @@ declare global {
              * @param property   Potential contained property of object.
              * @param message   Message to display on error.
              */
-            property<T>(object: T, property: string, /* keyof T */ message?: string): void;
+            property<T>(object: T, property: string, /* keyof T */ message?: string): asserts object is T & { [property]: unknown };
 
             /**
              * Asserts that object does not have a property named by property.
@@ -1149,7 +1149,7 @@ declare global {
              * @param property   Potential contained property of object.
              * @param message   Message to display on error.
              */
-            notProperty<T>(object: T, property: string, /* keyof T */ message?: string): void;
+            notProperty<T>(object: T, property: string, /* keyof T */ message?: string): asserts object is Exclude<T, { [property]: unknown }>;
 
             /**
              * Asserts that object has a property named by property, which can be a string
@@ -1183,7 +1183,7 @@ declare global {
              * @param value   Potential expected property value.
              * @param message   Message to display on error.
              */
-            propertyVal<T, V>(object: T, property: string, /* keyof T */ value: V, message?: string): void;
+            propertyVal<T, V>(object: T, property: string, /* keyof T */ value: V, message?: string): asserts object is T & { [property]: V };
 
             /**
              * Asserts that object has a property named by property with value given by value.
@@ -1195,7 +1195,7 @@ declare global {
              * @param value   Potential expected property value.
              * @param message   Message to display on error.
              */
-            notPropertyVal<T, V>(object: T, property: string, /* keyof T */ value: V, message?: string): void;
+            notPropertyVal<T, V>(object: T, property: string, /* keyof T */ value: V, message?: string): asserts object is Exclude<T, { [property]: V }>;
 
             /**
              * Asserts that object has a property named by property, which can be a string


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://www.chaijs.com/api/assert/#method_isstring>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. `[N/A]`
