### PR TITLE
[papaparse] feat: add BYTE_ORDER_MARK constant

### DIFF
--- a/types/papaparse/index.d.ts
+++ b/types/papaparse/index.d.ts
@@ -82,6 +82,12 @@ export function unparse<T>(data: T[] | UnparseObject<T>, config?: UnparseConfig)
 /** An array of characters that are not allowed as delimiters. `\r`, `\n`, `"`, `\ufeff` */
 export const BAD_DELIMITERS: readonly string[];
 
+/**
+ * The unicode Byte Order Mark (\ufeff).
+ * @see https://en.wikipedia.org/wiki/Byte_order_mark
+ */
+export const BYTE_ORDER_MARK: "\ufeff";
+
 /** The true delimiter. Invisible. ASCII code 30. Should be doing the job we strangely rely upon commas and tabs for. */
 export const RECORD_SEP: "\x1E";
 

--- a/types/papaparse/papaparse-tests.ts
+++ b/types/papaparse/papaparse-tests.ts
@@ -313,6 +313,7 @@ Papa.unparse(
 Papa.RECORD_SEP;
 Papa.UNIT_SEP;
 Papa.BAD_DELIMITERS;
+Papa.BYTE_ORDER_MARK;
 
 /**
  * Parser


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  https://www.papaparse.com/docs#extras
     - It's looks like just missing. This prop exists before 10 years ago.
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.


https://github.com/mholt/PapaParse/blob/b10b87ef8686c6f88299b50dd25e83606e9c36d4/papaparse.js#L67
