### PR TITLE
reveal.js: include config fields from notes plugin

### DIFF
--- a/types/reveal.js/plugin/notes/notes.esm.d.ts
+++ b/types/reveal.js/plugin/notes/notes.esm.d.ts
@@ -8,3 +8,10 @@ import Reveal = require("../../.");
 declare const RevealNotes: Reveal.PluginFunction;
 
 export = RevealNotes;
+
+declare module "reveal.js" {
+    interface Options {
+        totalTime?: number | undefined;
+        minTimePerSlide?: number | undefined;
+    }
+}

--- a/types/reveal.js/plugin/notes/notes/index.d.ts
+++ b/types/reveal.js/plugin/notes/notes/index.d.ts
@@ -8,3 +8,10 @@ import Reveal = require("../../../.");
 declare const RevealNotes: Reveal.PluginFunction;
 
 export = RevealNotes;
+
+declare module "reveal.js" {
+    interface Options {
+        totalTime?: number | undefined;
+        minTimePerSlide?: number | undefined;
+    }
+}

--- a/types/reveal.js/reveal.esm.js-tests.ts
+++ b/types/reveal.js/reveal.esm.js-tests.ts
@@ -461,6 +461,8 @@ deck.configure({});
 // $ExpectType void
 deck.configure({ slideNumber: true, width: 20, height: 20 });
 
+deck.configure({ totalTime: 0, minTimePerSlide: 0 });
+
 // -------------- //
 // destroy method //
 // -------------- //

--- a/types/reveal.js/reveal.js-tests.ts
+++ b/types/reveal.js/reveal.js-tests.ts
@@ -499,6 +499,8 @@ deck.configure({ controls: "speaker-only" });
 // @ts-expect-error
 deck.configure({ controls: "foo" });
 
+deck.configure({ totalTime: 0, minTimePerSlide: 0 });
+
 // -------------- //
 // destroy method //
 // -------------- //


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hakimel/reveal.js/blob/6dbfd7e7180fb5431b8ce36f3bcd2649ee88beee/plugin/notes/speaker-view.html#L599 and following line
