### PR TITLE
[node] worker_threads: change MessagePort to a NodeEventTarget

### DIFF
--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -584,6 +584,85 @@ declare module "events" {
              */
             readonly asyncResource: EventEmitterReferencingAsyncResource;
         }
+        /**
+         * The `NodeEventTarget` is a Node.js-specific extension to `EventTarget`
+         * that emulates a subset of the `EventEmitter` API.
+         * @since v14.5.0
+         */
+        export interface NodeEventTarget extends EventTarget {
+            /**
+             * Node.js-specific extension to the `EventTarget` class that emulates the
+             * equivalent `EventEmitter` API. The only difference between `addListener()` and
+             * `addEventListener()` is that `addListener()` will return a reference to the
+             * `EventTarget`.
+             * @since v14.5.0
+             */
+            addListener(type: string, listener: (arg: any) => void): this;
+            /**
+             * Node.js-specific extension to the `EventTarget` class that dispatches the
+             * `arg` to the list of handlers for `type`.
+             * @since v15.2.0
+             * @returns `true` if event listeners registered for the `type` exist,
+             * otherwise `false`.
+             */
+            emit(type: string, arg: any): boolean;
+            /**
+             * Node.js-specific extension to the `EventTarget` class that returns an array
+             * of event `type` names for which event listeners are registered.
+             * @since 14.5.0
+             */
+            eventNames(): string[];
+            /**
+             * Node.js-specific extension to the `EventTarget` class that returns the number
+             * of event listeners registered for the `type`.
+             * @since v14.5.0
+             */
+            listenerCount(type: string): number;
+            /**
+             * Node.js-specific extension to the `EventTarget` class that sets the number
+             * of max event listeners as `n`.
+             * @since v14.5.0
+             */
+            setMaxListeners(n: number): void;
+            /**
+             * Node.js-specific extension to the `EventTarget` class that returns the number
+             * of max event listeners.
+             * @since v14.5.0
+             */
+            getMaxListeners(): number;
+            /**
+             * Node.js-specific alias for `eventTarget.removeEventListener()`.
+             * @since v14.5.0
+             */
+            off(type: string, listener: (arg: any) => void, options?: EventListenerOptions): this;
+            /**
+             * Node.js-specific alias for `eventTarget.addEventListener()`.
+             * @since v14.5.0
+             */
+            on(type: string, listener: (arg: any) => void): this;
+            /**
+             * Node.js-specific extension to the `EventTarget` class that adds a `once`
+             * listener for the given event `type`. This is equivalent to calling `on`
+             * with the `once` option set to `true`.
+             * @since v14.5.0
+             */
+            once(type: string, listener: (arg: any) => void): this;
+            /**
+             * Node.js-specific extension to the `EventTarget` class. If `type` is specified,
+             * removes all registered listeners for `type`, otherwise removes all registered
+             * listeners.
+             * @since v14.5.0
+             */
+            removeAllListeners(type?: string): this;
+            /**
+             * Node.js-specific extension to the `EventTarget` class that removes the
+             * `listener` for the given `type`. The only difference between `removeListener()`
+             * and `removeEventListener()` is that `removeListener()` will return a reference
+             * to the `EventTarget`.
+             * @since v14.5.0
+             */
+            removeListener(type: string, listener: (arg: any) => void, options?: EventListenerOptions): this;
+        }
     }
     global {
         namespace NodeJS {

--- a/types/node/v18/events.d.ts
+++ b/types/node/v18/events.d.ts
@@ -479,6 +479,85 @@ declare module "events" {
             /** The underlying AsyncResource */
             readonly asyncResource: EventEmitterReferencingAsyncResource;
         }
+        /**
+         * The `NodeEventTarget` is a Node.js-specific extension to `EventTarget`
+         * that emulates a subset of the `EventEmitter` API.
+         * @since v14.5.0
+         */
+        export interface NodeEventTarget extends EventTarget {
+            /**
+             * Node.js-specific extension to the `EventTarget` class that emulates the
+             * equivalent `EventEmitter` API. The only difference between `addListener()` and
+             * `addEventListener()` is that `addListener()` will return a reference to the
+             * `EventTarget`.
+             * @since v14.5.0
+             */
+            addListener(type: string, listener: (arg: any) => void): this;
+            /**
+             * Node.js-specific extension to the `EventTarget` class that dispatches the
+             * `arg` to the list of handlers for `type`.
+             * @since v15.2.0
+             * @returns `true` if event listeners registered for the `type` exist,
+             * otherwise `false`.
+             */
+            emit(type: string, arg: any): boolean;
+            /**
+             * Node.js-specific extension to the `EventTarget` class that returns an array
+             * of event `type` names for which event listeners are registered.
+             * @since 14.5.0
+             */
+            eventNames(): string[];
+            /**
+             * Node.js-specific extension to the `EventTarget` class that returns the number
+             * of event listeners registered for the `type`.
+             * @since v14.5.0
+             */
+            listenerCount(type: string): number;
+            /**
+             * Node.js-specific extension to the `EventTarget` class that sets the number
+             * of max event listeners as `n`.
+             * @since v14.5.0
+             */
+            setMaxListeners(n: number): void;
+            /**
+             * Node.js-specific extension to the `EventTarget` class that returns the number
+             * of max event listeners.
+             * @since v14.5.0
+             */
+            getMaxListeners(): number;
+            /**
+             * Node.js-specific alias for `eventTarget.removeEventListener()`.
+             * @since v14.5.0
+             */
+            off(type: string, listener: (arg: any) => void, options?: EventListenerOptions): this;
+            /**
+             * Node.js-specific alias for `eventTarget.addEventListener()`.
+             * @since v14.5.0
+             */
+            on(type: string, listener: (arg: any) => void): this;
+            /**
+             * Node.js-specific extension to the `EventTarget` class that adds a `once`
+             * listener for the given event `type`. This is equivalent to calling `on`
+             * with the `once` option set to `true`.
+             * @since v14.5.0
+             */
+            once(type: string, listener: (arg: any) => void): this;
+            /**
+             * Node.js-specific extension to the `EventTarget` class. If `type` is specified,
+             * removes all registered listeners for `type`, otherwise removes all registered
+             * listeners.
+             * @since v14.5.0
+             */
+            removeAllListeners(type?: string): this;
+            /**
+             * Node.js-specific extension to the `EventTarget` class that removes the
+             * `listener` for the given `type`. The only difference between `removeListener()`
+             * and `removeEventListener()` is that `removeListener()` will return a reference
+             * to the `EventTarget`.
+             * @since v14.5.0
+             */
+            removeListener(type: string, listener: (arg: any) => void, options?: EventListenerOptions): this;
+        }
     }
     global {
         namespace NodeJS {

--- a/types/node/v18/web-globals/events.d.ts
+++ b/types/node/v18/web-globals/events.d.ts
@@ -42,6 +42,7 @@ interface EventListenerObject {
     handleEvent(object: Event): void;
 }
 
+type _EventListenerOptions = typeof globalThis extends { onmessage: any } ? {} : EventListenerOptions;
 interface EventListenerOptions {
     capture?: boolean;
 }
@@ -68,6 +69,8 @@ declare global {
             prototype: Event;
             new(type: string, eventInitDict?: EventInit): Event;
         };
+
+    interface EventListenerOptions extends _EventListenerOptions {}
 
     interface EventTarget extends _EventTarget {}
     var EventTarget: typeof globalThis extends { onmessage: any; EventTarget: infer T } ? T

--- a/types/node/v18/worker_threads.d.ts
+++ b/types/node/v18/worker_threads.d.ts
@@ -53,7 +53,7 @@
  */
 declare module "worker_threads" {
     import { Context } from "node:vm";
-    import { EventEmitter } from "node:events";
+    import { EventEmitter, NodeEventTarget } from "node:events";
     import { EventLoopUtilityFunction } from "node:perf_hooks";
     import { FileHandle } from "node:fs/promises";
     import { Readable, Writable } from "node:stream";
@@ -106,7 +106,7 @@ declare module "worker_threads" {
      * This implementation matches [browser `MessagePort`](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort) s.
      * @since v10.5.0
      */
-    class MessagePort extends EventEmitter {
+    class MessagePort extends EventTarget {
         /**
          * Disables further sending of messages on either side of the connection.
          * This method can be called when no further communication will happen over this`MessagePort`.
@@ -214,42 +214,32 @@ declare module "worker_threads" {
          * @since v10.5.0
          */
         start(): void;
-        addListener(event: "close", listener: () => void): this;
+        addListener(event: "close", listener: (ev: Event) => void): this;
         addListener(event: "message", listener: (value: any) => void): this;
         addListener(event: "messageerror", listener: (error: Error) => void): this;
-        addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        emit(event: "close"): boolean;
+        addListener(event: string, listener: (arg: any) => void): this;
+        emit(event: "close", ev: Event): boolean;
         emit(event: "message", value: any): boolean;
         emit(event: "messageerror", error: Error): boolean;
-        emit(event: string | symbol, ...args: any[]): boolean;
-        on(event: "close", listener: () => void): this;
+        emit(event: string, arg: any): boolean;
+        off(event: "close", listener: (ev: Event) => void, options?: EventListenerOptions): this;
+        off(event: "message", listener: (value: any) => void, options?: EventListenerOptions): this;
+        off(event: "messageerror", listener: (error: Error) => void, options?: EventListenerOptions): this;
+        off(event: string, listener: (arg: any) => void, options?: EventListenerOptions): this;
+        on(event: "close", listener: (ev: Event) => void): this;
         on(event: "message", listener: (value: any) => void): this;
         on(event: "messageerror", listener: (error: Error) => void): this;
-        on(event: string | symbol, listener: (...args: any[]) => void): this;
-        once(event: "close", listener: () => void): this;
+        on(event: string, listener: (arg: any) => void): this;
+        once(event: "close", listener: (ev: Event) => void): this;
         once(event: "message", listener: (value: any) => void): this;
         once(event: "messageerror", listener: (error: Error) => void): this;
-        once(event: string | symbol, listener: (...args: any[]) => void): this;
-        prependListener(event: "close", listener: () => void): this;
-        prependListener(event: "message", listener: (value: any) => void): this;
-        prependListener(event: "messageerror", listener: (error: Error) => void): this;
-        prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        prependOnceListener(event: "close", listener: () => void): this;
-        prependOnceListener(event: "message", listener: (value: any) => void): this;
-        prependOnceListener(event: "messageerror", listener: (error: Error) => void): this;
-        prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        removeListener(event: "close", listener: () => void): this;
-        removeListener(event: "message", listener: (value: any) => void): this;
-        removeListener(event: "messageerror", listener: (error: Error) => void): this;
-        removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        off(event: "close", listener: () => void): this;
-        off(event: "message", listener: (value: any) => void): this;
-        off(event: "messageerror", listener: (error: Error) => void): this;
-        off(event: string | symbol, listener: (...args: any[]) => void): this;
-        addEventListener: EventTarget["addEventListener"];
-        dispatchEvent: EventTarget["dispatchEvent"];
-        removeEventListener: EventTarget["removeEventListener"];
+        once(event: string, listener: (arg: any) => void): this;
+        removeListener(event: "close", listener: (ev: Event) => void, options?: EventListenerOptions): this;
+        removeListener(event: "message", listener: (value: any) => void, options?: EventListenerOptions): this;
+        removeListener(event: "messageerror", listener: (error: Error) => void, options?: EventListenerOptions): this;
+        removeListener(event: string, listener: (arg: any) => void, options?: EventListenerOptions): this;
     }
+    interface MessagePort extends NodeEventTarget {}
     interface WorkerOptions {
         /**
          * List of arguments which would be stringified and appended to

--- a/types/node/v20/events.d.ts
+++ b/types/node/v20/events.d.ts
@@ -585,6 +585,85 @@ declare module "events" {
              */
             readonly asyncResource: EventEmitterReferencingAsyncResource;
         }
+        /**
+         * The `NodeEventTarget` is a Node.js-specific extension to `EventTarget`
+         * that emulates a subset of the `EventEmitter` API.
+         * @since v14.5.0
+         */
+        export interface NodeEventTarget extends EventTarget {
+            /**
+             * Node.js-specific extension to the `EventTarget` class that emulates the
+             * equivalent `EventEmitter` API. The only difference between `addListener()` and
+             * `addEventListener()` is that `addListener()` will return a reference to the
+             * `EventTarget`.
+             * @since v14.5.0
+             */
+            addListener(type: string, listener: (arg: any) => void): this;
+            /**
+             * Node.js-specific extension to the `EventTarget` class that dispatches the
+             * `arg` to the list of handlers for `type`.
+             * @since v15.2.0
+             * @returns `true` if event listeners registered for the `type` exist,
+             * otherwise `false`.
+             */
+            emit(type: string, arg: any): boolean;
+            /**
+             * Node.js-specific extension to the `EventTarget` class that returns an array
+             * of event `type` names for which event listeners are registered.
+             * @since 14.5.0
+             */
+            eventNames(): string[];
+            /**
+             * Node.js-specific extension to the `EventTarget` class that returns the number
+             * of event listeners registered for the `type`.
+             * @since v14.5.0
+             */
+            listenerCount(type: string): number;
+            /**
+             * Node.js-specific extension to the `EventTarget` class that sets the number
+             * of max event listeners as `n`.
+             * @since v14.5.0
+             */
+            setMaxListeners(n: number): void;
+            /**
+             * Node.js-specific extension to the `EventTarget` class that returns the number
+             * of max event listeners.
+             * @since v14.5.0
+             */
+            getMaxListeners(): number;
+            /**
+             * Node.js-specific alias for `eventTarget.removeEventListener()`.
+             * @since v14.5.0
+             */
+            off(type: string, listener: (arg: any) => void, options?: EventListenerOptions): this;
+            /**
+             * Node.js-specific alias for `eventTarget.addEventListener()`.
+             * @since v14.5.0
+             */
+            on(type: string, listener: (arg: any) => void): this;
+            /**
+             * Node.js-specific extension to the `EventTarget` class that adds a `once`
+             * listener for the given event `type`. This is equivalent to calling `on`
+             * with the `once` option set to `true`.
+             * @since v14.5.0
+             */
+            once(type: string, listener: (arg: any) => void): this;
+            /**
+             * Node.js-specific extension to the `EventTarget` class. If `type` is specified,
+             * removes all registered listeners for `type`, otherwise removes all registered
+             * listeners.
+             * @since v14.5.0
+             */
+            removeAllListeners(type?: string): this;
+            /**
+             * Node.js-specific extension to the `EventTarget` class that removes the
+             * `listener` for the given `type`. The only difference between `removeListener()`
+             * and `removeEventListener()` is that `removeListener()` will return a reference
+             * to the `EventTarget`.
+             * @since v14.5.0
+             */
+            removeListener(type: string, listener: (arg: any) => void, options?: EventListenerOptions): this;
+        }
     }
     global {
         namespace NodeJS {

--- a/types/node/v20/web-globals/events.d.ts
+++ b/types/node/v20/web-globals/events.d.ts
@@ -51,6 +51,7 @@ interface EventListenerObject {
     handleEvent(object: Event): void;
 }
 
+type _EventListenerOptions = typeof globalThis extends { onmessage: any } ? {} : EventListenerOptions;
 interface EventListenerOptions {
     capture?: boolean;
 }
@@ -84,6 +85,8 @@ declare global {
             prototype: Event;
             new(type: string, eventInitDict?: EventInit): Event;
         };
+
+    interface EventListenerOptions extends _EventListenerOptions {}
 
     interface EventTarget extends _EventTarget {}
     var EventTarget: typeof globalThis extends { onmessage: any; EventTarget: infer T } ? T

--- a/types/node/v20/worker_threads.d.ts
+++ b/types/node/v20/worker_threads.d.ts
@@ -53,7 +53,7 @@
  */
 declare module "worker_threads" {
     import { Context } from "node:vm";
-    import { EventEmitter } from "node:events";
+    import { EventEmitter, NodeEventTarget } from "node:events";
     import { EventLoopUtilityFunction } from "node:perf_hooks";
     import { FileHandle } from "node:fs/promises";
     import { Readable, Writable } from "node:stream";
@@ -106,7 +106,7 @@ declare module "worker_threads" {
      * This implementation matches [browser `MessagePort`](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort) s.
      * @since v10.5.0
      */
-    class MessagePort extends EventEmitter {
+    class MessagePort extends EventTarget {
         /**
          * Disables further sending of messages on either side of the connection.
          * This method can be called when no further communication will happen over this `MessagePort`.
@@ -214,42 +214,32 @@ declare module "worker_threads" {
          * @since v10.5.0
          */
         start(): void;
-        addListener(event: "close", listener: () => void): this;
+        addListener(event: "close", listener: (ev: Event) => void): this;
         addListener(event: "message", listener: (value: any) => void): this;
         addListener(event: "messageerror", listener: (error: Error) => void): this;
-        addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        emit(event: "close"): boolean;
+        addListener(event: string, listener: (arg: any) => void): this;
+        emit(event: "close", ev: Event): boolean;
         emit(event: "message", value: any): boolean;
         emit(event: "messageerror", error: Error): boolean;
-        emit(event: string | symbol, ...args: any[]): boolean;
-        on(event: "close", listener: () => void): this;
+        emit(event: string, arg: any): boolean;
+        off(event: "close", listener: (ev: Event) => void, options?: EventListenerOptions): this;
+        off(event: "message", listener: (value: any) => void, options?: EventListenerOptions): this;
+        off(event: "messageerror", listener: (error: Error) => void, options?: EventListenerOptions): this;
+        off(event: string, listener: (arg: any) => void, options?: EventListenerOptions): this;
+        on(event: "close", listener: (ev: Event) => void): this;
         on(event: "message", listener: (value: any) => void): this;
         on(event: "messageerror", listener: (error: Error) => void): this;
-        on(event: string | symbol, listener: (...args: any[]) => void): this;
-        once(event: "close", listener: () => void): this;
+        on(event: string, listener: (arg: any) => void): this;
+        once(event: "close", listener: (ev: Event) => void): this;
         once(event: "message", listener: (value: any) => void): this;
         once(event: "messageerror", listener: (error: Error) => void): this;
-        once(event: string | symbol, listener: (...args: any[]) => void): this;
-        prependListener(event: "close", listener: () => void): this;
-        prependListener(event: "message", listener: (value: any) => void): this;
-        prependListener(event: "messageerror", listener: (error: Error) => void): this;
-        prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        prependOnceListener(event: "close", listener: () => void): this;
-        prependOnceListener(event: "message", listener: (value: any) => void): this;
-        prependOnceListener(event: "messageerror", listener: (error: Error) => void): this;
-        prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        removeListener(event: "close", listener: () => void): this;
-        removeListener(event: "message", listener: (value: any) => void): this;
-        removeListener(event: "messageerror", listener: (error: Error) => void): this;
-        removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        off(event: "close", listener: () => void): this;
-        off(event: "message", listener: (value: any) => void): this;
-        off(event: "messageerror", listener: (error: Error) => void): this;
-        off(event: string | symbol, listener: (...args: any[]) => void): this;
-        addEventListener: EventTarget["addEventListener"];
-        dispatchEvent: EventTarget["dispatchEvent"];
-        removeEventListener: EventTarget["removeEventListener"];
+        once(event: string, listener: (arg: any) => void): this;
+        removeListener(event: "close", listener: (ev: Event) => void, options?: EventListenerOptions): this;
+        removeListener(event: "message", listener: (value: any) => void, options?: EventListenerOptions): this;
+        removeListener(event: "messageerror", listener: (error: Error) => void, options?: EventListenerOptions): this;
+        removeListener(event: string, listener: (arg: any) => void, options?: EventListenerOptions): this;
     }
+    interface MessagePort extends NodeEventTarget {}
     interface WorkerOptions {
         /**
          * List of arguments which would be stringified and appended to

--- a/types/node/v22/events.d.ts
+++ b/types/node/v22/events.d.ts
@@ -584,6 +584,85 @@ declare module "events" {
              */
             readonly asyncResource: EventEmitterReferencingAsyncResource;
         }
+        /**
+         * The `NodeEventTarget` is a Node.js-specific extension to `EventTarget`
+         * that emulates a subset of the `EventEmitter` API.
+         * @since v14.5.0
+         */
+        export interface NodeEventTarget extends EventTarget {
+            /**
+             * Node.js-specific extension to the `EventTarget` class that emulates the
+             * equivalent `EventEmitter` API. The only difference between `addListener()` and
+             * `addEventListener()` is that `addListener()` will return a reference to the
+             * `EventTarget`.
+             * @since v14.5.0
+             */
+            addListener(type: string, listener: (arg: any) => void): this;
+            /**
+             * Node.js-specific extension to the `EventTarget` class that dispatches the
+             * `arg` to the list of handlers for `type`.
+             * @since v15.2.0
+             * @returns `true` if event listeners registered for the `type` exist,
+             * otherwise `false`.
+             */
+            emit(type: string, arg: any): boolean;
+            /**
+             * Node.js-specific extension to the `EventTarget` class that returns an array
+             * of event `type` names for which event listeners are registered.
+             * @since 14.5.0
+             */
+            eventNames(): string[];
+            /**
+             * Node.js-specific extension to the `EventTarget` class that returns the number
+             * of event listeners registered for the `type`.
+             * @since v14.5.0
+             */
+            listenerCount(type: string): number;
+            /**
+             * Node.js-specific extension to the `EventTarget` class that sets the number
+             * of max event listeners as `n`.
+             * @since v14.5.0
+             */
+            setMaxListeners(n: number): void;
+            /**
+             * Node.js-specific extension to the `EventTarget` class that returns the number
+             * of max event listeners.
+             * @since v14.5.0
+             */
+            getMaxListeners(): number;
+            /**
+             * Node.js-specific alias for `eventTarget.removeEventListener()`.
+             * @since v14.5.0
+             */
+            off(type: string, listener: (arg: any) => void, options?: EventListenerOptions): this;
+            /**
+             * Node.js-specific alias for `eventTarget.addEventListener()`.
+             * @since v14.5.0
+             */
+            on(type: string, listener: (arg: any) => void): this;
+            /**
+             * Node.js-specific extension to the `EventTarget` class that adds a `once`
+             * listener for the given event `type`. This is equivalent to calling `on`
+             * with the `once` option set to `true`.
+             * @since v14.5.0
+             */
+            once(type: string, listener: (arg: any) => void): this;
+            /**
+             * Node.js-specific extension to the `EventTarget` class. If `type` is specified,
+             * removes all registered listeners for `type`, otherwise removes all registered
+             * listeners.
+             * @since v14.5.0
+             */
+            removeAllListeners(type?: string): this;
+            /**
+             * Node.js-specific extension to the `EventTarget` class that removes the
+             * `listener` for the given `type`. The only difference between `removeListener()`
+             * and `removeEventListener()` is that `removeListener()` will return a reference
+             * to the `EventTarget`.
+             * @since v14.5.0
+             */
+            removeListener(type: string, listener: (arg: any) => void, options?: EventListenerOptions): this;
+        }
     }
     global {
         namespace NodeJS {

--- a/types/node/v22/web-globals/events.d.ts
+++ b/types/node/v22/web-globals/events.d.ts
@@ -51,6 +51,7 @@ interface EventListenerObject {
     handleEvent(object: Event): void;
 }
 
+type _EventListenerOptions = typeof globalThis extends { onmessage: any } ? {} : EventListenerOptions;
 interface EventListenerOptions {
     capture?: boolean;
 }
@@ -84,6 +85,8 @@ declare global {
             prototype: Event;
             new(type: string, eventInitDict?: EventInit): Event;
         };
+
+    interface EventListenerOptions extends _EventListenerOptions {}
 
     interface EventTarget extends _EventTarget {}
     var EventTarget: typeof globalThis extends { onmessage: any; EventTarget: infer T } ? T

--- a/types/node/v22/worker_threads.d.ts
+++ b/types/node/v22/worker_threads.d.ts
@@ -56,7 +56,7 @@
  */
 declare module "worker_threads" {
     import { Context } from "node:vm";
-    import { EventEmitter } from "node:events";
+    import { EventEmitter, NodeEventTarget } from "node:events";
     import { EventLoopUtilityFunction } from "node:perf_hooks";
     import { FileHandle } from "node:fs/promises";
     import { Readable, Writable } from "node:stream";
@@ -111,7 +111,7 @@ declare module "worker_threads" {
      * This implementation matches [browser `MessagePort`](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort) s.
      * @since v10.5.0
      */
-    class MessagePort extends EventEmitter {
+    class MessagePort extends EventTarget {
         /**
          * Disables further sending of messages on either side of the connection.
          * This method can be called when no further communication will happen over this `MessagePort`.
@@ -224,42 +224,32 @@ declare module "worker_threads" {
          * @since v10.5.0
          */
         start(): void;
-        addListener(event: "close", listener: () => void): this;
+        addListener(event: "close", listener: (ev: Event) => void): this;
         addListener(event: "message", listener: (value: any) => void): this;
         addListener(event: "messageerror", listener: (error: Error) => void): this;
-        addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        emit(event: "close"): boolean;
+        addListener(event: string, listener: (arg: any) => void): this;
+        emit(event: "close", ev: Event): boolean;
         emit(event: "message", value: any): boolean;
         emit(event: "messageerror", error: Error): boolean;
-        emit(event: string | symbol, ...args: any[]): boolean;
-        on(event: "close", listener: () => void): this;
+        emit(event: string, arg: any): boolean;
+        off(event: "close", listener: (ev: Event) => void, options?: EventListenerOptions): this;
+        off(event: "message", listener: (value: any) => void, options?: EventListenerOptions): this;
+        off(event: "messageerror", listener: (error: Error) => void, options?: EventListenerOptions): this;
+        off(event: string, listener: (arg: any) => void, options?: EventListenerOptions): this;
+        on(event: "close", listener: (ev: Event) => void): this;
         on(event: "message", listener: (value: any) => void): this;
         on(event: "messageerror", listener: (error: Error) => void): this;
-        on(event: string | symbol, listener: (...args: any[]) => void): this;
-        once(event: "close", listener: () => void): this;
+        on(event: string, listener: (arg: any) => void): this;
+        once(event: "close", listener: (ev: Event) => void): this;
         once(event: "message", listener: (value: any) => void): this;
         once(event: "messageerror", listener: (error: Error) => void): this;
-        once(event: string | symbol, listener: (...args: any[]) => void): this;
-        prependListener(event: "close", listener: () => void): this;
-        prependListener(event: "message", listener: (value: any) => void): this;
-        prependListener(event: "messageerror", listener: (error: Error) => void): this;
-        prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        prependOnceListener(event: "close", listener: () => void): this;
-        prependOnceListener(event: "message", listener: (value: any) => void): this;
-        prependOnceListener(event: "messageerror", listener: (error: Error) => void): this;
-        prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        removeListener(event: "close", listener: () => void): this;
-        removeListener(event: "message", listener: (value: any) => void): this;
-        removeListener(event: "messageerror", listener: (error: Error) => void): this;
-        removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        off(event: "close", listener: () => void): this;
-        off(event: "message", listener: (value: any) => void): this;
-        off(event: "messageerror", listener: (error: Error) => void): this;
-        off(event: string | symbol, listener: (...args: any[]) => void): this;
-        addEventListener: EventTarget["addEventListener"];
-        dispatchEvent: EventTarget["dispatchEvent"];
-        removeEventListener: EventTarget["removeEventListener"];
+        once(event: string, listener: (arg: any) => void): this;
+        removeListener(event: "close", listener: (ev: Event) => void, options?: EventListenerOptions): this;
+        removeListener(event: "message", listener: (value: any) => void, options?: EventListenerOptions): this;
+        removeListener(event: "messageerror", listener: (error: Error) => void, options?: EventListenerOptions): this;
+        removeListener(event: string, listener: (arg: any) => void, options?: EventListenerOptions): this;
     }
+    interface MessagePort extends NodeEventTarget {}
     interface WorkerOptions {
         /**
          * List of arguments which would be stringified and appended to

--- a/types/node/web-globals/events.d.ts
+++ b/types/node/web-globals/events.d.ts
@@ -51,6 +51,7 @@ interface EventListenerObject {
     handleEvent(object: Event): void;
 }
 
+type _EventListenerOptions = typeof globalThis extends { onmessage: any } ? {} : EventListenerOptions;
 interface EventListenerOptions {
     capture?: boolean;
 }
@@ -84,6 +85,8 @@ declare global {
             prototype: Event;
             new(type: string, eventInitDict?: EventInit): Event;
         };
+
+    interface EventListenerOptions extends _EventListenerOptions {}
 
     interface EventTarget extends _EventTarget {}
     var EventTarget: typeof globalThis extends { onmessage: any; EventTarget: infer T } ? T

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -56,7 +56,7 @@
  */
 declare module "worker_threads" {
     import { Context } from "node:vm";
-    import { EventEmitter } from "node:events";
+    import { EventEmitter, NodeEventTarget } from "node:events";
     import { EventLoopUtilityFunction } from "node:perf_hooks";
     import { FileHandle } from "node:fs/promises";
     import { Readable, Writable } from "node:stream";
@@ -112,7 +112,7 @@ declare module "worker_threads" {
      * This implementation matches [browser `MessagePort`](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort) s.
      * @since v10.5.0
      */
-    class MessagePort extends EventEmitter {
+    class MessagePort extends EventTarget {
         /**
          * Disables further sending of messages on either side of the connection.
          * This method can be called when no further communication will happen over this `MessagePort`.
@@ -225,42 +225,32 @@ declare module "worker_threads" {
          * @since v10.5.0
          */
         start(): void;
-        addListener(event: "close", listener: () => void): this;
+        addListener(event: "close", listener: (ev: Event) => void): this;
         addListener(event: "message", listener: (value: any) => void): this;
         addListener(event: "messageerror", listener: (error: Error) => void): this;
-        addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        emit(event: "close"): boolean;
+        addListener(event: string, listener: (arg: any) => void): this;
+        emit(event: "close", ev: Event): boolean;
         emit(event: "message", value: any): boolean;
         emit(event: "messageerror", error: Error): boolean;
-        emit(event: string | symbol, ...args: any[]): boolean;
-        on(event: "close", listener: () => void): this;
+        emit(event: string, arg: any): boolean;
+        off(event: "close", listener: (ev: Event) => void, options?: EventListenerOptions): this;
+        off(event: "message", listener: (value: any) => void, options?: EventListenerOptions): this;
+        off(event: "messageerror", listener: (error: Error) => void, options?: EventListenerOptions): this;
+        off(event: string, listener: (arg: any) => void, options?: EventListenerOptions): this;
+        on(event: "close", listener: (ev: Event) => void): this;
         on(event: "message", listener: (value: any) => void): this;
         on(event: "messageerror", listener: (error: Error) => void): this;
-        on(event: string | symbol, listener: (...args: any[]) => void): this;
-        once(event: "close", listener: () => void): this;
+        on(event: string, listener: (arg: any) => void): this;
+        once(event: "close", listener: (ev: Event) => void): this;
         once(event: "message", listener: (value: any) => void): this;
         once(event: "messageerror", listener: (error: Error) => void): this;
-        once(event: string | symbol, listener: (...args: any[]) => void): this;
-        prependListener(event: "close", listener: () => void): this;
-        prependListener(event: "message", listener: (value: any) => void): this;
-        prependListener(event: "messageerror", listener: (error: Error) => void): this;
-        prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        prependOnceListener(event: "close", listener: () => void): this;
-        prependOnceListener(event: "message", listener: (value: any) => void): this;
-        prependOnceListener(event: "messageerror", listener: (error: Error) => void): this;
-        prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        removeListener(event: "close", listener: () => void): this;
-        removeListener(event: "message", listener: (value: any) => void): this;
-        removeListener(event: "messageerror", listener: (error: Error) => void): this;
-        removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
-        off(event: "close", listener: () => void): this;
-        off(event: "message", listener: (value: any) => void): this;
-        off(event: "messageerror", listener: (error: Error) => void): this;
-        off(event: string | symbol, listener: (...args: any[]) => void): this;
-        addEventListener: EventTarget["addEventListener"];
-        dispatchEvent: EventTarget["dispatchEvent"];
-        removeEventListener: EventTarget["removeEventListener"];
+        once(event: string, listener: (arg: any) => void): this;
+        removeListener(event: "close", listener: (ev: Event) => void, options?: EventListenerOptions): this;
+        removeListener(event: "message", listener: (value: any) => void, options?: EventListenerOptions): this;
+        removeListener(event: "messageerror", listener: (error: Error) => void, options?: EventListenerOptions): this;
+        removeListener(event: string, listener: (arg: any) => void, options?: EventListenerOptions): this;
     }
+    interface MessagePort extends NodeEventTarget {}
     interface WorkerOptions {
         /**
          * List of arguments which would be stringified and appended to


### PR DESCRIPTION
At present, we're providing the web-derived MessagePort as a subclass of Node.js's EventEmitter.

It's not: it's an EventTarget, or specifically a NodeEventTarget, a mixin for DOM's EventTarget that emulates _some_ EventEmitter-style methods with listeners that receive raw event data instead of DOM Event objects. Typing these as EventEmitters is incorrect, as they do not inherit from `EventEmitter.prototype`, nor do they provide the full range of EventEmitter methods and functionality.

MessagePort is still the only API that uses this pattern.