### PR TITLE
node: re-add deprecated `EncodeIntoResult` alias in v25

### DIFF
--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -1246,6 +1246,9 @@ declare module "node:util" {
         text: string,
         options?: StyleTextOptions,
     ): string;
+    /** @deprecated This alias will be removed in a future version. Use the canonical `TextEncoderEncodeIntoResult` instead. */
+    // TODO: remove in future major
+    export interface EncodeIntoResult extends TextEncoderEncodeIntoResult {}
     //// parseArgs
     /**
      * Provides a higher level API for command-line argument parsing than interacting


### PR DESCRIPTION
A GH code search for conventional usage yielded no real results, but @types/bun were using `import('util').EncodeIntoResult` in their TextEncoder definition. Re-add a deprecated alias to smooth the transition.