### PR TITLE
feat(emscripten): add `stringToNewUTF8` and `stringToUTF8OnStack` function definitions

### DIFF
--- a/types/emscripten/emscripten-tests.ts
+++ b/types/emscripten/emscripten-tests.ts
@@ -194,6 +194,8 @@ function StringConv(): void {
     stringToUTF16(s, p, 42);
     stringToUTF32(s, p);
     stringToUTF32(s, p, 42);
+    p = stringToNewUTF8(s);
+    Module._free(p);
     p = allocateUTF8(s);
     Module._free(p);
 }
@@ -202,7 +204,8 @@ function StringConv(): void {
 function StackAlloc() {
     const stack = stackSave();
     const ptr = stackAlloc(42);
-    const strPtr = allocateUTF8OnStack("testString");
+    const strPtr = stringToUTF8OnStack("testString");
+    const legacyStrPtr = allocateUTF8OnStack("testString");
     stackRestore(stack);
 }
 

--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -467,8 +467,12 @@ declare function AsciiToString(ptr: number): string;
 declare function UTF8ToString(ptr: number, maxBytesToRead?: number): string;
 declare function stringToUTF8(str: string, outPtr: number, maxBytesToRead?: number): void;
 declare function lengthBytesUTF8(str: string): number;
+/** @deprecated - Use `stringToNewUTF8` instead */
 declare function allocateUTF8(str: string): number;
+/** @deprecated - Use `stringToUTF8OnStack` instead */
 declare function allocateUTF8OnStack(str: string): number;
+declare function stringToNewUTF8(str: string): number;
+declare function stringToUTF8OnStack(str: string): number;
 declare function UTF16ToString(ptr: number): string;
 declare function stringToUTF16(str: string, outPtr: number, maxBytesToRead?: number): void;
 declare function lengthBytesUTF16(str: string): number;


### PR DESCRIPTION
- [ :heavy_check_mark: ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ :heavy_check_mark: ] Test the change in your own code. (Compile and run.)
- [ :heavy_check_mark: ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ :heavy_check_mark: ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ :heavy_check_mark: ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ :heavy_check_mark: ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [ :heavy_check_mark: ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/emscripten-core/emscripten/pull/19089
- [ :x: ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. _Not bumping version number - I don't have enough certainty that this is completely up to date with any given version of emscripten._

As per the above referenced emscripten PR, the functions `stringToNewUTF8` and `stringToUTF8OnStack` directly replace `allocateUTF8` and `allocateUTF8OnStack` respectively in emscripten 3.1.35. The `allocate*` functions are now marked as legacy, although I don't know if these should be marked accordingly in the types?

For reference:
* `stringToNewUTF8` was added in emscripten v1.38.23 (10th Jan 2019 in commit `cd1aacc7e`)
* `stringToUTF8OnStack` was added in emscripten v3.1.35 (3rd Apr 2023 in commit `443447b14`)