### PR TITLE
[react] add hint popover type

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2747,7 +2747,7 @@ declare namespace React {
         unselectable?: "on" | "off" | undefined;
 
         // Popover API
-        popover?: "" | "auto" | "manual" | undefined;
+        popover?: "" | "auto" | "manual" | "hint" | undefined;
         popoverTargetAction?: "toggle" | "show" | "hide" | undefined;
         popoverTarget?: string | undefined;
 

--- a/types/react/test/elementAttributes.tsx
+++ b/types/react/test/elementAttributes.tsx
@@ -149,6 +149,7 @@ const testCases = [
         </div>
         <div popover="auto" />
         <div popover="manual" />
+        <div popover="hint" />
         <div
             // @ts-expect-error accidental boolean
             popover

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -2745,7 +2745,7 @@ declare namespace React {
         unselectable?: "on" | "off" | undefined;
 
         // Popover API
-        popover?: "" | "auto" | "manual" | undefined;
+        popover?: "" | "auto" | "manual" | "hint" | undefined;
         popoverTargetAction?: "toggle" | "show" | "hide" | undefined;
         popoverTarget?: string | undefined;
 

--- a/types/react/ts5.0/test/elementAttributes.tsx
+++ b/types/react/ts5.0/test/elementAttributes.tsx
@@ -149,6 +149,7 @@ const testCases = [
         </div>
         <div popover="auto" />
         <div popover="manual" />
+        <div popover="hint" />
         <div
             // @ts-expect-error accidental boolean
             popover

--- a/types/react/v18/canary.d.ts
+++ b/types/react/v18/canary.d.ts
@@ -124,7 +124,7 @@ declare module "." {
     type ToggleEventHandler<T = Element> = EventHandler<ToggleEvent<T>>;
 
     interface HTMLAttributes<T> {
-        popover?: "" | "auto" | "manual" | undefined;
+        popover?: "" | "auto" | "manual" | "hint" | undefined;
         popoverTargetAction?: "toggle" | "show" | "hide" | undefined;
         popoverTarget?: string | undefined;
         onToggle?: ToggleEventHandler<T> | undefined;

--- a/types/react/v18/test/canary.tsx
+++ b/types/react/v18/test/canary.tsx
@@ -437,6 +437,7 @@ function PopoverAPI() {
             </div>
             <div popover="auto" />
             <div popover="manual" />
+            <div popover="hint" />
             <div
                 // @ts-expect-error accidental boolean
                 popover

--- a/types/react/v18/ts5.0/canary.d.ts
+++ b/types/react/v18/ts5.0/canary.d.ts
@@ -124,7 +124,7 @@ declare module "." {
     type ToggleEventHandler<T = Element> = EventHandler<ToggleEvent<T>>;
 
     interface HTMLAttributes<T> {
-        popover?: "" | "auto" | "manual" | undefined;
+        popover?: "" | "auto" | "manual" | "hint" | undefined;
         popoverTargetAction?: "toggle" | "show" | "hide" | undefined;
         popoverTarget?: string | undefined;
         onToggle?: ToggleEventHandler<T> | undefined;

--- a/types/react/v18/ts5.0/test/canary.tsx
+++ b/types/react/v18/ts5.0/test/canary.tsx
@@ -437,6 +437,7 @@ function PopoverAPI() {
             </div>
             <div popover="auto" />
             <div popover="manual" />
+            <div popover="hint" />
             <div
                 // @ts-expect-error accidental boolean
                 popover


### PR DESCRIPTION
The `popover="hint"` is part of the specs and it is already available in Chromium browsers. 

- [WHATDG html specs PR](https://github.com/whatwg/html/pull/9778)
- [flow-typed added it](https://github.com/facebook/react/blob/c44fbf43b1e05417619c3b9411d0559824739569/flow-typed/environments/html.js#L255)
- [Svelte recently added it](https://github.com/sveltejs/svelte/blob/b92a55994b7349e5c681df97a571481488020bc4/packages/svelte/elements.d.ts#L784)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://html.spec.whatwg.org/multipage/popover.html#attr-popover-hint
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
