### PR TITLE
Added toolbar type for compatibility with openseadragon 5.0.1

### DIFF
--- a/types/openseadragon/index.d.ts
+++ b/types/openseadragon/index.d.ts
@@ -385,6 +385,7 @@ declare namespace OpenSeadragon {
         showSequenceControl?: boolean | undefined;
         sequenceControlAnchor?: ControlAnchor | undefined;
         navPrevNextWrap?: boolean | undefined;
+        toolbar?: string | Element | undefined;
         zoomInButton?: string | Element | undefined;
         zoomOutButton?: string | Element | undefined;
         homeButton?: string | Element | undefined;

--- a/types/openseadragon/openseadragon-tests.ts
+++ b/types/openseadragon/openseadragon-tests.ts
@@ -103,7 +103,9 @@ viewer = OpenSeadragon({
 });
 
 declare const buttonElement: Element;
+declare const toolbarElement: Element;
 viewer = OpenSeadragon({
+    toolbar: "toolbar-id",
     zoomInButton: "zoomInButton-id",
     zoomOutButton: "zoomOutButton-id",
     homeButton: "homeButton-id",
@@ -114,6 +116,7 @@ viewer = OpenSeadragon({
     nextButton: "nextButton-id",
 });
 viewer = OpenSeadragon({
+    toolbar: toolbarElement,
     zoomInButton: buttonElement,
     zoomOutButton: buttonElement,
     homeButton: buttonElement,

--- a/types/openseadragon/package.json
+++ b/types/openseadragon/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/openseadragon",
-    "version": "5.0.99991",
+    "version": "5.0.9999",
     "projects": [
         "https://openseadragon.github.io/"
     ],

--- a/types/openseadragon/package.json
+++ b/types/openseadragon/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/openseadragon",
-    "version": "5.0.9999",
+    "version": "5.0.99991",
     "projects": [
         "https://openseadragon.github.io/"
     ],


### PR DESCRIPTION
## Project Checklist:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

## Changes Checklist:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

## PR Info

This pull request is to add the toolbar property to the Options interface when creating a OpenSeaDragon instance. 

Documentation for this property can be found here: [https://openseadragon.github.io/examples/ui-toolbar/](https://openseadragon.github.io/examples/ui-toolbar/)

I believe this is likely not the only change in types between OpenSeaDragon 5.0.0 and 5.0.1 so I did not update the version of the package to 5.0.1. Let me know if this was incorrect to do.
