### PR TITLE
[leaflet-rotate]: Add missing type definitions in MapOptions and MarkerOptions interfaces

### DIFF
--- a/types/leaflet-rotate/index.d.ts
+++ b/types/leaflet-rotate/index.d.ts
@@ -7,7 +7,10 @@ declare module "leaflet" {
         trackContainerMutation?: boolean;
         touchRotate?: boolean | string;
         shiftKeyRotate?: boolean | string;
-        rotateControl?: boolean;
+        rotateControl?: {
+            position?: string;
+            closeOnZeroBearing?: boolean;
+        };
     }
 
     interface Map {
@@ -25,6 +28,7 @@ declare module "leaflet" {
     interface MarkerOptions {
         rotation?: number;
         rotateWithView?: boolean;
+        scale?: number;
     }
 
     interface Marker {

--- a/types/leaflet-rotate/index.d.ts
+++ b/types/leaflet-rotate/index.d.ts
@@ -7,7 +7,7 @@ declare module "leaflet" {
         trackContainerMutation?: boolean;
         touchRotate?: boolean | string;
         shiftKeyRotate?: boolean | string;
-        rotateControl?: {
+        rotateControl?: boolean | {
             position?: string;
             closeOnZeroBearing?: boolean;
         };

--- a/types/leaflet-rotate/leaflet-rotate-tests.ts
+++ b/types/leaflet-rotate/leaflet-rotate-tests.ts
@@ -31,5 +31,6 @@ point.rotateFrom(60, point2);
 const marker = new L.Marker([0, 0], {
     rotation: 30,
     rotateWithView: true,
+    scale: 0.5
 });
 marker.setRotation(30);

--- a/types/leaflet-rotate/package.json
+++ b/types/leaflet-rotate/package.json
@@ -1,9 +1,9 @@
 {
     "private": true,
     "name": "@types/leaflet-rotate",
-    "version": "0.1.9999",
+    "version": "0.2.1",
     "projects": [
-        "https://github.com//Raruto/leaflet-rotate"
+        "https://github.com/Raruto/leaflet-rotate"
     ],
     "dependencies": {
         "@types/leaflet": "^1.9"

--- a/types/leaflet-rotate/package.json
+++ b/types/leaflet-rotate/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/leaflet-rotate",
-    "version": "0.2.1",
+    "version": "0.2.9999",
     "projects": [
         "https://github.com/Raruto/leaflet-rotate"
     ],

--- a/types/leaflet-rotate/package.json
+++ b/types/leaflet-rotate/package.json
@@ -1,5 +1,6 @@
 {
     "private": true,
+    "type": "module",
     "name": "@types/leaflet-rotate",
     "version": "0.2.9999",
     "projects": [


### PR DESCRIPTION
0.1.0 rotateControl.closeOnZeroBearing and rotateControl.position were already present, even though the code is able to deal with rotateControl == true
0.2.0 introduced MapOptions.rotateControl.position
0.2.1 introduced MarkerOptions.scale

