### PR TITLE
[chrome] update since Chrome 141-142

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -1710,6 +1710,12 @@ declare namespace chrome {
             INCOGNITO_SESSION_ONLY = "incognito_session_only",
         }
 
+        /** @since Chrome 141 */
+        export enum SoundContentSetting {
+            ALLOW = "allow",
+            BLOCK = "block",
+        }
+
         /**
          * Whether to allow sites to download multiple files automatically. One of
          *
@@ -6901,16 +6907,26 @@ declare namespace chrome {
      */
     export namespace loginState {
         export enum ProfileType {
+            /** Specifies that the extension is in the signin profile. */
             SIGNIN_PROFILE = "SIGNIN_PROFILE",
+            /** Specifies that the extension is in the user profile. */
             USER_PROFILE = "USER_PROFILE",
+            /** Specifies that the extension is in the lock screen profile. */
+            LOCK_PROFILE = "LOCK_PROFILE",
         }
 
         export enum SessionState {
+            /** Specifies that the session state is unknown. */
             UNKNOWN = "UNKNOWN",
+            /** Specifies that the user is in the out-of-box-experience screen. */
             IN_OOBE_SCREEN = "IN_OOBE_SCREEN",
+            /** Specifies that the user is in the login screen. */
             IN_LOGIN_SCREEN = "IN_LOGIN_SCREEN",
+            /** Specifies that the user is in the session. */
             IN_SESSION = "IN_SESSION",
+            /** Specifies that the user is in the lock screen. */
             IN_LOCK_SCREEN = "IN_LOCK_SCREEN",
+            /** Specifies that the device is in RMA mode, finalizing repairs. */
             IN_RMA_SCREEN = "IN_RMA_SCREEN",
         }
 
@@ -13687,7 +13703,7 @@ declare namespace chrome {
          * @since Chrome 86
          */
         export enum HeaderOperation {
-            /** Adds a new entry for the specified header. This operation is not supported for request headers. */
+            /** Adds a new entry for the specified header. When modifying the headers of a request, this operation is only supported for specific headers. */
             APPEND = "append",
             /** Sets a new value for the specified header, removing any existing headers with the same name. */
             SET = "set",
@@ -14317,6 +14333,21 @@ declare namespace chrome {
      * @since Chrome 114, MV3
      */
     export namespace sidePanel {
+        /** @since Chrome 141 */
+        export type CloseOptions =
+            | {
+                /** The tab in which to close the side panel. If a tab-specific side panel is open in the specified tab, it will be closed for that tab. At least one of this or `windowId` must be provided.  */
+                tabId: number;
+                /** The window in which to close the side panel. If a global side panel is open in the specified window, it will be closed for all tabs in that window where no tab-specific panel is active. At least one of this or `tabId` must be provided. */
+                windowId?: number | undefined;
+            }
+            | {
+                /** The tab in which to close the side panel. If a tab-specific side panel is open in the specified tab, it will be closed for that tab. At least one of this or `windowId` must be provided.  */
+                tabId?: number | undefined;
+                /** The window in which to close the side panel. If a global side panel is open in the specified window, it will be closed for all tabs in that window where no tab-specific panel is active. At least one of this or `tabId` must be provided. */
+                windowId: number;
+            };
+
         export interface GetPanelOptions {
             /**
              * If specified, the side panel options for the given tab will be returned.
@@ -14357,6 +14388,16 @@ declare namespace chrome {
         /** @since Chrome 140 */
         export interface PanelLayout {
             side: `${Side}`;
+        }
+
+        /** @since Chrome 141 */
+        export interface PanelOpenedInfo {
+            /** The path of the local resource within the extension package whose content is displayed in the panel. */
+            path: string;
+            /** The optional ID of the tab where the side panel is opened. This is provided only when the panel is tab-specific. */
+            tabId?: number;
+            /** The ID of the window where the side panel is opened. This is available for both global and tab-specific panels. */
+            windowId: number;
         }
 
         export interface PanelOptions {
@@ -14437,6 +14478,12 @@ declare namespace chrome {
          */
         export function setPanelBehavior(behavior: PanelBehavior): Promise<void>;
         export function setPanelBehavior(behavior: PanelBehavior, callback: () => void): void;
+
+        /**
+         * Fired when the extension's side panel is opened.
+         * @since Chrome 141
+         */
+        const onOpened: events.Event<(info: PanelOpenedInfo) => void>;
     }
 
     ////////////////////

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -14385,6 +14385,16 @@ declare namespace chrome {
             openPanelOnActionClick?: boolean | undefined;
         }
 
+        /** @since Chrome 142 */
+        export interface PanelClosedInfo {
+            /** The path of the local resource within the extension package whose content is displayed in the panel. */
+            path: string;
+            /** The optional ID of the tab where the side panel was closed. This is provided only when the panel is tab-specific. */
+            tabId?: number;
+            /** The ID of the window where the side panel was closed. This is available for both global and tab-specific panels. */
+            windowId: number;
+        }
+
         /** @since Chrome 140 */
         export interface PanelLayout {
             side: `${Side}`;

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -546,6 +546,9 @@ function testContentSettings() {
     chrome.contentSettings.Scope.INCOGNITO_SESSION_ONLY === "incognito_session_only";
     chrome.contentSettings.Scope.REGULAR === "regular";
 
+    chrome.contentSettings.SoundContentSetting.ALLOW === "allow";
+    chrome.contentSettings.SoundContentSetting.BLOCK === "block";
+
     const contentSettingsGetParams: chrome.contentSettings.ContentSettingGetParams = {
         primaryUrl: "https://example.com",
         secondaryUrl: "https://example2.com",
@@ -6297,6 +6300,12 @@ function testSidePanel() {
     chrome.sidePanel.setPanelBehavior(setPanelBehavior, () => void 0); // $ExpectType void
     // @ts-expect-error
     chrome.sidePanel.setPanelBehavior(setPanelBehavior, () => {}).then(() => {});
+
+    checkChromeEvent(chrome.sidePanel.onOpened, (info) => {
+        info.path; // $ExpectType string
+        info.tabId; // $ExpectType number | undefined
+        info.windowId; // $ExpectType number
+    });
 }
 
 // https://developer.chrome.com/docs/extensions/reference/api/instanceID
@@ -6349,6 +6358,7 @@ function testInstanceID() {
 function testLoginState() {
     chrome.loginState.ProfileType.SIGNIN_PROFILE === "SIGNIN_PROFILE";
     chrome.loginState.ProfileType.USER_PROFILE === "USER_PROFILE";
+    chrome.loginState.ProfileType.LOCK_PROFILE === "LOCK_PROFILE";
 
     chrome.loginState.SessionState.IN_LOCK_SCREEN === "IN_LOCK_SCREEN";
     chrome.loginState.SessionState.IN_LOGIN_SCREEN === "IN_LOGIN_SCREEN";
@@ -6357,9 +6367,9 @@ function testLoginState() {
     chrome.loginState.SessionState.IN_SESSION === "IN_SESSION";
     chrome.loginState.SessionState.UNKNOWN === "UNKNOWN";
 
-    chrome.loginState.getProfileType(); // $ExpectType Promise<"SIGNIN_PROFILE" | "USER_PROFILE">
+    chrome.loginState.getProfileType(); // $ExpectType Promise<"SIGNIN_PROFILE" | "USER_PROFILE" | "LOCK_PROFILE">
     chrome.loginState.getProfileType((result) => { // $ExpectType void
-        result; // $ExpectType "SIGNIN_PROFILE" | "USER_PROFILE"
+        result; // $ExpectType "SIGNIN_PROFILE" | "USER_PROFILE" | "LOCK_PROFILE"
     });
     // @ts-expect-error
     chrome.loginState.getProfileType(() => {}).then(() => {});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://developer.chrome.com/docs/extensions/reference/api/contentSettings#type-SoundContentSetting
  - https://developer.chrome.com/docs/extensions/reference/api/loginState#type-ProfileType
  - https://developer.chrome.com/docs/extensions/reference/api/sidePanel#event-onOpened
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.


Notes:
- add `contentSettings.SoundContentSetting` enum
- update `loginState.ProfileType` enum: add `LOCK_PROFILE` value
- add `sidePanel.onOpened` event
- add `sidePanel.CloseOptions` type (It requires that `close()` be documented)
- add `sidePanel.PanelClosedInfo` type (It requires that `onClosed` event be documented)
- add `sidePanel.PanelOpenedInfo` type
- update JSDoc
- update tests

Runtime:
<img width="680" height="107" alt="image" src="https://github.com/user-attachments/assets/65933322-b544-4681-9574-5e06f924e3e7" />

[doc checker 25/10/25](https://github.com/erwanjugand/chrome-extension-docs-checker/commit/67312ab17e59d236b15bd64578b77441e652a8db#diff-9ed46070e78681d8451745cce3f961e448a6a5ace9dbf178ea3abe35b49c744e)
[doc checker 01/11/25](https://github.com/erwanjugand/chrome-extension-docs-checker/commit/3e345fd9c070f3567f410c1b24fcbe8f96c220d5)