### PR TITLE
[chrome] update pageAction namespace (MV2 only)

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -7551,8 +7551,6 @@ declare namespace chrome {
      * MV2 only
      */
     export namespace pageAction {
-        export interface PageActionClickedEvent extends chrome.events.Event<(tab: chrome.tabs.Tab) => void> {}
-
         export interface TitleDetails {
             /** The id of the tab for which you want to modify the page action. */
             tabId: number;
@@ -7560,77 +7558,77 @@ declare namespace chrome {
             title: string;
         }
 
-        export interface GetDetails {
-            /** Specify the tab to get the title from. */
+        export interface TabDetails {
+            /** The ID of the tab to query state for. */
             tabId: number;
         }
 
         export interface PopupDetails {
             /** The id of the tab for which you want to modify the page action. */
             tabId: number;
-            /** The html file to show in a popup. If set to the empty string (''), no popup is shown. */
+            /** The relative path to the HTML file to show in a popup. If set to the empty string (`''`), no popup is shown. */
             popup: string;
         }
 
-        export interface IconDetails {
-            /** The id of the tab for which you want to modify the page action. */
-            tabId: number;
-            /**
-             * Optional.
-             * @deprecated This argument is ignored.
-             */
-            iconIndex?: number | undefined;
-            /**
-             * Optional.
-             * Either an ImageData object or a dictionary {size -> ImageData} representing icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals scale, then image with size scale * 19 will be selected. Initially only scales 1 and 2 will be supported. At least one image must be specified. Note that 'details.imageData = foo' is equivalent to 'details.imageData = {'19': foo}'
-             */
-            imageData?: ImageData | { [index: number]: ImageData } | undefined;
-            /**
-             * Optional.
-             * Either a relative image path or a dictionary {size -> relative image path} pointing to icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals scale, then image with size scale * 19 will be selected. Initially only scales 1 and 2 will be supported. At least one image must be specified. Note that 'details.path = foo' is equivalent to 'details.imageData = {'19': foo}'
-             */
-            path?: string | { [index: string]: string } | undefined;
-        }
+        export type IconDetails =
+            & {
+                /** @deprecated This argument is ignored. */
+                iconIndex?: number | undefined;
+                /** The id of the tab for which you want to modify the page action. */
+                tabId: number;
+            }
+            & (
+                | {
+                    /** Either an ImageData object or a dictionary {size -> ImageData} representing icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals `scale`, then image with size `scale` \* n will be selected, where n is the size of the icon in the UI. At least one image must be specified. Note that 'details.imageData = foo' is equivalent to 'details.imageData = {'16': foo}' */
+                    imageData: ImageData | { [index: number]: ImageData };
+                    /** Either a relative image path or a dictionary {size -> relative image path} pointing to icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals `scale`, then image with size `scale` \* n will be selected, where n is the size of the icon in the UI. At least one image must be specified. Note that 'details.path = foo' is equivalent to 'details.path = {'16': foo}' */
+                    path?: string | { [index: string]: string } | undefined;
+                }
+                | {
+                    /** Either an ImageData object or a dictionary {size -> ImageData} representing icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals `scale`, then image with size `scale` \* n will be selected, where n is the size of the icon in the UI. At least one image must be specified. Note that 'details.imageData = foo' is equivalent to 'details.imageData = {'16': foo}' */
+                    imageData?: ImageData | { [index: number]: ImageData } | undefined;
+                    /** Either a relative image path or a dictionary {size -> relative image path} pointing to icon to be set. If the icon is specified as a dictionary, the actual image to be used is chosen depending on screen's pixel density. If the number of image pixels that fit into one screen space unit equals `scale`, then image with size `scale` \* n will be selected, where n is the size of the icon in the UI. At least one image must be specified. Note that 'details.path = foo' is equivalent to 'details.path = {'16': foo}' */
+                    path: string | { [index: string]: string };
+                }
+            );
+
+        /**
+         * Hides the page action. Hidden page actions still appear in the Chrome toolbar, but are grayed out.
+         * @param tabId The id of the tab for which you want to modify the page action.
+         * @param callback Since Chrome 67
+         */
+        export function hide(tabId: number, callback?: () => void): void;
 
         /**
          * Shows the page action. The page action is shown whenever the tab is selected.
          * @param tabId The id of the tab for which you want to modify the page action.
-         * @param callback Supported since Chrome 67
-         */
-        export function hide(tabId: number, callback?: () => void): void;
-        /**
-         * Shows the page action. The page action is shown whenever the tab is selected.
-         * @param tabId The id of the tab for which you want to modify the page action.
-         * @param callback Supported since Chrome 67
+         * @param callback Since Chrome 67
          */
         export function show(tabId: number, callback?: () => void): void;
+
         /**
          * Sets the title of the page action. This is displayed in a tooltip over the page action.
-         * @param callback Supported since Chrome 67
+         * @param callback Since Chrome 67
          */
         export function setTitle(details: TitleDetails, callback?: () => void): void;
+
         /**
-         * Sets the html document to be opened as a popup when the user clicks on the page action's icon.
-         * @param callback Supported since Chrome 67
+         * Sets the HTML document to be opened as a popup when the user clicks on the page action's icon.
+         * @param callback Since Chrome 67
          */
         export function setPopup(details: PopupDetails, callback?: () => void): void;
-        /**
-         * Gets the title of the page action.
-         * @since Chrome 19
-         */
-        export function getTitle(details: GetDetails, callback: (result: string) => void): void;
-        /**
-         * Gets the html document set as the popup for this page action.
-         * @since Chrome 19
-         */
-        export function getPopup(details: GetDetails, callback: (result: string) => void): void;
-        /**
-         * Sets the icon for the page action. The icon can be specified either as the path to an image file or as the pixel data from a canvas element, or as dictionary of either one of those. Either the path or the imageData property must be specified.
-         */
+
+        /** Gets the title of the page action. */
+        export function getTitle(details: TabDetails, callback: (result: string) => void): void;
+
+        /** Gets the html document set as the popup for this page action. */
+        export function getPopup(details: TabDetails, callback: (result: string) => void): void;
+
+        /** Sets the icon for the page action. The icon can be specified either as the path to an image file or as the pixel data from a canvas element, or as dictionary of either one of those. Either the path or the imageData property must be specified. */
         export function setIcon(details: IconDetails, callback?: () => void): void;
 
         /** Fired when a page action icon is clicked. This event will not fire if the page action has a popup. */
-        export var onClicked: PageActionClickedEvent;
+        export const onClicked: events.Event<(tab: chrome.tabs.Tab) => void>;
     }
 
     ////////////////////

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -4912,6 +4912,67 @@ function testI18n() {
     chrome.i18n.getUILanguage(); // $ExpectType string
 }
 
+// https://developer.chrome.com/docs/extensions/mv2/reference/pageAction
+function testPageAction() {
+    const tabId = 1;
+    const getDetails: chrome.pageAction.TabDetails = { tabId };
+
+    chrome.pageAction.getPopup(getDetails, (result) => { // $ExpectType void
+        result; // $ExpectType string
+    });
+    // @ts-expect-error No matching signature
+    chrome.pageAction.getPopup(getDetails);
+
+    chrome.pageAction.getTitle(getDetails, (result) => { // $ExpectType void
+        result; // $ExpectType string
+    });
+    // @ts-expect-error No matching signature
+    chrome.pageAction.getTitle(getDetails);
+
+    chrome.pageAction.hide(tabId); // $ExpectType void
+    chrome.pageAction.hide(tabId, () => void 0); // $ExpectType void
+
+    const iconDetails: chrome.pageAction.IconDetails = {
+        tabId,
+        path: "path/to/icon.png",
+    };
+
+    const iconDetails2: chrome.pageAction.IconDetails = {
+        tabId,
+        imageData: new ImageData(16, 16),
+    };
+
+    chrome.pageAction.setIcon(iconDetails); // $ExpectType void
+    chrome.pageAction.setIcon(iconDetails2); // $ExpectType void
+    chrome.pageAction.setIcon(iconDetails, () => void 0); // $ExpectType void
+    chrome.pageAction.setIcon(iconDetails2, () => void 0); // $ExpectType void
+    // @ts-expect-error Either the path or imageData property must be specified.
+    chrome.pageAction.setIcon({});
+
+    const popupDetails: chrome.pageAction.PopupDetails = {
+        popup: "popup.html",
+        tabId,
+    };
+
+    chrome.pageAction.setPopup(popupDetails); // $ExpectType void
+    chrome.pageAction.setPopup(popupDetails, () => void 0); // $ExpectType void
+
+    const titleDetails: chrome.pageAction.TitleDetails = {
+        title: "My Page Action",
+        tabId,
+    };
+
+    chrome.pageAction.setTitle(titleDetails); // $ExpectType void
+    chrome.pageAction.setTitle(titleDetails, () => void 0); // $ExpectType void
+
+    chrome.pageAction.show(tabId); // $ExpectType void
+    chrome.pageAction.show(tabId, () => void 0); // $ExpectType void
+
+    checkChromeEvent(chrome.pageAction.onClicked, (tab) => {
+        tab; // $ExpectType Tab
+    });
+}
+
 // https://developer.chrome.com/docs/extensions/reference/api/pageCapture
 function testPageCapture() {
     const details = { tabId: 0 };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/mv2/reference/pageAction
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes:
- the documentation mixes MV2 and MV3, but this namespace is only available for MV2!
- rename `GetDetails` to `TabDetails` (official name)
- update `setIcon()`: Either the path or imageData property must be specified
  <img width="587" height="96" alt="image" src="https://github.com/user-attachments/assets/32db565c-3b90-411d-b65a-950f41ff3e9d" />
- add tests
- update JSDoc

Runtime:
<img width="447" height="248" alt="image" src="https://github.com/user-attachments/assets/2e70c242-efb8-451b-989f-b0c9680f27cd" />
