### PR TITLE
feat(node): add Uint8Array base64/hex helpers

### DIFF
--- a/types/node/globals.d.ts
+++ b/types/node/globals.d.ts
@@ -168,3 +168,13 @@ declare namespace NodeJS {
         [Symbol.asyncIterator](): NodeJS.AsyncIterator<T, TReturn, TNext>;
     }
 }
+
+interface Uint8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> {
+    toBase64(): string;
+    toHex(): string;
+}
+
+interface Uint8ArrayConstructor {
+    fromBase64(data: string): Uint8Array<ArrayBufferLike>;
+    fromHex(data: string): Uint8Array<ArrayBufferLike>;
+}

--- a/types/node/test/globals.ts
+++ b/types/node/test/globals.ts
@@ -95,3 +95,12 @@ declare var RANDOM_GLOBAL_VARIABLE: true;
     // @ts-expect-error The pseudoglobal `NodeJS` namespace should not be addressable outside ambient contexts
     NodeJS;
 }
+
+{
+    const bytes = new Uint8Array([0, 255]);
+    bytes.toBase64(); // $ExpectType string
+    bytes.toHex(); // $ExpectType string
+
+    Uint8Array.fromBase64(bytes.toBase64()); // $ExpectType Uint8Array<ArrayBufferLike>
+    Uint8Array.fromHex(bytes.toHex()); // $ExpectType Uint8Array<ArrayBufferLike>
+}


### PR DESCRIPTION
## Summary
- add Node 25 helpers `Uint8Array.prototype.toBase64`, `Uint8Array.prototype.toHex`, `Uint8Array.fromBase64`, and `Uint8Array.fromHex`
- extend the globals test suite to assert the string return values and constructor types
- align the Node typings with the runtime that already exposes these helpers in Node.js 25

## Test Plan
- unable to run `pnpm test types/node` in this environment (pnpm via npx stops because the workspace lacks a generated lockfile); change is limited to ambient declarations and dtslint coverage
