### PR TITLE
[react] Remove `digest` from `ErrorInfo`

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -4057,7 +4057,6 @@ declare namespace React {
          * Captures which component contained the exception, and its ancestors.
          */
         componentStack?: string | null;
-        digest?: string | null;
     }
 
     // Keep in sync with JSX namespace in ./jsx-runtime.d.ts and ./jsx-dev-runtime.d.ts

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -4056,7 +4056,6 @@ declare namespace React {
          * Captures which component contained the exception, and its ancestors.
          */
         componentStack?: string | null;
-        digest?: string | null;
     }
 
     // Keep in sync with JSX namespace in ./jsx-runtime.d.ts and ./jsx-dev-runtime.d.ts


### PR DESCRIPTION
This has been removed for a while and moved to the passed error objects.