### PR TITLE
feat(@types/archiver): bump to v7

### DIFF
--- a/types/archiver/archiver-tests.ts
+++ b/types/archiver/archiver-tests.ts
@@ -41,6 +41,7 @@ archiver.append(readStream, { name: "buffer.txt", mode: 1 });
 archiver.append(readStream, { name: "buffer.txt", mode: 1, stats: ({} as fs.Stats) });
 archiver.append("Some content", { name: "filename", store: true });
 archiver.append(readStream, { name: "archiver.d.ts" }).append(readStream, { name: "archiver.d.ts" });
+archiver.append(Readable.from(["test"]), { name: "buffer.txt", date: new Date() });
 
 archiver.directory("./path", "./someOtherPath");
 archiver.directory("./", "", {});

--- a/types/archiver/package.json
+++ b/types/archiver/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/archiver",
-    "version": "6.0.9999",
+    "version": "7.0.9999",
     "projects": [
         "https://github.com/archiverjs/node-archiver"
     ],


### PR DESCRIPTION
In similar fashion to #67252, this bumps it up to the latest major version.

[Changes][changes] appear to be again related to dropping old Node.js versions.

Additionally added something to the tests to reflect a test that was added upstream.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [changes]
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

[changes]: https://github.com/archiverjs/node-archiver/compare/6.0.0...7.0.1