### PR TITLE
Updated TextButtonStyle enum

### DIFF
--- a/types/google-apps-script/google-apps-script.card-service.d.ts
+++ b/types/google-apps-script/google-apps-script.card-service.d.ts
@@ -831,13 +831,19 @@ declare namespace GoogleAppsScript {
         /**
          * An enum that specifies the style for TextButton.
          *
-         * TEXT is the default; it renders a simple text button with clear background.
+         * OUTLINED is the default; it renders a simple text button with clear background.
          * FILLED buttons have a background color you can set with
          * TextButton.setBackgroundColor(backgroundColor).
+         *
+         * To call an enum, you call its parent class, name, and property.
+         * For example, CardService.TextButtonStyle.OUTLINED.
          */
         enum TextButtonStyle {
-            TEXT,
+            OUTLINED,
+            /** @deprecated DO NOT USE */ TEXT,
             FILLED,
+            FILLED_TONAL,
+            BORDERLESS,
         }
         /**
          * A input field widget that accepts text input.

--- a/types/google-apps-script/test/google-apps-script-tests.ts
+++ b/types/google-apps-script/test/google-apps-script-tests.ts
@@ -599,6 +599,11 @@ CardService.newAction().setInteraction(CardService.Interaction.OPEN_DIALOG); // 
 
 CardService.newTextButton().setAltText("alt text"); // $ExpectType TextButton
 
+CardService.newTextButton().setTextButtonStyle(CardService.TextButtonStyle.OUTLINED); // $ExpectType TextButton
+CardService.newTextButton().setTextButtonStyle(CardService.TextButtonStyle.FILLED); // $ExpectType TextButton
+CardService.newTextButton().setTextButtonStyle(CardService.TextButtonStyle.FILLED_TONAL); // $ExpectType TextButton
+CardService.newTextButton().setTextButtonStyle(CardService.TextButtonStyle.BORDERLESS); // $ExpectType TextButton
+
 CardService.newLinkPreview().setTitle("Smart chip title"); // $ExpectType LinkPreview
 
 CardService.newDecoratedText(); // $ExpectType DecoratedText


### PR DESCRIPTION
Aligned `TextButtonStyle` enum to the latest [reference](https://developers.google.com/apps-script/reference/card-service/text-button-style).

Marked `TEXT` as deprecated as shown in the reference.