### PR TITLE
[chrome] update management namespace

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -6881,54 +6881,42 @@ declare namespace chrome {
      * Permissions: "management"
      */
     export namespace management {
+        /**
+         * A reason the item is disabled.
+         * @since Chrome 44
+         */
+        export enum ExtensionDisabledReason {
+            UNKNOWN = "unknown",
+            PERMISSIONS_INCREASE = "permissions_increase",
+        }
+
         /** Information about an installed extension, app, or theme. */
         export interface ExtensionInfo {
-            /**
-             * Optional.
-             * A reason the item is disabled.
-             * @since Chrome 17
-             */
-            disabledReason?: string | undefined;
-            /** Optional. The launch url (only present for apps). */
-            appLaunchUrl?: string | undefined;
-            /**
-             * The description of this extension, app, or theme.
-             * @since Chrome 9
-             */
+            /** A reason the item is disabled. */
+            disabledReason?: `${ExtensionDisabledReason}`;
+            /** The launch url (only present for apps). */
+            appLaunchUrl?: string;
+            /** The description of this extension, app, or theme. */
             description: string;
-            /**
-             * Returns a list of API based permissions.
-             * @since Chrome 9
-             */
+            /** Returns a list of API based permissions. */
             permissions: string[];
-            /**
-             * Optional.
-             * A list of icon information. Note that this just reflects what was declared in the manifest, and the actual image at that url may be larger or smaller than what was declared, so you might consider using explicit width and height attributes on img tags referencing these images. See the manifest documentation on icons for more details.
-             */
-            icons?: IconInfo[] | undefined;
-            /**
-             * Returns a list of host based permissions.
-             * @since Chrome 9
-             */
+            /** A list of icon information. Note that this just reflects what was declared in the manifest, and the actual image at that url may be larger or smaller than what was declared, so you might consider using explicit width and height attributes on img tags referencing these images. See the manifest documentation on icons for more details. */
+            icons?: IconInfo[];
+            /** Returns a list of host based permissions. */
             hostPermissions: string[];
             /** Whether it is currently enabled or disabled. */
             enabled: boolean;
-            /**
-             * Optional.
-             * The URL of the homepage of this extension, app, or theme.
-             * @since Chrome 11
-             */
-            homepageUrl?: string | undefined;
-            /**
-             * Whether this extension can be disabled or uninstalled by the user.
-             * @since Chrome 12
-             */
+            /** The URL of the homepage of this extension, app, or theme. */
+            homepageUrl?: string;
+            /** Whether this extension can be disabled or uninstalled by the user. */
             mayDisable: boolean;
             /**
-             * How the extension was installed.
-             * @since Chrome 22
+             * Whether this extension can be enabled by the user. This is only returned for extensions which are not enabled.
+             * @since Chrome 62
              */
-            installType: string;
+            mayEnable?: boolean;
+            /** How the extension was installed. */
+            installType: `${ExtensionInstallType}`;
             /** The version of this extension, app, or theme. */
             version: string;
             /**
@@ -6938,266 +6926,217 @@ declare namespace chrome {
             versionName?: string;
             /** The extension's unique identifier. */
             id: string;
-            /**
-             * Whether the extension, app, or theme declares that it supports offline.
-             * @since Chrome 15
-             */
+            /** Whether the extension, app, or theme declares that it supports offline. */
             offlineEnabled: boolean;
-            /**
-             * Optional.
-             * The update URL of this extension, app, or theme.
-             * @since Chrome 16
-             */
-            updateUrl?: string | undefined;
-            /**
-             * The type of this extension, app, or theme.
-             * @since Chrome 23
-             */
-            type: string;
+            /** The update URL of this extension, app, or theme. */
+            updateUrl?: string;
+            /** The type of this extension, app, or theme. */
+            type: `${ExtensionType}`;
             /** The url for the item's options page, if it has one. */
             optionsUrl: string;
             /** The name of this extension, app, or theme. */
             name: string;
-            /**
-             * A short version of the name of this extension, app, or theme.
-             * @since Chrome 31
-             */
+            /** A short version of the name of this extension, app, or theme. */
             shortName: string;
             /**
              * True if this is an app.
-             * @deprecated since Chrome 33. Please use management.ExtensionInfo.type.
+             * @deprecated since Chrome 33. Please use {@link management.ExtensionInfo.type}.
              */
             isApp: boolean;
-            /**
-             * Optional.
-             * The app launch type (only present for apps).
-             * @since Chrome 37
-             */
-            launchType?: string | undefined;
-            /**
-             * Optional.
-             * The currently available launch types (only present for apps).
-             * @since Chrome 37
-             */
-            availableLaunchTypes?: string[] | undefined;
+            /** The app launch type (only present for apps). */
+            launchType?: `${LaunchType}`;
+            /** The currently available launch types (only present for apps). */
+            availableLaunchTypes?: `${LaunchType}`[];
+        }
+
+        /**
+         * How the extension was installed
+         * @since Chrome 44
+         */
+        export enum ExtensionInstallType {
+            /** The extension was installed because of an administrative policy. */
+            ADMIN = "admin",
+            /** The extension was loaded unpacked in developer mode. */
+            DEVELOPMENT = "development",
+            /** The extension was installed normally via a .crx file. */
+            NORMAL = "normal",
+            /** The extension was installed by other software on the machine. */
+            SIDELOAD = "sideload",
+            /** The extension was installed by other means. */
+            OTHER = "other",
+        }
+
+        /**
+         * The type of this extension, app, or theme.
+         * @since Chrome 44
+         */
+        export enum ExtensionType {
+            EXTENSION = "extension",
+            HOSTED_APP = "hosted_app",
+            PACKAGE_APP = "package_app",
+            LEGACY_PACKAGED_APP = "legacy_packaged_app",
+            THEME = "theme",
+            LOGIN_SCREEN_EXTENSION = "login_screen_extension",
         }
 
         /** Information about an icon belonging to an extension, app, or theme. */
         export interface IconInfo {
-            /** The URL for this icon image. To display a grayscale version of the icon (to indicate that an extension is disabled, for example), append ?grayscale=true to the URL. */
+            /** The URL for this icon image. To display a grayscale version of the icon (to indicate that an extension is disabled, for example), append `?grayscale=true` to the URL. */
             url: string;
             /** A number representing the width and height of the icon. Likely values include (but are not limited to) 128, 48, 24, and 16. */
             size: number;
         }
 
+        /** These are all possible app launch types. */
+        export enum LaunchType {
+            OPEN_AS_REGULAR_TAB = "OPEN_AS_REGULAR_TAB",
+            OPEN_AS_PINNED_TAB = "OPEN_AS_PINNED_TAB",
+            OPEN_AS_WINDOW = "OPEN_AS_WINDOW",
+            OPEN_FULL_SCREEN = "OPEN_FULL_SCREEN",
+        }
+
+        /**
+         * Options for how to handle the extension's uninstallation.
+         * @since Chrome 88
+         */
         export interface UninstallOptions {
-            /**
-             * Optional.
-             * Whether or not a confirm-uninstall dialog should prompt the user. Defaults to false for self uninstalls. If an extension uninstalls another extension, this parameter is ignored and the dialog is always shown.
-             */
+            /** Whether or not a confirm-uninstall dialog should prompt the user. Defaults to false for self uninstalls. If an extension uninstalls another extension, this parameter is ignored and the dialog is always shown. */
             showConfirmDialog?: boolean | undefined;
         }
 
-        export interface ManagementDisabledEvent extends chrome.events.Event<(info: ExtensionInfo) => void> {}
-
-        export interface ManagementUninstalledEvent extends chrome.events.Event<(id: string) => void> {}
-
-        export interface ManagementInstalledEvent extends chrome.events.Event<(info: ExtensionInfo) => void> {}
-
-        export interface ManagementEnabledEvent extends chrome.events.Event<(info: ExtensionInfo) => void> {}
-
         /**
-         * Enables or disables an app or extension.
-         * @param id This should be the id from an item of management.ExtensionInfo.
+         * Enables or disables an app or extension. In most cases this function must be called in the context of a user gesture (e.g. an onclick handler for a button), and may present the user with a native confirmation UI as a way of preventing abuse.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         * @param id This should be the id from an item of {@link management.ExtensionInfo}.
          * @param enabled Whether this item should be enabled or disabled.
-         * @return The `setEnabled` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
          */
         export function setEnabled(id: string, enabled: boolean): Promise<void>;
-        /**
-         * Enables or disables an app or extension.
-         * @param id This should be the id from an item of management.ExtensionInfo.
-         * @param enabled Whether this item should be enabled or disabled.
-         */
         export function setEnabled(id: string, enabled: boolean, callback: () => void): void;
+
         /**
          * Returns a list of permission warnings for the given extension id.
-         * @since Chrome 15
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
          * @param id The ID of an already installed extension.
-         * @return The `getPermissionWarningsById` method provides its result via callback or returned as a `Promise` (MV3 only).
          */
         export function getPermissionWarningsById(id: string): Promise<string[]>;
-        /**
-         * Returns a list of permission warnings for the given extension id.
-         * @since Chrome 15
-         * @param id The ID of an already installed extension.
-         */
         export function getPermissionWarningsById(id: string, callback: (permissionWarnings: string[]) => void): void;
+
         /**
          * Returns information about the installed extension, app, or theme that has the given ID.
-         * @since Chrome 9
-         * @param id The ID from an item of management.ExtensionInfo.
-         * @return The `get` method provides its result via callback or returned as a `Promise` (MV3 only).
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         * @param id The ID from an item of {@link management.ExtensionInfo}.
          */
         export function get(id: string): Promise<ExtensionInfo>;
-        /**
-         * Returns information about the installed extension, app, or theme that has the given ID.
-         * @since Chrome 9
-         * @param id The ID from an item of management.ExtensionInfo.
-         */
         export function get(id: string, callback: (result: ExtensionInfo) => void): void;
+
         /**
          * Returns a list of information about installed extensions and apps.
-         * @return The `getAll` method provides its result via callback or returned as a `Promise` (MV3 only).
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
          */
         export function getAll(): Promise<ExtensionInfo[]>;
-        /**
-         * Returns a list of information about installed extensions and apps.
-         */
         export function getAll(callback: (result: ExtensionInfo[]) => void): void;
+
         /**
          * Returns a list of permission warnings for the given extension manifest string. Note: This function can be used without requesting the 'management' permission in the manifest.
-         * @since Chrome 15
-         * @param manifestStr Extension manifest JSON string.
-         * @return The `getPermissionWarningsByManifest` method provides its result via callback or returned as a `Promise` (MV3 only).
-         */
-        export function getPermissionWarningsByManifest(
-            manifestStr: string,
-        ): Promise<string[]>;
-        /**
-         * Returns a list of permission warnings for the given extension manifest string. Note: This function can be used without requesting the 'management' permission in the manifest.
-         * @since Chrome 15
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
          * @param manifestStr Extension manifest JSON string.
          */
+        export function getPermissionWarningsByManifest(manifestStr: string): Promise<string[]>;
         export function getPermissionWarningsByManifest(
             manifestStr: string,
-            callback: (permissionwarnings: string[]) => void,
+            callback: (permissionWarnings: string[]) => void,
         ): void;
+
         /**
          * Launches an application.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
          * @param id The extension id of the application.
-         * @return The `launchApp` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
          */
         export function launchApp(id: string): Promise<void>;
-        /**
-         * Launches an application.
-         * @param id The extension id of the application.
-         */
         export function launchApp(id: string, callback: () => void): void;
+
         /**
-         * Uninstalls a currently installed app or extension.
-         * @since Chrome 21
-         * @param id This should be the id from an item of management.ExtensionInfo.
-         * @return The `uninstall` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+         * Uninstalls a currently installed app or extension. Note: This function does not work in managed environments when the user is not allowed to uninstall the specified extension/app. If the uninstall fails (e.g. the user cancels the dialog) the promise will be rejected or the callback will be called with {@link runtime.lastError} set.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         * @param id This should be the id from an item of {@link management.ExtensionInfo}.
          */
         export function uninstall(id: string, options?: UninstallOptions): Promise<void>;
-        /**
-         * Uninstalls a currently installed app or extension.
-         * @since Chrome 21
-         * @param id This should be the id from an item of management.ExtensionInfo.
-         */
         export function uninstall(id: string, callback: () => void): void;
-        export function uninstall(id: string, options: UninstallOptions, callback: () => void): void;
-        /**
-         * Uninstalls a currently installed app or extension.
-         * @deprecated since Chrome 21. The options parameter was added to this function.
-         * @param id This should be the id from an item of management.ExtensionInfo.
-         * @return The `uninstall` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
-         */
-        export function uninstall(id: string): Promise<void>;
-        /**
-         * Uninstalls a currently installed app or extension.
-         * @deprecated since Chrome 21. The options parameter was added to this function.
-         * @param id This should be the id from an item of management.ExtensionInfo.
-         */
-        export function uninstall(id: string, callback: () => void): void;
+        export function uninstall(id: string, options: UninstallOptions | undefined, callback: () => void): void;
+
         /**
          * Returns information about the calling extension, app, or theme. Note: This function can be used without requesting the 'management' permission in the manifest.
-         * @since Chrome 39
-         * @return The `getSelf` method provides its result via callback or returned as a `Promise` (MV3 only).
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
          */
         export function getSelf(): Promise<ExtensionInfo>;
-        /**
-         * Returns information about the calling extension, app, or theme. Note: This function can be used without requesting the 'management' permission in the manifest.
-         * @since Chrome 39
-         */
         export function getSelf(callback: (result: ExtensionInfo) => void): void;
+
         /**
-         * Uninstalls the calling extension.
-         * Note: This function can be used without requesting the 'management' permission in the manifest.
-         * @since Chrome 26
-         * @return The `uninstallSelf` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+         * Launches the replacement_web_app specified in the manifest. Prompts the user to install if not already installed.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         * @since Chrome 77
+         */
+        export function installReplacementWebApp(): Promise<void>;
+        export function installReplacementWebApp(callback: () => void): void;
+
+        /**
+         * Uninstalls the calling extension. Note: This function can be used without requesting the 'management' permission in the manifest. This function does not work in managed environments when the user is not allowed to uninstall the specified extension/app.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
          */
         export function uninstallSelf(options?: UninstallOptions): Promise<void>;
-        /**
-         * Uninstalls the calling extension.
-         * Note: This function can be used without requesting the 'management' permission in the manifest.
-         * @since Chrome 26
-         */
         export function uninstallSelf(callback: () => void): void;
-        export function uninstallSelf(options: UninstallOptions, callback: () => void): void;
-        /**
-         * Uninstalls the calling extension.
-         * Note: This function can be used without requesting the 'management' permission in the manifest.
-         * @since Chrome 26
-         * @return The `uninstallSelf` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
-         */
-        export function uninstallSelf(): Promise<void>;
-        /**
-         * Uninstalls the calling extension.
-         * Note: This function can be used without requesting the 'management' permission in the manifest.
-         * @since Chrome 26
-         */
-        export function uninstallSelf(callback: () => void): void;
+        export function uninstallSelf(options: UninstallOptions | undefined, callback: () => void): void;
+
         /**
          * Display options to create shortcuts for an app. On Mac, only packaged app shortcuts can be created.
-         * @since Chrome 37
-         * @return The `createAppShortcut` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         * @param id This should be the id from an app item of {@link management.ExtensionInfo}.
          */
         export function createAppShortcut(id: string): Promise<void>;
-        /**
-         * Display options to create shortcuts for an app. On Mac, only packaged app shortcuts can be created.
-         * @since Chrome 37
-         */
         export function createAppShortcut(id: string, callback: () => void): void;
+
         /**
          * Set the launch type of an app.
-         * @since Chrome 37
-         * @param id This should be the id from an app item of management.ExtensionInfo.
-         * @param launchType The target launch type. Always check and make sure this launch type is in ExtensionInfo.availableLaunchTypes, because the available launch types vary on different platforms and configurations.
-         * @return The `setLaunchType` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
+         * @param id This should be the id from an app item of {@link management.ExtensionInfo}.
+         * @param launchType The target launch type. Always check and make sure this launch type is in {@link ExtensionInfo.availableLaunchTypes}, because the available launch types vary on different platforms and configurations.
          */
-        export function setLaunchType(id: string, launchType: string): Promise<void>;
-        /**
-         * Set the launch type of an app.
-         * @since Chrome 37
-         * @param id This should be the id from an app item of management.ExtensionInfo.
-         * @param launchType The target launch type. Always check and make sure this launch type is in ExtensionInfo.availableLaunchTypes, because the available launch types vary on different platforms and configurations.
-         */
-        export function setLaunchType(id: string, launchType: string, callback: () => void): void;
+        export function setLaunchType(id: string, launchType: `${LaunchType}`): Promise<void>;
+        export function setLaunchType(id: string, launchType: `${LaunchType}`, callback: () => void): void;
+
         /**
          * Generate an app for a URL. Returns the generated bookmark app.
-         * @since Chrome 37
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 88.
          * @param url The URL of a web page. The scheme of the URL can only be "http" or "https".
          * @param title The title of the generated app.
-         * @return The `generateAppForLink` method provides its result via callback or returned as a `Promise` (MV3 only).
          */
         export function generateAppForLink(url: string, title: string): Promise<ExtensionInfo>;
-        /**
-         * Generate an app for a URL. Returns the generated bookmark app.
-         * @since Chrome 37
-         * @param url The URL of a web page. The scheme of the URL can only be "http" or "https".
-         * @param title The title of the generated app.
-         */
         export function generateAppForLink(url: string, title: string, callback: (result: ExtensionInfo) => void): void;
 
         /** Fired when an app or extension has been disabled. */
-        export var onDisabled: ManagementDisabledEvent;
+        export const onDisabled: events.Event<(info: ExtensionInfo) => void>;
+
         /** Fired when an app or extension has been uninstalled. */
-        export var onUninstalled: ManagementUninstalledEvent;
+        export const onUninstalled: events.Event<(id: string) => void>;
+
         /** Fired when an app or extension has been installed. */
-        export var onInstalled: ManagementInstalledEvent;
+        export const onInstalled: events.Event<(info: ExtensionInfo) => void>;
+
         /** Fired when an app or extension has been enabled. */
-        export var onEnabled: ManagementEnabledEvent;
+        export const onEnabled: events.Event<(info: ExtensionInfo) => void>;
     }
 
     ////////////////////

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -2241,22 +2241,161 @@ async function testCookie() {
     });
 }
 
-// https://developer.chrome.com/docs/extensions/reference/management
-async function testManagementForPromise() {
-    await chrome.management.setEnabled("id1", true);
-    await chrome.management.getPermissionWarningsById("id1");
-    await chrome.management.get("id1");
-    await chrome.management.getAll();
-    await chrome.management.getPermissionWarningsByManifest("manifestStr1");
-    await chrome.management.launchApp("id1");
-    await chrome.management.uninstall("id1");
-    await chrome.management.uninstall("id1", {});
-    await chrome.management.getSelf();
-    await chrome.management.uninstallSelf({});
-    await chrome.management.uninstallSelf();
-    await chrome.management.createAppShortcut("id1");
-    await chrome.management.setLaunchType("id1", "launchType1");
-    await chrome.management.generateAppForLink("url1", "title1");
+// https://developer.chrome.com/docs/extensions/reference/api/management
+async function testManagement() {
+    chrome.management.ExtensionDisabledReason.PERMISSIONS_INCREASE === "permissions_increase";
+    chrome.management.ExtensionDisabledReason.UNKNOWN === "unknown";
+
+    chrome.management.ExtensionInstallType.ADMIN === "admin";
+    chrome.management.ExtensionInstallType.DEVELOPMENT === "development";
+    chrome.management.ExtensionInstallType.NORMAL === "normal";
+    chrome.management.ExtensionInstallType.OTHER === "other";
+    chrome.management.ExtensionInstallType.SIDELOAD === "sideload";
+
+    chrome.management.ExtensionType.EXTENSION === "extension";
+    chrome.management.ExtensionType.HOSTED_APP === "hosted_app";
+    chrome.management.ExtensionType.LEGACY_PACKAGED_APP === "legacy_packaged_app";
+    chrome.management.ExtensionType.LOGIN_SCREEN_EXTENSION === "login_screen_extension";
+    chrome.management.ExtensionType.PACKAGE_APP === "package_app";
+    chrome.management.ExtensionType.THEME === "theme";
+
+    chrome.management.LaunchType.OPEN_AS_PINNED_TAB === "OPEN_AS_PINNED_TAB";
+    chrome.management.LaunchType.OPEN_AS_REGULAR_TAB === "OPEN_AS_REGULAR_TAB";
+    chrome.management.LaunchType.OPEN_AS_WINDOW === "OPEN_AS_WINDOW";
+    chrome.management.LaunchType.OPEN_FULL_SCREEN === "OPEN_FULL_SCREEN";
+
+    const id = "id";
+    const title = "title";
+    const url = "https://example.com";
+
+    chrome.management.createAppShortcut(id); // $ExpectType Promise<void>
+    chrome.management.createAppShortcut(id, () => void 0); // $ExpectType void
+    // @ts-expect-error
+    chrome.management.createAppShortcut(id, () => {}).then(() => {});
+
+    chrome.management.generateAppForLink(url, title); // $ExpectType Promise<ExtensionInfo>
+    chrome.management.generateAppForLink(url, title, (result) => { // $ExpectType void
+        result.appLaunchUrl; // $ExpectType string | undefined
+        result.availableLaunchTypes; // $ExpectType ("OPEN_AS_PINNED_TAB" | "OPEN_AS_REGULAR_TAB" | "OPEN_AS_WINDOW" | "OPEN_FULL_SCREEN")[] | undefined
+        result.description; // $ExpectType string
+        result.disabledReason; // $ExpectType "unknown" | "permissions_increase" | undefined
+        result.enabled; // $ExpectType boolean
+        result.homepageUrl; // $ExpectType string | undefined
+        result.hostPermissions; // $ExpectType string[]
+        result.icons; // $ExpectType IconInfo[] | undefined
+        result.icons![0].size; // $ExpectType number
+        result.icons![0].url; // $ExpectType string
+        result.id; // $ExpectType string
+        result.installType; // $ExpectType "admin" | "development" | "normal" | "other" | "sideload"
+        result.isApp; // $ExpectType boolean
+        result.launchType; // $ExpectType "OPEN_AS_PINNED_TAB" | "OPEN_AS_REGULAR_TAB" | "OPEN_AS_WINDOW" | "OPEN_FULL_SCREEN" | undefined
+        result.mayDisable; // $ExpectType boolean
+        result.mayEnable; // $ExpectType boolean | undefined
+        result.name; // $ExpectType string
+        result.offlineEnabled; // $ExpectType boolean
+        result.optionsUrl; // $ExpectType string
+        result.permissions; // $ExpectType string[]
+        result.shortName; // $ExpectType string
+        result.type; // $ExpectType "extension" | "hosted_app" | "legacy_packaged_app" | "login_screen_extension" | "package_app" | "theme"
+        result.updateUrl; // $ExpectType string | undefined
+        result.version; // $ExpectType string
+        result.versionName; // $ExpectType string | undefined
+    });
+    // @ts-expect-error
+    chrome.management.generateAppForLink(url, title, () => {}).then(() => {});
+
+    chrome.management.get(id); // $ExpectType Promise<ExtensionInfo>
+    chrome.management.get(id, (result) => { // $ExpectType void
+        result; // $ExpectType ExtensionInfo
+    });
+    // @ts-expect-error
+    chrome.management.get(id, () => {}).then(() => {});
+
+    chrome.management.getAll(); // $ExpectType Promise<ExtensionInfo[]>
+    chrome.management.getAll((result) => { // $ExpectType void
+        result; // $ExpectType ExtensionInfo[]
+    });
+    // @ts-expect-error
+    chrome.management.getAll(() => {}).then(() => {});
+
+    chrome.management.getPermissionWarningsById(id); // $ExpectType Promise<string[]>
+    chrome.management.getPermissionWarningsById(id, (permissionWarnings) => { // $ExpectType void
+        permissionWarnings; // $ExpectType string[]
+    });
+    // @ts-expect-error
+    chrome.management.getPermissionWarningsById(id, () => {}).then(() => {});
+
+    const manifestStr = "{}";
+
+    chrome.management.getPermissionWarningsByManifest(manifestStr); // $ExpectType Promise<string[]>
+    chrome.management.getPermissionWarningsByManifest(manifestStr, (permissionWarnings) => { // $ExpectType void
+        permissionWarnings; // $ExpectType string[]
+    });
+    // @ts-expect-error
+    chrome.management.getPermissionWarningsByManifest(manifestStr, () => {}).then(() => {});
+
+    chrome.management.getSelf(); // $ExpectType Promise<ExtensionInfo>
+    chrome.management.getSelf((result) => { // $ExpectType void
+        result; // $ExpectType ExtensionInfo
+    });
+    // @ts-expect-error
+    chrome.management.getSelf(() => {}).then(() => {});
+
+    chrome.management.installReplacementWebApp(); // $ExpectType Promise<void>
+    chrome.management.installReplacementWebApp(() => void 0); // $ExpectType void
+    // @ts-expect-error
+    chrome.management.installReplacementWebApp(() => {}).then(() => {});
+
+    chrome.management.launchApp(id); // $ExpectType Promise<void>
+    chrome.management.launchApp(id, () => void 0); // $ExpectType void
+    // @ts-expect-error
+    chrome.management.launchApp(id, () => {}).then(() => {});
+
+    chrome.management.setEnabled(id, true); // $ExpectType Promise<void>
+    chrome.management.setEnabled(id, true, () => void 0); // $ExpectType void
+    // @ts-expect-error
+    chrome.management.setEnabled(id, true, () => {}).then(() => {});
+
+    const launchType = "OPEN_AS_PINNED_TAB";
+
+    chrome.management.setLaunchType(id, launchType); // $ExpectType Promise<void>
+    chrome.management.setLaunchType(id, launchType, () => void 0); // $ExpectType void
+    // @ts-expect-error
+    chrome.management.setLaunchType(id, launchType, () => {}).then(() => {});
+
+    const options: chrome.management.UninstallOptions = {
+        showConfirmDialog: true,
+    };
+
+    chrome.management.uninstall(id); // $ExpectType Promise<void>
+    chrome.management.uninstall(id, options); // $ExpectType Promise<void>
+    chrome.management.uninstall(id, () => void 0); // $ExpectType void
+    chrome.management.uninstall(id, options, () => void 0); // $ExpectType void
+    // @ts-expect-error
+    chrome.management.uninstall(id, () => {}).then(() => {});
+
+    chrome.management.uninstallSelf(); // $ExpectType Promise<void>
+    chrome.management.uninstallSelf(options); // $ExpectType Promise<void>
+    chrome.management.uninstallSelf(() => void 0); // $ExpectType void
+    chrome.management.uninstallSelf(options, () => void 0); // $ExpectType void
+    // @ts-expect-error
+    chrome.management.uninstallSelf(() => {}).then(() => {});
+
+    checkChromeEvent(chrome.management.onDisabled, (info) => {
+        info; // $ExpectType ExtensionInfo
+    });
+
+    checkChromeEvent(chrome.management.onEnabled, (info) => {
+        info; // $ExpectType ExtensionInfo
+    });
+
+    checkChromeEvent(chrome.management.onInstalled, (info) => {
+        info; // $ExpectType ExtensionInfo
+    });
+
+    checkChromeEvent(chrome.management.onUninstalled, (id) => {
+        id; // $ExpectType string
+    });
 }
 
 // https://developer.chrome.com/docs/extensions/reference/api/scripting


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  https://developer.chrome.com/docs/extensions/mv2/reference/management
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes:
- add enums: `ExtensionDisabledReason`, `ExtensionInstallType`, `ExtensionType`, `LaunchType`
- add `installReplacementWebApp()`
- update `ExtensionInfo`:
  - `availableLaunchTypes`: `string[]` → `LaunchType[]`
  - `disabledReason`: `string` → `ExtensionDisabledReason`
  - `installType`: `string` → `ExtensionInstallType`
  - `launchType`: `string` → `LaunchType`
  - `type`: `string` → `ExtensionType`
  - add `mayEnable` key
- update `setLaunchType()`: change `launchType` param from `string` to `LaunchType`
- update tests
- update JSDoc

Runtime:
<img width="577" height="785" alt="image" src="https://github.com/user-attachments/assets/7698cfd0-9c7d-499d-a748-65ec504afa27" />
