### PR TITLE
fix: braintree - Update response Date types to be strings as they are…

### DIFF
--- a/types/braintree/braintree-tests.ts
+++ b/types/braintree/braintree-tests.ts
@@ -170,9 +170,9 @@ const gateway: BraintreeGateway = new braintree.BraintreeGateway({
     escrowStatus === Transaction.EscrowStatus.Refunded;
 
     // Assert overlap between source and static field
-    "Api" === Transaction.Source.Api;
-    "Recurring" === Transaction.Source.Recurring;
-    "ControlPanel" === Transaction.Source.ControlPanel;
+    "api" === Transaction.Source.Api;
+    "recurring" === Transaction.Source.Recurring;
+    "control_panel" === Transaction.Source.ControlPanel;
 
     // Assert overlap between created using and static field
     "token" === Transaction.CreatedUsing.Token;
@@ -262,6 +262,7 @@ const gateway: BraintreeGateway = new braintree.BraintreeGateway({
 
     // $ExpectType string
     subscription.nextBillingDate;
+    subscription.firstBillingDate;
 
     // Assert overlap between subscription status and static field
     subscription.status === braintree.Subscription.Status.Active;
@@ -269,6 +270,9 @@ const gateway: BraintreeGateway = new braintree.BraintreeGateway({
     subscription.status === braintree.Subscription.Status.Expired;
     subscription.status === braintree.Subscription.Status.PastDue;
     subscription.status === braintree.Subscription.Status.Pending;
+
+    // $ExpectType ValidatedResponse<Subscription>
+    const cancelResult = await gateway.subscription.cancel("subscriptionId");
 })();
 
 // $ExpectType () => string[]

--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -325,7 +325,7 @@ declare namespace braintree {
     }
 
     interface SubscriptionGateway {
-        cancel(subscriptionId: string): Promise<Subscription>;
+        cancel(subscriptionId: string): Promise<ValidatedResponse<Subscription>>;
         create(request: SubscriptionCreateRequest): Promise<ValidatedResponse<Subscription>>;
         find(subscriptionId: string): Promise<Subscription>;
         retryCharge(
@@ -793,9 +793,9 @@ declare namespace braintree {
         reason: string;
         reasonCode: string;
         reasonDescription: string;
-        receivedDate: Date;
+        receivedDate: string;
         referenceNumber: string;
-        replyByDate: Date;
+        replyByDate: string;
         status: DisputeStatus;
         statusHistory: DisputeStatusHistory[];
         transaction: {
@@ -812,17 +812,17 @@ declare namespace braintree {
     export type DisputeStatus = "Accepted" | "Disputed" | "Expired" | "Open" | "Lost" | "Won";
 
     export interface DisputeStatusHistory {
-        disbursementDate: Date;
-        effectiveDate: Date;
+        disbursementDate: string;
+        effectiveDate: string;
         status: DisputeStatus;
-        timestamp: Date;
+        timestamp: string;
     }
 
     export interface Evidence {
         comment?: string | undefined;
         createdAt: string;
         id: string;
-        sendToProcessorAt: Date;
+        sendToProcessorAt: string;
         url?: string | undefined;
     }
 
@@ -838,7 +838,7 @@ declare namespace braintree {
 
         id: string;
         amount: string;
-        disbursementDate: Date;
+        disbursementDate: string;
         disbursementType: DisbursementType;
         transactionIds: string[];
         merchantAccount: DisbursementMerchantAccount;
@@ -1127,7 +1127,7 @@ declare namespace braintree {
      * Account Updater
      */
     export class AccountUpdaterDailyReport {
-        reportDate: Date;
+        reportDate: string;
         reportUrl: string;
     }
 
@@ -1142,7 +1142,7 @@ declare namespace braintree {
 
     export interface BaseWebhookNotification {
         kind: WebhookNotificationKind;
-        timestamp: Date;
+        timestamp: string;
     }
 
     export interface TransactionNotification extends BaseWebhookNotification {
@@ -1218,7 +1218,7 @@ declare namespace braintree {
         | "subscription_expired"
         | "subscription_trial_ended"
         | "subscription_went_active"
-        | "subscription_went_past_due";
+        | "subscription_billing_skipped";
 
     export type SubMerchantAccountApprovedNotificationKind = "sub_merchant_account_approved";
 
@@ -1339,7 +1339,7 @@ declare namespace braintree {
         descriptor?: Descriptor | undefined;
         discounts?: Discount[] | undefined;
         failureCount?: number | undefined;
-        firstBillingDate?: Date | undefined;
+        firstBillingDate?: string | undefined;
         id: string;
         merchantAccountId: string;
         neverExpires?: boolean | undefined;
@@ -1347,7 +1347,7 @@ declare namespace braintree {
         nextBillingDate: string;
         nextBillingPeriodAmount: string;
         numberOfBillingCycles?: number | undefined;
-        paidThroughDate?: Date | undefined;
+        paidThroughDate?: string | undefined;
         paymentMethodToken: string;
         planId: string;
         price?: string | undefined;
@@ -1451,9 +1451,9 @@ declare namespace braintree {
         };
 
         static Source: {
-            Api: "Api";
-            ControlPanel: "ControlPanel";
-            Recurring: "Recurring";
+            Api: "api";
+            ControlPanel: "control_panel";
+            Recurring: "recurring";
         };
 
         static CreatedUsing: {
@@ -1540,7 +1540,7 @@ declare namespace braintree {
             }
             | undefined;
         authorizationAdjustments?: AuthorizationAdjustment[] | undefined;
-        authorizationExpiresAt?: Date | undefined;
+        authorizationExpiresAt?: string | undefined;
         avsErrorResponseCode: string;
         avsPostalCodeResponseCode: string;
         avsStreetAddressResponseCode: string;
@@ -1726,8 +1726,8 @@ declare namespace braintree {
         statusHistory?: TransactionStatusHistory[] | undefined;
         subscription?:
             | {
-                billingPeriodEndDate: Date;
-                billingPeriodStartDate: Date;
+                billingPeriodEndDate: string;
+                billingPeriodStartDate: string;
             }
             | undefined;
         subscriptionId?: string | undefined;
@@ -1913,7 +1913,7 @@ declare namespace braintree {
     export interface AuthorizationAdjustment {
         amount: string;
         success: boolean;
-        timestamp: Date;
+        timestamp: string;
         processorResponseType: string;
         processorResponseCode: string;
         processorResponseText: string;
@@ -1926,7 +1926,7 @@ declare namespace braintree {
     }
 
     export interface DisbursementDetails {
-        disbursementDate: Date;
+        disbursementDate: string;
         fundsHeld: boolean;
         settlementAmount: string;
         settlementCurrencyExchangeRate: string;
@@ -1998,12 +1998,12 @@ declare namespace braintree {
     export interface TransactionStatusHistory {
         amount: string;
         status: TransactionStatus;
-        timestamp: Date;
-        transactionsource: TransactionSource;
+        timestamp: string;
+        transactionSource: TransactionSource;
         user: string;
     }
 
-    export type TransactionSource = "Api" | "ControlPanel" | "Recurring";
+    export type TransactionSource = "api" | "control_panel" | "recurring";
 
     export interface TransactionThreeDSecureInfo {
         enrolled: string;

--- a/types/braintree/index.d.ts
+++ b/types/braintree/index.d.ts
@@ -1218,6 +1218,7 @@ declare namespace braintree {
         | "subscription_expired"
         | "subscription_trial_ended"
         | "subscription_went_active"
+        | "subscription_went_past_due"
         | "subscription_billing_skipped";
 
     export type SubMerchantAccountApprovedNotificationKind = "sub_merchant_account_approved";


### PR DESCRIPTION
… not serialized upon response. Update `transactionsource` to be `transactionSource` due to casing issue.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.