### PR TITLE
fix(jasmine) add missing `forbidDuplicateNames` to `Configuration`

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -313,7 +313,7 @@ declare namespace jasmine {
          * @since 5.5.0
          * @default false
          */
-        forbidDuplicateNames?: boolean | undefined,
+        forbidDuplicateNames?: boolean | undefined;
         /**
          * Whether to fail the spec if it ran no expectations. By default
          * a spec that ran no expectations is reported as passed. Setting this

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -311,7 +311,7 @@ declare namespace jasmine {
          * the same name multiple times in the same immediate parent suite is an
          * error.
          * @since 5.5.0
-         * @default true
+         * @default false
          */
         forbidDuplicateNames?: boolean | undefined,
         /**

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -307,6 +307,14 @@ declare namespace jasmine {
          */
         stopOnSpecFailure?: boolean | undefined;
         /**
+         * Whether to forbid duplicate spec or suite names. If set to true, using
+         * the same name multiple times in the same immediate parent suite is an
+         * error.
+         * @since 5.5.0
+         * @default true
+         */
+        forbidDuplicateNames?: boolean | undefined,
+        /**
          * Whether to fail the spec if it ran no expectations. By default
          * a spec that ran no expectations is reported as passed. Setting this
          * to true will report such spec as a failure.

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -14,6 +14,7 @@ import JasmineClass from "jasmine";
     jasmineClass.addMatchingHelperFiles(["dir/**/*.js"]);
 
     jasmineClass.env.configure({
+        forbidDuplicateNames: true,
         random: true,
         failSpecWithNoExpectations: true,
         hideDisabled: true,


### PR DESCRIPTION
Add the missing `Configuration` [forbidDuplicateNames](https://jasmine.github.io/api/5.12/Configuration.html#:~:text=forbidDuplicateNames) ([related release note](https://github.com/jasmine/jasmine/blob/main/release_notes/5.5.0.md))

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add  test](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://jasmine.github.io/api/5.12/Configuration.html#:~:text=forbidDuplicateNames
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
