### PR TITLE
[react-big-calendar] Add missing props type definitions to `date` and…

### DIFF
--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -209,8 +209,8 @@ export interface Components<TEvent extends object = Event, TResource extends obj
     toolbar?: React.ComponentType<ToolbarProps<TEvent, TResource>> | undefined;
     agenda?:
         | {
-            date?: React.ComponentType | undefined;
-            time?: React.ComponentType | undefined;
+            date?: React.ComponentType<AgendaDateProps> | undefined;
+            time?: React.ComponentType<AgendaTimeProps> | undefined;
             event?: React.ComponentType<EventProps<TEvent>> | undefined;
         }
         | undefined;
@@ -267,6 +267,17 @@ export interface EventProps<TEvent extends object = Event> {
     localizer: DateLocalizer;
     slotStart: Date;
     slotEnd: Date;
+}
+
+export interface AgendaDateProps {
+    day: Date;
+    label: string;
+}
+
+export interface AgendaTimeProps {
+    event: Event;
+    day: Date;
+    label: string;
 }
 
 export interface EventWrapperProps<TEvent extends object = Event> {

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 import {
+    AgendaDateProps,
+    AgendaTimeProps,
     Calendar,
     CalendarProps,
     Culture,
@@ -585,6 +587,35 @@ class Toolbar extends React.Component<ToolbarProps<CalendarEvent, CalendarResour
 
     const Basic = ({ localizer }: CalendarProps) => (
         <Calendar events={[]} localizer={localizer} components={{ month: { header, dateHeader, event } }} />
+    );
+
+    <Basic localizer={localizer} />;
+}
+
+// Test components.agenda
+{
+    const localizer: DateLocalizer = momentLocalizer(moment);
+
+    const date: React.FC<AgendaDateProps> = ({day,label}) => <>date</>;
+
+    const time: React.FC<AgendaTimeProps> = ({day,label,event}) => <>time</>;
+
+    const event: React.FC<EventProps> = ({
+        event,
+        title,
+        continuesPrior,
+        continuesAfter,
+        isAllDay,
+        localizer,
+        slotStart,
+        slotEnd,
+    }) => {
+        const { formats, propType, startOfWeek, format, messages } = localizer;
+        return <>Event</>;
+    };
+
+    const Basic = ({ localizer }: CalendarProps) => (
+        <Calendar events={[]} localizer={localizer} components={{ agenda: { date,time,event } }} />
     );
 
     <Basic localizer={localizer} />;


### PR DESCRIPTION
… `time` of components.agenda of react-big-calendar

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

AgendaDate: https://github.com/jquense/react-big-calendar/blob/b8dc3db1a61feb609f380ea13b6d5a41d1c30e68/src/Agenda.js#L122
AgendaTime: https://github.com/jquense/react-big-calendar/blob/b8dc3db1a61feb609f380ea13b6d5a41d1c30e68/src/Agenda.js#L122

- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

