### PR TITLE
fix(react-native-video): Move React-Native to peerDependencies

### DIFF
--- a/types/react-native-video/package.json
+++ b/types/react-native-video/package.json
@@ -7,7 +7,9 @@
         "https://github.com/brentvatne/react-native-video"
     ],
     "dependencies": {
-        "@types/react": "*",
+        "@types/react": "*"
+    },
+    "peerDependencies": {
         "react-native": "*"
     },
     "devDependencies": {


### PR DESCRIPTION
Fixes an issue similar to https://github.com/DefinitelyTyped/DefinitelyTyped/pull/73482

RN type dependencies should specify React-Native as `peerDependencies` and not explicit dependencies to avoid installing multiple React-Native versions, especially when hoisting is enabled.

The upstream package has react-native as a peer dependency: https://github.com/TheWidlarzGroup/react-native-video/blob/master/package.json#L38

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/73482
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.