### PR TITLE
[tapable] fix test, bump to 2.3.0

### DIFF
--- a/types/tapable/package.json
+++ b/types/tapable/package.json
@@ -1,12 +1,12 @@
 {
     "private": true,
     "name": "@types/tapable",
-    "version": "2.2.9999",
+    "version": "2.3.9999",
     "projects": [
         "https://github.com/webpack/tapable.git"
     ],
     "dependencies": {
-        "tapable": "^2.2.0"
+        "tapable": "^2.3.0"
     },
     "devDependencies": {
         "@types/tapable": "workspace:."

--- a/types/tapable/tapable-tests.ts
+++ b/types/tapable/tapable-tests.ts
@@ -1,2 +1,2 @@
 import { HookFactory } from "tapable";
-const hf: HookFactory<boolean> = (key, hook) => !!hook;
+const hf: HookFactory<boolean> = (key) => !!key;


### PR DESCRIPTION
Due to https://github.com/webpack/tapable/pull/195

I don't think this test actually matters, it seemed to be left behind in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51712.