### PR TITLE
google-apps-script: Added Validation for TextInput

### DIFF
--- a/types/google-apps-script/google-apps-script.card-service.d.ts
+++ b/types/google-apps-script/google-apps-script.card-service.d.ts
@@ -270,6 +270,7 @@ declare namespace GoogleAppsScript {
             SwitchControlType: typeof SwitchControlType;
             TextButtonStyle: typeof TextButtonStyle;
             UpdateDraftBodyType: typeof UpdateDraftBodyType;
+            InputType: typeof InputType;
             newAction(): Action;
             newActionResponseBuilder(): ActionResponseBuilder;
             newAttachment(): Attachment;
@@ -336,6 +337,7 @@ declare namespace GoogleAppsScript {
             newUpdateDraftCcRecipientsAction(): UpdateDraftCcRecipientsAction;
             newUpdateDraftSubjectAction(): UpdateDraftSubjectAction;
             newUpdateDraftToRecipientsAction(): UpdateDraftToRecipientsAction;
+            newValidation(): Validation;
         }
         /**
          * The response object that may be returned from a callback method for compose action in a Gmail add-on.
@@ -839,6 +841,7 @@ declare namespace GoogleAppsScript {
             setSuggestions(suggestions: Suggestions): TextInput;
             setSuggestionsAction(suggestionsAction: Action): TextInput;
             setTitle(title: string): TextInput;
+            setValidation(validation: Validation): TextInput;
             setValue(value: string): TextInput;
         }
         /**
@@ -993,6 +996,29 @@ declare namespace GoogleAppsScript {
         interface UpdateDraftToRecipientsAction {
             addUpdateToRecipients(toRecipientEmails: string[]): UpdateDraftToRecipientsAction;
         }
+
+        /**
+         * An object that defines the validation rule for the widget that it is attached to.
+         * 
+         * const validation = CardService.newValidation()
+         *     .setCharacterLimit('10')
+         *     .setInputType(CardService.InputType.TEXT);
+         */
+        interface Validation {
+            setCharacterLimit(characterLimit: Integer): Validation;
+            setInputType(inputType: InputType): Validation;
+        }
+
+        /**
+         * An enum that defines the input type of the widget.
+         */
+        enum InputType {
+            TEXT,
+            INTEGER,
+            FLOAT,
+            EMAIL,
+        }
+
         /**
          * The fixed footer shown at the bottom of an add-on Card.
          */

--- a/types/google-apps-script/test/google-apps-script-tests.ts
+++ b/types/google-apps-script/test/google-apps-script-tests.ts
@@ -627,6 +627,10 @@ CardService.newMaterialIcon().setGrade(100); // $ExpectType MaterialIcon
 CardService.newMaterialIcon().setName(""); // $ExpectType MaterialIcon
 CardService.newMaterialIcon().setWeight(100); // $ExpectType MaterialIcon
 
+CardService.newValidation(); // $ExpectType Validation
+CardService.newValidation().setCharacterLimit(10) // $ExpectType Validation
+CardService.newValidation().setInputType(CardService.InputType.TEXT) // $ExpectType Validation
+
 // CardService.newCardBuilder().setDisplayStyle(CardService.DisplayStyle.PEEK)
 CardService.DisplayStyle.PEEK;
 CardService.DisplayStyle.REPLACE;


### PR DESCRIPTION
Added [`Validation`](https://developers.google.com/apps-script/reference/card-service/validation) for [`TextInput`](https://developers.google.com/apps-script/reference/card-service/text-input)

Also added the [`InputType`](https://developers.google.com/apps-script/reference/card-service/input-type) enum. Even though the documentation marks it as `Developer Preview`, the [`Validation`](https://developers.google.com/apps-script/reference/card-service/validation) documentation [uses it in a method](https://developers.google.com/apps-script/reference/card-service/validation#setinputtypeinputtype) not marked as `Developer Preview`.