### PR TITLE
fix(instafeed.js) Fix Template and generics

### DIFF
--- a/types/instafeed.js/index.d.ts
+++ b/types/instafeed.js/index.d.ts
@@ -19,7 +19,7 @@ declare namespace Instafeed {
         apiLimit?: number;
         before?: () => void;
         debug?: boolean;
-        error?: (err: unknown) => any;
+        error?: (err: Error) => any;
         filter?: (item: T) => boolean;
         limit?: number;
         mock?: boolean;
@@ -29,16 +29,16 @@ declare namespace Instafeed {
         target?: string | Element;
         template?: string;
         templateBoundaries?: string[];
-        transform?: (item: InstagramDataItem) => T;
+        transform?: (item: InstafeedDefaultItem) => T;
     }
 
     interface InstafeedDefaultItem {
         caption: string;
-        tags: string[];
         id: string;
         image: string;
         link: string;
         model: InstagramDataItem;
+        tags: string[];
         timestamp: string;
         type: string;
         username: string;

--- a/types/instafeed.js/index.d.ts
+++ b/types/instafeed.js/index.d.ts
@@ -32,7 +32,7 @@ declare namespace Instafeed {
         transform?: (item: InstafeedDefaultItem) => T;
     }
 
-    type InstafeedDefaultItem = {
+    interface InstafeedDefaultItem {
         caption: string;
         id: string;
         image: string;
@@ -72,7 +72,7 @@ declare namespace Instafeed {
         previous?: string;
     }
 
-    type InstagramResponseData = {
+    interface InstagramResponseData {
         data: InstagramDataItem[];
         paging: InstagramPaging;
     }

--- a/types/instafeed.js/index.d.ts
+++ b/types/instafeed.js/index.d.ts
@@ -58,10 +58,10 @@ declare namespace Instafeed {
         media_type: "VIDEO";
         media_url: string;
         permalink: string;
-        thumbnail_url: string
+        thumbnail_url: string;
         timestamp: string;
         username: string;
-    }
+    };
 
     interface InstagramPaging {
         cursors: {

--- a/types/instafeed.js/index.d.ts
+++ b/types/instafeed.js/index.d.ts
@@ -32,7 +32,7 @@ declare namespace Instafeed {
         transform?: (item: InstafeedDefaultItem) => T;
     }
 
-    interface InstafeedDefaultItem {
+    type InstafeedDefaultItem = {
         caption: string;
         id: string;
         image: string;
@@ -44,12 +44,21 @@ declare namespace Instafeed {
         username: string;
     }
 
-    interface InstagramDataItem {
+    type InstagramDataItem = {
         caption: string;
         id: string;
-        media_type: string;
+        media_type: "CAROUSEL_ALBUM" | "IMAGE";
         media_url: string;
         permalink: string;
+        timestamp: string;
+        username: string;
+    } | {
+        caption: string;
+        id: string;
+        media_type: "VIDEO";
+        media_url: string;
+        permalink: string;
+        thumbnail_url: string
         timestamp: string;
         username: string;
     }
@@ -63,7 +72,7 @@ declare namespace Instafeed {
         previous?: string;
     }
 
-    interface InstagramResponseData {
+    type InstagramResponseData = {
         data: InstagramDataItem[];
         paging: InstagramPaging;
     }

--- a/types/instafeed.js/index.d.ts
+++ b/types/instafeed.js/index.d.ts
@@ -20,7 +20,7 @@ declare namespace Instafeed {
         before?: () => void;
         debug?: boolean;
         error?: (err: unknown) => any;
-        filter?: (item: InstagramDataItem) => boolean;
+        filter?: (item: T) => boolean;
         limit?: number;
         mock?: boolean;
         render?: (item: T, options: Instafeed.InstafeedOptions) => string;
@@ -29,7 +29,7 @@ declare namespace Instafeed {
         target?: string | Element;
         template?: string;
         templateBoundaries?: string[];
-        transform?: (item: InstagramDataItem) => Record<string, any>;
+        transform?: (item: InstagramDataItem) => T;
     }
 
     interface InstafeedDefaultItem {

--- a/types/instafeed.js/index.d.ts
+++ b/types/instafeed.js/index.d.ts
@@ -29,7 +29,7 @@ declare namespace Instafeed {
         target?: string | Element;
         template?: string;
         templateBoundaries?: string[];
-        transform?: (item: InstagramDataItem) => Record<string, unknown>;
+        transform?: (item: InstagramDataItem) => Record<string, any>;
     }
 
     interface InstafeedDefaultItem {

--- a/types/instafeed.js/instafeed.js-tests.ts
+++ b/types/instafeed.js/instafeed.js-tests.ts
@@ -1,4 +1,5 @@
 import Instafeed = require("instafeed.js");
+import { type InstafeedDefaultItem } from "instafeed.js";
 
 // $ExpectType Instafeed<InstafeedDefaultItem>
 new Instafeed({ accessToken: "aa" });
@@ -12,9 +13,31 @@ new Instafeed({});
 // @ts-expect-error
 new Instafeed();
 
-// $ExpectType Instafeed<InstafeedDefaultItem>
+// test if transform return type is passed to other hooks
 new Instafeed({ 
-  accessToken: "aa",  
-  // $ExpectType ((item: T) => T
-  transform: (item) => item
+  accessToken: "aa";
+  transform(item) { 
+    return { ...item, extra: 'foo' }
+  },
+  filter(item) {
+    // $ExpectType (InstafeedDefaultItem & { extra: string })
+    item;
+    // $ExpectType string
+    item.extra;
+    
+    return true;
+  }
+});
+
+interface CustomInstafeedItem extends InstafeedDefaultItem {
+  extra: string;
+}
+
+// test if omiting expected extra field breaks compiler as expected
+new Instafeed<CustomInstafeedItem>({ 
+  accessToken: "aa";
+  // @ts-expect-error
+  transform(item) { 
+    return item;
+  }
 });

--- a/types/instafeed.js/instafeed.js-tests.ts
+++ b/types/instafeed.js/instafeed.js-tests.ts
@@ -14,27 +14,27 @@ new Instafeed({});
 new Instafeed();
 
 // test if transform return type is passed to other hooks
-new Instafeed({ 
-  accessToken: "aa",
-  transform(item) { 
-    return { ...item, extra: 'foo' };
-  },
-  filter(item) {
-    // $ExpectType string
-    item.extra;
-    return true;
-  }
+new Instafeed({
+    accessToken: "aa",
+    transform(item) {
+        return { ...item, extra: "foo" };
+    },
+    filter(item) {
+        // $ExpectType string
+        item.extra;
+        return true;
+    },
 });
 
 interface CustomInstafeedItem extends InstafeedDefaultItem {
-  extra: string;
+    extra: string;
 }
 
 // test if omiting expected extra field breaks compiler as expected
-new Instafeed<CustomInstafeedItem>({ 
-  accessToken: "aa",
-  // @ts-expect-error
-  transform(item) { 
-    return item;
-  }
+new Instafeed<CustomInstafeedItem>({
+    accessToken: "aa",
+    // @ts-expect-error
+    transform(item) {
+        return item;
+    },
 });

--- a/types/instafeed.js/instafeed.js-tests.ts
+++ b/types/instafeed.js/instafeed.js-tests.ts
@@ -15,9 +15,9 @@ new Instafeed();
 
 // test if transform return type is passed to other hooks
 new Instafeed({ 
-  accessToken: "aa";
+  accessToken: "aa",
   transform(item) { 
-    return { ...item, extra: 'foo' }
+    return { ...item, extra: 'foo' };
   },
   filter(item) {
     // $ExpectType (InstafeedDefaultItem & { extra: string })
@@ -35,7 +35,7 @@ interface CustomInstafeedItem extends InstafeedDefaultItem {
 
 // test if omiting expected extra field breaks compiler as expected
 new Instafeed<CustomInstafeedItem>({ 
-  accessToken: "aa";
+  accessToken: "aa",
   // @ts-expect-error
   transform(item) { 
     return item;

--- a/types/instafeed.js/instafeed.js-tests.ts
+++ b/types/instafeed.js/instafeed.js-tests.ts
@@ -11,3 +11,10 @@ new Instafeed({});
 
 // @ts-expect-error
 new Instafeed();
+
+// $ExpectType Instafeed<InstafeedDefaultItem>
+new Instafeed({ 
+  accessToken: "aa",  
+  // $ExpectType ((item: T) => T
+  transform: (item) => item
+});

--- a/types/instafeed.js/instafeed.js-tests.ts
+++ b/types/instafeed.js/instafeed.js-tests.ts
@@ -20,11 +20,8 @@ new Instafeed({
     return { ...item, extra: 'foo' };
   },
   filter(item) {
-    // $ExpectType (InstafeedDefaultItem & { extra: string })
-    item;
     // $ExpectType string
     item.extra;
-    
     return true;
   }
 });


### PR DESCRIPTION
### _Quick Context_:
##### the package code we´re discussing about: https://github.com/stevenschobert/instafeed.js/wiki/Data-Transformations


## Why is there a bug and how this PR solves it:
 - `transform(item: InstagramDataItem)` parameter type should be `InstafeedDefaultItem`;
 - `filter(item: InstagramDataItem)` parameter type should actually be `T`;
 
the above statements are based on official package [wiki](https://github.com/stevenschobert/instafeed.js/wiki/Data-Transformations#order-of-operations), its [source code](https://github.com/stevenschobert/instafeed.js/blob/master/src/instafeed.js) and actually running the package and debugging its behavior;


------

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).



