### PR TITLE
feat(validator): update isLicensePlate's locale list

### DIFF
--- a/types/validator/index.d.ts
+++ b/types/validator/index.d.ts
@@ -851,18 +851,18 @@ declare namespace validator {
         | "en-IN"
         | "en-SG"
         | "es-AR"
+        | "fi-FI"
         | "hu-HU"
         | "pt-BR"
         | "pt-PT"
         | "sq-AL"
         | "sv-SE"
-        | "en-PK"
-        | "any";
+        | "en-PK";
 
     /**
      * Check if the string matches the format of a country's license plate.
      */
-    export function isLicensePlate(str: string, locale: LicensePlateLocale): boolean;
+    export function isLicensePlate(str: string, locale: LicensePlateLocale | "any"): boolean;
     export function isLicensePlate(str: string, locale: string): unknown;
 
     /**

--- a/types/validator/validator-tests.ts
+++ b/types/validator/validator-tests.ts
@@ -280,7 +280,7 @@ import whitelistFunc from "validator/lib/whitelist";
     let _isLength = validator.isLength;
     _isLength = isLengthFunc;
 
-    // $ExpectType { (str: string, locale: LicensePlateLocale): boolean; (str: string, locale: string): unknown; }
+    // $ExpectType { (str: string, locale: "any" | LicensePlateLocale): boolean; (str: string, locale: string): unknown; }
     let _isLicensePlate = validator.isLicensePlate;
     _isLicensePlate = isLicensePlateFunc;
 
@@ -864,8 +864,20 @@ const any: any = null;
     result = validator.isLength("sample", isLengthOptions);
     result = validator.isLength("sample");
 
-    const licensePlateLocale: validator.LicensePlateLocale = "any";
-    result = validator.isLicensePlate("sample", licensePlateLocale);
+    result = validator.isLicensePlate("sample", "cs-CZ" satisfies validator.LicensePlateLocale);
+    result = validator.isLicensePlate("sample", "de-DE");
+    result = validator.isLicensePlate("sample", "de-LI");
+    result = validator.isLicensePlate("sample", "en-IN");
+    result = validator.isLicensePlate("sample", "en-SG");
+    result = validator.isLicensePlate("sample", "es-AR");
+    result = validator.isLicensePlate("sample", "fi-FI");
+    result = validator.isLicensePlate("sample", "hu-HU");
+    result = validator.isLicensePlate("sample", "pt-BR");
+    result = validator.isLicensePlate("sample", "pt-PT");
+    result = validator.isLicensePlate("sample", "sq-AL");
+    result = validator.isLicensePlate("sample", "sv-SE");
+    result = validator.isLicensePlate("sample", "en-PK");
+    result = validator.isLicensePlate("sample", "any");
     // $ExpectType unknown
     validator.isLicensePlate("sample", "");
 


### PR DESCRIPTION
- `"fi-FI"` has been missing, see https://github.com/validatorjs/validator.js/blob/master/src/lib/isLicensePlate.js#L12.
- `"any"` is moved away from the `LicensePlateLocale`, to match the convention of other similarly-defined locale types.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
