### PR TITLE
Update proofread method to accept options parameter

### DIFF
--- a/types/dom-chromium-ai/dom-chromium-ai-tests.ts
+++ b/types/dom-chromium-ai/dom-chromium-ai-tests.ts
@@ -434,7 +434,9 @@ async function topLevel() {
     });
     console.log(proofreaderAvailability2);
 
-    const proofreaderResult: ProofreadResult = await proofreader.proofread("foo", { signal: (new AbortController()).signal });
+    const proofreaderResult: ProofreadResult = await proofreader.proofread("foo", {
+        signal: (new AbortController()).signal,
+    });
     console.log(proofreaderResult);
 
     // for await (

--- a/types/dom-chromium-ai/dom-chromium-ai-tests.ts
+++ b/types/dom-chromium-ai/dom-chromium-ai-tests.ts
@@ -434,11 +434,11 @@ async function topLevel() {
     });
     console.log(proofreaderAvailability2);
 
-    const proofreaderResult: ProofreadResult = await proofreader.proofread("foo");
+    const proofreaderResult: ProofreadResult = await proofreader.proofread("foo", { signal: (new AbortController()).signal });
     console.log(proofreaderResult);
 
     // for await (
-    //     const chunk of proofreader.proofreadStreaming("foo")
+    //     const chunk of proofreader.proofreadStreaming("foo", { signal: (new AbortController()).signal })
     // ) {
     //     console.log(chunk);
     // }

--- a/types/dom-chromium-ai/index.d.ts
+++ b/types/dom-chromium-ai/index.d.ts
@@ -397,7 +397,7 @@ declare abstract class Proofreader implements DestroyableModel {
     static create(options?: ProofreaderCreateOptions): Promise<Proofreader>;
     static availability(options?: ProofreaderCreateCoreOptions): Promise<Availability>;
 
-    proofread(input: string): Promise<ProofreadResult>;
+    proofread(input: string, options?: ProofreaderProofreadOptions): Promise<ProofreadResult>;
     // proofreadStreaming(input: string): ReadableStream<unknown>;
 
     readonly includeCorrectionTypes: boolean;
@@ -418,6 +418,10 @@ interface ProofreaderCreateCoreOptions {
 interface ProofreaderCreateOptions extends ProofreaderCreateCoreOptions {
     signal?: AbortSignal;
     monitor?: CreateMonitorCallback;
+}
+
+interface ProofreaderProofreadOptions {
+    signal?: AbortSignal;
 }
 
 interface ProofreadResult {

--- a/types/dom-chromium-ai/index.d.ts
+++ b/types/dom-chromium-ai/index.d.ts
@@ -398,7 +398,7 @@ declare abstract class Proofreader implements DestroyableModel {
     static availability(options?: ProofreaderCreateCoreOptions): Promise<Availability>;
 
     proofread(input: string, options?: ProofreaderProofreadOptions): Promise<ProofreadResult>;
-    // proofreadStreaming(input: string): ReadableStream<unknown>;
+    // proofreadStreaming(input: string, options?: ProofreaderProofreadOptions): ReadableStream<unknown>;
 
     readonly includeCorrectionTypes: boolean;
     readonly includeCorrectionExplanations: boolean;


### PR DESCRIPTION
I think there's a missing options parameter for the Proofreader API, see reference:

https://github.com/webmachinelearning/proofreader-api?tab=readme-ov-file#destruction-and-aborting

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
