### PR TITLE
fix(aws-lambda): add missing `CustomEmailSender_Authentication` type

### DIFF
--- a/types/aws-lambda/test/cognito-tests.ts
+++ b/types/aws-lambda/test/cognito-tests.ts
@@ -379,6 +379,7 @@ const customEmailSender: CustomEmailSenderTriggerHandler = async (event, _, call
     triggerSource === "CustomEmailSender_UpdateUserAttribute";
     triggerSource === "CustomEmailSender_ResendCode";
     triggerSource === "CustomEmailSender_SignUp";
+    triggerSource === "CustomEmailSender_Authentication";
     triggerSource === "CustomEmailSender_AccountTakeOverNotification";
 };
 

--- a/types/aws-lambda/trigger/cognito-user-pool-trigger/custom-email-sender.d.ts
+++ b/types/aws-lambda/trigger/cognito-user-pool-trigger/custom-email-sender.d.ts
@@ -50,6 +50,10 @@ export interface CustomEmailSenderAdminCreateUserTriggerEvent
     extends BaseCustomEmailSenderTriggerEvent<"CustomEmailSender_AdminCreateUser">
 {}
 
+export interface CustomEmailSenderAuthenticationTriggerEvent
+    extends BaseCustomEmailSenderTriggerEvent<"CustomEmailSender_Authentication">
+{}
+
 export interface CustomEmailSenderAccountTakeOverNotificationTriggerEvent
     extends BaseTriggerEvent<"CustomEmailSender_AccountTakeOverNotification">
 {
@@ -71,6 +75,7 @@ export type CustomEmailSenderTriggerEvent =
     | CustomEmailSenderUpdateUserAttributeTriggerEvent
     | CustomEmailSenderVerifyUserAttributeTriggerEvent
     | CustomEmailSenderAdminCreateUserTriggerEvent
+    | CustomEmailSenderAuthenticationTriggerEvent
     | CustomEmailSenderAccountTakeOverNotificationTriggerEvent;
 
 export type CustomEmailSenderTriggerHandler = Handler<CustomEmailSenderTriggerEvent>;


### PR DESCRIPTION
Adds `CustomEmailSenderAuthenticationTriggerEvent`, which corresponds to the `CustomEmailSender_Authentication` trigger documented by AWS:
https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-email-sender.html#:~:text=a%20welcome%20message.-,CustomEmailSender_Authentication,-A%20user%20signs

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-email-sender.html#:~:text=a%20welcome%20message.-,CustomEmailSender_Authentication,-A%20user%20signs


