### PR TITLE
Fix `trusted-types` when using  `module: esnext`

### DIFF
--- a/types/trusted-types/index.d.ts
+++ b/types/trusted-types/index.d.ts
@@ -1,4 +1,4 @@
-import * as lib from "./lib";
+import * as lib from "./lib/index";
 
 // Re-export the type definitions globally.
 declare global {


### PR DESCRIPTION
When using `esnext`, I was seeing a compile error on the import `./lib`. I believe we should include the file name in this case too in order to support more module types

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [ ]  Provide a URL to documentation or source code which provides context for the suggested changes: NA?
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`: NA
