### PR TITLE
[suncalc] decorate interfaces and properties to improve usability and fix two properties

### DIFF
--- a/types/suncalc/index.d.ts
+++ b/types/suncalc/index.d.ts
@@ -1,44 +1,209 @@
+/**
+ * Sunlight times result Object
+ * 
+ * https://github.com/mourner/suncalc?tab=readme-ov-file#sunlight-times
+ */
 export interface GetTimesResult {
+    /**
+     * dawn (morning nautical twilight ends, morning civil twilight starts)
+     */
     dawn: Date;
+    /**
+     * dusk (evening nautical twilight starts)
+     */
     dusk: Date;
+    /**
+     * evening golden hour starts
+     */
     goldenHour: Date;
+    /**
+     * morning golden hour (soft light, best time for photography) ends
+     */
     goldenHourEnd: Date;
+    /**
+     * nadir (darkest moment of the night, sun is in the lowest position)
+     */
     nadir: Date;
+    /**
+     * nautical dawn (morning nautical twilight starts)
+     */
     nauticalDawn: Date;
+    /**
+     * nautical dusk (evening astronomical twilight starts)
+     */
     nauticalDusk: Date;
+    /**
+     * night starts (dark enough for astronomical observations)
+     */
     night: Date;
+    /**
+     * night ends (morning astronomical twilight starts)
+     */
     nightEnd: Date;
+    /**
+     * solar noon (sun is in the highest position)
+     */
     solarNoon: Date;
+    /**
+     * sunrise (top edge of the sun appears on the horizon)
+     */
     sunrise: Date;
+    /**
+     * sunrise ends (bottom edge of the sun touches the horizon)
+     */
     sunriseEnd: Date;
+    /**
+     * sunset (sun disappears below the horizon, evening civil twilight starts)
+     */
     sunset: Date;
+    /**
+     * sunset starts (bottom edge of the sun touches the horizon)
+     */
     sunsetStart: Date;
 }
+
+/**
+ * Sun position result Object
+ * 
+ * https://github.com/mourner/suncalc?tab=readme-ov-file#sun-position
+ */
 export interface GetSunPositionResult {
+    /**
+     * sun altitude above the horizon in radians, e.g. `0` at the horizon and `PI/2` at the zenith (straight over your head)
+     */
     altitude: number;
+    /**
+     * sun azimuth in radians (direction along the horizon, measured from south to west), e.g. `0` is south and `Math.PI * 3/4` is northwest
+     */
     azimuth: number;
 }
+
+/**
+ * Moon position result Object
+ * 
+ * https://github.com/mourner/suncalc?tab=readme-ov-file#moon-position
+ */
 export interface GetMoonPositionResult {
+    /**
+     * moon altitude above the horizon in radian
+     */
     altitude: number;
+    /**
+     * moon azimuth in radians
+     */
     azimuth: number;
+    /**
+     * distance to moon in kilometers
+     */
     distance: number;
+    /**
+     * parallactic angle of the moon in radians
+     */
     parallacticAngle: number;
 }
+
+/**
+ * Moon illumination result Object
+ * 
+ * https://github.com/mourner/suncalc?tab=readme-ov-file#moon-illumination
+ */
 export interface GetMoonIlluminationResult {
+    /**
+     * illuminated fraction of the moon; varies from `0.0` (new moon) to `1.0` (full moon)
+     */
     fraction: number;
+    /**
+     * moon phase; varies from `0.0` to `1.0`
+     * 
+     * See https://github.com/mourner/suncalc?tab=readme-ov-file#moon-illumination for moon phase interpretation
+     */
     phase: number;
+    /**
+     * midpoint angle in radians of the illuminated limb of the moon reckoned eastward from the north point of the disk; the moon is waxing if the angle is negative, and waning if positive
+     */
     angle: number;
 }
+
+/**
+ * Moon rise and set times result Object
+ * 
+ * https://github.com/mourner/suncalc?tab=readme-ov-file#moon-rise-and-set-times
+ */
 export interface GetMoonTimesResult {
-    rise: Date;
-    set: Date;
+    /**
+     * moonrise (top edge of the moon appears on the horizon)
+     */
+    rise?: Date;
+    /**
+     * moonset (moon disappears below the horizon)
+     */
+    set?: Date;
+    /**
+     * `true` if the moon never rises/sets and is _always_ above the horizon during the day
+     */
     alwaysUp?: true;
+    /**
+     * `true` if the moon is _always_ below the horizon
+     */
     alwaysDown?: true;
 }
 
+/**
+ * Sunlight times - get the solar event times at a location on earth for a given date
+ * 
+ * https://github.com/mourner/suncalc?tab=readme-ov-file#sunlight-times
+ * 
+ * @param date - Date
+ * @param latitude - Latitude of the location
+ * @param longitude - Longitude of the location
+ * @param height - Optional height (elevation) above the spheroid of earth in meters
+ */
 export function getTimes(date: Date, latitude: number, longitude: number, height?: number): GetTimesResult;
+
+/**
+ * https://github.com/mourner/suncalc/blob/master/suncalc.js#L91-L104
+ */
 export function addTime(angleInDegrees: number, morningName: string, eveningName: string): void;
+
+/**
+ * Sun position - get the position (altitude and azimuth) of the sun from the perspective of an observer at a location on earth at a given date and time
+ * 
+ * https://github.com/mourner/suncalc?tab=readme-ov-file#sun-position
+ * 
+ * @param timeAndDate - Date
+ * @param latitude - Latitude of the location
+ * @param longitude - Longitude of the location
+ */
 export function getPosition(timeAndDate: Date, latitude: number, longitude: number): GetSunPositionResult;
+
+/**
+ * Moon position - get the position (altitude, azimuth, distance and parallacticAngle) of the moon from the perspective of an observer at a location on earth at a given date and time
+ * 
+ * https://github.com/mourner/suncalc?tab=readme-ov-file#moon-position
+ * 
+ * @param timeAndDate - Date
+ * @param latitude - Latitude of the location
+ * @param longitude - Longitude of the location
+ */
 export function getMoonPosition(timeAndDate: Date, latitude: number, longitude: number): GetMoonPositionResult;
-export function getMoonIllumination(timeAndDate: Date): GetMoonIlluminationResult;
+
+/**
+ * Moon illumination - get the illumination parameters of the moon (fraction, phase and angle) of the moon for a given date
+ * 
+ * https://github.com/mourner/suncalc?tab=readme-ov-file#moon-illumination
+ * 
+ * @param timeAndDate - Date (defaults to user system date and time)
+ */
+export function getMoonIllumination(timeAndDate?: Date): GetMoonIlluminationResult;
+
+/**
+ * Moon rise and set times - get the lunar event times at a location on earth for a given date
+ * 
+ * https://github.com/mourner/suncalc?tab=readme-ov-file#moon-rise-and-set-times
+ * 
+ * @param date - Date
+ * @param latitude - Latitude of the location
+ * @param longitude - Longitude of the location
+ * @param inUTC - By default, it will search for moon rise and set during user system day (from 0 to 24 hours); if `inUTC` is set to true, it will instead search the specified date from 0 to 24 UTC hours
+ */
 export function getMoonTimes(date: Date, latitude: number, longitude: number, inUTC?: boolean): GetMoonTimesResult;

--- a/types/suncalc/index.d.ts
+++ b/types/suncalc/index.d.ts
@@ -29,7 +29,7 @@ export interface GetMoonIlluminationResult {
     phase: number;
     angle: number;
 }
-export interface GetMoonTimes {
+export interface GetMoonTimesResult {
     rise: Date;
     set: Date;
     alwaysUp?: true;
@@ -41,4 +41,4 @@ export function addTime(angleInDegrees: number, morningName: string, eveningName
 export function getPosition(timeAndDate: Date, latitude: number, longitude: number): GetSunPositionResult;
 export function getMoonPosition(timeAndDate: Date, latitude: number, longitude: number): GetMoonPositionResult;
 export function getMoonIllumination(timeAndDate: Date): GetMoonIlluminationResult;
-export function getMoonTimes(date: Date, latitude: number, longitude: number, inUTC?: boolean): GetMoonTimes;
+export function getMoonTimes(date: Date, latitude: number, longitude: number, inUTC?: boolean): GetMoonTimesResult;

--- a/types/suncalc/index.d.ts
+++ b/types/suncalc/index.d.ts
@@ -132,10 +132,14 @@ export interface GetMoonIlluminationResult {
 export interface GetMoonTimesResult {
     /**
      * moonrise (top edge of the moon appears on the horizon)
+     * 
+     * `undefined` if there is no moonrise at location and date (calendar day) provided
      */
     rise?: Date;
     /**
      * moonset (moon disappears below the horizon)
+     * 
+     * `undefined` if there is no moonset at location and date (calendar day) provided
      */
     set?: Date;
     /**
@@ -204,6 +208,6 @@ export function getMoonIllumination(timeAndDate?: Date): GetMoonIlluminationResu
  * @param date - Date
  * @param latitude - Latitude of the location
  * @param longitude - Longitude of the location
- * @param inUTC - By default, it will search for moon rise and set during user system day (from 0 to 24 hours); if `inUTC` is set to true, it will instead search the specified date from 0 to 24 UTC hours
+ * @param inUTC - By default, `getMoonTimes()` will search for moon rise and set during user system day (from 0 to 24 hours); if `inUTC` is set to true, it will instead search the specified date from 0 to 24 UTC hours
  */
 export function getMoonTimes(date: Date, latitude: number, longitude: number, inUTC?: boolean): GetMoonTimesResult;

--- a/types/suncalc/package.json
+++ b/types/suncalc/package.json
@@ -10,6 +10,10 @@
     },
     "owners": [
         {
+            "name": "City of Vernonia, Oregon",
+            "githubUsername": "COV-GIS"
+        },
+        {
             "name": "horiuchi",
             "githubUsername": "horiuchi"
         }

--- a/types/suncalc/package.json
+++ b/types/suncalc/package.json
@@ -10,10 +10,6 @@
     },
     "owners": [
         {
-            "name": "City of Vernonia, Oregon",
-            "githubUsername": "COV-GIS"
-        },
-        {
             "name": "horiuchi",
             "githubUsername": "horiuchi"
         }

--- a/types/suncalc/suncalc-tests.ts
+++ b/types/suncalc/suncalc-tests.ts
@@ -1,6 +1,7 @@
 import * as SunCalc from "suncalc";
 
 let d: Date;
+let c: Date | undefined;
 let x: number;
 let b: boolean | undefined;
 
@@ -59,7 +60,7 @@ x = mi.phase;
 x = mi.angle;
 
 const mt = SunCalc.getMoonTimes(date, latitude, longitude, true);
-d = mt.rise;
-d = mt.set;
+c = mt.rise;
+c = mt.set;
 b = mt.alwaysUp;
 b = mt.alwaysDown;


### PR DESCRIPTION
Non-definition changes:

* Decorate interfaces and properties to improve usability.
* Rename `GetMoonTimes` to `GetMoonTimesResult` to be the same naming convention of the other function return interfaces.

Definition and test change:

The `getMoonTimes()`'s `rise` and `set` return properties may be `undefined`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mourner/suncalc/blob/master/suncalc.js#L234-L285