### PR TITLE
feat(chrome-remote-interface): update domain types to v0.33

### DIFF
--- a/types/chrome-remote-interface/chrome-remote-interface-tests.ts
+++ b/types/chrome-remote-interface/chrome-remote-interface-tests.ts
@@ -11,14 +11,261 @@ function assertType<T>(value: T): T {
         const cdpPort = { port: 9223 };
         client = await CDP(cdpPort);
         client.on("disconnect", () => {});
-        client.on("Network.requestWillBeSent", (params) => {
-            params.documentURL;
-        });
-        client.on("Debugger.resumed", () => {});
-        client.on("Network.requestWillBeSent.123", (params) => {});
         client.on("event", (message) => {
             if (message.method === "Network.requestWillBeSent") {}
         });
+
+        // Stable Domains
+        {
+            client.on("Browser.downloadWillBegin", (params) => {
+                // $ExpectType DownloadWillBeginEvent
+                params;
+            });
+            client.on("Browser.downloadProgress", (params) => {
+                // $ExpectType DownloadProgressEvent
+                params;
+            });
+            client.on("Debugger.breakpointResolved", (params) => {
+                // $ExpectType BreakpointResolvedEvent
+                params;
+            });
+            client.on("Debugger.paused", (params) => {
+                // $ExpectType PausedEvent
+                params;
+            });
+            client.on("Debugger.scriptFailedToParse", (params) => {
+                // $ExpectType ScriptFailedToParseEvent
+                params;
+            });
+            client.on("Debugger.scriptParsed", (params) => {
+                // $ExpectType ScriptParsedEvent
+                params;
+            });
+            client.on("Debugger.resumed", () => {});
+            client.on("DOM.childNodeInserted", (params) => {
+                // $ExpectType ChildNodeInsertedEvent
+                params;
+            });
+            client.on("DOM.attributeRemoved", (params) => {
+                // $ExpectType AttributeRemovedEvent
+                params;
+            });
+            client.on("DOM.documentUpdated", () => {});
+            client.on("DOM.setChildNodes", (params) => {
+                // $ExpectType SetChildNodesEvent
+                params;
+            });
+            client.on("Emulation.virtualTimeBudgetExpired", () => {});
+            client.on("Fetch.requestPaused", (params) => {
+                // $ExpectType RequestPausedEvent
+                params;
+            });
+            client.on("Fetch.authRequired", (params) => {
+                // $ExpectType AuthRequiredEvent
+                params;
+            });
+            client.on("Input.dragIntercepted", (params) => {
+                // $ExpectType DragInterceptedEvent
+                params;
+            });
+            client.on("Log.entryAdded", (params) => {
+                // $ExpectType EntryAddedEvent
+                params;
+            });
+            client.on("Network.requestWillBeSent", (params) => {
+                // $ExpectType RequestWillBeSentEvent
+                params;
+            });
+            client.on("Network.loadingFailed", (params) => {
+                // $ExpectType LoadingFailedEvent
+                params;
+            });
+            client.on("Network.loadingFinished", (params) => {
+                // $ExpectType LoadingFinishedEvent
+                params;
+            });
+            client.on("Network.responseReceived", (params) => {
+                // $ExpectType ResponseReceivedEvent
+                params;
+            });
+            client.on("Page.domContentEventFired", (params) => {
+                // $ExpectType DomContentEventFiredEvent
+                params;
+            });
+            client.on("Page.frameNavigated", (params) => {
+                // $ExpectType FrameNavigatedEvent
+                params;
+            });
+            client.on("Page.loadEventFired", (params) => {
+                // $ExpectType LoadEventFiredEvent
+                params;
+            });
+            client.on("Performance.metrics", (params) => {
+                // $ExpectType MetricsEvent
+                params;
+            });
+            client.on("Profiler.consoleProfileFinished", (params) => {
+                // $ExpectType ConsoleProfileFinishedEvent
+                params;
+            });
+            client.on("Runtime.bindingCalled", (params) => {
+                // $ExpectType BindingCalledEvent
+                params;
+            });
+            client.on("Runtime.consoleAPICalled", (params) => {
+                // $ExpectType ConsoleAPICalledEvent
+                params;
+            });
+            client.on("Runtime.exceptionThrown", (params) => {
+                // $ExpectType ExceptionThrownEvent
+                params;
+            });
+            client.on("Runtime.executionContextCreated", (params) => {
+                // $ExpectType ExecutionContextCreatedEvent
+                params;
+            });
+            client.on("Runtime.executionContextDestroyed", (params) => {
+                // $ExpectType ExecutionContextDestroyedEvent
+                params;
+            });
+            client.on("Runtime.inspectRequested", (params) => {
+                // $ExpectType InspectRequestedEvent
+                params;
+            });
+            client.on("Security.certificateError", (params) => {
+                // $ExpectType CertificateErrorEvent
+                params;
+            });
+            client.on("Target.targetCreated", (params) => {
+                // $ExpectType TargetCreatedEvent
+                params;
+            });
+        }
+
+        // Deprecated domain events
+        client.on("Console.messageAdded", (params) => {
+            // $ExpectType MessageAddedEvent
+            params;
+        });
+
+        // Experimental domain events
+        {
+            client.on("Accessibility.loadComplete", (params) => {
+                // $ExpectType LoadCompleteEvent
+                params;
+            });
+            client.on("Accessibility.nodesUpdated", (params) => {
+                // $ExpectType NodesUpdatedEvent
+                params;
+            });
+            client.on("Animation.animationCreated", (params) => {
+                // $ExpectType AnimationCreatedEvent
+                params;
+            });
+            client.on("Audits.issueAdded", (params) => {
+                // $ExpectType IssueAddedEvent
+                params;
+            });
+            client.on("BackgroundService.recordingStateChanged", (params) => {
+                // $ExpectType RecordingStateChangedEvent
+                params;
+            });
+            client.on("BackgroundService.backgroundServiceEventReceived", (params) => {
+                // $ExpectType BackgroundServiceEventReceivedEvent
+                params;
+            });
+            client.on("Cast.sinksUpdated", (params) => {
+                // $ExpectType SinksUpdatedEvent
+                params;
+            });
+            client.on("Cast.issueUpdated", (params) => {
+                // $ExpectType IssueUpdatedEvent
+                params;
+            });
+            client.on("CSS.fontsUpdated", (params) => {
+                // $ExpectType FontsUpdatedEvent
+                params;
+            });
+            client.on("CSS.styleSheetAdded", (params) => {
+                // $ExpectType StyleSheetAddedEvent
+                params;
+            });
+            client.on("Database.addDatabase", (params) => {
+                // $ExpectType AddDatabaseEvent
+                params;
+            });
+            client.on("DeviceAccess.deviceRequestPrompted", (params) => {
+                // $ExpectType DeviceRequestPromptedEvent
+                params;
+            });
+            client.on("DOMStorage.domStorageItemAdded", (params) => {
+                // $ExpectType DomStorageItemAddedEvent
+                params;
+            });
+            client.on("FedCm.dialogShown", (params) => {
+                // $ExpectType DialogShownEvent
+                params;
+            });
+            client.on("HeapProfiler.heapStatsUpdate", (params) => {
+                // $ExpectType HeapStatsUpdateEvent
+                params;
+            });
+            client.on("Inspector.detached", (params) => {
+                // $ExpectType DetachedEvent
+                params;
+            });
+            client.on("Inspector.targetCrashed", () => {});
+            client.on("Inspector.targetReloadedAfterCrash", () => {});
+            client.on("LayerTree.layerTreeDidChange", (params) => {
+                // $ExpectType LayerTreeDidChangeEvent
+                params;
+            });
+            client.on("Media.playerPropertiesChanged", (params) => {
+                // $ExpectType PlayerPropertiesChangedEvent
+                params;
+            });
+            client.on("Overlay.inspectNodeRequested", (params) => {
+                // $ExpectType InspectNodeRequestedEvent
+                params;
+            });
+            client.on("Overlay.nodeHighlightRequested", (params) => {
+                // $ExpectType NodeHighlightRequestedEvent
+                params;
+            });
+            client.on("PerformanceTimeline.timelineEventAdded", (params) => {
+                // $ExpectType TimelineEventAddedEvent
+                params;
+            });
+            client.on("Preload.prerenderAttemptCompleted", (params) => {
+                // $ExpectType PrerenderAttemptCompletedEvent
+                params;
+            });
+            client.on("ServiceWorker.workerVersionUpdated", (params) => {
+                // $ExpectType WorkerVersionUpdatedEvent
+                params;
+            });
+            client.on("Storage.cacheStorageContentUpdated", (params) => {
+                // $ExpectType CacheStorageContentUpdatedEvent
+                params;
+            });
+            client.on("Tethering.accepted", (params) => {
+                // $ExpectType AcceptedEvent
+                params;
+            });
+            client.on("Tracing.dataCollected", (params) => {
+                // $ExpectType DataCollectedEvent
+                params;
+            });
+            client.on("WebAudio.contextCreated", (params) => {
+                // $ExpectType ContextCreatedEvent
+                params;
+            });
+            client.on("WebAuthn.credentialAdded", (params) => {
+                // $ExpectType CredentialAddedEvent
+                params;
+            });
+        }
+
         const { Network, Page, Runtime } = client;
         await Network.enable();
         await Network.enable({});

--- a/types/chrome-remote-interface/index.d.ts
+++ b/types/chrome-remote-interface/index.d.ts
@@ -183,20 +183,74 @@ declare namespace CDP {
 
     type ImproveAPI<T> = { [key in keyof T]: DoEventObj<key> & AddOptParams<OptIfParamNullable<T[key]>> };
     interface StableDomains {
+        /**
+         * The Browser domain defines methods and events for browser managing.
+         */
         Browser: ProtocolProxyApi.BrowserApi;
+        /**
+         * Debugger domain exposes JavaScript debugging capabilities. It allows setting and removing
+         * breakpoints, stepping through execution, exploring stack traces, etc.
+         */
         Debugger: ProtocolProxyApi.DebuggerApi;
+        /**
+         * This domain exposes DOM read/write operations. Each DOM Node is represented with its mirror
+         * object that has an `id`. This `id` can be used to get additional information on the Node,
+         * resolve it into the JavaScript object wrapper, etc. It is important that client receives
+         * DOM events only for the nodes that are known to the client. Backend keeps track of the nodes
+         * that were sent to the client and never sends the same node twice. It is client's
+         * responsibility to collect information about the nodes that were sent to the client.
+         * Note that `iframe` owner elements will return corresponding document elements as their child
+         * nodes.
+         */
         DOM: ProtocolProxyApi.DOMApi;
+        /**
+         * DOM debugging allows setting breakpoints on particular DOM operations and events. JavaScript
+         * execution will stop on these operations as if there was a regular breakpoint set.
+         */
         DOMDebugger: ProtocolProxyApi.DOMDebuggerApi;
+        /**
+         * This domain emulates different environments for the page.
+         */
         Emulation: ProtocolProxyApi.EmulationApi;
+        /**
+         * A domain for letting clients substitute browser's network layer with client code.
+         */
+        Fetch: ProtocolProxyApi.FetchApi;
         Input: ProtocolProxyApi.InputApi;
+        /**
+         * Input/Output operations for streams produced by DevTools.
+         */
         IO: ProtocolProxyApi.IOApi;
+        /**
+         * Provides access to log entries.
+         */
         Log: ProtocolProxyApi.LogApi;
+        /**
+         * Network domain allows tracking network activities of the page. It exposes information about
+         * http, file, data and other requests and responses, their headers, bodies, timing, etc.
+         */
         Network: ProtocolProxyApi.NetworkApi;
+        /**
+         * Actions and events related to the inspected page belong to the page domain.
+         */
         Page: ProtocolProxyApi.PageApi;
         Performance: ProtocolProxyApi.PerformanceApi;
         Profiler: ProtocolProxyApi.ProfilerApi;
+        /**
+         * Runtime domain exposes JavaScript runtime by means of remote evaluation and mirror objects.
+         * Evaluation results are returned as mirror object that expose object type, string
+         * representation and unique identifier that can be used for further object reference. Original
+         * objects are maintained in memory unless they are either explicitly released or are released
+         * along with the other objects in their object group.
+         */
         Runtime: ProtocolProxyApi.RuntimeApi;
+        /**
+         * Security
+         */
         Security: ProtocolProxyApi.SecurityApi;
+        /**
+         * Supports additional targets discovery and allows to attach to them.
+         */
         Target: ProtocolProxyApi.TargetApi;
     }
     interface DeprecatedDomains {
@@ -206,61 +260,100 @@ declare namespace CDP {
         Schema: ProtocolProxyApi.SchemaApi;
     }
     interface ExperimentalDomains {
-        /** @deprecated this API is experimental. */
         Accessibility: ProtocolProxyApi.AccessibilityApi;
-        /** @deprecated this API is experimental. */
         Animation: ProtocolProxyApi.AnimationApi;
-        /** @deprecated this API is experimental. */
-        ApplicationCache: ProtocolProxyApi.ApplicationCacheApi;
-        /** @deprecated this API is experimental. */
+        /**
+         * Audits domain allows investigation of page violations and possible improvements.
+         */
         Audits: ProtocolProxyApi.AuditsApi;
-        /** @deprecated this API is experimental. */
+        /**
+         * Defines commands and events for Autofill.
+         */
+        Autofill: ProtocolProxyApi.AutofillApi;
+        /**
+         * Defines events for background web platform features.
+         */
         BackgroundService: ProtocolProxyApi.BackgroundServiceApi;
-        /** @deprecated this API is experimental. */
         CacheStorage: ProtocolProxyApi.CacheStorageApi;
-        /** @deprecated this API is experimental. */
+        /**
+         * A domain for interacting with Cast, Presentation API, and Remote Playback API
+         * functionalities.
+         */
         Cast: ProtocolProxyApi.CastApi;
-        /** @deprecated this API is experimental. */
+        /**
+         * This domain exposes CSS read/write operations. All CSS objects (stylesheets, rules, and
+         * styles) have an associated `id` used in subsequent operations on the related object. Each
+         * object type has a specific `id` structure, and those are not interchangeable between objects
+         * of different kinds. CSS objects can be loaded using the `get*ForNode()` calls (which accept
+         * a DOM node id). A client can also keep track of stylesheets via the
+         * `styleSheetAdded`/`styleSheetRemoved` events and subsequently load the required stylesheet
+         * contents using the `getStyleSheet[Text]()` methods.
+         */
         CSS: ProtocolProxyApi.CSSApi;
-        /** @deprecated this API is experimental. */
         Database: ProtocolProxyApi.DatabaseApi;
-        /** @deprecated this API is experimental. */
+        DeviceAccess: ProtocolProxyApi.DeviceAccessApi;
         DeviceOrientation: ProtocolProxyApi.DeviceOrientationApi;
-        /** @deprecated this API is experimental. */
+        /**
+         * This domain facilitates obtaining document snapshots with DOM, layout, and style
+         * information.
+         */
         DOMSnapshot: ProtocolProxyApi.DOMSnapshotApi;
-        /** @deprecated this API is experimental. */
+        /**
+         * Query and modify DOM storage.
+         */
         DOMStorage: ProtocolProxyApi.DOMStorageApi;
-        /** @deprecated this API is experimental. */
-        Fetch: ProtocolProxyApi.FetchApi;
-        /** @deprecated this API is experimental. */
+        /**
+         * EventBreakpoints permits setting breakpoints on particular operations and events in targets
+         * that run JavaScript but do not have a DOM. JavaScript execution will stop on these
+         * operations as if there was a regular breakpoint set.
+         */
+        EventBreakpoints: ProtocolProxyApi.EventBreakpointsApi;
+        /**
+         * This domain allows interacting with the FedCM dialog.
+         */
+        FedCm: ProtocolProxyApi.FedCmApi;
+        /**
+         * This domain provides experimental commands only supported in headless mode.
+         */
         HeadlessExperimental: ProtocolProxyApi.HeadlessExperimentalApi;
-        /** @deprecated this API is experimental. */
         HeapProfiler: ProtocolProxyApi.HeapProfilerApi;
-        /** @deprecated this API is experimental. */
         IndexedDB: ProtocolProxyApi.IndexedDBApi;
-        /** @deprecated this API is experimental. */
         Inspector: ProtocolProxyApi.InspectorApi;
-        /** @deprecated this API is experimental. */
         LayerTree: ProtocolProxyApi.LayerTreeApi;
-        /** @deprecated this API is experimental. */
+        /**
+         * This domain allows detailed inspection of media elements
+         */
         Media: ProtocolProxyApi.MediaApi;
-        /** @deprecated this API is experimental. */
         Memory: ProtocolProxyApi.MemoryApi;
-        /** @deprecated this API is experimental. */
+        /**
+         * This domain provides various functionality related to drawing atop the inspected page.
+         */
         Overlay: ProtocolProxyApi.OverlayApi;
-        /** @deprecated this API is experimental. */
+        /**
+         * Reporting of performance timeline events, as specified in
+         * https://w3c.github.io/performance-timeline/#dom-performanceobserver.
+         */
+        PerformanceTimeline: ProtocolProxyApi.PerformanceTimelineApi;
+        Preload: ProtocolProxyApi.PreloadApi;
         ServiceWorker: ProtocolProxyApi.ServiceWorkerApi;
-        /** @deprecated this API is experimental. */
         Storage: ProtocolProxyApi.StorageApi;
-        /** @deprecated this API is experimental. */
+        /**
+         * The SystemInfo domain defines methods and events for querying low-level system information.
+         */
         SystemInfo: ProtocolProxyApi.SystemInfoApi;
-        /** @deprecated this API is experimental. */
+        /**
+         * The Tethering domain defines methods and events for browser port binding.
+         */
         Tethering: ProtocolProxyApi.TetheringApi;
-        /** @deprecated this API is experimental. */
         Tracing: ProtocolProxyApi.TracingApi;
-        /** @deprecated this API is experimental. */
+        /**
+         * This domain allows inspection of Web Audio API.
+         * https://webaudio.github.io/web-audio-api/
+         */
         WebAudio: ProtocolProxyApi.WebAudioApi;
-        /** @deprecated this API is experimental. */
+        /**
+         * This domain allows configuring virtual authenticators to test the WebAuthn API.
+         */
         WebAuthn: ProtocolProxyApi.WebAuthnApi;
     }
     type AllDomains = StableDomains & DeprecatedDomains & ExperimentalDomains;

--- a/types/chrome-remote-interface/package.json
+++ b/types/chrome-remote-interface/package.json
@@ -1,12 +1,12 @@
 {
     "private": true,
     "name": "@types/chrome-remote-interface",
-    "version": "0.31.9999",
+    "version": "0.33.9999",
     "projects": [
         "https://github.com/cyrus-and/chrome-remote-interface"
     ],
     "dependencies": {
-        "devtools-protocol": "0.0.927104"
+        "devtools-protocol": "0.0.1173815"
     },
     "devDependencies": {
         "@types/chrome-remote-interface": "workspace:."


### PR DESCRIPTION
`protocol.json` is last updated in `Jul 29, 2023`. See https://github.com/cyrus-and/chrome-remote-interface/commits/master/lib/protocol.json; The closest release of `devtools-protocol` to that date is `v0.0.1173815`, see https://github.com/ChromeDevTools/devtools-protocol/commit/e22d6aa8bd68b05ff63de6bf99068105545a63db. Hence the `devtools-protocol` dep is pinned to that specific version.

With the package upgrade, certain changes are brought to `StableDomains` & `ExperimentalDomains` interfaces. The updates are based on `protocol.json`, with its `"deprecated": true` / `"experimental": true` marking on each domain entry.

Tests are added for (almost) fully covering `.on()` events.

Resolves discussion https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/74129.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
