### PR TITLE
[chrome] update since Chrome 139-140

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -153,7 +153,7 @@ declare namespace chrome {
     export namespace action {
         export interface BadgeColorDetails {
             /** An array of four integers in the range [0,255] that make up the RGBA color of the badge. For example, opaque red is `[255, 0, 0, 255]`. Can also be a string with a CSS value, with opaque red being `#FF0000` or `#F00`. */
-            color: string | ColorArray;
+            color: string | extensionTypes.ColorArray;
             /** Limits the change to when a particular tab is selected. Automatically resets when the tab is closed. */
             tabId?: number | undefined;
         }
@@ -164,8 +164,6 @@ declare namespace chrome {
             /** Limits the change to when a particular tab is selected. Automatically resets when the tab is closed. */
             tabId?: number | undefined;
         }
-
-        export type ColorArray = [number, number, number, number];
 
         export interface TitleDetails {
             /** The string the action should display when moused over. */
@@ -241,8 +239,11 @@ declare namespace chrome {
          *
          * Can return its result via Promise.
          */
-        export function getBadgeBackgroundColor(details: TabDetails): Promise<ColorArray>;
-        export function getBadgeBackgroundColor(details: TabDetails, callback: (result: ColorArray) => void): void;
+        export function getBadgeBackgroundColor(details: TabDetails): Promise<extensionTypes.ColorArray>;
+        export function getBadgeBackgroundColor(
+            details: TabDetails,
+            callback: (result: extensionTypes.ColorArray) => void,
+        ): void;
 
         /**
          * Gets the badge text of the action. If no tab is specified, the non-tab-specific badge text is returned. If {@link declarativeNetRequest.ExtensionActionOptions.displayActionCountAsBadgeText displayActionCountAsBadgeText} is enabled, a placeholder text will be returned unless the {@link runtime.ManifestPermissions declarativeNetRequestFeedback} permission is present or tab-specific badge text was provided.
@@ -258,8 +259,11 @@ declare namespace chrome {
          * Can return its result via Promise.
          * @since Chrome 110
          */
-        export function getBadgeTextColor(details: TabDetails): Promise<ColorArray>;
-        export function getBadgeTextColor(details: TabDetails, callback: (result: ColorArray) => void): void;
+        export function getBadgeTextColor(details: TabDetails): Promise<extensionTypes.ColorArray>;
+        export function getBadgeTextColor(
+            details: TabDetails,
+            callback: (result: extensionTypes.ColorArray) => void,
+        ): void;
 
         /**
          * Gets the html document set as the popup for this action.
@@ -864,7 +868,7 @@ declare namespace chrome {
     export namespace browserAction {
         export interface BadgeBackgroundColorDetails {
             /** An array of four integers in the range [0,255] that make up the RGBA color of the badge. For example, opaque red is [255, 0, 0, 255]. Can also be a string with a CSS value, with opaque red being #FF0000 or #F00. */
-            color: string | ColorArray;
+            color: string | extensionTypes.ColorArray;
             /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
             tabId?: number | undefined;
         }
@@ -875,8 +879,6 @@ declare namespace chrome {
             /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
             tabId?: number | undefined;
         }
-
-        export type ColorArray = [number, number, number, number];
 
         export interface TitleDetails {
             /** The string the browser action should display when moused over. */
@@ -1005,13 +1007,16 @@ declare namespace chrome {
          * @since Chrome 19
          * Gets the background color of the browser action.
          */
-        export function getBadgeBackgroundColor(details: TabDetails, callback: (result: ColorArray) => void): void;
+        export function getBadgeBackgroundColor(
+            details: TabDetails,
+            callback: (result: extensionTypes.ColorArray) => void,
+        ): void;
         /**
          * @since Chrome 19
          * Gets the background color of the browser action.
          * @return The `getBadgeBackgroundColor` method provides its result via callback or returned as a `Promise` (MV3 only).
          */
-        export function getBadgeBackgroundColor(details: TabDetails): Promise<ColorArray>;
+        export function getBadgeBackgroundColor(details: TabDetails): Promise<extensionTypes.ColorArray>;
         /**
          * @since Chrome 19
          * Gets the html document set as the popup for this browser action.
@@ -4473,6 +4478,9 @@ declare namespace chrome {
     ////////////////////
     /** The `chrome.extensionTypes` API contains type declarations for Chrome extensions. */
     export namespace extensionTypes {
+        /** @since Chrome 139 */
+        export type ColorArray = [number, number, number, number];
+
         /**
          * The origin of injected CSS.
          * @since Chrome 66

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -2824,6 +2824,11 @@ declare namespace chrome {
             onHidden: events.Event<() => void>;
             /** Fired upon a search action (start of a new search, search result navigation, or search being canceled). */
             onSearch: events.Event<(action: string, queryString?: string) => void>;
+            /**
+             * Shows the panel by activating the corresponding tab.
+             * @since Chrome 140
+             */
+            show(): void;
         }
 
         /** A button created by the extension. */
@@ -11118,6 +11123,11 @@ declare namespace chrome {
             /** Whether the tabs are pinned. */
             pinned?: boolean | undefined;
             /**
+             * The ID of the Split View that the tabs are in, or `tabs.SPLIT_VIEW_ID_NONE` for tabs that aren't in a Split View.
+             * @since Chrome 140
+             */
+            splitViewId?: number | undefined;
+            /**
              * Whether the tabs are audible.
              * @since Chrome 45
              */
@@ -11180,6 +11190,11 @@ declare namespace chrome {
             mutedInfo?: MutedInfo;
             /** The tab's new pinned state. */
             pinned?: boolean;
+            /**
+             * The tab's new Split View.
+             * @since Chrome 140
+             */
+            splitViewId?: number;
             /** The tab's loading status. */
             status?: `${TabStatus}`;
             /**
@@ -14321,6 +14336,11 @@ declare namespace chrome {
             openPanelOnActionClick?: boolean;
         }
 
+        /** @since Chrome 140 */
+        export interface PanelLayout {
+            side: `${Side}`;
+        }
+
         export interface PanelOptions {
             /** Whether the side panel should be enabled. This is optional. The default value is true. */
             enabled?: boolean;
@@ -14334,10 +14354,26 @@ declare namespace chrome {
             tabId?: number;
         }
 
+        /**
+         * Defines the possible alignment for the side panel in the browser UI.
+         * @since Chrome 140
+         */
+        export enum Side {
+            LEFT = "left",
+            RIGHT = "right",
+        }
+
         export interface SidePanel {
             /** Developer specified path for side panel display. */
             default_path: string;
         }
+
+        /**
+         * Returns the side panel's current layout.
+         * @since Chrome 140
+         */
+        export function getLayout(): Promise<PanelLayout>;
+        export function getLayout(callback: (layout: PanelLayout) => void): void;
 
         /**
          * Returns the active panel configuration.

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1419,7 +1419,11 @@ function testDevtoolsPanels() {
 
     chrome.devtools.panels.create(title, iconPath, pagePath); // $ExpectType void
     chrome.devtools.panels.create(title, iconPath, pagePath, panel => { // $ExpectType void
-        panel; // $ExpectType ExtensionPanel
+        checkChromeEvent(panel.onHidden, () => void 0);
+        checkChromeEvent(panel.onSearch, () => void 0);
+        checkChromeEvent(panel.onShown, () => void 0);
+        panel.createStatusBarButton("iconPath", "tooltipText", true); // $ExpectType Button
+        panel.show(); // $ExpectType void
     });
 
     const url = "url";
@@ -2715,6 +2719,7 @@ async function testTabs() {
         lastFocusedWindow: true,
         muted: true,
         pinned: true,
+        splitViewId: 1,
         status: "complete",
         title: "title",
         url: "url",
@@ -2879,6 +2884,7 @@ async function testTabs() {
         changeInfo.groupId; // $ExpectType number | undefined
         changeInfo.mutedInfo; // $ExpectType MutedInfo | undefined
         changeInfo.pinned; // $ExpectType boolean | undefined
+        changeInfo.splitViewId; // $ExpectType number | undefined
         changeInfo.status; // $ExpectType "unloaded" | "loading" | "complete" | undefined
         changeInfo.title; // $ExpectType string | undefined
         changeInfo.url; // $ExpectType string | undefined
@@ -5348,8 +5354,15 @@ async function testSessionsForPromise() {
     await chrome.sessions.restore("myString");
 }
 
-// Test for chrome.sidePanel API
-function testSidePanelAPI() {
+// https://developer.chrome.com/docs/extensions/reference/api/sidePanel
+function testSidePanel() {
+    chrome.sidePanel.getLayout(); // $ExpectType Promise<PanelLayout>
+    chrome.sidePanel.getLayout((layout) => { // $ExpectType void
+        layout.side; // $ExpectType "left" | "right"
+    });
+    // @ts-expect-error
+    chrome.sidePanel.getLayout(() => {}).then(() => {});
+
     let getPanelOptions: chrome.sidePanel.GetPanelOptions = {
         tabId: 123,
     };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://developer.chrome.com/docs/extensions/reference/api/extensionTypes#type-ColorArray
  - https://developer.chrome.com/docs/extensions/reference/api/devtools/panels#type-ExtensionPanel
  - https://developer.chrome.com/docs/extensions/reference/api/tabs#method-query
  - https://developer.chrome.com/docs/extensions/reference/api/sidePanel#method-getLayout
  
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes:
- move `action.ColorArray` and `browserAction.ColorArray` to `extensionTypes.ColorArray`
- update `devtools.panels.ExtensionPanel`: add `show()`
- update `tabs.QueryInfo` and `tabs.OnUpdatedInfo`: add `splitViewId`
- add `sidePanel.getLayout()`
- update tests