### PR TITLE
[@wordpress/block-editor] Add blockParent selectors

### DIFF
--- a/types/wordpress__block-editor/package.json
+++ b/types/wordpress__block-editor/package.json
@@ -1,17 +1,17 @@
 {
     "private": true,
     "name": "@types/wordpress__block-editor",
-    "version": "11.5.9999",
+    "version": "14.21.9999",
     "projects": [
         "https://github.com/WordPress/gutenberg/tree/master/packages/block-editor/README.md"
     ],
     "dependencies": {
         "@types/react": "^18",
         "@types/wordpress__blocks": "*",
-        "@wordpress/components": "^27.2.0",
-        "@wordpress/data": "^9.13.0",
-        "@wordpress/element": "^5.0.0",
-        "@wordpress/keycodes": "^3.54.0",
+        "@wordpress/components": "^29.12.0",
+        "@wordpress/data": "^10.26.0",
+        "@wordpress/element": "^6.26.0",
+        "@wordpress/keycodes": "^4.26.0",
         "react-autosize-textarea": "^7.1.0"
     },
     "devDependencies": {

--- a/types/wordpress__block-editor/package.json
+++ b/types/wordpress__block-editor/package.json
@@ -29,6 +29,10 @@
         {
             "name": "Dennis Snell",
             "githubUsername": "dmsnell"
+        },
+        {
+            "name": "Joshua Lipstone",
+            "githubUsername": "joshualip-plaudit"
         }
     ]
 }

--- a/types/wordpress__block-editor/store/selectors.d.ts
+++ b/types/wordpress__block-editor/store/selectors.d.ts
@@ -123,7 +123,7 @@ export function getBlockOrder(rootClientId?: string): string[];
  *
  * @param clientId - Block client ID.
  * @param ascending - If true, the client ids will be returned from closest to farthest instead of the default of farthest to closest
- * 
+ *
  * @returns The client IDs of all parent blocks
  */
 export function getBlockParents(clientId: string, ascending?: boolean): string[];
@@ -134,10 +134,14 @@ export function getBlockParents(clientId: string, ascending?: boolean): string[]
  * @param clientId - Block client ID.
  * @param blockName - the name or names of the block types to which the parents list should be filtered
  * @param ascending - If true, the client ids will be returned from closest to farthest instead of the default of farthest to closest
- * 
+ *
  * @returns The client IDs of all parent blocks filtered by the passed block name or names
  */
-export function getBlockParentsByBlockName(clientId: string, blockName: string|string[], ascending?: boolean): string[];
+export function getBlockParentsByBlockName(
+    clientId: string,
+    blockName: string | string[],
+    ascending?: boolean,
+): string[];
 
 /**
  * Given a block client ID, returns the root block from which the block is nested, an empty string

--- a/types/wordpress__block-editor/store/selectors.d.ts
+++ b/types/wordpress__block-editor/store/selectors.d.ts
@@ -119,6 +119,27 @@ export function getBlockName(clientId: string): string | null;
 export function getBlockOrder(rootClientId?: string): string[];
 
 /**
+ * Returns a block's parents' client IDs given its client ID
+ *
+ * @param clientId - Block client ID.
+ * @param ascending - If true, the client ids will be returned from closest to farthest instead of the default of farthest to closest
+ * 
+ * @returns The client IDs of all parent blocks
+ */
+export function getBlockParents(clientId: string, ascending?: boolean): string[];
+
+/**
+ * Returns a block's parents' client IDs given its client ID pre-filtered to only include blocks with the passed blockNames
+ *
+ * @param clientId - Block client ID.
+ * @param blockName - the name or names of the block types to which the parents list should be filtered
+ * @param ascending - If true, the client ids will be returned from closest to farthest instead of the default of farthest to closest
+ * 
+ * @returns The client IDs of all parent blocks filtered by the passed block name or names
+ */
+export function getBlockParentsByBlockName(clientId: string, blockName: string|string[], ascending?: boolean): string[];
+
+/**
  * Given a block client ID, returns the root block from which the block is nested, an empty string
  * for top-level blocks, or `null` if the block does not exist.
  *

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -566,7 +566,6 @@ select("core/block-editor").getAdjacentBlockClientId("foo");
 select("core/block-editor").getAdjacentBlockClientId("foo", -1);
 select("core/block-editor").getAdjacentBlockClientId("foo", 1);
 
-
 // $ExpectType string[]
 select("core/block-editor").getBlockParents("foo");
 select("core/block-editor").getBlockParentsByBlockName("foo", ["core/query"]);

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -566,6 +566,13 @@ select("core/block-editor").getAdjacentBlockClientId("foo");
 select("core/block-editor").getAdjacentBlockClientId("foo", -1);
 select("core/block-editor").getAdjacentBlockClientId("foo", 1);
 
+
+// $ExpectType string[]
+select("core/block-editor").getBlockParents("foo");
+select("core/block-editor").getBlockParentsByBlockName("foo", ["core/query"]);
+select("core/block-editor").getBlockParents("foo", true);
+select("core/block-editor").getBlockParentsByBlockName("foo", ["core/query"], true);
+
 {
     const blockProps: UseBlockProps.Merged & UseBlockProps.Reserved = be.useBlockProps();
     blockProps;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Official Docs](https://developer.wordpress.org/block-editor/reference-guides/data/data-core-block-editor/#getblockparents)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.


This PR is technically a two-parter. The first is adding definitions for a couple of selectors. The second is updating the version number for the package to match its current version AND updating the dependency version numbers to match the current version. The second part is necessary here because the decoupled version numbers in the dependencies cause weird issues with type resolutions when trying to use the selectors for which this PR is adding definitions.