### PR TITLE
[leaflet-deepzoom] mark as type=module

### DIFF
--- a/types/leaflet-deepzoom/package.json
+++ b/types/leaflet-deepzoom/package.json
@@ -2,6 +2,7 @@
     "private": true,
     "name": "@types/leaflet-deepzoom",
     "version": "2.0.9999",
+    "type": "module",
     "projects": [
         "https://github.com/alfarisi/leaflet-deepzoom/"
     ],


### PR DESCRIPTION
This package marked itself as `type=module` in a patch release, which is nearly always a breaking change  unless special care was taken (it was not).

Update the types to match and make CI pass again.