### PR TITLE
[Node] Fix `path.normalize` description to include info on empty strings.

### DIFF
--- a/types/node/path.d.ts
+++ b/types/node/path.d.ts
@@ -67,7 +67,7 @@ declare module "path" {
         interface PlatformPath {
             /**
              * Normalize a string path, reducing '..' and '.' parts.
-             * When multiple slashes are found, they're replaced by a single one; when the path contains a trailing slash, it is preserved. On Windows backslashes are used.
+             * When multiple slashes are found, they're replaced by a single one; when the path contains a trailing slash, it is preserved. On Windows backslashes are used. If the path is a zero-length string, '.' is returned, representing the current working directory.
              *
              * @param path string path to normalize.
              * @throws {TypeError} if `path` is not a string.

--- a/types/node/v20/path.d.ts
+++ b/types/node/v20/path.d.ts
@@ -67,7 +67,7 @@ declare module "path" {
         interface PlatformPath {
             /**
              * Normalize a string path, reducing '..' and '.' parts.
-             * When multiple slashes are found, they're replaced by a single one; when the path contains a trailing slash, it is preserved. On Windows backslashes are used.
+             * When multiple slashes are found, they're replaced by a single one; when the path contains a trailing slash, it is preserved. On Windows backslashes are used. If the path is a zero-length string, '.' is returned, representing the current working directory.
              *
              * @param path string path to normalize.
              * @throws {TypeError} if `path` is not a string.

--- a/types/node/v22/path.d.ts
+++ b/types/node/v22/path.d.ts
@@ -67,7 +67,7 @@ declare module "path" {
         interface PlatformPath {
             /**
              * Normalize a string path, reducing '..' and '.' parts.
-             * When multiple slashes are found, they're replaced by a single one; when the path contains a trailing slash, it is preserved. On Windows backslashes are used.
+             * When multiple slashes are found, they're replaced by a single one; when the path contains a trailing slash, it is preserved. On Windows backslashes are used. If the path is a zero-length string, '.' is returned, representing the current working directory.
              *
              * @param path string path to normalize.
              * @throws {TypeError} if `path` is not a string.


### PR DESCRIPTION
If an empty string is passed to Node's `path.normalize` function then a dot (`.`) will be added to indicate cwd (eg. `''` -> `'.'`).
This is as explained in the [Node Docs](https://nodejs.org/api/path.html#pathnormalizepath):

>If the path is a zero-length string, '.' is returned, representing the current working directory.

This needs to be added to it's type definition description so IDE's can use intellisense to show the description to the user, which will prevent significant time debugging.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)  - **Not relevant**
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. - **Not relevant**
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request). - **Not relevant**
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes). - **Not relevant**
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests). - **Not relevant**

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/path.html#pathnormalizepath
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
