### PR TITLE
[leaflet.vectorgrid] add other allowed tile layer style definitions

### DIFF
--- a/types/leaflet.vectorgrid/index.d.ts
+++ b/types/leaflet.vectorgrid/index.d.ts
@@ -1,6 +1,6 @@
 import * as geojson from "geojson";
-import geojsonvt = require("geojson-vt");
 import * as L from "leaflet";
+import geojsonvt = require("geojson-vt");
 
 declare module "leaflet" {
     interface TileProps {
@@ -74,7 +74,8 @@ declare module "leaflet" {
         rendererFactory?: TileFactoryFunction<T>;
         /** A data structure holding initial symbolizer definitions for the vector features. */
         vectorTileLayerStyles?:
-            | Record<string, PathOptions>
+            | Record<string, PathOptions | PathOptions[]>
+            | Record<string, ((properties: Record<string, string>, zoom: number) => PathOptions | PathOptions[])>
             | ((properties: Record<string, string>, zoom: number) => PathOptions);
         /** Whether this VectorGrid fires Interactive Layer events. */
         interactive?: boolean;

--- a/types/leaflet.vectorgrid/leaflet.vectorgrid-tests.ts
+++ b/types/leaflet.vectorgrid/leaflet.vectorgrid-tests.ts
@@ -1,6 +1,6 @@
-import "leaflet.vectorgrid";
 import * as GJ from "geojson";
 import * as L from "leaflet";
+import "leaflet.vectorgrid";
 
 const data: GJ.FeatureCollection = {
     type: "FeatureCollection",
@@ -96,5 +96,51 @@ new L.VectorGrid({
     ...vectorgridOptions,
     vectorTileLayerStyles: (_properties, _zoom) => {
         return {};
+    },
+});
+
+// $ExpectType VectorGrid<HTMLCanvasElement | SVGViewElement>
+new L.VectorGrid({
+    ...vectorgridOptions,
+    vectorTileLayerStyles: {
+        name: {},
+    },
+});
+
+// $ExpectType VectorGrid<HTMLCanvasElement | SVGViewElement>
+new L.VectorGrid({
+    ...vectorgridOptions,
+    vectorTileLayerStyles: {
+        name: [{}],
+    },
+});
+
+// $ExpectType VectorGrid<HTMLCanvasElement | SVGViewElement>
+new L.VectorGrid({
+    ...vectorgridOptions,
+    vectorTileLayerStyles: {
+        name: (
+            // $ExpectType Record<string, string>
+            _properties,
+            // $ExpectType number
+            _zoom,
+        ) => {
+            return {};
+        },
+    },
+});
+
+// $ExpectType VectorGrid<HTMLCanvasElement | SVGViewElement>
+new L.VectorGrid({
+    ...vectorgridOptions,
+    vectorTileLayerStyles: {
+        name: (
+            // $ExpectType Record<string, string>
+            _properties,
+            // $ExpectType number
+            _zoom,
+        ) => {
+            return [{}];
+        },
     },
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

- https://github.com/Leaflet/Leaflet.VectorGrid/blob/2ac9a8b72285e28465384d0c303acdc08e05f95e/src/Leaflet.VectorGrid.js#L89 (lines 89 to 120)
- also visible in this example: https://github.com/Leaflet/Leaflet.VectorGrid/blob/2ac9a8b72285e28465384d0c303acdc08e05f95e/docs/demo-points.html#L42
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.