### PR TITLE
[pdfmake] Make TableCell definition more strict to prevent unsafe use

### DIFF
--- a/types/pdfmake/interfaces.d.ts
+++ b/types/pdfmake/interfaces.d.ts
@@ -521,7 +521,7 @@ export interface TableCellProperties {
  * - Use empty objects (`{}`) as placeholders for cells that are covered by other cells
  *   spanning multiple rows or columns.
  */
-export type TableCell = {} | (Content & TableCellProperties);
+export type TableCell = Record<PropertyKey, never> | (Content & TableCellProperties);
 
 /**
  * A table.

--- a/types/pdfmake/test/pdfmake-interfaces-tests.ts
+++ b/types/pdfmake/test/pdfmake-interfaces-tests.ts
@@ -8,6 +8,7 @@ import {
     ContentUnorderedList,
     CustomTableLayout,
     Table,
+    TableCell,
     TDocumentDefinitions,
 } from "pdfmake/interfaces";
 
@@ -292,6 +293,18 @@ const tableHeights: Table = {
     body: [],
     heights: [100, "auto"],
 };
+
+const tableCells: TableCell[] = [
+    {},
+    "test",
+    100,
+    { text: "test" },
+    { ol: [] },
+    // @ts-expect-error
+    { invalidContentProperty: "" },
+    // @ts-expect-error
+    Promise.resolve("test"),
+];
 
 // via https://pdfmake.github.io/docs/0.1/document-definition-object/patterns/
 const tilingPatterns: TDocumentDefinitions = {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Official docs suggest using an "empty cell" for cells covered with `rowSpan`/`colSpan`: https://pdfmake.github.io/docs/0.1/document-definition-object/tables/#colspan-and-rowspan
  - Current type definitions suggest using an empty object in the same situation: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/7eba7127f78cba041c757df2dedc07e1e59991b9/types/pdfmake/interfaces.d.ts#L521
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.