### PR TITLE
[wicg-file-system-access] update types to match DOM declaration

### DIFF
--- a/types/wicg-file-system-access/index.d.ts
+++ b/types/wicg-file-system-access/index.d.ts
@@ -144,9 +144,9 @@ declare global {
         removeEntry(name: string, options?: FileSystemRemoveOptions): Promise<void>;
         resolve(possibleDescendant: FileSystemHandle): Promise<string[] | null>;
         keys(): AsyncIterableIterator<string>;
-        values(): AsyncIterableIterator<FileSystemHandle>;
-        entries(): AsyncIterableIterator<[string, FileSystemHandle]>;
-        [Symbol.asyncIterator](): AsyncIterableIterator<[string, FileSystemHandle]>;
+        values(): AsyncIterableIterator<FileSystemDirectoryHandle | FileSystemFileHandle>;
+        entries(): AsyncIterableIterator<[string, FileSystemDirectoryHandle | FileSystemFileHandle]>;
+        [Symbol.asyncIterator](): AsyncIterableIterator<[string, FileSystemDirectoryHandle | FileSystemFileHandle]>;
         /**
          * @deprecated Old property just for Chromium <=85. Use `kind` property in the new API.
          */

--- a/types/wicg-file-system-access/index.d.ts
+++ b/types/wicg-file-system-access/index.d.ts
@@ -144,9 +144,9 @@ declare global {
         removeEntry(name: string, options?: FileSystemRemoveOptions): Promise<void>;
         resolve(possibleDescendant: FileSystemHandle): Promise<string[] | null>;
         keys(): AsyncIterableIterator<string>;
-        values(): AsyncIterableIterator<FileSystemDirectoryHandle | FileSystemFileHandle>;
-        entries(): AsyncIterableIterator<[string, FileSystemDirectoryHandle | FileSystemFileHandle]>;
-        [Symbol.asyncIterator]: FileSystemDirectoryHandle["entries"];
+        values(): AsyncIterableIterator<FileSystemHandle>;
+        entries(): AsyncIterableIterator<[string, FileSystemHandle]>;
+        [Symbol.asyncIterator](): AsyncIterableIterator<[string, FileSystemHandle]>;
         /**
          * @deprecated Old property just for Chromium <=85. Use `kind` property in the new API.
          */

--- a/types/wicg-file-system-access/wicg-file-system-access-tests.ts
+++ b/types/wicg-file-system-access/wicg-file-system-access-tests.ts
@@ -53,9 +53,9 @@
         // tslint:disable-next-line await-promise
         for await (const [name, handle] of dirHandle) {
             if (handle.kind === "file") {
-                yield (handle as FileSystemFileHandle).getFile();
+                yield handle.getFile();
             } else {
-                yield* recursivelyWalkDir(handle as FileSystemDirectoryHandle);
+                yield* recursivelyWalkDir(handle);
             }
         }
     })(dirHandle);
@@ -95,9 +95,9 @@
     (async function* recursivelyWalkDir(dirHandle: FileSystemDirectoryHandle): AsyncIterable<File> {
         for await (const handle of dirHandle.getEntries()) {
             if (handle.isFile) {
-                yield (handle as FileSystemFileHandle).getFile();
+                yield handle.getFile();
             } else {
-                yield* recursivelyWalkDir(handle as FileSystemDirectoryHandle);
+                yield* recursivelyWalkDir(handle);
             }
         }
     })(dirHandle);

--- a/types/wicg-file-system-access/wicg-file-system-access-tests.ts
+++ b/types/wicg-file-system-access/wicg-file-system-access-tests.ts
@@ -53,9 +53,9 @@
         // tslint:disable-next-line await-promise
         for await (const [name, handle] of dirHandle) {
             if (handle.kind === "file") {
-                yield handle.getFile();
+                yield (handle as FileSystemFileHandle).getFile();
             } else {
-                yield* recursivelyWalkDir(handle);
+                yield* recursivelyWalkDir(handle as FileSystemDirectoryHandle);
             }
         }
     })(dirHandle);
@@ -95,9 +95,9 @@
     (async function* recursivelyWalkDir(dirHandle: FileSystemDirectoryHandle): AsyncIterable<File> {
         for await (const handle of dirHandle.getEntries()) {
             if (handle.isFile) {
-                yield handle.getFile();
+                yield (handle as FileSystemFileHandle).getFile();
             } else {
-                yield* recursivelyWalkDir(handle);
+                yield* recursivelyWalkDir(handle as FileSystemDirectoryHandle);
             }
         }
     })(dirHandle);


### PR DESCRIPTION
It's not clear how much this package will matter after TS 6.0. Likely we could typesVersions this and just drop the contents entirely.

But, these changes make the code match what 6.0 has declared. Unfortunately, not using a discriminated union for the file/dir handles, so that is probably a regression for some.