### PR TITLE
feat(validator): make isDate() accept Date in 1st arg & format string in 2nd arg

### DIFF
--- a/types/validator/es/lib/isDate.d.ts
+++ b/types/validator/es/lib/isDate.d.ts
@@ -1,2 +1,3 @@
 import validator from "../../";
+export type IsDateOptions = validator.IsDateOptions;
 export default validator.isDate;

--- a/types/validator/index.d.ts
+++ b/types/validator/index.d.ts
@@ -417,7 +417,8 @@ declare namespace validator {
     /**
      * Check if the string is a valid date.
      */
-    export function isDate(str: string, options?: IsDateOptions): boolean;
+    export function isDate(input: Date, formatOrOptions: IsDateOptions & { strictMode: true }): false;
+    export function isDate(input: string | Date, formatOrOptions?: string | IsDateOptions): boolean;
 
     export type DecimalLocale = FloatLocale;
 

--- a/types/validator/lib/isDate.d.ts
+++ b/types/validator/lib/isDate.d.ts
@@ -1,2 +1,3 @@
 import validator from "../";
+export type IsDateOptions = validator.IsDateOptions;
 export default validator.isDate;

--- a/types/validator/validator-tests.ts
+++ b/types/validator/validator-tests.ts
@@ -25,7 +25,7 @@ import isByteLengthFunc, { IsByteLengthOptions } from "validator/lib/isByteLengt
 import isCreditCardFunc from "validator/lib/isCreditCard";
 import isCurrencyFunc from "validator/lib/isCurrency";
 import isDataURIFunc from "validator/lib/isDataURI";
-import isDateFunc from "validator/lib/isDate";
+import isDateFunc, { IsDateOptions } from "validator/lib/isDate";
 import isDecimalFunc from "validator/lib/isDecimal";
 import isDivisibleByFunc from "validator/lib/isDivisibleBy";
 import isEANFunc from "validator/lib/isEAN";
@@ -432,7 +432,7 @@ import isByteLengthFuncEs, { IsByteLengthOptions as IsByteLengthOptionsEs } from
 import isCreditCardFuncEs from "validator/es/lib/isCreditCard";
 import isCurrencyFuncEs from "validator/es/lib/isCurrency";
 import isDataURIFuncEs from "validator/es/lib/isDataURI";
-import isDateFuncEs from "validator/es/lib/isDate";
+import isDateFuncEs, { IsDateOptions as IsDateOptionsEs } from "validator/es/lib/isDate";
 import isDecimalFuncEs from "validator/es/lib/isDecimal";
 import isDivisibleByFuncEs from "validator/es/lib/isDivisibleBy";
 import isEANFuncEs from "validator/es/lib/isEAN";
@@ -788,9 +788,28 @@ const any: any = null;
 
     result = validator.isDataURI("sample");
 
-    const isDateOptions: validator.IsDateOptions = {};
     result = validator.isDate("sample");
-    result = validator.isDate("sample", isDateOptions);
+    result = validator.isDate("sample", "YYYY/MM/DD");
+    result = validator.isDate("sample", {} satisfies IsDateOptions);
+    result = validator.isDate("sample", { format: "YYYY/MM/DD", delimiters: ["/", "-"], strictMode: false });
+    validator.isDate("sample", { strictMode: true }); // $ExpectType boolean
+    validator.isDate("sample", { strictMode: false }); // $ExpectType boolean
+    validator.isDate("sample", { strictMode: result }); // $ExpectType boolean
+
+    result = validator.isDate(new Date());
+    result = validator.isDate(new Date(), "YYYY/MM/DD");
+    result = validator.isDate(new Date(), {} satisfies IsDateOptions);
+    result = validator.isDate(new Date(), { format: "YYYY/MM/DD", delimiters: ["/", "-"], strictMode: false });
+    // If options.strictMode is known to be true in compile time, we return false.
+    validator.isDate(new Date(), { strictMode: true }); // $ExpectType false
+    // If options.strictMode is false or unknown in compile time, we return a boolean type as fallback
+    validator.isDate(new Date(), { strictMode: false }); // $ExpectType boolean
+    validator.isDate(new Date(), { strictMode: result }); // $ExpectType boolean
+    // Let's test for union type as well.
+    result = validator.isDate(
+        result ? "sample" : new Date(),
+        result ? "YYYY/MM/DD" : { format: "YYYY/MM/DD", delimiters: ["/", "-"], strictMode: false },
+    );
 
     const isDecimalOptions: validator.IsDecimalOptions = {};
     result = validator.isDecimal("sample");


### PR DESCRIPTION
See https://github.com/validatorjs/validator.js/blob/master/src/lib/isDate.js.

`Date` type shall be allowed, due to this implementation.

```js
if (!options.strictMode) {
    return Object.prototype.toString.call(input) === '[object Date]' && isFinite(input);
}
```

Same for `format` string.

```js
if (typeof options === 'string') { // Allow backward compatibility for old format isDate(input [, format])
    options = merge({ format: options }, default_date_options);
} else {
    options = merge(options, default_date_options);
}
```

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
