### PR TITLE
google-apps-script: Added missing methods for Action

### DIFF
--- a/types/google-apps-script/google-apps-script.card-service.d.ts
+++ b/types/google-apps-script/google-apps-script.card-service.d.ts
@@ -14,12 +14,25 @@ declare namespace GoogleAppsScript {
          *             .setParameters({imageSrc: 'carImage'}));
          */
         interface Action {
+            addRequiredWidget(requiredWidget: string): Action;
+            setAllWidgetsAreRequired(allWidgetsAreRequired: boolean): Action
             setFunctionName(functionName: string): Action;
+            setInteraction(interaction: Interaction): Action;
             setLoadIndicator(loadIndicator: LoadIndicator): Action;
             setParameters(parameters: { [key: string]: string }): Action;
             /** @deprecated DO NOT USE */ setMethodName(functionName: string): Action;
             setPersistValues(persistValues: boolean): Action;
         }
+
+        /**
+         * An enum type that specifies what to do in response to an interaction with a user,
+         * such as a user clicking a button in a card message.
+         */
+        enum Interaction {
+            INTERACTION_UNSPECIFIED,
+            OPEN_DIALOG
+        }
+
         /**
          * The response object that may be returned from a callback function (e.g., a form response handler)
          * to perform one or more actions on the client. Some combinations of actions are not supported.
@@ -271,6 +284,7 @@ declare namespace GoogleAppsScript {
             TextButtonStyle: typeof TextButtonStyle;
             UpdateDraftBodyType: typeof UpdateDraftBodyType;
             InputType: typeof InputType;
+            Interaction: typeof Interaction;
             newAction(): Action;
             newActionResponseBuilder(): ActionResponseBuilder;
             newAttachment(): Attachment;

--- a/types/google-apps-script/google-apps-script.card-service.d.ts
+++ b/types/google-apps-script/google-apps-script.card-service.d.ts
@@ -15,7 +15,7 @@ declare namespace GoogleAppsScript {
          */
         interface Action {
             addRequiredWidget(requiredWidget: string): Action;
-            setAllWidgetsAreRequired(allWidgetsAreRequired: boolean): Action
+            setAllWidgetsAreRequired(allWidgetsAreRequired: boolean): Action;
             setFunctionName(functionName: string): Action;
             setInteraction(interaction: Interaction): Action;
             setLoadIndicator(loadIndicator: LoadIndicator): Action;
@@ -30,7 +30,7 @@ declare namespace GoogleAppsScript {
          */
         enum Interaction {
             INTERACTION_UNSPECIFIED,
-            OPEN_DIALOG
+            OPEN_DIALOG,
         }
 
         /**

--- a/types/google-apps-script/test/google-apps-script-tests.ts
+++ b/types/google-apps-script/test/google-apps-script-tests.ts
@@ -592,10 +592,10 @@ function timeDriven(e: GoogleAppsScript.Events.TimeDriven) {
     }
 }
 
-CardService.newAction() // $ExpectType Action
-CardService.newAction().addRequiredWidget('') // $ExpectType Action
-CardService.newAction().setAllWidgetsAreRequired(true) // $ExpectType Action
-CardService.newAction().setInteraction(CardService.Interaction.OPEN_DIALOG) // $ExpectType Action
+CardService.newAction(); // $ExpectType Action
+CardService.newAction().addRequiredWidget(""); // $ExpectType Action
+CardService.newAction().setAllWidgetsAreRequired(true); // $ExpectType Action
+CardService.newAction().setInteraction(CardService.Interaction.OPEN_DIALOG); // $ExpectType Action
 
 CardService.newTextButton().setAltText("alt text"); // $ExpectType TextButton
 

--- a/types/google-apps-script/test/google-apps-script-tests.ts
+++ b/types/google-apps-script/test/google-apps-script-tests.ts
@@ -592,6 +592,11 @@ function timeDriven(e: GoogleAppsScript.Events.TimeDriven) {
     }
 }
 
+CardService.newAction() // $ExpectType Action
+CardService.newAction().addRequiredWidget('') // $ExpectType Action
+CardService.newAction().setAllWidgetsAreRequired(true) // $ExpectType Action
+CardService.newAction().setInteraction(CardService.Interaction.OPEN_DIALOG) // $ExpectType Action
+
 CardService.newTextButton().setAltText("alt text"); // $ExpectType TextButton
 
 CardService.newLinkPreview().setTitle("Smart chip title"); // $ExpectType LinkPreview


### PR DESCRIPTION
Added two methods to set [required](https://developers.google.com/apps-script/reference/card-service/action#addrequiredwidgetrequiredwidget) [widgets](https://developers.google.com/apps-script/reference/card-service/action#setallwidgetsarerequiredallwidgetsarerequired) on [`Action`](https://developers.google.com/apps-script/reference/card-service/action).

Also added a [missing method](https://developers.google.com/apps-script/reference/card-service/action#setinteractioninteraction), as well as the [`Interaction`](https://developers.google.com/apps-script/reference/card-service/interaction) enum.