### PR TITLE
feat(rails__actioncable): Add Subscription.send() method

### DIFF
--- a/types/rails__actioncable/index.d.ts
+++ b/types/rails__actioncable/index.d.ts
@@ -33,6 +33,7 @@ export class Subscription<M extends BaseMixin = BaseMixin> {
 
     constructor(consumer: Consumer, params: ChannelNameWithParams, mixin: M);
     perform(action: string, data?: object): boolean;
+    send(data: any): boolean;
     unsubscribe(): this;
 }
 

--- a/types/rails__actioncable/rails__actioncable-tests.ts
+++ b/types/rails__actioncable/rails__actioncable-tests.ts
@@ -50,6 +50,7 @@ consumer.disconnect(); // $ExpectType void
     subscription.away();
     subscription.perform("action"); // $ExpectType boolean
     subscription.perform("action", {}); // $ExpectType boolean
+    subscription.send({ hello: "world" }); // $ExpectType boolean
     subscription.unsubscribe();
 
     // @ts-expect-error (typo)


### PR DESCRIPTION
Add the send() method to the Subscription class type definition. This is a public API documented in the official Rails Guides for transmitting data from client to server through an established subscription.

Reference: https://guides.rubyonrails.org/action_cable_overview.html#rebroadcasting-a-message

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://guides.rubyonrails.org/action_cable_overview.html#rebroadcasting-a-message
