### PR TITLE
[aws-lambda] fix casing of fields in SNSMessage type

### DIFF
--- a/types/aws-lambda/test/sns-tests.ts
+++ b/types/aws-lambda/test/sns-tests.ts
@@ -11,12 +11,12 @@ const handler: SNSHandler = async (event, context, callback) => {
     str = message.SignatureVersion;
     str = message.Timestamp;
     str = message.Signature;
-    str = message.SigningCertUrl;
+    str = message.SigningCertURL;
     str = message.MessageId;
     str = message.Message;
     const attributes: SNSMessageAttributes = message.MessageAttributes;
     str = message.Type;
-    str = message.UnsubscribeUrl;
+    str = message.UnsubscribeURL;
     str = message.TopicArn;
     strOrUndefined = message.Subject;
     strOrUndefined = message.Token;

--- a/types/aws-lambda/trigger/sns.d.ts
+++ b/types/aws-lambda/trigger/sns.d.ts
@@ -16,12 +16,12 @@ export interface SNSMessage {
     SignatureVersion: string;
     Timestamp: string;
     Signature: string;
-    SigningCertUrl: string;
+    SigningCertURL: string;
     MessageId: string;
     Message: string;
     MessageAttributes: SNSMessageAttributes;
     Type: string;
-    UnsubscribeUrl: string;
+    UnsubscribeURL: string;
     TopicArn: string;
     Subject?: string;
     Token?: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/sns/latest/dg/http-notification-json.html#:~:text=and%20TopicArn%20values.-,SigningCertURL,-The%20URL%20to
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
