### PR TITLE
[plotly.js] Add missing `hoversubplots` property

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -639,6 +639,15 @@ export interface Layout {
     hovermode: "closest" | "x" | "y" | "x unified" | "y unified" | false;
     hoverdistance: number;
     hoverlabel: Partial<HoverLabel>;
+    /**
+     * Determines expansion of hover effects to other subplots.
+     * If "single" just the axis pair of the primary point is included without overlaying subplots.
+     * If "overlaying" all subplots using the main axis and occupying the same space are included.
+     * If "axis", also include stacked subplots using the same axis
+     * when `hovermode` is set to "x", "x unified", "y" or "y unified".
+     * @default "overlaying"
+     */
+    hoversubplots: "single" | "overlaying" | "axis";
     calendar: Calendar;
 
     // these are just the most common nested property updates that you might

--- a/types/plotly.js/test/core-tests.ts
+++ b/types/plotly.js/test/core-tests.ts
@@ -53,7 +53,8 @@ const layout = {
     datarevision: 0,
     editrevision: 0,
     selectionrevision: 0,
-};
+    hoversubplots: "overlaying",
+} satisfies Partial<Layout>;
 
 //////////////////////////////////////////////////////////////////////
 // Plotly.newPlot

--- a/types/plotly.js/v2/index.d.ts
+++ b/types/plotly.js/v2/index.d.ts
@@ -642,6 +642,15 @@ export interface Layout {
     hovermode: "closest" | "x" | "y" | "x unified" | "y unified" | false;
     hoverdistance: number;
     hoverlabel: Partial<HoverLabel>;
+    /**
+     * Determines expansion of hover effects to other subplots.
+     * If "single" just the axis pair of the primary point is included without overlaying subplots.
+     * If "overlaying" all subplots using the main axis and occupying the same space are included.
+     * If "axis", also include stacked subplots using the same axis
+     * when `hovermode` is set to "x", "x unified", "y" or "y unified".
+     * @default "overlaying"
+     */
+    hoversubplots: "single" | "overlaying" | "axis";
     calendar: Calendar;
     "xaxis.range": [Datum, Datum];
     "xaxis.range[0]": Datum;

--- a/types/plotly.js/v2/test/core-tests.ts
+++ b/types/plotly.js/v2/test/core-tests.ts
@@ -49,7 +49,8 @@ const layout = {
     datarevision: 0,
     editrevision: 0,
     selectionrevision: 0,
-};
+    hoversubplots: "overlaying",
+} satisfies Partial<Layout>;
 
 //////////////////////////////////////////////////////////////////////
 // Plotly.newPlot


### PR DESCRIPTION
Related discussion: #73425

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - <https://github.com/plotly/plotly.js/blob/master/CHANGELOG.md#2310----2024-04-10>
  - <https://plotly.com/javascript/reference/layout/#layout-hoversubplots>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.