### PR TITLE
feat(validator): add overload to isLength(), enforce discreteLengths to be array

### DIFF
--- a/types/validator/index.d.ts
+++ b/types/validator/index.d.ts
@@ -882,7 +882,7 @@ declare namespace validator {
         /**
          * @default undefined
          */
-        discreteLengths?: number | Array<number> | undefined;
+        discreteLengths?: Array<number> | undefined;
     }
 
     /**
@@ -892,7 +892,8 @@ declare namespace validator {
      *
      * @param [options] - Options
      */
-    export function isLength(str: string, options?: IsLengthOptions): boolean;
+    export function isLength(str: string, minOrOptions?: number | IsLengthOptions): boolean;
+    export function isLength(str: string, min: number, max: number): boolean;
 
     export type LicensePlateLocale =
         | "cs-CZ"

--- a/types/validator/validator-tests.ts
+++ b/types/validator/validator-tests.ts
@@ -61,7 +61,7 @@ import isISSNFunc from "validator/lib/isISSN";
 import isJSONFunc, { IsJSONOptions } from "validator/lib/isJSON";
 import isJWTFunc from "validator/lib/isJWT";
 import isLatLongFunc, { IsLatLongOptions } from "validator/lib/isLatLong";
-import isLengthFunc from "validator/lib/isLength";
+import isLengthFunc, { IsLengthOptions } from "validator/lib/isLength";
 import isLicensePlateFunc from "validator/lib/isLicensePlate";
 import isLocaleFunc from "validator/lib/isLocale";
 import isLowercaseFunc from "validator/lib/isLowercase";
@@ -471,7 +471,7 @@ import isISSNFuncEs from "validator/es/lib/isISSN";
 import isJSONFuncEs, { IsJSONOptions as IsJSONOptionsEs } from "validator/es/lib/isJSON";
 import isJWTFuncEs from "validator/es/lib/isJWT";
 import isLatLongFuncEs, { IsLatLongOptions as IsLatLongOptionsEs } from "validator/es/lib/isLatLong";
-import isLengthFuncEs from "validator/es/lib/isLength";
+import isLengthFuncEs, { IsLengthOptions as IsLengthOptionsEs } from "validator/es/lib/isLength";
 import isLicensePlateFuncEs from "validator/es/lib/isLicensePlate";
 import isLocaleFuncEs from "validator/es/lib/isLocale";
 import isLowercaseFuncEs from "validator/es/lib/isLowercase";
@@ -987,9 +987,17 @@ const any: any = null;
     result = validator.isLatLong("sample", {});
     result = validator.isLatLong("sample", { checkDMS: true } satisfies IsLatLongOptions);
 
-    const isLengthOptions: validator.IsLengthOptions = {};
-    result = validator.isLength("sample", isLengthOptions);
     result = validator.isLength("sample");
+    result = validator.isLength("sample", {});
+    result = validator.isLength("sample", { min: 0, max: 3, discreteLengths: [1, 2] } satisfies IsLengthOptions);
+    result = validator.isLength("sample", 0);
+    result = validator.isLength("sample", 0, 3);
+    // Both overloads happen to allow using exactly two argument, [str, number] & [str, object]
+    // Hence if 2nd arg is of union type `number | object`, typechecking can pass.
+    result = validator.isLength("sample", result ? 0 : { min: 0, max: 3 });
+    // @ts-expect-error
+    // Using 3rd arg here is problematic, without first ensuring that the 2nd argument is a number.
+    result = validator.isLength("sample", result ? 0 : { min: 0, max: 3 }, 3);
 
     result = validator.isLicensePlate("sample", "cs-CZ" satisfies validator.LicensePlateLocale);
     result = validator.isLicensePlate("sample", "de-DE");


### PR DESCRIPTION
See https://github.com/validatorjs/validator.js/blob/master/src/lib/isLength.js.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
