### PR TITLE
[react-reconciler]: update Reconciler.createContainer signature

### DIFF
--- a/types/react-reconciler/index.d.ts
+++ b/types/react-reconciler/index.d.ts
@@ -926,6 +926,8 @@ declare namespace ReactReconciler {
 
     type IntersectionObserverOptions = any;
 
+    interface BaseErrorInfo { componentStack?: string }
+
     interface Reconciler<Container, Instance, TextInstance, SuspenseInstance, FormInstance, PublicInstance> {
         createContainer(
             containerInfo: Container,
@@ -934,7 +936,10 @@ declare namespace ReactReconciler {
             isStrictMode: boolean,
             concurrentUpdatesByDefaultOverride: null | boolean,
             identifierPrefix: string,
-            onRecoverableError: (error: Error) => void,
+            onUncaughtError: (error: Error, info: BaseErrorInfo & { errorBoundary?: Component }) => void,
+            onCaughtError: (error: Error, info: BaseErrorInfo) => void,
+            onRecoverableError: (error: Error, info: BaseErrorInfo) => void,
+            onDefaultTransitionIndicator: () => void,
             transitionCallbacks: null | TransitionTracingCallbacks,
         ): OpaqueRoot;
 

--- a/types/react-reconciler/index.d.ts
+++ b/types/react-reconciler/index.d.ts
@@ -926,7 +926,9 @@ declare namespace ReactReconciler {
 
     type IntersectionObserverOptions = any;
 
-    interface BaseErrorInfo { componentStack?: string }
+    interface BaseErrorInfo {
+        componentStack?: string;
+    }
 
     interface Reconciler<Container, Instance, TextInstance, SuspenseInstance, FormInstance, PublicInstance> {
         createContainer(


### PR DESCRIPTION
If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react/blob/74dee8ef641c7a0a67db192f83c11ac0d9f279ff/packages/react-reconciler/src/ReactFiberReconciler.js#L236 

Note: although react-reconciler got bumped to v0.33.0 recently this also applies to v0.32.0 which most people are still using. I'm not bumping the version because I didn't update it to reflect the changes in v0.33.0 (might do that later)
