### PR TITLE
[gulp-sass] Update type declarations for gulp-sass v6

### DIFF
--- a/types/gulp-sass/gulp-sass-tests.ts
+++ b/types/gulp-sass/gulp-sass-tests.ts
@@ -1,17 +1,46 @@
 import gulp = require("gulp");
 import gulpSass = require("gulp-sass");
+import gulpSassLegacy = require("gulp-sass/legacy");
+import * as sass from "sass";
+import * as sassEmbedded from "sass-embedded";
 
-const sass = gulpSass({}); // compiler
+const gulpSassWithSass = gulpSass(sass);
+const gulpSassWithSassEmbedded = gulpSass(sassEmbedded);
+const gulpSassLegacyWithSass = gulpSassLegacy(sass);
 
 gulp.task("sass", function() {
     gulp.src("./scss/*.scss")
-        .pipe(sass())
+        .pipe(gulpSassWithSass({ style: "compressed" }))
         .pipe(gulp.dest("./css"));
 });
 
 gulp.task("sass", function() {
     gulp.src("./scss/*.scss")
-        .pipe(sass({ errLogToConsole: true }))
-        .pipe(sass.sync())
+        .pipe(gulpSassWithSass({ style: "compressed", importers: [new sass.NodePackageImporter(".")] }))
+        .pipe(gulp.dest("./css"));
+});
+
+gulp.task("sass", function() {
+    gulp.src("./scss/*.scss")
+        .pipe(gulpSassWithSassEmbedded({ style: "compressed", importers: [new sassEmbedded.NodePackageImporter(".")] }))
+        .pipe(gulp.dest("./css"));
+});
+
+gulp.task("sass", function() {
+    gulp.src("./scss/*.scss")
+        // @ts-expect-error -- The NodePackageImporter must come from the same implementation of Sass
+        .pipe(gulpSassWithSassEmbedded({ style: "compressed", importers: [new sass.NodePackageImporter(".")] }))
+        .pipe(gulp.dest("./css"));
+});
+
+gulp.task("sass", function() {
+    gulp.src("./scss/*.scss")
+        .pipe(gulpSassWithSass.sync())
+        .pipe(gulp.dest("./css"));
+});
+
+gulp.task("sass-legacy", function() {
+    gulp.src("./scss/*.scss")
+        .pipe(gulpSassLegacyWithSass({ outputStyle: "compressed" }))
         .pipe(gulp.dest("./css"));
 });

--- a/types/gulp-sass/index.d.ts
+++ b/types/gulp-sass/index.d.ts
@@ -1,42 +1,34 @@
 /// <reference types="node"/>
 
-import { Options } from "node-sass";
+import { CompileResult, FileImporter, Importer, Options } from "@sass/types";
 
-interface SassResults {
-    css: string;
-    map: string;
-    stats: {
-        entry: string;
-        start: Date;
-        end: Date;
-        duration: number;
-        includedFiles: string[];
+interface GulpSassError extends Error {
+    messageFormatted: string;
+    messageOriginal: string;
+    relativePath: string;
+}
+
+type GulpSassOptions<sync extends "sync" | "async", TNodePackageImporter extends {}> =
+    & Omit<Options<sync>, "importers">
+    & {
+        importers?: (Importer<sync> | FileImporter<sync> | TNodePackageImporter)[];
     };
+
+interface GulpSass<TNodePackageImporter extends {}> {
+    (opts?: GulpSassOptions<"async", TNodePackageImporter>): NodeJS.ReadWriteStream;
+    logError(error?: GulpSassError): void;
+    sync(options?: GulpSassOptions<"sync", TNodePackageImporter>): NodeJS.ReadWriteStream;
 }
 
-interface SassOptions extends Options {
-    success?: ((results: SassResults) => any) | undefined;
-    error?: ((err: Error) => any) | undefined;
-    imagePaths?: string[] | undefined;
+interface Compiler<TNodePackageImporter extends {}> {
+    compile(path: string, options: GulpSassOptions<"sync", TNodePackageImporter>): CompileResult;
+    compileAsync(path: string, options: GulpSassOptions<"async", TNodePackageImporter>): Promise<CompileResult>;
+    compileString(source: string, options: GulpSassOptions<"sync", TNodePackageImporter>): CompileResult;
+    compileStringAsync(source: string, options: GulpSassOptions<"async", TNodePackageImporter>): Promise<CompileResult>;
 }
-
-interface GulpSassOptions extends SassOptions {
-    errLogToConsole?: boolean | undefined;
-    onSuccess?: ((css: string) => any) | undefined;
-    onError?: ((err: Error) => any) | undefined;
-    sync?: boolean | undefined;
-}
-
-interface GulpSass {
-    (opts?: GulpSassOptions): NodeJS.ReadWriteStream;
-    logError(error?: string): void;
-    sync(options?: GulpSassOptions): NodeJS.ReadWriteStream;
-}
-
-type Compiler = any;
 
 interface GulpSassFactory {
-    (compiler: Compiler): GulpSass;
+    <TNodePackageImporter extends {}>(compiler: Compiler<TNodePackageImporter>): GulpSass<TNodePackageImporter>;
 }
 
 declare var _tmp: GulpSassFactory;

--- a/types/gulp-sass/legacy.d.ts
+++ b/types/gulp-sass/legacy.d.ts
@@ -1,0 +1,44 @@
+/// <reference types="node"/>
+
+import { LegacyException, LegacyResult, LegacySharedOptions } from "@sass/types";
+
+interface GulpSassError extends Error {
+    messageFormatted: string;
+    messageOriginal: string;
+    relativePath: string;
+}
+
+type LegacyGulpSassOptions<sync extends "sync" | "async", TNodePackageImporter extends {}> =
+    & Omit<LegacySharedOptions<sync>, "pkgImporter">
+    & {
+        pkgImporter?: TNodePackageImporter;
+    };
+
+interface LegacyGulpSass<TNodePackageImporter extends {}> {
+    (opts?: LegacyGulpSassOptions<"async", TNodePackageImporter>): NodeJS.ReadWriteStream;
+    logError(error?: GulpSassError): void;
+    sync(options?: LegacyGulpSassOptions<"sync", TNodePackageImporter>): NodeJS.ReadWriteStream;
+}
+
+interface GulpSassInjectedOptions {
+    data: string;
+    file?: string;
+    indentedSyntax?: boolean;
+}
+
+interface LegacyCompiler<TNodePackageImporter extends {}> {
+    render(
+        options: LegacyGulpSassOptions<"async", TNodePackageImporter> & GulpSassInjectedOptions,
+        callback: (exception?: LegacyException, result?: LegacyResult) => void,
+    ): void;
+    renderSync(options: LegacyGulpSassOptions<"sync", TNodePackageImporter> & GulpSassInjectedOptions): LegacyResult;
+}
+
+interface LegacyGulpSassFactory {
+    <TNodePackageImporter extends {}>(
+        compiler: LegacyCompiler<TNodePackageImporter>,
+    ): LegacyGulpSass<TNodePackageImporter>;
+}
+
+declare var _tmp: LegacyGulpSassFactory;
+export = _tmp;

--- a/types/gulp-sass/package.json
+++ b/types/gulp-sass/package.json
@@ -1,15 +1,17 @@
 {
     "private": true,
     "name": "@types/gulp-sass",
-    "version": "5.0.9999",
+    "version": "6.0.9999",
     "projects": [
         "https://github.com/dlmanning/gulp-sass"
     ],
     "dependencies": {
-        "@types/node": "*",
-        "@types/node-sass": "*"
+        "@sass/types": "^1.93",
+        "@types/node": "*"
     },
     "devDependencies": {
+        "sass": "^1.93",
+        "sass-embedded": "^1.93",
         "@types/gulp": "*",
         "@types/gulp-sass": "workspace:."
     },

--- a/types/gulp-sass/tsconfig.json
+++ b/types/gulp-sass/tsconfig.json
@@ -14,6 +14,7 @@
     },
     "files": [
         "index.d.ts",
+        "legacy.d.ts",
         "gulp-sass-tests.ts"
     ]
 }


### PR DESCRIPTION
The new version defaults to using the modern Sass JS API instead of the legacy ones, while still providing a legacy API using the Sass JS legacy API for projects not able to migrate yet.

The new type declarations are also stricter about the API, by defining the expected type for the compiler during initialization instead of using `any`.
A trick is used to support the `NodePackageImporter` where each implementation supports only its own implementation of it, allowing both to support `sass` and `sass-embedded` at the same time in type declarations and to enforce using the correct implementation, as the `NodePackageImporter` from `@sass/types` is treated as incompatible with the `NodePackageImporter` from `sass` or `sass-embedded` right now.
Tests are written to ensure that usage with both `sass` and `sass-embedded` works fine.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/dlmanning/gulp-sass/releases/tag/v6.0.0
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
