### PR TITLE
fix: `linkSort` and `nodeSort` argument typing

### DIFF
--- a/types/d3-sankey/d3-sankey-tests.ts
+++ b/types/d3-sankey/d3-sankey-tests.ts
@@ -278,8 +278,9 @@ num = slgDAG.iterations();
 
 // test multiple definitions
 slgDAG = slgDAG.nodeSort((node: SNode) => (node.index === 0 ? 1 : -1));
-slgDAG = slgDAG.nodeSort(() => undefined);
-slgDAG = slgDAG.nodeSort((node: SNode) => (node.name === "test" ? null : undefined));
+slgDAG = slgDAG.nodeSort(undefined);
+slgDAG = slgDAG.nodeSort(null);
+slgDAG = slgDAG.nodeSort((node: SNode) => (node.name === "test" ? 0 : -1));
 
 // ---------------------------------------------------------------------------
 // LinkSort
@@ -287,8 +288,9 @@ slgDAG = slgDAG.nodeSort((node: SNode) => (node.name === "test" ? null : undefin
 
 // test multiple definitions
 slgDAG = slgDAG.linkSort((link: SLink) => (link.index === 0 ? 1 : -1));
-slgDAG = slgDAG.linkSort(() => undefined);
-slgDAG = slgDAG.linkSort((link: SLink) => (link.source > link.target ? null : undefined));
+slgDAG = slgDAG.linkSort(undefined);
+slgDAG = slgDAG.linkSort(null);
+slgDAG = slgDAG.linkSort((link: SLink) => (link.source > link.target ? 0 : -1));
 
 // ---------------------------------------------------------------------------
 // Node Id

--- a/types/d3-sankey/index.d.ts
+++ b/types/d3-sankey/index.d.ts
@@ -348,7 +348,7 @@ export interface SankeyLayout<Data, N extends SankeyExtraProperties, L extends S
      *
      * @param compare Node comparison function.
      */
-    nodeSort(compare: (a: SankeyNode<N, L>, b: SankeyNode<N, L>) => number | undefined | null): this;
+    nodeSort(compare: ((a: SankeyNode<N, L>, b: SankeyNode<N, L>) => number) | undefined | null): this;
 
     /**
      * Returns the link comparison function which defaults to undefined.
@@ -360,7 +360,7 @@ export interface SankeyLayout<Data, N extends SankeyExtraProperties, L extends S
      *
      * @param compare Link comparison function.
      */
-    linkSort(compare: (a: SankeyLink<N, L>, b: SankeyLink<N, L>) => number | undefined | null): this;
+    linkSort(compare: ((a: SankeyLink<N, L>, b: SankeyLink<N, L>) => number) | undefined | null): this;
 }
 
 /**

--- a/types/d3-sankey/index.d.ts
+++ b/types/d3-sankey/index.d.ts
@@ -341,24 +341,24 @@ export interface SankeyLayout<Data, N extends SankeyExtraProperties, L extends S
     /**
      * Returns the node comparison function which defaults to undefined.
      */
-    nodeSort(): ((a: SankeyNode<N, L>, b: SankeyNode<N, L>) => number) | undefined;
+    nodeSort(): ((a: SankeyNode<N, L>, b: SankeyNode<N, L>) => number) | undefined | null;
 
     /**
      * Set the node comparison function and return this Sankey layout generator.
      *
-     * @param compare Node comparison function.
+     * @param compare Node comparison function. If `null`, the order is fixed by the input.
      */
     nodeSort(compare: ((a: SankeyNode<N, L>, b: SankeyNode<N, L>) => number) | undefined | null): this;
 
     /**
      * Returns the link comparison function which defaults to undefined.
      */
-    linkSort(): ((a: SankeyLink<N, L>, b: SankeyLink<N, L>) => number) | undefined;
+    linkSort(): ((a: SankeyLink<N, L>, b: SankeyLink<N, L>) => number) | undefined | null;
 
     /**
      * Set the link comparison function and return this Sankey layout generator.
      *
-     * @param compare Link comparison function.
+     * @param compare Link comparison function. If `null`, the order is fixed by the input.
      */
     linkSort(compare: ((a: SankeyLink<N, L>, b: SankeyLink<N, L>) => number) | undefined | null): this;
 }


### PR DESCRIPTION
### Context

The D3 Sankey docs inform the `linkSort`/`nodeSort` do not match with the types.

- The docs say that they can get either `undefined` `null` or a sorting function.
- The typing says they cna get a sorting function that can return number, undefined or null

### Template

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
	- https://github.com/d3/d3-sankey/tree/master?tab=readme-ov-file#sankey_linkSort
	- https://github.com/d3/d3-sankey/tree/master?tab=readme-ov-file#sankey_nodeSort 
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

