### PR TITLE
[uri-template-lite] Fix type definitions to match CommonJS exports

### DIFF
--- a/types/uri-template-lite/index.d.ts
+++ b/types/uri-template-lite/index.d.ts
@@ -1,9 +1,13 @@
-export namespace URI {
-    function expand(template: string, data: { [key: string]: unknown }): string;
-
-    class Template {
-        constructor(template: string);
-        expand: (data: { [key: string]: unknown }) => string;
-        match: (template: string) => { [key: string]: string };
-    }
+declare class Template {
+    constructor(template: string);
+    expand(data: { [key: string]: unknown }): string;
+    match(uri: string): { [key: string]: string };
 }
+
+declare function expand(template: string, data: { [key: string]: unknown }): string;
+
+declare namespace Template {
+    export { expand };
+}
+
+export = Template;

--- a/types/uri-template-lite/uri-template-lite-tests.ts
+++ b/types/uri-template-lite/uri-template-lite-tests.ts
@@ -1,10 +1,11 @@
-import { URI } from "uri-template-lite";
+import Template from "uri-template-lite";
 
-// Call `expand` directly
+// Call `expand` directly via the static method
 const dataSet = { domain: "example.com", user: "fred", query: "mycelium" };
-URI.expand("http://{domain}/~{user}/foo{?query,number}", dataSet);
+Template.expand("http://{domain}/~{user}/foo{?query,number}", dataSet);
 
-const template = new URI.Template("http://{domain}/~{user}/foo{?query,number}");
+// Create a template instance
+const template = new Template("http://{domain}/~{user}/foo{?query,number}");
 template.expand(dataSet);
 template.match("http://example.com/~fred/foo?query=mycelium&number=3");
 template.match("http://other.com/?query=mycelium");


### PR DESCRIPTION
The previous type definitions used an incorrect namespace export pattern that didn't match the actual runtime exports of the package.

Changes:
- Changed from 'export namespace URI' to 'export = Template'
- Template is now the default export matching 'module.exports = Template'
- Static expand function is available as Template.expand
- Enables ES6 default imports: 'import Template from "uri-template-lite"'
- Updated tests to use ES6 default import syntax
- Verified runtime safety with both node16 and commonjs module targets

Fixes the issue where users had to use require() instead of import.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/litejs/uri-template-lite/blob/master/index.js#L10-L11)
- [] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

 ## Problem

The previous type definitions used an incorrect namespace pattern (`export namespace URI`) that didn't match the runtime behavior. The actual package exports `module.exports = Template` (see [source code](https://github.com/litejs/uri-template-lite/blob/master/index.js#L10-L11)).

This caused issues where users couldn't use ES6 imports and had to fall back to `require()`.

## Solution

- Changed from `export namespace URI` to `export = Template` pattern to match CommonJS exports
- Enables ES6 default imports: `import Template from "uri-template-lite"`
- Also works with: `import Template = require("uri-template-lite")`
- Updated tests to use ES6 default import syntax

