### PR TITLE
Blessed library typing: reinforcing log element's properties align and valign

### DIFF
--- a/types/blessed/index.d.ts
+++ b/types/blessed/index.d.ts
@@ -3072,10 +3072,10 @@ export namespace Widgets {
          * scroll to bottom on input even if the user has scrolled up. default: false.
          */
         scrollOnInput: boolean;
-        
+
         /**
-         * forced to reassign align and valign because typescript is so script about inheritance. 
-         * Align text alignmentL left, center, right. 
+         * forced to reassign align and valign because typescript is so script about inheritance.
+         * Align text alignmentL left, center, right.
          */
         align?: "left" | "center" | "right" | undefined;
 

--- a/types/blessed/index.d.ts
+++ b/types/blessed/index.d.ts
@@ -3072,6 +3072,17 @@ export namespace Widgets {
          * scroll to bottom on input even if the user has scrolled up. default: false.
          */
         scrollOnInput: boolean;
+        
+        /**
+         * forced to reassign align and valign because typescript is so script about inheritance. 
+         * Align text alignmentL left, center, right. 
+         */
+        align?: "left" | "center" | "right" | undefined;
+
+        /**
+         * Vertical text alignment: top, middle, or bottom.
+         */
+        valign?: "top" | "middle" | "bottom" | undefined;
 
         /**
          * add a log line.


### PR DESCRIPTION
I have not modified the blessed-test.ts file because I am very green and am not sure what other developers or the owners might be looking for in such a test. It seems that a test might not be necessary at all. I have used the modified index.d.ts file in my own code and it does indeed work. With these changes, Typescript does now find log's properties align and valign which clearly are properties the log elements does inherit in the actual blessed library.


Select one of these and delete the others:

If changing an existing definition:

- [ ] Provide a URL: 
<<https://www.npmjs.com/package/blessed#element-from-node>>
<<https://www.npmjs.com/package/blessed#log-from-scrollabletext>>
- [ ] If this PR brings the type definitions up to date: It does not

This is my first PR ever, I love criticism and advice!
