### PR TITLE
[netmask]: Fix netmask.broadcast is undefined for /31 /32 route

### DIFF
--- a/types/netmask/index.d.ts
+++ b/types/netmask/index.d.ts
@@ -27,7 +27,7 @@ export class Netmask {
     /**
      * The blocks broadcast address (eg: 192.168.1.0/24 => 192.168.1.255)
      */
-    broadcast: string;
+    broadcast: string | undefined;
     /**
      * The number of IP addresses in a block (eg: 256).
      */

--- a/types/netmask/netmask-tests.ts
+++ b/types/netmask/netmask-tests.ts
@@ -12,7 +12,7 @@ block = new netmask.Netmask("216.240.32.0", 24);
 
 block = new netmask.Netmask("216.240.32.0");
 if (typeof block.broadcast === undefined) {
-    console.log("no broadcast address for /32 block")
+    console.log("no broadcast address for /32 block");
 }
 
 class CustomizedNetmask extends netmask.Netmask {

--- a/types/netmask/netmask-tests.ts
+++ b/types/netmask/netmask-tests.ts
@@ -10,6 +10,11 @@ if (block.contains("10.0.8.10")) {
 block = new netmask.Netmask("216.240.32.0", "255.255.255.0");
 block = new netmask.Netmask("216.240.32.0", 24);
 
+block = new netmask.Netmask("216.240.32.0");
+if (typeof block.broadcast === undefined) {
+    console.log("no broadcast address for /32 block")
+}
+
 class CustomizedNetmask extends netmask.Netmask {
     // Test that we can override `next` to return a CustomizedNetmask (as opposed to netmask.Netmask) object
     next(count: number = 1): CustomizedNetmask {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [x] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [source code](https://github.com/rs/node-netmask/blob/879e53d17bf290443ccc7f09389eb0edbdf92f3c/lib/netmask.coffee#L133C10-L133C19), compile to: `this.broadcast = this.bitmask <= 30 ? long2ip(this.netLong + this.size - 1) : void 0;`
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
