### PR TITLE
fix(formidable): `FormidableError` class has property `code` and not `internalCode`

### DIFF
--- a/types/formidable/FormidableError.d.ts
+++ b/types/formidable/FormidableError.d.ts
@@ -1,5 +1,5 @@
 declare class FormidableError extends Error {
-    internalCode: number;
+    code: number;
     httpCode?: number | undefined;
     constructor(message: string, internalCode: number, httpCode?: number);
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [formidable error source](https://github.com/node-formidable/formidable/blob/master/src/FormidableError.js)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

In both the master branch and v2-latest branch of formidable, the parameter `internalCode` when initialising the class would be assigned to `this.code` instead of `this.internalCode`

v2-latest https://github.com/node-formidable/formidable/blob/v2-latest/src/FormidableError.js

```javascript
const FormidableError = class extends Error {
  constructor(message, internalCode, httpCode = 500) {
    super(message);
    this.code = internalCode;
    this.httpCode = httpCode;
  }
};
```

master https://github.com/node-formidable/formidable/blob/master/src/FormidableError.js

```javascript
const FormidableError = class extends Error {
  constructor(message, internalCode, httpCode = 500) {
    super(message);
    this.code = internalCode;
    this.httpCode = httpCode;
  }
};
```