### PR TITLE
[postcss-js] Update to v4.1

### DIFF
--- a/types/postcss-js/index.d.ts
+++ b/types/postcss-js/index.d.ts
@@ -4,12 +4,16 @@ import NoWorkResult = require("postcss/lib/no-work-result");
 /** CSS-in-JS object */
 export type CssInJs = Record<string, any>;
 
+export interface ObjectifyOptions {
+    stringifyImportant?: boolean | undefined;
+}
+
 /**
  * Convert a PostCSS `Root` into a CSS-in-JS object
  * @param root The root to convert
  * @returns CSS-in-JS object
  */
-export function objectify(root: Root): CssInJs;
+export function objectify(root: Root, options?: ObjectifyOptions): CssInJs;
 
 /**
  * Parse a CSS-in-JS object into a PostCSS `Root`

--- a/types/postcss-js/package.json
+++ b/types/postcss-js/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/postcss-js",
-    "version": "4.0.9999",
+    "version": "4.1.9999",
     "projects": [
         "https://github.com/postcss/postcss-js"
     ],

--- a/types/postcss-js/postcss-js-tests.ts
+++ b/types/postcss-js/postcss-js-tests.ts
@@ -22,6 +22,8 @@ postcss().process(".a {}", { parser: postcssJs.parse });
 postcssJs.parse(style);
 
 postcssJs.objectify(postcss.root());
+postcssJs.objectify(postcss.root(), {});
+postcssJs.objectify(postcss.root(), { stringifyImportant: true });
 
 // Sync and async fail to work if no parameters are passed
 // @ts-expect-error


### PR DESCRIPTION
Updates the type definitions from v4.0 to v4.1.

Although v5 is available, the vast majority of users still use v4, and no API changes have been made from v4 to v5 (so the v4 types can be used by v5 users without issue).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - <https://github.com/postcss/postcss-js/blob/main/CHANGELOG.md#410>
  - <https://github.com/postcss/postcss-js/commit/dc501f2c052f2e5dc656b229191663612e0fc8cd>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.