### PR TITLE
fix(wechat-miniprogram): add OnBackgroundFetchDataCallbackResult interface

### DIFF
--- a/types/wechat-miniprogram/lib.wx.api.d.ts
+++ b/types/wechat-miniprogram/lib.wx.api.d.ts
@@ -3733,6 +3733,12 @@ innerAudioContext.onError((res) => {
         fetchedData: string;
         /** 客户端拿到缓存数据的时间戳 */
         timeStamp: number;
+        /** 小程序页面路径 */
+        path: string;
+        /** 传给页面的 query 参数 */
+        query: string;
+        /** 进入小程序的场景值 */
+        scene: number;
     }
     interface OnBeaconServiceChangeCallbackResult {
         /** 服务目前是否可用 */


### PR DESCRIPTION
add OnBackgroundFetchDataCallbackResult interface
- Add path, query, scene fields for miniprogram context

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [wx.getBackgroundFetchData](https://developers.weixin.qq.com/miniprogram/dev/api/storage/background-fetch/wx.getBackgroundFetchData.html)