### PR TITLE
[three] Allow TextureNode to accept Texture or TextureNode

### DIFF
--- a/types/three/src/nodes/accessors/TextureNode.d.ts
+++ b/types/three/src/nodes/accessors/TextureNode.d.ts
@@ -60,7 +60,7 @@ export default class TextureNode extends UniformNode<Texture> {
 }
 
 export const texture: (
-    value?: Texture,
+    value?: Texture | TextureNode,
     uvNode?: Node | null,
     levelNode?: Node | number | null,
     biasNode?: Node | null,
@@ -71,7 +71,7 @@ export const uniformTexture: (
 ) => ShaderNodeObject<TextureNode>;
 
 export const textureLoad: (
-    value?: Texture,
+    value?: Texture | TextureNode,
     uvNode?: Node,
     levelNode?: Node | number,
     biasNode?: Node,


### PR DESCRIPTION
The `texture()` and `textureLoad()` functions in Three.js TSL accept TextureNode as well as Texture. The inline type for this can be seen [here](https://github.com/mrdoob/three.js/blob/3c32743c1e5355f43d9e8319086caf92a0b19955/src/nodes/accessors/TextureNode.js#L822). This has been the case since r177 and the change can be found in [this PR](https://github.com/mrdoob/three.js/pull/31190).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.