### PR TITLE
feat(validator): add overload for isByteLength()

### DIFF
--- a/types/validator/index.d.ts
+++ b/types/validator/index.d.ts
@@ -262,9 +262,11 @@ declare namespace validator {
     /**
      * Check if the string's length (in UTF-8 bytes) falls in a range.
      *
-     * @param [options] - Options
+     * @param [optionsOrMin] - Options, or the minimum byte length allowed.
+     * @param [max] - The maximum byte length allowed.
      */
-    export function isByteLength(str: string, options?: IsByteLengthOptions): boolean;
+    export function isByteLength(str: string, optionsOrMin?: number | IsByteLengthOptions): boolean;
+    export function isByteLength(str: string, min: number, max: number): boolean;
 
     export interface IsCreditCardOptions {
         /**

--- a/types/validator/validator-tests.ts
+++ b/types/validator/validator-tests.ts
@@ -20,7 +20,7 @@ import isBeforeFunc from "validator/lib/isBefore";
 import isBICFunc from "validator/lib/isBIC";
 import isBooleanFunc from "validator/lib/isBoolean";
 import isBtcAddressFunc from "validator/lib/isBtcAddress";
-import isByteLengthFunc from "validator/lib/isByteLength";
+import isByteLengthFunc, { IsByteLengthOptions } from "validator/lib/isByteLength";
 import isCreditCardFunc from "validator/lib/isCreditCard";
 import isCurrencyFunc from "validator/lib/isCurrency";
 import isDataURIFunc from "validator/lib/isDataURI";
@@ -423,7 +423,7 @@ import isBeforeFuncEs from "validator/es/lib/isBefore";
 import isBICFuncEs from "validator/es/lib/isBIC";
 import isBooleanFuncEs from "validator/es/lib/isBoolean";
 import isBtcAddressFuncEs from "validator/es/lib/isBtcAddress";
-import isByteLengthFuncEs from "validator/es/lib/isByteLength";
+import isByteLengthFuncEs, { IsByteLengthOptions as IsByteLengthOptionsEs } from "validator/es/lib/isByteLength";
 import isCreditCardFuncEs from "validator/es/lib/isCreditCard";
 import isCurrencyFuncEs from "validator/es/lib/isCurrency";
 import isDataURIFuncEs from "validator/es/lib/isDataURI";
@@ -665,8 +665,17 @@ const any: any = null;
 
     result = validator.isBoolean("sample");
 
-    const isByteLengthOptions: validator.IsByteLengthOptions = {};
-    result = validator.isByteLength("sample", isByteLengthOptions);
+    result = validator.isByteLength("sample");
+    result = validator.isByteLength("sample", {});
+    result = validator.isByteLength("sample", { min: 16, max: 64 } satisfies IsByteLengthOptions);
+    result = validator.isByteLength("sample", 16);
+    result = validator.isByteLength("sample", 16, 64);
+    // Both overloads happen to allow using exactly two argument, [str, number] & [str, object]
+    // Hence if 2nd arg is of union type `number | object`, typechecking can pass.
+    result = validator.isByteLength("sample", result ? 16 : { min: 16 });
+    // @ts-expect-error
+    // Using 3rd arg here is problematic, without first ensuring that the 2nd argument is a number.
+    result = validator.isByteLength("sample", result ? 16 : { min: 16 }, 64);
 
     const isCreditCardOptions: validator.IsCreditCardOptions = {};
     result = validator.isCreditCard("sample"); // $ExpectType boolean


### PR DESCRIPTION
See https://github.com/validatorjs/validator.js/blob/master/src/lib/isByteLength.js#L11. The backward compatible way of function calling shall be made available via typescript overloads.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
