### PR TITLE
Update event listener typing to allow union type inputs in package pg

### DIFF
--- a/types/pg-pool/index.d.ts
+++ b/types/pg-pool/index.d.ts
@@ -8,8 +8,11 @@ declare class Pool<T extends pg.Client> extends pg.Pool {
     connect(): Promise<T & pg.PoolClient>;
     connect(callback: (err?: Error, client?: T & pg.PoolClient, done?: (release?: any) => void) => void): void;
 
-    on(event: "error", listener: (err: Error, client: T & pg.PoolClient) => void): this;
-    on(event: "connect" | "acquire" | "remove", listener: (client: T & pg.PoolClient) => void): this;
+    on<K extends "error" | "release" | "connect" | "acquire" | "remove">(
+        event: K,
+        listener: K extends "error" | "release" ? (err: Error, client: T & pg.PoolClient) => void
+            : (client: T & pg.PoolClient) => void,
+    ): this;
 }
 
 declare namespace Pool {

--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -229,10 +229,9 @@ export class Pool extends events.EventEmitter {
     // tslint:enable:no-unnecessary-generics
 
     on<K extends "error" | "release" | "connect" | "acquire" | "remove">(
-      event: K,
-      listener: K extends "error" | "release"
-        ? (err: Error, client: PoolClient) => void
-        : (client: PoolClient) => void,
+        event: K,
+        listener: K extends "error" | "release" ? (err: Error, client: PoolClient) => void
+            : (client: PoolClient) => void,
     ): this;
 }
 
@@ -281,7 +280,13 @@ export class ClientBase extends events.EventEmitter {
     setTypeParser: typeof pgTypes.setTypeParser;
     getTypeParser: typeof pgTypes.getTypeParser;
 
-    on<E extends "drain" | "error" | "notice" | "notification" | "end">(event: E, listener: E extends "drain" | "end" ? () => void : E extends "error" ? (err: Error) => void : E extends "notice" ? (notice: NoticeMessage) => void : (message: Notification) => void): this;
+    on<E extends "drain" | "error" | "notice" | "notification" | "end">(
+        event: E,
+        listener: E extends "drain" | "end" ? () => void
+            : E extends "error" ? (err: Error) => void
+            : E extends "notice" ? (notice: NoticeMessage) => void
+            : (message: Notification) => void,
+    ): this;
 }
 
 export class Client extends ClientBase {
@@ -316,7 +321,12 @@ export class Query<R extends QueryResultRow = any, I extends any[] = any> extend
         callback?: (error: Error | undefined, result: ResultBuilder<R>) => void,
     );
     submit: (connection: Connection) => void;
-    on<E extends "row" | "error" | "end">(event: E, listener: E extends "row" ? (row: R, result?: ResultBuilder<R>) => void : E extends "error" ? (err: Error) => void : (result: ResultBuilder<R>) => void): this;
+    on<E extends "row" | "error" | "end">(
+        event: E,
+        listener: E extends "row" ? (row: R, result?: ResultBuilder<R>) => void
+            : E extends "error" ? (err: Error) => void
+            : (result: ResultBuilder<R>) => void,
+    ): this;
 }
 
 export class Events extends events.EventEmitter {

--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -228,8 +228,12 @@ export class Pool extends events.EventEmitter {
     ): void;
     // tslint:enable:no-unnecessary-generics
 
-    on(event: "release" | "error", listener: (err: Error, client: PoolClient) => void): this;
-    on(event: "connect" | "acquire" | "remove", listener: (client: PoolClient) => void): this;
+    on<K extends "error" | "release" | "connect" | "acquire" | "remove">(
+      event: K,
+      listener: K extends "error" | "release"
+        ? (err: Error, client: PoolClient) => void
+        : (client: PoolClient) => void,
+    ): this;
 }
 
 export class ClientBase extends events.EventEmitter {
@@ -277,12 +281,7 @@ export class ClientBase extends events.EventEmitter {
     setTypeParser: typeof pgTypes.setTypeParser;
     getTypeParser: typeof pgTypes.getTypeParser;
 
-    on(event: "drain", listener: () => void): this;
-    on(event: "error", listener: (err: Error) => void): this;
-    on(event: "notice", listener: (notice: NoticeMessage) => void): this;
-    on(event: "notification", listener: (message: Notification) => void): this;
-    // tslint:disable-next-line unified-signatures
-    on(event: "end", listener: () => void): this;
+    on<E extends "drain" | "error" | "notice" | "notification" | "end">(event: E, listener: E extends "drain" | "end" ? () => void : E extends "error" ? (err: Error) => void : E extends "notice" ? (notice: NoticeMessage) => void : (message: Notification) => void): this;
 }
 
 export class Client extends ClientBase {
@@ -317,9 +316,7 @@ export class Query<R extends QueryResultRow = any, I extends any[] = any> extend
         callback?: (error: Error | undefined, result: ResultBuilder<R>) => void,
     );
     submit: (connection: Connection) => void;
-    on(event: "row", listener: (row: R, result?: ResultBuilder<R>) => void): this;
-    on(event: "error", listener: (err: Error) => void): this;
-    on(event: "end", listener: (result: ResultBuilder<R>) => void): this;
+    on<E extends "row" | "error" | "end">(event: E, listener: E extends "row" ? (row: R, result?: ResultBuilder<R>) => void : E extends "error" ? (err: Error) => void : (result: ResultBuilder<R>) => void): this;
 }
 
 export class Events extends events.EventEmitter {

--- a/types/pg/package.json
+++ b/types/pg/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/pg",
-    "version": "8.15.9999",
+    "version": "8.16.0",
     "projects": [
         "https://github.com/brianc/node-postgres"
     ],

--- a/types/pg/package.json
+++ b/types/pg/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/pg",
-    "version": "8.16.0",
+    "version": "8.16.9999",
     "projects": [
         "https://github.com/brianc/node-postgres"
     ],

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -335,12 +335,14 @@ pool.on("remove", (client) => {
 });
 
 const listeners: {
-  [K in "error" | "release" | "connect" | "remove" | "acquire"]?: K extends "error" | "release" ? (err: Error, client: pg.PoolClient) => void : (client: pg.PoolClient) => void;
+    [K in "error" | "release" | "connect" | "remove" | "acquire"]?: K extends "error" | "release"
+        ? (err: Error, client: pg.PoolClient) => void
+        : (client: pg.PoolClient) => void;
 } = {};
 
-for(const eventName in listeners) {
+for (const eventName in listeners) {
     const listener = listeners[eventName as keyof typeof listeners];
-    if(listener) {
+    if (listener) {
         pool.on(eventName as keyof typeof listeners, listener);
     }
 }

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -312,6 +312,8 @@ pool.on("connect", (client) => {
     // $ExpectType PoolClient
     client;
 });
+// @ts-expect-error - test wrong number of arguments
+pool.on("connect", (error, client) => {});
 pool.on("acquire", (client) => {
     // $ExpectType PoolClient
     client;
@@ -323,10 +325,25 @@ pool.on("release", (err, client) => {
         console.error("connection released to pool: ", err.message);
     }
 });
+pool.on("release", (error) => {
+    // $ExpectType Error
+    error;
+});
 pool.on("remove", (client) => {
     // $ExpectType PoolClient
     client;
 });
+
+const listeners: {
+  [K in "error" | "release" | "connect" | "remove" | "acquire"]?: K extends "error" | "release" ? (err: Error, client: pg.PoolClient) => void : (client: pg.PoolClient) => void;
+} = {};
+
+for(const eventName in listeners) {
+    const listener = listeners[eventName as keyof typeof listeners];
+    if(listener) {
+        pool.on(eventName as keyof typeof listeners, listener);
+    }
+}
 
 (async () => {
     const client = await pool.connect();


### PR DESCRIPTION
Overload-style typing of the .on methods for attaching event handlers to clients and pools means unioned event name types were not accepted by TS as valid inputs. This PR addresses that. See gist for example of where this caused issues:

https://gist.github.com/frej4189/eabd3d04b86952e32943a78249ab48a8

Also bumps the package.json version to 8.16 as the typings were already compatible with the new version.
