### PR TITLE
fix(aws-lambda): add vpcId and vpceId to APIGatewayEventIdentity

### DIFF
--- a/types/aws-lambda/common/api-gateway.d.ts
+++ b/types/aws-lambda/common/api-gateway.d.ts
@@ -80,4 +80,6 @@ export interface APIGatewayEventIdentity {
     user: string | null;
     userAgent: string | null;
     userArn: string | null;
+    vpcId: string | null;
+    vpceId: string | null;
 }

--- a/types/aws-lambda/test/api-gateway-tests.ts
+++ b/types/aws-lambda/test/api-gateway-tests.ts
@@ -152,6 +152,8 @@ let proxyHandler: APIGatewayProxyHandler = async (event, context, callback) => {
     strOrNull = requestContext.identity.user;
     strOrNull = requestContext.identity.userAgent;
     strOrNull = requestContext.identity.userArn;
+    strOrNull = requestContext.identity.vpcId;
+    strOrNull = requestContext.identity.vpceId;
     strOrUndefined = requestContext.messageDirection;
     strOrUndefinedOrNull = requestContext.messageId;
     str = requestContext.path;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
  - https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#context-variable-reference 
  - Regarding $context.identity.vpcId and $context.identity.vpceId
  