### PR TITLE
add hints to `discord-rpc`'s `Presence` interface

### DIFF
--- a/types/discord-rpc/index.d.ts
+++ b/types/discord-rpc/index.d.ts
@@ -481,6 +481,9 @@ export interface Presence {
      * Tooltip for the smallImageKey
      */
     smallImageText?: string | undefined;
+    /**
+     * Whether or not the activity is an instanced game session
+     */
     instance?: boolean | undefined;
     /**
      * ID of the player's party, lobby, or group
@@ -494,14 +497,20 @@ export interface Presence {
      * Maximum size of the player's party, lobby, or group
      */
     partyMax?: number | undefined;
+    /**
+     * Secret for a specified instanced match
+     */
     matchSecret?: string | undefined;
+    /**
+     * Secret for spectating a game
+     */
     spectateSecret?: string | undefined;
     /**
      * Unique hashed string for chat invitations and Ask to Join
      */
     joinSecret?: string | undefined;
     /**
-     * Buttons and their URLs — can add up to two.
+     * Custom buttons shown in the Rich Presence (max 2)
      */
     buttons?: Array<{ label: string; url: string }> | undefined;
 }

--- a/types/discord-rpc/index.d.ts
+++ b/types/discord-rpc/index.d.ts
@@ -449,20 +449,59 @@ export interface VoiceSettings {
 }
 
 export interface Presence {
+    /**
+     * The user's current party status
+     */
     state?: string | undefined;
+    /**
+     * What the user is currently doing
+     */
     details?: string | undefined;
+    /**
+     * Epoch seconds for game start — including will show time as "elapsed"
+     */
     startTimestamp?: number | Date | undefined;
+    /**
+     * Epoch seconds for game end — including will show time as "remaining"
+     */
     endTimestamp?: number | Date | undefined;
+    /**
+     * Key of the uploaded image for the large profile artwork
+     */
     largeImageKey?: string | undefined;
+    /**
+     * Tooltip for the largeImageKey
+     */
     largeImageText?: string | undefined;
+    /**
+     * Key of the uploaded image for the small profile artwork
+     */
     smallImageKey?: string | undefined;
+    /**
+     * Tooltip for the smallImageKey
+     */
     smallImageText?: string | undefined;
     instance?: boolean | undefined;
+    /**
+     * ID of the player's party, lobby, or group
+     */
     partyId?: string | undefined;
+    /**
+     * Current size of the player's party, lobby, or group
+     */
     partySize?: number | undefined;
+    /**
+     * Maximum size of the player's party, lobby, or group
+     */
     partyMax?: number | undefined;
     matchSecret?: string | undefined;
     spectateSecret?: string | undefined;
+    /**
+     * Unique hashed string for chat invitations and Ask to Join
+     */
     joinSecret?: string | undefined;
+    /**
+     * Buttons and their URLs — can add up to two.
+     */
     buttons?: Array<{ label: string; url: string }> | undefined;
 }


### PR DESCRIPTION
adds hints for the `Presence` interface. most are gleaned from discord's RPC visualizer and I filled in the missing ones from the docs.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] ~~[Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.~~ (n/a)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

---

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Discord RPC Visualizer (replace CLIENT_ID with your own)](https://discord.com/developers/applications/CLIENT_ID/rich-presence/visualizer) and [RPC Docs](https://discord.com/developers/docs/events/gateway-events)
- [ ] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.~~ (n/a)