### PR TITLE
node: v24.6

### DIFF
--- a/types/node/assert.d.ts
+++ b/types/node/assert.d.ts
@@ -4,13 +4,33 @@
  * @see [source](https://github.com/nodejs/node/blob/v24.x/lib/assert.js)
  */
 declare module "assert" {
+    import strict = require("assert/strict");
     /**
-     * An alias of {@link ok}.
+     * An alias of {@link assert.ok}.
      * @since v0.5.9
      * @param value The input that is checked for being truthy.
      */
     function assert(value: unknown, message?: string | Error): asserts value;
     namespace assert {
+        type AssertMethodNames =
+            | "deepEqual"
+            | "deepStrictEqual"
+            | "doesNotMatch"
+            | "doesNotReject"
+            | "doesNotThrow"
+            | "equal"
+            | "fail"
+            | "ifError"
+            | "match"
+            | "notDeepEqual"
+            | "notDeepStrictEqual"
+            | "notEqual"
+            | "notStrictEqual"
+            | "ok"
+            | "partialDeepStrictEqual"
+            | "rejects"
+            | "strictEqual"
+            | "throws";
         /**
          * Indicates the failure of an assertion. All errors thrown by the `node:assert` module will be instances of the `AssertionError` class.
          */
@@ -970,83 +990,9 @@ declare module "assert" {
          * @since v22.13.0
          */
         function partialDeepStrictEqual(actual: unknown, expected: unknown, message?: string | Error): void;
-        /**
-         * In strict assertion mode, non-strict methods behave like their corresponding strict methods. For example,
-         * {@link deepEqual} will behave like {@link deepStrictEqual}.
-         *
-         * In strict assertion mode, error messages for objects display a diff. In legacy assertion mode, error
-         * messages for objects display the objects, often truncated.
-         *
-         * To use strict assertion mode:
-         *
-         * ```js
-         * import { strict as assert } from 'node:assert';
-         * import assert from 'node:assert/strict';
-         * ```
-         *
-         * Example error diff:
-         *
-         * ```js
-         * import { strict as assert } from 'node:assert';
-         *
-         * assert.deepEqual([[[1, 2, 3]], 4, 5], [[[1, 2, '3']], 4, 5]);
-         * // AssertionError: Expected inputs to be strictly deep-equal:
-         * // + actual - expected ... Lines skipped
-         * //
-         * //   [
-         * //     [
-         * // ...
-         * //       2,
-         * // +     3
-         * // -     '3'
-         * //     ],
-         * // ...
-         * //     5
-         * //   ]
-         * ```
-         *
-         * To deactivate the colors, use the `NO_COLOR` or `NODE_DISABLE_COLORS` environment variables. This will also
-         * deactivate the colors in the REPL. For more on color support in terminal environments, read the tty
-         * `getColorDepth()` documentation.
-         *
-         * @since v15.0.0, v13.9.0, v12.16.2, v9.9.0
-         */
-        namespace strict {
-            type AssertionError = assert.AssertionError;
-            type AssertPredicate = assert.AssertPredicate;
-            type CallTrackerCall = assert.CallTrackerCall;
-            type CallTrackerReportInformation = assert.CallTrackerReportInformation;
-        }
-        const strict:
-            & Omit<
-                typeof assert,
-                | "equal"
-                | "notEqual"
-                | "deepEqual"
-                | "notDeepEqual"
-                | "ok"
-                | "strictEqual"
-                | "deepStrictEqual"
-                | "ifError"
-                | "strict"
-                | "AssertionError"
-            >
-            & {
-                (value: unknown, message?: string | Error): asserts value;
-                equal: typeof strictEqual;
-                notEqual: typeof notStrictEqual;
-                deepEqual: typeof deepStrictEqual;
-                notDeepEqual: typeof notDeepStrictEqual;
-                // Mapped types and assertion functions are incompatible?
-                // TS2775: Assertions require every name in the call target
-                // to be declared with an explicit type annotation.
-                ok: typeof ok;
-                strictEqual: typeof strictEqual;
-                deepStrictEqual: typeof deepStrictEqual;
-                ifError: typeof ifError;
-                strict: typeof strict;
-                AssertionError: typeof AssertionError;
-            };
+    }
+    namespace assert {
+        export { strict };
     }
     export = assert;
 }

--- a/types/node/assert.d.ts
+++ b/types/node/assert.d.ts
@@ -11,6 +11,7 @@ declare module "assert" {
      * @param value The input that is checked for being truthy.
      */
     function assert(value: unknown, message?: string | Error): asserts value;
+    const kOptions: unique symbol;
     namespace assert {
         type AssertMethodNames =
             | "deepEqual"
@@ -31,10 +32,100 @@ declare module "assert" {
             | "rejects"
             | "strictEqual"
             | "throws";
+        interface AssertOptions {
+            /**
+             * If set to `'full'`, shows the full diff in assertion errors.
+             * @default 'simple'
+             */
+            diff?: "simple" | "full" | undefined;
+            /**
+             * If set to `true`, non-strict methods behave like their
+             * corresponding strict methods.
+             * @default true
+             */
+            strict?: boolean | undefined;
+        }
+        interface Assert extends Pick<typeof assert, AssertMethodNames> {
+            readonly [kOptions]: AssertOptions & { strict: false };
+        }
+        interface AssertStrict extends Pick<typeof strict, AssertMethodNames> {
+            readonly [kOptions]: AssertOptions & { strict: true };
+        }
+        /**
+         * The `Assert` class allows creating independent assertion instances with custom options.
+         * @since v24.6.0
+         */
+        var Assert: {
+            /**
+             * Creates a new assertion instance. The `diff` option controls the verbosity of diffs in assertion error messages.
+             *
+             * ```js
+             * const { Assert } = require('node:assert');
+             * const assertInstance = new Assert({ diff: 'full' });
+             * assertInstance.deepStrictEqual({ a: 1 }, { a: 2 });
+             * // Shows a full diff in the error message.
+             * ```
+             *
+             * **Important**: When destructuring assertion methods from an `Assert` instance,
+             * the methods lose their connection to the instance's configuration options (such as `diff` and `strict` settings).
+             * The destructured methods will fall back to default behavior instead.
+             *
+             * ```js
+             * const myAssert = new Assert({ diff: 'full' });
+             *
+             * // This works as expected - uses 'full' diff
+             * myAssert.strictEqual({ a: 1 }, { b: { c: 1 } });
+             *
+             * // This loses the 'full' diff setting - falls back to default 'simple' diff
+             * const { strictEqual } = myAssert;
+             * strictEqual({ a: 1 }, { b: { c: 1 } });
+             * ```
+             *
+             * When destructured, methods lose access to the instance's `this` context and revert to default assertion behavior
+             * (diff: 'simple', non-strict mode).
+             * To maintain custom options when using destructured methods, avoid
+             * destructuring and call methods directly on the instance.
+             * @since v24.6.0
+             */
+            new(
+                options?: AssertOptions & { strict?: true },
+            ): AssertStrict;
+            new(
+                options: AssertOptions,
+            ): Assert;
+        };
+        interface AssertionErrorOptions {
+            /**
+             * If provided, the error message is set to this value.
+             */
+            message?: string | undefined;
+            /**
+             * The `actual` property on the error instance.
+             */
+            actual?: unknown;
+            /**
+             * The `expected` property on the error instance.
+             */
+            expected?: unknown;
+            /**
+             * The `operator` property on the error instance.
+             */
+            operator?: string | undefined;
+            /**
+             * If provided, the generated stack trace omits frames before this function.
+             */
+            stackStartFn?: Function | undefined;
+            /**
+             * If set to `'full'`, shows the full diff in assertion errors.
+             * @default 'simple'
+             */
+            diff?: "simple" | "full" | undefined;
+        }
         /**
          * Indicates the failure of an assertion. All errors thrown by the `node:assert` module will be instances of the `AssertionError` class.
          */
         class AssertionError extends Error {
+            constructor(options: AssertionErrorOptions);
             /**
              * Set to the `actual` argument for methods such as {@link assert.strictEqual()}.
              */
@@ -44,10 +135,6 @@ declare module "assert" {
              */
             expected: unknown;
             /**
-             * Set to the passed in operator value.
-             */
-            operator: string;
-            /**
              * Indicates if the message was auto-generated (`true`) or not.
              */
             generatedMessage: boolean;
@@ -55,19 +142,10 @@ declare module "assert" {
              * Value is always `ERR_ASSERTION` to show that the error is an assertion error.
              */
             code: "ERR_ASSERTION";
-            constructor(options?: {
-                /** If provided, the error message is set to this value. */
-                message?: string | undefined;
-                /** The `actual` property on the error instance. */
-                actual?: unknown | undefined;
-                /** The `expected` property on the error instance. */
-                expected?: unknown | undefined;
-                /** The `operator` property on the error instance. */
-                operator?: string | undefined;
-                /** If provided, the generated stack trace omits frames before this function. */
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-                stackStartFn?: Function | undefined;
-            });
+            /**
+             * Set to the passed in operator value.
+             */
+            operator: string;
         }
         /**
          * This feature is deprecated and will be removed in a future version.

--- a/types/node/assert/strict.d.ts
+++ b/types/node/assert/strict.d.ts
@@ -46,8 +46,12 @@
  */
 declare module "assert/strict" {
     import {
+        Assert,
         AssertionError,
+        AssertionErrorOptions,
+        AssertOptions,
         AssertPredicate,
+        AssertStrict,
         CallTracker,
         CallTrackerCall,
         CallTrackerReportInformation,
@@ -69,8 +73,12 @@ declare module "assert/strict" {
     function strict(value: unknown, message?: string | Error): asserts value;
     namespace strict {
         export {
+            Assert,
             AssertionError,
+            AssertionErrorOptions,
+            AssertOptions,
             AssertPredicate,
+            AssertStrict,
             CallTracker,
             CallTrackerCall,
             CallTrackerReportInformation,

--- a/types/node/assert/strict.d.ts
+++ b/types/node/assert/strict.d.ts
@@ -1,8 +1,103 @@
+/**
+ * In strict assertion mode, non-strict methods behave like their corresponding
+ * strict methods. For example, `assert.deepEqual()` will behave like
+ * `assert.deepStrictEqual()`.
+ *
+ * In strict assertion mode, error messages for objects display a diff. In legacy
+ * assertion mode, error messages for objects display the objects, often truncated.
+ *
+ * To use strict assertion mode:
+ *
+ * ```js
+ * import { strict as assert } from 'node:assert';
+ * ```
+ *
+ * ```js
+ * import assert from 'node:assert/strict';
+ * ```
+ *
+ * Example error diff:
+ *
+ * ```js
+ * import { strict as assert } from 'node:assert';
+ *
+ * assert.deepEqual([[[1, 2, 3]], 4, 5], [[[1, 2, '3']], 4, 5]);
+ * // AssertionError: Expected inputs to be strictly deep-equal:
+ * // + actual - expected ... Lines skipped
+ * //
+ * //   [
+ * //     [
+ * // ...
+ * //       2,
+ * // +     3
+ * // -     '3'
+ * //     ],
+ * // ...
+ * //     5
+ * //   ]
+ * ```
+ *
+ * To deactivate the colors, use the `NO_COLOR` or `NODE_DISABLE_COLORS`
+ * environment variables. This will also deactivate the colors in the REPL. For
+ * more on color support in terminal environments, read the tty
+ * [`getColorDepth()`](https://nodejs.org/docs/latest-v24.x/api/tty.html#writestreamgetcolordepthenv) documentation.
+ * @since v15.0.0
+ * @see [source](https://github.com/nodejs/node/blob/v24.x/lib/assert/strict.js)
+ */
 declare module "assert/strict" {
-    import { strict } from "node:assert";
+    import {
+        AssertionError,
+        AssertPredicate,
+        CallTracker,
+        CallTrackerCall,
+        CallTrackerReportInformation,
+        deepStrictEqual,
+        doesNotMatch,
+        doesNotReject,
+        doesNotThrow,
+        fail,
+        ifError,
+        match,
+        notDeepStrictEqual,
+        notStrictEqual,
+        ok,
+        partialDeepStrictEqual,
+        rejects,
+        strictEqual,
+        throws,
+    } from "node:assert";
+    function strict(value: unknown, message?: string | Error): asserts value;
+    namespace strict {
+        export {
+            AssertionError,
+            AssertPredicate,
+            CallTracker,
+            CallTrackerCall,
+            CallTrackerReportInformation,
+            deepStrictEqual,
+            deepStrictEqual as deepEqual,
+            doesNotMatch,
+            doesNotReject,
+            doesNotThrow,
+            fail,
+            ifError,
+            match,
+            notDeepStrictEqual,
+            notDeepStrictEqual as notDeepEqual,
+            notStrictEqual,
+            notStrictEqual as notEqual,
+            ok,
+            partialDeepStrictEqual,
+            rejects,
+            strict,
+            strictEqual,
+            strictEqual as equal,
+            throws,
+        };
+    }
     export = strict;
 }
 declare module "node:assert/strict" {
-    import { strict } from "node:assert";
+    import strict = require("assert/strict");
     export = strict;
 }

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -270,6 +270,13 @@ declare module "http" {
          */
         keepAliveTimeout?: number | undefined;
         /**
+         * An additional buffer time added to the
+         * `server.keepAliveTimeout` to extend the internal socket timeout.
+         * @since 24.6.0
+         * @default 1000
+         */
+        keepAliveTimeoutBuffer?: number | undefined;
+        /**
          * Sets the interval value in milliseconds to check for request and headers timeout in incomplete requests.
          * @default 30000
          */
@@ -413,12 +420,18 @@ declare module "http" {
         /**
          * The number of milliseconds of inactivity a server needs to wait for additional
          * incoming data, after it has finished writing the last response, before a socket
-         * will be destroyed. If the server receives new data before the keep-alive
-         * timeout has fired, it will reset the regular inactivity timeout, i.e., `server.timeout`.
+         * will be destroyed.
+         *
+         * This timeout value is combined with the
+         * `server.keepAliveTimeoutBuffer` option to determine the actual socket
+         * timeout, calculated as:
+         * socketTimeout = keepAliveTimeout + keepAliveTimeoutBuffer
+         * If the server receives new data before the keep-alive timeout has fired, it
+         * will reset the regular inactivity timeout, i.e., `server.timeout`.
          *
          * A value of `0` will disable the keep-alive timeout behavior on incoming
          * connections.
-         * A value of `0` makes the http server behave similarly to Node.js versions prior
+         * A value of `0` makes the HTTP server behave similarly to Node.js versions prior
          * to 8.0.0, which did not have a keep-alive timeout.
          *
          * The socket timeout logic is set up on connection, so changing this value only
@@ -426,6 +439,18 @@ declare module "http" {
          * @since v8.0.0
          */
         keepAliveTimeout: number;
+        /**
+         * An additional buffer time added to the
+         * `server.keepAliveTimeout` to extend the internal socket timeout.
+         *
+         * This buffer helps reduce connection reset (`ECONNRESET`) errors by increasing
+         * the socket timeout slightly beyond the advertised keep-alive timeout.
+         *
+         * This option applies only to new incoming connections.
+         * @since v24.6.0
+         * @default 1000
+         */
+        keepAliveTimeoutBuffer: number;
         /**
          * Sets the timeout value in milliseconds for receiving the entire request from
          * the client.

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -18,7 +18,7 @@
         }
     },
     "dependencies": {
-        "undici-types": "~7.12.0"
+        "undici-types": "~7.13.0"
     },
     "devDependencies": {
         "@types/node": "workspace:."

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "24.5.9999",
+    "version": "24.6.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -79,6 +79,7 @@
  * @see [source](https://github.com/nodejs/node/blob/v24.x/lib/test.js)
  */
 declare module "node:test" {
+    import { AssertMethodNames } from "node:assert";
     import { Readable } from "node:stream";
     import TestFn = test.TestFn;
     import TestOptions = test.TestOptions;
@@ -1171,29 +1172,7 @@ declare module "node:test" {
              */
             readonly mock: MockTracker;
         }
-        interface TestContextAssert extends
-            Pick<
-                typeof import("assert"),
-                | "deepEqual"
-                | "deepStrictEqual"
-                | "doesNotMatch"
-                | "doesNotReject"
-                | "doesNotThrow"
-                | "equal"
-                | "fail"
-                | "ifError"
-                | "match"
-                | "notDeepEqual"
-                | "notDeepStrictEqual"
-                | "notEqual"
-                | "notStrictEqual"
-                | "ok"
-                | "partialDeepStrictEqual"
-                | "rejects"
-                | "strictEqual"
-                | "throws"
-            >
-        {
+        interface TestContextAssert extends Pick<typeof import("assert"), AssertMethodNames> {
             /**
              * This function serializes `value` and writes it to the file specified by `path`.
              *

--- a/types/node/test/assert.ts
+++ b/types/node/test/assert.ts
@@ -1,7 +1,9 @@
 import assert = require("node:assert");
+import strict = require("node:assert/strict");
 
 {
-    const { stack } = new assert.AssertionError({});
+    // Assert that all assert exports are present in assert/strict
+    const keys: keyof typeof strict = {} as keyof typeof assert;
 }
 
 {
@@ -151,9 +153,6 @@ assert.strict.strict.strict(1);
 assert.strict.strict(1);
 assert.strict(1);
 
-const strictAssertionError: assert.strict.AssertionError = new assert.strict.AssertionError();
-assert(1);
-
 assert.match("test", /test/, new Error("yeet"));
 assert.match("test", /test/, "yeet");
 
@@ -185,50 +184,33 @@ assert["fail"](true, true, "works like a charm");
 
 assert.partialDeepStrictEqual({ a: 1, b: 2, c: 3 }, { a: 1, b: 2 });
 
+// Test assert predicates
 {
-    const a = null as any;
+    let a!: Error | null;
     assert.ifError(a);
-    a; // $ExpectType null | undefined
-}
+    a; // $ExpectType null
 
-{
-    const a = true as boolean;
-    assert(a);
-    a; // $ExpectType true
-}
+    let b!: boolean;
+    assert(b);
+    b; // $ExpectType true
 
-{
-    const a = 13 as number | null | undefined;
-    assert(a);
-    a; // $ExpectType number
-}
+    let c!: boolean;
+    assert.ok(c);
+    c; // $ExpectType true
 
-{
-    const a = true as boolean;
-    assert.ok(a);
-    a; // $ExpectType true
-}
+    let d!: unknown;
+    assert.strictEqual(d, "test");
+    d; // $ExpectType "test"
 
-{
-    const a = 13 as number | null | undefined;
-    assert.ok(a);
-    a; // $ExpectType number
-}
+    let e!: unknown;
+    strict.equal(e, "test");
+    e; // $ExpectType "test"
 
-{
-    const a = "test" as any;
-    assert.strictEqual(a, "test");
-    a; // $ExpectType string || "test"
-}
+    let f!: unknown;
+    assert.deepStrictEqual(f, { n: 2 as const });
+    f; // $ExpectType { n: 2; }
 
-{
-    const a = { b: 2 } as any;
-    assert.deepStrictEqual(a, { b: 2 });
-    a; // $ExpectType { b: number; }
+    let g!: unknown;
+    strict.deepEqual(g, { n: 2 as const });
+    g; // $ExpectType { n: 2; }
 }
-
-// This is a regression test for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71889.
-// Due to the nature of the bug this can't be switched to `import strict from "node:assert/strict";`
-// or to `import strict = require("node:assert/strict");`
-import { AssertionError } from "node:assert/strict";
-new AssertionError({ message: "some message" });

--- a/types/node/test/assert.ts
+++ b/types/node/test/assert.ts
@@ -7,24 +7,20 @@ import strict = require("node:assert/strict");
 }
 
 {
-    const { message } = new assert.AssertionError({
+    const assertionError = new assert.AssertionError({
         actual: 1,
         expected: 2,
         operator: "strictEqual",
+        diff: "full",
     });
 
-    try {
-        assert.strictEqual(1, 2);
-    } catch (err) {
-        assert(err instanceof assert.AssertionError);
-        assert.strictEqual(err.message, message);
-        assert.strictEqual(err.name, "AssertionError");
-        assert.strictEqual(err.actual, 1);
-        assert.strictEqual(err.expected, 2);
-        assert.strictEqual(err.code, "ERR_ASSERTION");
-        assert.strictEqual(err.operator, "strictEqual");
-        assert.strictEqual(err.generatedMessage, true);
-    }
+    // Assertion errors are native errors
+    const nativeError: Error = assertionError;
+
+    assertionError.message; // $ExpectType string
+    assertionError.code; // $ExpectType "ERR_ASSERTION"
+    assertionError.operator; // $ExpectType string
+    assertionError.generatedMessage; // $ExpectType boolean
 }
 
 {
@@ -213,4 +209,38 @@ assert.partialDeepStrictEqual({ a: 1, b: 2, c: 3 }, { a: 1, b: 2 });
     let g!: unknown;
     strict.deepEqual(g, { n: 2 as const });
     g; // $ExpectType { n: 2; }
+}
+
+{
+    let n!: number;
+    let _1: 1;
+
+    const legacyCustomAssert: assert.Assert = new assert.Assert({
+        strict: false,
+    });
+    legacyCustomAssert.equal(n, 1);
+    // @ts-expect-error non-strict assert.equal is not an assert predicate
+    _1 = n;
+
+    // The type annotation is mandatory here to avoid TS2775
+    const strictCustomAssert: assert.AssertStrict = new assert.Assert({
+        diff: "full",
+    });
+    strictCustomAssert.equal(n, 1);
+    _1 = n;
+
+    // @ts-expect-error legacy Assert instances should not be assignable to AssertStrict
+    const invalidAssignment: assert.AssertStrict = new assert.Assert({
+        strict: false,
+    });
+
+    // Verify that all assertion methods are present on the Assert interfaces
+    const legacyKeys: keyof assert.Assert = {} as Exclude<
+        keyof typeof assert,
+        "Assert" | "AssertionError" | "CallTracker" | "strict"
+    >;
+    const strictKeys: keyof assert.AssertStrict = {} as Exclude<
+        keyof typeof strict,
+        "Assert" | "AssertionError" | "CallTracker" | "strict"
+    >;
 }

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -755,6 +755,22 @@ import { promisify } from "node:util";
             type: "pkcs8",
         },
     });
+
+    const mldsaRes: {
+        publicKey: Buffer;
+        privateKey: string;
+    } = crypto.generateKeyPairSync("ml-dsa-44", {
+        publicKeyEncoding: {
+            format: "der",
+            type: "spki",
+        },
+        privateKeyEncoding: {
+            cipher: "some-cipher",
+            format: "pem",
+            passphrase: "secret",
+            type: "pkcs8",
+        },
+    });
 }
 
 {
@@ -879,6 +895,21 @@ import { promisify } from "node:util";
         },
         (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: string) => {},
     );
+
+    crypto.generateKeyPair(
+        "ml-dsa-44",
+        {
+            publicKeyEncoding: {
+                format: "pem",
+                type: "spki",
+            },
+            privateKeyEncoding: {
+                format: "pem",
+                type: "pkcs8",
+            },
+        },
+        (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: string) => {},
+    );
 }
 
 {
@@ -971,6 +1002,20 @@ import { promisify } from "node:util";
         publicKey: string;
         privateKey: string;
     }> = generateKeyPairPromisified("x25519", {
+        publicKeyEncoding: {
+            format: "pem",
+            type: "spki",
+        },
+        privateKeyEncoding: {
+            format: "pem",
+            type: "pkcs8",
+        },
+    });
+
+    const mldsaRes: Promise<{
+        publicKey: string;
+        privateKey: string;
+    }> = generateKeyPairPromisified("ml-dsa-44", {
         publicKeyEncoding: {
             format: "pem",
             type: "spki",

--- a/types/node/test/fs.ts
+++ b/types/node/test/fs.ts
@@ -1153,3 +1153,19 @@ const anyStatFs: fs.StatsFs | fs.BigIntStatsFs = fs.statfsSync(".", { bigint: Ma
     // @ts-expect-error
     fd.readFile({ encoding: "utf-8", flag: "r" });
 });
+
+{
+    const u8s = new fs.Utf8Stream({
+        dest: "/tmp/out",
+        append: false,
+        contentMode: "utf8",
+        retryEAGAIN: () => true,
+        sync: true,
+    });
+    u8s.on("write", (n) => {
+        n; // $ExpectType number
+    });
+    u8s.write("the quick brown fox jumped over the lazy dog");
+    u8s.flushSync();
+    u8s.end();
+}

--- a/types/node/test/http.ts
+++ b/types/node/test/http.ts
@@ -36,6 +36,7 @@ import * as url from "node:url";
         keepAlive: true,
         keepAliveInitialDelay: 1000,
         keepAliveTimeout: 100,
+        keepAliveTimeoutBuffer: 200,
         headersTimeout: 50000,
         requireHostHeader: false,
         rejectNonStandardBodyWrites: false,
@@ -51,6 +52,7 @@ import * as url from "node:url";
     const timeout: number = server.timeout;
     const listening: boolean = server.listening;
     const keepAliveTimeout: number = server.keepAliveTimeout;
+    const keepAliveTimeoutBuffer: number = server.keepAliveTimeoutBuffer;
     const requestTimeout: number = server.requestTimeout;
     server.setTimeout().setTimeout(1000);
     server.setTimeout((socket) => {

--- a/types/node/test/https.ts
+++ b/types/node/test/https.ts
@@ -105,6 +105,7 @@ import * as url from "node:url";
         const timeout: number = server.timeout;
         const listening: boolean = server.listening;
         const keepAliveTimeout: number = server.keepAliveTimeout;
+        const keepAliveTimeoutBuffer: number = server.keepAliveTimeoutBuffer;
         const maxHeadersCount: number | null = server.maxHeadersCount;
         const maxRequestsPerSocket: number | null = server.maxRequestsPerSocket;
         const headersTimeout: number = server.headersTimeout;

--- a/types/node/test/test.ts
+++ b/types/node/test/test.ts
@@ -1029,7 +1029,7 @@ const invalidSuiteContext = new SuiteContext();
 test("check all assertion functions are re-exported", t => {
     type AssertModuleExports = keyof typeof import("assert");
     const keys: keyof { [K in keyof typeof t.assert as K extends AssertModuleExports ? K : never]: any } =
-        {} as Exclude<AssertModuleExports, "AssertionError" | "CallTracker" | "strict">;
+        {} as Exclude<AssertModuleExports, "Assert" | "AssertionError" | "CallTracker" | "strict">;
 });
 
 test("planning with streams", (t: TestContext, done) => {

--- a/types/node/test/util.ts
+++ b/types/node/test/util.ts
@@ -255,6 +255,8 @@ const encIntoRes: util.EncodeIntoResult = te.encodeInto("asdf", new Uint8Array(1
 
 const errorMap: Map<number, [string, string]> = util.getSystemErrorMap();
 
+util.setTraceSigInt(true);
+
 {
     const logger: util.DebugLogger = util.debuglog("section");
     logger.enabled; // $ExpectType boolean

--- a/types/node/test/worker_threads.ts
+++ b/types/node/test/worker_threads.ts
@@ -67,6 +67,9 @@ import { createContext } from "node:vm";
 
 {
     const w = new workerThreads.Worker(__filename);
+    w.cpuUsage().then((usage: NodeJS.CpuUsage) => {
+        w.cpuUsage(usage); // $ExpectType Promise<CpuUsage>
+    });
     w.getHeapSnapshot().then((stream: Readable) => {
         //
     });

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -339,6 +339,11 @@ declare module "util" {
      */
     export function getSystemErrorName(err: number): string;
     /**
+     * Enable or disable printing a stack trace on `SIGINT`. The API is only available on the main thread.
+     * @since 24.6.0
+     */
+    export function setTraceSigInt(enable: boolean): void;
+    /**
      * Returns a Map of all system error codes available from the Node.js API.
      * The mapping between error codes and error names is platform-dependent.
      * See `Common System Errors` for the names of common errors.

--- a/types/node/v18/assert.d.ts
+++ b/types/node/v18/assert.d.ts
@@ -11,6 +11,24 @@ declare module "assert" {
      */
     function assert(value: unknown, message?: string | Error): asserts value;
     namespace assert {
+        type AssertMethodNames =
+            | "deepEqual"
+            | "deepStrictEqual"
+            | "doesNotMatch"
+            | "doesNotReject"
+            | "doesNotThrow"
+            | "equal"
+            | "fail"
+            | "ifError"
+            | "match"
+            | "notDeepEqual"
+            | "notDeepStrictEqual"
+            | "notEqual"
+            | "notStrictEqual"
+            | "ok"
+            | "rejects"
+            | "strictEqual"
+            | "throws";
         /**
          * Indicates the failure of an assertion. All errors thrown by the `assert` module
          * will be instances of the `AssertionError` class.

--- a/types/node/v20/assert.d.ts
+++ b/types/node/v20/assert.d.ts
@@ -11,6 +11,24 @@ declare module "assert" {
      */
     function assert(value: unknown, message?: string | Error): asserts value;
     namespace assert {
+        type AssertMethodNames =
+            | "deepEqual"
+            | "deepStrictEqual"
+            | "doesNotMatch"
+            | "doesNotReject"
+            | "doesNotThrow"
+            | "equal"
+            | "fail"
+            | "ifError"
+            | "match"
+            | "notDeepEqual"
+            | "notDeepStrictEqual"
+            | "notEqual"
+            | "notStrictEqual"
+            | "ok"
+            | "rejects"
+            | "strictEqual"
+            | "throws";
         /**
          * Indicates the failure of an assertion. All errors thrown by the `node:assert` module will be instances of the `AssertionError` class.
          */

--- a/types/node/v20/test.d.ts
+++ b/types/node/v20/test.d.ts
@@ -79,6 +79,7 @@
  * @see [source](https://github.com/nodejs/node/blob/v20.13.1/lib/test.js)
  */
 declare module "node:test" {
+    import { AssertMethodNames } from "node:assert";
     import { Readable } from "node:stream";
     import TestFn = test.TestFn;
     import TestOptions = test.TestOptions;
@@ -933,28 +934,7 @@ declare module "node:test" {
              */
             readonly mock: MockTracker;
         }
-        interface TestContextAssert extends
-            Pick<
-                typeof import("assert"),
-                | "deepEqual"
-                | "deepStrictEqual"
-                | "doesNotMatch"
-                | "doesNotReject"
-                | "doesNotThrow"
-                | "equal"
-                | "fail"
-                | "ifError"
-                | "match"
-                | "notDeepEqual"
-                | "notDeepStrictEqual"
-                | "notEqual"
-                | "notStrictEqual"
-                | "ok"
-                | "rejects"
-                | "strictEqual"
-                | "throws"
-            >
-        {}
+        interface TestContextAssert extends Pick<typeof import("assert"), AssertMethodNames> {}
         /**
          * An instance of `SuiteContext` is passed to each suite function in order to
          * interact with the test runner. However, the `SuiteContext` constructor is not

--- a/types/node/v22/assert.d.ts
+++ b/types/node/v22/assert.d.ts
@@ -11,6 +11,25 @@ declare module "assert" {
      */
     function assert(value: unknown, message?: string | Error): asserts value;
     namespace assert {
+        type AssertMethodNames =
+            | "deepEqual"
+            | "deepStrictEqual"
+            | "doesNotMatch"
+            | "doesNotReject"
+            | "doesNotThrow"
+            | "equal"
+            | "fail"
+            | "ifError"
+            | "match"
+            | "notDeepEqual"
+            | "notDeepStrictEqual"
+            | "notEqual"
+            | "notStrictEqual"
+            | "ok"
+            | "partialDeepStrictEqual"
+            | "rejects"
+            | "strictEqual"
+            | "throws";
         /**
          * Indicates the failure of an assertion. All errors thrown by the `node:assert` module will be instances of the `AssertionError` class.
          */

--- a/types/node/v22/test.d.ts
+++ b/types/node/v22/test.d.ts
@@ -79,6 +79,7 @@
  * @see [source](https://github.com/nodejs/node/blob/v22.x/lib/test.js)
  */
 declare module "node:test" {
+    import { AssertMethodNames } from "node:assert";
     import { Readable } from "node:stream";
     import TestFn = test.TestFn;
     import TestOptions = test.TestOptions;
@@ -1157,29 +1158,7 @@ declare module "node:test" {
              */
             readonly mock: MockTracker;
         }
-        interface TestContextAssert extends
-            Pick<
-                typeof import("assert"),
-                | "deepEqual"
-                | "deepStrictEqual"
-                | "doesNotMatch"
-                | "doesNotReject"
-                | "doesNotThrow"
-                | "equal"
-                | "fail"
-                | "ifError"
-                | "match"
-                | "notDeepEqual"
-                | "notDeepStrictEqual"
-                | "notEqual"
-                | "notStrictEqual"
-                | "ok"
-                | "partialDeepStrictEqual"
-                | "rejects"
-                | "strictEqual"
-                | "throws"
-            >
-        {
+        interface TestContextAssert extends Pick<typeof import("assert"), AssertMethodNames> {
             /**
              * This function serializes `value` and writes it to the file specified by `path`.
              *

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -474,6 +474,13 @@ declare module "worker_threads" {
          */
         terminate(): Promise<number>;
         /**
+         * This method returns a `Promise` that will resolve to an object identical to `process.threadCpuUsage()`,
+         * or reject with an `ERR_WORKER_NOT_RUNNING` error if the worker is no longer running.
+         * This methods allows the statistics to be observed from outside the actual thread.
+         * @since v24.6.0
+         */
+        cpuUsage(prev?: NodeJS.CpuUsage): Promise<NodeJS.CpuUsage>;
+        /**
          * Returns a readable stream for a V8 snapshot of the current state of the Worker.
          * See `v8.getHeapSnapshot()` for more details.
          *

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -70,6 +70,7 @@ declare module "worker_threads" {
     const resourceLimits: ResourceLimits;
     const SHARE_ENV: unique symbol;
     const threadId: number;
+    const threadName: string | null;
     const workerData: any;
     /**
      * Instances of the `worker.MessageChannel` class represent an asynchronous,
@@ -402,6 +403,12 @@ declare module "worker_threads" {
          * @since v10.5.0
          */
         readonly threadId: number;
+        /**
+         * A string identifier for the referenced thread or null if the thread is not running.
+         * Inside the worker thread, it is available as `require('node:worker_threads').threadName`.
+         * @since v24.6.0
+         */
+        readonly threadName: string | null;
         /**
          * Provides the set of JS engine resource constraints for this Worker thread.
          * If the `resourceLimits` option was passed to the `Worker` constructor,

--- a/types/node/zlib.d.ts
+++ b/types/node/zlib.d.ts
@@ -180,6 +180,12 @@ declare module "zlib" {
          * If `true`, returns an object with `buffer` and `engine`.
          */
         info?: boolean | undefined;
+        /**
+         * Optional dictionary used to improve compression efficiency when compressing or decompressing data that
+         * shares common patterns with the dictionary.
+         * @since v24.6.0
+         */
+        dictionary?: NodeJS.ArrayBufferView | undefined;
     }
     interface Zlib {
         readonly bytesWritten: number;


### PR DESCRIPTION
- **crypto:** support ML-DSA KeyObject, sign, and verify
- **deps:** update undici to 7.13.0
- **fs:** port SonicBoom module to fs module as Utf8Stream
- **http:** add server.keepAliveTimeoutBuffer option
- **lib:** add trace-sigint APIs
- **lib:** restructure assert to become a class
- **worker:** add name for worker
- **worker:** add cpuUsage for worker
- **zlib:** add dictionary support to zstdCompress and zstdDecompress

This requires significant changes to the assert and assert/strict modules, to make assert/strict a true module with aliased exports, rather than the hacky pseudo-namespace that existed before. This structural change is backported to keep everything consistent.
