### PR TITLE
[node] Change http AgentOptions to extend partial with undefined

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -143,6 +143,8 @@ declare namespace NodeJS {
         readonly [key: string]: T | undefined;
     }
 
+    type PartialOptions<T> = { [K in keyof T]?: T[K] | undefined };
+
     interface GCFunction {
         (minor?: boolean): void;
         (options: NodeJS.GCOptions & { execution: "async" }): Promise<void>;

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -1452,7 +1452,7 @@ declare module "http" {
         https_proxy?: string | undefined;
         no_proxy?: string | undefined;
     }
-    interface AgentOptions extends PartialWithUndefined<TcpSocketConnectOpts> {
+    interface AgentOptions extends NodeJS.PartialOptions<TcpSocketConnectOpts> {
         /**
          * Keep sockets around in a pool to be used by other requests in the future. Default = false
          */
@@ -2103,7 +2103,3 @@ declare module "http" {
 declare module "node:http" {
     export * from "http";
 }
-
-type PartialWithUndefined<T> = {
-    [P in keyof T]?: T[P] | undefined;
-};

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -1452,7 +1452,7 @@ declare module "http" {
         https_proxy?: string | undefined;
         no_proxy?: string | undefined;
     }
-    interface AgentOptions extends Partial<TcpSocketConnectOpts> {
+    interface AgentOptions extends PartialWithUndefined<TcpSocketConnectOpts> {
         /**
          * Keep sockets around in a pool to be used by other requests in the future. Default = false
          */
@@ -2103,3 +2103,7 @@ declare module "http" {
 declare module "node:http" {
     export * from "http";
 }
+
+type PartialWithUndefined<T> = {
+    [P in keyof T]?: T[P] | undefined;
+};

--- a/types/node/v18/globals.d.ts
+++ b/types/node/v18/globals.d.ts
@@ -143,6 +143,8 @@ declare namespace NodeJS {
         readonly [key: string]: T | undefined;
     }
 
+    type PartialOptions<T> = { [K in keyof T]?: T[K] | undefined };
+
     interface GCFunction {
         (minor?: boolean): void;
         (options: NodeJS.GCOptions & { execution: "async" }): Promise<void>;

--- a/types/node/v18/http.d.ts
+++ b/types/node/v18/http.d.ts
@@ -1398,7 +1398,7 @@ declare module "http" {
          */
         destroy(error?: Error): this;
     }
-    interface AgentOptions extends Partial<TcpSocketConnectOpts> {
+    interface AgentOptions extends PartialWithUndefined<TcpSocketConnectOpts> {
         /**
          * Keep sockets around in a pool to be used by other requests in the future. Default = false
          */
@@ -1917,3 +1917,7 @@ declare module "http" {
 declare module "node:http" {
     export * from "http";
 }
+
+type PartialWithUndefined<T> = {
+    [P in keyof T]?: T[P] | undefined;
+};

--- a/types/node/v18/http.d.ts
+++ b/types/node/v18/http.d.ts
@@ -1398,7 +1398,7 @@ declare module "http" {
          */
         destroy(error?: Error): this;
     }
-    interface AgentOptions extends PartialWithUndefined<TcpSocketConnectOpts> {
+    interface AgentOptions extends NodeJS.PartialOptions<TcpSocketConnectOpts> {
         /**
          * Keep sockets around in a pool to be used by other requests in the future. Default = false
          */
@@ -1917,7 +1917,3 @@ declare module "http" {
 declare module "node:http" {
     export * from "http";
 }
-
-type PartialWithUndefined<T> = {
-    [P in keyof T]?: T[P] | undefined;
-};

--- a/types/node/v20/globals.d.ts
+++ b/types/node/v20/globals.d.ts
@@ -143,6 +143,8 @@ declare namespace NodeJS {
         readonly [key: string]: T | undefined;
     }
 
+    type PartialOptions<T> = { [K in keyof T]?: T[K] | undefined };
+
     interface GCFunction {
         (minor?: boolean): void;
         (options: NodeJS.GCOptions & { execution: "async" }): Promise<void>;

--- a/types/node/v20/http.d.ts
+++ b/types/node/v20/http.d.ts
@@ -1417,7 +1417,7 @@ declare module "http" {
          */
         destroy(error?: Error): this;
     }
-    interface AgentOptions extends PartialWithUndefined<TcpSocketConnectOpts> {
+    interface AgentOptions extends NodeJS.PartialOptions<TcpSocketConnectOpts> {
         /**
          * Keep sockets around in a pool to be used by other requests in the future. Default = false
          */
@@ -2029,7 +2029,3 @@ declare module "http" {
 declare module "node:http" {
     export * from "http";
 }
-
-type PartialWithUndefined<T> = {
-    [P in keyof T]?: T[P] | undefined;
-};

--- a/types/node/v20/http.d.ts
+++ b/types/node/v20/http.d.ts
@@ -1417,7 +1417,7 @@ declare module "http" {
          */
         destroy(error?: Error): this;
     }
-    interface AgentOptions extends Partial<TcpSocketConnectOpts> {
+    interface AgentOptions extends PartialWithUndefined<TcpSocketConnectOpts> {
         /**
          * Keep sockets around in a pool to be used by other requests in the future. Default = false
          */
@@ -2029,3 +2029,7 @@ declare module "http" {
 declare module "node:http" {
     export * from "http";
 }
+
+type PartialWithUndefined<T> = {
+    [P in keyof T]?: T[P] | undefined;
+};

--- a/types/node/v22/globals.d.ts
+++ b/types/node/v22/globals.d.ts
@@ -143,6 +143,8 @@ declare namespace NodeJS {
         readonly [key: string]: T | undefined;
     }
 
+    type PartialOptions<T> = { [K in keyof T]?: T[K] | undefined };
+
     interface GCFunction {
         (minor?: boolean): void;
         (options: NodeJS.GCOptions & { execution: "async" }): Promise<void>;

--- a/types/node/v22/http.d.ts
+++ b/types/node/v22/http.d.ts
@@ -1419,7 +1419,7 @@ declare module "http" {
          */
         destroy(error?: Error): this;
     }
-    interface AgentOptions extends Partial<TcpSocketConnectOpts> {
+    interface AgentOptions extends PartialWithUndefined<TcpSocketConnectOpts> {
         /**
          * Keep sockets around in a pool to be used by other requests in the future. Default = false
          */
@@ -2044,3 +2044,7 @@ declare module "http" {
 declare module "node:http" {
     export * from "http";
 }
+
+type PartialWithUndefined<T> = {
+    [P in keyof T]?: T[P] | undefined;
+};

--- a/types/node/v22/http.d.ts
+++ b/types/node/v22/http.d.ts
@@ -1419,7 +1419,7 @@ declare module "http" {
          */
         destroy(error?: Error): this;
     }
-    interface AgentOptions extends PartialWithUndefined<TcpSocketConnectOpts> {
+    interface AgentOptions extends NodeJS.PartialOptions<TcpSocketConnectOpts> {
         /**
          * Keep sockets around in a pool to be used by other requests in the future. Default = false
          */
@@ -2044,7 +2044,3 @@ declare module "http" {
 declare module "node:http" {
     export * from "http";
 }
-
-type PartialWithUndefined<T> = {
-    [P in keyof T]?: T[P] | undefined;
-};


### PR DESCRIPTION
EOPT can't be turned on in the node types in general, but changing this does handle the case in https://github.com/microsoft/TypeScript/issues/62569.