### PR TITLE
[chrome] update browserAction namespace (MV2 only)

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -867,174 +867,120 @@ declare namespace chrome {
      */
     export namespace browserAction {
         export interface BadgeBackgroundColorDetails {
-            /** An array of four integers in the range [0,255] that make up the RGBA color of the badge. For example, opaque red is [255, 0, 0, 255]. Can also be a string with a CSS value, with opaque red being #FF0000 or #F00. */
+            /** An array of four integers in the range 0-255 that make up the RGBA color of the badge. Can also be a string with a CSS hex color value; for example, `#FF0000` or `#F00` (red). Renders colors at full opacity. */
             color: string | extensionTypes.ColorArray;
-            /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
-            tabId?: number | undefined;
+            /** Limits the change to when a particular tab is selected. Automatically resets when the tab is closed. */
+            tabId?: number | null | undefined;
         }
 
         export interface BadgeTextDetails {
-            /** Any number of characters can be passed, but only about four can fit in the space. */
+            /** Any number of characters can be passed, but only about four can fit into the space. If an empty string (`''`) is passed, the badge text is cleared. If `tabId` is specified and `text` is null, the text for the specified tab is cleared and defaults to the global badge text. */
             text?: string | null | undefined;
-            /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
-            tabId?: number | undefined;
+            /** Limits the change to when a particular tab is selected. Automatically resets when the tab is closed. */
+            tabId?: number | null | undefined;
         }
 
         export interface TitleDetails {
             /** The string the browser action should display when moused over. */
             title: string;
             /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
-            tabId?: number | null;
+            tabId?: number | null | undefined;
         }
 
         export interface TabDetails {
-            /** Optional. Specify the tab to get the information. If no tab is specified, the non-tab-specific information is returned.  */
-            tabId?: number | null;
+            /** The ID of the tab to query state for. If no tab is specified, the non-tab-specific state is returned. */
+            tabId?: number | null | undefined;
         }
 
-        export interface TabIconDetails {
-            /** Optional. Either a relative image path or a dictionary {size -> relative image path} pointing to icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals scale, then image with size scale * 19 will be selected. Initially only scales 1 and 2 will be supported. At least one image must be specified. Note that 'details.path = foo' is equivalent to 'details.imageData = {'19': foo}'  */
-            path?: string | { [index: string]: string } | undefined;
-            /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
-            tabId?: number | undefined;
-            /** Optional. Either an ImageData object or a dictionary {size -> ImageData} representing icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals scale, then image with size scale * 19 will be selected. Initially only scales 1 and 2 will be supported. At least one image must be specified. Note that 'details.imageData = foo' is equivalent to 'details.imageData = {'19': foo}'  */
-            imageData?: ImageData | { [index: number]: ImageData } | undefined;
-        }
+        export type TabIconDetails =
+            & {
+                /** Limits the change to when a particular tab is selected. Automatically resets when the tab is closed. */
+                tabId?: number | null | undefined;
+            }
+            & (
+                | {
+                    /** Either an ImageData object or a dictionary {size -> ImageData} representing an icon to be set. If the icon is specified as a dictionary, the image used is chosen depending on the screen's pixel density. If the number of image pixels that fit into one screen space unit equals `scale`, then an image with size `scale` \* n is selected, where _n_ is the size of the icon in the UI. At least one image must be specified. Note that 'details.imageData = foo' is equivalent to 'details.imageData = {'16': foo}' */
+                    imageData: ImageData | { [index: number]: ImageData };
+                    /** Either a relative image path or a dictionary {size -> relative image path} pointing to an icon to be set. If the icon is specified as a dictionary, the image used is chosen depending on the screen's pixel density. If the number of image pixels that fit into one screen space unit equals `scale`, then an image with size `scale` \* n is selected, where _n_ is the size of the icon in the UI. At least one image must be specified. Note that 'details.path = foo' is equivalent to 'details.path = {'16': foo}' */
+                    path?: string | { [index: string]: string } | undefined;
+                }
+                | {
+                    /** Either an ImageData object or a dictionary {size -> ImageData} representing an icon to be set. If the icon is specified as a dictionary, the image used is chosen depending on the screen's pixel density. If the number of image pixels that fit into one screen space unit equals `scale`, then an image with size `scale` \* n is selected, where _n_ is the size of the icon in the UI. At least one image must be specified. Note that 'details.imageData = foo' is equivalent to 'details.imageData = {'16': foo}' */
+                    imageData?: ImageData | { [index: number]: ImageData } | undefined;
+                    /** Either a relative image path or a dictionary {size -> relative image path} pointing to an icon to be set. If the icon is specified as a dictionary, the image used is chosen depending on the screen's pixel density. If the number of image pixels that fit into one screen space unit equals `scale`, then an image with size `scale` \* n is selected, where _n_ is the size of the icon in the UI. At least one image must be specified. Note that 'details.path = foo' is equivalent to 'details.path = {'16': foo}' */
+                    path: string | { [index: string]: string };
+                }
+            );
 
         export interface PopupDetails {
-            /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
-            tabId?: number | null;
-            /** The html file to show in a popup. If set to the empty string (''), no popup is shown. */
+            /** Limits the change to when a particular tab is selected. Automatically resets when the tab is closed. */
+            tabId?: number | null | undefined;
+            /** The relative path to the HTML file to show in a popup. If set to the empty string (`''`), no popup is shown.*/
             popup: string;
         }
 
-        export interface BrowserClickedEvent extends chrome.events.Event<(tab: chrome.tabs.Tab) => void> {}
-
         /**
-         * @since Chrome 22
-         * Enables the browser action for a tab. By default, browser actions are enabled.
-         * @param tabId The id of the tab for which you want to modify the browser action.
-         * @return The `enable` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
-         */
-        export function enable(tabId?: number | null): Promise<void>;
-        /**
-         * @since Chrome 22
-         * Enables the browser action for a tab. By default, browser actions are enabled.
-         * @param tabId The id of the tab for which you want to modify the browser action.
-         * @param callback Supported since Chrome 67
+         * Enables the browser action for a tab. Defaults to enabled.
+         * @param tabId The ID of the tab for which to modify the browser action.
+         * @param callback Since Chrome 67
          */
         export function enable(callback?: () => void): void;
         export function enable(tabId: number | null | undefined, callback?: () => void): void;
+
         /**
          * Sets the background color for the badge.
-         * @return The `setBadgeBackgroundColor` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
-         */
-        export function setBadgeBackgroundColor(details: BadgeBackgroundColorDetails): Promise<void>;
-        /**
-         * Sets the background color for the badge.
-         * @param callback Supported since Chrome 67
+         * @param callback Since Chrome 67
          */
         export function setBadgeBackgroundColor(details: BadgeBackgroundColorDetails, callback?: () => void): void;
+
         /**
          * Sets the badge text for the browser action. The badge is displayed on top of the icon.
-         * @return The `setBadgeText` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+         * @param callback Since Chrome 67
          */
-        export function setBadgeText(details: BadgeTextDetails): Promise<void>;
+        export function setBadgeText(details: BadgeTextDetails, callback?: () => void): void;
+
         /**
-         * Sets the badge text for the browser action. The badge is displayed on top of the icon.
-         * @param callback Supported since Chrome 67
+         * Sets the title of the browser action. This title appears in the tooltip.
+         * @param callback Since Chrome 67
          */
-        export function setBadgeText(details: BadgeTextDetails, callback: () => void): void;
-        /**
-         * Sets the title of the browser action. This shows up in the tooltip.
-         * @return The `setTitle` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
-         */
-        export function setTitle(details: TitleDetails): Promise<void>;
-        /**
-         * Sets the title of the browser action. This shows up in the tooltip.
-         * @param callback Supported since Chrome 67
-         */
-        export function setTitle(details: TitleDetails, callback: () => void): void;
-        /**
-         * @since Chrome 19
-         * Gets the badge text of the browser action. If no tab is specified, the non-tab-specific badge text is returned.
-         * @param callback Supported since Chrome 67
-         */
+        export function setTitle(details: TitleDetails, callback?: () => void): void;
+
+        /** Gets the badge text of the browser action. If no tab is specified, the non-tab-specific badge text is returned. */
         export function getBadgeText(details: TabDetails, callback: (result: string) => void): void;
+
         /**
-         * @since Chrome 19
-         * Gets the badge text of the browser action. If no tab is specified, the non-tab-specific badge text is returned.
-         * @return The `getBadgeText` method provides its result via callback or returned as a `Promise` (MV3 only).
-         */
-        export function getBadgeText(details: TabDetails): Promise<string>;
-        /**
-         * Sets the html document to be opened as a popup when the user clicks on the browser action's icon.
-         * @return The `setPopup` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
-         */
-        export function setPopup(details: PopupDetails): Promise<void>;
-        /**
-         * Sets the html document to be opened as a popup when the user clicks on the browser action's icon.
-         * @param callback Supported since Chrome 67
+         * Sets the HTML document to be opened as a popup when the user clicks the browser action icon.
+         * @param callback Since Chrome 67
          */
         export function setPopup(details: PopupDetails, callback?: () => void): void;
+
         /**
-         * @since Chrome 22
          * Disables the browser action for a tab.
-         * @param tabId The id of the tab for which you want to modify the browser action.
-         * @return The `disable` method provides its result via callback or returned as a `Promise` (MV3 only). It has no parameters.
+         * @param tabId The ID of the tab for which to modify the browser action.
+         * @param callback since Chrome 67
          */
-        export function disable(tabId?: number | null): Promise<void>;
-        /**
-         * @since Chrome 22
-         * Disables the browser action for a tab.
-         * @param tabId The id of the tab for which you want to modify the browser action.
-         * @param callback Supported since Chrome 67
-         */
-        export function disable(callback: () => void): void;
-        export function disable(tabId?: number | null, callback?: () => void): void;
-        /**
-         * @since Chrome 19
-         * Gets the title of the browser action.
-         */
+        export function disable(callback?: () => void): void;
+        export function disable(tabId: number | null | undefined, callback?: () => void): void;
+
+        /** Gets the title of the browser action. */
         export function getTitle(details: TabDetails, callback: (result: string) => void): void;
-        /**
-         * @since Chrome 19
-         * Gets the title of the browser action.
-         * @return The `getTitle` method provides its result via callback or returned as a `Promise` (MV3 only).
-         */
-        export function getTitle(details: TabDetails): Promise<string>;
-        /**
-         * @since Chrome 19
-         * Gets the background color of the browser action.
-         */
+
+        /** Gets the background color of the browser action. */
         export function getBadgeBackgroundColor(
             details: TabDetails,
             callback: (result: extensionTypes.ColorArray) => void,
         ): void;
-        /**
-         * @since Chrome 19
-         * Gets the background color of the browser action.
-         * @return The `getBadgeBackgroundColor` method provides its result via callback or returned as a `Promise` (MV3 only).
-         */
-        export function getBadgeBackgroundColor(details: TabDetails): Promise<extensionTypes.ColorArray>;
-        /**
-         * @since Chrome 19
-         * Gets the html document set as the popup for this browser action.
-         */
+
+        /** Gets the HTML document that is set as the popup for this browser action. */
         export function getPopup(details: TabDetails, callback: (result: string) => void): void;
+
         /**
-         * @since Chrome 19
-         * Gets the html document set as the popup for this browser action.
-         * @return The `getPopup` method provides its result via callback or returned as a `Promise` (MV3 only).
-         */
-        export function getPopup(details: TabDetails): Promise<string>;
-        /**
-         * Sets the icon for the browser action. The icon can be specified either as the path to an image file or as the pixel data from a canvas element, or as dictionary of either one of those. Either the path or the imageData property must be specified.
+         * Sets the icon for the browser action. The icon can be specified as the path to an image file, as the pixel data from a canvas element, or as a dictionary of one of those. Either the `path` or the `imageData` property must be specified.
          */
         export function setIcon(details: TabIconDetails, callback?: () => void): void;
 
-        /** Fired when a browser action icon is clicked. This event will not fire if the browser action has a popup. */
-        export var onClicked: BrowserClickedEvent;
+        /** Fired when a browser action icon is clicked. Does not fire if the browser action has a popup. */
+        export const onClicked: events.Event<(tab: chrome.tabs.Tab) => void>;
     }
 
     ////////////////////

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -153,25 +153,6 @@ function testBookmarks() {
     });
 }
 
-// https://developer.chrome.com/extensions/examples/api/browserAction/make_page_red/background.js
-function pageRedder() {
-    chrome.browserAction.onClicked.addListener(function(tab) {
-        // No tabs or host permissions needed!
-        console.log("Turning " + tab.url + " red!");
-        chrome.tabs.executeScript({
-            code: "document.body.style.backgroundColor=\"red\"",
-        });
-    });
-}
-
-// https://developer.chrome.com/extensions/examples/api/browserAction/print/background.js
-function printPage() {
-    chrome.browserAction.onClicked.addListener(function(tab) {
-        var action_url = "javascript:window.print();";
-        chrome.tabs.update(tab.id!, { url: action_url });
-    });
-}
-
 // https://developer.chrome.com/docs/extensions/reference/api/webNavigation
 function testWebNavigation() {
     /**
@@ -2202,196 +2183,101 @@ function testSearch() {
     chrome.search.query(queryInfo1, () => {}).then(() => {});
 }
 
-// https://developer.chrome.com/docs/extensions/reference/browserAction/#method-enable
-function testBrowserAcionEnable() {
-    chrome.browserAction.enable();
-    chrome.browserAction.enable(console.log);
-    chrome.browserAction.enable(0);
-    chrome.browserAction.enable(0, console.log);
-    chrome.browserAction.enable(null);
-    chrome.browserAction.enable(null, console.log);
-    chrome.browserAction.enable(undefined);
-    chrome.browserAction.enable(undefined, console.log);
-}
+// https://developer.chrome.com/docs/extensions/mv2/reference/browserAction
+function testBrowserAction() {
+    const tabId = 0;
+    chrome.browserAction.disable(); // $ExpectType void
+    chrome.browserAction.disable(() => void 0); // $ExpectType void
+    chrome.browserAction.disable(tabId); // $ExpectType void
+    chrome.browserAction.disable(tabId, () => void 0); // $ExpectType void
+    chrome.browserAction.disable(null); // $ExpectType void
+    chrome.browserAction.disable(null, () => void 0); // $ExpectType void
 
-// https://developer.chrome.com/docs/extensions/reference/browserAction/#method-disable
-function testBrowserAcionDisable() {
-    chrome.browserAction.disable();
-    chrome.browserAction.disable(console.log);
-    chrome.browserAction.disable(0);
-    chrome.browserAction.disable(0, console.log);
-    chrome.browserAction.disable(null);
-    chrome.browserAction.disable(null, console.log);
-    chrome.browserAction.disable(undefined);
-    chrome.browserAction.disable(undefined, console.log);
-}
+    chrome.browserAction.enable(); // $ExpectType void
+    chrome.browserAction.enable(() => void 0); // $ExpectType void
+    chrome.browserAction.enable(tabId); // $ExpectType void
+    chrome.browserAction.enable(tabId, () => void 0); // $ExpectType void
+    chrome.browserAction.enable(null); // $ExpectType void
+    chrome.browserAction.enable(null, () => void 0); // $ExpectType void
 
-// https://developer.chrome.com/docs/extensions/reference/browserAction/#method-getBadgeBackgroundColor
-function testBrowserAcionGetBadgeBackgroundColor() {
-    chrome.browserAction.getBadgeBackgroundColor({}, console.log);
-    chrome.browserAction.getBadgeBackgroundColor({ tabId: 0 }, console.log);
-    chrome.browserAction.getBadgeBackgroundColor({ tabId: null }, console.log);
-    chrome.browserAction.getBadgeBackgroundColor({ tabId: undefined }, console.log);
+    const getDetails: chrome.browserAction.TabDetails = { tabId };
 
-    // @ts-expect-error
-    chrome.browserAction.getBadgeBackgroundColor();
-    // @ts-expect-error
-    chrome.browserAction.getBadgeBackgroundColor(null);
-    // @ts-expect-error
-    chrome.browserAction.getBadgeBackgroundColor(undefined);
-}
+    chrome.browserAction.getBadgeBackgroundColor(getDetails, (result) => { // $ExpectType void
+        result; // $ExpectType ColorArray
+    });
+    // @ts-expect-error No matching signature
+    chrome.browserAction.getBadgeBackgroundColor(getDetails);
 
-// https://developer.chrome.com/docs/extensions/reference/browserAction/#method-getBadgeText
-function testBrowserAcionGetBadgeText() {
-    chrome.browserAction.getBadgeText({}, console.log);
-    chrome.browserAction.getBadgeText({ tabId: 0 }, console.log);
-    chrome.browserAction.getBadgeText({ tabId: null }, console.log);
-    chrome.browserAction.getBadgeText({ tabId: undefined }, console.log);
+    chrome.browserAction.getBadgeText(getDetails, (result) => { // $ExpectType void
+        result; // $ExpectType string
+    });
+    // @ts-expect-error No matching signature
+    chrome.browserAction.getBadgeText(getDetails);
 
-    // @ts-expect-error
-    chrome.browserAction.getBadgeText();
-    // @ts-expect-error
-    chrome.browserAction.getBadgeText(null);
-    // @ts-expect-error
-    chrome.browserAction.getBadgeText(undefined);
-    // @ts-expect-error
-    chrome.browserAction.getBadgeText(console.log);
-}
+    chrome.browserAction.getPopup(getDetails, (result) => { // $ExpectType void
+        result; // $ExpectType string
+    });
+    // @ts-expect-error No matching signature
+    chrome.browserAction.getPopup(getDetails);
 
-// https://developer.chrome.com/docs/extensions/reference/browserAction/#method-getPopup
-function testBrowserAcionGetPopup() {
-    chrome.browserAction.getPopup({});
-    chrome.browserAction.getPopup({}, console.log);
-    chrome.browserAction.getPopup({ tabId: 0 });
-    chrome.browserAction.getPopup({ tabId: 0 }, console.log);
-    chrome.browserAction.getPopup({ tabId: null });
-    chrome.browserAction.getPopup({ tabId: null }, console.log);
-    chrome.browserAction.getPopup({ tabId: undefined });
-    chrome.browserAction.getPopup({ tabId: undefined }, console.log);
+    chrome.browserAction.getTitle(getDetails, (result) => { // $ExpectType void
+        result; // $ExpectType string
+    });
+    // @ts-expect-error No matching signature
+    chrome.browserAction.getTitle(getDetails);
 
-    // @ts-expect-error
-    chrome.browserAction.getPopup();
-    // @ts-expect-error
-    chrome.browserAction.getPopup(null);
-    // @ts-expect-error
-    chrome.browserAction.getPopup(undefined);
-    // @ts-expect-error
-    chrome.browserAction.getPopup(console.log);
-}
+    const badgeBackgroundColorDetails: chrome.browserAction.BadgeBackgroundColorDetails = {
+        color: [255, 0, 0, 255],
+        tabId,
+    };
 
-// https://developer.chrome.com/docs/extensions/reference/browserAction/#method-getPopup
-function testBrowserAcionGetTitle() {
-    chrome.browserAction.getTitle({});
-    chrome.browserAction.getTitle({}, console.log);
-    chrome.browserAction.getTitle({ tabId: 0 });
-    chrome.browserAction.getTitle({ tabId: 0 }, console.log);
-    chrome.browserAction.getTitle({ tabId: null });
-    chrome.browserAction.getTitle({ tabId: null }, console.log);
-    chrome.browserAction.getTitle({ tabId: undefined });
-    chrome.browserAction.getTitle({ tabId: undefined }, console.log);
+    chrome.browserAction.setBadgeBackgroundColor(badgeBackgroundColorDetails); // $ExpectType void
+    chrome.browserAction.setBadgeBackgroundColor(badgeBackgroundColorDetails, () => void 0); // $ExpectType void
 
-    // @ts-expect-error
-    chrome.browserAction.getTitle();
-    // @ts-expect-error
-    chrome.browserAction.getTitle(null);
-    // @ts-expect-error
-    chrome.browserAction.getTitle(undefined);
-    // @ts-expect-error
-    chrome.browserAction.getTitle(console.log);
-}
+    const badgeTextDetails: chrome.browserAction.BadgeTextDetails = {
+        text: "text",
+        tabId,
+    };
 
-// https://developer.chrome.com/docs/extensions/reference/browserAction/#method-setBadgeBackgroundColor
-function testBrowserAcionSetBadgeBackgroundColor() {
-    chrome.browserAction.setBadgeBackgroundColor({ color: "red" });
-    chrome.browserAction.setBadgeBackgroundColor({ color: "red" }, console.log);
-    chrome.browserAction.setBadgeBackgroundColor({ color: "red", tabId: 0 });
-    chrome.browserAction.setBadgeBackgroundColor({ color: "red", tabId: 0 }, console.log);
-    chrome.browserAction.setBadgeBackgroundColor({ color: [1, 2, 3, 4], tabId: 0 });
-    chrome.browserAction.setBadgeBackgroundColor({ color: [1, 2, 3, 4], tabId: 0 }, console.log);
+    chrome.browserAction.setBadgeText(badgeTextDetails); // $ExpectType void
+    chrome.browserAction.setBadgeText(badgeTextDetails, () => void 0); // $ExpectType void
 
-    // @ts-expect-error
-    chrome.browserAction.setBadgeBackgroundColor();
-    // @ts-expect-error
-    chrome.browserAction.setBadgeBackgroundColor({});
-    // @ts-expect-error
-    chrome.browserAction.setBadgeBackgroundColor({ tabId: 0 });
-    // @ts-expect-error
-    chrome.browserAction.setBadgeBackgroundColor({ color: [1, 2, 3] }, console.log);
-    // @ts-expect-error
-    chrome.browserAction.setBadgeBackgroundColor(null);
-    // @ts-expect-error
-    chrome.browserAction.setBadgeBackgroundColor(undefined);
-}
+    const iconDetails: chrome.browserAction.TabIconDetails = {
+        imageData: { 16: new ImageData(16, 16) },
+        tabId,
+    };
 
-// https://developer.chrome.com/docs/extensions/reference/browserAction/#method-setBadgeText
-function testBrowserActionSetBrowserBadgeText() {
-    chrome.browserAction.setBadgeText({});
-    chrome.browserAction.setBadgeText({ text: "test" });
-    chrome.browserAction.setBadgeText({ text: null });
-    chrome.browserAction.setBadgeText({ text: undefined });
-    chrome.browserAction.setBadgeText({ tabId: 123 });
-    chrome.browserAction.setBadgeText({ text: "test", tabId: 123 });
-    chrome.browserAction.setBadgeText({}, () => {});
+    const iconDetails2: chrome.browserAction.TabIconDetails = {
+        path: "path/to/icon.png",
+        tabId,
+    };
 
-    // @ts-expect-error
-    chrome.browserAction.setBadgeText();
-    // @ts-expect-error
-    chrome.browserAction.setBadgeText(undefined);
-}
+    chrome.browserAction.setIcon(iconDetails); // $ExpectType void
+    chrome.browserAction.setIcon(iconDetails2); // $ExpectType void
+    chrome.browserAction.setIcon(iconDetails, () => void 0); // $ExpectType void
+    chrome.browserAction.setIcon(iconDetails2, () => void 0); // $ExpectType void
+    // @ts-expect-error Either the path or imageData property must be specified.
+    chrome.browserAction.setIcon({});
 
-// https://developer.chrome.com/docs/extensions/reference/browserAction/#method-setIcon
-function testBrowserAcionSetIcon() {
-    chrome.browserAction.setIcon({ path: "/icon.png" });
-    chrome.browserAction.setIcon({ path: "/icon.png" }, console.log);
-    chrome.browserAction.setIcon({ path: { 16: "/icon.png" } });
-    chrome.browserAction.setIcon({ path: { 16: "/icon.png" } }, console.log);
-    chrome.browserAction.setIcon({ path: { 16: "/icon.png" }, tabId: 0 });
-    chrome.browserAction.setIcon({ path: { 16: "/icon.png" }, tabId: 0 }, console.log);
+    const popupDetails: chrome.browserAction.PopupDetails = {
+        popup: "popup.html",
+        tabId,
+    };
 
-    // @ts-expect-error
-    chrome.browserAction.setIcon();
-    // @ts-expect-error
-    chrome.browserAction.setIcon(null);
-    // @ts-expect-error
-    chrome.browserAction.setIcon(undefined);
-}
+    chrome.browserAction.setPopup(popupDetails); // $ExpectType void
+    chrome.browserAction.setPopup(popupDetails, () => void 0); // $ExpectType void
 
-// https://developer.chrome.com/docs/extensions/reference/browserAction/#method-setPopup
-function testBrowserAcionSetPopup() {
-    chrome.browserAction.setPopup({ popup: "index.html" });
-    chrome.browserAction.setPopup({ popup: "index.html" }, console.log);
-    chrome.browserAction.setPopup({ popup: "index.html", tabId: 0 });
-    chrome.browserAction.setPopup({ popup: "index.html", tabId: 0 }, console.log);
-    chrome.browserAction.setPopup({ popup: "index.html", tabId: null });
-    chrome.browserAction.setPopup({ popup: "index.html", tabId: null }, console.log);
-    chrome.browserAction.setPopup({ popup: "index.html", tabId: undefined });
-    chrome.browserAction.setPopup({ popup: "index.html", tabId: undefined }, console.log);
+    const titleDetails: chrome.browserAction.TitleDetails = {
+        title: "title",
+        tabId,
+    };
 
-    // @ts-expect-error
-    chrome.browserAction.setPopup();
-    // @ts-expect-error
-    chrome.browserAction.setPopup(null);
-    // @ts-expect-error
-    chrome.browserAction.setPopup(undefined);
-}
+    chrome.browserAction.setTitle(titleDetails); // $ExpectType void
+    chrome.browserAction.setTitle(titleDetails, () => void 0); // $ExpectType void
 
-// https://developer.chrome.com/docs/extensions/reference/browserAction/#method-setTitle
-function testBrowserAcionSetTitle() {
-    chrome.browserAction.setTitle({ title: "Title" });
-    chrome.browserAction.setTitle({ title: "Title" }, console.log);
-    chrome.browserAction.setTitle({ title: "Title", tabId: 0 });
-    chrome.browserAction.setTitle({ title: "Title", tabId: 0 }, console.log);
-    chrome.browserAction.setTitle({ title: "Title", tabId: null });
-    chrome.browserAction.setTitle({ title: "Title", tabId: null }, console.log);
-    chrome.browserAction.setTitle({ title: "Title", tabId: undefined });
-    chrome.browserAction.setTitle({ title: "Title", tabId: undefined }, console.log);
-
-    // @ts-expect-error
-    chrome.browserAction.setTitle();
-    // @ts-expect-error
-    chrome.browserAction.setTitle(null);
-    // @ts-expect-error
-    chrome.browserAction.setTitle(undefined);
+    checkChromeEvent(chrome.browserAction.onClicked, (tab) => {
+        tab; // $ExpectType Tab
+    });
 }
 
 // https://developer.chrome.com/docs/extensions/reference/api/action
@@ -2680,20 +2566,6 @@ async function testBookmarksForPromise() {
     await chrome.bookmarks.getChildren("id1");
     await chrome.bookmarks.getSubTree("id1");
     await chrome.bookmarks.removeTree("id1");
-}
-
-// https://developer.chrome.com/docs/extensions/reference/browserAction
-async function testBrowserActionForPromise() {
-    await chrome.browserAction.enable(0);
-    await chrome.browserAction.setBadgeBackgroundColor({ color: "color1" });
-    await chrome.browserAction.setBadgeText({});
-    await chrome.browserAction.setTitle({ title: "title1" });
-    await chrome.browserAction.getBadgeText({});
-    await chrome.browserAction.setPopup({ popup: "popup1" });
-    await chrome.browserAction.disable(0);
-    await chrome.browserAction.getTitle({});
-    await chrome.browserAction.getBadgeBackgroundColor({});
-    await chrome.browserAction.getPopup({});
 }
 
 // https://developer.chrome.com/docs/extensions/reference/api/cookies


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/mv2/reference/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes:
- the documentation mixes MV2 and MV3, but this namespace is only available for MV2!
- remove `promise` support (MV3 only) for all functions (I don’t know why Promise was added through [this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/53120) that adds support for this namespace)
  > Promises are only supported for Manifest V3 and later, other platforms need to use callbacks.
  <img width="285" height="62" alt="image" src="https://github.com/user-attachments/assets/b419f32d-17f9-436c-86fb-34593643e9cf" />
- update  `tabId` param: can be `null`
  <img width="496" height="165" alt="image" src="https://github.com/user-attachments/assets/a455b218-7330-4792-be92-82dcd18e55aa" />
- update `setIcon()`: Either the path or imageData property must be specified
  <img width="670" height="117" alt="image" src="https://github.com/user-attachments/assets/29a26ddb-94db-40e4-93c7-a31e134a52f6" />
- update tests
- update JSDoc

Runtime:
<img width="690" height="361" alt="image" src="https://github.com/user-attachments/assets/771c51db-d1de-4140-ac6c-31454e2d54d5" />
