### PR TITLE
fix(@mailchimp/mailchimp_marketing): correct typo of 'longitude' in MemberLocation interface

### DIFF
--- a/types/mailchimp__mailchimp_marketing/index.d.ts
+++ b/types/mailchimp__mailchimp_marketing/index.d.ts
@@ -1455,7 +1455,7 @@ export namespace lists {
 
     interface MemberLocation {
         latitude: number;
-        logitude: number;
+        longitude: number;
     }
 
     interface FullMemberLocation extends MemberLocation {


### PR DESCRIPTION
Fixes the misspelled 'longitude'  key in the MemberLocationOption

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Mailchimp Marketing API Documentation](https://mailchimp.com/developer/marketing/api/audiences-contacts/get-contact/)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
