### PR TITLE
feat: Add an `abort` method to the return value of `GM.xmlHttpRequest`

### DIFF
--- a/types/tampermonkey/index.d.ts
+++ b/types/tampermonkey/index.d.ts
@@ -199,6 +199,8 @@ declare namespace Tampermonkey {
         abort(): TReturn;
     }
 
+    type PromiseWithAbort<T> = Promise<T> & AbortHandle<void>;
+
     interface OpenTabOptions {
         /** A boolean value indicating whether the new tab should be active (selected) or not (default is `false`). */
         active?: boolean;
@@ -1125,7 +1127,7 @@ declare var GM: Readonly<{
     xmlHttpRequest<TContext = any>(
         // onload and the like still work
         details: Tampermonkey.Request<TContext>, // eslint-disable-line @definitelytyped/no-unnecessary-generics
-    ): Promise<Tampermonkey.Response<TContext>>;
+    ): Tampermonkey.PromiseWithAbort<Tampermonkey.Response<TContext>>;
 
     // GM_download has two signatures, GM.download has one
     /**

--- a/types/tampermonkey/package.json
+++ b/types/tampermonkey/package.json
@@ -26,6 +26,10 @@
         {
             "name": "double-beep",
             "githubUsername": "double-beep"
+        },
+        {
+            "name": "ziuchen",
+            "githubUsername": "ziuchen"
         }
     ]
 }

--- a/types/tampermonkey/tampermonkey-tests.ts
+++ b/types/tampermonkey/tampermonkey-tests.ts
@@ -658,6 +658,15 @@ unsafeWindow.GM;
     // $ExpectType string
     minResponse.responseText;
 
+    // Test abort method on promise
+    const abortableRequest = GM.xmlHttpRequest({
+        url: "https://github.com/",
+        method: "GET",
+    });
+    // $ExpectType void
+    abortableRequest.abort();
+    const abortedResponse = await abortableRequest;
+
     // GET request
     await GM.xmlHttpRequest({
         method: "GET",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

API Reference:
https://www.tampermonkey.net/documentation.php?ext=dhdg#api:GM_xmlhttpRequest
