### PR TITLE
fix(chrome): Fix definitions of MV2 permissions

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -246,7 +246,7 @@ declare namespace chrome {
         ): void;
 
         /**
-         * Gets the badge text of the action. If no tab is specified, the non-tab-specific badge text is returned. If {@link declarativeNetRequest.ExtensionActionOptions.displayActionCountAsBadgeText displayActionCountAsBadgeText} is enabled, a placeholder text will be returned unless the {@link runtime.ManifestPermissions declarativeNetRequestFeedback} permission is present or tab-specific badge text was provided.
+         * Gets the badge text of the action. If no tab is specified, the non-tab-specific badge text is returned. If {@link declarativeNetRequest.ExtensionActionOptions.displayActionCountAsBadgeText displayActionCountAsBadgeText} is enabled, a placeholder text will be returned unless the {@link runtime.ManifestPermission declarativeNetRequestFeedback} permission is present or tab-specific badge text was provided.
          *
          * Can return its result via Promise.
          */
@@ -7667,7 +7667,7 @@ declare namespace chrome {
             /** The list of host permissions, including those specified in the `optional_permissions` or `permissions` keys in the manifest, and those associated with [Content Scripts](https://developer.chrome.com/docs/extensions/develop/concepts/content-scripts). */
             origins?: string[];
             /** List of named permissions (does not include hosts or origins). */
-            permissions?: chrome.runtime.ManifestPermissions[];
+            permissions?: chrome.runtime.ManifestPermission[];
         }
 
         export interface AddHostAccessRequest {
@@ -8973,7 +8973,7 @@ declare namespace chrome {
         }
 
         /** Source: https://developer.chrome.com/docs/extensions/reference/permissions-list */
-        export type ManifestPermissions =
+        export type ManifestPermission =
             | "accessibilityFeatures.modify"
             | "accessibilityFeatures.read"
             | "activeTab"
@@ -9057,9 +9057,14 @@ declare namespace chrome {
             | "webRequestBlocking"
             | "webRequestAuthProvider";
 
+        /**
+         * @deprecated Use `ManifestPermission` instead.
+         */
+        export type ManifestPermissions = ManifestPermission;
+
         /** Source : https://developer.chrome.com/docs/extensions/reference/api/permissions */
-        export type ManifestOptionalPermissions = Exclude<
-            ManifestPermissions,
+        export type ManifestOptionalPermission = Exclude<
+            ManifestPermission,
             | "debugger"
             | "declarativeNetRequest"
             | "devtools"
@@ -9073,6 +9078,11 @@ declare namespace chrome {
             | "wallpaper"
             | "webAuthenticationProxy"
         >;
+
+        /**
+         * @deprecated Use `ManifestOptionalPermission` instead.
+         */
+        export type ManifestOptionalPermissions = ManifestOptionalPermission;
 
         export interface SearchProvider {
             name?: string | undefined;
@@ -9293,8 +9303,8 @@ declare namespace chrome {
                 }
                 | undefined;
             content_security_policy?: string | undefined;
-            optional_permissions?: ManifestOptionalPermissions[] | string[] | undefined;
-            permissions?: ManifestPermissions[] | string[] | undefined;
+            optional_permissions?: (ManifestOptionalPermission | string)[] | undefined;
+            permissions?: (ManifestPermission | string)[] | undefined;
             web_accessible_resources?: string[] | undefined;
         }
 
@@ -9329,9 +9339,9 @@ declare namespace chrome {
                 sandbox?: string;
             };
             host_permissions?: string[] | undefined;
-            optional_permissions?: ManifestOptionalPermissions[] | undefined;
+            optional_permissions?: ManifestOptionalPermission[] | undefined;
             optional_host_permissions?: string[] | undefined;
-            permissions?: ManifestPermissions[] | undefined;
+            permissions?: ManifestPermission[] | undefined;
             web_accessible_resources?:
                 | Array<
                     & {

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1052,8 +1052,13 @@ function testGetManifest() {
         manifest.content_security_policy; // $ExpectType string | undefined
 
         manifest.host_permissions; // $ExpectType any
-        manifest.optional_permissions; // $ExpectType ManifestOptionalPermissions[] | string[] | undefined
-        manifest.permissions; // $ExpectType ManifestPermissions[] |string[] | undefined
+        manifest.optional_permissions; // $ExpectType string[] | undefined
+        manifest.permissions; // $ExpectType string[] | undefined
+        // Verify that string permissions can be added.
+        if (manifest.optional_permissions && manifest.permissions) {
+            manifest.optional_permissions.push("*://developer.mozilla.org/*");
+            manifest.permissions.push("*://developer.mozilla.org/*");
+        }
 
         manifest.web_accessible_resources; // $ExpectType string[] | undefined
     } else if (manifest.manifest_version === 3) {
@@ -1067,9 +1072,9 @@ function testGetManifest() {
         };
 
         manifest.host_permissions; // $ExpectType string[] | undefined
-        manifest.optional_permissions; // $ExpectType ManifestOptionalPermissions[] | undefined
+        manifest.optional_permissions; // $ExpectType ManifestOptionalPermission[] | undefined
         manifest.optional_host_permissions; // $ExpectType string[] | undefined
-        manifest.permissions; // $ExpectType ManifestPermissions[] | undefined
+        manifest.permissions; // $ExpectType ManifestPermission[] | undefined
 
         manifest.web_accessible_resources = [{
             resources: ["resource.js"],


### PR DESCRIPTION
Add previously failing test cases.

Also rename `ManifestPermissions` and `ManifestOptionalPermissions` types to `ManifestPermission` and `ManifestOptionalPermission` respectively.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: This is a bug fix and doesn't require documentation. The tests document the change.
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

