### PR TITLE
[chrome] update userScripts namespace

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -14442,133 +14442,165 @@ declare namespace chrome {
      * @since Chrome 120, MV3
      */
     export namespace userScripts {
-        /**
-         * Execution environment for a user script.
-         */
-        export type ExecutionWorld = "MAIN" | "USER_SCRIPT";
+        /** The JavaScript world for a user script to execute within. */
+        export enum ExecutionWorld {
+            /** Specifies the execution environment of the DOM, which is the execution environment shared with the host page's JavaScript. */
+            MAIN = "MAIN",
+            /** Specifies the execution environment that is specific to user scripts and is exempt from the page's CSP. */
+            USER_SCRIPT = "USER_SCRIPT",
+        }
 
         /** @since Chrome 135 */
-        export interface InjectionResult {
-            /** The document associated with the injection. */
-            documentId: string;
-            /** The error, if any. `error` and `result` are mutually exclusive. */
-            error?: string;
-            /** The frame associated with the injection. */
-            frameId: number;
-            /** The result of the script execution. */
-            result: any;
-        }
+        export type InjectionResult<T = unknown> =
+            & {
+                /** The document associated with the injection. */
+                documentId: string;
+                /** The frame associated with the injection. */
+                frameId: number;
+            }
+            & (
+                | {
+                    /** The error, if any */
+                    error?: never;
+                    /** The result of the script execution. */
+                    result: T;
+                }
+                | {
+                    /** The error, if any */
+                    error: string;
+                    /** The result of the script execution. */
+                    result?: never;
+                }
+            );
 
         export interface WorldProperties {
             /** Specifies the world csp. The default is the `ISOLATED` world csp. */
-            csp?: string;
-            /** Specifies whether messaging APIs are exposed. The default is false.*/
-            messaging?: boolean;
+            csp?: string | undefined;
+            /** Specifies whether messaging APIs are exposed. The default is `false`.*/
+            messaging?: boolean | undefined;
             /**
              * Specifies the ID of the specific user script world to update. If not provided, updates the properties of the default user script world. Values with leading underscores (`_`) are reserved.
              * @since Chrome 133
              */
-            worldId?: string;
+            worldId?: string | undefined;
         }
 
         export interface UserScriptFilter {
-            ids?: string[];
+            /** {@link getScripts} only returns scripts with the IDs specified in this list. */
+            ids?: string[] | undefined;
         }
 
-        /** @since Chrome 135 */
-        export interface InjectionTarget {
-            /** Whether the script should inject into all frames within the tab. Defaults to false. This must not be true if `frameIds` is specified. */
-            allFrames?: boolean;
-            /** The IDs of specific documentIds to inject into. This must not be set if `frameIds` is set. */
-            documentIds?: string[];
-            /** The IDs of specific frames to inject into. */
-            frameIds?: number[];
-            /** The ID of the tab into which to inject. */
-            tabId: number;
-        }
+        // /** @since Chrome 135 */
+        export type InjectionTarget =
+            & {
+                /** The ID of the tab into which to inject. */
+                tabId: number;
+            }
+            & (
+                | {
+                    /** Whether the script should inject into all frames within the tab. Defaults to false. */
+                    allFrames?: boolean | undefined;
+                    /** The IDs of specific documentIds to inject into. */
+                    documentIds?: never;
+                    /** The IDs of specific frames to inject into. */
+                    frameIds?: never;
+                }
+                | {
+                    /** Whether the script should inject into all frames within the tab. Defaults to false. */
+                    allFrames?: false | undefined;
+                    /** The IDs of specific documentIds to inject into. */
+                    documentIds?: never;
+                    /** The IDs of specific frames to inject into. */
+                    frameIds: number[] | undefined;
+                }
+                | {
+                    /** Whether the script should inject into all frames within the tab. Defaults to false. */
+                    allFrames?: false | undefined;
+                    /** The IDs of specific documentIds to inject into. */
+                    documentIds?: string[] | undefined;
+                    /** The IDs of specific frames to inject into. */
+                    frameIds?: never;
+                }
+            );
 
         export interface RegisteredUserScript {
             /** If true, it will inject into all frames, even if the frame is not the top-most frame in the tab. Each frame is checked independently for URL requirements; it will not inject into child frames if the URL requirements are not met. Defaults to false, meaning that only the top frame is matched. */
-            allFrames?: boolean;
+            allFrames?: boolean | undefined;
             /** Specifies wildcard patterns for pages this user script will NOT be injected into. */
-            excludeGlobs?: string[];
+            excludeGlobs?: string[] | undefined;
             /**Excludes pages that this user script would otherwise be injected into. See Match Patterns for more details on the syntax of these strings. */
-            excludeMatches?: string[];
+            excludeMatches?: string[] | undefined;
             /** The ID of the user script specified in the API call. This property must not start with a '_' as it's reserved as a prefix for generated script IDs. */
             id: string;
             /** Specifies wildcard patterns for pages this user script will be injected into. */
-            includeGlobs?: string[];
+            includeGlobs?: string[] | undefined;
             /** The list of ScriptSource objects defining sources of scripts to be injected into matching pages. This property must be specified for {@link register}, and when specified it must be a non-empty array.*/
             js: ScriptSource[];
-            /** Specifies which pages this user script will be injected into. See Match Patterns for more details on the syntax of these strings. This property must be specified for ${ref:register}. */
-            matches?: string[];
-            /** Specifies when JavaScript files are injected into the web page. The preferred and default value is document_idle */
-            runAt?: extensionTypes.RunAt;
+            /** Specifies which pages this user script will be injected into. See Match Patterns for more details on the syntax of these strings. This property must be specified for {@link register}. */
+            matches?: string[] | undefined;
+            /** Specifies when JavaScript files are injected into the web page. The preferred and default value is `document_idle` */
+            runAt?: extensionTypes.RunAt | undefined;
             /** The JavaScript execution environment to run the script in. The default is `USER_SCRIPT` */
-            world?: ExecutionWorld;
+            world?: `${ExecutionWorld}` | undefined;
             /**
              * Specifies the user script world ID to execute in. If omitted, the script will execute in the default user script world. Only valid if `world` is omitted or is `USER_SCRIPT`. Values with leading underscores (`_`) are reserved.
              * @since Chrome 133
              */
-            worldId?: string;
+            worldId?: string | undefined;
         }
 
         /** @since Chrome 135 */
         export interface UserScriptInjection {
             /** Whether the injection should be triggered in the target as soon as possible. Note that this is not a guarantee that injection will occur prior to page load, as the page may have already loaded by the time the script reaches the target. */
-            injectImmediately?: boolean;
+            injectImmediately?: boolean | undefined;
             /** The list of ScriptSource objects defining sources of scripts to be injected into the target. */
-            js: ScriptSource[];
+            js: [ScriptSource, ...ScriptSource[]];
             /** Details specifying the target into which to inject the script. */
             target: InjectionTarget;
             /** The JavaScript "world" to run the script in. The default is `USER_SCRIPT`. */
-            world?: ExecutionWorld;
+            world?: `${ExecutionWorld}` | undefined;
             /** Specifies the user script world ID to execute in. If omitted, the script will execute in the default user script world. Only valid if `world` is omitted or is `USER_SCRIPT`. Values with leading underscores (`_`) are reserved. */
-            worldId?: string;
+            worldId?: string | undefined;
         }
 
-        /**
-         * Properties for a script source.
-         */
-        export interface ScriptSource {
-            /** A string containing the JavaScript code to inject. Exactly one of file or code must be specified. */
-            code?: string;
-            /** The path of the JavaScript file to inject relative to the extension's root directory. Exactly one of file or code must be specified. */
-            file?: string;
-        }
+        export type ScriptSource = {
+            /** A string containing the JavaScript code to inject. */
+            code: string;
+            /** The path of the JavaScript file to inject relative to the extension's root directory. */
+            file?: undefined;
+        } | {
+            /** A string containing the JavaScript code to inject. */
+            code?: undefined;
+            /** The path of the JavaScript file to inject relative to the extension's root directory. */
+            file: string;
+        };
 
         /**
          * Configures the `USER_SCRIPT` execution environment.
          *
-         * @param properties - Contains the user script world configuration.
-         * @returns A Promise that resolves with the same type that is passed to the callback.
+         * Can return its result via Promise.
+         * @param properties Contains the user script world configuration.
          */
         export function configureWorld(properties: WorldProperties): Promise<void>;
-        /**
-         * Configures the `USER_SCRIPT` execution environment.
-         *
-         * @param properties - Contains the user script world configuration.
-         * @param callback - Callback function to be executed after configuring the world.
-         */
         export function configureWorld(properties: WorldProperties, callback: () => void): void;
 
         /**
          * Returns all dynamically-registered user scripts for this extension.
          *
-         * @param filter - If specified, this method returns only the user scripts that match it.
-         * @returns A Promise that resolves with the same type that is passed to the callback.
+         * Can return its result via Promise.
+         * @param filter If specified, this method returns only the user scripts that match it.
          */
         export function getScripts(filter?: UserScriptFilter): Promise<RegisteredUserScript[]>;
-        /**
-         * Returns all dynamically-registered user scripts for this extension.
-         *
-         * @param filter - If specified, this method returns only the user scripts that match it.
-         * @param callback - Callback function to be executed after getting user scripts.
-         */
-        export function getScripts(filter: UserScriptFilter, callback: (scripts: RegisteredUserScript[]) => void): void;
+        export function getScripts(callback: (scripts: RegisteredUserScript[]) => void): void;
+        export function getScripts(
+            filter: UserScriptFilter | undefined,
+            callback: (scripts: RegisteredUserScript[]) => void,
+        ): void;
 
         /**
          * Retrieves all registered world configurations.
+         *
+         * Can return its result via Promise.
          * @since Chrome 133
          */
         export function getWorldConfigurations(): Promise<WorldProperties[]>;
@@ -14576,24 +14608,23 @@ declare namespace chrome {
 
         /**
          * Injects a script into a target context. By default, the script will be run at `document_idle`, or immediately if the page has already loaded. If the `injectImmediately` property is set, the script will inject without waiting, even if the page has not finished loading. If the script evaluates to a promise, the browser will wait for the promise to settle and return the resulting value.
+         *
+         * Can return its result via Promise.
          * @since Chrome 135
          */
-        export function execute(injection: UserScriptInjection): Promise<InjectionResult[]>;
-        export function execute(injection: UserScriptInjection, callback: (result: InjectionResult[]) => void): void;
+        export function execute<T>(injection: UserScriptInjection): Promise<InjectionResult<T>[]>;
+        export function execute<T>(
+            injection: UserScriptInjection,
+            callback: (result: InjectionResult<T>[]) => void,
+        ): void;
 
         /**
          * Registers one or more user scripts for this extension.
          *
+         * Can return its result via Promise.
          * @param scripts - Contains a list of user scripts to be registered.
-         * @returns A Promise that resolves with the same type that is passed to the callback.
          */
         export function register(scripts: RegisteredUserScript[]): Promise<void>;
-        /**
-         * Registers one or more user scripts for this extension.
-         *
-         * @param scripts - Contains a list of user scripts to be registered.
-         * @param callback - Callback function to be executed after registering user scripts.
-         */
         export function register(scripts: RegisteredUserScript[], callback: () => void): void;
 
         /**
@@ -14601,41 +14632,26 @@ declare namespace chrome {
          * @param worldId The ID of the user script world to reset. If omitted, resets the default world's configuration.
          */
         export function resetWorldConfiguration(worldId?: string): Promise<void>;
-        export function resetWorldConfiguration(worldId: string, callback: () => void): void;
         export function resetWorldConfiguration(callback: () => void): void;
+        export function resetWorldConfiguration(worldId: string | undefined, callback: () => void): void;
 
         /**
          * Unregisters all dynamically-registered user scripts for this extension.
          *
-         * @param filter - If specified, this method unregisters only the user scripts that match it.
-         * @returns A Promise that resolves with the same type that is passed to the callback.
+         * Can return its result via Promise.
+         * @param filter If specified, this method unregisters only the user scripts that match it.
          */
         export function unregister(filter?: UserScriptFilter): Promise<void>;
-        /**
-         * Unregisters all dynamically-registered user scripts for this extension.
-         *
-         * @param filter - If specified, this method unregisters only the user scripts that match it.
-         * @param callback - Callback function to be executed after unregistering user scripts.
-         */
-        export function unregister(filter: UserScriptFilter, callback: () => void): void;
+        export function unregister(callback: () => void): void;
+        export function unregister(filter: UserScriptFilter | undefined, callback: () => void): void;
 
         /**
          * Updates one or more user scripts for this extension.
          *
-         * @param scripts - Contains a list of user scripts to be updated. A property is only updated for the existing script
-         *                  if it is specified in this object. If there are errors during script parsing/file validation, or if
-         *                  the IDs specified do not correspond to a fully registered script, then no scripts are updated.
-         * @returns A Promise that resolves with the same type that is passed to the callback.
+         * Can return its result via Promise.
+         * @param scripts Contains a list of user scripts to be updated. A property is only updated for the existing script if it is specified in this object. If there are errors during script parsing/file validation, or if the IDs specified do not correspond to a fully registered script, then no scripts are updated.
          */
         export function update(scripts: RegisteredUserScript[]): Promise<void>;
-        /**
-         * Updates one or more user scripts for this extension.
-         *
-         * @param scripts - Contains a list of user scripts to be updated. A property is only updated for the existing script
-         *                  if it is specified in this object. If there are errors during script parsing/file validation, or if
-         *                  the IDs specified do not correspond to a fully registered script, then no scripts are updated.
-         * @param callback - Callback function to be executed after updating user scripts.
-         */
         export function update(scripts: RegisteredUserScript[], callback: () => void): void;
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/userScripts
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes:
- convert type `ExecutionWorld` to enum
- update `unregister()`:  `filter` param is not required with callback function
- update `getFilters()`:  `filter` param is not required with callback function
- update `register()` (Several interfaces have been converted to type 🚨)
  - User script must specify at least one js source.
    <img width="550" height="50" alt="image" src="https://github.com/user-attachments/assets/932ad41f-15b7-42f5-9549-efae463d0c59" />  
  - User script must specify exactly one of 'code' or 'file' as a js source
    <img width="912" height="48" alt="image" src="https://github.com/user-attachments/assets/2868d3a1-fa67-4a7c-80cb-004366c11f88" />
  -  Cannot specify 'allFrames' if either 'frameIds' or 'documentIds' is specified.
     <img width="857" height="47" alt="image" src="https://github.com/user-attachments/assets/11be3734-e6b2-40e3-9a49-09224cc8e280" />
   - Cannot specify both 'frameIds' and 'documentIds'.Understand this error
     <img width="852" height="48" alt="image" src="https://github.com/user-attachments/assets/5dc104d6-f355-4c92-a31e-01f79b46f798" />
   - `error` and `result` are mutually exclusive.
      <img width="718" height="172" alt="image" src="https://github.com/user-attachments/assets/d8b2c155-298b-487d-b7c5-1c6872b2eb63" />
   - Allow override `result` type
 - update tests
 - update JSDoc

Runtime:
<img width="745" height="235" alt="image" src="https://github.com/user-attachments/assets/2d283c3e-5ecb-4680-b7eb-da63192da4c4" />
