### PR TITLE
[jqrangeslider] work around 6.0 change

### DIFF
--- a/types/jqrangeslider/jqrangeslider-tests.ts
+++ b/types/jqrangeslider/jqrangeslider-tests.ts
@@ -158,7 +158,7 @@ $("#rulersExample").rangeSlider({
                 return false;
             },
             label: function() {
-                return null;
+                return "";
             },
         },
     ],


### PR DESCRIPTION
This package sets the cursed combo of `strictNullChecks=false` and `noImplicitAny=true` while using `null`. Just work around this inference change in the test.

https://github.com/microsoft/TypeScript/pull/62243