### PR TITLE
[@types/wordpress__block-editor] Fix `PanelColorSettings` type definitions

### DIFF
--- a/types/wordpress__block-editor/components/panel-color-settings.d.ts
+++ b/types/wordpress__block-editor/components/panel-color-settings.d.ts
@@ -3,9 +3,16 @@ import type { ComponentProps, ComponentType, ReactNode } from "react";
 
 declare namespace PanelColorSettings {
     interface ColorSetting {
+        /** The current color of the setting. */
         value: string;
+        /** Callback on change of the setting. */
         onChange: (value: string | undefined) => void;
+        /** Label of the setting. */
         label: string;
+        /** Whether to disable custom colors for this specific setting. */
+        disableCustomColors?: boolean;
+        /** Whether to disable custom gradients for this specific setting. */
+        disableCustomGradients?: boolean;
     }
     interface Props {
         /** A user-provided set of color settings. */

--- a/types/wordpress__block-editor/components/panel-color-settings.d.ts
+++ b/types/wordpress__block-editor/components/panel-color-settings.d.ts
@@ -1,14 +1,35 @@
-import { ColorPalette, PanelBody } from "@wordpress/components";
-import { ComponentProps, ComponentType } from "react";
+import { ColorPalette, GradientPicker } from "@wordpress/components";
+import type { ComponentProps, ComponentType, ReactNode } from "react";
 
 declare namespace PanelColorSettings {
-    type ColorSetting =
-        & Partial<ComponentProps<typeof ColorPalette>>
-        & Pick<ComponentProps<typeof ColorPalette>, "onChange" | "value">
-        & { label: string };
-    interface Props extends Omit<ComponentProps<typeof PanelBody>, "children"> {
-        colorSettings: ColorSetting[];
-        disableCustomColors?: boolean | undefined;
+    interface ColorSetting {
+        value: string;
+        onChange: (value: string | undefined) => void;
+        label: string;
+    }
+    interface Props {
+        /** A user-provided set of color settings. */
+        colorSettings?: ColorSetting[];
+        /** Added to the underlying ToolsPanel instance. */
+        className?: string;
+        /** Array of colors to be used. */
+        colors?: ComponentProps<typeof ColorPalette>["colors"];
+        /** Not recommended to be used since `PanelColorSettings` resets it. */
+        gradients?: ComponentProps<typeof GradientPicker>["gradients"];
+        /** Whether the addition of custom colors is enabled. */
+        disableCustomColors?: boolean;
+        /** Not recommended to be used since `PanelColorSettings` sets it. */
+        disableCustomGradients?: boolean;
+        /** Displayed below the underlying `PanelColorGradientSettings` instance. */
+        children?: ReactNode;
+        /** Title of the underlying `ToolsPanel`. */
+        title?: string;
+        /** Whether to show the title of the `ToolsPanel`. */
+        showTitle?: boolean;
+        /** Whether this is rendered in the sidebar. */
+        __experimentalIsRenderedInSidebar?: boolean;
+        /** Whether to enable setting opacity when specifying a color. */
+        enableAlpha?: boolean;
     }
 }
 declare const PanelColorSettings: ComponentType<PanelColorSettings.Props>;

--- a/types/wordpress__block-editor/components/panel-color-settings.d.ts
+++ b/types/wordpress__block-editor/components/panel-color-settings.d.ts
@@ -9,6 +9,8 @@ declare namespace PanelColorSettings {
         onChange: (value: string | undefined) => void;
         /** Label of the setting. */
         label: string;
+        /** Colors palette for this specific setting. */
+        colors?: ComponentProps<typeof ColorPalette>["colors"];
         /** Whether to disable custom colors for this specific setting. */
         disableCustomColors?: boolean;
         /** Whether to disable custom gradients for this specific setting. */

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -306,6 +306,7 @@ be.withFontSizes("fontSize")(() => <h1>Hello World</h1>);
                 color && console.log(color);
             },
             label: "Background Color",
+            disableCustomColors: false
         },
     ]}
     disableCustomColors={true}

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -299,7 +299,6 @@ be.withFontSizes("fontSize")(() => <h1>Hello World</h1>);
 //
 <be.PanelColorSettings
     title="Color Settings"
-    initialOpen={false}
     colorSettings={[
         {
             value: "#ff0000",
@@ -307,19 +306,11 @@ be.withFontSizes("fontSize")(() => <h1>Hello World</h1>);
                 color && console.log(color);
             },
             label: "Background Color",
-            disableCustomColors: true,
-            colors: [
-                {
-                    color: "#ff0000",
-                    name: "Red",
-                },
-                {
-                    color: "#ffff00",
-                    name: "Yellow",
-                },
-            ],
         },
     ]}
+    disableCustomColors={true}
+    showTitle={true}
+    enableAlpha={true}
 />;
 <be.PanelColorSettings
     colorSettings={[

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -306,7 +306,17 @@ be.withFontSizes("fontSize")(() => <h1>Hello World</h1>);
                 color && console.log(color);
             },
             label: "Background Color",
-            disableCustomColors: false
+            colors: [
+                {
+                    color: "#ff0000",
+                    name: "Red",
+                },
+                {
+                    color: "#ffff00",
+                    name: "Yellow",
+                },
+            ],
+            disableCustomColors: false,
         },
     ]}
     disableCustomColors={true}


### PR DESCRIPTION
Update PanelColorSettings props to match official documentation and fix incorrect existing types.
**Documentation:** https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/panel-color-settings/README.md

Additionally, adds undocumented `colorSettings` props found in source code: https://github.com/WordPress/gutenberg/blob/c54fa0beb059a2e3b2d2f5a32f26ab47598be0b6/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js#L53