### PR TITLE
[react-dom] Add types for `headersLengthHint`, `importMap` and `onHeaders` to /server and /static rendering APIs

### DIFF
--- a/types/react-dom/server.d.ts
+++ b/types/react-dom/server.d.ts
@@ -65,8 +65,15 @@ export interface RenderToPipeableStreamOptions {
     bootstrapScriptContent?: string;
     bootstrapScripts?: Array<string | BootstrapScriptDescriptor>;
     bootstrapModules?: Array<string | BootstrapScriptDescriptor>;
+    /**
+     * Maximum length of the header content in unicode code units i.e. string.length.
+     * Must be a positive integer if specified.
+     * @default 2000
+     */
+    headersLengthHint?: number | undefined;
     importMap?: ReactImportMap | undefined;
     progressiveChunkSize?: number;
+    onHeaders?: ((headers: Headers) => void) | undefined;
     onShellReady?: () => void;
     onShellError?: (error: unknown) => void;
     onAllReady?: () => void;
@@ -121,9 +128,16 @@ export interface RenderToReadableStreamOptions {
     bootstrapScriptContent?: string;
     bootstrapScripts?: Array<string | BootstrapScriptDescriptor>;
     bootstrapModules?: Array<string | BootstrapScriptDescriptor>;
+    /**
+     * Maximum length of the header content in unicode code units i.e. string.length.
+     * Must be a positive integer if specified.
+     * @default 2000
+     */
+    headersLengthHint?: number | undefined;
     progressiveChunkSize?: number;
     signal?: AbortSignal;
     onError?: (error: unknown, errorInfo: ErrorInfo) => string | void;
+    onHeaders?: ((headers: Headers) => void) | undefined;
     formState?: ReactFormState | null;
 }
 

--- a/types/react-dom/server.d.ts
+++ b/types/react-dom/server.d.ts
@@ -24,11 +24,39 @@ declare global {
 import { ReactNode } from "react";
 import { ErrorInfo, ReactFormState } from "./client";
 
-export type BootstrapScriptDescriptor = {
+export interface BootstrapScriptDescriptor {
     src: string;
     integrity?: string | undefined;
     crossOrigin?: string | undefined;
-};
+}
+
+/**
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap Import maps}
+ */
+// TODO: Ideally TypeScripts standard library would include this type.
+// Until then we keep the prefixed one for future compatibility.
+export interface ReactImportMap {
+    /**
+     * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap#imports `imports` reference}
+     */
+    imports?: {
+        [specifier: string]: string;
+    } | undefined;
+    /**
+     * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap#integrity `integrity` reference}
+     */
+    integrity?: {
+        [moduleURL: string]: string;
+    } | undefined;
+    /**
+     * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap#scopes `scopes` reference}
+     */
+    scopes?: {
+        [scope: string]: {
+            [specifier: string]: string;
+        };
+    } | undefined;
+}
 
 export interface RenderToPipeableStreamOptions {
     identifierPrefix?: string;
@@ -37,6 +65,7 @@ export interface RenderToPipeableStreamOptions {
     bootstrapScriptContent?: string;
     bootstrapScripts?: Array<string | BootstrapScriptDescriptor>;
     bootstrapModules?: Array<string | BootstrapScriptDescriptor>;
+    importMap?: ReactImportMap | undefined;
     progressiveChunkSize?: number;
     onShellReady?: () => void;
     onShellError?: (error: unknown) => void;
@@ -86,6 +115,7 @@ export function renderToStaticMarkup(element: ReactNode, options?: ServerOptions
 
 export interface RenderToReadableStreamOptions {
     identifierPrefix?: string;
+    importMap?: ReactImportMap | undefined;
     namespaceURI?: string;
     nonce?: string;
     bootstrapScriptContent?: string;

--- a/types/react-dom/static.d.ts
+++ b/types/react-dom/static.d.ts
@@ -65,10 +65,17 @@ export interface PrerenderOptions {
     bootstrapScriptContent?: string;
     bootstrapScripts?: Array<string | BootstrapScriptDescriptor>;
     bootstrapModules?: Array<string | BootstrapScriptDescriptor>;
+    /**
+     * Maximum length of the header content in unicode code units i.e. string.length.
+     * Must be a positive integer if specified.
+     * @default 2000
+     */
+    headersLengthHint?: number | undefined;
     identifierPrefix?: string;
     importMap?: ImportMap | undefined;
     namespaceURI?: string;
     onError?: (error: unknown, errorInfo: ErrorInfo) => string | void;
+    onHeaders?: (headers: Headers) => void | undefined;
     progressiveChunkSize?: number;
     signal?: AbortSignal;
 }

--- a/types/react-dom/static.d.ts
+++ b/types/react-dom/static.d.ts
@@ -27,17 +27,46 @@ declare global {
 import { ReactNode } from "react";
 import { ErrorInfo } from "./client";
 
-export type BootstrapScriptDescriptor = {
+/**
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap Import maps}
+ */
+// TODO: Ideally TypeScripts standard library would include this type.
+// Until then we keep the prefixed one for future compatibility.
+export interface ReactImportMap {
+    /**
+     * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap#imports `imports` reference}
+     */
+    imports?: {
+        [specifier: string]: string;
+    } | undefined;
+    /**
+     * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap#integrity `integrity` reference}
+     */
+    integrity?: {
+        [moduleURL: string]: string;
+    } | undefined;
+    /**
+     * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap#scopes `scopes` reference}
+     */
+    scopes?: {
+        [scope: string]: {
+            [specifier: string]: string;
+        };
+    } | undefined;
+}
+
+export interface BootstrapScriptDescriptor {
     src: string;
     integrity?: string | undefined;
     crossOrigin?: string | undefined;
-};
+}
 
 export interface PrerenderOptions {
     bootstrapScriptContent?: string;
     bootstrapScripts?: Array<string | BootstrapScriptDescriptor>;
     bootstrapModules?: Array<string | BootstrapScriptDescriptor>;
     identifierPrefix?: string;
+    importMap?: ImportMap | undefined;
     namespaceURI?: string;
     onError?: (error: unknown, errorInfo: ErrorInfo) => string | void;
     progressiveChunkSize?: number;

--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -45,7 +45,7 @@ describe("ReactDOM", () => {
     });
 });
 
-const importMap: ReactDOMStatic.ImportMap = {
+const importMap: ReactDOMStatic.ReactImportMap = {
     imports: {
         "moduleA": "/modules/moduleA.v1.0.0.js",
     },
@@ -61,8 +61,6 @@ describe("ReactDOMServer", () => {
         const content: string = ReactDOMServer.renderToString(React.createElement("div"));
         ReactDOMServer.renderToString(React.createElement("div"), {
             identifierPrefix: "react-18-app",
-            // @ts-expect-error Not supported in legacy APIS
-            importMap,
         });
     });
 
@@ -70,8 +68,6 @@ describe("ReactDOMServer", () => {
         const content: string = ReactDOMServer.renderToStaticMarkup(React.createElement("div"));
         ReactDOMServer.renderToStaticMarkup(React.createElement("div"), {
             identifierPrefix: "react-18-app",
-            // @ts-expect-error Not supported in legacy APIS
-            importMap,
         });
     });
 });
@@ -80,7 +76,15 @@ describe("ReactDOMStatic", () => {
     it("prerender", async () => {
         const prelude: ReadableStream<Uint8Array> =
             (await ReactDOMStatic.prerender(React.createElement("div"))).prelude;
-        ReactDOMStatic.prerender(React.createElement("div"), { bootstrapScripts: ["./my-script.js"], importMap });
+        ReactDOMStatic.prerender(React.createElement("div"), {
+            bootstrapScripts: ["./my-script.js"],
+            headersLengthHint: 4000,
+            importMap,
+            onHeaders(headers) {
+                // $ExpectType Headers
+                headers;
+            },
+        });
     });
 
     it("prerenderToNodeStream", async () => {
@@ -88,7 +92,12 @@ describe("ReactDOMStatic", () => {
             (await ReactDOMStatic.prerenderToNodeStream(React.createElement("div"))).prelude;
         ReactDOMStatic.prerenderToNodeStream(React.createElement("div"), {
             bootstrapScripts: ["./my-script.js"],
+            headersLengthHint: 4000,
             importMap,
+            onHeaders(headers) {
+                // $ExpectType Headers
+                headers;
+            },
         });
     });
 });
@@ -229,7 +238,12 @@ function pipeableStreamDocumentedExample() {
     const response: Response = {} as any;
     const { pipe, abort } = ReactDOMServer.renderToPipeableStream(<App />, {
         bootstrapScripts: ["/main.js"],
+        headersLengthHint: 4000,
         importMap,
+        onHeaders(headers) {
+            // $ExpectType Headers
+            headers;
+        },
         onShellReady() {
             response.statusCode = didError ? 500 : 200;
             response.setHeader("content-type", "text/html");
@@ -277,7 +291,12 @@ function pipeableStreamDocumentedStringExample() {
     const response: Response = {} as any;
     const { pipe, abort } = ReactDOMServer.renderToPipeableStream("app", {
         bootstrapScripts: ["/main.js"],
+        headersLengthHint: 4000,
         importMap,
+        onHeaders(headers) {
+            // $ExpectType Headers
+            headers;
+        },
         onShellReady() {
             response.statusCode = didError ? 500 : 200;
             response.setHeader("content-type", "text/html");
@@ -319,11 +338,16 @@ async function readableStreamDocumentedExample() {
                 <body>Success</body>
             </html>,
             {
+                headersLengthHint: 4000,
                 importMap,
                 signal: controller.signal,
                 onError(error) {
                     didError = true;
                     console.error(error);
+                },
+                onHeaders(headers) {
+                    // $ExpectType Headers
+                    headers;
                 },
             },
         );
@@ -352,11 +376,16 @@ async function readableStreamDocumentedStringExample() {
         const stream = await ReactDOMServer.renderToReadableStream(
             "app",
             {
+                headersLengthHint: 4000,
                 importMap,
                 signal: controller.signal,
                 onError(error) {
                     didError = true;
                     console.error(error);
+                },
+                onHeaders(headers) {
+                    // $ExpectType Headers
+                    headers;
                 },
             },
         );

--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -45,15 +45,34 @@ describe("ReactDOM", () => {
     });
 });
 
+const importMap: ReactDOMStatic.ImportMap = {
+    imports: {
+        "moduleA": "/modules/moduleA.v1.0.0.js",
+    },
+    scopes: {
+        "/modules/": {
+            "moduleB": "/modules/moduleB.v1.0.0.js",
+        },
+    },
+};
+
 describe("ReactDOMServer", () => {
     it("renderToString", () => {
         const content: string = ReactDOMServer.renderToString(React.createElement("div"));
-        ReactDOMServer.renderToString(React.createElement("div"), { identifierPrefix: "react-18-app" });
+        ReactDOMServer.renderToString(React.createElement("div"), {
+            identifierPrefix: "react-18-app",
+            // @ts-expect-error Not supported in legacy APIS
+            importMap,
+        });
     });
 
     it("renderToStaticMarkup", () => {
         const content: string = ReactDOMServer.renderToStaticMarkup(React.createElement("div"));
-        ReactDOMServer.renderToStaticMarkup(React.createElement("div"), { identifierPrefix: "react-18-app" });
+        ReactDOMServer.renderToStaticMarkup(React.createElement("div"), {
+            identifierPrefix: "react-18-app",
+            // @ts-expect-error Not supported in legacy APIS
+            importMap,
+        });
     });
 });
 
@@ -61,13 +80,16 @@ describe("ReactDOMStatic", () => {
     it("prerender", async () => {
         const prelude: ReadableStream<Uint8Array> =
             (await ReactDOMStatic.prerender(React.createElement("div"))).prelude;
-        ReactDOMStatic.prerender(React.createElement("div"), { bootstrapScripts: ["./my-script.js"] });
+        ReactDOMStatic.prerender(React.createElement("div"), { bootstrapScripts: ["./my-script.js"], importMap });
     });
 
     it("prerenderToNodeStream", async () => {
         const prelude: NodeJS.ReadableStream =
             (await ReactDOMStatic.prerenderToNodeStream(React.createElement("div"))).prelude;
-        ReactDOMStatic.prerenderToNodeStream(React.createElement("div"), { bootstrapScripts: ["./my-script.js"] });
+        ReactDOMStatic.prerenderToNodeStream(React.createElement("div"), {
+            bootstrapScripts: ["./my-script.js"],
+            importMap,
+        });
     });
 });
 
@@ -207,6 +229,7 @@ function pipeableStreamDocumentedExample() {
     const response: Response = {} as any;
     const { pipe, abort } = ReactDOMServer.renderToPipeableStream(<App />, {
         bootstrapScripts: ["/main.js"],
+        importMap,
         onShellReady() {
             response.statusCode = didError ? 500 : 200;
             response.setHeader("content-type", "text/html");
@@ -254,6 +277,7 @@ function pipeableStreamDocumentedStringExample() {
     const response: Response = {} as any;
     const { pipe, abort } = ReactDOMServer.renderToPipeableStream("app", {
         bootstrapScripts: ["/main.js"],
+        importMap,
         onShellReady() {
             response.statusCode = didError ? 500 : 200;
             response.setHeader("content-type", "text/html");
@@ -295,6 +319,7 @@ async function readableStreamDocumentedExample() {
                 <body>Success</body>
             </html>,
             {
+                importMap,
                 signal: controller.signal,
                 onError(error) {
                     didError = true;
@@ -327,6 +352,7 @@ async function readableStreamDocumentedStringExample() {
         const stream = await ReactDOMServer.renderToReadableStream(
             "app",
             {
+                importMap,
                 signal: controller.signal,
                 onError(error) {
                     didError = true;


### PR DESCRIPTION

Types for https://github.com/facebook/react/pull/27641 and https://github.com/facebook/react/pull/27260