### PR TITLE
feat(koa-qs): type the options argument

### DIFF
--- a/types/koa-qs/index.d.ts
+++ b/types/koa-qs/index.d.ts
@@ -1,9 +1,10 @@
 import koa = require("koa");
+import qs = require("qs");
 
 declare namespace koaQs {
     type ParseMode = "extended" | "strict" | "first";
 }
 
-declare function koaQs(app: koa, mode?: koaQs.ParseMode): koa;
+declare function koaQs(app: koa, mode?: koaQs.ParseMode, options?: qs.IParseOptions): koa;
 
 export = koaQs;

--- a/types/koa-qs/koa-qs-tests.ts
+++ b/types/koa-qs/koa-qs-tests.ts
@@ -4,3 +4,7 @@ import Koa = require("koa");
 const app = koaQs(new Koa());
 
 app.listen(80);
+
+const appWithOptions = koaQs(new Koa(), "extended", { arrayLimit: 50 });
+
+appWithOptions.listen(80);

--- a/types/koa-qs/package.json
+++ b/types/koa-qs/package.json
@@ -6,7 +6,8 @@
         "https://github.com/koajs/qs#readme"
     ],
     "dependencies": {
-        "@types/koa": "*"
+        "@types/koa": "*",
+        "@types/qs": "*"
     },
     "devDependencies": {
         "@types/koa-qs": "workspace:."


### PR DESCRIPTION
## Summary
- allow passing `qs.IParseOptions` through the `koaQs` signature so consumers can configure parsing behavior (the upstream implementation already accepts `module.exports = function (app, mode, options)` and forwards `options` to `qs.parse`: https://github.com/koajs/qs/blob/master/index.js#L3-L34)
- add `@types/qs` as a dependency to satisfy the new import
- extend the dtslint test to cover calling `koaQs(new Koa(), "extended", { arrayLimit: 50 })`, exercising the third parameter

