### PR TITLE
fix(express-serve-static-core): update `req.body` default type to `unknown` to match default behaviour

### DIFF
--- a/types/body-parser/body-parser-tests.ts
+++ b/types/body-parser/body-parser-tests.ts
@@ -33,7 +33,7 @@ app.post("/api/users", jsonParser, (req, res) => {});
 app.use(jsonParser);
 
 const urlencodedParser = urlencoded({ extended: false });
-app.post("/login", urlencodedParser, (req, res) => {
+app.post<{}, any, { username: string }>("/login", urlencodedParser, (req, res) => {
     res.send("welcome, " + req.body.username);
 });
 app.use(urlencodedParser);

--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -167,7 +167,7 @@ app.post("/", (req, res) => {
     // @ts-expect-error
     req.params[0];
 
-    req.body; // $ExpectType any
+    req.body; // $ExpectType unknown
     res.send("ok"); // $ExpectType Response<any, Record<string, any>, number>
 });
 
@@ -176,7 +176,7 @@ app.route("/").post((req, res) => {
     // @ts-expect-error
     req.params[0];
 
-    req.body; // $ExpectType any
+    req.body; // $ExpectType unknown
     res.send("ok"); // $ExpectType Response<any, Record<string, any>, number>
 });
 
@@ -184,7 +184,7 @@ app.route("/").post((req, res) => {
 app.post("/" as string, (req, res) => {
     req.params[0]; // $ExpectType string
 
-    req.body; // $ExpectType any
+    req.body; // $ExpectType unknown
     res.send("ok"); // $ExpectType Response<any, Record<string, any>, number>
 });
 
@@ -192,7 +192,7 @@ app.post("/" as string, (req, res) => {
 app.route("/" as string).post((req, res) => {
     req.params[0]; // $ExpectType string
 
-    req.body; // $ExpectType any
+    req.body; // $ExpectType unknown
     res.send("ok"); // $ExpectType Response<any, Record<string, any>, number>
 });
 
@@ -202,7 +202,7 @@ app.get<never, { foo: string }>("/", (req, res) => {
     req.params.baz;
 
     res.send({ foo: "ok" }); // $ExpectType Response<{ foo: string; }, Record<string, any>, number>
-    req.body; // $ExpectType any
+    req.body; // $ExpectType unknown
 });
 
 // No params, only response body type - under route
@@ -211,7 +211,7 @@ app.route("/").get<never, { foo: string }>((req, res) => {
     req.params.baz;
 
     res.send({ foo: "ok" }); // $ExpectType Response<{ foo: string; }, Record<string, any>, number>
-    req.body; // $ExpectType any
+    req.body; // $ExpectType unknown
 });
 
 // No params, request body type and response body type

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -52,7 +52,7 @@ export interface Locals extends Express.Locals {}
 export interface RequestHandler<
     P = ParamsDictionary,
     ResBody = any,
-    ReqBody = any,
+    ReqBody = unknown,
     ReqQuery = ParsedQs,
     LocalsObj extends Record<string, any> = Record<string, any>,
 > {
@@ -67,7 +67,7 @@ export interface RequestHandler<
 export type ErrorRequestHandler<
     P = ParamsDictionary,
     ResBody = any,
-    ReqBody = any,
+    ReqBody = unknown,
     ReqQuery = ParsedQs,
     LocalsObj extends Record<string, any> = Record<string, any>,
 > = (
@@ -82,7 +82,7 @@ export type PathParams = string | RegExp | Array<string | RegExp>;
 export type RequestHandlerParams<
     P = ParamsDictionary,
     ResBody = any,
-    ReqBody = any,
+    ReqBody = unknown,
     ReqQuery = ParsedQs,
     LocalsObj extends Record<string, any> = Record<string, any>,
 > =
@@ -121,7 +121,7 @@ export interface IRouterMatcher<
         Route extends string,
         P = RouteParameters<Route>,
         ResBody = any,
-        ReqBody = any,
+        ReqBody = unknown,
         ReqQuery = ParsedQs,
         LocalsObj extends Record<string, any> = Record<string, any>,
     >(
@@ -134,7 +134,7 @@ export interface IRouterMatcher<
         Path extends string,
         P = RouteParameters<Path>,
         ResBody = any,
-        ReqBody = any,
+        ReqBody = unknown,
         ReqQuery = ParsedQs,
         LocalsObj extends Record<string, any> = Record<string, any>,
     >(
@@ -146,7 +146,7 @@ export interface IRouterMatcher<
     <
         P = ParamsDictionary,
         ResBody = any,
-        ReqBody = any,
+        ReqBody = unknown,
         ReqQuery = ParsedQs,
         LocalsObj extends Record<string, any> = Record<string, any>,
     >(
@@ -157,7 +157,7 @@ export interface IRouterMatcher<
     <
         P = ParamsDictionary,
         ResBody = any,
-        ReqBody = any,
+        ReqBody = unknown,
         ReqQuery = ParsedQs,
         LocalsObj extends Record<string, any> = Record<string, any>,
     >(
@@ -174,7 +174,7 @@ export interface IRouterHandler<T, Route extends string = string> {
     <
         P = RouteParameters<Route>,
         ResBody = any,
-        ReqBody = any,
+        ReqBody = unknown,
         ReqQuery = ParsedQs,
         LocalsObj extends Record<string, any> = Record<string, any>,
     >(
@@ -185,7 +185,7 @@ export interface IRouterHandler<T, Route extends string = string> {
     <
         P = RouteParameters<Route>,
         ResBody = any,
-        ReqBody = any,
+        ReqBody = unknown,
         ReqQuery = ParsedQs,
         LocalsObj extends Record<string, any> = Record<string, any>,
     >(
@@ -196,7 +196,7 @@ export interface IRouterHandler<T, Route extends string = string> {
     <
         P = ParamsDictionary,
         ResBody = any,
-        ReqBody = any,
+        ReqBody = unknown,
         ReqQuery = ParsedQs,
         LocalsObj extends Record<string, any> = Record<string, any>,
     >(
@@ -207,7 +207,7 @@ export interface IRouterHandler<T, Route extends string = string> {
     <
         P = ParamsDictionary,
         ResBody = any,
-        ReqBody = any,
+        ReqBody = unknown,
         ReqQuery = ParsedQs,
         LocalsObj extends Record<string, any> = Record<string, any>,
     >(
@@ -395,7 +395,7 @@ export type Errback = (err: Error) => void;
 export interface Request<
     P = ParamsDictionary,
     ResBody = any,
-    ReqBody = any,
+    ReqBody = unknown,
     ReqQuery = ParsedQs,
     LocalsObj extends Record<string, any> = Record<string, any>,
 > extends http.IncomingMessage, Express.Request {

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -51,7 +51,7 @@ namespace express_tests {
         }),
     );
     app.post("/search", express.urlencoded(), (req, res) => {
-        res.json(Object.keys(req.body));
+        res.json(Object.keys(req.body ?? {}));
     });
 
     const router = express.Router({ caseSensitive: true, mergeParams: true, strict: true });

--- a/types/json-server/json-server-tests.ts
+++ b/types/json-server/json-server-tests.ts
@@ -32,7 +32,10 @@ server.use(jsonServer.bodyParser);
 
 server.use((req, res, next) => {
     if (req.method === "POST") {
-        req.body.createdAt = Date.now();
+        req.body = {
+            ...req.body ?? {},
+            createdAt: Date.now(),
+        };
     }
     next();
 });

--- a/types/logfmt/logfmt-tests.ts
+++ b/types/logfmt/logfmt-tests.ts
@@ -1,6 +1,7 @@
 import * as express from "express";
 import * as http from "http";
 import * as logfmt from "logfmt";
+import { Stream } from "stream";
 import * as through from "through";
 
 // Examples taken from project README
@@ -42,7 +43,7 @@ http.createServer((req, res) => {
 
 const app = express();
 app.use(logfmt.bodyParserStream());
-app.post("/logs", (req, res) => {
+app.post<{}, any, Stream>("/logs", (req, res) => {
     if (!req.body) {
         return res.send("OK");
     }
@@ -57,7 +58,7 @@ app.post("/logs", (req, res) => {
 const app2 = express();
 app2.use(logfmt.bodyParser());
 // req.body is now an array of objects
-app2.post("/logs", (req, res) => {
+app2.post<{}, any, object[]>("/logs", (req, res) => {
     console.log("BODY: " + JSON.stringify(req.body));
     req.body.forEach((data: object) => {
         console.log(data);

--- a/types/node-slack/node-slack-tests.ts
+++ b/types/node-slack/node-slack-tests.ts
@@ -26,7 +26,7 @@ slack.send({
 });
 
 app.post("/yesman", function(req, res) {
-    var reply = slack.respond(req.body, function(hook: any) {
+    var reply = slack.respond(req.body as Slack.Query, function(hook: any) {
         return {
             text: "Good point, " + hook.user_name,
             username: "Bot",

--- a/types/saml2-js/saml2-js-tests.ts
+++ b/types/saml2-js/saml2-js-tests.ts
@@ -80,8 +80,8 @@ import * as saml2 from "saml2-js";
 
     // Assert endpoint for when login completes
     app.post("/assert", function(req, res) {
-        const options = {
-            request_body: req.body,
+        const options: saml2.PostAssertOptions = {
+            request_body: req.body as saml2.PostAssertOptions["request_body"],
             notbefore_skew: 5,
         };
         sp.post_assert(idp, options, function(err, saml_response) {


### PR DESCRIPTION
Types for `express-serve-static-core` have `req.body` as `any`, but Express v5 sets the default value to `undefined` if no body is parsed (see [docs](https://expressjs.com/en/guide/migrating-5.html#req.body)). `any` is way too wide a type to represent this and will cause this breaking change to be missed, whereas `unknown` forces runtime type checks.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://expressjs.com/en/guide/migrating-5.html#req.body
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
