### PR TITLE
[phoenix] handle generics for the `on` function

### DIFF
--- a/types/phoenix/index.d.ts
+++ b/types/phoenix/index.d.ts
@@ -24,7 +24,7 @@ export class Channel {
     onError(callback: (reason?: any) => void | Promise<void>): number;
     onMessage(event: string, payload: any, ref: any): any;
 
-    on<TResponse>(event: string, callback: (response?: TResponse) => void | Promise<void>): number;
+    on<TResponse = any>(event: string, callback: (response?: TResponse) => void | Promise<void>): number;
     off(event: string, ref?: number): void;
 
     push(event: string, payload: object, timeout?: number): Push;

--- a/types/phoenix/index.d.ts
+++ b/types/phoenix/index.d.ts
@@ -24,7 +24,7 @@ export class Channel {
     onError(callback: (reason?: any) => void | Promise<void>): number;
     onMessage(event: string, payload: any, ref: any): any;
 
-    on(event: string, callback: (response?: any) => void | Promise<void>): number;
+    on<TResponse>(event: string, callback: (response?: TResponse) => void | Promise<void>): number;
     off(event: string, ref?: number): void;
 
     push(event: string, payload: object, timeout?: number): Push;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

## Why im making this change

This PR is here to enable a bit more flexability in the use of this packages type but putting in a generic for the `on` event callback. I have 2 motivations for making this change:

1. To allow a bit cleaner code in our repos, always a win.
2. To fix a potentially dangerous situtation, im not actually fixing it here as it would be a breaking change, (unless others feel this is a good idea), examples:

Currently, to inject types to this we do something like this locally

```
  const channelHandler = channel.on('event', (res: { id: string }) => {
    // some lovely code
  })
```

which is fine, however because of the `res?:any` thats in the code and our overwritting of the type its far to easy to write something like

```
  const channelHandler = channel.on('event', (res: { id: string }) => {
    console.log(res.id)
  })
```

which could cause an exception because res is optional.

The proposed change would result in a TS Error because we've been more specific in the typing, if this makes sense?
```
  const channelHandler = channel.on<{ id: string }>('event', (res) => {
    console.log(res.id) // TS error because res could be undefined
  })
```

I've done this so that this would still be happy enough though the error would still get muted in this scenario, unless we release a breaking change and i'll remove the `= any` in the generic definition

```
  const channelHandler = channel.on('event', (res: { id: string }) => {
    // some lovely code
  })
```