### PR TITLE
[relay-runtime] Export readFragment from index and resolverDataInjector from experimental

### DIFF
--- a/types/relay-runtime/experimental.d.ts
+++ b/types/relay-runtime/experimental.d.ts
@@ -9,9 +9,9 @@ export type IdOf<_A extends string, Typename extends undefined | string = undefi
     ? { id: DataID }
     : { id: DataID; __typename: Typename };
 
-interface ErrorResult<Error> {
+interface ErrorResult<E> {
     ok: false;
-    errors: readonly Error[];
+    errors: readonly E[];
 }
 
 interface OkayResult<T> {
@@ -20,8 +20,8 @@ interface OkayResult<T> {
 }
 
 // The type returned by fields annotated with `@catch`
-export type Result<T, Error> = OkayResult<T> | ErrorResult<Error>;
+export type Result<T, E> = OkayResult<T> | ErrorResult<E>;
 
-export function isValueResult<T = unknown>(input: Result<T, Error>): input is OkayResult<T>;
+export function isValueResult<T = unknown>(input: Result<T, unknown>): input is OkayResult<T>;
 
-export function isErrorResult(input: Result<unknown, Error>): input is ErrorResult<Error>;
+export function isErrorResult<E = unknown>(input: Result<unknown, E>): input is ErrorResult<E>;

--- a/types/relay-runtime/experimental.d.ts
+++ b/types/relay-runtime/experimental.d.ts
@@ -1,9 +1,9 @@
 import { DataID } from "./lib/util/RelayRuntimeTypes";
 
+export { resolverDataInjector } from "./lib/store/live-resolvers/resolverDataInjector";
 export { observeFragment } from "./lib/store/observeFragmentExperimental";
 export { observeQuery } from "./lib/store/observeQueryExperimental";
 export { waitForFragmentData } from "./lib/store/waitForFragmentExperimental";
-export { resolverDataInjector } from "./lib/store/live-resolvers/resolverDataInjector";
 
 export type IdOf<_A extends string, Typename extends undefined | string = undefined> = Typename extends undefined
     ? { id: DataID }

--- a/types/relay-runtime/experimental.d.ts
+++ b/types/relay-runtime/experimental.d.ts
@@ -1,3 +1,27 @@
+import { DataID } from "./lib/util/RelayRuntimeTypes";
+
 export { observeFragment } from "./lib/store/observeFragmentExperimental";
 export { observeQuery } from "./lib/store/observeQueryExperimental";
 export { waitForFragmentData } from "./lib/store/waitForFragmentExperimental";
+export { resolverDataInjector } from "./lib/store/live-resolvers/resolverDataInjector";
+
+export type IdOf<_A extends string, Typename extends undefined | string = undefined> = Typename extends undefined
+    ? { id: DataID }
+    : { id: DataID; __typename: Typename };
+
+interface ErrorResult<Error> {
+    ok: false;
+    errors: readonly Error[];
+}
+
+interface OkayResult<T> {
+    ok: true;
+    value: T;
+}
+
+// The type returned by fields annotated with `@catch`
+export type Result<T, Error> = OkayResult<T> | ErrorResult<Error>;
+
+export function isValueResult<T = unknown>(input: Result<T, Error>): input is OkayResult<T>;
+
+export function isErrorResult(input: Result<unknown, Error>): input is ErrorResult<Error>;

--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -154,6 +154,7 @@ export { RelayModernRecord as Record } from "./lib/store/RelayModernRecord";
 export { default as Store } from "./lib/store/RelayModernStore";
 export { RelayRecordSource as RecordSource } from "./lib/store/RelayRecordSource";
 
+export { type IdOf, isErrorResult, isValueResult, type Result } from "./experimental";
 export { createFragmentSpecResolver } from "./lib/store/createFragmentSpecResolver";
 export { readInlineData } from "./lib/store/readInlineData";
 export { createOperationDescriptor, createRequestDescriptor } from "./lib/store/RelayModernOperationDescriptor";
@@ -186,7 +187,6 @@ export {
     TYPENAME_KEY,
 } from "./lib/store/RelayStoreUtils";
 export { readFragment } from "./lib/store/ResolverFragments";
-export { isErrorResult, isValueResult, type IdOf, type Result } from "./experimental"
 
 // Extensions
 import RelayDefaultHandlerProvider from "./lib/handlers/RelayDefaultHandlerProvider";

--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -185,6 +185,8 @@ export {
     ROOT_TYPE,
     TYPENAME_KEY,
 } from "./lib/store/RelayStoreUtils";
+export { readFragment } from "./lib/store/ResolverFragments";
+export { isErrorResult, isValueResult, type IdOf, type Result } from "./experimental"
 
 // Extensions
 import RelayDefaultHandlerProvider from "./lib/handlers/RelayDefaultHandlerProvider";
@@ -267,16 +269,3 @@ export type FragmentRefs<Refs extends string> = {
 
 // This is a utility type for converting from a data type to a fragment reference that will resolve to that data type.
 export type FragmentRef<Fragment> = Fragment extends _RefType<infer U> ? _FragmentRefs<U> : never;
-
-interface ErrorResult<Error> {
-    ok: false;
-    errors: readonly Error[];
-}
-
-interface OkayResult<T> {
-    ok: true;
-    value: T;
-}
-
-// The type returned by fields annotated with `@catch`
-export type Result<T, Error> = OkayResult<T> | ErrorResult<Error>;

--- a/types/relay-runtime/lib/store/live-resolvers/resolverDataInjector.d.ts
+++ b/types/relay-runtime/lib/store/live-resolvers/resolverDataInjector.d.ts
@@ -10,7 +10,7 @@ import type { FragmentType } from "../RelayStoreTypes";
  * - (optional) fieldName: individual field that needs to be read out of the fragment.
  *
  * This will not call the `resolverFn` if the fragment data for it is null/undefined.
- * The the compiler generates calls to this function, ensuring the correct set of arguments.
+ * The compiler generates calls to this function, ensuring the correct set of arguments.
  */
 export function resolverDataInjector(
     fragment: GraphQLTaggedNode,

--- a/types/relay-runtime/lib/store/live-resolvers/resolverDataInjector.d.ts
+++ b/types/relay-runtime/lib/store/live-resolvers/resolverDataInjector.d.ts
@@ -1,0 +1,21 @@
+import type { GraphQLTaggedNode } from "../../query/RelayModernGraphQLTag";
+import type { FragmentType } from "../RelayStoreTypes"
+
+/**
+ *
+ * This a higher order function that returns a relay resolver that can read the data for
+ * the fragment`.
+ *
+ * - fragment: contains fragment Reader AST with resolver's data dependencies.
+ * - resolverFn: original resolver function that expects a data from the fragment
+ * - (optional) fieldName: individual field that needs to be read out of the fragment.
+ *
+ * This will not call the `resolverFn` if the fragment data for it is null/undefined.
+ * The the compiler generates calls to this function, ensuring the correct set of arguments.
+ */
+export function resolverDataInjector(
+  fragment: GraphQLTaggedNode,
+  _resolverFn: unknown,
+  fieldName?: string,
+  isRequiredField?: boolean,
+): (fragmentKey: FragmentType, args: unknown) => unknown

--- a/types/relay-runtime/lib/store/live-resolvers/resolverDataInjector.d.ts
+++ b/types/relay-runtime/lib/store/live-resolvers/resolverDataInjector.d.ts
@@ -1,8 +1,7 @@
 import type { GraphQLTaggedNode } from "../../query/RelayModernGraphQLTag";
-import type { FragmentType } from "../RelayStoreTypes"
+import type { FragmentType } from "../RelayStoreTypes";
 
 /**
- *
  * This a higher order function that returns a relay resolver that can read the data for
  * the fragment`.
  *
@@ -14,8 +13,8 @@ import type { FragmentType } from "../RelayStoreTypes"
  * The the compiler generates calls to this function, ensuring the correct set of arguments.
  */
 export function resolverDataInjector(
-  fragment: GraphQLTaggedNode,
-  _resolverFn: unknown,
-  fieldName?: string,
-  isRequiredField?: boolean,
-): (fragmentKey: FragmentType, args: unknown) => unknown
+    fragment: GraphQLTaggedNode,
+    _resolverFn: unknown,
+    fieldName?: string,
+    isRequiredField?: boolean,
+): (fragmentKey: FragmentType, args: unknown) => unknown;

--- a/types/relay-runtime/package.json
+++ b/types/relay-runtime/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/relay-runtime",
-    "version": "19.0.9999",
+    "version": "20.1.9999",
     "projects": [
         "https://github.com/facebook/relay",
         "https://facebook.github.io/relay"

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -15,7 +15,9 @@ import {
     getRefetchMetadata,
     getRequest,
     graphql,
+    isErrorResult,
     isPromise,
+    isValueResult,
     LiveState,
     Network,
     PreloadableConcreteRequest,
@@ -23,6 +25,7 @@ import {
     QueryResponseCache,
     ReaderFragment,
     ReaderInlineDataFragment,
+    readFragment,
     readInlineData,
     RecordProxy,
     RecordSource,
@@ -34,11 +37,14 @@ import {
     Store,
     suspenseSentinel,
     Variables,
-    isErrorResult,
-    isValueResult,
-    readFragment,
 } from "relay-runtime";
-import { IdOf, observeFragment, observeQuery, resolverDataInjector, waitForFragmentData } from "relay-runtime/experimental";
+import {
+    IdOf,
+    observeFragment,
+    observeQuery,
+    resolverDataInjector,
+    waitForFragmentData,
+} from "relay-runtime/experimental";
 
 import type { HandlerProvider } from "relay-runtime/lib/handlers/RelayDefaultHandlerProvider";
 import * as multiActorEnvironment from "relay-runtime/multi-actor-environment";
@@ -1069,26 +1075,26 @@ function observeQueryTest() {
 // ~~~~~~~~~~~~~~~~~~
 
 const MyResolverType__id_graphql: ReaderFragment = {
-  "argumentDefinitions": [],
-  "kind": "Fragment",
-  "metadata": null,
-  "name": "MyResolverType__id",
-  "selections": [
-    {
-      "kind": "ClientExtension",
-      "selections": [
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "MyResolverType__id",
+    "selections": [
         {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "id",
-          "storageKey": null
-        }
-      ]
-    }
-  ],
-  "type": "MyResolverType",
-  "abstractKey": null
+            "kind": "ClientExtension",
+            "selections": [
+                {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "id",
+                    "storageKey": null,
+                },
+            ],
+        },
+    ],
+    "type": "MyResolverType",
+    "abstractKey": null,
 };
 
 interface MyResolverType {
@@ -1097,11 +1103,16 @@ interface MyResolverType {
 
 function myResolverTypeRelayModelInstanceResolver(id: DataID): MyResolverType {
     return {
-        id
+        id,
     };
 }
 
-export const resolverModule = resolverDataInjector(MyResolverType__id_graphql, myResolverTypeRelayModelInstanceResolver, 'id', true);
+export const resolverModule = resolverDataInjector(
+    MyResolverType__id_graphql,
+    myResolverTypeRelayModelInstanceResolver,
+    "id",
+    true,
+);
 
 // ~~~~~~~~~~~~~~~~~~
 // Client edge resolver

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -929,16 +929,16 @@ export function handleResult<T, E>(result: Result<T, E>) {
 }
 
 // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-export function handleValueResult<T>(result: Result<T, Error>) {
+export function handleValueResult<T, E>(result: Result<T, E>) {
     if (isValueResult(result)) {
         const value: T = result.value;
     }
 }
 
 // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
-export function handleErrorResult<T>(result: Result<T, Error>) {
+export function handleErrorResult<T, E>(result: Result<T, E>) {
     if (isErrorResult(result)) {
-        const errors: readonly Error[] = result.errors;
+        const errors: readonly E[] = result.errors;
     }
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - [`readFragment` export]( https://github.com/facebook/relay/blob/v20.1.1/packages/relay-runtime/index.js#L320)
    - [`resolverDataInjector`](https://github.com/facebook/relay/blob/v20.1.1/packages/relay-runtime/store/live-resolvers/resolverDataInjector.js)
    - [`IdOf`](https://github.com/facebook/relay/blob/v20.1.1/packages/relay-runtime/experimental.js#L25) and [`isValueResult`/`isErrorResult`](https://github.com/facebook/relay/blob/v20.1.1/packages/relay-runtime/experimental.js#L58)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

