### PR TITLE
fix(markdown-it-container): import from `markdown-it/lib/renderer`

### DIFF
--- a/types/markdown-it-container/index.d.ts
+++ b/types/markdown-it-container/index.d.ts
@@ -1,10 +1,11 @@
 import MarkdownIt = require("markdown-it");
+import Renderer = require("markdown-it/lib/renderer");
 
 declare namespace MarkdownItContainer {
     interface ContainerOpts {
         marker?: string | undefined;
         validate?(params: string): boolean;
-        render?: MarkdownIt.Renderer.RenderRule | undefined;
+        render?: Renderer.RenderRule | undefined;
     }
 }
 

--- a/types/markdown-it-container/markdown-it-container-tests.ts
+++ b/types/markdown-it-container/markdown-it-container-tests.ts
@@ -5,7 +5,7 @@ import MarkdownItContainer = require("markdown-it-container");
 const md = new MarkdownIt();
 
 md.use(MarkdownItContainer, "spoiler", {
-    validate: (params: any) => params.trim().match(/^spoiler\s+(.*)$/),
+    validate: (params: string) => params.trim().match(/^spoiler\s+(.*)$/),
     render: (tokens: MarkdownIt.Token[], index: number) => {
         const match = tokens[index].info.trim().match(/^spoiler\s+(.*)$/);
         const onClick = "this.parentNode.classList.toggle('_expanded');" + "event.preventDefault();";
@@ -26,6 +26,7 @@ md.use(MarkdownItContainer, "spoiler", {
             return "</div></div>\n";
         }
     },
+    marker: "marker",
 });
 
 const src = `:::spoiler This Is Spoiler Title

--- a/types/markdown-it-container/package.json
+++ b/types/markdown-it-container/package.json
@@ -6,7 +6,7 @@
         "https://github.com/markdown-it/markdown-it-container"
     ],
     "dependencies": {
-        "@types/markdown-it": "*"
+        "@types/markdown-it": "<14"
     },
     "devDependencies": {
         "@types/markdown-it-container": "workspace:."


### PR DESCRIPTION
Resolves discussion https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/74094. Looks like older version of `@types/markdown-it` does not expose `Renderer` type directly.

Based on https://app.unpkg.com/markdown-it-container@4.0.0/files/package.json, I think it is safe to assert `@types/markdown-it@2.0.x` will have a dependency `@types/markdown-it@<14`

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
