### PR TITLE
[dygraphs] Add missing fields in config and annotation types

### DIFF
--- a/types/dygraphs/dygraphs-tests.ts
+++ b/types/dygraphs/dygraphs-tests.ts
@@ -69,6 +69,7 @@ const d = new Dygraph(new HTMLDivElement(), "data", {
     labelsSeparateLines: true,
     legend: "always",
     rangeSelectorForegroundStrokeColor: "white",
+    resizable: "both",
     rollPeriod: 14,
     series: {
         y: {
@@ -232,6 +233,10 @@ d.setAnnotations([
             // $ExpectType MouseEvent
             event;
         },
+    },
+    {
+        series: "sine wave",
+        xval: 20700,
     },
 ]);
 

--- a/types/dygraphs/index.d.ts
+++ b/types/dygraphs/index.d.ts
@@ -778,6 +778,17 @@ export namespace dygraphs {
         rangeSelectorPlotStrokeColor?: string | null | undefined;
 
         /**
+         * Whether to add a ResizeObserver to the container div ("passive") and additionally
+         * make it resizable ("horizontal", "vertical", "both"). In any case, if the container
+         * div has CSS "overflow:visible;" it will be changed to "overflow:hidden;" to make CSS
+         * resizing possible. Note that this is distinct from resizing the graph when the window
+         * size changes, which is always active; this feature adds user-resizable “handles” to
+         * the container div.
+         * @default no
+         */
+        resizable?: "passive" | "horizontal" | "vertical" | "both" | "no" | undefined;
+
+        /**
          * Number of pixels to leave blank at the right edge of the Dygraph. This makes it easier to
          * highlight the right-most data point.
          * @default 5
@@ -1099,6 +1110,12 @@ export namespace dygraphs {
          * You must set either x or xval.
          */
         x?: number | string | undefined;
+
+        /**
+         * The numeric x value of the point, milliseconds since the epoch for a Date x axis.
+         * You must set either x or xval.
+         */
+        xval?: number | undefined;
 
         /** Text that will appear on the annotation's flag. */
         shortText?: string | undefined;


### PR DESCRIPTION
- `resizable` in `Options`
- `xval` in `Annotation`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - `resizable`: https://github.com/danvk/dygraphs/blob/master/src/dygraph.js#L881
  - `xval`: https://github.com/danvk/dygraphs/blob/master/src/extras/super-annotations.js#L33 and https://dygraphs.com/annotations.html
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.~~
