### PR TITLE
Log element: adding align and valign to properties

### DIFF
--- a/types/blessed/blessed-tests.ts
+++ b/types/blessed/blessed-tests.ts
@@ -832,6 +832,50 @@ const list = blessed.list({
 
 list.setItems(["string1", "string2", "string3"]);
 
+// https://github.com/chjj/blessed/blob/master/test/widget-log.js
+// modified for testing purposes
+
+screen = blessed.screen({
+    dump: __dirname + "/logs/logger.log",
+    smartCSR: true,
+    autoPadding: false,
+    warnings: true,
+});
+
+var logger = blessed.log({
+    parent: screen,
+    top: "center",
+    left: "center",
+    width: "50%",
+    height: "50%",
+    border: "line",
+    tags: true,
+    keys: true,
+    vi: true,
+    mouse: true,
+    scrollback: 100,
+    scrollbar: {
+        ch: " ",
+        track: {
+            bg: "yellow",
+        },
+        style: {
+            inverse: true,
+        },
+    },
+});
+
+logger.align = "right";
+logger.valign = "bottom";
+
+logger.focus();
+
+screen.key("q", function() {
+    return screen.destroy();
+});
+
+screen.render();
+
 // https://github.com/chjj/blessed/blob/master/test/program-mouse.js
 
 const program = blessed.program({

--- a/types/blessed/index.d.ts
+++ b/types/blessed/index.d.ts
@@ -514,6 +514,8 @@ export namespace Widgets {
 
         type TAlign = "left" | "center" | "right";
 
+        type TValign = "top" | "middle" | "bottom";
+
         interface ListbarCommand {
             key: string;
             callback(): void;
@@ -3072,6 +3074,12 @@ export namespace Widgets {
          * scroll to bottom on input even if the user has scrolled up. default: false.
          */
         scrollOnInput: boolean;
+
+        /**
+         * Content/Text alignment
+         */
+        align: "left" | "center" | "right";
+        valign: "top" | "middle" | "bottom";
 
         /**
          * add a log line.

--- a/types/blessed/index.d.ts
+++ b/types/blessed/index.d.ts
@@ -514,8 +514,6 @@ export namespace Widgets {
 
         type TAlign = "left" | "center" | "right";
 
-        type TValign = "top" | "middle" | "bottom";
-
         interface ListbarCommand {
             key: string;
             callback(): void;


### PR DESCRIPTION
changing an existing definition:
- [ ] Provide a URL: <<https://www.npmjs.com/package/blessed#log-from-scrollabletext>>

This is my first PR, critique and advice is very welcome.
I've done a bunch of testing on this change. Basically, the align and valign options and properties are inherited for all elements by the element class. However, they do not apply to all options. I was originally planning on adding these types to the BlessedElement class, but some elements don't use either, or only use one or the other. Some elements can only utilize them as options, and not as properties. The log element definitely can utilize both align and valign as options and properties. Following these lines of logic, I assume the best place to define these types would be directly in the Log element's class. This also means other elements might also still require the addition of either align, valign, or both in their property definitions, I will do test in the future if this helps. 

Please let me know if anyone can confirm that my logic is sound, has insights into the structure of these typing definitions, has critiques of any kind. I'm here to help, and I'd love to continue. I've actually read the blessed codebase and modified it for my own purposes quite a bit and at least half understand whats going on there.