### PR TITLE
[node]: Fix the return type of fs.mkdtempDisposableSync being an asyncDisposable

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -2152,7 +2152,7 @@ declare module "node:fs" {
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
     function mkdtempSync(prefix: string, options?: EncodingOption): string | NonSharedBuffer;
-    interface DisposableTempDir extends AsyncDisposable {
+    interface DisposableTempDir extends Disposable {
         /**
          * The path of the created directory.
          */
@@ -2160,11 +2160,11 @@ declare module "node:fs" {
         /**
          * A function which removes the created directory.
          */
-        remove(): Promise<void>;
+        remove(): void;
         /**
          * The same as `remove`.
          */
-        [Symbol.asyncDispose](): Promise<void>;
+        [Symbol.dispose](): void;
     }
     /**
      * Returns a disposable object whose `path` property holds the created directory

--- a/types/node/fs/promises.d.ts
+++ b/types/node/fs/promises.d.ts
@@ -20,7 +20,6 @@ declare module "node:fs/promises" {
         CopyOptions,
         Dir,
         Dirent,
-        DisposableTempDir,
         EncodingOption,
         GlobOptions,
         GlobOptionsWithFileTypes,
@@ -980,6 +979,20 @@ declare module "node:fs/promises" {
         prefix: string,
         options?: ObjectEncodingOptions | BufferEncoding | null,
     ): Promise<string | NonSharedBuffer>;
+    interface DisposableTempDir extends AsyncDisposable {
+        /**
+         * The path of the created directory.
+         */
+        path: string;
+        /**
+         * A function which removes the created directory.
+         */
+        remove(): Promise<void>;
+        /**
+         * The same as `remove`.
+         */
+        [Symbol.asyncDispose](): Promise<void>;
+    }
     /**
      * The resulting Promise holds an async-disposable object whose `path` property
      * holds the created directory path. When the object is disposed, the directory

--- a/types/node/node-tests/fs.ts
+++ b/types/node/node-tests/fs.ts
@@ -238,10 +238,10 @@ async function testPromisify() {
     const disposable = fs.mkdtempDisposableSync("/tmp/foo-");
     // $ExpectType string
     disposable.path;
-    // $ExpectType Promise<void>
+    // $ExpectType void
     disposable.remove();
-    // $ExpectType Promise<void>
-    disposable[Symbol.asyncDispose]();
+    // $ExpectType void
+    disposable[Symbol.dispose]();
 
     fs.promises.mkdtempDisposable("/tmp/foo-").then((result) => {
         // $ExpectType string

--- a/types/node/v24/fs.d.ts
+++ b/types/node/v24/fs.d.ts
@@ -2193,7 +2193,7 @@ declare module "fs" {
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
     export function mkdtempSync(prefix: string, options?: EncodingOption): string | NonSharedBuffer;
-    export interface DisposableTempDir extends AsyncDisposable {
+    export interface DisposableTempDir extends Disposable {
         /**
          * The path of the created directory.
          */
@@ -2201,11 +2201,11 @@ declare module "fs" {
         /**
          * A function which removes the created directory.
          */
-        remove(): Promise<void>;
+        remove(): void;
         /**
          * The same as `remove`.
          */
-        [Symbol.asyncDispose](): Promise<void>;
+        [Symbol.dispose](): void;
     }
     /**
      * Returns a disposable object whose `path` property holds the created directory

--- a/types/node/v24/fs/promises.d.ts
+++ b/types/node/v24/fs/promises.d.ts
@@ -21,7 +21,6 @@ declare module "fs/promises" {
         CopyOptions,
         Dir,
         Dirent,
-        DisposableTempDir,
         EncodingOption,
         GlobOptions,
         GlobOptionsWithFileTypes,
@@ -981,6 +980,20 @@ declare module "fs/promises" {
         prefix: string,
         options?: ObjectEncodingOptions | BufferEncoding | null,
     ): Promise<string | NonSharedBuffer>;
+    interface DisposableTempDir extends AsyncDisposable {
+        /**
+         * The path of the created directory.
+         */
+        path: string;
+        /**
+         * A function which removes the created directory.
+         */
+        remove(): Promise<void>;
+        /**
+         * The same as `remove`.
+         */
+        [Symbol.asyncDispose](): Promise<void>;
+    }
     /**
      * The resulting Promise holds an async-disposable object whose `path` property
      * holds the created directory path. When the object is disposed, the directory

--- a/types/node/v24/test/fs.ts
+++ b/types/node/v24/test/fs.ts
@@ -238,10 +238,10 @@ async function testPromisify() {
     const disposable = fs.mkdtempDisposableSync("/tmp/foo-");
     // $ExpectType string
     disposable.path;
-    // $ExpectType Promise<void>
+    // $ExpectType void
     disposable.remove();
-    // $ExpectType Promise<void>
-    disposable[Symbol.asyncDispose]();
+    // $ExpectType void
+    disposable[Symbol.dispose]();
 
     fs.promises.mkdtempDisposable("/tmp/foo-").then((result) => {
         // $ExpectType string


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/blob/v24.12.0/lib/fs.js#L3060-L3069 https://github.com/nodejs/node/blob/v24.12.0/lib/internal/fs/promises.js#L1208-L1223
https://nodejs.org/dist/latest-v24.x/docs/api/fs.html#fsmkdtempdisposablesyncprefix-options
https://github.com/nodejs/node/blob/main/lib/fs.js#L3037-L3046
https://github.com/nodejs/node/blob/main/lib/internal/fs/promises.js#L1208-L1223
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
