### PR TITLE
[react] Add HTML Invoker Commands API attributes

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3005,6 +3005,20 @@ declare namespace React {
         name?: string | undefined;
         type?: "submit" | "reset" | "button" | undefined;
         value?: string | readonly string[] | number | undefined;
+
+        /**
+         * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLButtonElement/command}
+         */
+        command?:
+            | "show-modal"
+            | "close"
+            | "request-close"
+            | "show-popover"
+            | "hide-popover"
+            | "toggle-popover"
+            | `--${string}`
+            | undefined;
+        commandfor?: string | undefined;
     }
 
     interface CanvasHTMLAttributes<T> extends HTMLAttributes<T> {

--- a/types/react/test/elementAttributes.tsx
+++ b/types/react/test/elementAttributes.tsx
@@ -168,6 +168,34 @@ const testCases = [
             Hide
         </button>
     </>,
+    // Invoker Commands API
+    <>
+        <dialog id="my-dialog">Dialog content</dialog>
+        <div id="my-popover" popover="auto">Popover content</div>
+
+        {/* Dialog commands */}
+        <button commandfor="my-dialog" command="show-modal">Open Dialog</button>
+        <button commandfor="my-dialog" command="close">Close Dialog</button>
+        <button commandfor="my-dialog" command="request-close">Request Close Dialog</button>
+
+        {/* Popover commands */}
+        <button commandfor="my-popover" command="toggle-popover">Toggle Popover</button>
+        <button commandfor="my-popover" command="show-popover">Show Popover</button>
+        <button commandfor="my-popover" command="hide-popover">Hide Popover</button>
+
+        {/* Custom commands starting with "--" */}
+        <button commandfor="my-element" command="--custom-action">Custom Action</button>
+        <button commandfor="my-element" command="--my-command">My Command</button>
+
+        {/* Invalid command value should error (doesn't start with "--" and not a built-in) */}
+        <button
+            commandfor="my-dialog"
+            // @ts-expect-error
+            command="invalid-command"
+        >
+            Bad Command
+        </button>
+    </>,
     <>
         <template>
             <div part="base" />


### PR DESCRIPTION
Add support for the Invoker Commands API attributes (`command` and `commandfor`) to React JSX types.

See: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#command

Caveat here: Claude wrote the tests 🙂 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
