### PR TITLE
Fix VS Code types

### DIFF
--- a/types/vscode/.eslintrc.json
+++ b/types/vscode/.eslintrc.json
@@ -6,9 +6,10 @@
         "@definitelytyped/strict-export-declare-modifiers": "off",
         "@definitelytyped/no-single-declare-module": "off",
         "@typescript-eslint/no-unsafe-function-type": "off",
-"@typescript-eslint/no-wrapper-object-types": "off",
+        "@typescript-eslint/no-wrapper-object-types": "off",
         "@typescript-eslint/no-empty-interface": "off",
         "@typescript-eslint/no-invalid-void-type": "off",
-        "@typescript-eslint/array-type": "off"
+        "@typescript-eslint/array-type": "off",
+        "jsdoc/check-tag-names": "off"
     }
 }

--- a/types/vscode/package.json
+++ b/types/vscode/package.json
@@ -2,6 +2,8 @@
     "private": true,
     "name": "@types/vscode",
     "version": "1.106.9999",
+    "nonNpm": "conflict",
+    "nonNpmDescription": "TypeScript definitions for the Visual Studio Code Extension API",
     "projects": [
         "https://github.com/microsoft/vscode"
     ],


### PR DESCRIPTION
Fixes CI, then also correctly marks the package as conflicting so we can remove it from https://github.com/microsoft/DefinitelyTyped-tools/blob/main/packages/dtslint