### PR TITLE
[node] worker_threads: linearise MessagePort heritage graph

### DIFF
--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -36,39 +36,6 @@
  */
 declare module "events" {
     import { AsyncResource, AsyncResourceOptions } from "node:async_hooks";
-    // NOTE: This class is in the docs but is **not actually exported** by Node.
-    // If https://github.com/nodejs/node/issues/39903 gets resolved and Node
-    // actually starts exporting the class, uncomment below.
-    // import { EventListener, EventListenerObject } from '__dom-events';
-    // /** The NodeEventTarget is a Node.js-specific extension to EventTarget that emulates a subset of the EventEmitter API. */
-    // interface NodeEventTarget extends EventTarget {
-    //     /**
-    //      * Node.js-specific extension to the `EventTarget` class that emulates the equivalent `EventEmitter` API.
-    //      * The only difference between `addListener()` and `addEventListener()` is that addListener() will return a reference to the EventTarget.
-    //      */
-    //     addListener(type: string, listener: EventListener | EventListenerObject, options?: { once: boolean }): this;
-    //     /** Node.js-specific extension to the `EventTarget` class that returns an array of event `type` names for which event listeners are registered. */
-    //     eventNames(): string[];
-    //     /** Node.js-specific extension to the `EventTarget` class that returns the number of event listeners registered for the `type`. */
-    //     listenerCount(type: string): number;
-    //     /** Node.js-specific alias for `eventTarget.removeListener()`. */
-    //     off(type: string, listener: EventListener | EventListenerObject): this;
-    //     /** Node.js-specific alias for `eventTarget.addListener()`. */
-    //     on(type: string, listener: EventListener | EventListenerObject, options?: { once: boolean }): this;
-    //     /** Node.js-specific extension to the `EventTarget` class that adds a `once` listener for the given event `type`. This is equivalent to calling `on` with the `once` option set to `true`. */
-    //     once(type: string, listener: EventListener | EventListenerObject): this;
-    //     /**
-    //      * Node.js-specific extension to the `EventTarget` class.
-    //      * If `type` is specified, removes all registered listeners for `type`,
-    //      * otherwise removes all registered listeners.
-    //      */
-    //     removeAllListeners(type: string): this;
-    //     /**
-    //      * Node.js-specific extension to the `EventTarget` class that removes the listener for the given `type`.
-    //      * The only difference between `removeListener()` and `removeEventListener()` is that `removeListener()` will return a reference to the `EventTarget`.
-    //      */
-    //     removeListener(type: string, listener: EventListener | EventListenerObject): this;
-    // }
     interface EventEmitterOptions {
         /**
          * Enables automatic capturing of promise rejection.

--- a/types/node/v18/events.d.ts
+++ b/types/node/v18/events.d.ts
@@ -37,41 +37,6 @@
 declare module "events" {
     import { AsyncResource, AsyncResourceOptions } from "node:async_hooks";
 
-    // NOTE: This class is in the docs but is **not actually exported** by Node.
-    // If https://github.com/nodejs/node/issues/39903 gets resolved and Node
-    // actually starts exporting the class, uncomment below.
-
-    // import { EventListener, EventListenerObject } from '__dom-events';
-    // /** The NodeEventTarget is a Node.js-specific extension to EventTarget that emulates a subset of the EventEmitter API. */
-    // interface NodeEventTarget extends EventTarget {
-    //     /**
-    //      * Node.js-specific extension to the `EventTarget` class that emulates the equivalent `EventEmitter` API.
-    //      * The only difference between `addListener()` and `addEventListener()` is that addListener() will return a reference to the EventTarget.
-    //      */
-    //     addListener(type: string, listener: EventListener | EventListenerObject, options?: { once: boolean }): this;
-    //     /** Node.js-specific extension to the `EventTarget` class that returns an array of event `type` names for which event listeners are registered. */
-    //     eventNames(): string[];
-    //     /** Node.js-specific extension to the `EventTarget` class that returns the number of event listeners registered for the `type`. */
-    //     listenerCount(type: string): number;
-    //     /** Node.js-specific alias for `eventTarget.removeListener()`. */
-    //     off(type: string, listener: EventListener | EventListenerObject): this;
-    //     /** Node.js-specific alias for `eventTarget.addListener()`. */
-    //     on(type: string, listener: EventListener | EventListenerObject, options?: { once: boolean }): this;
-    //     /** Node.js-specific extension to the `EventTarget` class that adds a `once` listener for the given event `type`. This is equivalent to calling `on` with the `once` option set to `true`. */
-    //     once(type: string, listener: EventListener | EventListenerObject): this;
-    //     /**
-    //      * Node.js-specific extension to the `EventTarget` class.
-    //      * If `type` is specified, removes all registered listeners for `type`,
-    //      * otherwise removes all registered listeners.
-    //      */
-    //     removeAllListeners(type: string): this;
-    //     /**
-    //      * Node.js-specific extension to the `EventTarget` class that removes the listener for the given `type`.
-    //      * The only difference between `removeListener()` and `removeEventListener()` is that `removeListener()` will return a reference to the `EventTarget`.
-    //      */
-    //     removeListener(type: string, listener: EventListener | EventListenerObject): this;
-    // }
-
     interface EventEmitterOptions {
         /**
          * Enables automatic capturing of promise rejection.

--- a/types/node/v18/worker_threads.d.ts
+++ b/types/node/v18/worker_threads.d.ts
@@ -106,7 +106,7 @@ declare module "worker_threads" {
      * This implementation matches [browser `MessagePort`](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort) s.
      * @since v10.5.0
      */
-    class MessagePort extends EventTarget {
+    class MessagePort implements EventTarget {
         /**
          * Disables further sending of messages on either side of the connection.
          * This method can be called when no further communication will happen over this`MessagePort`.

--- a/types/node/v20/events.d.ts
+++ b/types/node/v20/events.d.ts
@@ -36,39 +36,6 @@
  */
 declare module "events" {
     import { AsyncResource, AsyncResourceOptions } from "node:async_hooks";
-    // NOTE: This class is in the docs but is **not actually exported** by Node.
-    // If https://github.com/nodejs/node/issues/39903 gets resolved and Node
-    // actually starts exporting the class, uncomment below.
-    // import { EventListener, EventListenerObject } from '__dom-events';
-    // /** The NodeEventTarget is a Node.js-specific extension to EventTarget that emulates a subset of the EventEmitter API. */
-    // interface NodeEventTarget extends EventTarget {
-    //     /**
-    //      * Node.js-specific extension to the `EventTarget` class that emulates the equivalent `EventEmitter` API.
-    //      * The only difference between `addListener()` and `addEventListener()` is that addListener() will return a reference to the EventTarget.
-    //      */
-    //     addListener(type: string, listener: EventListener | EventListenerObject, options?: { once: boolean }): this;
-    //     /** Node.js-specific extension to the `EventTarget` class that returns an array of event `type` names for which event listeners are registered. */
-    //     eventNames(): string[];
-    //     /** Node.js-specific extension to the `EventTarget` class that returns the number of event listeners registered for the `type`. */
-    //     listenerCount(type: string): number;
-    //     /** Node.js-specific alias for `eventTarget.removeListener()`. */
-    //     off(type: string, listener: EventListener | EventListenerObject): this;
-    //     /** Node.js-specific alias for `eventTarget.addListener()`. */
-    //     on(type: string, listener: EventListener | EventListenerObject, options?: { once: boolean }): this;
-    //     /** Node.js-specific extension to the `EventTarget` class that adds a `once` listener for the given event `type`. This is equivalent to calling `on` with the `once` option set to `true`. */
-    //     once(type: string, listener: EventListener | EventListenerObject): this;
-    //     /**
-    //      * Node.js-specific extension to the `EventTarget` class.
-    //      * If `type` is specified, removes all registered listeners for `type`,
-    //      * otherwise removes all registered listeners.
-    //      */
-    //     removeAllListeners(type: string): this;
-    //     /**
-    //      * Node.js-specific extension to the `EventTarget` class that removes the listener for the given `type`.
-    //      * The only difference between `removeListener()` and `removeEventListener()` is that `removeListener()` will return a reference to the `EventTarget`.
-    //      */
-    //     removeListener(type: string, listener: EventListener | EventListenerObject): this;
-    // }
     interface EventEmitterOptions {
         /**
          * Enables automatic capturing of promise rejection.

--- a/types/node/v20/worker_threads.d.ts
+++ b/types/node/v20/worker_threads.d.ts
@@ -106,7 +106,7 @@ declare module "worker_threads" {
      * This implementation matches [browser `MessagePort`](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort) s.
      * @since v10.5.0
      */
-    class MessagePort extends EventTarget {
+    class MessagePort implements EventTarget {
         /**
          * Disables further sending of messages on either side of the connection.
          * This method can be called when no further communication will happen over this `MessagePort`.

--- a/types/node/v22/events.d.ts
+++ b/types/node/v22/events.d.ts
@@ -36,39 +36,6 @@
  */
 declare module "events" {
     import { AsyncResource, AsyncResourceOptions } from "node:async_hooks";
-    // NOTE: This class is in the docs but is **not actually exported** by Node.
-    // If https://github.com/nodejs/node/issues/39903 gets resolved and Node
-    // actually starts exporting the class, uncomment below.
-    // import { EventListener, EventListenerObject } from '__dom-events';
-    // /** The NodeEventTarget is a Node.js-specific extension to EventTarget that emulates a subset of the EventEmitter API. */
-    // interface NodeEventTarget extends EventTarget {
-    //     /**
-    //      * Node.js-specific extension to the `EventTarget` class that emulates the equivalent `EventEmitter` API.
-    //      * The only difference between `addListener()` and `addEventListener()` is that addListener() will return a reference to the EventTarget.
-    //      */
-    //     addListener(type: string, listener: EventListener | EventListenerObject, options?: { once: boolean }): this;
-    //     /** Node.js-specific extension to the `EventTarget` class that returns an array of event `type` names for which event listeners are registered. */
-    //     eventNames(): string[];
-    //     /** Node.js-specific extension to the `EventTarget` class that returns the number of event listeners registered for the `type`. */
-    //     listenerCount(type: string): number;
-    //     /** Node.js-specific alias for `eventTarget.removeListener()`. */
-    //     off(type: string, listener: EventListener | EventListenerObject): this;
-    //     /** Node.js-specific alias for `eventTarget.addListener()`. */
-    //     on(type: string, listener: EventListener | EventListenerObject, options?: { once: boolean }): this;
-    //     /** Node.js-specific extension to the `EventTarget` class that adds a `once` listener for the given event `type`. This is equivalent to calling `on` with the `once` option set to `true`. */
-    //     once(type: string, listener: EventListener | EventListenerObject): this;
-    //     /**
-    //      * Node.js-specific extension to the `EventTarget` class.
-    //      * If `type` is specified, removes all registered listeners for `type`,
-    //      * otherwise removes all registered listeners.
-    //      */
-    //     removeAllListeners(type: string): this;
-    //     /**
-    //      * Node.js-specific extension to the `EventTarget` class that removes the listener for the given `type`.
-    //      * The only difference between `removeListener()` and `removeEventListener()` is that `removeListener()` will return a reference to the `EventTarget`.
-    //      */
-    //     removeListener(type: string, listener: EventListener | EventListenerObject): this;
-    // }
     interface EventEmitterOptions {
         /**
          * Enables automatic capturing of promise rejection.

--- a/types/node/v22/worker_threads.d.ts
+++ b/types/node/v22/worker_threads.d.ts
@@ -111,7 +111,7 @@ declare module "worker_threads" {
      * This implementation matches [browser `MessagePort`](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort) s.
      * @since v10.5.0
      */
-    class MessagePort extends EventTarget {
+    class MessagePort implements EventTarget {
         /**
          * Disables further sending of messages on either side of the connection.
          * This method can be called when no further communication will happen over this `MessagePort`.

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -113,7 +113,7 @@ declare module "worker_threads" {
      * This implementation matches [browser `MessagePort`](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort) s.
      * @since v10.5.0
      */
-    class MessagePort extends EventTarget {
+    class MessagePort implements EventTarget {
         /**
          * Disables further sending of messages on either side of the connection.
          * This method can be called when no further communication will happen over this `MessagePort`.


### PR DESCRIPTION
Angular mutates the global EventTarget interface (naughty...) and defines its own `removeAllListeners()` on that prototype.

NodeEventTarget can override this definition without conflict, but an object cannot extend both NodeEventTarget and the mutated EventTarget at the same heritage depth, as that _does_ cause conflict. The MessagePort definition was added as "dom-compatible EventTarget-derived class plus NodeEventTarget augmentation", which hits this behaviour.

Also removes some old dead commentary related to NodeEventTarget, since it's now implemented.