### PR TITLE
[chrome] fix StorageArea type with union

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -10047,10 +10047,10 @@ declare namespace chrome {
              *
              * Can return its result via Promise in Manifest V3 or later since Chrome 95.
              */
-            getBytesInUse(keys: never[]): Promise<0>;
+            getBytesInUse<T = { [key: string]: any }>(keys: never[]): Promise<0>;
             getBytesInUse<T = { [key: string]: any }>(keys?: keyof T | Array<keyof T> | null): Promise<number>;
             getBytesInUse<T = { [key: string]: any }>(callback: (bytesInUse: number) => void): void;
-            getBytesInUse(keys: never[], callback: (bytesInUse: 0) => void): void;
+            getBytesInUse<T = { [key: string]: any }>(keys: never[], callback: (bytesInUse: 0) => void): void;
             getBytesInUse<T = { [key: string]: any }>(
                 keys: keyof T | Array<keyof T> | null | undefined,
                 callback: (bytesInUse: number) => void,
@@ -10088,12 +10088,17 @@ declare namespace chrome {
              *
              * Can return its result via Promise in Manifest V3 or later since Chrome 95.
              */
-            get(keys: never[] | Record<string, never>): Promise<{ [key: string]: never }>;
+            get<T = { [key: string]: unknown }>(
+                keys: never[] | Record<string, never>,
+            ): Promise<{ [key: string]: never }>;
             get<T = { [key: string]: unknown }>(
                 keys?: NoInferX<keyof T> | Array<NoInferX<keyof T>> | Partial<NoInferX<T>> | null,
             ): Promise<T>;
             get<T = { [key: string]: unknown }>(callback: (items: T) => void): void;
-            get(keys: never[] | Record<string, never>, callback: (items: { [key: string]: never }) => void): void;
+            get<T = { [key: string]: unknown }>(
+                keys: never[] | Record<string, never>,
+                callback: (items: { [key: string]: never }) => void,
+            ): void;
             get<T = { [key: string]: unknown }>(
                 keys: NoInferX<keyof T> | Array<NoInferX<keyof T>> | Partial<NoInferX<T>> | null | undefined,
                 callback: (items: T) => void,

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -10047,10 +10047,8 @@ declare namespace chrome {
              *
              * Can return its result via Promise in Manifest V3 or later since Chrome 95.
              */
-            getBytesInUse<T = { [key: string]: any }>(keys: never[]): Promise<0>;
             getBytesInUse<T = { [key: string]: any }>(keys?: keyof T | Array<keyof T> | null): Promise<number>;
             getBytesInUse<T = { [key: string]: any }>(callback: (bytesInUse: number) => void): void;
-            getBytesInUse<T = { [key: string]: any }>(keys: never[], callback: (bytesInUse: 0) => void): void;
             getBytesInUse<T = { [key: string]: any }>(
                 keys: keyof T | Array<keyof T> | null | undefined,
                 callback: (bytesInUse: number) => void,
@@ -10089,16 +10087,9 @@ declare namespace chrome {
              * Can return its result via Promise in Manifest V3 or later since Chrome 95.
              */
             get<T = { [key: string]: unknown }>(
-                keys: never[] | Record<string, never>,
-            ): Promise<{ [key: string]: never }>;
-            get<T = { [key: string]: unknown }>(
                 keys?: NoInferX<keyof T> | Array<NoInferX<keyof T>> | Partial<NoInferX<T>> | null,
             ): Promise<T>;
             get<T = { [key: string]: unknown }>(callback: (items: T) => void): void;
-            get<T = { [key: string]: unknown }>(
-                keys: never[] | Record<string, never>,
-                callback: (items: { [key: string]: never }) => void,
-            ): void;
             get<T = { [key: string]: unknown }>(
                 keys: NoInferX<keyof T> | Array<NoInferX<keyof T>> | Partial<NoInferX<T>> | null | undefined,
                 callback: (items: T) => void,

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1374,9 +1374,7 @@ function testStorage() {
         chrome.storage[area].get(); // $ExpectType Promise<{ [key: string]: unknown; }>
         chrome.storage[area].get(null); // $ExpectType Promise<{ [key: string]: unknown; }>
         chrome.storage[area].get(key); // $ExpectType Promise<{ [key: string]: unknown; }>
-        chrome.storage[area].get([]); // $ExpectType Promise<{ [key: string]: never; }>
         chrome.storage[area].get([key]); // $ExpectType Promise<{ [key: string]: unknown; }>
-        chrome.storage[area].get({}); // $ExpectType Promise<{ [key: string]: never; }>
         chrome.storage[area].get({ key }); // $ExpectType Promise<{ [key: string]: unknown; }>
         chrome.storage[area].get(badKey); // $ExpectType Promise<{ [key: string]: unknown; }>
         chrome.storage[area].get<StorageData>(key); // $ExpectType Promise<StorageData>
@@ -1389,17 +1387,11 @@ function testStorage() {
         chrome.storage[area].get(key, (items) => { // $ExpectType void
             items; // $ExpectType { [key: string]: unknown; }
         });
-        chrome.storage[area].get([], (items) => { // $ExpectType void
-            items; // $ExpectType { [key: string]: never; }
-        });
         chrome.storage[area].get([key], (items) => { // $ExpectType void
             items; // $ExpectType { [key: string]: unknown; }
         });
         chrome.storage[area].get({ key }, (items) => { // $ExpectType void
             items; // $ExpectType { [key: string]: unknown; }
-        });
-        chrome.storage[area].get({}, (items) => { // $ExpectType void
-            items; // $ExpectType { [key: string]: never; }
         });
         chrome.storage[area].get(badKey, (items) => { // $ExpectType void
             items; // $ExpectType { [key: string]: unknown; }
@@ -1412,26 +1404,10 @@ function testStorage() {
         // @ts-expect-error
         chrome.storage[area].get(undefined, () => {}).then(() => {});
 
-        // Test for union type compatibility (chrome.storage | browser.storage)
-        interface BrowserStorageArea {
-            get(keys?: null | string | string[] | { [key: string]: any }): Promise<{ [key: string]: any }>;
-            getBytesInUse(keys?: null | string | string[]): Promise<number>;
-        }
-        interface BrowserStorage {
-            sync: BrowserStorageArea;
-            managed: BrowserStorageArea;
-            local: BrowserStorageArea;
-            session: BrowserStorageArea;
-        }
-        const storage: BrowserStorage | typeof chrome.storage = chrome.storage;
-        storage[area].get(); // $ExpectType Promise<{ [key: string]: unknown; }> | Promise<{ [key: string]: any; }>
-        storage[area].getBytesInUse([key]); // $ExpectType Promise<number>
-
         chrome.storage[area].getBytesInUse(); // $ExpectType Promise<number>
         chrome.storage[area].getBytesInUse(null); // $ExpectType Promise<number>
         chrome.storage[area].getBytesInUse(key); // $ExpectType Promise<number>
         chrome.storage[area].getBytesInUse([key]); // $ExpectType Promise<number>
-        chrome.storage[area].getBytesInUse([]); // $ExpectType Promise<0>
         chrome.storage[area].getBytesInUse(badKey); // $ExpectType Promise<number>
         chrome.storage[area].getBytesInUse<StorageData>(key); // $ExpectType Promise<number>
         chrome.storage[area].getBytesInUse<StorageData>(key); // $ExpectType Promise<number>
@@ -1446,9 +1422,6 @@ function testStorage() {
         });
         chrome.storage[area].getBytesInUse([key], (bytesInUse) => { // $ExpectType void
             bytesInUse; // $ExpectType number
-        });
-        chrome.storage[area].getBytesInUse([], (bytesInUse) => { // $ExpectType void
-            bytesInUse; // $ExpectType 0
         });
         chrome.storage[area].getBytesInUse(badKey, (bytesInUse) => { // $ExpectType void
             bytesInUse; // $ExpectType number

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1412,6 +1412,21 @@ function testStorage() {
         // @ts-expect-error
         chrome.storage[area].get(undefined, () => {}).then(() => {});
 
+        // Test for union type compatibility (chrome.storage | browser.storage)
+        interface BrowserStorageArea {
+            get(keys?: null | string | string[] | { [key: string]: any }): Promise<{ [key: string]: any }>;
+            getBytesInUse(keys?: null | string | string[]): Promise<number>;
+        }
+        interface BrowserStorage {
+            sync: BrowserStorageArea;
+            managed: BrowserStorageArea;
+            local: BrowserStorageArea;
+            session: BrowserStorageArea;
+        }
+        const storage: BrowserStorage | typeof chrome.storage = chrome.storage;
+        storage[area].get(); // $ExpectType Promise<{ [key: string]: unknown; }> | Promise<{ [key: string]: any; }>
+        storage[area].getBytesInUse([key]); // $ExpectType Promise<number>
+
         chrome.storage[area].getBytesInUse(); // $ExpectType Promise<number>
         chrome.storage[area].getBytesInUse(null); // $ExpectType Promise<number>
         chrome.storage[area].getBytesInUse(key); // $ExpectType Promise<number>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

~~This change adds missing generic type parameters to specific overloads of `chrome.storage` methods to improve type consistency and compatibility (Example: `chrome.storage | browser.storage`)~~

Relax type if param if empty array or empty object for `get()` and `getBytesInUse()`

Related : https://github.com/ruffle-rs/ruffle/pull/22269