### PR TITLE
[passport] Fix state option to support object

### DIFF
--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -158,7 +158,7 @@ declare namespace passport {
          */
         successRedirect?: string | undefined;
         successReturnToOrRedirect?: string | undefined;
-        state?: string | undefined;
+        state?: string | object | undefined;
         /**
          * Pause the request stream before deserializing the user
          * object from the session.  Defaults to `false`.  Should

--- a/types/passport/passport-tests.ts
+++ b/types/passport/passport-tests.ts
@@ -191,7 +191,10 @@ app.post("/logout", (req, res, next) => {
     });
 });
 
-app.post("/auth/token", passport.authenticate(["basic", "oauth2-client-password"], { session: false }));
+app.post(
+    "/auth/token",
+    passport.authenticate(["basic", "oauth2-client-password"], { session: false, state: { test: "test" } }),
+);
 
 function authSetting(): void {
     const authOption = {


### PR DESCRIPTION
passport-oauth2 supports using a state object in the strategy's AuthenticateOptions. See previous discussion in https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/65450.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jaredhanson/passport-oauth2/blob/be9bf58cee75938c645a9609f0cc87c4c724e7c8/lib/strategy.js#L257-L266