### PR TITLE
[@types/plotly.js] Add `zorder` property to PlotData interface

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1684,6 +1684,7 @@ export interface PlotData {
     zsmooth: "fast" | "best" | false;
     zmin: number;
     zmax: number;
+    zorder: number;
     ygap: number;
     xgap: number;
     transpose: boolean;


### PR DESCRIPTION
Add the `zorder` property to the `PlotData` interface.

The `zorder` property controls the layer order for SVG traces on the same subplot. It's been part of Plotly.js since v2.27.0 (2023) but was missing from the TypeScript definitions.

**Reference:** https://plotly.com/javascript/reference/scatter/#scatter-zorder

**Example usage:**
```ts
const data: Partial<PlotData>[] = [
  { x: [1, 2], y: [1, 2], zorder: 10 },  // renders on top
  { x: [1, 2], y: [2, 1], zorder: 1 },   // renders below
];
```