### PR TITLE
[nova-editor-node] remove no-default-lib directive

### DIFF
--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -48,6 +48,7 @@ type ResolvedTaskAction = TaskCommandAction | TaskProcessAction;
 
 interface TaskAssistant {
     provideTasks(): AssistantArray<Task>;
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
     resolveTaskAction?<T extends Transferrable>(
         context: TaskActionResolveContext<T>,
     ): ResolvedTaskAction | Promise<ResolvedTaskAction>;
@@ -74,7 +75,7 @@ declare class Charset {
 
 /// https://docs.nova.app/api-reference/clipboard/
 
-declare interface Clipboard {
+interface Clipboard {
     readText(): Promise<string>;
     writeText(text: string): Promise<void>;
 }
@@ -790,7 +791,7 @@ interface NovaSymbol {
 
 /// https://docs.nova.app/api-reference/task/
 
-declare type TaskName = string & { __type: "TaskName" };
+type TaskName = string & { __type: "TaskName" };
 
 declare class Task {
     static readonly Build: TaskName;
@@ -987,7 +988,7 @@ declare class TreeView<E> extends Disposable {
 /// https://docs.nova.app/api-reference/workspace/
 
 // The line is optional, unless a column is specified
-declare type FileLocation =
+type FileLocation =
     | {
         line?: number;
         column?: never;

--- a/types/nova-editor-node/index.d.ts
+++ b/types/nova-editor-node/index.d.ts
@@ -1,8 +1,5 @@
 /// https://docs.nova.app/extensions/#javascript-runtime
 
-// This runs in an extension of Apple's JavaScriptCore, manually set libs
-
-/// <reference no-default-lib="true"/>
 /// <reference lib="es2020" />
 /// <reference lib="WebWorker" />
 


### PR DESCRIPTION
This feature is being removed in TS 6.0. https://github.com/microsoft/TypeScript/issues/62209

While it's okay to leave it, I think it's misleading. This directive behaves in very strange ways, and in practice is unlikely to have even worked right for this use case. Not to mention, the directives in this file are themselves kinda out of date.