### PR TITLE
webpack-hot-middleware: fix CI

### DIFF
--- a/types/webpack-hot-middleware/webpack-hot-middleware-tests.ts
+++ b/types/webpack-hot-middleware/webpack-hot-middleware-tests.ts
@@ -13,7 +13,7 @@ webpackHotMiddlewareInstance = webpackHotMiddleware(compiler, {
     heartbeat: 2000,
 });
 
-const multiCompiler = webpack([{}])!;
+const multiCompiler = webpack([webpack.config.getNormalizedWebpackOptions({})])!;
 
 webpackHotMiddlewareInstance = webpackHotMiddleware(multiCompiler);
 


### PR DESCRIPTION
External dependencies are fun.