### PR TITLE
Add highlight fn to @babel/code-frame types

### DIFF
--- a/types/babel__code-frame/babel__code-frame-tests.ts
+++ b/types/babel__code-frame/babel__code-frame-tests.ts
@@ -1,4 +1,4 @@
-import codeFrame, { codeFrameColumns } from "@babel/code-frame";
+import codeFrame, { codeFrameColumns, highlight } from "@babel/code-frame";
 
 const code = `
     const number = 1;
@@ -24,3 +24,5 @@ codeFrameColumns(
     { start: { line: 2, column: 2 } },
     { highlightCode: true },
 );
+
+highlight(code);

--- a/types/babel__code-frame/index.d.ts
+++ b/types/babel__code-frame/index.d.ts
@@ -46,3 +46,12 @@ export default function codeFrame(
     colNumber: number,
     options?: BabelCodeFrameOptions,
 ): string;
+
+/**
+ * Add syntax highlighting to a code snippet, to be displayed in a terminal.
+ *
+ * @param code Raw code to be highlighted
+ *
+ * @returns Highlighted code
+ */
+export function highlight(code: string): string;

--- a/types/babel__code-frame/package.json
+++ b/types/babel__code-frame/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/babel__code-frame",
-    "version": "7.0.9999",
+    "version": "7.27.9999",
     "projects": [
         "https://github.com/babel/babel/tree/master/packages/babel-code-frame",
         "https://babeljs.io"


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://babeljs.io/docs/babel-code-frame.html#highlight
  - https://github.com/babel/babel/pull/16896
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
