### PR TITLE
feat(nodemailer): flatten nested groups return for addressparser

### DIFF
--- a/types/nodemailer/lib/addressparser/index.d.ts
+++ b/types/nodemailer/lib/addressparser/index.d.ts
@@ -6,7 +6,7 @@ declare namespace addressparser {
 
     interface Group {
         name: string;
-        group: AddressOrGroup[];
+        group: Address[];
     }
 
     type AddressOrGroup = Address | Group;

--- a/types/nodemailer/nodemailer-tests.ts
+++ b/types/nodemailer/nodemailer-tests.ts
@@ -1543,13 +1543,9 @@ async function mailcomposer_build_promise_test() {
 
 // addressparser
 
-function isAddress(addressOrGroup: addressparser.AddressOrGroup): addressOrGroup is addressparser.Address {
-    return (addressOrGroup as addressparser.Address).address !== undefined;
-}
+declare function isAddress(arg: unknown): arg is addressparser.Address;
 
-function isGroup(addressOrGroup: addressparser.AddressOrGroup): addressOrGroup is addressparser.Group {
-    return (addressOrGroup as addressparser.Group).group !== undefined;
-}
+declare function isGroup(arg: unknown): arg is addressparser.Group;
 
 function addressparser_test() {
     const input = "andris@tr.ee";
@@ -1559,7 +1555,7 @@ function addressparser_test() {
         const address: string = firstResult.address;
         const name: string = firstResult.name;
     } else if (isGroup(firstResult)) {
-        const group: addressparser.AddressOrGroup[] = firstResult.group;
+        const group: addressparser.Address[] = firstResult.group;
         const name: string = firstResult.name;
     }
 }


### PR DESCRIPTION
See https://github.com/nodemailer/nodemailer/commit/8f8a77c67f0ba94ddf4e16c68f604a5920fb5d26. The test file update in `test/addressparser/addressparser-test.js` shows how the return shape is changed.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
