### PR TITLE
[aws-kcl] Add shutdownRequested to RecordProcessor

### DIFF
--- a/types/aws-kcl/aws-kcl-tests.ts
+++ b/types/aws-kcl/aws-kcl-tests.ts
@@ -45,6 +45,32 @@ const recordProcessor = {
         });
         completeCallback();
     },
+
+    shutdownRequested(shutdownRequestedInput: kcl.ShutdownRequestedInput, completeCallback: kcl.Callback) {
+        shutdownRequestedInput.checkpointer.checkpoint((_err?: string) => {
+            completeCallback();
+        });
+    },
 };
 
 kcl(recordProcessor).run();
+
+const recordProcessorWithoutShutdownRequested: kcl.RecordProcessor = {
+    initialize(_initializeInput: kcl.InitializeInput, completeCallback: kcl.Callback) {
+        completeCallback();
+    },
+
+    processRecords(processRecordsInput: kcl.ProcessRecordsInput, completeCallback: kcl.Callback) {
+        completeCallback();
+    },
+
+    leaseLost(_leaseLostInput: kcl.LeaseLossInput, completeCallback: kcl.Callback) {
+        completeCallback();
+    },
+
+    shardEnded(shardEndedInput: kcl.ShardEndedInput, completeCallback: kcl.Callback) {
+        completeCallback();
+    },
+};
+
+kcl(recordProcessorWithoutShutdownRequested).run();

--- a/types/aws-kcl/index.d.ts
+++ b/types/aws-kcl/index.d.ts
@@ -58,6 +58,8 @@ declare namespace KCLProcess {
 
     interface ShardEndedInput extends CheckpointInput {} // eslint-disable-line @typescript-eslint/no-empty-interface
 
+    interface ShutdownRequestedInput extends CheckpointInput {} // eslint-disable-line @typescript-eslint/no-empty-interface
+
     interface RecordProcessor {
         /**
          * Called once by the KCL before any calls to processRecords. Any initialization
@@ -110,6 +112,16 @@ declare namespace KCLProcess {
          *               ended operations are completed.
          */
         shardEnded(shardEndedInput: ShardEndedInput, completeCallback: Callback): void;
+        /**
+         * Called by the KCL to indicate that this record processor should shut down.
+         * This is called when the KCL is being shutdown using requestedShutdown.
+         * Clients should checkpoint at this time if they wish to save their progress.
+         *
+         * @param shutdownRequestedInput - Shutdown request information with checkpointer.
+         * @param completeCallback - The callback must be invoked once shutdown
+         *             requested operations are completed.
+         */
+        shutdownRequested?(shutdownRequestedInput: ShutdownRequestedInput, completeCallback: Callback): void;
     }
 
     interface KCLInput {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change.
- [x] Follow the advice from the readme.
- [x] Avoid common mistakes.
- [x] Run `pnpm test aws-kcl`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/awslabs/amazon-kinesis-client-nodejs/blob/master/lib/kcl/kcl_manager.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

## Summary

- Add `ShutdownRequestedInput` interface extending `CheckpointInput`
- Add optional `shutdownRequested` method to `RecordProcessor` interface
- Support graceful shutdown with checkpoint capability

## Context

The `shutdownRequested` callback is invoked when the KCL is being shut down via `requestedShutdown`. This allows record processors to checkpoint their progress before shutdown.

Reference: https://github.com/awslabs/amazon-kinesis-client-nodejs/blob/master/lib/kcl/kcl_manager.js