### PR TITLE
[css-tree] Add missing visit method to WalkOptionsNoVisit

### DIFF
--- a/types/css-tree/index.d.ts
+++ b/types/css-tree/index.d.ts
@@ -565,6 +565,7 @@ export type EnterOrLeaveFn<NodeType = CssNode> = (
 ) => void;
 
 export interface WalkOptionsNoVisit {
+    visit?: never;
     enter?: EnterOrLeaveFn | undefined;
     leave?: EnterOrLeaveFn | undefined;
     reverse?: boolean | undefined;


### PR DESCRIPTION
See https://github.com/microsoft/TypeScript/pull/62501#issuecomment-3347056755. This fixes a bug that caused issues with `WalkOptions` discrimination, caught by `typescript-go`.