### PR TITLE
fix express-serve-static-core application event emitter types

### DIFF
--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -349,3 +349,7 @@ app.get("/async", Promise.resolve);
 
 // Starting with Express 5, app.router is the app's in-built instance of router
 app.router.stack;
+
+app.on('mount', (app) => {
+    app; // $ExpectType Application<Record<string,any>
+});

--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -350,6 +350,6 @@ app.get("/async", Promise.resolve);
 // Starting with Express 5, app.router is the app's in-built instance of router
 app.router.stack;
 
-app.on('mount', (app) => {
+app.on("mount", (app) => {
     app; // $ExpectType Application<Record<string,any>
 });

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -1230,7 +1230,7 @@ export interface Application<
      *  - Not inherit the value of settings that have a default value. You must set the value in the sub-app.
      *  - Inherit the value of settings with no default value.
      */
-    on: (event: 'mount', callback: (parent: Application) => void) => this;
+    on: (event: "mount", callback: (parent: Application) => void) => this;
 
     /**
      * The app.mountpath property contains one or more path patterns on which a sub-app was mounted.

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -1230,7 +1230,7 @@ export interface Application<
      *  - Not inherit the value of settings that have a default value. You must set the value in the sub-app.
      *  - Inherit the value of settings with no default value.
      */
-    on: (event: string, callback: (parent: Application) => void) => this;
+    on: (event: 'mount', callback: (parent: Application) => void) => this;
 
     /**
      * The app.mountpath property contains one or more path patterns on which a sub-app was mounted.

--- a/types/express-serve-static-core/package.json
+++ b/types/express-serve-static-core/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/express-serve-static-core",
-    "version": "5.0.9999",
+    "version": "5.1.9999",
     "projects": [
         "http://expressjs.com"
     ],

--- a/types/express-serve-static-core/v4/index.d.ts
+++ b/types/express-serve-static-core/v4/index.d.ts
@@ -1281,7 +1281,7 @@ export interface Application<
      *  - Not inherit the value of settings that have a default value. You must set the value in the sub-app.
      *  - Inherit the value of settings with no default value.
      */
-    on: (event: string, callback: (parent: Application) => void) => this;
+    on: (event: 'mount', callback: (parent: Application) => void) => this;
 
     /**
      * The app.mountpath property contains one or more path patterns on which a sub-app was mounted.


### PR DESCRIPTION
Updated express/application event emitter types.

Express/Application only emits one event: `mount`.  
See [documentation](https://expressjs.com/en/5x/api.html#app.onmount).  
  
The way this was defined was:
```typescript
on: (event: string, callback: (parent: Application) => void) => this;
```

Meaning every event emitted by `#Application` will emit the parent which is not true because the user can emit own events.

## Example

```javascript

const app = express();

const onAccount = 'accountCreated'; 

app.on(onAccount , function sendWelcomeMessage(user) { /*...*/});

app.post('/users/', createUserMiddleware, function(req, res){
  res.status(201);
  app.emit(onAccount, req.user);
  res.end();
});
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
[https://expressjs.com/en/5x/api.html#app.onmount](https://expressjs.com/en/5x/api.html#app.onmount) and 
[https://github.com/expressjs/express/blob/master/lib/application.js#L240](https://github.com/expressjs/express/blob/master/lib/application.js#L240)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. 

## I have updated express version to 5.1 from 5.0

