### PR TITLE
[new-relic-browser] change namespace declaration to a module

### DIFF
--- a/types/new-relic-browser/index.d.ts
+++ b/types/new-relic-browser/index.d.ts
@@ -1,8 +1,154 @@
+declare global {
+    let newrelic: NewRelicAPI | undefined;
+
+    interface GlobalThis {
+        newrelic?: NewRelicAPI;
+    }
+}
+
+export interface EventObject {
+    /** Event name */
+    name: string;
+    /** Start time in ms since epoch */
+    start: number;
+    /** End time in ms since epoch.  Defaults to same as start resulting in trace object with a duration of zero. */
+    end?: number | undefined;
+    /** Origin of event */
+    origin?: string | undefined;
+    /** Event type - I can't find this being used in the newrelic-browser-agent code */
+    type?: string | undefined;
+}
+
+export interface BrowserInteraction {
+    /**
+     * Sets the text value of the HTML element that was clicked to start a browser interaction.
+     *
+     * @param value The text value of the HTML element that represents the action that started the interaction.
+     * @returns This method returns the same API object created by interaction().
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/actiontext-browser-spa-api
+     */
+    actionText(value: string): this;
+
+    /**
+     * Times sub-components of a SPA interaction separately, including wait time and JS execution time.
+     *
+     * @param name This will be used as the name of the tracer. If you do not include a name,
+     *   New Relic Browser does not add a node to the interaction tree. The callback time will be
+     *   attributed to the parent node.
+     * @param callback A callback that contains the synchronous work to run at the end of the async work.
+     *   To execute this callback, call the wrapper function returned using createTracer()
+     * @returns This method ends the async time. It calls (and times) the callback that was passed into createTracer().
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-create-tracer
+     */
+    createTracer(name: string, callback?: Callback): Wrapper;
+
+    /**
+     * Ends the New Relic SPA interaction at the current time.
+     *
+     * @returns This method returns the same API object created by interaction().
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-end
+     */
+    end(): this;
+
+    /**
+     * Stores values across the current SPA interaction asynchronously in New Relic Browser.
+     *
+     * @param callback A function that accepts the interaction context object
+     *   as its only argument.
+     * @returns This method returns the same API object created by interaction().
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-get-context
+     */
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+    getContext<T extends ContextObject = ContextObject>(callback: GetContextCallback<T>): this;
+
+    /**
+     * Overrides other SPA save() calls; ignores an interaction so it is not saved or sent to New Relic.
+     *
+     * @returns This method returns the same API object created by interaction().
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-ignore-browser
+     */
+    ignore(): this;
+
+    /**
+     * Adds custom attributes for SPA interactions to the end of an event. It is called when the interaction
+     * has finished. You can invoke methods to modify the interaction, but methods that have asynchronous
+     * side effects will not have an effect.
+     *
+     * @returns This method returns the same API object created by interaction().
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-on-end
+     */
+    // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+    onEnd<T extends ContextObject = ContextObject>(callback: GetContextCallback<T>): this;
+
+    /**
+     * Ensures a SPA browser interaction will be saved when it ends.
+     *
+     * @returns This method returns the same API object created by interaction().
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-save
+     */
+    save(): this;
+
+    /**
+     * Adds a custom SPA attribute only to the current interaction in New Relic Browser.
+     *
+     * @param key Used as the attribute name on the BrowserInteraction event.
+     * @param value Used as the attribute value on the BrowserInteraction event. This can be a
+     *   string, number, boolean, or object. If it is an object, New Relic serializes it to a JSON string.
+     * @returns This method returns the same API object created by interaction().
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-set-attribute
+     */
+    setAttribute(key: string, value: ComplexType): this;
+
+    /**
+     * Sets the name and trigger of a SPA's browser interaction that is not a route change or URL change.
+     *
+     * @param name If null, the name will be set using the targetGroupedUrl attribute.
+     *   If not null, this will set the browserInteractionName attribute in the BrowserInteraction event.
+     * @param trigger If not null, this will set the TRIGGER attribute on the BrowserInteraction event.
+     * @returns This method returns the same API object created by interaction().
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-set-name
+     */
+    setName(name: string, trigger?: string): this;
+}
+
+export interface ContextObject extends Record<string, any> {}
+
+export interface Callback {
+    (): void;
+}
+
+export interface ErrorHandler {
+    (err: any): boolean;
+}
+
+export interface GetContextCallback<T extends ContextObject = ContextObject> {
+    (contextObject: T): void;
+}
+
+export interface Wrapper {
+    (): void;
+}
+
+export type SimpleType = string | number;
+export type ComplexType = string | number | boolean | unknown;
+
+export interface Info {
+    agent: string;
+    applicationID: string;
+    beacon: string;
+    errorBeacon: string;
+    jsAttributes: Record<string, ComplexType>;
+    licenseKey: string;
+    sa: number;
+}
+
 /**
  * The browser and Single Page Application (SPA) APIs
  * allow you to customize and extend your browser monitoring.
  */
-declare namespace newrelic {
+export interface NewRelicAPI {
+    info: Info;
+
     /**
      * Adds a unique name and ID to identify releases with multiple JavaScript bundles on the same page.
      *
@@ -11,9 +157,9 @@ declare namespace newrelic {
      * @param releaseId The ID or version of this release; for example, a version number, build number
      *   from your CI environment, GitHub SHA, GUID, or a hash of the contents. Since New Relic converts this
      *   value into a string, you can also use null or undefined if necessary
-     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/add-release
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/addrelease
      */
-    function addRelease(releaseName: string, releaseId: string): void;
+    addRelease(releaseName: string, releaseId: string): void;
 
     /**
      * Reports a Browser PageAction event to Insights along with a name and attributes.
@@ -21,9 +167,9 @@ declare namespace newrelic {
      * @param name Name or category of the action. Reports to Insights as the actionName attribute.
      * @param attributes JSON object with one or more key/value pairs.
      *   The key will report to Insights as its own PageAction attribute with the specified values.
-     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/addpageaction
      */
-    function addPageAction(name: string, attributes?: Record<string, SimpleType>): void;
+    addPageAction(name: string, attributes?: Record<string, SimpleType>): void;
 
     /**
      * Adds a JavaScript object with a custom name, start time, etc. to an in-progress session trace.
@@ -31,18 +177,18 @@ declare namespace newrelic {
      * @param eventObject If you are sending the same event object to New Relic Insights as a
      *   PageAction, omit the TYPE attribute. If included, it will override the event type and cause the
      *   PageAction event to be sent incorrectly. Instead, use the NAME attribute for event information.
-     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/add-to-trace
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/addtotrace
      */
-    function addToTrace(eventObject: EventObject): void;
+    addToTrace(eventObject: EventObject): void;
 
     /**
      * Records an additional time point as "finished" in a session trace, and sends the event to Insights.
      *
      * @param timestamp Defaults to the current time of the call. If used, this marks the time that
      *   the page is "finished" according to your own criteria.
-     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/finished
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/finished
      */
-    function finished(timestamp?: number): void;
+    finished(timestamp?: number): void;
 
     /**
      * Identifies a browser error without disrupting your app's operations.
@@ -50,9 +196,9 @@ declare namespace newrelic {
      * @param error Provide a meaningful error message that you can use when analyzing data on
      *   New Relic Browser's JavaScript errors page.
      * @param customAttributes An object containing name/value pairs representing custom attributes.
-     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/notice-error
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/noticeerror
      */
-    function noticeError(error: Error | string, customAttributes?: Record<string, SimpleType>): void;
+    noticeError(error: Error | string, customAttributes?: Record<string, SimpleType>): void;
 
     /**
      * Adds a user-defined application version string to subsequent events on the page.
@@ -64,7 +210,7 @@ declare namespace newrelic {
      * subsequent events.
      * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/setApplicationVersion/
      */
-    function setApplicationVersion(value: string | null): void;
+    setApplicationVersion(value: string | null): void;
 
     /**
      * Adds a user-defined attribute name and value to subsequent events on the page.
@@ -74,18 +220,18 @@ declare namespace newrelic {
      * @param value Value of the attribute. Appears as the value in the named attribute column in the
      *   PageView event. It will appear as a column in the PageAction event if you are using it. Custom attribute
      *   values cannot be complex objects, only simple types such as strings and numbers.
-     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/set-custom-attribute
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/set-custom-attribute
      */
-    function setCustomAttribute(name: string, value: SimpleType, persist?: boolean): void;
+    setCustomAttribute(name: string, value: SimpleType, persist?: boolean): void;
 
     /**
      * Allows selective ignoring of known errors that the Browser agent captures.
      *
      * @param filterCallback The callback will be called with each error, so it is not
      *   specific to one error. `err` will usually be an error object, but it can be other data types.
-     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/set-error-handler
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/seterrorhandler
      */
-    function setErrorHandler(filterCallback: ErrorHandler): void;
+    setErrorHandler(filterCallback: ErrorHandler): void;
 
     /**
      * Groups page views to help URL structure or to capture the URL's routing information.
@@ -95,9 +241,9 @@ declare namespace newrelic {
      *   To further group these custom transactions, provide a custom host. Otherwise, the page views will be
      *   assigned the default domain custom.transaction. Segments within the name must be explicitly added to
      *   the Whitelist segments in your URL whitelist settings if they do not already appear.
-     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/set-pageview-name
+     * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/setpageviewname
      */
-    function setPageViewName(name: string, host?: string): void;
+    setPageViewName(name: string, host?: string): void;
 
     /**
      * Returns a new API object that is bound to the current SPA interaction.
@@ -107,7 +253,7 @@ declare namespace newrelic {
      *   references the same interaction.
      * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/interaction-browser-spa-api
      */
-    function interaction(): BrowserInteraction;
+    interaction(): BrowserInteraction;
 
     /**
      * Gives SPA routes more accurate names than default names. Monitors specific routes rather than by default
@@ -119,7 +265,7 @@ declare namespace newrelic {
      *   the default naming strategy.
      * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-set-current-route-name
      */
-    function setCurrentRouteName(name: string | null): void;
+    setCurrentRouteName(name: string | null): void;
 
     /**
      * Adds a user-defined identifier string to subsequent events on the page.
@@ -129,143 +275,5 @@ declare namespace newrelic {
      * validation. Passing a null value unsets any existing user ID.
      * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/setuserid/
      */
-    function setUserId(userId: string | null): void;
-
-    interface EventObject {
-        /** Event name */
-        name: string;
-        /** Start time in ms since epoch */
-        start: number;
-        /** End time in ms since epoch.  Defaults to same as start resulting in trace object with a duration of zero. */
-        end?: number | undefined;
-        /** Origin of event */
-        origin?: string | undefined;
-        /** Event type */
-        type?: string | undefined;
-    }
-
-    interface BrowserInteraction {
-        /**
-         * Sets the text value of the HTML element that was clicked to start a browser interaction.
-         *
-         * @param value The text value of the HTML element that represents the action that started the interaction.
-         * @returns This method returns the same API object created by interaction().
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/actiontext-browser-spa-api
-         */
-        actionText(value: string): this;
-
-        /**
-         * Times sub-components of a SPA interaction separately, including wait time and JS execution time.
-         *
-         * @param name This will be used as the name of the tracer. If you do not include a name,
-         *   New Relic Browser does not add a node to the interaction tree. The callback time will be
-         *   attributed to the parent node.
-         * @param callback A callback that contains the synchronous work to run at the end of the async work.
-         *   To execute this callback, call the wrapper function returned using createTracer()
-         * @returns This method ends the async time. It calls (and times) the callback that was passed into createTracer().
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-create-tracer
-         */
-        createTracer(name: string, callback?: Callback): Wrapper;
-
-        /**
-         * Ends the New Relic SPA interaction at the current time.
-         *
-         * @returns This method returns the same API object created by interaction().
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-end
-         */
-        end(): this;
-
-        /**
-         * Stores values across the current SPA interaction asynchronously in New Relic Browser.
-         *
-         * @param callback A function that accepts the interaction context object
-         *   as its only argument.
-         * @returns This method returns the same API object created by interaction().
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-get-context
-         */
-        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        getContext<T extends ContextObject = ContextObject>(callback: GetContextCallback<T>): this;
-
-        /**
-         * Overrides other SPA save() calls; ignores an interaction so it is not saved or sent to New Relic.
-         *
-         * @returns This method returns the same API object created by interaction().
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-ignore-browser
-         */
-        ignore(): this;
-
-        /**
-         * Adds custom attributes for SPA interactions to the end of an event. It is called when the interaction
-         * has finished. You can invoke methods to modify the interaction, but methods that have asynchronous
-         * side effects will not have an effect.
-         *
-         * @returns This method returns the same API object created by interaction().
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-on-end
-         */
-        // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-        onEnd<T extends ContextObject = ContextObject>(callback: GetContextCallback<T>): this;
-
-        /**
-         * Ensures a SPA browser interaction will be saved when it ends.
-         *
-         * @returns This method returns the same API object created by interaction().
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-save
-         */
-        save(): this;
-
-        /**
-         * Adds a custom SPA attribute only to the current interaction in New Relic Browser.
-         *
-         * @param key Used as the attribute name on the BrowserInteraction event.
-         * @param value Used as the attribute value on the BrowserInteraction event. This can be a
-         *   string, number, boolean, or object. If it is an object, New Relic serializes it to a JSON string.
-         * @returns This method returns the same API object created by interaction().
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-set-attribute
-         */
-        setAttribute(key: string, value: ComplexType): this;
-
-        /**
-         * Sets the name and trigger of a SPA's browser interaction that is not a route change or URL change.
-         *
-         * @param name If null, the name will be set using the targetGroupedUrl attribute.
-         *   If not null, this will set the browserInteractionName attribute in the BrowserInteraction event.
-         * @param trigger If not null, this will set the TRIGGER attribute on the BrowserInteraction event.
-         * @returns This method returns the same API object created by interaction().
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-set-name
-         */
-        setName(name: string, trigger?: string): this;
-    }
-
-    interface ContextObject extends Record<string, any> {}
-
-    interface Callback {
-        (): void;
-    }
-
-    interface ErrorHandler {
-        (err: any): boolean;
-    }
-
-    interface GetContextCallback<T extends ContextObject = ContextObject> {
-        (contextObject: T): void;
-    }
-
-    interface Wrapper {
-        (): void;
-    }
-
-    type SimpleType = string | number;
-    type ComplexType = string | number | boolean | unknown;
-
-    interface Info {
-        agent: string;
-        applicationID: string;
-        beacon: string;
-        errorBeacon: string;
-        jsAttributes: Record<string, ComplexType>;
-        licenseKey: string;
-        sa: number;
-    }
-
-    const info: Info;
+    setUserId(userId: string | null): void;
 }

--- a/types/new-relic-browser/new-relic-browser-tests.ts
+++ b/types/new-relic-browser/new-relic-browser-tests.ts
@@ -4,49 +4,49 @@
 // --- NewRelic.Browser methods ----------------------------------------------
 
 // addRelease()
-newrelic.addRelease("checkout page", "a818994");
+newrelic?.addRelease("checkout page", "a818994");
 
 // addPageAction()
-newrelic.addPageAction("copy-text-button", { result: "success" });
-newrelic.addPageAction("async-action", { duration: 3000 });
+newrelic?.addPageAction("copy-text-button", { result: "success" });
+newrelic?.addPageAction("async-action", { duration: 3000 });
 
 // addToTrace()
-newrelic.addToTrace({
+newrelic?.addToTrace({
     name: "Event Name",
     start: 1417044274239,
     end: 1417044274252,
     origin: "Origin of event",
     type: "What type of event was this",
 });
-newrelic.addToTrace({
+newrelic?.addToTrace({
     name: "Event Name",
     start: 1417044274239,
 });
 
 // finished()
-newrelic.finished();
+newrelic?.finished();
 
 // noticeError()
 try {
     JSON.parse("{ \"bar\"");
 } catch (err) {
-    newrelic.noticeError(err);
+    newrelic?.noticeError(err);
 }
-newrelic.noticeError(new Error("bar"));
-newrelic.noticeError("bar");
-newrelic.noticeError("bar", { foo: "bar", baz: 1 });
+newrelic?.noticeError(new Error("bar"));
+newrelic?.noticeError("bar");
+newrelic?.noticeError("bar", { foo: "bar", baz: 1 });
 
 // setApplicationVersion()
-newrelic.setApplicationVersion("1.0.0");
-newrelic.setApplicationVersion(null);
+newrelic?.setApplicationVersion("1.0.0");
+newrelic?.setApplicationVersion(null);
 
 // setCustomAttribute()
-newrelic.setCustomAttribute("nodeId", "123");
-newrelic.setCustomAttribute("nodeId", 123);
-newrelic.setCustomAttribute("nodeId", 123, true);
+newrelic?.setCustomAttribute("nodeId", "123");
+newrelic?.setCustomAttribute("nodeId", 123);
+newrelic?.setCustomAttribute("nodeId", 123, true);
 
 // setErrorHandler()
-newrelic.setErrorHandler(err => {
+newrelic?.setErrorHandler(err => {
     if (err.message !== "foo") {
         return true;
     } else {
@@ -55,46 +55,46 @@ newrelic.setErrorHandler(err => {
 });
 
 // setPageViewName()
-newrelic.setPageViewName("/login", "https://www.myapp.com");
+newrelic?.setPageViewName("/login", "https://www.myapp.com");
 
 // setCurrentRouteName()
-newrelic.setCurrentRouteName("/users/:id");
-newrelic.setCurrentRouteName(null);
+newrelic?.setCurrentRouteName("/users/:id");
+newrelic?.setCurrentRouteName(null);
 
 // setUserId()
-newrelic.setUserId("123");
-newrelic.setUserId(null);
+newrelic?.setUserId("123");
+newrelic?.setUserId(null);
 
 // --- NewRelic.BrowserInteraction methods -----------------------------------
 
 // actionText()
-newrelic.interaction().actionText("Create Subscription");
+newrelic?.interaction().actionText("Create Subscription");
 
 // createTracer()
-newrelic.interaction().createTracer("customSegment", () => {})();
+newrelic?.interaction().createTracer("customSegment", () => {})();
 
 // end()
-newrelic.interaction().end();
+newrelic?.interaction().end();
 
 interface ProductContext {
     productId: number;
 }
 // getContext(), setAttribute()
-const interaction = newrelic.interaction();
-interaction.getContext<ProductContext>(ctx => {
+const interaction = newrelic?.interaction();
+interaction?.getContext<ProductContext>(ctx => {
     if (ctx.productId) {
-        interaction.setAttribute("productId", ctx.productId);
+        interaction?.setAttribute("productId", ctx.productId);
     }
 });
-interaction.getContext((ctx: ProductContext) => {
+interaction?.getContext((ctx: ProductContext) => {
     if (ctx.productId) {
-        interaction.setAttribute("productId", ctx.productId);
+        interaction?.setAttribute("productId", ctx.productId);
     }
 });
 
-interaction.getContext(ctx => {
+interaction?.getContext(ctx => {
     if (ctx.productId) {
-        interaction.setAttribute("productId", ctx.productId);
+        interaction?.setAttribute("productId", ctx.productId);
     }
 });
 
@@ -104,17 +104,17 @@ interface MyAppContext {
 }
 
 // ignore()
-newrelic.interaction().ignore();
+newrelic?.interaction().ignore();
 
 // onEnd(), setAttribute()
-newrelic.interaction().onEnd((ctx: MyAppContext) => {
-    interaction.setAttribute("averageChartLoadTime", ctx.totalChartLoadTime / ctx.chartLoadCount);
+newrelic?.interaction().onEnd((ctx: MyAppContext) => {
+    interaction?.setAttribute("averageChartLoadTime", ctx.totalChartLoadTime / ctx.chartLoadCount);
 });
 
-newrelic.interaction().onEnd<MyAppContext>(ctx => {
-    interaction.setAttribute("averageChartLoadTime", ctx.totalChartLoadTime / ctx.chartLoadCount);
+newrelic?.interaction().onEnd<MyAppContext>(ctx => {
+    interaction?.setAttribute("averageChartLoadTime", ctx.totalChartLoadTime / ctx.chartLoadCount);
 });
 
 // setName(), setAttribute(), save()
-newrelic.interaction().setName("loadNextPage").setAttribute("username", "userName").setAttribute("userId", 123).save();
-newrelic.interaction().setName("createSubscription");
+newrelic?.interaction().setName("loadNextPage").setAttribute("username", "userName").setAttribute("userId", 123).save();
+newrelic?.interaction().setName("createSubscription");


### PR DESCRIPTION
Hi there, 
I'm not sure if you're accepting public contributions but hopefully this is helpful 😁  

When a property (eg. `newrelic`) is defined directly on the global object such as `window` an alias is automatically created for it. You don't have to type `window.newrelic.addPageAction()` and can use `newrelic.addPageAction()` instead.

However, because these types are declared as a namespace called `newrelic` Typescript treats that automatic alias as always available. This led to an incident for our team where we accidentally used this object and received no warning from typescript about it being potentially `undefined` (which it was because some users were blocking new relic scripts)

Converting to a module declaration with declare global properly reflects that newrelic might not be available at runtime, and I believe is the modern best practice.

I also updated the links in the jsdoc comments to point to the url where the docs currently live.
old:   https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action
new: https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/addpageaction

Some types like [setCustomAttribute](https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/setcustomattribute/) need to be updated, but I left those changes out to keep this PR focused.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
