### PR TITLE
Update type for @ember/routing router.location because it's incorrect

### DIFF
--- a/types/ember__routing/router.d.ts
+++ b/types/ember__routing/router.d.ts
@@ -24,7 +24,7 @@ export default class Router extends EmberObject {
      *
      * @note the `'auto'` location is [deprecated](https://deprecations.emberjs.com/v4.x/#toc_deprecate-auto-location).
      */
-    location: "history" | "hash" | "none" | "auto";
+    location: string;
     /**
      * Represents the URL of the root of the application, often '/'. This prefix is
      * assumed on all routes defined on this router.

--- a/types/ember__routing/test/router.ts
+++ b/types/ember__routing/test/router.ts
@@ -2,7 +2,9 @@ import EmberObject, { get } from "@ember/object";
 import Router from "@ember/routing/router";
 import Service, { inject as service } from "@ember/service";
 
-const AppRouter = Router.extend({});
+const AppRouter = Router.extend({
+    location: "history",
+});
 
 AppRouter.map(function() {
     this.route("index", { path: "/" });


### PR DESCRIPTION
This definition is wrong, in the modern built-in types for Ember it is defined as follows: 

```
location: (keyof LocationRegistry & string) | EmberLocation;
```

This just allows it to be auto-completed with known strings but because of the `& string` **any string is a valid value for this property**.

You can see it defined as such here: https://github.com/emberjs/ember.js/blob/v5.12.0/packages/%40ember/routing/router.ts#L168


## Template

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
