### PR TITLE
[socketcluster] Bump version numbers for v20

### DIFF
--- a/types/socketcluster-client/package.json
+++ b/types/socketcluster-client/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/socketcluster-client",
-    "version": "19.1.9999",
+    "version": "20.0.9999",
     "projects": [
         "https://github.com/SocketCluster/socketcluster-client",
         "http://socketcluster.io"

--- a/types/socketcluster-server/package.json
+++ b/types/socketcluster-server/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/socketcluster-server",
-    "version": "19.0.9999",
+    "version": "20.0.9999",
     "projects": [
         "https://github.com/SocketCluster/socketcluster-server"
     ],


### PR DESCRIPTION
There are no type changes between v19 and v20. Since it seems like a fairly trivial upgrade, I didn't add a version directory for `v19` since it seems like it would only be an unnecessary maintenance burden for a relatively unpopular library.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/SocketCluster/socketcluster-client/commit/e7492cf11a6de3203b7a9f0b32def945bfc25e03 and https://github.com/SocketCluster/socketcluster-server/commit/7cc68580ab724a4bbf833583509a5091c7490a63
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
