### PR TITLE
feat(firefox-webext-browser): add type checking for browser.scripting.executeScript between func and args property

### DIFF
--- a/types/firefox-webext-browser/firefox-webext-browser-tests.ts
+++ b/types/firefox-webext-browser/firefox-webext-browser-tests.ts
@@ -124,3 +124,21 @@ console.log(filter.status);
 
 browser.storage.session.get("sessionObject");
 browser.storage.session.set({ "sessionObject": "value" });
+
+browser.scripting.executeScript({
+    target: { tabId: 1 },
+    func: () => {},
+});
+
+browser.scripting.executeScript({
+    target: { tabId: 1 },
+    // @ts-expect-error
+    args: [true],
+    func: (_n: number) => {},
+});
+
+browser.scripting.executeScript({
+    target: { tabId: 1 },
+    args: [0, "", false, [], {}],
+    func: (_n: number, _s: string, _b: boolean, _a: [], _o: {}) => {},
+});

--- a/types/firefox-webext-browser/index.d.ts
+++ b/types/firefox-webext-browser/index.d.ts
@@ -4664,11 +4664,11 @@ declare namespace browser.runtime {
 declare namespace browser.scripting {
     /* scripting types */
     /** Details of a script injection */
-    interface ScriptInjection {
+    interface ScriptInjection<Args extends any[]> {
         /**
          * The arguments to curry into a provided function. This is only valid if the `func` parameter is specified. These arguments must be JSON-serializable.
          */
-        args?: any[] | undefined;
+        args?: Args | undefined;
         /**
          * The path of the JS files to inject, relative to the extension's root directory. Exactly one of `files` and `func` must be specified.
          */
@@ -4677,7 +4677,7 @@ declare namespace browser.scripting {
          * A JavaScript function to inject. This function will be serialized, and then deserialized for injection. This means that any bound parameters and execution context will be lost. Exactly one of `files` and `func` must be specified.
          */
         // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-        func?: () => void | undefined;
+        func?: (...args: Args) => void | undefined;
         /** Details specifying the target into which to inject the script. */
         target: InjectionTarget;
         world?: ExecutionWorld | undefined;
@@ -4801,7 +4801,8 @@ declare namespace browser.scripting {
      * Injects a script into a target context. The script will be run at `document_idle`.
      * @param injection The details of the script which to inject.
      */
-    function executeScript(injection: ScriptInjection): Promise<InjectionResult[]>;
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+    function executeScript<T extends any[]>(injection: ScriptInjection<T>): Promise<InjectionResult[]>;
 
     /**
      * Inserts a CSS stylesheet into a target context. If multiple frames are specified, unsuccessful injections are ignored.

--- a/types/firefox-webext-browser/index.d.ts
+++ b/types/firefox-webext-browser/index.d.ts
@@ -4664,7 +4664,7 @@ declare namespace browser.runtime {
 declare namespace browser.scripting {
     /* scripting types */
     /** Details of a script injection */
-    interface ScriptInjection<Args extends any[]> {
+    interface ScriptInjection<Args extends any[] = any[]> {
         /**
          * The arguments to curry into a provided function. This is only valid if the `func` parameter is specified. These arguments must be JSON-serializable.
          */


### PR DESCRIPTION
Also fixes false positive of TS2322 when function with args is set to browser.scripting.executeScript func property

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting/executeScript#details>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.