### PR TITLE
[@wordpress/block-editor] Add basic link control definitions

### DIFF
--- a/types/wordpress__block-editor/components/index.d.ts
+++ b/types/wordpress__block-editor/components/index.d.ts
@@ -19,6 +19,7 @@ export * from "./font-sizes";
 export { default as InnerBlocks, useInnerBlocksProps } from "./inner-blocks";
 export { default as InspectorAdvancedControls } from "./inspector-advanced-controls";
 export { default as InspectorControls } from "./inspector-controls";
+export { default as LinkControl } from "./link-control";
 export { default as MediaPlaceholder } from "./media-placeholder";
 export { default as MediaUpload } from "./media-upload";
 export { default as MediaUploadCheck } from "./media-upload/check";

--- a/types/wordpress__block-editor/components/link-control.d.ts
+++ b/types/wordpress__block-editor/components/link-control.d.ts
@@ -1,0 +1,52 @@
+import { ComponentType, ReactNode } from "react";
+
+interface WPLinkControlDefaultValue {
+    url?: string;
+    title?: string;
+    opensInNewTab?: boolean;
+}
+
+interface WPLinkControlSettingsValue {
+    [setting: string]: any;
+}
+
+declare namespace LinkControl {
+    interface Props {
+        settings?: Setting[];
+        forceIsEditingLink?: boolean;
+        value?: Value;
+        onChange?: (nextValue?: Value) => void;
+        onRemove?: () => void;
+        onCancel?: () => void;
+
+        noDirectEntry?: boolean;
+        showSuggestions?: boolean;
+        showInitialSuggestions?: boolean;
+        withCreateSuggestion?: boolean;
+        suggestionsQuery?: any;
+        noURLSuggestion?: boolean;
+        hasTextControl?: boolean;
+        createSuggestion?: ((title: string) => Suggestion) | undefined;
+        createSuggestionButtonText?: string | ((searchTerm: string | undefined) => ReactNode);
+        renderControlBottom?: () => ReactNode;
+        handleEntities?: boolean;
+        hasRichPreviews?: boolean;
+    }
+
+    interface Setting {
+        id: string;
+        title: string;
+    }
+
+    interface Suggestion {
+        id: string;
+        type: string;
+        title: string;
+        url: string;
+    }
+
+    interface Value extends WPLinkControlDefaultValue, WPLinkControlSettingsValue {}
+}
+declare const LinkControl: ComponentType<LinkControl.Props> & { DEFAULT_LINK_SETTINGS: LinkControl.Setting[] };
+
+export default LinkControl;

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -247,6 +247,15 @@ be.withFontSizes("fontSize")(() => <h1>Hello World</h1>);
 <be.InspectorControls.Slot />;
 
 //
+// link-control
+//
+<be.LinkControl
+    onChange={item => console.log(item)}
+    onRemove={() => console.log("removed")}
+    settings={be.LinkControl.DEFAULT_LINK_SETTINGS}
+/>;
+
+//
 // media-placeholder
 //
 <be.MediaPlaceholder


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [LinkControl's source code](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/link-control/index.js)

These definitions are just a quick translation of the JSDoc from the repo with a few corrections for where it got out of sync with the code. They are likely incomplete, but should work as a temporary patch while the actual TypeScript conversion takes place.