### PR TITLE
[eslint-scope] update for v9

### DIFF
--- a/types/eslint-scope/eslint-scope-tests.ts
+++ b/types/eslint-scope/eslint-scope-tests.ts
@@ -38,8 +38,21 @@ const scope = scopeManager.acquire(ast);
 scopeManager.release(ast);
 
 if (scope) {
-    // $ExpectType "function" | "module" | "block" | "catch" | "class" | "for" | "function-expression-name" | "global" | "switch" | "with" | "TDZ"
-    scope.type;
+    ((
+        type:
+            | "function"
+            | "module"
+            | "block"
+            | "catch"
+            | "class"
+            | "class-field-initializer"
+            | "class-static-block"
+            | "for"
+            | "function-expression-name"
+            | "global"
+            | "switch"
+            | "with",
+    ) => type satisfies typeof scope.type);
     // $ExpectType boolean
     scope.isStrict;
     // $ExpectType Scope<Variable<Reference>, Reference> | null
@@ -58,6 +71,10 @@ if (scope) {
     scope.functionExpressionScope;
     // $ExpectType Reference[]
     scope.implicit.left;
+    // $ExpectType Map<string, Variable<Reference>>
+    scope.implicit.set;
+    // $ExpectType Variable<Reference>[]
+    scope.implicit.variables;
     // $ExpectType  Map<string, Variable>
     scope.set;
     // $ExpectType Reference[]
@@ -94,8 +111,16 @@ if (reference) {
 
 const definition = variable?.defs[0];
 if (definition) {
-    // $ExpectType "CatchClause" | "TDZ" | "ClassName" | "FunctionName" | "ImplicitGlobalVariable" | "ImportBinding" | "Parameter" | "Variable"
-    definition.type;
+    ((
+        type:
+            | "CatchClause"
+            | "ClassName"
+            | "FunctionName"
+            | "ImplicitGlobalVariable"
+            | "ImportBinding"
+            | "Parameter"
+            | "Variable",
+    ) => type satisfies typeof definition.type);
     // $ExpectType Identifier
     definition.name;
     // $ExpectType ImportDeclaration | VariableDeclaration | null
@@ -126,8 +151,16 @@ const definition2 = new eslintScope.Definition(
     null,
     "let",
 );
-// $ExpectType "CatchClause" | "TDZ" | "ClassName" | "FunctionName" | "ImplicitGlobalVariable" | "ImportBinding" | "Parameter" | "Variable"
-definition2.type;
+((
+    type:
+        | "CatchClause"
+        | "ClassName"
+        | "FunctionName"
+        | "ImplicitGlobalVariable"
+        | "ImportBinding"
+        | "Parameter"
+        | "Variable",
+) => type satisfies typeof definition2.type);
 // $ExpectType Identifier
 definition2.name;
 
@@ -178,8 +211,21 @@ const scopeInstance = new eslintScope.Scope(
     ast,
     false,
 );
-// $ExpectType "function" | "module" | "block" | "catch" | "class" | "for" | "function-expression-name" | "global" | "switch" | "with" | "TDZ"
-scopeInstance.type;
+((
+    type:
+        | "function"
+        | "module"
+        | "block"
+        | "catch"
+        | "class"
+        | "class-field-initializer"
+        | "class-static-block"
+        | "for"
+        | "function-expression-name"
+        | "global"
+        | "switch"
+        | "with",
+) => type satisfies typeof scopeInstance.type);
 // $ExpectType boolean
 scopeInstance.isStrict;
 // $ExpectType Scope<Variable<Reference>, Reference> | null
@@ -196,7 +242,7 @@ scopeInstance.childScopes;
 scopeInstance.block;
 // $ExpectType boolean
 scopeInstance.functionExpressionScope;
-// $ExpectType { left: Reference[]; set: Map<string, Variable<Reference>>; }
+// $ExpectType { left: Reference[]; set: Map<string, Variable<Reference>>; variables: Variable<Reference>[]; }
 scopeInstance.implicit;
 // $ExpectType Map<string, Variable>
 scopeInstance.set;
@@ -229,6 +275,8 @@ const scopeManagerInstance = new eslintScope.ScopeManager({
 scopeManagerInstance.globalScope;
 // $ExpectType Scope<Variable<Reference>, Reference>[]
 scopeManagerInstance.scopes;
+// $ExpectType void
+scopeManagerInstance.addGlobals(["window", "self"]);
 // $ExpectType Scope<Variable<Reference>, Reference> | null
 scopeManagerInstance.acquire(ast);
 // $ExpectType Scope<Variable<Reference>, Reference>[] | null

--- a/types/eslint-scope/index.d.cts
+++ b/types/eslint-scope/index.d.cts
@@ -92,6 +92,13 @@ export class ScopeManager implements eslint.Scope.ScopeManager {
     scopes: Scope[];
 
     /**
+     * Adds variables to the global scope and resolves references to them.
+     * @param names An array of strings, the names of variables to add to the global scope.
+     * @returns void
+     */
+    addGlobals(names: ReadonlyArray<string>): void;
+
+    /**
      * Acquires the scope for a given node.
      * @param node The AST node to get the scope for.
      * @param inner Whether to get the innermost scope.
@@ -201,7 +208,7 @@ export class Scope<TVariable extends Variable = Variable, TReference extends Ref
     /**
      * Implicit references (e.g., 'arguments' in functions).
      */
-    implicit: { left: TReference[]; set: Map<string, Variable> };
+    implicit: { left: TReference[]; set: Map<string, Variable>; variables: Variable[] };
 
     /**
      * Map of variable names to variables.

--- a/types/eslint-scope/package.json
+++ b/types/eslint-scope/package.json
@@ -4,7 +4,7 @@
     "version": "9.0.9999",
     "type": "module",
     "projects": [
-        "https://github.com/eslint/eslint-scope"
+        "https://github.com/eslint/js/tree/main/packages/eslint-scope"
     ],
     "dependencies": {
         "@types/esrecurse": "*",

--- a/types/eslint-scope/package.json
+++ b/types/eslint-scope/package.json
@@ -1,13 +1,12 @@
 {
     "private": true,
     "name": "@types/eslint-scope",
-    "version": "8.3.9999",
+    "version": "9.0.9999",
     "type": "module",
     "projects": [
         "https://github.com/eslint/eslint-scope"
     ],
     "dependencies": {
-        "@types/eslint": "*",
         "@types/esrecurse": "*",
         "@types/estree": "*",
         "eslint-visitor-keys": "*"
@@ -15,6 +14,9 @@
     "devDependencies": {
         "@types/eslint-scope": "workspace:.",
         "@types/espree": "*"
+    },
+    "peerDependencies": {
+        "eslint": "*"
     },
     "exports": {
         ".": {

--- a/types/eslint-scope/tsconfig.json
+++ b/types/eslint-scope/tsconfig.json
@@ -8,6 +8,7 @@
         "noImplicitThis": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
+        "exactOptionalPropertyTypes": true,
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - `ScopeManager["addGlobals"]`: eslint/js#682
  - `Scope["implicit"]`: https://github.com/eslint/js/blob/main/packages/eslint-scope/README.md#properties-1
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

This pull request updates the types for the the recently released `eslint-scope` v9. Here's an overview of the changes:
* Added new method `ScopeManager["addGlobals"]`.
* Updated `Scope["implicit"]` to match the [documented interface](https://github.com/eslint/js/blob/main/packages/eslint-scope/README.md#properties-1).
* Replaced dependency on discontinued `@types/eslint` with a peer dependency on `eslint`.
* Update project URL to https://github.com/eslint/js/tree/main/packages/eslint-scope.

Build-related changes:

* Updated tests for `Scope["type"]`: `"class-field-initializer" | "class-static-block"` were added in eslint/eslint#20110; `"TDZ"` pending removal (eslint/eslint#20231).
* Updated tests for `Definition["type"]`: `"TDZ"` pending removal (eslint/eslint#20231).
* Added `"exactOptionalPropertyTypes": true` to compiler options.
