### PR TITLE
[react-html5-camera-photo] Return `ReactElement` instead of `ReactNode`

### DIFF
--- a/types/react-html5-camera-photo/index.d.ts
+++ b/types/react-html5-camera-photo/index.d.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { ReactElement } from "react";
 
 declare namespace ReactHtml5CameraPhoto {
     // Facing modes for camera
@@ -103,6 +103,6 @@ declare namespace ReactHtml5CameraPhoto {
  * A camera component.
  * @param props Camera properties.
  */
-declare function ReactHtml5CameraPhoto(props: ReactHtml5CameraPhoto.CameraProps): ReactNode;
+declare function ReactHtml5CameraPhoto(props: ReactHtml5CameraPhoto.CameraProps): ReactElement;
 
 export = ReactHtml5CameraPhoto;

--- a/types/react-html5-camera-photo/react-html5-camera-photo-tests.tsx
+++ b/types/react-html5-camera-photo/react-html5-camera-photo-tests.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import Camera, { FACING_MODES, IMAGE_TYPES } from "react-html5-camera-photo";
 
+// $ExpectType Element
 <Camera />;
 
 <Camera


### PR DESCRIPTION
Related discussion: #72939

The `ReactElement` type is more specific and correct.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - It can be seen that the function in question returns a JSX `<div>`: <https://github.com/MABelanger/react-html5-camera-photo/blob/e0936b1751e402d80395f798142d974fc4314472/src/lib/components/Camera/index.js#L124-L151>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.