### PR TITLE
[@types/aws-cloudfront-function] override`cf.kvs` for optional argument (#73959)

### DIFF
--- a/types/aws-cloudfront-function/aws-cloudfront-function-tests.ts
+++ b/types/aws-cloudfront-function/aws-cloudfront-function-tests.ts
@@ -137,6 +137,10 @@ function handler2(event: AWSCloudFrontFunction.Event): AWSCloudFrontFunction.Req
 
 import cf from "cloudfront";
 
+// $ExpectType KVStore
+cf.kvs();
+
+// $ExpectType KVStore
 const kvsHandle = cf.kvs("example-kvs-id");
 
 async function handler3(

--- a/types/aws-cloudfront-function/index.d.ts
+++ b/types/aws-cloudfront-function/index.d.ts
@@ -62,9 +62,21 @@ declare namespace AWSCloudFrontFunction {
 
 declare module "cloudfront" {
     /**
-     * Retrieves a reference to a CloudFront Key-Value Store (KVS) by its ID.
-     * @param kvsId The identifier of the KVS to use.
-     * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-custom-methods.html
+     * Retrieves the current Function's associated KeyValueStore. See the
+     * {@link https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-custom-methods.html | CloudFront Developer Guide}.
+     * @returns An instance of the associated KeyValueStore.
+     * @throws If no KeyValueStore is associated with the Function.
+     */
+    function kvs(): KVStore;
+
+    /**
+     * Retrieves a reference to the current Function's associated KeyValueStore by its ID. Though not documented
+     * in the {@link https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-custom-methods.html | CloudFront Developer Guide},
+     * this overload has been proven to work in practice and is shown in the
+     * {@link https://aws.amazon.com/blogs/aws/introducing-amazon-cloudfront-keyvaluestore-a-low-latency-datastore-for-cloudfront-functions/ | AWS News Blog announcement}.
+     * @param kvsId The identifier of an associated KeyValueStore.
+     * @returns An instance of the KeyValueStore.
+     * @throws If KeyValueStore does not exist or is not associated with the Function.
      */
     function kvs(kvsId: string): KVStore;
 


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [CloudFront Developer Guide: Helper methods for key value stores](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-custom-methods.html)
  - [AWS News Blog: Introducing Amazon CloudFront KeyValueStore: A low-latency datastore for CloudFront Functions](https://aws.amazon.com/blogs/aws/introducing-amazon-cloudfront-keyvaluestore-a-low-latency-datastore-for-cloudfront-functions/)
  - Issue #73959