### PR TITLE
`dom-webcodecs`: Add `rotation` and `flip` field to `VideoDecoderConfig` and `VideoFrame`

### DIFF
--- a/types/dom-webcodecs/test/dom-webcodecs-tests.ts
+++ b/types/dom-webcodecs/test/dom-webcodecs-tests.ts
@@ -363,6 +363,12 @@ const videoDecoderConfig: VideoDecoderConfig = {
     codec: "avc1.64000c",
 };
 
+const videoDecoderConfigWithRotationAndFlip: VideoDecoderConfig = {
+    codec: "avc1.64000c",
+    rotation: 180,
+    flip: false,
+};
+
 // @ts-expect-error
 VideoDecoder.isConfigSupported();
 
@@ -370,6 +376,13 @@ VideoDecoder.isConfigSupported();
 VideoDecoder.isConfigSupported({ description: new Uint8Array(0) });
 
 VideoDecoder.isConfigSupported(videoDecoderConfig).then((result: VideoDecoderSupport) => {
+    // $ExpectType boolean | undefined
+    result.supported;
+    // $ExpectType VideoDecoderConfig | undefined
+    result.config;
+});
+
+VideoDecoder.isConfigSupported(videoDecoderConfigWithRotationAndFlip).then((result: VideoDecoderSupport) => {
     // $ExpectType boolean | undefined
     result.supported;
     // $ExpectType VideoDecoderConfig | undefined
@@ -417,6 +430,9 @@ videoDecoder.configure({ description: new Uint8Array(0) });
 
 // $ExpectType void
 videoDecoder.configure(videoDecoderConfig);
+
+// $ExpectType void  
+videoDecoder.configure(videoDecoderConfigWithRotationAndFlip);
 
 // additional properties are allowed
 const futureVideoDecoderConfig = {
@@ -593,6 +609,10 @@ videoFrame.visibleRect?.height;
 videoFrame.displayWidth;
 // $ExpectType number
 videoFrame.displayHeight;
+// $ExpectType number | undefined
+videoFrame.rotation;
+// $ExpectType boolean | undefined
+videoFrame.flip;
 
 // @ts-expect-error
 new VideoFrame(new ArrayBuffer(1024), {

--- a/types/dom-webcodecs/test/dom-webcodecs-tests.ts
+++ b/types/dom-webcodecs/test/dom-webcodecs-tests.ts
@@ -431,7 +431,7 @@ videoDecoder.configure({ description: new Uint8Array(0) });
 // $ExpectType void
 videoDecoder.configure(videoDecoderConfig);
 
-// $ExpectType void  
+// $ExpectType void
 videoDecoder.configure(videoDecoderConfigWithRotationAndFlip);
 
 // additional properties are allowed

--- a/types/dom-webcodecs/webcodecs.generated.d.ts
+++ b/types/dom-webcodecs/webcodecs.generated.d.ts
@@ -121,6 +121,8 @@ interface VideoDecoderConfig {
     displayAspectWidth?: number | undefined;
     hardwareAcceleration?: HardwarePreference | undefined;
     optimizeForLatency?: boolean | undefined;
+    rotation?: number | undefined;
+    flip?: boolean | undefined;
 }
 
 interface VideoDecoderInit {
@@ -427,6 +429,7 @@ interface VideoFrame {
     readonly timestamp: number;
     readonly visibleRect: DOMRectReadOnly | null;
     readonly rotation?: number;
+    readonly flip?: boolean;
     allocationSize(options?: VideoFrameCopyToOptions): number;
     clone(): VideoFrame;
     close(): void;


### PR DESCRIPTION
similar to https://github.com/DefinitelyTyped/DefinitelyTyped/pull/73315. 

`VideoDecoderConfig` (and associated `VideoFrame`) now supports rotation and flip options. Optional as firefox, safari, and some mobile browsers don't support it yet. 

Spec: https://w3c.github.io/webcodecs/#dom-videodecoderconfig-rotation, https://w3c.github.io/webcodecs/#dom-videodecoderconfig-rotation, [#dom-videodecoderconfig-flip](https://w3c.github.io/webcodecs/#dom-videodecoderconfig-flip), [#dom-videoframe-flip](https://w3c.github.io/webcodecs/#dom-videoframe-flip)
Spec PR: https://github.com/w3c/webcodecs/pull/874

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (see above)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
