### PR TITLE
feat(emscripten): add `contents` field to `FSNode` for `MEMFS` compatibility

### DIFF
--- a/types/emscripten/emscripten-tests.ts
+++ b/types/emscripten/emscripten-tests.ts
@@ -150,6 +150,11 @@ function FSTest(): void {
     const lookup = FS.lookupPath("path", { parent: true, follow: false });
     // $ExpectType number
     lookup.node.mode;
+    // Due to TypeScript versioning issues, this is not currently typeable as expected ($ExpectType)
+    // Expected: Uint8Array, but actual type varies by TS version:
+    // TS 5.2-5.6: {} | Uint8Array | null | undefined
+    // TS 5.7+: {} | Uint8Array<ArrayBufferLike> | null | undefined
+    lookup.node.contents;
 
     const analyze = FS.analyzePath("path");
     // $ExpectType boolean

--- a/types/emscripten/emscripten-tests.ts
+++ b/types/emscripten/emscripten-tests.ts
@@ -150,10 +150,7 @@ function FSTest(): void {
     const lookup = FS.lookupPath("path", { parent: true, follow: false });
     // $ExpectType number
     lookup.node.mode;
-    // Due to TypeScript versioning issues, this is not currently typeable as expected ($ExpectType)
-    // Expected: Uint8Array, but actual type varies by TS version:
-    // TS 5.2-5.6: {} | Uint8Array | null | undefined
-    // TS 5.7+: {} | Uint8Array<ArrayBufferLike> | null | undefined
+    // $ExpectType any
     lookup.node.contents;
 
     const analyze = FS.analyzePath("path");

--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -163,6 +163,8 @@ declare namespace FS {
         parent: FSNode;
         mount: Mount;
         mounted?: Mount;
+        // Supported in MEMFS
+        contents?: Uint8Array | {} | null;
         id: number;
         name: string;
         mode: number;

--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -164,7 +164,7 @@ declare namespace FS {
         mount: Mount;
         mounted?: Mount;
         // Supported in MEMFS
-        contents?: Uint8Array | {} | null;
+        contents?: any;
         id: number;
         name: string;
         mode: number;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

According to `libfs.js` in Emscripten, the [`FSNode` class](https://github.com/emscripten-core/emscripten/blob/main/src/lib/libfs.js#L130) does not define a `contents` field.
However, certain `FileSystemType` implementations—such as `MEMFS`—require a [`contents` property](https://github.com/emscripten-core/emscripten/blob/main/src/lib/libmemfs.js#L69) in their logic.

Because this field is omitted from the current type definition, using `lookupPath` with `MEMFS` can result in type errors.

To address this, I added a `contents` field to the `FSNode` type.
I’m not entirely sure if this is the best approach, so please let me know if you have any suggestions or better alternatives. Thanks!