### PR TITLE
Add test for crypto.getCiphers() method

### DIFF
--- a/types/node/test/crypto.ts
+++ b/types/node/test/crypto.ts
@@ -1843,3 +1843,15 @@ import { promisify } from "node:util";
     const publicKey = crypto.decapsulate(privateKey, Buffer.from("the quick brown fox jumped over the lazy dog"));
     const { sharedKey, ciphertext } = crypto.encapsulate(publicKey);
 }
+
+{
+    // crypto_getCiphers_test
+    const ciphers: string[] = crypto.getCiphers();
+    ciphers; // $ExpectType string[]
+
+    // Verify the array is not empty
+    assert(ciphers.length > 0);
+
+    // Check that a common cipher algorithm is included
+    assert(ciphers.includes("aes-256-cbc"));
+}


### PR DESCRIPTION
## Summary
This PR adds type tests for the `crypto.getCiphers()` method in the Node.js crypto module.

## Changes
- Added test coverage for `crypto.getCiphers()` in `types/node/test/crypto.ts`
- Verifies that the method returns a `string[]` type
- Includes runtime assertions to validate:
  - The returned array is not empty
  - Common cipher algorithms (e.g., `aes-256-cbc`) are included in the result

## Test Location
`types/node/test/crypto.ts:1847-1857`