### PR TITLE
feat(rails__actioncable): update to v8.0 with simplified API

### DIFF
--- a/types/rails__actioncable/index.d.ts
+++ b/types/rails__actioncable/index.d.ts
@@ -1,221 +1,54 @@
 export as namespace ActionCable;
 
-export enum MessageTypes {
-    confirmation = "confirm_subscription",
-    disconnect = "disconnect",
-    ping = "ping",
-    rejection = "reject_subscription",
-    welcome = "welcome",
-}
-
-export enum DisconnectReasons {
-    invalid_request = "invalid_request",
-    server_restart = "server_restart",
-    unauthorized = "unauthorized",
-}
-
-export interface Mixin {
-    appear?(): void;
-    away?(): void;
-    connected?(): void;
-    disconnected?(): void;
-    initialized?(): void;
-    install?(): void;
-    rejected?(): void;
-    uninstall?(): void;
-    update?(): void;
-
-    received?(data: any): void;
-
-    readonly documentIsActive?: boolean | undefined;
-    readonly appearingOn?: string | null | undefined;
-
-    [key: string]: any;
-}
-
 export interface ChannelNameWithParams {
     channel: string;
     [key: string]: any;
 }
 
 /**
- * @see https://github.com/rails/rails/blob/main/actioncable/app/javascript/action_cable/internal.js
- */
-export const INTERNAL: {
-    default_mount_path: "/cable";
-    disconnect_reasons: typeof DisconnectReasons;
-    message_types: typeof MessageTypes;
-    protocols: ["actioncable-v1-json", "actioncable-unsupported"];
-};
-
-/**
- * @see https://github.com/rails/rails/blob/main/actioncable/app/javascript/action_cable/connection.js
- */
-export class Connection<C = Consumer> {
-    constructor(consumer: C);
-
-    readonly consumer: C;
-
-    readonly subscriptions: Subscriptions<C>;
-
-    readonly monitor: ConnectionMonitor<C>;
-
-    readonly disconnected: boolean;
-
-    send(data: object): boolean;
-
-    open(this: Connection<C>): boolean;
-
-    close(options?: { allowReconnect: boolean }): any;
-
-    reopen(): void;
-
-    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-    getProtocol(): void | string;
-
-    isOpen(): boolean;
-
-    isActive(): boolean;
-
-    static readonly reopenDelay: number;
-
-    static readonly events: {
-        message(event: {
-            data: {
-                identifier: string;
-                message: string;
-                reason: DisconnectReasons;
-                reconnect: boolean;
-                type: MessageTypes;
-            };
-        }): any;
-
-        open(): void;
-
-        close(): void;
-
-        error(): void;
-    };
-}
-
-/**
- * @see https://github.com/rails/rails/blob/main/actioncable/app/javascript/action_cable/connection_monitor.js
- */
-export class ConnectionMonitor<C = Consumer> {
-    constructor(connection: C);
-
-    readonly connection: C;
-
-    readonly reconnectAttempts: number;
-
-    start(): void;
-
-    stop(): void;
-
-    isRunning(): boolean;
-
-    recordPing(): void;
-
-    recordConnect(): void;
-
-    recordDisconnect(): void;
-
-    visibilityDidChange(this: ConnectionMonitor<C>): void;
-
-    static readonly staleThreshold: number;
-
-    static readonly reconnectionBackoffRate: number;
-}
-
-/**
- * @see https://github.com/rails/rails/blob/main/actioncable/app/javascript/action_cable/consumer.js
+ * @see https://github.com/rails/rails/blob/8-0-stable/actioncable/app/javascript/action_cable/consumer.js
  */
 export class Consumer {
+    readonly subscriptions: Subscriptions;
+
     constructor(url: string);
-
-    readonly subscriptions: Subscriptions<this>;
-
-    readonly connection: Connection<this>;
-
     get url(): string;
-
-    send(data: object): boolean;
-
     connect(): boolean;
+    disconnect(): void;
+}
 
-    disconnect(): any;
-
-    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-    ensureActiveConnection(): void | boolean;
+export interface BaseMixin {
+    connected?(arg: { reconnected: boolean }): void;
+    disconnected?(arg: { willAttemptReconnect: boolean | undefined }): void;
+    initialized?(): void;
+    rejected?(): void;
+    received?(data: any): void;
 }
 
 /**
- * @see https://github.com/rails/rails/blob/main/actioncable/app/javascript/action_cable/subscription.js
+ * @see https://github.com/rails/rails/blob/8-0-stable/actioncable/app/javascript/action_cable/subscription.js
  */
-export class Subscription<C = Consumer> {
-    constructor(consumer: C, params?: object, mixin?: Mixin);
-
-    readonly consumer: C;
-
+export class Subscription<M extends BaseMixin = BaseMixin> {
     readonly identifier: string;
 
+    constructor(consumer: Consumer, params: ChannelNameWithParams, mixin: M);
     perform(action: string, data?: object): boolean;
-
-    send(data: object): boolean;
-
     unsubscribe(): this;
 }
 
 /**
- * @see https://github.com/rails/rails/blob/main/actioncable/app/javascript/action_cable/subscriptions.js
+ * @see https://github.com/rails/rails/blob/8-0-stable/actioncable/app/javascript/action_cable/subscriptions.js
  */
-export class Subscriptions<C = Consumer> {
-    constructor(consumer: C);
-
-    readonly consumer: C;
-
-    readonly subscriptions: Array<Subscription<C>>;
-
-    create<M>(channelName: string | ChannelNameWithParams, mixin?: Mixin & M): Subscription<C> & Mixin & M;
-
-    private add<T extends Subscription>(subscription: T): T;
-
-    private remove<T extends Subscription>(subscription: T): T;
-
-    private reject(identifier: string): Subscription[];
-
-    private forget<T extends Subscription>(subscription: T): T;
-
-    private findAll(identifier: string): Subscription[];
-
-    private reload(): Subscription[];
-
-    private notifyAll(callbackName: string, ...args: any): Subscription[];
-
-    private notify(subscription: Subscription, callbackName: string, ...args: any): Subscription[];
-
-    private subscribe(subscription: Subscription): void;
-
-    private confirmSubscription(identifier: string): void;
-
-    private sendCommand(subscription: Subscription, command: any): boolean;
+export class Subscriptions {
+    constructor(consumer: Consumer);
+    create<M extends BaseMixin = {}>(
+        channelName: string | ChannelNameWithParams,
+        mixin?: M & ThisType<Subscription & M>,
+    ): Subscription & M;
 }
 
 /**
- * @see https://github.com/rails/rails/blob/main/actioncable/app/javascript/action_cable/adapters.js
- */
-export const adapters: {
-    logger: Console;
-    WebSocket: WebSocket;
-};
-
-/**
- * @see https://github.com/rails/rails/blob/main/actioncable/app/javascript/action_cable/consumer.js
- */
-export function createWebSocketURL(url: string): string;
-
-/**
- * @see https://github.com/rails/rails/blob/main/actioncable/app/javascript/action_cable/logger.js
+ * @see https://github.com/rails/rails/blob/8-0-stable/actioncable/app/javascript/action_cable/logger.js
  */
 export const logger: {
     log(...messages: any[]): void;
@@ -223,8 +56,6 @@ export const logger: {
 };
 
 /**
- * @see https://github.com/rails/rails/blob/main/actioncable/app/javascript/action_cable/index.js
+ * @see https://github.com/rails/rails/blob/8-0-stable/actioncable/app/javascript/action_cable/index.js
  */
 export function createConsumer(url?: string | (() => string)): Consumer;
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-export function getConfig(name: string): string | void;

--- a/types/rails__actioncable/package.json
+++ b/types/rails__actioncable/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/rails__actioncable",
-    "version": "6.1.9999",
+    "version": "8.0.9999",
     "projects": [
         "https://github.com/rails/rails/blob/main/actioncable/app/javascript/action_cable"
     ],
@@ -12,6 +12,10 @@
         {
             "name": "Martin Badin",
             "githubUsername": "martin-badin"
+        },
+        {
+            "name": "Shunichi Ikegami",
+            "githubUsername": "shunichi"
         }
     ]
 }

--- a/types/rails__actioncable/rails__actioncable-tests.ts
+++ b/types/rails__actioncable/rails__actioncable-tests.ts
@@ -1,193 +1,66 @@
-import {
-    Connection,
-    ConnectionMonitor,
-    Consumer,
-    createConsumer,
-    createWebSocketURL,
-    DisconnectReasons,
-    INTERNAL,
-    logger,
-    MessageTypes,
-    Subscription,
-    Subscriptions,
-} from "@rails/actioncable";
+import { createConsumer, logger } from "@rails/actioncable";
 
-INTERNAL.message_types.welcome;
-INTERNAL.message_types.disconnect;
-INTERNAL.message_types.ping;
-INTERNAL.message_types.confirmation;
-INTERNAL.message_types.rejection;
-
-INTERNAL.disconnect_reasons.unauthorized;
-INTERNAL.disconnect_reasons.invalid_request;
-INTERNAL.disconnect_reasons.server_restart;
-
-createWebSocketURL("url"); // $ExpectType string
 logger.enabled = true;
 
-/**
- * Consumer
- */
-const consumer = new Consumer("url"); // $ExpectType Consumer
-createConsumer("url"); // $ExpectType Consumer
+const consumer = createConsumer("url"); // $ExpectType Consumer
 createConsumer(() => "url"); // $ExpectType Consumer
 
 consumer.url; // $ExpectType string
 
-consumer.send({}); // $ExpectType boolean
 consumer.connect(); // $ExpectType boolean
-consumer.disconnect(); // $ExpectType any
-consumer.ensureActiveConnection(); // $ExpectType boolean | void
+consumer.disconnect(); // $ExpectType void
 
 {
     const subscription = consumer.subscriptions.create(
         { channel: "channel", room: "room", chat_id: 1 },
         {
-            received(data) {
-                this.appendLine(data);
-            },
-            appendLine(data: any) {
-                const html = this.createLine(data);
-                const element = document.querySelector("[data-chat-room='Best Room']");
-
-                if (element) {
-                    element.insertAdjacentHTML("beforeend", html);
-                }
-            },
-            createLine(data: any) {
-                return `
-                    <article class="chat-line">
-                        <span class="speaker">${data["sent_by"]}</span>
-                        <span class="body">${data["body"]}</span>
-                    </article>
-                `;
-            },
             initialized() {
-                this.update = this.update.bind(this);
             },
-            connected() {
-                this.install();
+            connected(_arg: { reconnected: boolean }) {
                 this.update();
             },
-            disconnected() {
-                this.uninstall();
+            disconnected(_arg: { willAttemptReconnect: boolean | undefined }) {
             },
             rejected() {
-                this.uninstall();
+            },
+            received(data: any) {
+                this.appendLine(data);
+            },
+
+            isActive: true,
+            appendLine(_data: any) {
             },
             update() {
-                if (this.documentIsActive) {
+                const active = this.isActive; // $ExpectType boolean
+                if (active) {
                     this.appear();
                 } else {
                     this.away();
                 }
             },
             appear() {
-                this.perform("appear", { appearing_on: this.appearingOn });
+                this.perform("appear"); // $ExpectType boolean
             },
             away() {
-                this.perform("away");
-            },
-            install() {
-                window.addEventListener("focus", this.update);
-                window.addEventListener("blur", this.update);
-                document.addEventListener("turbolinks:load", this.update);
-                document.addEventListener("visibilitychange", this.update);
-            },
-            uninstall() {
-                window.removeEventListener("focus", this.update);
-                window.removeEventListener("blur", this.update);
-                document.removeEventListener("turbolinks:load", this.update);
-                document.removeEventListener("visibilitychange", this.update);
+                this.perform("away"); // $ExpectType boolean
             },
         },
     );
 
-    subscription.uninstall();
     subscription.away();
-    subscription.update();
+    subscription.perform("action"); // $ExpectType boolean
+    subscription.perform("action", {}); // $ExpectType boolean
+    subscription.unsubscribe();
+
+    // @ts-expect-error (typo)
+    subscription.apear();
 }
 
-/**
- * Connection
- */
-Connection.reopenDelay; // $ExpectType number
-// $ExpectType any
-Connection.events.message({
-    data: {
-        identifier: "string",
-        message: "message",
-        reason: DisconnectReasons.invalid_request,
-        reconnect: true,
-        type: MessageTypes.confirmation,
+consumer.subscriptions.create("channel"); // $ExpectType Subscription<BaseMixin>
+consumer.subscriptions.create({ channel: "channel", room: "room" }); // $ExpectType Subscription<BaseMixin>
+
+consumer.subscriptions.create("channel", {
+    // @ts-expect-error
+    connected(wrongArgument: string) {
     },
 });
-Connection.events.open(); // $ExpectType void
-Connection.events.close(); // $ExpectType void
-Connection.events.error(); // $ExpectType void
-
-const connection = new Connection(consumer); // $ExpectType Connection<Consumer>
-
-connection.send({}); // $ExpectType boolean
-connection.open(); // $ExpectType boolean
-connection.close(); // $ExpectType any
-connection.close({ allowReconnect: true }); // $ExpectType any
-connection.reopen(); // $ExpectType void
-connection.getProtocol(); // $ExpectType string | void
-connection.isOpen(); // $ExpectType boolean
-connection.isActive(); // $ExpectType boolean
-
-/**
- * Connection Monitor
- */
-ConnectionMonitor.staleThreshold; // $ExpectType number
-ConnectionMonitor.reconnectionBackoffRate; // $ExpectType number
-
-const connectionMonitor = new ConnectionMonitor(connection); // $ExpectType ConnectionMonitor<Connection<Consumer>>
-
-connectionMonitor.start(); // $ExpectType void
-connectionMonitor.stop(); // $ExpectType void
-connectionMonitor.isRunning(); // $ExpectType boolean
-connectionMonitor.recordPing(); // $ExpectType void
-connectionMonitor.recordConnect(); // $ExpectType void
-connectionMonitor.recordDisconnect(); // $ExpectType void
-
-/**
- * Subscription
- */
-const subscription = new Subscription(consumer); // $ExpectType Subscription<Consumer>
-
-subscription.perform("action"); // $ExpectType boolean
-subscription.perform("action", {}); // $ExpectType boolean
-subscription.send({}); // $ExpectType boolean
-subscription.unsubscribe(); // $ExpectType Subscription<Consumer>
-
-/**
- * Subscriptions
- */
-const subscriptions = new Subscriptions(consumer); // $ExpectType Subscriptions<Consumer>
-
-subscriptions.create("channel"); // $ExpectType Subscription<Consumer> & Mixin
-subscriptions.create({ channel: "channel", room: "room" }); // $ExpectType Subscription<Consumer> & Mixin
-// @ts-expect-error
-subscriptions.add(subscription);
-// @ts-expect-error
-subscriptions.remove(subscription);
-// @ts-expect-error
-subscriptions.reject(subscription.identifier);
-// @ts-expect-error
-subscriptions.forget(subscription);
-// @ts-expect-error
-subscriptions.findAll(subscription.identifier);
-// @ts-expect-error
-subscriptions.reload();
-// @ts-expect-error
-subscriptions.notifyAll("callbackName");
-// @ts-expect-error
-subscriptions.notify(subscription, "callbackName");
-// @ts-expect-error
-subscriptions.subscribe(subscription);
-// @ts-expect-error
-subscriptions.confirmSubscription(subscription.identifier);
-// @ts-expect-error
-subscriptions.sendCommand(subscription, {});


### PR DESCRIPTION
Update type definitions to align with Rails ActionCable 8.0 stable:
- Remove internal classes, functions, and enums marked as not intended for direct user manipulation
- Simplify Consumer, Subscription, and Subscriptions APIs
- Update mixin interface with proper connection/disconnection signatures
- Add proper generic type support for mixins with ThisType
- Update tests to match the new streamlined API

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://github.com/rails/rails/blob/7-0-stable/actioncable/CHANGELOG.md (Major refactoring)
  - https://github.com/rails/rails/blob/7-1-stable/actioncable/CHANGELOG.md (connected callback signature changed)
  - https://github.com/rails/rails/blob/7-2-stable/actioncable/CHANGELOG.md (No major JS changes)
  - https://github.com/rails/rails/blob/8-0-stable/actioncable/CHANGELOG.md (No major JS changes)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
