### PR TITLE
node/worker_threads: update argument types for BroadcastChannel onmessage and onmessageerror

### DIFF
--- a/types/node/test/worker_threads.ts
+++ b/types/node/test/worker_threads.ts
@@ -144,8 +144,12 @@ import { createContext } from "node:vm";
     bc.close();
     bc.ref();
     bc.unref();
-    bc.onmessage = (msg: MessageEvent) => {};
-    bc.onmessageerror = (msg: unknown) => {};
+    bc.onmessage = (msg) => {
+        msg; // $ExpectType MessageEvent<any>
+    };
+    bc.onmessageerror = (msg) => {
+        msg; // $ExpectType MessageEvent<any>
+    };
 
     // Test global alias
     const bc2 = new BroadcastChannel("test");

--- a/types/node/test/worker_threads.ts
+++ b/types/node/test/worker_threads.ts
@@ -144,7 +144,7 @@ import { createContext } from "node:vm";
     bc.close();
     bc.ref();
     bc.unref();
-    bc.onmessage = (msg: unknown) => {};
+    bc.onmessage = (msg: MessageEvent) => {};
     bc.onmessageerror = (msg: unknown) => {};
 
     // Test global alias

--- a/types/node/v18/test/worker_threads.ts
+++ b/types/node/v18/test/worker_threads.ts
@@ -128,8 +128,12 @@ import { createContext } from "node:vm";
     bc.close();
     bc.ref();
     bc.unref();
-    bc.onmessage = (msg: MessageEvent) => {};
-    bc.onmessageerror = (msg: unknown) => {};
+    bc.onmessage = (msg) => {
+        msg; // $ExpectType MessageEvent<any>
+    };
+    bc.onmessageerror = (msg) => {
+        msg; // $ExpectType MessageEvent<any>
+    };
 
     // Test global alias
     const bc2 = new BroadcastChannel("test");

--- a/types/node/v18/test/worker_threads.ts
+++ b/types/node/v18/test/worker_threads.ts
@@ -128,7 +128,7 @@ import { createContext } from "node:vm";
     bc.close();
     bc.ref();
     bc.unref();
-    bc.onmessage = (msg: unknown) => {};
+    bc.onmessage = (msg: MessageEvent) => {};
     bc.onmessageerror = (msg: unknown) => {};
 
     // Test global alias

--- a/types/node/v18/worker_threads.d.ts
+++ b/types/node/v18/worker_threads.d.ts
@@ -536,7 +536,7 @@ declare module "worker_threads" {
          * Invoked with a received message cannot be deserialized.
          * @since v15.4.0
          */
-        onmessageerror: (message: unknown) => void;
+        onmessageerror: (message: MessageEvent) => void;
         constructor(name: string);
         /**
          * Closes the `BroadcastChannel` connection.

--- a/types/node/v18/worker_threads.d.ts
+++ b/types/node/v18/worker_threads.d.ts
@@ -525,7 +525,7 @@ declare module "worker_threads" {
      * ```
      * @since v15.4.0
      */
-    class BroadcastChannel {
+    class BroadcastChannel extends EventTarget {
         readonly name: string;
         /**
          * Invoked with a single \`MessageEvent\` argument when a message is received.

--- a/types/node/v18/worker_threads.d.ts
+++ b/types/node/v18/worker_threads.d.ts
@@ -59,6 +59,7 @@ declare module "worker_threads" {
     import { Readable, Writable } from "node:stream";
     import { ReadableStream, TransformStream, WritableStream } from "node:stream/web";
     import { URL } from "node:url";
+    import { MessageEvent } from "undici-types";
     const isMainThread: boolean;
     const parentPort: null | MessagePort;
     const resourceLimits: ResourceLimits;

--- a/types/node/v18/worker_threads.d.ts
+++ b/types/node/v18/worker_threads.d.ts
@@ -531,7 +531,7 @@ declare module "worker_threads" {
          * Invoked with a single \`MessageEvent\` argument when a message is received.
          * @since v15.4.0
          */
-        onmessage: (message: unknown) => void;
+        onmessage: (message: MessageEvent) => void;
         /**
          * Invoked with a received message cannot be deserialized.
          * @since v15.4.0

--- a/types/node/v20/test/worker_threads.ts
+++ b/types/node/v20/test/worker_threads.ts
@@ -128,8 +128,12 @@ import { createContext } from "node:vm";
     bc.close();
     bc.ref();
     bc.unref();
-    bc.onmessage = (msg: MessageEvent) => {};
-    bc.onmessageerror = (msg: unknown) => {};
+    bc.onmessage = (msg) => {
+        msg; // $ExpectType MessageEvent<any>
+    };
+    bc.onmessageerror = (msg) => {
+        msg; // $ExpectType MessageEvent<any>
+    };
 
     // Test global alias
     const bc2 = new BroadcastChannel("test");

--- a/types/node/v20/test/worker_threads.ts
+++ b/types/node/v20/test/worker_threads.ts
@@ -128,7 +128,7 @@ import { createContext } from "node:vm";
     bc.close();
     bc.ref();
     bc.unref();
-    bc.onmessage = (msg: unknown) => {};
+    bc.onmessage = (msg: MessageEvent) => {};
     bc.onmessageerror = (msg: unknown) => {};
 
     // Test global alias

--- a/types/node/v20/worker_threads.d.ts
+++ b/types/node/v20/worker_threads.d.ts
@@ -555,7 +555,7 @@ declare module "worker_threads" {
          * Invoked with a received message cannot be deserialized.
          * @since v15.4.0
          */
-        onmessageerror: (message: unknown) => void;
+        onmessageerror: (message: MessageEvent) => void;
         constructor(name: string);
         /**
          * Closes the `BroadcastChannel` connection.

--- a/types/node/v20/worker_threads.d.ts
+++ b/types/node/v20/worker_threads.d.ts
@@ -550,7 +550,7 @@ declare module "worker_threads" {
          * Invoked with a single \`MessageEvent\` argument when a message is received.
          * @since v15.4.0
          */
-        onmessage: (message: unknown) => void;
+        onmessage: (message: MessageEvent) => void;
         /**
          * Invoked with a received message cannot be deserialized.
          * @since v15.4.0

--- a/types/node/v20/worker_threads.d.ts
+++ b/types/node/v20/worker_threads.d.ts
@@ -544,7 +544,7 @@ declare module "worker_threads" {
      * ```
      * @since v15.4.0
      */
-    class BroadcastChannel {
+    class BroadcastChannel extends EventTarget {
         readonly name: string;
         /**
          * Invoked with a single \`MessageEvent\` argument when a message is received.

--- a/types/node/v20/worker_threads.d.ts
+++ b/types/node/v20/worker_threads.d.ts
@@ -59,6 +59,7 @@ declare module "worker_threads" {
     import { Readable, Writable } from "node:stream";
     import { ReadableStream, TransformStream, WritableStream } from "node:stream/web";
     import { URL } from "node:url";
+    import { MessageEvent } from "undici-types";
     const isMainThread: boolean;
     const parentPort: null | MessagePort;
     const resourceLimits: ResourceLimits;

--- a/types/node/v22/test/worker_threads.ts
+++ b/types/node/v22/test/worker_threads.ts
@@ -144,8 +144,12 @@ import { createContext } from "node:vm";
     bc.close();
     bc.ref();
     bc.unref();
-    bc.onmessage = (msg: MessageEvent) => {};
-    bc.onmessageerror = (msg: unknown) => {};
+    bc.onmessage = (msg) => {
+        msg; // $ExpectType MessageEvent<any>
+    };
+    bc.onmessageerror = (msg) => {
+        msg; // $ExpectType MessageEvent<any>
+    };
 
     // Test global alias
     const bc2 = new BroadcastChannel("test");

--- a/types/node/v22/test/worker_threads.ts
+++ b/types/node/v22/test/worker_threads.ts
@@ -144,7 +144,7 @@ import { createContext } from "node:vm";
     bc.close();
     bc.ref();
     bc.unref();
-    bc.onmessage = (msg: unknown) => {};
+    bc.onmessage = (msg: MessageEvent) => {};
     bc.onmessageerror = (msg: unknown) => {};
 
     // Test global alias

--- a/types/node/v22/worker_threads.d.ts
+++ b/types/node/v22/worker_threads.d.ts
@@ -573,7 +573,7 @@ declare module "worker_threads" {
      * ```
      * @since v15.4.0
      */
-    class BroadcastChannel {
+    class BroadcastChannel extends EventTarget {
         readonly name: string;
         /**
          * Invoked with a single \`MessageEvent\` argument when a message is received.

--- a/types/node/v22/worker_threads.d.ts
+++ b/types/node/v22/worker_threads.d.ts
@@ -579,7 +579,7 @@ declare module "worker_threads" {
          * Invoked with a single \`MessageEvent\` argument when a message is received.
          * @since v15.4.0
          */
-        onmessage: (message: unknown) => void;
+        onmessage: (message: MessageEvent) => void;
         /**
          * Invoked with a received message cannot be deserialized.
          * @since v15.4.0

--- a/types/node/v22/worker_threads.d.ts
+++ b/types/node/v22/worker_threads.d.ts
@@ -63,6 +63,7 @@ declare module "worker_threads" {
     import { ReadableStream, TransformStream, WritableStream } from "node:stream/web";
     import { URL } from "node:url";
     import { HeapInfo } from "node:v8";
+    import { MessageEvent } from "undici-types";
     const isInternalThread: boolean;
     const isMainThread: boolean;
     const parentPort: null | MessagePort;

--- a/types/node/v22/worker_threads.d.ts
+++ b/types/node/v22/worker_threads.d.ts
@@ -584,7 +584,7 @@ declare module "worker_threads" {
          * Invoked with a received message cannot be deserialized.
          * @since v15.4.0
          */
-        onmessageerror: (message: unknown) => void;
+        onmessageerror: (message: MessageEvent) => void;
         constructor(name: string);
         /**
          * Closes the `BroadcastChannel` connection.

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -63,6 +63,7 @@ declare module "worker_threads" {
     import { ReadableStream, TransformStream, WritableStream } from "node:stream/web";
     import { URL } from "node:url";
     import { HeapInfo } from "node:v8";
+    import { MessageEvent } from "undici-types";
     const isInternalThread: boolean;
     const isMainThread: boolean;
     const parentPort: null | MessagePort;

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -585,7 +585,7 @@ declare module "worker_threads" {
          * Invoked with a received message cannot be deserialized.
          * @since v15.4.0
          */
-        onmessageerror: (message: unknown) => void;
+        onmessageerror: (message: MessageEvent) => void;
         constructor(name: string);
         /**
          * Closes the `BroadcastChannel` connection.

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -574,7 +574,7 @@ declare module "worker_threads" {
      * ```
      * @since v15.4.0
      */
-    class BroadcastChannel {
+    class BroadcastChannel extends EventTarget {
         readonly name: string;
         /**
          * Invoked with a single \`MessageEvent\` argument when a message is received.

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -580,7 +580,7 @@ declare module "worker_threads" {
          * Invoked with a single \`MessageEvent\` argument when a message is received.
          * @since v15.4.0
          */
-        onmessage: (message: unknown) => void;
+        onmessage: (message: MessageEvent) => void;
         /**
          * Invoked with a received message cannot be deserialized.
          * @since v15.4.0


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v18.x/api/worker_threads.html#broadcastchannelonmessage
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
