### PR TITLE
[react] Add types for Promise subclasses React special cases

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1926,7 +1926,31 @@ declare namespace React {
         reducer: (state: State, action: Action) => State,
     ): [State, (action: Action) => void];
 
-    export type Usable<T> = PromiseLike<T> | Context<T>;
+    interface UntrackedReactPromise<T> extends PromiseLike<T> {
+        status?: void;
+    }
+
+    export interface PendingReactPromise<T> extends PromiseLike<T> {
+        status: "pending";
+    }
+
+    export interface FulfilledReactPromise<T> extends PromiseLike<T> {
+        status: "fulfilled";
+        value: T;
+    }
+
+    export interface RejectedReactPromise<T> extends PromiseLike<T> {
+        status: "rejected";
+        reason: unknown;
+    }
+
+    export type ReactPromise<T> =
+        | UntrackedReactPromise<T>
+        | PendingReactPromise<T>
+        | FulfilledReactPromise<T>
+        | RejectedReactPromise<T>;
+
+    export type Usable<T> = ReactPromise<T> | Context<T>;
 
     export function use<T>(usable: Usable<T>): T;
 

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -1925,7 +1925,31 @@ declare namespace React {
         reducer: (state: State, action: Action) => State,
     ): [State, (action: Action) => void];
 
-    export type Usable<T> = PromiseLike<T> | Context<T>;
+    interface UntrackedReactPromise<T> extends PromiseLike<T> {
+        status?: void;
+    }
+
+    export interface PendingReactPromise<T> extends PromiseLike<T> {
+        status: "pending";
+    }
+
+    export interface FulfilledReactPromise<T> extends PromiseLike<T> {
+        status: "fulfilled";
+        value: T;
+    }
+
+    export interface RejectedReactPromise<T> extends PromiseLike<T> {
+        status: "rejected";
+        reason: unknown;
+    }
+
+    export type ReactPromise<T> =
+        | UntrackedReactPromise<T>
+        | PendingReactPromise<T>
+        | FulfilledReactPromise<T>
+        | RejectedReactPromise<T>;
+
+    export type Usable<T> = ReactPromise<T> | Context<T>;
 
     export function use<T>(usable: Usable<T>): T;
 


### PR DESCRIPTION
So that libraries can use these types to write better Suspense integrations.

Part of making these Promise subclasses part of the public API (https://github.com/reactjs/react.dev/pull/8125).