### PR TITLE
[ramda] Fix for TS 6.0

### DIFF
--- a/types/ramda/test/index-tests.ts
+++ b/types/ramda/test/index-tests.ts
@@ -1,21 +1,17 @@
 import * as R from "ramda";
 import * as dist from "ramda/dist/ramda";
 import * as distMin from "ramda/dist/ramda.min";
-import * as src from "ramda/src";
 import * as srcIndex from "ramda/src/index";
 
 (async () => {
     const Res = await import("ramda");
-    const es = await import("ramda/es");
     const esIndex = await import("ramda/es/index");
 
     let typeChecker: typeof R;
     typeChecker = R;
-    typeChecker = src;
     typeChecker = srcIndex;
     typeChecker = dist;
     typeChecker = distMin;
     typeChecker = Res;
-    typeChecker = es;
     typeChecker = esIndex;
 });

--- a/types/ramda/test/maxBy-tests.ts
+++ b/types/ramda/test/maxBy-tests.ts
@@ -1,8 +1,7 @@
 import * as R from "ramda";
-import { Ord } from "ramda/tools";
 
 (() => {
-    function cmp(obj: { x: Ord }) {
+    function cmp(obj: { x: number | string | boolean | Date }) {
         return obj.x;
     }
 

--- a/types/ramda/test/minBy-tests.ts
+++ b/types/ramda/test/minBy-tests.ts
@@ -1,8 +1,7 @@
 import * as R from "ramda";
-import { Ord } from "ramda/tools";
 
 (() => {
-    function cmp(obj: { x: Ord }) {
+    function cmp(obj: { x: number | string | boolean | Date }) {
         return obj.x;
     }
 

--- a/types/ramda/tools.d.ts
+++ b/types/ramda/tools.d.ts
@@ -1,3 +1,0 @@
-// only keep what is used in test files
-
-export type Ord = number | string | boolean | Date;


### PR DESCRIPTION
Inline a type in the tests; `tools.d.ts` does not exist upstream and should not be in the package. (#64939 _almost_ removed it)

Also, remove tests of the `ramda/src` and `ramda/es` imports. These do not work at runtime.

```
node:internal/modules/esm/resolve:313
  return new ERR_PACKAGE_PATH_NOT_EXPORTED(
         ^

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './es' is not defined by "exports" in /home/jabaile/work/repros/ramda-test/node_modules/ramda/package.json imported from /home/jabaile/work/repros/ramda-test/main.mjs
    at exportsNotFound (node:internal/modules/esm/resolve:313:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:661:9)
    at packageResolve (node:internal/modules/esm/resolve:774:12)
    at moduleResolve (node:internal/modules/esm/resolve:858:18)
    at defaultResolve (node:internal/modules/esm/resolve:990:11)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:749:20)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:726:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:312:38)
    at #link (node:internal/modules/esm/module_job:208:49) {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}

Node.js v24.7.0
```

```
node:internal/modules/esm/resolve:313
  return new ERR_PACKAGE_PATH_NOT_EXPORTED(
         ^

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './src' is not defined by "exports" in /home/jabaile/work/repros/ramda-test/node_modules/ramda/package.json imported from /home/jabaile/work/repros/ramda-test/main.mjs
    at exportsNotFound (node:internal/modules/esm/resolve:313:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:661:9)
    at packageResolve (node:internal/modules/esm/resolve:774:12)
    at moduleResolve (node:internal/modules/esm/resolve:858:18)
    at defaultResolve (node:internal/modules/esm/resolve:990:11)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:749:20)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:726:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:312:38)
    at #link (node:internal/modules/esm/module_job:208:49) {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}

Node.js v24.7.0
```