### PR TITLE
[heap] Use JSDoc instead of plain comments

### DIFF
--- a/types/heap/index.d.ts
+++ b/types/heap/index.d.ts
@@ -5,77 +5,82 @@ declare class Heap<T> {
 
     // Instance Methods
 
-    // Push item onto heap.
+    /** Push item onto heap. */
     push(item: T): void;
     insert(item: T): void;
 
-    // Pop the smallest item off the heap and return it.
+    /** Pop the smallest item off the heap and return it. */
     pop(): T | undefined;
 
-    // Return the smallest item of the heap.
+    /** Return the smallest item of the heap. */
     peek(): T | undefined;
     top(): T | undefined;
     front(): T | undefined;
 
-    // Pop and return the current smallest value, and add the new item.
-    // This is more efficient than pop() followed by push(), and can be more appropriate when using a fixed size heap.
-    // Note that the value returned may be larger than item!
+    /**
+     * Pop and return the current smallest value, and add the new item.
+     * This is more efficient than {@link Heap#pop} followed by {@link Heap#push}, and can be more appropriate when using a fixed size heap.
+     * Note that the value returned may be larger than item!
+     */
     replace(item: T): T;
 
-    // Fast version of a push followed by a pop.
+    /** Fast version of a push followed by a pop. */
     pushpop(item: T): T;
 
-    // Rebuild the heap. This method may come handy when the priority of the internal data is being modified.
+    /** Rebuild the heap. This method may come handy when the priority of the internal data is being modified. */
     heapify(): void;
 
-    // Update the position of the given item in the heap. This function should be called every time the item is being modified.
+    /** Update the position of the given item in the heap. This function should be called every time the item is being modified. */
     updateItem(item: T): void;
 
-    // Determine whether the given item is in the heap.
+    /** Determine whether the given item is in the heap. */
     contains(item: T): boolean;
     has(item: T): boolean;
 
-    // Clear the heap.
+    /** Clear the heap. */
     clear(): void;
 
-    // Determine whether the heap is empty.
+    /** Determine whether the heap is empty. */
     empty(): boolean;
 
-    // Get the number of elements stored in the heap.
+    /** Get the number of elements stored in the heap. */
     size(): number;
 
-    // Return the array representation of the heap. (note: the array is a shallow copy of the heap's internal nodes)
+    /** Return the array representation of the heap. (note: the array is a shallow copy of the heap's internal nodes) */
     toArray(): T[];
 
-    // Return a clone of the heap. (note: the internal data is a shallow copy of the original one)
+    /** Return a clone of the heap. (note: the internal data is a shallow copy of the original one) */
     clone(): Heap<T>;
     copy(): Heap<T>;
 
-    // Static Methods
+    /** Static Methods */
 
-    // Push item onto array, maintaining the heap invariant.
+    /** Push item onto array, maintaining the heap invariant. */
     static push<T>(array: T[], item: T, cmp?: (a: T, b: T) => number): void;
 
-    // Pop the smallest item off the array, maintaining the heap invariant.
+    /** Pop the smallest item off the array, maintaining the heap invariant. */
     static pop<T>(array: T[], cmp?: (a: T, b: T) => number): T;
 
-    // Pop and return the current smallest value, and add the new item.
-    // This is more efficient than heappop() followed by heappush(), and can be more appropriate when using a fixed size heap. Note that the value returned may be larger than item!
+    /**
+     * Pop and return the current smallest value, and add the new item.
+     * This is more efficient than heappop() followed by heappush(),
+     * and can be more appropriate when using a fixed size heap. Note that the value returned may be larger than item!
+     */
     static replace<T>(array: T[], item: T, cmp?: (a: T, b: T) => number): T;
 
-    // Fast version of a heappush followed by a heappop.
+    /** Fast version of a heappush followed by a heappop. */
     static pushpop<T>(array: T[], item: T, cmp?: (a: T, b: T) => number): T;
 
-    // Build the heap.
+    /** Build the heap. */
     static heapify<T>(array: T[], cmp?: (a: T, b: T) => number): Heap<T>;
 
-    // Update the position of the given item in the heap. This function should be called every time the item is being modified.
+    /** Update the position of the given item in the heap. This function should be called every time the item is being modified. */
     static updateItem<T>(array: T[], item: T, cmp?: (a: T, b: T) => number): void;
 
-    // Find the n largest elements in a dataset.
+    /** Find the n largest elements in a dataset. */
     static nlargest<T>(array: T[], n: number, cmp?: (a: T, b: T) => number): T[];
 
-    // Find the n smallest elements in a dataset.
+    /** Find the n smallest elements in a dataset. */
     static nsmallest<T>(array: T[], n: number, cmp?: (a: T, b: T) => number): T[];
 }
 

--- a/types/heap/package.json
+++ b/types/heap/package.json
@@ -8,5 +8,10 @@
     "devDependencies": {
         "@types/heap": "workspace:."
     },
-    "owners": []
+    "owners": [
+        {
+            "name": "Adam Thompson-Sharpe",
+            "githubUsername": "MysteryBlokHed"
+        }
+    ]
 }


### PR DESCRIPTION
Replaces method documentation comments with JSDoc so that IDE integration works properly.

I've also added myself as an owner, since the package had no other owners.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Docs are the same as before, sourced from here: <https://github.com/qiao/heap.js?tab=readme-ov-file#document>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.