### PR TITLE
[selenium-webdriver] Fix driver.wait() return type for elementsLocated()

### DIFF
--- a/types/selenium-webdriver/lib/webdriver.d.ts
+++ b/types/selenium-webdriver/lib/webdriver.d.ts
@@ -111,6 +111,14 @@ export class Condition<T> {
  */
 export class WebElementCondition extends Condition<WebElement> {
     /**
+     * Private discriminator to prevent structural type compatibility with
+     * Condition<WebElement[]>. This ensures TypeScript correctly resolves
+     * driver.wait() overloads when using elementsLocated() vs elementLocated().
+     * @see https://github.com/SeleniumHQ/selenium/issues/14239
+     */
+    private readonly __isWebElementCondition: true;
+
+    /**
      * @param {string} message A descriptive error message. Should complete the
      *     sentence "Waiting [...]"
      * @param {function(!WebDriver): !(WebElement|IThenable<!WebElement>)}

--- a/types/selenium-webdriver/test/index.ts
+++ b/types/selenium-webdriver/test/index.ts
@@ -599,6 +599,29 @@ function TestUntilModule() {
     conditionWebElements = webdriver.until.elementsLocated(webdriver.By.className("class"));
 }
 
+// Test for https://github.com/SeleniumHQ/selenium/issues/14239
+// driver.wait(until.elementsLocated(...)) should return Promise<WebElement[]>, not WebElementPromise
+async function TestElementsLocatedReturnsArray() {
+    let driver: webdriver.WebDriver = new webdriver.Builder().withCapabilities(webdriver.Capabilities.chrome()).build();
+
+    // elementsLocated should return Condition<WebElement[]>
+    // driver.wait should correctly resolve this to Promise<WebElement[]>
+    const elements: webdriver.WebElement[] = await driver.wait(
+        webdriver.until.elementsLocated(webdriver.By.css(".foo")),
+    );
+
+    // These should compile - elements is an array
+    const length: number = elements.length;
+    elements.forEach((el: webdriver.WebElement) => el.click());
+    const mapped: string[] = elements.map((el: webdriver.WebElement) => "test");
+
+    // elementLocated (singular) should still return WebElementPromise
+    const singleElement: webdriver.WebElement = await driver.wait(
+        webdriver.until.elementLocated(webdriver.By.css(".foo")),
+    );
+    singleElement.click();
+}
+
 function TestShadowRoot() {
     let driver: webdriver.WebDriver = new webdriver.Builder().withCapabilities(webdriver.Capabilities.chrome()).build();
 


### PR DESCRIPTION
Add private discriminator field to WebElementCondition to prevent TypeScript's structural typing from incorrectly matching `Condition<WebElement[]>` to the WebElementCondition overload.

This fixes the issue where `driver.wait(until.elementsLocated(...))` incorrectly returned WebElementPromise instead of `Promise<WebElement[]>`.

Fixes https://github.com/SeleniumHQ/selenium/issues/14239 and supersedes https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71956

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests). --> Sorry, I cannot fully clone this repo at the moment, I am relying on CI/CD here.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/SeleniumHQ/selenium/issues/14239 and supersedes https://github.com/DefinitelyTyped/DefinitelyTyped/pull/71956