### PR TITLE
Update DT references to deprecated @types/node globals

### DIFF
--- a/types/blocked/index.d.ts
+++ b/types/blocked/index.d.ts
@@ -10,7 +10,7 @@
 
 export = Blocked;
 
-declare function Blocked(callback: (ms: number) => void, options?: Blocked.Options): NodeJS.Timer;
+declare function Blocked(callback: (ms: number) => void, options?: Blocked.Options): NodeJS.Timeout;
 
 declare namespace Blocked {
     interface Options {

--- a/types/codependency/index.d.ts
+++ b/types/codependency/index.d.ts
@@ -20,5 +20,5 @@ export interface RequirePeerFunction {
     resolve(name: string): DependencyInfo;
 }
 
-export function register(baseModule: NodeModule, options?: { index: string[] }): RequirePeerFunction;
+export function register(baseModule: NodeJS.Module, options?: { index: string[] }): RequirePeerFunction;
 export function get(middlewareName: string): RequirePeerFunction;

--- a/types/express-minify/index.d.ts
+++ b/types/express-minify/index.d.ts
@@ -15,12 +15,12 @@ declare namespace ExpressMinifyInterfaces {
         /**
          * Customize UglifyJS instance (require('uglify-js')).
          */
-        uglifyJS?: NodeRequire | undefined;
+        uglifyJS?: NodeJS.Require | undefined;
 
         /**
          * Customize cssmin instance (require('cssmin')).
          */
-        cssmin?: NodeRequire | undefined;
+        cssmin?: NodeJS.Require | undefined;
 
         /**
          * Handle compiling errors or minifying errors. You can determine what to respond when facing such errors.

--- a/types/express-mysql-session/index.d.ts
+++ b/types/express-mysql-session/index.d.ts
@@ -99,7 +99,7 @@ declare class MySQLStoreClass extends expressSession.Store {
 
     options: MySQLStore.Options;
 
-    private _expirationInterval?: NodeJS.Timer | null;
+    private _expirationInterval?: NodeJS.Timeout | null;
 
     onReady(): Promise<void>;
 

--- a/types/find-package-json/index.d.ts
+++ b/types/find-package-json/index.d.ts
@@ -10,7 +10,7 @@ export = find;
  * @param root The root directory we should start searching in.
  * @returns Iterator interface.
  */
-declare function find(root?: string | NodeModule): find.FinderIterator;
+declare function find(root?: string | NodeJS.Module): find.FinderIterator;
 
 declare namespace find {
     interface FinderIterator extends IterableIterator<PackageWithPath> {

--- a/types/folder-walker/index.d.ts
+++ b/types/folder-walker/index.d.ts
@@ -3,7 +3,7 @@
 import * as fs from "fs";
 
 interface WalkerOptions {
-    fs?: NodeRequire;
+    fs?: NodeJS.Require;
     maxDepth?: number;
     filter: (filename: string) => boolean;
 }

--- a/types/ignore-styles/index.d.ts
+++ b/types/ignore-styles/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference types='node' />
 
-export type Handler = (m: NodeModule, filename: string) => any;
+export type Handler = (m: NodeJS.Module, filename: string) => any;
 
 export const DEFAULT_EXTENSIONS: string[];
 

--- a/types/interpret/index.d.ts
+++ b/types/interpret/index.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 
 export interface Hook {
-    (m: { extensions: string } | NodeModule): any;
+    (m: { extensions: string } | NodeJS.Module): any;
     install(m?: { extension: string; [key: string]: any }): void;
 }
 

--- a/types/kurento-client/index.d.ts
+++ b/types/kurento-client/index.d.ts
@@ -5,7 +5,7 @@ declare namespace kurento {
         (ws_uri: string, options?: Options): Promise<ClientInstance>;
         getComplexType: (complex: "IceCandidate") => (value: any) => any;
         getSingleton(ws_uri: string, options?: Options): Promise<ClientInstance>;
-        register: (module: string | ReturnType<NodeRequire>) => void;
+        register: (module: string | ReturnType<NodeJS.Require>) => void;
         on: undefined;
     }
 

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -1237,7 +1237,7 @@ namespace MeteorTests {
         });
     }
 
-    function canAcceptUpdates(module: NodeModule) {
+    function canAcceptUpdates(module: NodeJS.Module) {
         return true;
     }
     if (module.hot) {

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -1255,7 +1255,7 @@ namespace MeteorTests {
         });
     }
 
-    function canAcceptUpdates(module: NodeModule) {
+    function canAcceptUpdates(module: NodeJS.Module) {
         return true;
     }
     if (module.hot) {

--- a/types/nodal/index.d.ts
+++ b/types/nodal/index.d.ts
@@ -993,4 +993,4 @@ export const my: {
     Schema?: any;
     bootstrapper?: any;
 };
-export const require: NodeRequire;
+export const require: NodeJS.Require;

--- a/types/pkginfo/index.d.ts
+++ b/types/pkginfo/index.d.ts
@@ -12,7 +12,7 @@ declare namespace PkgInfo {
     }
 
     interface PkgInfo {
-        (pmodule: NodeModule, options?: Options | string[] | string, ...properties: string[]): PkgInfo;
+        (pmodule: NodeJS.Module, options?: Options | string[] | string, ...properties: string[]): PkgInfo;
 
         //
         // ### function find (dir)
@@ -22,12 +22,12 @@ declare namespace PkgInfo {
         // which contains a `package.json` file.
         //
         read(
-            pmodule: NodeModule,
+            pmodule: NodeJS.Module,
             dir?: string,
         ): FindResults;
 
         find(
-            pmodule: NodeModule,
+            pmodule: NodeJS.Module,
             dir?: string,
         ): Record<string, any>;
     }

--- a/types/react-timeout/index.d.ts
+++ b/types/react-timeout/index.d.ts
@@ -1,5 +1,3 @@
-/// <reference types="node" />
-
 import * as React from "react";
 
 export = ReactTimeout;
@@ -9,17 +7,18 @@ declare function ReactTimeout<T>(
 ): React.ComponentClass<T>;
 
 declare namespace ReactTimeout {
-    type Timer = NodeJS.Timer | number;
+    type Timer = typeof globalThis extends { setTimeout(...args: any[]): infer T } ? T : Id;
+    type Immediate = typeof globalThis extends { setImmediate(...args: any[]): infer T } ? T : Id;
 
     type Id = number;
 
     interface ReactTimeoutProps {
         setTimeout?: ((callback: (...args: any[]) => void, ms: number, ...args: any[]) => Timer) | undefined;
-        clearTimeout?: ((timer: Timer) => void) | undefined;
-        setInterval?: ((callback: (...args: any[]) => void, ms: number, ...args: any[]) => Id) | undefined;
-        clearInterval?: ((id: Id) => void) | undefined;
-        setImmediate?: ((callback: (...args: any[]) => void, ...args: any[]) => Id) | undefined;
-        clearImmediate?: ((id: Id) => void) | undefined;
+        clearTimeout?: ((timer: Timer | Id) => void) | undefined;
+        setInterval?: ((callback: (...args: any[]) => void, ms: number, ...args: any[]) => Timer) | undefined;
+        clearInterval?: ((id: Timer | Id) => void) | undefined;
+        setImmediate?: ((callback: (...args: any[]) => void, ...args: any[]) => Immediate) | undefined;
+        clearImmediate?: ((id: Immediate | Id) => void) | undefined;
         requestAnimationFrame?: ((callback: (...args: any[]) => void) => Id) | undefined;
         cancelAnimationFrame?: ((id: Id) => void) | undefined;
     }

--- a/types/react-timeout/package.json
+++ b/types/react-timeout/package.json
@@ -6,7 +6,6 @@
         "https://github.com/plougsgaard/react-timeout"
     ],
     "dependencies": {
-        "@types/node": "*",
         "@types/react": "*"
     },
     "devDependencies": {

--- a/types/require-directory/index.d.ts
+++ b/types/require-directory/index.d.ts
@@ -66,7 +66,7 @@ declare namespace requireDirectory {
  * @returns hash of modules in specified directory
  */
 declare function requireDirectory<T, U>(
-    m: NodeModule,
+    m: NodeJS.Module,
     path?: string | requireDirectory.RequireDirectoryOptions<T, U>,
     options?: requireDirectory.RequireDirectoryOptions<T, U>,
 ): requireDirectory.RequireDirectoryResult<U>;

--- a/types/socketcluster-client/lib/transport.d.ts
+++ b/types/socketcluster-client/lib/transport.d.ts
@@ -126,7 +126,7 @@ declare namespace AGTransport {
         data: any;
         callback?: EventObjectCallback | undefined;
         cid?: number | undefined;
-        timeout?: NodeJS.Timer | undefined;
+        timeout?: NodeJS.Timeout | undefined;
     }
 
     interface TransmitOptions {

--- a/types/socketcluster-client/v15/lib/transport.d.ts
+++ b/types/socketcluster-client/v15/lib/transport.d.ts
@@ -125,7 +125,7 @@ declare namespace AGTransport {
         data: any;
         callback?: EventObjectCallback | undefined;
         cid?: number | undefined;
-        timeout?: NodeJS.Timer | undefined;
+        timeout?: NodeJS.Timeout | undefined;
     }
 
     interface TransmitOptions {

--- a/types/socketcluster-client/v16/lib/transport.d.ts
+++ b/types/socketcluster-client/v16/lib/transport.d.ts
@@ -125,7 +125,7 @@ declare namespace AGTransport {
         data: any;
         callback?: EventObjectCallback | undefined;
         cid?: number | undefined;
-        timeout?: NodeJS.Timer | undefined;
+        timeout?: NodeJS.Timeout | undefined;
     }
 
     interface TransmitOptions {

--- a/types/socketcluster-client/v17/lib/transport.d.ts
+++ b/types/socketcluster-client/v17/lib/transport.d.ts
@@ -125,7 +125,7 @@ declare namespace AGTransport {
         data: any;
         callback?: EventObjectCallback | undefined;
         cid?: number | undefined;
-        timeout?: NodeJS.Timer | undefined;
+        timeout?: NodeJS.Timeout | undefined;
     }
 
     interface TransmitOptions {

--- a/types/socketcluster-client/v18/lib/transport.d.ts
+++ b/types/socketcluster-client/v18/lib/transport.d.ts
@@ -125,7 +125,7 @@ declare namespace AGTransport {
         data: any;
         callback?: EventObjectCallback | undefined;
         cid?: number | undefined;
-        timeout?: NodeJS.Timer | undefined;
+        timeout?: NodeJS.Timeout | undefined;
     }
 
     interface TransmitOptions {

--- a/types/stompjs/index.d.ts
+++ b/types/stompjs/index.d.ts
@@ -73,5 +73,5 @@ export function client(url: string, protocols?: string | string[]): Client;
 export function over(ws: WebSocket): Client;
 export function overTCP(host: string, port: number): Client;
 export function overWS(url: string): Client;
-export function setInterval(interval: number, f: (...args: any[]) => void): NodeJS.Timer;
-export function clearInterval(id: NodeJS.Timer): void;
+export function setInterval(interval: number, f: (...args: any[]) => void): NodeJS.Timeout;
+export function clearInterval(id: NodeJS.Timeout): void;

--- a/types/storybook-addon-jsx/index.d.ts
+++ b/types/storybook-addon-jsx/index.d.ts
@@ -18,7 +18,7 @@ export type AddWithJSXFunc<StoryFnReturnType> = (
 
 declare module "@storybook/addons" {
     interface ClientStoryApi<StoryFnReturnType = unknown> {
-        storiesOf(kind: string, module: NodeModule):
+        storiesOf(kind: string, module: NodeJS.Module):
             & StoryApi<StoryFnReturnType>
             & { addWithJSX: AddWithJSXFunc<StoryFnReturnType> };
         addDecorator(decorator: DecoratorFunction<StoryFnReturnType>): StoryApi<StoryFnReturnType>;

--- a/types/storybook__addon-info/index.d.ts
+++ b/types/storybook__addon-info/index.d.ts
@@ -61,7 +61,7 @@ export function setDefaults(newDefaults: Options): Options;
 
 declare module "@storybook/addons" {
     interface ClientStoryApi<StoryFnReturnType = unknown> {
-        storiesOf(kind: string, module: NodeModule): StoryApi<StoryFnReturnType>;
+        storiesOf(kind: string, module: NodeJS.Module): StoryApi<StoryFnReturnType>;
         addParameters(parameter: Parameters & { info: Options }): StoryApi<StoryFnReturnType>;
         addDecorator(decorator: DecoratorFunction<StoryFnReturnType>): StoryApi<StoryFnReturnType>;
     }

--- a/types/watchpack/index.d.ts
+++ b/types/watchpack/index.d.ts
@@ -14,7 +14,7 @@ declare class Watchpack extends EventEmitter {
     aggregatedChanges: Set<string>;
     aggregatedRemovals: Set<string>;
 
-    aggregateTimeout: NodeJS.Timer;
+    aggregateTimeout: number;
     dirWatchers: Watcher[];
     fileWatchers: Watcher[];
     /** Last modified times for files by path */

--- a/types/yargs/v15/yargs.d.ts
+++ b/types/yargs/v15/yargs.d.ts
@@ -5,5 +5,5 @@ export = Yargs;
 declare function Yargs(
     processArgs?: readonly string[],
     cwd?: string,
-    parentRequire?: NodeRequire,
+    parentRequire?: NodeJS.Require,
 ): Argv;

--- a/types/yargs/v16/yargs.d.ts
+++ b/types/yargs/v16/yargs.d.ts
@@ -5,5 +5,5 @@ export = Yargs;
 declare function Yargs(
     processArgs?: readonly string[],
     cwd?: string,
-    parentRequire?: NodeRequire,
+    parentRequire?: NodeJS.Require,
 ): Argv;

--- a/types/yargs/yargs.d.ts
+++ b/types/yargs/yargs.d.ts
@@ -5,5 +5,5 @@ export = Yargs;
 declare function Yargs(
     processArgs?: readonly string[] | string,
     cwd?: string,
-    parentRequire?: NodeRequire,
+    parentRequire?: NodeJS.Require,
 ): Argv;


### PR DESCRIPTION
Updates references to the following:
- `NodeJS.Module`, `NodeJS.Require` (since @types/node v13)
- `NodeJS.Timeout`, `NodeJS.Immediate` (since @types/node v10)