### PR TITLE
[googlepay] add support for ISO 3166-2 administrative area codes

### DIFF
--- a/types/googlepay/googlepay-tests.ts
+++ b/types/googlepay/googlepay-tests.ts
@@ -201,6 +201,10 @@ function getGooglePaymentDataConfiguration(): google.payments.api.PaymentDataReq
         },
         allowedPaymentMethods,
         shippingAddressRequired: true,
+        shippingAddressParameters: {
+            phoneNumberRequired: true,
+            format: "FULL-ISO3166",
+        },
         callbackIntents: ["OFFER", "PAYMENT_AUTHORIZATION", "PAYMENT_METHOD"],
     };
 }

--- a/types/googlepay/index.d.ts
+++ b/types/googlepay/index.d.ts
@@ -404,6 +404,15 @@ declare namespace google.payments.api {
          * @default false
          */
         phoneNumberRequired?: false | true | undefined;
+
+        /**
+         * Shipping address format.
+         *
+         * If omitted, defaults to [[ShippingAddressFormat|`FULL`]].
+         *
+         * * @default "FULL"
+         */
+        format?: ShippingAddressFormat | undefined;
     }
 
     /**
@@ -483,6 +492,14 @@ declare namespace google.payments.api {
          * number be returned.
          */
         phoneNumber?: string | undefined;
+
+        /**
+         * The 3166-2 administrative area code
+         *
+         * ISO 3166-2 administrative area code corresponding to administrativeArea.
+         * Only present if the shipping or billing address format is FULL-ISO3166.
+         */
+        iso3166AdministrativeAreaCode?: string | undefined;
     }
 
     /**
@@ -516,6 +533,14 @@ declare namespace google.payments.api {
          * The locality (e.g. city or town).
          */
         locality: string;
+
+        /**
+         * The 3166-2 administrative area code
+         *
+         * ISO 3166-2 administrative area code corresponding to administrativeArea.
+         * Only present if the shipping address format is FULL-ISO3166.
+         */
+        iso3166AdministrativeAreaCode?: string | undefined;
     }
 
     /**
@@ -1582,8 +1607,35 @@ declare namespace google.payments.api {
      *   Only select this format when it is required to process the order.
      *   Additional form entry or customer data requests can increase friction
      *   during the checkout process and can lead to a lower conversion rate.
+     *
+     * - `FULL-ISO3166`:
+     *   Same as `FULL` but includes [[Address.iso3166AdministrativeArea|`Address.iso3166AdministrativeArea`]]
      */
-    type BillingAddressFormat = "MIN" | "FULL";
+    type BillingAddressFormat = "MIN" | "FULL" | "FULL-ISO3166";
+
+    /**
+     * Shipping address format enum string.
+     *
+     * Options:
+     *
+     * - `FULL`:
+     *   Full shipping address
+     *
+     *   All the fields in [[Address|`Address`]] will
+     *   be returned, with the possible exception of
+     *   [[Address.phoneNumber|`Address.phoneNumber`]] which will only be
+     *   returned if
+     *   [[ShippingAddressParameters.phoneNumberRequired|`ShippingAddressParameters.phoneNumberRequired`]]
+     *   is set to `true`.
+     *
+     *   Only select this format when it is required to process the order.
+     *   Additional form entry or customer data requests can increase friction
+     *   during the checkout process and can lead to a lower conversion rate.
+     *
+     * - `FULL-ISO3166`:
+     *   Same as `FULL` but includes [[Address.iso3166AdministrativeArea|`Address.iso3166AdministrativeArea`]]
+     */
+    type ShippingAddressFormat = "MIN" | "FULL" | "FULL-ISO3166";
 
     /**
      * The status of the total price used.

--- a/types/googlepay/index.d.ts
+++ b/types/googlepay/index.d.ts
@@ -499,7 +499,7 @@ declare namespace google.payments.api {
          * ISO 3166-2 administrative area corresponding to administrativeArea.
          * Only present if the shipping or billing address format is FULL-ISO3166.
          */
-        iso3166AdministrativeAreaCode?: string | undefined;
+        iso3166AdministrativeArea?: string | undefined;
     }
 
     /**
@@ -540,7 +540,7 @@ declare namespace google.payments.api {
          * ISO 3166-2 administrative area corresponding to administrativeArea.
          * Only present if the shipping address format is FULL-ISO3166.
          */
-        iso3166AdministrativeAreaCode?: string | undefined;
+        iso3166AdministrativeArea?: string | undefined;
     }
 
     /**

--- a/types/googlepay/index.d.ts
+++ b/types/googlepay/index.d.ts
@@ -535,7 +535,7 @@ declare namespace google.payments.api {
         locality: string;
 
         /**
-         * The 3166-2 administrative area
+         * The ISO 3166-2 administrative area
          *
          * ISO 3166-2 administrative area corresponding to administrativeArea.
          * Only present if the shipping address format is FULL-ISO3166.

--- a/types/googlepay/index.d.ts
+++ b/types/googlepay/index.d.ts
@@ -494,9 +494,9 @@ declare namespace google.payments.api {
         phoneNumber?: string | undefined;
 
         /**
-         * The 3166-2 administrative area code
+         * The ISO 3166-2 administrative area
          *
-         * ISO 3166-2 administrative area code corresponding to administrativeArea.
+         * ISO 3166-2 administrative area corresponding to administrativeArea.
          * Only present if the shipping or billing address format is FULL-ISO3166.
          */
         iso3166AdministrativeAreaCode?: string | undefined;
@@ -535,9 +535,9 @@ declare namespace google.payments.api {
         locality: string;
 
         /**
-         * The 3166-2 administrative area code
+         * The 3166-2 administrative area
          *
-         * ISO 3166-2 administrative area code corresponding to administrativeArea.
+         * ISO 3166-2 administrative area corresponding to administrativeArea.
          * Only present if the shipping address format is FULL-ISO3166.
          */
         iso3166AdministrativeAreaCode?: string | undefined;
@@ -1635,7 +1635,7 @@ declare namespace google.payments.api {
      * - `FULL-ISO3166`:
      *   Same as `FULL` but includes [[Address.iso3166AdministrativeArea|`Address.iso3166AdministrativeArea`]]
      */
-    type ShippingAddressFormat = "MIN" | "FULL" | "FULL-ISO3166";
+    type ShippingAddressFormat = "FULL" | "FULL-ISO3166";
 
     /**
      * The status of the total price used.

--- a/types/googlepay/package.json
+++ b/types/googlepay/package.json
@@ -12,6 +12,26 @@
     },
     "owners": [
         {
+            "name": "Florian Luccioni",
+            "githubUsername": "Fluccioni"
+        },
+        {
+            "name": "Radu Raicea",
+            "githubUsername": "Radu-Raicea"
+        },
+        {
+            "name": "Filip Stanis",
+            "githubUsername": "fstanis"
+        },
+        {
+            "name": "Sergi Ferriz",
+            "githubUsername": "mumpo"
+        },
+        {
+            "name": "Soc Sieng",
+            "githubUsername": "socsieng"
+        },
+        {
             "name": "Jose L Ugia",
             "githubUsername": "JlUgia"
         },

--- a/types/googlepay/package.json
+++ b/types/googlepay/package.json
@@ -12,32 +12,20 @@
     },
     "owners": [
         {
-            "name": "Florian Luccioni",
-            "githubUsername": "Fluccioni"
-        },
-        {
-            "name": "Radu Raicea",
-            "githubUsername": "Radu-Raicea"
-        },
-        {
-            "name": "Filip Stanis",
-            "githubUsername": "fstanis"
-        },
-        {
-            "name": "Sergi Ferriz",
-            "githubUsername": "mumpo"
-        },
-        {
-            "name": "Soc Sieng",
-            "githubUsername": "socsieng"
-        },
-        {
             "name": "Jose L Ugia",
             "githubUsername": "JlUgia"
         },
         {
             "name": "Dominik Mengelt",
             "githubUsername": "dmengelt"
+        },
+        {
+            "name": "Matthew Class",
+            "githubUsername": "aikimatthew"
+        },
+        {
+            "name": "Stephen McDonald",
+            "githubUsername": "stephenmcd"
         }
     ]
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Google Pay request object reference](https://developers.google.com/pay/api/web/reference/request-objects#BillingAddressParameters)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

