### PR TITLE
nodemailer: Fix 'From' header incorrect array-less typing

### DIFF
--- a/types/nodemailer/lib/mailer/index.d.ts
+++ b/types/nodemailer/lib/mailer/index.d.ts
@@ -97,7 +97,7 @@ declare namespace Mail {
 
     interface Options {
         /** The e-mail address of the sender. All e-mail addresses can be plain 'sender@server.com' or formatted 'Sender Name <sender@server.com>' */
-        from?: string | Address | undefined;
+        from?: string | Address | Array<string | Address> | undefined;
         /** An e-mail address that will appear on the Sender: field */
         sender?: string | Address | undefined;
         /** Comma separated list or an array of recipients e-mail addresses that will appear on the To: field */

--- a/types/nodemailer/nodemailer-tests.ts
+++ b/types/nodemailer/nodemailer-tests.ts
@@ -127,7 +127,7 @@ function message_common_fields_array_test() {
         from: ["sender@server.com", { address: "sender2@server.com", name: "Sender2" }],
         to: ["receiver@sender.com", { address: "receiver2@sender.com", name: "Receiver2" }],
         cc: ["ccdreceiver@sender.com"],
-        bcc: ["bccdreceiver@sender.com"]
+        bcc: ["bccdreceiver@sender.com"],
     };
 }
 

--- a/types/nodemailer/nodemailer-tests.ts
+++ b/types/nodemailer/nodemailer-tests.ts
@@ -120,6 +120,17 @@ function message_common_fields_test() {
     };
 }
 
+// Array variant of common fields
+
+function message_common_fields_array_test() {
+    const message: Mail.Options = {
+        from: ["sender@server.com", { address: "sender2@server.com", name: "Sender2 }],
+        to: ["receiver@sender.com", { address: "receiver2@sender.com", name: "Receiver2 }],
+        cc: ["ccdreceiver@sender.com"],
+        bcc: ["bccdreceiver@sender.com"]
+    };
+}
+
 // More advanced fields
 
 function message_more_advanced_fields_test() {

--- a/types/nodemailer/nodemailer-tests.ts
+++ b/types/nodemailer/nodemailer-tests.ts
@@ -124,8 +124,8 @@ function message_common_fields_test() {
 
 function message_common_fields_array_test() {
     const message: Mail.Options = {
-        from: ["sender@server.com", { address: "sender2@server.com", name: "Sender2 }],
-        to: ["receiver@sender.com", { address: "receiver2@sender.com", name: "Receiver2 }],
+        from: ["sender@server.com", { address: "sender2@server.com", name: "Sender2" }],
+        to: ["receiver@sender.com", { address: "receiver2@sender.com", name: "Receiver2" }],
         cc: ["ccdreceiver@sender.com"],
         bcc: ["bccdreceiver@sender.com"]
     };


### PR DESCRIPTION
I've noticed when using the typings for `nodemailer`, the typings state that the `from` attribute can either be a string, address object, or undefined (intended to be translated into the "From" header in an email message), when in fact it can also be an array.
The library handles `cc`, `bcc`, `to`, and `from` headers the same, it expects either an address object, string, array of address objects or undefined (see below URL to source code that displays this).
I'm not surprised that whoever designed these types didn't realise this, it's incredibly niche nowadays but the RFC 5322 states that the `From` header can have multiple entries (i.e. multiple senders)!! The library does follow this spec and allows an array of `from`s, hence the typings are incorrect. This PR fixes this typing in the `sendMail` function options, but let me know if I missed any more.
To avoid any doubt, the `sender` typings are correct, the spec uses this header to specify who the actual sender is in case there are multiple addresses in the `from` header, hence only accepts one address.

Confirmed this behaviour by sending a test email using `nodemailer` to my own SMTP server with multiple `from`s.
```js
transport.sendMail({
    from: [{ address: 'sender@example.com', name: 'sender' }, { address: 'sender2@example.com', name: 'sender2' }],
    to: ["testaddress@example.com"],
    subject: "Hello from Nodemailer",
    text: "This demonstrates multiple addresses in the from header",
});
```

SMTP logs:
<img width="798" height="92" alt="image" src="https://github.com/user-attachments/assets/d28b937f-6c64-4037-b2f4-450d27acab25" />

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodemailer/nodemailer/blob/master/lib/mail-composer/index.js#L60C9-L66C12