### PR TITLE
fix(sinonjs__fake-timers): make microtask methods available on all cl…

### DIFF
--- a/types/sinonjs__fake-timers/index.d.ts
+++ b/types/sinonjs__fake-timers/index.d.ts
@@ -77,6 +77,11 @@ export interface GlobalTimers<TTimerId extends TimerId> {
      * Implements the Date object but using this clock to provide the correct time.
      */
     Date: typeof Date;
+
+    /**
+     * Mimics process.nextTick() explicitly dropping additional arguments.
+     */
+    queueMicrotask: (callback: () => void) => void;
 }
 
 /**
@@ -288,6 +293,11 @@ export interface FakeClock<TTimerId extends TimerId> extends GlobalTimers<TTimer
      * @param tickModeConfig The new configuration for how the clock should tick.
      */
     setTickMode: (tickModeConfig: TimerTickMode) => void;
+
+    /**
+     * Run all pending microtasks scheduled with `queueMicrotask`.
+     */
+    runMicrotasks: () => void;
 }
 
 /**
@@ -308,19 +318,9 @@ export type NodeClock = FakeClock<NodeTimer> & {
     hrtime(prevTime?: [number, number]): [number, number];
 
     /**
-     * Mimics process.nextTick() explicitly dropping additional arguments.
-     */
-    queueMicrotask: (callback: () => void) => void;
-
-    /**
      * Simulates process.nextTick().
      */
     nextTick: (callback: (...args: any[]) => void, ...args: any[]) => void;
-
-    /**
-     * Run all pending microtasks scheduled with nextTick.
-     */
-    runMicrotasks: () => void;
 };
 
 /**

--- a/types/sinonjs__fake-timers/sinonjs__fake-timers-tests.ts
+++ b/types/sinonjs__fake-timers/sinonjs__fake-timers-tests.ts
@@ -11,6 +11,7 @@ const fakeDate: Date = new timers.Date();
 timers.clearTimeout(fakeTimeout);
 timers.clearInterval(fakeInterval);
 timers.clearImmediate(fakeImmediate);
+timers.queueMicrotask(() => {});
 
 let browserClock: FakeTimers.BrowserClock = FakeTimers.createClock() as FakeTimers.BrowserClock;
 let nodeClock: FakeTimers.NodeClock = FakeTimers.createClock() as FakeTimers.NodeClock;
@@ -110,6 +111,7 @@ nodeClock.runAll();
 browserClock.runAllAsync().then(val => val.toExponential());
 nodeClock.runAllAsync().then(val => val.toExponential());
 
+browserClock.runMicrotasks();
 nodeClock.runMicrotasks();
 
 browserClock.runToFrame();
@@ -120,6 +122,9 @@ nodeClock.runToLast();
 
 browserClock.runToLastAsync().then(val => val.toExponential());
 nodeClock.runToLastAsync().then(val => val.toExponential());
+
+browserClock.queueMicrotask(() => {});
+nodeClock.queueMicrotask(() => {});
 
 browserClock.jump(7);
 browserClock.jump("08:03");
@@ -140,7 +145,6 @@ nodeClock.setTickMode({ mode: "nextAsync" });
 nodeClock.setTickMode({ mode: "interval", delta: 200 });
 
 nodeClock.nextTick(() => undefined);
-nodeClock.queueMicrotask(() => {});
 
 const browserTimersCount: number = browserClock.countTimers();
 const nodeTimersCount: number = nodeClock.countTimers();


### PR DESCRIPTION
…ocks

runMicrotasks and queueMicrotask were previously only available on the NodeClock. This commit moves them to the base FakeClock and GlobalTimers interfaces so they are available on all clock types.

Refs https://github.com/sinonjs/fake-timers/blob/main/src/fake-timers-src.js

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

