### PR TITLE
feat(google-apps-script): add subject option to Gmail draft reply methods

### DIFF
--- a/types/google-apps-script/google-apps-script.gmail.d.ts
+++ b/types/google-apps-script/google-apps-script.gmail.d.ts
@@ -183,6 +183,15 @@ declare namespace GoogleAppsScript {
              */
             replyTo?: string | undefined;
         }
+        /**
+         * Options for a Gmail draft reply.
+         */
+        interface GmailReplyOptions extends GmailAdvancedOptions {
+            /**
+             * The subject line for the reply draft (up to 250 characters).
+             */
+            subject?: string | undefined;
+        }
         /** alias to GmailAdvancedOptions */
         type GmailDraftOptions = GmailAdvancedOptions;
         /**
@@ -220,9 +229,9 @@ declare namespace GoogleAppsScript {
          */
         interface GmailMessage {
             createDraftReply(body: string): GmailDraft;
-            createDraftReply(body: string, options: GmailAdvancedOptions): GmailDraft;
+            createDraftReply(body: string, options: GmailReplyOptions): GmailDraft;
             createDraftReplyAll(body: string): GmailDraft;
-            createDraftReplyAll(body: string, options: GmailAdvancedOptions): GmailDraft;
+            createDraftReplyAll(body: string, options: GmailReplyOptions): GmailDraft;
             forward(recipient: string): GmailMessage;
             forward(recipient: string, options: GmailAdvancedOptions): GmailMessage;
             getAttachments(): GmailAttachment[];
@@ -264,9 +273,9 @@ declare namespace GoogleAppsScript {
         interface GmailThread {
             addLabel(label: GmailLabel): GmailThread;
             createDraftReply(body: string): GmailDraft;
-            createDraftReply(body: string, options: GmailAdvancedOptions): GmailDraft;
+            createDraftReply(body: string, options: GmailReplyOptions): GmailDraft;
             createDraftReplyAll(body: string): GmailDraft;
-            createDraftReplyAll(body: string, options: GmailAdvancedOptions): GmailDraft;
+            createDraftReplyAll(body: string, options: GmailReplyOptions): GmailDraft;
             getFirstMessageSubject(): string;
             getId(): string;
             getLabels(): GmailLabel[];

--- a/types/google-apps-script/test/google-apps-script-tests.ts
+++ b/types/google-apps-script/test/google-apps-script-tests.ts
@@ -1536,3 +1536,46 @@ function optionalFields() {
         console.log("Found an element");
     }
 }
+
+// GmailMessage.createDraftReply and createDraftReplyAll with subject option
+function testGmailDraftReplyWithSubject() {
+    const message = GmailApp.getMessageById("message-id");
+    const thread = GmailApp.getThreadById("thread-id");
+
+    // Test GmailMessage.createDraftReply with subject option
+    message.createDraftReply("Reply body"); // $ExpectType GmailDraft
+    message.createDraftReply("Reply body", { subject: "Custom subject" }); // $ExpectType GmailDraft
+    message.createDraftReply("Reply body", {
+        subject: "Custom subject",
+        cc: "cc@example.com",
+        bcc: "bcc@example.com",
+        htmlBody: "<p>HTML reply</p>",
+    }); // $ExpectType GmailDraft
+
+    // Test GmailMessage.createDraftReplyAll with subject option
+    message.createDraftReplyAll("Reply all body"); // $ExpectType GmailDraft
+    message.createDraftReplyAll("Reply all body", { subject: "Custom subject for all" }); // $ExpectType GmailDraft
+    message.createDraftReplyAll("Reply all body", {
+        subject: "Custom subject for all",
+        cc: "cc@example.com",
+        htmlBody: "<p>HTML reply all</p>",
+    }); // $ExpectType GmailDraft
+
+    // Test GmailThread.createDraftReply with subject option
+    thread.createDraftReply("Thread reply body"); // $ExpectType GmailDraft
+    thread.createDraftReply("Thread reply body", { subject: "Thread custom subject" }); // $ExpectType GmailDraft
+    thread.createDraftReply("Thread reply body", {
+        subject: "Thread custom subject",
+        from: "from@example.com",
+        name: "Custom Name",
+    }); // $ExpectType GmailDraft
+
+    // Test GmailThread.createDraftReplyAll with subject option
+    thread.createDraftReplyAll("Thread reply all body"); // $ExpectType GmailDraft
+    thread.createDraftReplyAll("Thread reply all body", { subject: "Thread custom subject for all" }); // $ExpectType GmailDraft
+    thread.createDraftReplyAll("Thread reply all body", {
+        subject: "Thread custom subject for all",
+        replyTo: "replyto@example.com",
+        attachments: [DriveApp.getFileById("file-id").getBlob()],
+    }); // $ExpectType GmailDraft
+}

--- a/types/google-apps-script/test/google-apps-script-tests.ts
+++ b/types/google-apps-script/test/google-apps-script-tests.ts
@@ -1545,37 +1545,41 @@ function testGmailDraftReplyWithSubject() {
     // Test GmailMessage.createDraftReply with subject option
     message.createDraftReply("Reply body"); // $ExpectType GmailDraft
     message.createDraftReply("Reply body", { subject: "Custom subject" }); // $ExpectType GmailDraft
+    // $ExpectType GmailDraft
     message.createDraftReply("Reply body", {
         subject: "Custom subject",
         cc: "cc@example.com",
         bcc: "bcc@example.com",
         htmlBody: "<p>HTML reply</p>",
-    }); // $ExpectType GmailDraft
+    });
 
     // Test GmailMessage.createDraftReplyAll with subject option
     message.createDraftReplyAll("Reply all body"); // $ExpectType GmailDraft
     message.createDraftReplyAll("Reply all body", { subject: "Custom subject for all" }); // $ExpectType GmailDraft
+    // $ExpectType GmailDraft
     message.createDraftReplyAll("Reply all body", {
         subject: "Custom subject for all",
         cc: "cc@example.com",
         htmlBody: "<p>HTML reply all</p>",
-    }); // $ExpectType GmailDraft
+    });
 
     // Test GmailThread.createDraftReply with subject option
     thread.createDraftReply("Thread reply body"); // $ExpectType GmailDraft
     thread.createDraftReply("Thread reply body", { subject: "Thread custom subject" }); // $ExpectType GmailDraft
+    // $ExpectType GmailDraft
     thread.createDraftReply("Thread reply body", {
         subject: "Thread custom subject",
         from: "from@example.com",
         name: "Custom Name",
-    }); // $ExpectType GmailDraft
+    });
 
     // Test GmailThread.createDraftReplyAll with subject option
     thread.createDraftReplyAll("Thread reply all body"); // $ExpectType GmailDraft
     thread.createDraftReplyAll("Thread reply all body", { subject: "Thread custom subject for all" }); // $ExpectType GmailDraft
+    // $ExpectType GmailDraft
     thread.createDraftReplyAll("Thread reply all body", {
         subject: "Thread custom subject for all",
         replyTo: "replyto@example.com",
         attachments: [DriveApp.getFileById("file-id").getBlob()],
-    }); // $ExpectType GmailDraft
+    });
 }


### PR DESCRIPTION
Adds support for the `subject` option in `createDraftReply` and `createDraftReplyAll` methods.

## Changes

- Created new `GmailReplyOptions` interface that extends `GmailAdvancedOptions` with a `subject` field
- Updated `GmailMessage.createDraftReply` and `createDraftReplyAll` to use `GmailReplyOptions`
- Updated `GmailThread.createDraftReply` and `createDraftReplyAll` to use `GmailReplyOptions`

This aligns with the [Google Apps Script documentation](https://developers.google.com/apps-script/reference/gmail/gmail-message#createdraftreplybody,-options) which specifies that the options parameter can include a subject field (up to 250 characters).