### PR TITLE
express: change serve-static to v2

### DIFF
--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -8,9 +8,6 @@ namespace express_tests {
     app.engine("jade", require("jade").__express);
     app.engine("html", require("ejs").renderFile);
 
-    express.static.mime.define({
-        "application/fx": ["fx"],
-    });
     app.use(
         "/static",
         express.static(__dirname + "/public", {

--- a/types/express/package.json
+++ b/types/express/package.json
@@ -8,7 +8,7 @@
     "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
-        "@types/serve-static": "^1"
+        "@types/serve-static": "^2"
     },
     "devDependencies": {
         "@types/express": "workspace:.",


### PR DESCRIPTION
Corrected `@types/serve-static` dependency version to v2, because express 5 uses serve-static v2.

Proof: https://github.com/expressjs/express/blob/cd7d4397c398a3f3ecadeaf9ef6ac1377bd414c4/package.json#L58

Additional proof:
- `static.mime` was mentioned in express v4 documentation: https://expressjs.com/en/4x/api.html#res.type
- but that statement was removed in v5: https://expressjs.com/en/5x/api.html#res.type

Previous change was from `*` to `^1`, in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/73829 both for v4 and v5, which was not entirely correct.

Merging this will also deduplicate `@types/send` version when installing `@types/express`

<img width="370" height="94" alt="Screenshot 2025-11-25 at 21 21 48" src="https://github.com/user-attachments/assets/b68a1f60-038e-4066-a2c4-2bbc78ea5554" />


Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
