### PR TITLE
fix(react-grid-layout): resizeHandle type definition

### DIFF
--- a/types/react-grid-layout/index.d.ts
+++ b/types/react-grid-layout/index.d.ts
@@ -247,7 +247,7 @@ declare namespace ReactGridLayout {
         /**
          * Defines custom component for resize handle
          */
-        resizeHandle?: React.ReactNode | ((resizeHandle: ResizeHandle) => React.ReactNode) | undefined;
+        resizeHandle?: React.ReactNode | ((resizeHandleAxis: ResizeHandle, ref: React.Ref<HTMLElement>) => React.ReactNode) | undefined;
 
         /**
          * Calls when drag starts.

--- a/types/react-grid-layout/index.d.ts
+++ b/types/react-grid-layout/index.d.ts
@@ -247,7 +247,10 @@ declare namespace ReactGridLayout {
         /**
          * Defines custom component for resize handle
          */
-        resizeHandle?: React.ReactNode | ((resizeHandleAxis: ResizeHandle, ref: React.Ref<HTMLElement>) => React.ReactNode) | undefined;
+        resizeHandle?:
+            | React.ReactNode
+            | ((resizeHandleAxis: ResizeHandle, ref: React.Ref<HTMLElement>) => React.ReactNode)
+            | undefined;
 
         /**
          * Calls when drag starts.

--- a/types/react-grid-layout/react-grid-layout-tests.tsx
+++ b/types/react-grid-layout/react-grid-layout-tests.tsx
@@ -106,3 +106,35 @@ class InnerRefCallbackTest extends React.Component {
         return <ReactGridLayout innerRef={(_: HTMLDivElement | null) => {}} />;
     }
 }
+
+class ResizeHandleFunctionTest extends React.Component {
+    render() {
+        return (
+            <ReactGridLayout
+                resizeHandle={(resizeHandleAxis, ref) => (
+                    <div ref={ref as React.Ref<HTMLDivElement>} className={`custom-handle-${resizeHandleAxis}`}>
+                        {resizeHandleAxis}
+                    </div>
+                )}
+            />
+        );
+    }
+}
+
+class ResizeHandleElementTest extends React.Component {
+    render() {
+        return <ReactGridLayout resizeHandle={<div className="custom-handle" />} />;
+    }
+}
+
+class ResizeHandleResponsiveTest extends React.Component {
+    render() {
+        return (
+            <Responsive
+                resizeHandle={(axis, ref) => {
+                    return <span ref={ref} data-axis={axis} />;
+                }}
+            />
+        );
+    }
+}


### PR DESCRIPTION
This fixes the type definition for `resizeHandle` in `react-grid-layout`.

The current type definition is 

```typescript
resizeHandle?: React.ReactNode | ((resizeHandle: ResizeHandle) => React.ReactNode) | undefined;
```

but it should be 

```typescript
resizeHandle?: React.ReactNode | ((resizeHandleAxis: ResizeHandle, ref: React.Ref<HTMLElement>) => React.ReactNode) | undefined;
```

Reference: https://github.com/react-grid-layout/react-grid-layout/blob/master/lib/ReactGridLayoutPropTypes.js#L23-L28

[Stackblitz Reproduction](https://stackblitz.com/~/github.com/csamuel/react-grid-layout-resizehandle-repro?file=App.tsx)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  https://github.com/react-grid-layout/react-grid-layout/blob/master/lib/ReactGridLayoutPropTypes.js#L23-L28