### PR TITLE
node: v24.8

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -4714,6 +4714,15 @@ declare module "crypto" {
         interface Algorithm {
             name: string;
         }
+        interface Argon2Params extends Algorithm {
+            associatedData?: BufferSource;
+            memory: number;
+            nonce: BufferSource;
+            parallelism: number;
+            passes: number;
+            secretValue?: BufferSource;
+            version?: number;
+        }
         interface CShakeParams extends Algorithm {
             customization?: BufferSource;
             functionName?: BufferSource;
@@ -4988,6 +4997,9 @@ declare module "crypto" {
              *
              * The algorithms currently supported include:
              *
+             * * `'Argon2d'`
+             * * `'Argon2i'`
+             * * `'Argon2id'`
              * * `'ECDH'`
              * * `'HKDF'`
              * * `'PBKDF2'`
@@ -5001,7 +5013,7 @@ declare module "crypto" {
                 length?: number | null,
             ): Promise<ArrayBuffer>;
             deriveBits(
-                algorithm: EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params,
+                algorithm: EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params | Argon2Params,
                 baseKey: CryptoKey,
                 length: number,
             ): Promise<ArrayBuffer>;
@@ -5014,6 +5026,9 @@ declare module "crypto" {
              *
              * The algorithms currently supported include:
              *
+             * * `'Argon2d'`
+             * * `'Argon2i'`
+             * * `'Argon2id'`
              * * `'ECDH'`
              * * `'HKDF'`
              * * `'PBKDF2'`
@@ -5023,7 +5038,7 @@ declare module "crypto" {
              * @since v15.0.0
              */
             deriveKey(
-                algorithm: EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params,
+                algorithm: EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params | Argon2Params,
                 baseKey: CryptoKey,
                 derivedKeyAlgorithm: AlgorithmIdentifier | HmacImportParams | AesDerivedKeyParams | KmacImportParams,
                 extractable: boolean,

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -1310,6 +1310,7 @@ declare module "crypto" {
      * @since v0.1.92
      * @param options `stream.Writable` options
      */
+    // TODO: signing algorithm type
     function createSign(algorithm: string, options?: stream.WritableOptions): Sign;
     type DSAEncoding = "der" | "ieee-p1363";
     interface SigningOptions {
@@ -1319,6 +1320,7 @@ declare module "crypto" {
         padding?: number | undefined;
         saltLength?: number | undefined;
         dsaEncoding?: DSAEncoding | undefined;
+        context?: ArrayBuffer | NodeJS.ArrayBufferView | undefined;
     }
     interface SignPrivateKeyInput extends PrivateKeyInput, SigningOptions {}
     interface SignKeyObjectInput extends SigningOptions {
@@ -2460,6 +2462,18 @@ declare module "crypto" {
         | "ml-kem-768"
         | "rsa-pss"
         | "rsa"
+        | "slh-dsa-sha2-128f"
+        | "slh-dsa-sha2-128s"
+        | "slh-dsa-sha2-192f"
+        | "slh-dsa-sha2-192s"
+        | "slh-dsa-sha2-256f"
+        | "slh-dsa-sha2-256s"
+        | "slh-dsa-shake-128f"
+        | "slh-dsa-shake-128s"
+        | "slh-dsa-shake-192f"
+        | "slh-dsa-shake-192s"
+        | "slh-dsa-shake-256f"
+        | "slh-dsa-shake-256s"
         | "x25519"
         | "x448";
     type KeyFormat = "pem" | "der" | "jwk";
@@ -2478,6 +2492,7 @@ declare module "crypto" {
     interface X448KeyPairKeyObjectOptions {}
     interface MLDSAKeyPairKeyObjectOptions {}
     interface MLKEMKeyPairKeyObjectOptions {}
+    interface SLHDSAKeyPairKeyObjectOptions {}
     interface ECKeyPairKeyObjectOptions {
         /**
          * Name of the curve to use
@@ -2652,6 +2667,15 @@ declare module "crypto" {
         };
     }
     interface MLKEMKeyPairOptions<PubF extends KeyFormat, PrivF extends KeyFormat> {
+        publicKeyEncoding: {
+            type: "spki";
+            format: PubF;
+        };
+        privateKeyEncoding: BasePrivateKeyEncodingOptions<PrivF> & {
+            type: "pkcs8";
+        };
+    }
+    interface SLHDSAKeyPairOptions<PubF extends KeyFormat, PrivF extends KeyFormat> {
         publicKeyEncoding: {
             type: "spki";
             format: PubF;
@@ -2881,6 +2905,86 @@ declare module "crypto" {
     function generateKeyPairSync(
         type: "ml-kem-1024" | "ml-kem-512" | "ml-kem-768",
         options?: MLKEMKeyPairKeyObjectOptions,
+    ): KeyPairKeyObjectResult;
+    function generateKeyPairSync(
+        type:
+            | "slh-dsa-sha2-128f"
+            | "slh-dsa-sha2-128s"
+            | "slh-dsa-sha2-192f"
+            | "slh-dsa-sha2-192s"
+            | "slh-dsa-sha2-256f"
+            | "slh-dsa-sha2-256s"
+            | "slh-dsa-shake-128f"
+            | "slh-dsa-shake-128s"
+            | "slh-dsa-shake-192f"
+            | "slh-dsa-shake-192s"
+            | "slh-dsa-shake-256f"
+            | "slh-dsa-shake-256s",
+        options: SLHDSAKeyPairOptions<"pem", "pem">,
+    ): KeyPairSyncResult<string, string>;
+    function generateKeyPairSync(
+        type:
+            | "slh-dsa-sha2-128f"
+            | "slh-dsa-sha2-128s"
+            | "slh-dsa-sha2-192f"
+            | "slh-dsa-sha2-192s"
+            | "slh-dsa-sha2-256f"
+            | "slh-dsa-sha2-256s"
+            | "slh-dsa-shake-128f"
+            | "slh-dsa-shake-128s"
+            | "slh-dsa-shake-192f"
+            | "slh-dsa-shake-192s"
+            | "slh-dsa-shake-256f"
+            | "slh-dsa-shake-256s",
+        options: SLHDSAKeyPairOptions<"pem", "der">,
+    ): KeyPairSyncResult<string, Buffer>;
+    function generateKeyPairSync(
+        type:
+            | "slh-dsa-sha2-128f"
+            | "slh-dsa-sha2-128s"
+            | "slh-dsa-sha2-192f"
+            | "slh-dsa-sha2-192s"
+            | "slh-dsa-sha2-256f"
+            | "slh-dsa-sha2-256s"
+            | "slh-dsa-shake-128f"
+            | "slh-dsa-shake-128s"
+            | "slh-dsa-shake-192f"
+            | "slh-dsa-shake-192s"
+            | "slh-dsa-shake-256f"
+            | "slh-dsa-shake-256s",
+        options: SLHDSAKeyPairOptions<"der", "pem">,
+    ): KeyPairSyncResult<Buffer, string>;
+    function generateKeyPairSync(
+        type:
+            | "slh-dsa-sha2-128f"
+            | "slh-dsa-sha2-128s"
+            | "slh-dsa-sha2-192f"
+            | "slh-dsa-sha2-192s"
+            | "slh-dsa-sha2-256f"
+            | "slh-dsa-sha2-256s"
+            | "slh-dsa-shake-128f"
+            | "slh-dsa-shake-128s"
+            | "slh-dsa-shake-192f"
+            | "slh-dsa-shake-192s"
+            | "slh-dsa-shake-256f"
+            | "slh-dsa-shake-256s",
+        options: SLHDSAKeyPairOptions<"der", "der">,
+    ): KeyPairSyncResult<Buffer, Buffer>;
+    function generateKeyPairSync(
+        type:
+            | "slh-dsa-sha2-128f"
+            | "slh-dsa-sha2-128s"
+            | "slh-dsa-sha2-192f"
+            | "slh-dsa-sha2-192s"
+            | "slh-dsa-sha2-256f"
+            | "slh-dsa-sha2-256s"
+            | "slh-dsa-shake-128f"
+            | "slh-dsa-shake-128s"
+            | "slh-dsa-shake-192f"
+            | "slh-dsa-shake-192s"
+            | "slh-dsa-shake-256f"
+            | "slh-dsa-shake-256s",
+        options?: SLHDSAKeyPairKeyObjectOptions,
     ): KeyPairKeyObjectResult;
     /**
      * Generates a new asymmetric key pair of the given `type`. RSA, RSA-PSS, DSA, EC,
@@ -3170,6 +3274,91 @@ declare module "crypto" {
     function generateKeyPair(
         type: "ml-kem-1024" | "ml-kem-512" | "ml-kem-768",
         options: MLKEMKeyPairKeyObjectOptions | undefined,
+        callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void,
+    ): void;
+    function generateKeyPair(
+        type:
+            | "slh-dsa-sha2-128f"
+            | "slh-dsa-sha2-128s"
+            | "slh-dsa-sha2-192f"
+            | "slh-dsa-sha2-192s"
+            | "slh-dsa-sha2-256f"
+            | "slh-dsa-sha2-256s"
+            | "slh-dsa-shake-128f"
+            | "slh-dsa-shake-128s"
+            | "slh-dsa-shake-192f"
+            | "slh-dsa-shake-192s"
+            | "slh-dsa-shake-256f"
+            | "slh-dsa-shake-256s",
+        options: SLHDSAKeyPairOptions<"pem", "pem">,
+        callback: (err: Error | null, publicKey: string, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type:
+            | "slh-dsa-sha2-128f"
+            | "slh-dsa-sha2-128s"
+            | "slh-dsa-sha2-192f"
+            | "slh-dsa-sha2-192s"
+            | "slh-dsa-sha2-256f"
+            | "slh-dsa-sha2-256s"
+            | "slh-dsa-shake-128f"
+            | "slh-dsa-shake-128s"
+            | "slh-dsa-shake-192f"
+            | "slh-dsa-shake-192s"
+            | "slh-dsa-shake-256f"
+            | "slh-dsa-shake-256s",
+        options: SLHDSAKeyPairOptions<"pem", "der">,
+        callback: (err: Error | null, publicKey: string, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type:
+            | "slh-dsa-sha2-128f"
+            | "slh-dsa-sha2-128s"
+            | "slh-dsa-sha2-192f"
+            | "slh-dsa-sha2-192s"
+            | "slh-dsa-sha2-256f"
+            | "slh-dsa-sha2-256s"
+            | "slh-dsa-shake-128f"
+            | "slh-dsa-shake-128s"
+            | "slh-dsa-shake-192f"
+            | "slh-dsa-shake-192s"
+            | "slh-dsa-shake-256f"
+            | "slh-dsa-shake-256s",
+        options: SLHDSAKeyPairOptions<"der", "pem">,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: string) => void,
+    ): void;
+    function generateKeyPair(
+        type:
+            | "slh-dsa-sha2-128f"
+            | "slh-dsa-sha2-128s"
+            | "slh-dsa-sha2-192f"
+            | "slh-dsa-sha2-192s"
+            | "slh-dsa-sha2-256f"
+            | "slh-dsa-sha2-256s"
+            | "slh-dsa-shake-128f"
+            | "slh-dsa-shake-128s"
+            | "slh-dsa-shake-192f"
+            | "slh-dsa-shake-192s"
+            | "slh-dsa-shake-256f"
+            | "slh-dsa-shake-256s",
+        options: SLHDSAKeyPairOptions<"der", "der">,
+        callback: (err: Error | null, publicKey: Buffer, privateKey: Buffer) => void,
+    ): void;
+    function generateKeyPair(
+        type:
+            | "slh-dsa-sha2-128f"
+            | "slh-dsa-sha2-128s"
+            | "slh-dsa-sha2-192f"
+            | "slh-dsa-sha2-192s"
+            | "slh-dsa-sha2-256f"
+            | "slh-dsa-sha2-256s"
+            | "slh-dsa-shake-128f"
+            | "slh-dsa-shake-128s"
+            | "slh-dsa-shake-192f"
+            | "slh-dsa-shake-192s"
+            | "slh-dsa-shake-256f"
+            | "slh-dsa-shake-256s",
+        options: SLHDSAKeyPairKeyObjectOptions | undefined,
         callback: (err: Error | null, publicKey: KeyObject, privateKey: KeyObject) => void,
     ): void;
     namespace generateKeyPair {
@@ -3477,6 +3666,98 @@ declare module "crypto" {
         function __promisify__(
             type: "ml-kem-1024" | "ml-kem-512" | "ml-kem-768",
             options?: MLKEMKeyPairKeyObjectOptions,
+        ): Promise<KeyPairKeyObjectResult>;
+        function __promisify__(
+            type:
+                | "slh-dsa-sha2-128f"
+                | "slh-dsa-sha2-128s"
+                | "slh-dsa-sha2-192f"
+                | "slh-dsa-sha2-192s"
+                | "slh-dsa-sha2-256f"
+                | "slh-dsa-sha2-256s"
+                | "slh-dsa-shake-128f"
+                | "slh-dsa-shake-128s"
+                | "slh-dsa-shake-192f"
+                | "slh-dsa-shake-192s"
+                | "slh-dsa-shake-256f"
+                | "slh-dsa-shake-256s",
+            options: SLHDSAKeyPairOptions<"pem", "pem">,
+        ): Promise<{
+            publicKey: string;
+            privateKey: string;
+        }>;
+        function __promisify__(
+            type:
+                | "slh-dsa-sha2-128f"
+                | "slh-dsa-sha2-128s"
+                | "slh-dsa-sha2-192f"
+                | "slh-dsa-sha2-192s"
+                | "slh-dsa-sha2-256f"
+                | "slh-dsa-sha2-256s"
+                | "slh-dsa-shake-128f"
+                | "slh-dsa-shake-128s"
+                | "slh-dsa-shake-192f"
+                | "slh-dsa-shake-192s"
+                | "slh-dsa-shake-256f"
+                | "slh-dsa-shake-256s",
+            options: SLHDSAKeyPairOptions<"pem", "der">,
+        ): Promise<{
+            publicKey: string;
+            privateKey: Buffer;
+        }>;
+        function __promisify__(
+            type:
+                | "slh-dsa-sha2-128f"
+                | "slh-dsa-sha2-128s"
+                | "slh-dsa-sha2-192f"
+                | "slh-dsa-sha2-192s"
+                | "slh-dsa-sha2-256f"
+                | "slh-dsa-sha2-256s"
+                | "slh-dsa-shake-128f"
+                | "slh-dsa-shake-128s"
+                | "slh-dsa-shake-192f"
+                | "slh-dsa-shake-192s"
+                | "slh-dsa-shake-256f"
+                | "slh-dsa-shake-256s",
+            options: SLHDSAKeyPairOptions<"der", "pem">,
+        ): Promise<{
+            publicKey: Buffer;
+            privateKey: string;
+        }>;
+        function __promisify__(
+            type:
+                | "slh-dsa-sha2-128f"
+                | "slh-dsa-sha2-128s"
+                | "slh-dsa-sha2-192f"
+                | "slh-dsa-sha2-192s"
+                | "slh-dsa-sha2-256f"
+                | "slh-dsa-sha2-256s"
+                | "slh-dsa-shake-128f"
+                | "slh-dsa-shake-128s"
+                | "slh-dsa-shake-192f"
+                | "slh-dsa-shake-192s"
+                | "slh-dsa-shake-256f"
+                | "slh-dsa-shake-256s",
+            options: SLHDSAKeyPairOptions<"der", "der">,
+        ): Promise<{
+            publicKey: Buffer;
+            privateKey: Buffer;
+        }>;
+        function __promisify__(
+            type:
+                | "slh-dsa-sha2-128f"
+                | "slh-dsa-sha2-128s"
+                | "slh-dsa-sha2-192f"
+                | "slh-dsa-sha2-192s"
+                | "slh-dsa-sha2-256f"
+                | "slh-dsa-sha2-256s"
+                | "slh-dsa-shake-128f"
+                | "slh-dsa-shake-128s"
+                | "slh-dsa-shake-192f"
+                | "slh-dsa-shake-192s"
+                | "slh-dsa-shake-256f"
+                | "slh-dsa-shake-256s",
+            options?: SLHDSAKeyPairKeyObjectOptions,
         ): Promise<KeyPairKeyObjectResult>;
     }
     /**

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -4737,9 +4737,6 @@ declare module "crypto" {
         interface EcdsaParams extends Algorithm {
             hash: HashAlgorithmIdentifier;
         }
-        interface Ed448Params extends Algorithm {
-            context?: BufferSource;
-        }
         interface HkdfParams extends Algorithm {
             hash: HashAlgorithmIdentifier;
             info: BufferSource;
@@ -5210,7 +5207,7 @@ declare module "crypto" {
              * @since v15.0.0
              */
             sign(
-                algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams | Ed448Params | ContextParams,
+                algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams | ContextParams,
                 key: CryptoKey,
                 data: BufferSource,
             ): Promise<ArrayBuffer>;
@@ -5283,7 +5280,7 @@ declare module "crypto" {
              *
              * * `'ECDSA'`
              * * `'Ed25519'`
-             * * `'Ed448'`[^secure-curves]
+             * * `'Ed448'`
              * * `'HMAC'`
              * * `'ML-DSA-44'`
              * * `'ML-DSA-65'`

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -4777,6 +4777,19 @@ declare module "crypto" {
         interface KeyAlgorithm {
             name: string;
         }
+        interface KmacImportParams extends Algorithm {
+            length?: number;
+        }
+        interface KmacKeyAlgorithm extends KeyAlgorithm {
+            length: number;
+        }
+        interface KmacKeyGenParams extends Algorithm {
+            length?: number;
+        }
+        interface KmacParams extends Algorithm {
+            customization?: BufferSource;
+            length: number;
+        }
         interface Pbkdf2Params extends Algorithm {
             hash: HashAlgorithmIdentifier;
             iterations: number;
@@ -4906,6 +4919,10 @@ declare module "crypto" {
          */
         interface SubtleCrypto {
             /**
+             * A message recipient uses their asymmetric private key to decrypt an
+             * "encapsulated key" (ciphertext), thereby recovering a temporary symmetric
+             * key (represented as `ArrayBuffer`) which is then used to decrypt a message.
+             *
              * The algorithms currently supported include:
              *
              * * `'ML-KEM-512'`
@@ -4920,6 +4937,10 @@ declare module "crypto" {
                 ciphertext: BufferSource,
             ): Promise<ArrayBuffer>;
             /**
+             * A message recipient uses their asymmetric private key to decrypt an
+             * "encapsulated key" (ciphertext), thereby recovering a temporary symmetric
+             * key (represented as `CryptoKey`) which is then used to decrypt a message.
+             *
              * The algorithms currently supported include:
              *
              * * `'ML-KEM-512'`
@@ -4933,13 +4954,13 @@ declare module "crypto" {
                 decapsulationAlgorithm: AlgorithmIdentifier,
                 decapsulationKey: CryptoKey,
                 ciphertext: BufferSource,
-                sharedKeyAlgorithm: AlgorithmIdentifier | HmacImportParams | AesDerivedKeyParams,
+                sharedKeyAlgorithm: AlgorithmIdentifier | HmacImportParams | AesDerivedKeyParams | KmacImportParams,
                 extractable: boolean,
                 usages: KeyUsage[],
             ): Promise<CryptoKey>;
             /**
              * Using the method and parameters specified in `algorithm` and the keying material provided by `key`,
-             * `subtle.decrypt()` attempts to decipher the provided `data`. If successful,
+             * this method attempts to decipher the provided `data`. If successful,
              * the returned promise will be resolved with an `<ArrayBuffer>` containing the plaintext result.
              *
              * The algorithms currently supported include:
@@ -4959,7 +4980,7 @@ declare module "crypto" {
             ): Promise<ArrayBuffer>;
             /**
              * Using the method and parameters specified in `algorithm` and the keying material provided by `baseKey`,
-             * `subtle.deriveBits()` attempts to generate `length` bits.
+             * this method attempts to generate `length` bits.
              * The Node.js implementation requires that when `length` is a number it must be multiple of `8`.
              * When `length` is `null` the maximum number of bits for a given algorithm is generated. This is allowed
              * for the `'ECDH'`, `'X25519'`, and `'X448'` algorithms.
@@ -4986,7 +5007,7 @@ declare module "crypto" {
             ): Promise<ArrayBuffer>;
             /**
              * Using the method and parameters specified in `algorithm`, and the keying material provided by `baseKey`,
-             * `subtle.deriveKey()` attempts to generate a new <CryptoKey>` based on the method and parameters in `derivedKeyAlgorithm`.
+             * this method attempts to generate a new <CryptoKey>` based on the method and parameters in `derivedKeyAlgorithm`.
              *
              * Calling `subtle.deriveKey()` is equivalent to calling `subtle.deriveBits()` to generate raw keying material,
              * then passing the result into the `subtle.importKey()` method using the `deriveKeyAlgorithm`, `extractable`, and `keyUsages` parameters as input.
@@ -5004,7 +5025,7 @@ declare module "crypto" {
             deriveKey(
                 algorithm: EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params,
                 baseKey: CryptoKey,
-                derivedKeyAlgorithm: AlgorithmIdentifier | HmacImportParams | AesDerivedKeyParams,
+                derivedKeyAlgorithm: AlgorithmIdentifier | HmacImportParams | AesDerivedKeyParams | KmacImportParams,
                 extractable: boolean,
                 keyUsages: readonly KeyUsage[],
             ): Promise<CryptoKey>;
@@ -5029,6 +5050,9 @@ declare module "crypto" {
              */
             digest(algorithm: AlgorithmIdentifier | CShakeParams, data: BufferSource): Promise<ArrayBuffer>;
             /**
+             * Uses a message recipient's asymmetric public key to encrypt a temporary symmetric key.
+             * This encrypted key is the "encapsulated key" represented as `EncapsulatedBits`.
+             *
              * The algorithms currently supported include:
              *
              * * `'ML-KEM-512'`
@@ -5042,6 +5066,9 @@ declare module "crypto" {
                 encapsulationKey: CryptoKey,
             ): Promise<EncapsulatedBits>;
             /**
+             * Uses a message recipient's asymmetric public key to encrypt a temporary symmetric key.
+             * This encrypted key is the "encapsulated key" represented as `EncapsulatedKey`.
+             *
              * The algorithms currently supported include:
              *
              * * `'ML-KEM-512'`
@@ -5054,13 +5081,13 @@ declare module "crypto" {
             encapsulateKey(
                 encapsulationAlgorithm: AlgorithmIdentifier,
                 encapsulationKey: CryptoKey,
-                sharedKeyAlgorithm: AlgorithmIdentifier | HmacImportParams | AesDerivedKeyParams,
+                sharedKeyAlgorithm: AlgorithmIdentifier | HmacImportParams | AesDerivedKeyParams | KmacImportParams,
                 extractable: boolean,
                 usages: KeyUsage[],
             ): Promise<EncapsulatedKey>;
             /**
              * Using the method and parameters specified by `algorithm` and the keying material provided by `key`,
-             * `subtle.encrypt()` attempts to encipher `data`. If successful,
+             * this method attempts to encipher `data`. If successful,
              * the returned promise is resolved with an `<ArrayBuffer>` containing the encrypted result.
              *
              * The algorithms currently supported include:
@@ -5119,7 +5146,7 @@ declare module "crypto" {
              * * `'X25519'`
              * * `'X448'`
              *
-             * The {CryptoKey} (secret key) generating algorithms supported include:
+             * The `CryptoKey` (secret key) generating algorithms supported include:
              * * `'AES-CBC'`
              * * `'AES-CTR'`
              * * `'AES-GCM'`
@@ -5127,6 +5154,8 @@ declare module "crypto" {
              * * `'AES-OCB'`
              * * `'ChaCha20-Poly1305'`
              * * `'HMAC'`
+             * * `'KMAC128'`
+             * * `'KMAC256'`
              * @param keyUsages See {@link https://nodejs.org/docs/latest/api/webcrypto.html#cryptokeyusages Key usages}.
              * @since v15.0.0
              */
@@ -5136,7 +5165,7 @@ declare module "crypto" {
                 keyUsages: readonly KeyUsage[],
             ): Promise<CryptoKeyPair>;
             generateKey(
-                algorithm: AesKeyGenParams | HmacKeyGenParams | Pbkdf2Params,
+                algorithm: AesKeyGenParams | HmacKeyGenParams | Pbkdf2Params | KmacKeyGenParams,
                 extractable: boolean,
                 keyUsages: readonly KeyUsage[],
             ): Promise<CryptoKey>;
@@ -5158,7 +5187,7 @@ declare module "crypto" {
              * to create a `<CryptoKey>` instance using the provided `algorithm`, `extractable`, and `keyUsages` arguments.
              * If the import is successful, the returned promise will be resolved with the created `<CryptoKey>`.
              *
-             * If importing a `'PBKDF2'` key, `extractable` must be `false`.
+             * If importing KDF algorithm keys, `extractable` must be `false`.
              * @param format Must be one of `'raw'`, `'pkcs8'`, `'spki'`, `'jwk'`, `'raw-secret'`,
              * `'raw-public'`, or `'raw-seed'`.
              * @param keyUsages See {@link https://nodejs.org/docs/latest/api/webcrypto.html#cryptokeyusages Key usages}.
@@ -5172,7 +5201,8 @@ declare module "crypto" {
                     | RsaHashedImportParams
                     | EcKeyImportParams
                     | HmacImportParams
-                    | AesKeyAlgorithm,
+                    | AesKeyAlgorithm
+                    | KmacImportParams,
                 extractable: boolean,
                 keyUsages: readonly KeyUsage[],
             ): Promise<CryptoKey>;
@@ -5184,13 +5214,14 @@ declare module "crypto" {
                     | RsaHashedImportParams
                     | EcKeyImportParams
                     | HmacImportParams
-                    | AesKeyAlgorithm,
+                    | AesKeyAlgorithm
+                    | KmacImportParams,
                 extractable: boolean,
                 keyUsages: KeyUsage[],
             ): Promise<CryptoKey>;
             /**
              * Using the method and parameters given by `algorithm` and the keying material provided by `key`,
-             * `subtle.sign()` attempts to generate a cryptographic signature of `data`. If successful,
+             * this method attempts to generate a cryptographic signature of `data`. If successful,
              * the returned promise is resolved with an `<ArrayBuffer>` containing the generated signature.
              *
              * The algorithms currently supported include:
@@ -5199,6 +5230,8 @@ declare module "crypto" {
              * * `'Ed25519'`
              * * `'Ed448'`
              * * `'HMAC'`
+             * * `'KMAC128'`
+             * * `'KMAC256'`
              * * `'ML-DSA-44'`
              * * `'ML-DSA-65'`
              * * `'ML-DSA-87'`
@@ -5207,13 +5240,13 @@ declare module "crypto" {
              * @since v15.0.0
              */
             sign(
-                algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams | ContextParams,
+                algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams | ContextParams | KmacParams,
                 key: CryptoKey,
                 data: BufferSource,
             ): Promise<ArrayBuffer>;
             /**
              * In cryptography, "wrapping a key" refers to exporting and then encrypting the keying material.
-             * The `subtle.unwrapKey()` method attempts to decrypt a wrapped key and create a `<CryptoKey>` instance.
+             * This method attempts to decrypt a wrapped key and create a `<CryptoKey>` instance.
              * It is equivalent to calling `subtle.decrypt()` first on the encrypted key data (using the `wrappedKey`, `unwrapAlgo`, and `unwrappingKey` arguments as input)
              * then passing the results in to the `subtle.importKey()` method using the `unwrappedKeyAlgo`, `extractable`, and `keyUsages` arguments as inputs.
              * If successful, the returned promise is resolved with a `<CryptoKey>` object.
@@ -5241,6 +5274,8 @@ declare module "crypto" {
              * * `'Ed25519'`
              * * `'Ed448'`
              * * `'HMAC'`
+             * * `'KMAC128'`
+             * * `'KMAC256'`
              * * `'ML-DSA-44'`
              * * `'ML-DSA-65'`
              * * `'ML-DSA-87'`
@@ -5267,13 +5302,14 @@ declare module "crypto" {
                     | RsaHashedImportParams
                     | EcKeyImportParams
                     | HmacImportParams
-                    | AesKeyAlgorithm,
+                    | AesKeyAlgorithm
+                    | KmacImportParams,
                 extractable: boolean,
                 keyUsages: KeyUsage[],
             ): Promise<CryptoKey>;
             /**
              * Using the method and parameters given in `algorithm` and the keying material provided by `key`,
-             * `subtle.verify()` attempts to verify that `signature` is a valid cryptographic signature of `data`.
+             * This method attempts to verify that `signature` is a valid cryptographic signature of `data`.
              * The returned promise is resolved with either `true` or `false`.
              *
              * The algorithms currently supported include:
@@ -5282,6 +5318,8 @@ declare module "crypto" {
              * * `'Ed25519'`
              * * `'Ed448'`
              * * `'HMAC'`
+             * * `'KMAC128'`
+             * * `'KMAC256'`
              * * `'ML-DSA-44'`
              * * `'ML-DSA-65'`
              * * `'ML-DSA-87'`
@@ -5290,14 +5328,14 @@ declare module "crypto" {
              * @since v15.0.0
              */
             verify(
-                algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams | Ed448Params | ContextParams,
+                algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams | ContextParams | KmacParams,
                 key: CryptoKey,
                 signature: BufferSource,
                 data: BufferSource,
             ): Promise<boolean>;
             /**
              * In cryptography, "wrapping a key" refers to exporting and then encrypting the keying material.
-             * The `subtle.wrapKey()` method exports the keying material into the format identified by `format`,
+             * This method exports the keying material into the format identified by `format`,
              * then encrypts it using the method and parameters specified by `wrapAlgo` and the keying material provided by `wrappingKey`.
              * It is the equivalent to calling `subtle.exportKey()` using `format` and `key` as the arguments,
              * then passing the result to the `subtle.encrypt()` method using `wrappingKey` and `wrapAlgo` as inputs.

--- a/types/node/diagnostics_channel.d.ts
+++ b/types/node/diagnostics_channel.d.ts
@@ -189,7 +189,6 @@ declare module "diagnostics_channel" {
          * });
          * ```
          * @since v15.1.0, v14.17.0
-         * @deprecated Since v18.7.0,v16.17.0 - Use {@link subscribe(name, onMessage)}
          * @param onMessage The handler to receive channel messages
          */
         subscribe(onMessage: ChannelListener): void;
@@ -210,7 +209,6 @@ declare module "diagnostics_channel" {
          * channel.unsubscribe(onMessage);
          * ```
          * @since v15.1.0, v14.17.0
-         * @deprecated Since v18.7.0,v16.17.0 - Use {@link unsubscribe(name, onMessage)}
          * @param onMessage The previous subscribed handler to remove
          * @return `true` if the handler was found, `false` otherwise.
          */

--- a/types/node/http2.d.ts
+++ b/types/node/http2.d.ts
@@ -284,61 +284,111 @@ declare module "http2" {
         addListener(event: "continue", listener: () => {}): this;
         addListener(
             event: "headers",
-            listener: (headers: IncomingHttpHeaders & IncomingHttpStatusHeader, flags: number) => void,
+            listener: (
+                headers: IncomingHttpHeaders & IncomingHttpStatusHeader,
+                flags: number,
+                rawHeaders: string[],
+            ) => void,
         ): this;
         addListener(event: "push", listener: (headers: IncomingHttpHeaders, flags: number) => void): this;
         addListener(
             event: "response",
-            listener: (headers: IncomingHttpHeaders & IncomingHttpStatusHeader, flags: number) => void,
+            listener: (
+                headers: IncomingHttpHeaders & IncomingHttpStatusHeader,
+                flags: number,
+                rawHeaders: string[],
+            ) => void,
         ): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
         emit(event: "continue"): boolean;
-        emit(event: "headers", headers: IncomingHttpHeaders & IncomingHttpStatusHeader, flags: number): boolean;
+        emit(
+            event: "headers",
+            headers: IncomingHttpHeaders & IncomingHttpStatusHeader,
+            flags: number,
+            rawHeaders: string[],
+        ): boolean;
         emit(event: "push", headers: IncomingHttpHeaders, flags: number): boolean;
-        emit(event: "response", headers: IncomingHttpHeaders & IncomingHttpStatusHeader, flags: number): boolean;
+        emit(
+            event: "response",
+            headers: IncomingHttpHeaders & IncomingHttpStatusHeader,
+            flags: number,
+            rawHeaders: string[],
+        ): boolean;
         emit(event: string | symbol, ...args: any[]): boolean;
         on(event: "continue", listener: () => {}): this;
         on(
             event: "headers",
-            listener: (headers: IncomingHttpHeaders & IncomingHttpStatusHeader, flags: number) => void,
+            listener: (
+                headers: IncomingHttpHeaders & IncomingHttpStatusHeader,
+                flags: number,
+                rawHeaders: string[],
+            ) => void,
         ): this;
         on(event: "push", listener: (headers: IncomingHttpHeaders, flags: number) => void): this;
         on(
             event: "response",
-            listener: (headers: IncomingHttpHeaders & IncomingHttpStatusHeader, flags: number) => void,
+            listener: (
+                headers: IncomingHttpHeaders & IncomingHttpStatusHeader,
+                flags: number,
+                rawHeaders: string[],
+            ) => void,
         ): this;
         on(event: string | symbol, listener: (...args: any[]) => void): this;
         once(event: "continue", listener: () => {}): this;
         once(
             event: "headers",
-            listener: (headers: IncomingHttpHeaders & IncomingHttpStatusHeader, flags: number) => void,
+            listener: (
+                headers: IncomingHttpHeaders & IncomingHttpStatusHeader,
+                flags: number,
+                rawHeaders: string[],
+            ) => void,
         ): this;
         once(event: "push", listener: (headers: IncomingHttpHeaders, flags: number) => void): this;
         once(
             event: "response",
-            listener: (headers: IncomingHttpHeaders & IncomingHttpStatusHeader, flags: number) => void,
+            listener: (
+                headers: IncomingHttpHeaders & IncomingHttpStatusHeader,
+                flags: number,
+                rawHeaders: string[],
+            ) => void,
         ): this;
         once(event: string | symbol, listener: (...args: any[]) => void): this;
         prependListener(event: "continue", listener: () => {}): this;
         prependListener(
             event: "headers",
-            listener: (headers: IncomingHttpHeaders & IncomingHttpStatusHeader, flags: number) => void,
+            listener: (
+                headers: IncomingHttpHeaders & IncomingHttpStatusHeader,
+                flags: number,
+                rawHeaders: string[],
+            ) => void,
         ): this;
         prependListener(event: "push", listener: (headers: IncomingHttpHeaders, flags: number) => void): this;
         prependListener(
             event: "response",
-            listener: (headers: IncomingHttpHeaders & IncomingHttpStatusHeader, flags: number) => void,
+            listener: (
+                headers: IncomingHttpHeaders & IncomingHttpStatusHeader,
+                flags: number,
+                rawHeaders: string[],
+            ) => void,
         ): this;
         prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
         prependOnceListener(event: "continue", listener: () => {}): this;
         prependOnceListener(
             event: "headers",
-            listener: (headers: IncomingHttpHeaders & IncomingHttpStatusHeader, flags: number) => void,
+            listener: (
+                headers: IncomingHttpHeaders & IncomingHttpStatusHeader,
+                flags: number,
+                rawHeaders: string[],
+            ) => void,
         ): this;
         prependOnceListener(event: "push", listener: (headers: IncomingHttpHeaders, flags: number) => void): this;
         prependOnceListener(
             event: "response",
-            listener: (headers: IncomingHttpHeaders & IncomingHttpStatusHeader, flags: number) => void,
+            listener: (
+                headers: IncomingHttpHeaders & IncomingHttpStatusHeader,
+                flags: number,
+                rawHeaders: string[],
+            ) => void,
         ): this;
         prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
     }
@@ -976,6 +1026,7 @@ declare module "http2" {
                 stream: ClientHttp2Stream,
                 headers: IncomingHttpHeaders & IncomingHttpStatusHeader,
                 flags: number,
+                rawHeaders: string[],
             ) => void,
         ): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
@@ -987,6 +1038,7 @@ declare module "http2" {
             stream: ClientHttp2Stream,
             headers: IncomingHttpHeaders & IncomingHttpStatusHeader,
             flags: number,
+            rawHeaders: string[],
         ): boolean;
         emit(event: string | symbol, ...args: any[]): boolean;
         on(event: "altsvc", listener: (alt: string, origin: string, stream: number) => void): this;
@@ -998,6 +1050,7 @@ declare module "http2" {
                 stream: ClientHttp2Stream,
                 headers: IncomingHttpHeaders & IncomingHttpStatusHeader,
                 flags: number,
+                rawHeaders: string[],
             ) => void,
         ): this;
         on(event: string | symbol, listener: (...args: any[]) => void): this;
@@ -1013,6 +1066,7 @@ declare module "http2" {
                 stream: ClientHttp2Stream,
                 headers: IncomingHttpHeaders & IncomingHttpStatusHeader,
                 flags: number,
+                rawHeaders: string[],
             ) => void,
         ): this;
         once(event: string | symbol, listener: (...args: any[]) => void): this;
@@ -1028,6 +1082,7 @@ declare module "http2" {
                 stream: ClientHttp2Stream,
                 headers: IncomingHttpHeaders & IncomingHttpStatusHeader,
                 flags: number,
+                rawHeaders: string[],
             ) => void,
         ): this;
         prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
@@ -1043,6 +1098,7 @@ declare module "http2" {
                 stream: ClientHttp2Stream,
                 headers: IncomingHttpHeaders & IncomingHttpStatusHeader,
                 flags: number,
+                rawHeaders: string[],
             ) => void,
         ): this;
         prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
@@ -1160,7 +1216,12 @@ declare module "http2" {
         ): this;
         addListener(
             event: "stream",
-            listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void,
+            listener: (
+                stream: ServerHttp2Stream,
+                headers: IncomingHttpHeaders,
+                flags: number,
+                rawHeaders: string[],
+            ) => void,
         ): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
         emit(
@@ -1168,7 +1229,13 @@ declare module "http2" {
             session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
             socket: net.Socket | tls.TLSSocket,
         ): boolean;
-        emit(event: "stream", stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
+        emit(
+            event: "stream",
+            stream: ServerHttp2Stream,
+            headers: IncomingHttpHeaders,
+            flags: number,
+            rawHeaders: string[],
+        ): boolean;
         emit(event: string | symbol, ...args: any[]): boolean;
         on(
             event: "connect",
@@ -1179,7 +1246,12 @@ declare module "http2" {
         ): this;
         on(
             event: "stream",
-            listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void,
+            listener: (
+                stream: ServerHttp2Stream,
+                headers: IncomingHttpHeaders,
+                flags: number,
+                rawHeaders: string[],
+            ) => void,
         ): this;
         on(event: string | symbol, listener: (...args: any[]) => void): this;
         once(
@@ -1191,7 +1263,12 @@ declare module "http2" {
         ): this;
         once(
             event: "stream",
-            listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void,
+            listener: (
+                stream: ServerHttp2Stream,
+                headers: IncomingHttpHeaders,
+                flags: number,
+                rawHeaders: string[],
+            ) => void,
         ): this;
         once(event: string | symbol, listener: (...args: any[]) => void): this;
         prependListener(
@@ -1203,7 +1280,12 @@ declare module "http2" {
         ): this;
         prependListener(
             event: "stream",
-            listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void,
+            listener: (
+                stream: ServerHttp2Stream,
+                headers: IncomingHttpHeaders,
+                flags: number,
+                rawHeaders: string[],
+            ) => void,
         ): this;
         prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
         prependOnceListener(
@@ -1215,7 +1297,12 @@ declare module "http2" {
         ): this;
         prependOnceListener(
             event: "stream",
-            listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void,
+            listener: (
+                stream: ServerHttp2Stream,
+                headers: IncomingHttpHeaders,
+                flags: number,
+                rawHeaders: string[],
+            ) => void,
         ): this;
         prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
     }
@@ -1384,7 +1471,12 @@ declare module "http2" {
         addListener(event: "sessionError", listener: (err: Error) => void): this;
         addListener(
             event: "stream",
-            listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void,
+            listener: (
+                stream: ServerHttp2Stream,
+                headers: IncomingHttpHeaders,
+                flags: number,
+                rawHeaders: string[],
+            ) => void,
         ): this;
         addListener(event: "timeout", listener: () => void): this;
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
@@ -1399,7 +1491,13 @@ declare module "http2" {
             session: ServerHttp2Session<Http1Request, Http1Response, Http2Request, Http2Response>,
         ): boolean;
         emit(event: "sessionError", err: Error): boolean;
-        emit(event: "stream", stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
+        emit(
+            event: "stream",
+            stream: ServerHttp2Stream,
+            headers: IncomingHttpHeaders,
+            flags: number,
+            rawHeaders: string[],
+        ): boolean;
         emit(event: "timeout"): boolean;
         emit(event: string | symbol, ...args: any[]): boolean;
         on(
@@ -1417,7 +1515,12 @@ declare module "http2" {
         on(event: "sessionError", listener: (err: Error) => void): this;
         on(
             event: "stream",
-            listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void,
+            listener: (
+                stream: ServerHttp2Stream,
+                headers: IncomingHttpHeaders,
+                flags: number,
+                rawHeaders: string[],
+            ) => void,
         ): this;
         on(event: "timeout", listener: () => void): this;
         on(event: string | symbol, listener: (...args: any[]) => void): this;
@@ -1436,7 +1539,12 @@ declare module "http2" {
         once(event: "sessionError", listener: (err: Error) => void): this;
         once(
             event: "stream",
-            listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void,
+            listener: (
+                stream: ServerHttp2Stream,
+                headers: IncomingHttpHeaders,
+                flags: number,
+                rawHeaders: string[],
+            ) => void,
         ): this;
         once(event: "timeout", listener: () => void): this;
         once(event: string | symbol, listener: (...args: any[]) => void): this;
@@ -1455,7 +1563,12 @@ declare module "http2" {
         prependListener(event: "sessionError", listener: (err: Error) => void): this;
         prependListener(
             event: "stream",
-            listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void,
+            listener: (
+                stream: ServerHttp2Stream,
+                headers: IncomingHttpHeaders,
+                flags: number,
+                rawHeaders: string[],
+            ) => void,
         ): this;
         prependListener(event: "timeout", listener: () => void): this;
         prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
@@ -1474,7 +1587,12 @@ declare module "http2" {
         prependOnceListener(event: "sessionError", listener: (err: Error) => void): this;
         prependOnceListener(
             event: "stream",
-            listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void,
+            listener: (
+                stream: ServerHttp2Stream,
+                headers: IncomingHttpHeaders,
+                flags: number,
+                rawHeaders: string[],
+            ) => void,
         ): this;
         prependOnceListener(event: "timeout", listener: () => void): this;
         prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
@@ -2195,8 +2313,8 @@ declare module "http2" {
          * will result in a `TypeError` being thrown.
          * @since v8.4.0
          */
-        writeHead(statusCode: number, headers?: OutgoingHttpHeaders): this;
-        writeHead(statusCode: number, statusMessage: string, headers?: OutgoingHttpHeaders): this;
+        writeHead(statusCode: number, headers?: OutgoingHttpHeaders | readonly string[]): this;
+        writeHead(statusCode: number, statusMessage: string, headers?: OutgoingHttpHeaders | readonly string[]): this;
         /**
          * Call `http2stream.pushStream()` with the given headers, and wrap the
          * given `Http2Stream` on a newly created `Http2ServerResponse` as the callback

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "24.7.9999",
+    "version": "24.8.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [

--- a/types/node/sea.d.ts
+++ b/types/node/sea.d.ts
@@ -150,4 +150,13 @@ declare module "node:sea" {
      * @since v20.12.0
      */
     function getRawAsset(key: AssetKey): ArrayBuffer;
+    /**
+     * This method can be used to retrieve an array of all the keys of assets
+     * embedded into the single-executable application.
+     * An error is thrown when not running inside a single-executable application.
+     * @since v24.8.0
+     * @returns An array containing all the keys of the assets
+     * embedded in the executable. If no assets are embedded, returns an empty array.
+     */
+    function getAssetKeys(): string[];
 }

--- a/types/node/stream.d.ts
+++ b/types/node/stream.d.ts
@@ -1656,6 +1656,7 @@ declare module "stream" {
             ref(): void;
             unref(): void;
         }
+        // TODO: these should all take webstream arguments
         /**
          * Returns whether the stream has encountered an error.
          * @since v17.3.0, v16.14.0
@@ -1664,8 +1665,15 @@ declare module "stream" {
         /**
          * Returns whether the stream is readable.
          * @since v17.4.0, v16.14.0
+         * @returns Only returns `null` if `stream` is not a valid `Readable`, `Duplex` or `ReadableStream`.
          */
-        function isReadable(stream: Readable | NodeJS.ReadableStream): boolean;
+        function isReadable(stream: Readable | NodeJS.ReadableStream): boolean | null;
+        /**
+         * Returns whether the stream is writable.
+         * @since v20.0.0
+         * @returns Only returns `null` if `stream` is not a valid `Writable`, `Duplex` or `WritableStream`.
+         */
+        function isWritable(stream: Writable | NodeJS.WritableStream): boolean | null;
     }
     export = Stream;
 }

--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -787,6 +787,22 @@ import { promisify } from "node:util";
             type: "pkcs8",
         },
     });
+
+    const slhdsaRes: {
+        publicKey: Buffer;
+        privateKey: string;
+    } = crypto.generateKeyPairSync("slh-dsa-sha2-128s", {
+        publicKeyEncoding: {
+            format: "der",
+            type: "spki",
+        },
+        privateKeyEncoding: {
+            cipher: "some-cipher",
+            format: "pem",
+            passphrase: "secret",
+            type: "pkcs8",
+        },
+    });
 }
 
 {
@@ -941,6 +957,21 @@ import { promisify } from "node:util";
         },
         (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: string) => {},
     );
+
+    crypto.generateKeyPair(
+        "slh-dsa-sha2-128s",
+        {
+            publicKeyEncoding: {
+                format: "pem",
+                type: "spki",
+            },
+            privateKeyEncoding: {
+                format: "pem",
+                type: "pkcs8",
+            },
+        },
+        (err: NodeJS.ErrnoException | null, publicKey: string, privateKey: string) => {},
+    );
 }
 
 {
@@ -1061,6 +1092,20 @@ import { promisify } from "node:util";
         publicKey: string;
         privateKey: string;
     }> = generateKeyPairPromisified("ml-kem-1024", {
+        publicKeyEncoding: {
+            format: "pem",
+            type: "spki",
+        },
+        privateKeyEncoding: {
+            format: "pem",
+            type: "pkcs8",
+        },
+    });
+
+    const slhdsaRes: Promise<{
+        publicKey: string;
+        privateKey: string;
+    }> = generateKeyPairPromisified("slh-dsa-sha2-128s", {
         publicKeyEncoding: {
             format: "pem",
             type: "spki",
@@ -1348,6 +1393,8 @@ import { promisify } from "node:util";
         key: jwk,
         dsaEncoding: "der",
     });
+
+    crypto.sign("slh-dsa-sha2-128s", Buffer.from("asd"), { key, context: Uint8Array.of(1, 2, 3, 4).buffer });
 }
 
 {

--- a/types/node/test/http2.ts
+++ b/types/node/test/http2.ts
@@ -71,7 +71,10 @@ import { URL } from "node:url";
     http2Session.on("goaway", (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => {});
     http2Session.on("localSettings", (settings: Settings) => {});
     http2Session.on("remoteSettings", (settings: Settings) => {});
-    http2Session.on("stream", (stream: Http2Stream, headers: IncomingHttpHeaders, flags: number) => {});
+    http2Session.on(
+        "stream",
+        (stream: Http2Stream, headers: IncomingHttpHeaders, flags: number, rawHeaders: string[]) => {},
+    );
     http2Session.on("timeout", () => {});
     http2Session.on("ping", () => {});
 
@@ -179,9 +182,12 @@ import { URL } from "node:url";
     const clientHttp2Stream: ClientHttp2Stream = {} as any;
     clientHttp2Stream.on("headers", (headers: IncomingHttpHeaders, flags: number) => {});
     clientHttp2Stream.on("push", (headers: IncomingHttpHeaders, flags: number) => {});
-    clientHttp2Stream.on("response", (headers: IncomingHttpHeaders & IncomingHttpStatusHeader, flags: number) => {
-        const s: number = headers[":status"]!;
-    });
+    clientHttp2Stream.on(
+        "response",
+        (headers: IncomingHttpHeaders & IncomingHttpStatusHeader, flags: number, rawHeaders: string[]) => {
+            const s: number = headers[":status"]!;
+        },
+    );
 
     // ServerHttp2Stream
     const serverHttp2Stream: ServerHttp2Stream = {} as any;
@@ -237,7 +243,10 @@ import { URL } from "node:url";
         server.on("sessionError", (err: Error) => {});
         server.on("session", (session: ServerHttp2Session) => {});
         server.on("checkContinue", (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => {});
-        server.on("stream", (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => {});
+        server.on(
+            "stream",
+            (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number, rawHeaders: string[]) => {},
+        );
         server.on("request", (request: Http2ServerRequest, response: Http2ServerResponse) => {});
         server.on("timeout", () => {});
         server.setTimeout().setTimeout(5).setTimeout(5, () => {});
@@ -336,6 +345,7 @@ import { URL } from "node:url";
         response.writeHead(200, outgoingHeaders);
         response.writeHead(200, "OK", outgoingHeaders);
         response.writeHead(200, "OK");
+        response.writeHead(200, ["x-dts-library", "@types/node"]);
         response.write("");
         response.write("", (err: Error) => {});
         response.write("", "utf8");

--- a/types/node/test/sea.ts
+++ b/types/node/test/sea.ts
@@ -1,4 +1,4 @@
-import { getAsset, getAssetAsBlob, getRawAsset, isSea } from "node:sea";
+import { getAsset, getAssetAsBlob, getAssetKeys, getRawAsset, isSea } from "node:sea";
 
 {
     // $ExpectType boolean
@@ -14,4 +14,7 @@ import { getAsset, getAssetAsBlob, getRawAsset, isSea } from "node:sea";
 
     // $ExpectType ArrayBuffer
     getRawAsset("d.webm");
+
+    // $ExpectType string[]
+    getAssetKeys();
 }

--- a/types/node/test/stream.ts
+++ b/types/node/test/stream.ts
@@ -6,6 +6,7 @@ import {
     finished,
     isErrored,
     isReadable,
+    isWritable,
     pipeline,
     Readable,
     Transform,
@@ -571,8 +572,10 @@ addAbortSignal(new AbortSignal(), new Readable());
 }
 
 {
-    isReadable(new Readable()); // $ExpectType boolean
-    isReadable(new Duplex()); // $ExpectType boolean
+    isReadable(new Readable()); // $ExpectType boolean | null
+    isReadable(new Duplex()); // $ExpectType boolean | null
+    isWritable(new Writable()); // $ExpectType boolean | null
+    isWritable(new Duplex()); // $ExpectType boolean | null
 }
 
 {

--- a/types/node/test/vm.ts
+++ b/types/node/test/vm.ts
@@ -147,10 +147,10 @@ import {
         if (specifier === "foo") {
             return new SourceTextModule(
                 `
-                // The "secret" variable refers to the global variable we added to
-                // "contextifiedObject" when creating the context.
-                export default secret;
-            `,
+                    // The "secret" variable refers to the global variable we added to
+                    // "contextifiedObject" when creating the context.
+                    export default secret;
+                `,
                 { context: referencingModule.context },
             );
         }
@@ -167,6 +167,56 @@ import {
         // $ExpectType ImportPhase
         request.phase;
     }
+});
+
+(async () => {
+    const contextifiedObject = createContext({
+        secret: 42,
+        print: console.log,
+    });
+
+    const rootModule = new SourceTextModule(
+        `
+            import s from 'foo';
+            s;
+            print(s);
+        `,
+        { context: contextifiedObject },
+    );
+
+    const moduleMap = new Map([
+        ["root", rootModule],
+    ]);
+
+    function resolveAndLinkDependencies(module: SourceTextModule) {
+        const requestedModules = module.moduleRequests.map((request) => {
+            const specifier = request.specifier;
+
+            let requestedModule = moduleMap.get(specifier);
+            if (requestedModule === undefined) {
+                requestedModule = new SourceTextModule(
+                    `
+                        // The "secret" variable refers to the global variable we added to
+                        // "contextifiedObject" when creating the context.
+                        export default secret;
+                    `,
+                    { context: rootModule.context },
+                );
+                moduleMap.set(specifier, requestedModule);
+
+                resolveAndLinkDependencies(requestedModule);
+            }
+
+            return requestedModule;
+        });
+
+        module.linkRequests(requestedModules);
+    }
+
+    resolveAndLinkDependencies(rootModule);
+    rootModule.instantiate();
+
+    await rootModule.evaluate();
 });
 
 (async () => {

--- a/types/node/test/worker_threads.ts
+++ b/types/node/test/worker_threads.ts
@@ -76,6 +76,9 @@ import { createContext } from "node:vm";
     w.getHeapStatistics().then(statistics => {
         statistics; // $ExpectType HeapInfo
     });
+    w.startCpuProfile().then(handle => {
+        handle.stop().then(JSON.parse);
+    });
     w.terminate().then(() => {
         // woot
     });

--- a/types/node/v8.d.ts
+++ b/types/node/v8.d.ts
@@ -401,6 +401,22 @@ declare module "v8" {
      */
     function getHeapCodeStatistics(): HeapCodeStatistics;
     /**
+     * @since v24.8.0
+     */
+    interface CPUProfileHandle {
+        /**
+         * Stopping collecting the profile, then return a Promise that fulfills with an error or the
+         * profile data.
+         * @since v24.8.0
+         */
+        stop(): Promise<string>;
+        /**
+         * Stopping collecting the profile and the profile will be discarded.
+         * @since v24.8.0
+         */
+        [Symbol.asyncDispose](): Promise<void>;
+    }
+    /**
      * V8 only supports `Latin-1/ISO-8859-1` and `UTF16` as the underlying representation of a string.
      * If the `content` uses `Latin-1/ISO-8859-1` as the underlying representation, this function will return true;
      * otherwise, it returns false.

--- a/types/node/worker_threads.d.ts
+++ b/types/node/worker_threads.d.ts
@@ -62,7 +62,7 @@ declare module "worker_threads" {
     import { Readable, Writable } from "node:stream";
     import { ReadableStream, TransformStream, WritableStream } from "node:stream/web";
     import { URL } from "node:url";
-    import { HeapInfo } from "node:v8";
+    import { CPUProfileHandle, HeapInfo } from "node:v8";
     import { MessageEvent } from "undici-types";
     const isInternalThread: boolean;
     const isMainThread: boolean;
@@ -469,6 +469,44 @@ declare module "worker_threads" {
          * @since v24.0.0
          */
         getHeapStatistics(): Promise<HeapInfo>;
+        /**
+         * Starting a CPU profile then return a Promise that fulfills with an error
+         * or an `CPUProfileHandle` object. This API supports `await using` syntax.
+         *
+         * ```js
+         * const { Worker } = require('node:worker_threads');
+         *
+         * const worker = new Worker(`
+         *   const { parentPort } = require('worker_threads');
+         *   parentPort.on('message', () => {});
+         *   `, { eval: true });
+         *
+         * worker.on('online', async () => {
+         *   const handle = await worker.startCpuProfile();
+         *   const profile = await handle.stop();
+         *   console.log(profile);
+         *   worker.terminate();
+         * });
+         * ```
+         *
+         * `await using` example.
+         *
+         * ```js
+         * const { Worker } = require('node::worker_threads');
+         *
+         * const w = new Worker(`
+         *   const { parentPort } = require('worker_threads');
+         *   parentPort.on('message', () => {});
+         *   `, { eval: true });
+         *
+         * w.on('online', async () => {
+         *   // Stop profile automatically when return and profile will be discarded
+         *   await using handle = await w.startCpuProfile();
+         * });
+         * ```
+         * @since v24.8.0
+         */
+        startCpuProfile(): Promise<CPUProfileHandle>;
         /**
          * Calls `worker.terminate()` when the dispose scope is exited.
          *


### PR DESCRIPTION
- **crypto:** add Argon2 Web Cryptography algorithms
- **crypto:** add KMAC Web Cryptography algorithms
- **crypto:** support Ed448 and ML-DSA context parameter in Web Cryptography
- **crypto:** support SLH-DSA KeyObject, sign, and verify
- **diagnostics_channel:** revoke DEP0163
- **doc:** improve documentation for raw headers in HTTP/2 APIs
- **sea:** implement sea.getAssetKeys()
- **stream:** fix isReadable and isWritable return type value
- **worker:** add cpu profile APIs for worker
- **vm:** sync-ify SourceTextModule linkage