### PR TITLE
[jasmine] separated setSpecProperty and setSuiteProperty in tsdoc

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -1,5 +1,3 @@
-// For ddescribe / iit use : https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/karma-jasmine/karma-jasmine.d.ts
-
 /**
  * @deprecated Use {@link jasmine.ImplementationCallback} instead.
  */

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -1036,7 +1036,7 @@ declare namespace jasmine {
         duration: number | null;
 
         /**
-         * User-supplied properties, if any, that were set using {@link Env.setSpecProperty}
+         * User-supplied properties, if any, that were set using {@link Env.setSuiteProperty}
          */
         properties: { [key: string]: unknown } | null;
     }
@@ -1053,6 +1053,11 @@ declare namespace jasmine {
         pendingReason: string;
 
         debugLogs: DebugLogEntry[] | null;
+
+        /**
+         * User-supplied properties, if any, that were set using {@link Env.setSpecProperty}
+         */
+        properties: { [key: string]: unknown } | null;
     }
 
     interface DebugLogEntry {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

`SpecResult` extends `SuiteResult` but the content `properties` have a different "source". 
So I added an override to have two exact matching tsdoc comments.

Second commit:
[jasmine] remove reference to ddescribe
ddescribe is fdescribe since years and the link is dead anyway