### PR TITLE
fix(chrome): corrected typo for `chrome.declarativeNetRequest.RuleCondition.tabIds`

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -13787,7 +13787,7 @@ declare namespace chrome {
             requestMethods?: `${RequestMethod}`[] | undefined;
 
             /**
-             * List of {@link tabs.Tab.id} which the rule should not match.
+             * List of {@link tabs.Tab.id} which the rule should match.
              * An ID of {@link tabs.TAB_ID_NONE} matches requests which don't originate from a tab.
              * An empty list is not allowed. Only supported for session-scoped rules.
              * @since Chrome 92


### PR DESCRIPTION
There is a typo in the current description for `chrome.declarativeNetRequest.RuleCondition.tabIds`.
This PR is to fix the typo.
* Close #73946 

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest?hl=en

