### PR TITLE
[chrome] Change InstalledDetails.reason's type to the underlying enum

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -8835,7 +8835,7 @@ declare namespace chrome {
 
         export interface InstalledDetails {
             /** The reason that this event is being dispatched. */
-            reason: `${OnInstalledReason}`;
+            reason: OnInstalledReason;
             /** Indicates the previous version of the extension, which has just been updated. This is present only if 'reason' is 'update'. */
             previousVersion?: string;
             /** Indicates the ID of the imported shared module extension which updated. This is present only if 'reason' is 'shared_module_update'. */

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -842,7 +842,7 @@ function testRuntime() {
     checkChromeEvent(chrome.runtime.onInstalled, (details) => {
         details.id; // $ExpectType string | undefined
         details.previousVersion; // $ExpectType string | undefined
-        details.reason; // $ExpectType "install" | "update" | "chrome_update" | "shared_module_update"
+        details.reason; // $ExpectType OnInstalledReason
     });
 
     checkChromeEvent(chrome.runtime.onMessage, (message, sender, sendResponse) => {


### PR DESCRIPTION
It should be an enum, otherwise perfect code like the following:

    chrome.runtime.onInstalled.addListener(async (details) => {
      if (details.reason === chrome.runtime.OnInstalledReason.INSTALL) {}
    }

triggers:

    error  The two values in this comparison do not have a shared enum type  @typescript-eslint/no-unsafe-enum-comparison

Reference: https://developer.chrome.com/docs/extensions/reference/api/runtime#type-OnInstalledReason

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
