### PR TITLE
[express-serve-static-core] Fix `req.params` type

### DIFF
--- a/types/express-serve-static-core/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/express-serve-static-core-tests.ts
@@ -45,16 +45,16 @@ app.route("/:foo").get(req => {
     req.is(1);
 });
 
-// Params can used as an array
-app.get<express.ParamsArray>("/*", req => {
-    req.params[0]; // $ExpectType string
-    req.params.length; // $ExpectType number
+// Wildcard parameters return string arrays
+app.get("/*foo", req => {
+    req.params.foo; // $ExpectType string[]
+    req.params.foo.length; // $ExpectType number
 });
 
-// Params can used as an array - under route
-app.route("/*").get<express.ParamsArray>(req => {
-    req.params[0]; // $ExpectType string
-    req.params.length; // $ExpectType number
+// Wildcard parameters return string arrays - under route
+app.route("/*foo").get(req => {
+    req.params.foo; // $ExpectType string[]
+    req.params.foo.length; // $ExpectType number
 });
 
 // Params can be a custom type
@@ -74,10 +74,16 @@ app.route("/:foo/:bar").get<{ foo: string; bar: number }>(req => {
     req.params.baz;
 });
 
-// Optional params
-app.get("/:foo/:bar?", req => {
+// Regular expressions have parameters that always are strings, never arrays of strings
+app.get(/^\/(.*?)\|(?<b>\d+)/, req => {
+    req.params[0]; // $ExpectType string
     req.params.foo; // $ExpectType string
-    req.params.bar; // $ExpectType string | undefined
+});
+
+// Regular expressions have parameters that always are strings, never arrays of strings - under route
+app.route(/^\/(.*?)\|(?<b>\d+)/).get(req => {
+    req.params[0]; // $ExpectType string
+    req.params.foo; // $ExpectType string
 });
 
 // Express 5.0: Optional params
@@ -105,14 +111,6 @@ app.get("/:foo/:bar-:baz/:qux", req => {
     req.params.qux; // $ExpectType string
     // @ts-expect-error
     req.params.quxx;
-});
-
-// regex parameters - not supported
-app.get("/:foo/:bar(\\d:+)/:baz", req => {
-    req.params.foo; // $ExpectType string
-    req.params.bar; // $ExpectType string
-    req.params.qux; // $ExpectType string
-    req.params.quxx; // $ExpectType string
 });
 
 // long path parameters - https://github.com/DefinitelyTyped/DefinitelyTyped/pull/53513#issuecomment-870550063

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -42,10 +42,13 @@ export interface Dictionary<T> {
 }
 
 export interface ParamsDictionary {
-    [key: string]: string;
+    [key: string]: string | string[];
+    [key: number]: string;
 }
-export type ParamsArray = string[];
-export type Params = ParamsDictionary | ParamsArray;
+export interface ParamsFlatDictionary {
+    [key: string | number]: string;
+}
+export type Params = ParamsDictionary | ParamsFlatDictionary;
 
 export interface Locals extends Express.Locals {}
 
@@ -96,18 +99,24 @@ type GetRouteParameter<S extends string> = RemoveTail<
     `.${string}`
 >;
 
-// prettier-ignore
-export type RouteParameters<Route extends string> = Route extends `${infer Required}{${infer Optional}}${infer Next}`
-    ? ParseRouteParameters<Required> & Partial<ParseRouteParameters<Optional>> & RouteParameters<Next>
-    : ParseRouteParameters<Route>;
+// dprint-ignore
+export type RouteParameters<Route extends string | RegExp> = Route extends string
+    ? Route extends `${infer Required}{${infer Optional}}${infer Next}`
+        ? ParseRouteParameters<Required> & Partial<ParseRouteParameters<Optional>> & RouteParameters<Next>
+        : ParseRouteParameters<Route>
+    : ParamsFlatDictionary;
 
 type ParseRouteParameters<Route extends string> = string extends Route ? ParamsDictionary
-    : Route extends `${string}(${string}` ? ParamsDictionary // TODO: handling for regex parameters
     : Route extends `${string}:${infer Rest}` ?
             & (
                 GetRouteParameter<Rest> extends never ? ParamsDictionary
-                    : GetRouteParameter<Rest> extends `${infer ParamName}?` ? { [P in ParamName]?: string } // TODO: Remove old `?` handling when Express 5 is promoted to "latest"
                     : { [P in GetRouteParameter<Rest>]: string }
+            )
+            & (Rest extends `${GetRouteParameter<Rest>}${infer Next}` ? RouteParameters<Next> : unknown)
+    : Route extends `${string}*${infer Rest}` ?
+            & (
+                GetRouteParameter<Rest> extends never ? ParamsDictionary
+                    : { [P in GetRouteParameter<Rest>]: string[] }
             )
             & (Rest extends `${GetRouteParameter<Rest>}${infer Next}` ? RouteParameters<Next> : unknown)
     : {};
@@ -118,7 +127,7 @@ export interface IRouterMatcher<
     Method extends "all" | "get" | "post" | "put" | "delete" | "patch" | "options" | "head" = any,
 > {
     <
-        Route extends string,
+        Route extends string | RegExp,
         P = RouteParameters<Route>,
         ResBody = any,
         ReqBody = any,
@@ -131,7 +140,7 @@ export interface IRouterMatcher<
         ...handlers: Array<RequestHandler<P, ResBody, ReqBody, ReqQuery, LocalsObj>>
     ): T;
     <
-        Path extends string,
+        Path extends string | RegExp,
         P = RouteParameters<Path>,
         ResBody = any,
         ReqBody = any,
@@ -168,7 +177,7 @@ export interface IRouterMatcher<
     (path: PathParams, subApplication: Application): T;
 }
 
-export interface IRouterHandler<T, Route extends string = string> {
+export interface IRouterHandler<T, Route extends string | RegExp = string> {
     (...handlers: Array<RequestHandler<RouteParameters<Route>>>): T;
     (...handlers: Array<RequestHandlerParams<RouteParameters<Route>>>): T;
     <
@@ -284,7 +293,7 @@ export interface IRouter extends RequestHandler {
 
     use: IRouterHandler<this> & IRouterMatcher<this>;
 
-    route<T extends string>(prefix: T): IRoute<T>;
+    route<T extends string | RegExp>(prefix: T): IRoute<T>;
     route(prefix: PathParams): IRoute;
     /**
      * Stack of configured routes
@@ -303,7 +312,7 @@ export interface ILayer {
     handle: (req: Request, res: Response, next: NextFunction) => any;
 }
 
-export interface IRoute<Route extends string = string> {
+export interface IRoute<Route extends string | RegExp = string> {
     path: string;
     stack: ILayer[];
     all: IRouterHandler<this, Route>;
@@ -381,16 +390,14 @@ export type Errback = (err: Error) => void;
 
 /**
  * @param P  For most requests, this should be `ParamsDictionary`, but if you're
- * using this in a route handler for a route that uses a `RegExp` or a wildcard
- * `string` path (e.g. `'/user/*'`), then `req.params` will be an array, in
- * which case you should use `ParamsArray` instead.
- *
- * @see https://expressjs.com/en/api.html#req.params
+ * using this in a route handler for a route that uses a `RegExp`, then `req.params`
+ * will only contains strings, in which case you should use `ParamsFlatDictionary` instead.
  *
  * @example
- *     app.get('/user/:id', (req, res) => res.send(req.params.id)); // implicitly `ParamsDictionary`
- *     app.get<ParamsArray>(/user\/(.*)/, (req, res) => res.send(req.params[0]));
- *     app.get<ParamsArray>('/user/*', (req, res) => res.send(req.params[0]));
+ *     app.get('/user/:id', (req, res) => res.send(req.params.id)); // implicitly `ParamsDictionary`, parameter is string
+ *     app.get('/user/*id', (req, res) => res.send(req.params.id)); // implicitly `ParamsDictionary`, parameter is string[]
+ *     app.get(/user\/(?<id>.*)/, (req, res) => res.send(req.params.id)); // implicitly `ParamsFlatDictionary`, parameter is string
+ *     app.get(/user\/(.*)/, (req, res) => res.send(req.params[0])); // implicitly `ParamsFlatDictionary`, parameter is string
  */
 export interface Request<
     P = ParamsDictionary,

--- a/types/express-serve-static-core/v4/express-serve-static-core-tests.ts
+++ b/types/express-serve-static-core/v4/express-serve-static-core-tests.ts
@@ -42,18 +42,6 @@ app.route("/:foo").get(req => {
     req.is(1);
 });
 
-// Params can used as an array
-app.get<express.ParamsArray>("/*", req => {
-    req.params[0]; // $ExpectType string
-    req.params.length; // $ExpectType number
-});
-
-// Params can used as an array - under route
-app.route("/*").get<express.ParamsArray>(req => {
-    req.params[0]; // $ExpectType string
-    req.params.length; // $ExpectType number
-});
-
 // Params can be a custom type
 // NB. out-of-the-box all params are strings, however, other types are allowed to accommodate request validation/coercion middleware
 app.get<{ foo: string; bar: number }>("/:foo/:bar", req => {

--- a/types/express-serve-static-core/v4/index.d.ts
+++ b/types/express-serve-static-core/v4/index.d.ts
@@ -42,10 +42,9 @@ export interface Dictionary<T> {
 }
 
 export interface ParamsDictionary {
-    [key: string]: string;
+    [key: string | number]: string;
 }
-export type ParamsArray = string[];
-export type Params = ParamsDictionary | ParamsArray;
+export type Params = ParamsDictionary;
 
 export interface Locals extends Express.Locals {}
 
@@ -382,19 +381,6 @@ export interface RequestRanges extends RangeParserRanges {}
 
 export type Errback = (err: Error) => void;
 
-/**
- * @param P  For most requests, this should be `ParamsDictionary`, but if you're
- * using this in a route handler for a route that uses a `RegExp` or a wildcard
- * `string` path (e.g. `'/user/*'`), then `req.params` will be an array, in
- * which case you should use `ParamsArray` instead.
- *
- * @see https://expressjs.com/en/api.html#req.params
- *
- * @example
- *     app.get('/user/:id', (req, res) => res.send(req.params.id)); // implicitly `ParamsDictionary`
- *     app.get<ParamsArray>(/user\/(.*)/, (req, res) => res.send(req.params[0]));
- *     app.get<ParamsArray>('/user/*', (req, res) => res.send(req.params[0]));
- */
 export interface Request<
     P = ParamsDictionary,
     ResBody = any,

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -1,5 +1,5 @@
 import express = require("express");
-import { ParamsArray, Request, RequestRanges } from "express-serve-static-core";
+import { Request, RequestRanges } from "express-serve-static-core";
 import * as http from "http";
 
 namespace express_tests {
@@ -140,24 +140,6 @@ namespace express_tests {
         req.params.foo; // $ExpectType string
         // @ts-expect-error
         req.params[0];
-    });
-
-    // Params can used as an array
-    router.get<ParamsArray>("/*", req => {
-        req.params[0]; // $ExpectType string
-        req.params.length; // $ExpectType number
-    });
-
-    // Params can used as an array and can be specified via an explicit param type (express-serve-static-core)
-    router.get("/*", (req: Request<ParamsArray>) => {
-        req.params[0]; // $ExpectType string
-        req.params.length; // $ExpectType number
-    });
-
-    // Params can used as an array and can be specified via an explicit param type (express)
-    router.get("/*", (req: express.Request<ParamsArray>) => {
-        req.params[0]; // $ExpectType string
-        req.params.length; // $ExpectType number
     });
 
     // Params can be a custom type

--- a/types/express/v4/express-tests.ts
+++ b/types/express/v4/express-tests.ts
@@ -1,5 +1,5 @@
 import express = require("express");
-import { ParamsArray, Request, RequestRanges } from "express-serve-static-core";
+import { Request, RequestRanges } from "express-serve-static-core";
 import * as http from "http";
 
 namespace express_tests {
@@ -144,24 +144,6 @@ namespace express_tests {
         req.params.foo; // $ExpectType string
         // @ts-expect-error
         req.params[0];
-    });
-
-    // Params can used as an array
-    router.get<ParamsArray>("/*", req => {
-        req.params[0]; // $ExpectType string
-        req.params.length; // $ExpectType number
-    });
-
-    // Params can used as an array and can be specified via an explicit param type (express-serve-static-core)
-    router.get("/*", (req: Request<ParamsArray>) => {
-        req.params[0]; // $ExpectType string
-        req.params.length; // $ExpectType number
-    });
-
-    // Params can used as an array and can be specified via an explicit param type (express)
-    router.get("/*", (req: express.Request<ParamsArray>) => {
-        req.params[0]; // $ExpectType string
-        req.params.length; // $ExpectType number
     });
 
     // Params can be a custom type

--- a/types/i18n/i18n-tests.ts
+++ b/types/i18n/i18n-tests.ts
@@ -248,7 +248,7 @@ app.get("/ar", (_req: Express.Request, res: i18n.Response) => {
     i18n.setLocale(res, "ar");
     i18n.setLocale(res.locals, "ar");
 
-    i18n.setLocale([req, res.locals], req.params.lang);
+    i18n.setLocale([req, res.locals], "ar");
     i18n.setLocale(res, "ar", true);
 });
 


### PR DESCRIPTION
As reported in #74006 `@types/express-serve-static-core` contained some wrong assumptions about `req.params` type.

### What this PR does

- in `/v4` (Express 4):
  - **removes `ParamsArray`** type and instead adds `number` as allowed key type in `ParamsDictionary` - since Express 4 `req.params` always is an object, but the documentation is outdated (https://github.com/expressjs/expressjs.com/issues/2100)
  - removes misleading comment
  - removes tests for bad behaviour (`req.params` being an array)
- _latest_ version (Express 5):
  - **removes `ParamsArray`** type
  - **changes `ParamsDictionary`** to show that:
    - numeric keys (corresponding to unnamed groups in regular expressions) always have `string` values (**see warning below**)
    - string keys may have `string` (usually) or `string[]` (wildcard parameters) values
  - introduces `ParamsFlatDictionary` with `string` and `number` keys, but only `string` values as is the case when regular expression is used as a path
  - infers `ParamsFlatDictionary` when a regular expression is used, but does not try to extract groups (keys)
  - **adds support for wildcard parameters** and sets the corresponding value type to `string[]`
  - changes the misleading comment to something maybe more useful
  - removes old `?` optional parameters that are not supported in Express 5 ([since `5.1.0` it is _latest_ on NPM](https://expressjs.com/2025/03/31/v5-1-latest-release.html))
  - removes remains of regex support in string paths (mostly from tests) as those are no longer supported (instead these characters are reserved)

> [!WARNING]
> This may cause problems with wildcard parameters using quoted numeric names. Example:
> ```ts
> app.get<ParamsDictionary>('/*"0"', req => {
>     req.params["0"]; // reported as string, but really it is string[]
> }
> ```
> The solution is manually specifying the type as `{ 0: string[] }` in the above case.

### What it doesn't do

In Express 5, parameter names (`:` or `*`) must be either valid JS identifiers (remaining characters are not a part of parameter name, there are no explicit separators such as `.` or `-`, anything that isn't a valid ID continuation character acts as a separator) or be quoted. **The parameter name extraction logic has not changed!** Quoted parameter names and separators other than `/`, `-` and `.` still do not work. If someone wants to look into fixing this, the logic is [here in `path-to-regexp`](https://github.com/pillarjs/path-to-regexp/blob/05a5a973702a863fb69415294503d13cb9d18b20/src/index.ts#L196-L229).

## Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - `req.params` is an object since Express 4: [changelog](https://github.com/expressjs/express/blob/4453d83ccaed5c80f0c10a23d01216eff612ee56/History.md?plain=1#L1707), (decade old) PR https://github.com/expressjs/express/pull/1835
  - Path matching and parameter extraction logic of Express 5 comes from `path-to-regexp@8` ([docs](https://github.com/pillarjs/path-to-regexp/blob/05a5a973702a863fb69415294503d13cb9d18b20/Readme.md)) through [indirect dependency](https://github.com/pillarjs/router/blob/cb2a5fcdf31b9cc92296183ceeff8126b5c57453/package.json#L20) on [`router`](https://github.com/expressjs/express/blob/758d4355d45322b4c8cd347ebcefbf3b154c7e7f/package.json#L57)
  - `req.params` in official documentation - [4.x](https://expressjs.com/en/4x/api.html#req.params) and [5.x](https://expressjs.com/en/5x/api.html#req.params)
  - Express 5 migration guide - [`req.params` changes](https://expressjs.com/en/guide/migrating-5.html#req.params)
  - There are also some details in ~~open~~ issues and PRs for the Express documentation:
    - https://github.com/expressjs/expressjs.com/issues/2090
    - https://github.com/expressjs/expressjs.com/issues/2100
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
