### PR TITLE
feat(validator): update isStrongPassword() with fallback overload

### DIFF
--- a/types/validator/es/lib/isStrongPassword.d.ts
+++ b/types/validator/es/lib/isStrongPassword.d.ts
@@ -1,2 +1,3 @@
 import validator from "../../";
+export type StrongPasswordOptions = validator.StrongPasswordOptions;
 export default validator.isStrongPassword;

--- a/types/validator/index.d.ts
+++ b/types/validator/index.d.ts
@@ -1193,17 +1193,53 @@ declare namespace validator {
      */
 
     export interface StrongPasswordOptions {
+        /**
+         * @default 8
+         */
         minLength?: number | undefined;
+        /**
+         * @default 1
+         */
         minLowercase?: number | undefined;
+        /**
+         * @default 1
+         */
         minUppercase?: number | undefined;
+        /**
+         * @default 1
+         */
         minNumbers?: number | undefined;
+        /**
+         * @default 1
+         */
         minSymbols?: number | undefined;
+        /**
+         * @default false
+         */
         returnScore?: boolean | undefined;
+        /**
+         * @default 1
+         */
         pointsPerUnique?: number | undefined;
+        /**
+         * @default 0.5
+         */
         pointsPerRepeat?: number | undefined;
+        /**
+         * @default 10
+         */
         pointsForContainingLower?: number | undefined;
+        /**
+         * @default 10
+         */
         pointsForContainingUpper?: number | undefined;
+        /**
+         * @default 10
+         */
         pointsForContainingNumber?: number | undefined;
+        /**
+         * @default 10
+         */
         pointsForContainingSymbol?: number | undefined;
     }
 
@@ -1211,7 +1247,8 @@ declare namespace validator {
         str: string,
         options?: StrongPasswordOptions & { returnScore?: false | undefined },
     ): boolean;
-    export function isStrongPassword(str: string, options: StrongPasswordOptions & { returnScore: true }): number;
+    export function isStrongPassword(str: string, options?: StrongPasswordOptions & { returnScore: true }): number;
+    export function isStrongPassword(str: string, options?: StrongPasswordOptions): boolean | number;
 
     /**
      * Check if the string contains any surrogate pairs chars.

--- a/types/validator/lib/isStrongPassword.d.ts
+++ b/types/validator/lib/isStrongPassword.d.ts
@@ -1,2 +1,3 @@
 import validator from "../";
+export type StrongPasswordOptions = validator.StrongPasswordOptions;
 export default validator.isStrongPassword;

--- a/types/validator/validator-tests.ts
+++ b/types/validator/validator-tests.ts
@@ -1113,20 +1113,27 @@ const any: any = null;
     // $ExpectType boolean
     validator.isStrongPassword("sample23#@test");
     // $ExpectType boolean
+    validator.isStrongPassword("sample23#@test", {});
+    // $ExpectType boolean
     validator.isStrongPassword("sample23#@test", {
-        minLength: 10,
+        minLength: -1,
+        minLowercase: -1,
+        minUppercase: -1,
+        minNumbers: -1,
+        minSymbols: -1,
+        pointsPerUnique: -1,
+        pointsPerRepeat: -1,
+        pointsForContainingLower: -1,
+        pointsForContainingUpper: -1,
+        pointsForContainingNumber: -1,
+        pointsForContainingSymbol: -1,
     });
     // $ExpectType boolean
     validator.isStrongPassword("sample23#@test", { returnScore: false });
-    // $ExpectType boolean
-    validator.isStrongPassword("abc", {
-        minLength: 10,
-        returnScore: false,
-    });
     // $ExpectType number
     validator.isStrongPassword("sample23#@test", { returnScore: true });
-    // $ExpectType number
-    validator.isStrongPassword("sample23#@test", { minLength: 10, returnScore: true });
+    // $ExpectType boolean | number
+    validator.isStrongPassword("sample23#@test", { returnScore: Math.random() > 0.5 });
 }
 
 {


### PR DESCRIPTION
Current typedef partitions function return on boolean _literals_ of `options.returnScore`. In practice, it is possible for `options.returnScore` to be a _"undetermine" variable_ until resolved in runtime. In this case, we will need the fallback overlaod as introduced in this PR.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
