### PR TITLE
feat(@types/react): add Trusted Types support for {ScriptHTMLAttributes, SVGAttributes, IframeHTMLAttributes}

### DIFF
--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -158,7 +158,10 @@ interface TouchList {}
 interface WebGLRenderingContext {}
 interface WebGL2RenderingContext {}
 
+// See: https://www.w3.org/TR/trusted-types/
 interface TrustedHTML {}
+interface TrustedScript {}
+interface TrustedScriptURL {}
 
 interface Blob {}
 interface MediaStream {}

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2921,7 +2921,7 @@ declare namespace React {
         sizes?: string | undefined;
         span?: number | undefined;
         src?: string | undefined;
-        srcDoc?: string | undefined;
+        srcDoc?: string | TrustedHTML | undefined;
         srcLang?: string | undefined;
         srcSet?: string | undefined;
         start?: number | undefined;
@@ -3095,7 +3095,7 @@ declare namespace React {
         scrolling?: string | undefined;
         seamless?: boolean | undefined;
         src?: string | undefined;
-        srcDoc?: string | undefined;
+        srcDoc?: string | TrustedHTML | undefined;
         width?: number | string | undefined;
     }
 
@@ -3403,7 +3403,7 @@ declare namespace React {
         integrity?: string | undefined;
         noModule?: boolean | undefined;
         referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
-        src?: string | undefined;
+        src?: string | TrustedScriptURL | undefined;
         type?: string | undefined;
     }
 
@@ -3663,7 +3663,7 @@ declare namespace React {
         hanging?: number | string | undefined;
         horizAdvX?: number | string | undefined;
         horizOriginX?: number | string | undefined;
-        href?: string | undefined;
+        href?: string | TrustedScriptURL | undefined;
         ideographic?: number | string | undefined;
         imageRendering?: number | string | undefined;
         in2?: number | string | undefined;
@@ -3805,7 +3805,7 @@ declare namespace React {
         xHeight?: number | string | undefined;
         xlinkActuate?: string | undefined;
         xlinkArcrole?: string | undefined;
-        xlinkHref?: string | undefined;
+        xlinkHref?: string | TrustedScriptURL | undefined;
         xlinkRole?: string | undefined;
         xlinkShow?: string | undefined;
         xlinkTitle?: string | undefined;

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -569,9 +569,16 @@ React.createElement(
     }),
 );
 
+// Trusted types-related tests.
 declare const window: Window;
 const trustedTypes = window.trustedTypes!;
+const trustedTypesPolicy = trustedTypes.createPolicy("react-test", {
+    createScript: (s) => s,
+    createScriptURL: (s) => s,
+});
 const trustedHtml = trustedTypes.emptyHTML;
+const trustedScript = trustedTypesPolicy.createScript("");
+const trustedScriptURL = trustedTypesPolicy.createScriptURL("");
 
 const trustedTypesHTMLAttr: React.HTMLProps<HTMLElement> = {
     dangerouslySetInnerHTML: {
@@ -580,6 +587,52 @@ const trustedTypesHTMLAttr: React.HTMLProps<HTMLElement> = {
 };
 React.createElement("div", trustedTypesHTMLAttr);
 React.createElement("span", trustedTypesHTMLAttr);
+
+// Test Trusted Types specific attributes
+const trustedTypesIframeAttr: React.IframeHTMLAttributes<HTMLIFrameElement> = {
+    srcDoc: trustedHtml,
+};
+React.createElement("iframe", trustedTypesIframeAttr);
+
+const trustedTypesScriptAttr: React.ScriptHTMLAttributes<HTMLScriptElement> = {
+    src: trustedScriptURL,
+};
+React.createElement("script", trustedTypesScriptAttr);
+
+const trustedTypesSvgAAttr: React.SVGAttributes<SVGElement> = {
+    href: trustedScriptURL,
+    xlinkHref: trustedScriptURL,
+};
+React.createElement(
+    "svg",
+    null,
+    React.createElement("a", trustedTypesSvgAAttr),
+);
+
+const trustedTypesSvgUseAttr: React.SVGAttributes<SVGUseElement> = {
+    href: trustedScriptURL,
+    xlinkHref: trustedScriptURL,
+};
+React.createElement(
+    "svg",
+    null,
+    React.createElement("use", trustedTypesSvgUseAttr),
+);
+
+// Ensure string types still work
+const stringIframeAttr: React.IframeHTMLAttributes<HTMLIFrameElement> = {
+    srcDoc: "<iframe>content</iframe>",
+};
+React.createElement("iframe", stringIframeAttr);
+const stringScriptAttr: React.ScriptHTMLAttributes<HTMLScriptElement> = {
+    src: "script.js",
+};
+React.createElement("script", stringScriptAttr);
+const stringSvgAAttr: React.SVGAttributes<SVGElement> = {
+    href: "link.svg",
+    xlinkHref: "link.svg",
+};
+React.createElement("svg", null, React.createElement("a", stringSvgAAttr));
 
 //
 // React.Children


### PR DESCRIPTION
Align React's DOM/JSX type definitions with the W3C Trusted Types
specification to improve type safety and help prevent DOM-based
Cross-Site Scripting (XSS) vulnerabilities at compile time.

RATIONALE:

Trusted Types is a Web browser security feature that helps prevent DOM
XSS by ensuring that potentially dangerous DOM "sinks" (functions or
properties like `innerHTML` or `script.src`) only accept values that
have been explicitly vetted and marked as trusted.

- Sink: A DOM property or function that can execute arbitrary code or
  render HTML if passed unsanitized strings (e.g., `innerHTML`,
  `script.src`, `iframe.srcdoc`, `eval`).

- `TrustedHTML`: Represents an HTML string that is safe to insert into an
  HTML sink.

- `TrustedScript`: Represents a JavaScript code string that is safe to
  execute in a script sink.

- `TrustedScriptURL`: Represents a URL string that is safe to use as the
  source for loading executable script code.

CHANGELOG:

1.  Defined `TrustedScript` and `TrustedScriptURL` interfaces in
    `global.d.ts` (alongside the existing `TrustedHTML`).
2.  The `srcDoc` attribute (e.g. `IframeHTMLAttributes`) now accepts
    `TrustedHTML`.
3.  The `src` attribute on `ScriptHTMLAttributes` now accepts
    `TrustedScriptURL`.
4.  The `href` and `xlinkHref` attributes on `SVGAttributes` accept
    `TrustedScriptURL`.

This allows developers using environments where Trusted Types are
enforced (via Content Security Policy) to pass Trusted Type objects
directly to these props without type errors, encouraging safer coding
practices.

REFERENCES:

- [W3C Trusted Types Specification](https://www.w3.org/TR/trusted-types/)
- [MDN Web Docs - Trusted Types API](https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API)
- [Content Security Policy 3](https://www.w3.org/TR/CSP3/)
