### PR TITLE
Update types for migrate-mongo 12

### DIFF
--- a/types/migrate-mongo/package.json
+++ b/types/migrate-mongo/package.json
@@ -7,7 +7,7 @@
     ],
     "dependencies": {
         "@types/node": "*",
-        "mongodb": "^6.1.0"
+        "mongodb": "^7.0.0"
     },
     "devDependencies": {
         "@types/migrate-mongo": "workspace:."


### PR DESCRIPTION
Adapt types for migrate-mongo 12.
This is only about changing the mongo version to version 7 - no other changes.