### PR TITLE
[react] Switch the default revealOrder to "forwards" and tail "hidden" on SuspenseList

### DIFF
--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -69,17 +69,19 @@ declare module "." {
         children: Iterable<ReactElement> | AsyncIterable<ReactElement>;
         /**
          * Defines the order in which the `SuspenseList` children should be revealed.
+         * @default "forwards"
          */
-        revealOrder: "forwards" | "backwards" | "unstable_legacy-backwards";
+        revealOrder?: "forwards" | "backwards" | "unstable_legacy-backwards" | undefined;
         /**
          * Dictates how unloaded items in a SuspenseList is shown.
          *
-         * - By default, `SuspenseList` will show all fallbacks in the list.
          * - `collapsed` shows only the next fallback in the list.
          * - `hidden` doesn't show any unloaded items.
          * - `visible` shows all fallbacks in the list.
+         *
+         * @default "hidden"
          */
-        tail: SuspenseListTailMode;
+        tail?: SuspenseListTailMode | undefined;
     }
 
     interface NonDirectionalSuspenseListProps extends SuspenseListCommonProps {
@@ -87,7 +89,7 @@ declare module "." {
         /**
          * Defines the order in which the `SuspenseList` children should be revealed.
          */
-        revealOrder: Exclude<SuspenseListRevealOrder, DirectionalSuspenseListProps["revealOrder"]> | undefined;
+        revealOrder: Exclude<SuspenseListRevealOrder, DirectionalSuspenseListProps["revealOrder"]>;
         /**
          * The tail property is invalid when not using the `forwards` or `backwards` reveal orders.
          */

--- a/types/react/test/experimental.tsx
+++ b/types/react/test/experimental.tsx
@@ -22,59 +22,64 @@ function suspenseTest() {
     }
 }
 
-// @ts-expect-error -- no revealOrder
-<React.unstable_SuspenseList>
-    <React.Suspense fallback="Loading">Content</React.Suspense>
-</React.unstable_SuspenseList>;
-// Unsupported `revealOrder` triggers a runtime warning
-// @ts-expect-error
-<React.unstable_SuspenseList revealOrder="something">
-    <React.Suspense fallback="Loading">Content</React.Suspense>
-</React.unstable_SuspenseList>;
+function suspenseListTests() {
+    <React.unstable_SuspenseList>
+        <React.Suspense fallback="Loading">Content</React.Suspense>
+        <React.Suspense fallback="Loading">Content</React.Suspense>
+    </React.unstable_SuspenseList>;
+    // @ts-expect-error -- Directional SuspenseList needs more than one child
+    <React.unstable_SuspenseList>
+        <React.Suspense fallback="Loading">Content</React.Suspense>
+    </React.unstable_SuspenseList>;
+    // Unsupported `revealOrder` triggers a runtime warning
+    // @ts-expect-error
+    <React.unstable_SuspenseList revealOrder="something">
+        <React.Suspense fallback="Loading">Content</React.Suspense>
+    </React.unstable_SuspenseList>;
 
-// @ts-expect-error -- no tail
-<React.unstable_SuspenseList revealOrder="forwards">
-    <React.Suspense fallback="Loading">Content</React.Suspense>
-    <React.Suspense fallback="Loading">Content</React.Suspense>
-</React.unstable_SuspenseList>;
+    <React.unstable_SuspenseList revealOrder="forwards">
+        <React.Suspense fallback="Loading">Content</React.Suspense>
+        <React.Suspense fallback="Loading">Content</React.Suspense>
+    </React.unstable_SuspenseList>;
 
-<React.unstable_SuspenseList revealOrder="backwards" tail="collapsed">
-    <React.Suspense fallback="Loading">A</React.Suspense>
-    <React.Suspense fallback="Loading">B</React.Suspense>
-</React.unstable_SuspenseList>;
+    <React.unstable_SuspenseList revealOrder="backwards" tail="collapsed">
+        <React.Suspense fallback="Loading">A</React.Suspense>
+        <React.Suspense fallback="Loading">B</React.Suspense>
+    </React.unstable_SuspenseList>;
 
-// @ts-expect-error -- Must have more than one static child
-<React.unstable_SuspenseList revealOrder="backwards" tail="collapsed">
-    <React.Suspense fallback="Loading">B</React.Suspense>
-</React.unstable_SuspenseList>;
+    // @ts-expect-error -- Must have more than one static child
+    <React.unstable_SuspenseList revealOrder="backwards" tail="collapsed">
+        <React.Suspense fallback="Loading">B</React.Suspense>
+    </React.unstable_SuspenseList>;
 
-<React.unstable_SuspenseList revealOrder="unstable_legacy-backwards" tail="collapsed">
-    <React.Suspense fallback="Loading">A</React.Suspense>
-    <React.Suspense fallback="Loading">B</React.Suspense>
-</React.unstable_SuspenseList>;
+    <React.unstable_SuspenseList revealOrder="unstable_legacy-backwards" tail="collapsed">
+        <React.Suspense fallback="Loading">A</React.Suspense>
+        <React.Suspense fallback="Loading">B</React.Suspense>
+    </React.unstable_SuspenseList>;
 
-<React.unstable_SuspenseList revealOrder="independent">
-    <React.Suspense fallback="Loading">A</React.Suspense>
-    <React.Suspense fallback="Loading">B</React.Suspense>
-</React.unstable_SuspenseList>;
+    <React.unstable_SuspenseList revealOrder="independent">
+        <React.Suspense fallback="Loading">A</React.Suspense>
+        <React.Suspense fallback="Loading">B</React.Suspense>
+    </React.unstable_SuspenseList>;
 
-<React.unstable_SuspenseList revealOrder="forwards" tail="hidden">
-    <React.Suspense fallback="Loading">A</React.Suspense>
-    <React.Suspense fallback="Loading">B</React.Suspense>
-</React.unstable_SuspenseList>;
+    <React.unstable_SuspenseList revealOrder="forwards" tail="hidden">
+        <React.Suspense fallback="Loading">A</React.Suspense>
+        <React.Suspense fallback="Loading">B</React.Suspense>
+    </React.unstable_SuspenseList>;
 
-<React.unstable_SuspenseList revealOrder="together">
-    <React.Suspense fallback="Loading">A</React.Suspense>
-    <React.Suspense fallback="Loading">B</React.Suspense>
-</React.unstable_SuspenseList>;
+    <React.unstable_SuspenseList revealOrder="together">
+        <React.Suspense fallback="Loading">A</React.Suspense>
+        <React.Suspense fallback="Loading">B</React.Suspense>
+    </React.unstable_SuspenseList>;
 
-function Page({ children }: { children: NonNullable<React.ReactNode> }) {
-    return (
-        // @ts-expect-error -- Can't pass arbitrary Nodes. Must be an Element or Iterable of Elements.
-        <React.unstable_SuspenseList revealOrder="forwards" tail="collapsed">
-            {children}
-        </React.unstable_SuspenseList>
-    );
+    function Page({ children }: { children: NonNullable<React.ReactNode> }) {
+        return (
+            // @ts-expect-error -- Can't pass arbitrary Nodes. Must be an Element or Iterable of Elements.
+            <React.unstable_SuspenseList revealOrder="forwards" tail="collapsed">
+                {children}
+            </React.unstable_SuspenseList>
+        );
+    }
 }
 
 function elementTypeTests() {

--- a/types/react/ts5.0/experimental.d.ts
+++ b/types/react/ts5.0/experimental.d.ts
@@ -69,17 +69,19 @@ declare module "." {
         children: Iterable<ReactElement> | AsyncIterable<ReactElement>;
         /**
          * Defines the order in which the `SuspenseList` children should be revealed.
+         * @default "forwards"
          */
-        revealOrder: "forwards" | "backwards" | "unstable_legacy-backwards";
+        revealOrder?: "forwards" | "backwards" | "unstable_legacy-backwards" | undefined;
         /**
          * Dictates how unloaded items in a SuspenseList is shown.
          *
-         * - By default, `SuspenseList` will show all fallbacks in the list.
          * - `collapsed` shows only the next fallback in the list.
          * - `hidden` doesn't show any unloaded items.
          * - `visible` shows all fallbacks in the list.
+         *
+         * @default "hidden"
          */
-        tail: SuspenseListTailMode;
+        tail?: SuspenseListTailMode | undefined;
     }
 
     interface NonDirectionalSuspenseListProps extends SuspenseListCommonProps {
@@ -87,7 +89,7 @@ declare module "." {
         /**
          * Defines the order in which the `SuspenseList` children should be revealed.
          */
-        revealOrder: Exclude<SuspenseListRevealOrder, DirectionalSuspenseListProps["revealOrder"]> | undefined;
+        revealOrder: Exclude<SuspenseListRevealOrder, DirectionalSuspenseListProps["revealOrder"]>;
         /**
          * The tail property is invalid when not using the `forwards` or `backwards` reveal orders.
          */

--- a/types/react/ts5.0/test/experimental.tsx
+++ b/types/react/ts5.0/test/experimental.tsx
@@ -22,59 +22,64 @@ function suspenseTest() {
     }
 }
 
-// @ts-expect-error -- no revealOrder
-<React.unstable_SuspenseList>
-    <React.Suspense fallback="Loading">Content</React.Suspense>
-</React.unstable_SuspenseList>;
-// Unsupported `revealOrder` triggers a runtime warning
-// @ts-expect-error
-<React.unstable_SuspenseList revealOrder="something">
-    <React.Suspense fallback="Loading">Content</React.Suspense>
-</React.unstable_SuspenseList>;
+function suspenseListTests() {
+    <React.unstable_SuspenseList>
+        <React.Suspense fallback="Loading">Content</React.Suspense>
+        <React.Suspense fallback="Loading">Content</React.Suspense>
+    </React.unstable_SuspenseList>;
+    // @ts-expect-error -- Directional SuspenseList needs more than one child
+    <React.unstable_SuspenseList>
+        <React.Suspense fallback="Loading">Content</React.Suspense>
+    </React.unstable_SuspenseList>;
+    // Unsupported `revealOrder` triggers a runtime warning
+    // @ts-expect-error
+    <React.unstable_SuspenseList revealOrder="something">
+        <React.Suspense fallback="Loading">Content</React.Suspense>
+    </React.unstable_SuspenseList>;
 
-// @ts-expect-error -- no tail
-<React.unstable_SuspenseList revealOrder="forwards">
-    <React.Suspense fallback="Loading">Content</React.Suspense>
-    <React.Suspense fallback="Loading">Content</React.Suspense>
-</React.unstable_SuspenseList>;
+    <React.unstable_SuspenseList revealOrder="forwards">
+        <React.Suspense fallback="Loading">Content</React.Suspense>
+        <React.Suspense fallback="Loading">Content</React.Suspense>
+    </React.unstable_SuspenseList>;
 
-<React.unstable_SuspenseList revealOrder="backwards" tail="collapsed">
-    <React.Suspense fallback="Loading">A</React.Suspense>
-    <React.Suspense fallback="Loading">B</React.Suspense>
-</React.unstable_SuspenseList>;
+    <React.unstable_SuspenseList revealOrder="backwards" tail="collapsed">
+        <React.Suspense fallback="Loading">A</React.Suspense>
+        <React.Suspense fallback="Loading">B</React.Suspense>
+    </React.unstable_SuspenseList>;
 
-// @ts-expect-error -- Must have more than one static child
-<React.unstable_SuspenseList revealOrder="backwards" tail="collapsed">
-    <React.Suspense fallback="Loading">B</React.Suspense>
-</React.unstable_SuspenseList>;
+    // @ts-expect-error -- Must have more than one static child
+    <React.unstable_SuspenseList revealOrder="backwards" tail="collapsed">
+        <React.Suspense fallback="Loading">B</React.Suspense>
+    </React.unstable_SuspenseList>;
 
-<React.unstable_SuspenseList revealOrder="unstable_legacy-backwards" tail="collapsed">
-    <React.Suspense fallback="Loading">A</React.Suspense>
-    <React.Suspense fallback="Loading">B</React.Suspense>
-</React.unstable_SuspenseList>;
+    <React.unstable_SuspenseList revealOrder="unstable_legacy-backwards" tail="collapsed">
+        <React.Suspense fallback="Loading">A</React.Suspense>
+        <React.Suspense fallback="Loading">B</React.Suspense>
+    </React.unstable_SuspenseList>;
 
-<React.unstable_SuspenseList revealOrder="independent">
-    <React.Suspense fallback="Loading">A</React.Suspense>
-    <React.Suspense fallback="Loading">B</React.Suspense>
-</React.unstable_SuspenseList>;
+    <React.unstable_SuspenseList revealOrder="independent">
+        <React.Suspense fallback="Loading">A</React.Suspense>
+        <React.Suspense fallback="Loading">B</React.Suspense>
+    </React.unstable_SuspenseList>;
 
-<React.unstable_SuspenseList revealOrder="forwards" tail="hidden">
-    <React.Suspense fallback="Loading">A</React.Suspense>
-    <React.Suspense fallback="Loading">B</React.Suspense>
-</React.unstable_SuspenseList>;
+    <React.unstable_SuspenseList revealOrder="forwards" tail="hidden">
+        <React.Suspense fallback="Loading">A</React.Suspense>
+        <React.Suspense fallback="Loading">B</React.Suspense>
+    </React.unstable_SuspenseList>;
 
-<React.unstable_SuspenseList revealOrder="together">
-    <React.Suspense fallback="Loading">A</React.Suspense>
-    <React.Suspense fallback="Loading">B</React.Suspense>
-</React.unstable_SuspenseList>;
+    <React.unstable_SuspenseList revealOrder="together">
+        <React.Suspense fallback="Loading">A</React.Suspense>
+        <React.Suspense fallback="Loading">B</React.Suspense>
+    </React.unstable_SuspenseList>;
 
-function Page({ children }: { children: NonNullable<React.ReactNode> }) {
-    return (
-        // @ts-expect-error -- Can't pass arbitrary Nodes. Must be an Element or Iterable of Elements.
-        <React.unstable_SuspenseList revealOrder="forwards" tail="collapsed">
-            {children}
-        </React.unstable_SuspenseList>
-    );
+    function Page({ children }: { children: NonNullable<React.ReactNode> }) {
+        return (
+            // @ts-expect-error -- Can't pass arbitrary Nodes. Must be an Element or Iterable of Elements.
+            <React.unstable_SuspenseList revealOrder="forwards" tail="collapsed">
+                {children}
+            </React.unstable_SuspenseList>
+        );
+    }
 }
 
 function elementTypeTests() {


### PR DESCRIPTION
Types for https://github.com/facebook/react/pull/35018/