### PR TITLE
[chrome] update printerProvider namespace

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -7899,13 +7899,25 @@ declare namespace chrome {
             id: string;
             /** Printer's human readable name. */
             name: string;
-            /** Optional. Printer's human readable description. */
+            /** Printer's human readable description. */
             description?: string | undefined;
+        }
+
+        /** Error codes returned in response to {@link onPrintRequested} event. */
+        export enum PrintError {
+            /** Specifies that the operation was completed successfully. */
+            OK = "OK",
+            /** Specifies that a general failure occured. */
+            FAILED = "FAILED",
+            /** Specifies that the print ticket is invalid. For example, the ticket is inconsistent with some capabilities, or the extension is not able to handle all settings from the ticket. */
+            INVALID_TICKET = "INVALID_TICKET",
+            /** Specifies that the document is invalid. For example, data may be corrupted or the format is incompatible with the extension. */
+            INVALID_DATA = "INVALID_DATA",
         }
 
         export interface PrinterCapabilities {
             /** Device capabilities in CDD format. */
-            capabilities: any;
+            capabilities: { [key: string]: unknown };
         }
 
         export interface PrintJob {
@@ -7913,44 +7925,68 @@ declare namespace chrome {
             printerId: string;
             /** The print job title. */
             title: string;
-            /** Print ticket in  CJT format. */
+            /** Print ticket in CJT format. */
             ticket: { [key: string]: unknown };
-            /** The document content type. Supported formats are "application/pdf" and "image/pwg-raster". */
+            /** The document content type. Supported formats are `application/pdf` and `image/pwg-raster`. */
             contentType: string;
-            /** Blob containing the document data to print. Format must match |contentType|. */
+            /** Blob containing the document data to print. Format must match `contentType`. */
             document: Blob;
         }
 
-        export interface PrinterRequestedEvent
-            extends chrome.events.Event<(resultCallback: (printerInfo: PrinterInfo[]) => void) => void>
-        {}
-
-        export interface PrinterInfoRequestedEvent
-            extends chrome.events.Event<(device: any, resultCallback: (printerInfo?: PrinterInfo) => void) => void>
-        {}
-
-        export interface CapabilityRequestedEvent extends
-            chrome.events.Event<
-                (printerId: string, resultCallback: (capabilities: PrinterCapabilities) => void) => void
-            >
-        {}
-
-        export interface PrintRequestedEvent
-            extends chrome.events.Event<(printJob: PrintJob, resultCallback: (result: string) => void) => void>
-        {}
+        /** from https://developer.chrome.com/docs/apps/reference/usb#type-Device */
+        export interface Device {
+            /** An opaque ID for the USB device. It remains unchanged until the device is unplugged. */
+            device: number;
+            /**
+             * The iManufacturer string read from the device, if available.
+             * @since Chrome 46
+             */
+            manufacturerName: string;
+            /** The product ID. */
+            productId: number;
+            /**
+             * The iProduct string read from the device, if available.
+             * @since Chrome 46
+             */
+            productName: string;
+            /**
+             * The iSerialNumber string read from the device, if available.
+             * @since Chrome 46
+             */
+            serialNumber: string;
+            /** The device vendor ID. */
+            vendorId: number;
+            /**
+             * The device version (bcdDevice field).
+             * @since Chrome 51
+             */
+            version: number;
+        }
 
         /** Event fired when print manager requests printers provided by extensions. */
-        export var onGetPrintersRequested: PrinterRequestedEvent;
+        export const onGetPrintersRequested: events.Event<
+            (resultCallback: (printerInfo: PrinterInfo[]) => void) => void
+        >;
+
         /**
          * Event fired when print manager requests information about a USB device that may be a printer.
-         * Note: An application should not rely on this event being fired more than once per device. If a connected device is supported it should be returned in the onGetPrintersRequested event.
+         *
+         * Note: An application should not rely on this event being fired more than once per device. If a connected device is supported it should be returned in the {@link onGetPrintersRequested} event.
          * @since Chrome 45
          */
-        export var onGetUsbPrinterInfoRequested: PrinterInfoRequestedEvent;
+        export const onGetUsbPrinterInfoRequested: events.Event<
+            (device: Device, resultCallback: (printerInfo?: PrinterInfo) => void) => void
+        >;
+
         /** Event fired when print manager requests printer capabilities. */
-        export var onGetCapabilityRequested: CapabilityRequestedEvent;
+        export const onGetCapabilityRequested: events.Event<
+            (printerId: string, resultCallback: (capabilities: PrinterCapabilities) => void) => void
+        >;
+
         /** Event fired when print manager requests printing. */
-        export var onPrintRequested: PrintRequestedEvent;
+        export const onPrintRequested: events.Event<
+            (printJob: PrintJob, resultCallback: (result: `${PrintError}`) => void) => void
+        >;
     }
 
     ////////////////////

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -6282,6 +6282,49 @@ function testPower() {
     chrome.power.reportActivity(() => {}).then(() => {});
 }
 
+// https://developer.chrome.com/docs/extensions/reference/api/printerProvider
+function testPrinterProvider() {
+    chrome.printerProvider.PrintError.FAILED === "FAILED";
+    chrome.printerProvider.PrintError.INVALID_DATA === "INVALID_DATA";
+    chrome.printerProvider.PrintError.INVALID_TICKET === "INVALID_TICKET";
+    chrome.printerProvider.PrintError.OK === "OK";
+
+    const printInfo: chrome.printerProvider.PrinterInfo = {
+        description: "description",
+        id: "id",
+        name: "name",
+    };
+
+    checkChromeEvent(chrome.printerProvider.onGetCapabilityRequested, (printerId, resultCallback) => {
+        printerId; // $ExpectType string
+        resultCallback({ capabilities: {} }); // $ExpectType void
+    });
+
+    checkChromeEvent(chrome.printerProvider.onGetPrintersRequested, (resultCallback) => {
+        resultCallback([printInfo]); // $ExpectType void
+    });
+
+    checkChromeEvent(chrome.printerProvider.onGetUsbPrinterInfoRequested, (device, resultCallback) => {
+        device.device; // $ExpectType number
+        device.manufacturerName; // $ExpectType string
+        device.productId; // $ExpectType number
+        device.productName; // $ExpectType string
+        device.serialNumber; // $ExpectType string
+        device.vendorId; // $ExpectType number
+        device.version; // $ExpectType number
+        resultCallback(printInfo); // $ExpectType void
+    });
+
+    checkChromeEvent(chrome.printerProvider.onPrintRequested, (printJob, resultCallback) => {
+        printJob.contentType; // $ExpectType string
+        printJob.document; // $ExpectType Blob
+        printJob.printerId; // $ExpectType string
+        printJob.ticket; // $ExpectType { [key: string]: unknown; }
+        printJob.title; // $ExpectType string
+        resultCallback("OK"); // $ExpectType void
+    });
+}
+
 // https://developer.chrome.com/docs/extensions/reference/api/platformKeys
 function testPlatformKeys() {
     chrome.platformKeys.ClientCertificateType.ECDSA_SIGN === "ecdsaSign";


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/printerProvider
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes:
- add `PrintError` enum
- update `PrinterCapabilities`: remplace `any` by object
- update `onGetUsbPrinterInfoRequested`: replace `any` by `Device` (from chrome apps) for `device` param 
- update `onPrintRequested`: replace `string` by `PrintError` for `result` param
- add tests
- update jsdoc

Runtime:
<img width="852" height="342" alt="image" src="https://github.com/user-attachments/assets/4df98da5-7ed4-4abb-a68d-0d78f0623861" />
