### PR TITLE
node: revert polarity of EventEmitter ↔ NodeJS.EventEmitter heritage in v25

### DIFF
--- a/types/node/events.d.ts
+++ b/types/node/events.d.ts
@@ -88,376 +88,390 @@ declare module "node:events" {
      */
     class EventEmitter<T extends EventMap<T> = any> {
         constructor(options?: EventEmitterOptions);
-        /**
-         * The `Symbol.for('nodejs.rejection')` method is called in case a
-         * promise rejection happens when emitting an event and
-         * `captureRejections` is enabled on the emitter.
-         * It is possible to use `events.captureRejectionSymbol` in
-         * place of `Symbol.for('nodejs.rejection')`.
-         *
-         * ```js
-         * import { EventEmitter, captureRejectionSymbol } from 'node:events';
-         *
-         * class MyClass extends EventEmitter {
-         *   constructor() {
-         *     super({ captureRejections: true });
-         *   }
-         *
-         *   [captureRejectionSymbol](err, event, ...args) {
-         *     console.log('rejection happened for', event, 'with', err, ...args);
-         *     this.destroy(err);
-         *   }
-         *
-         *   destroy(err) {
-         *     // Tear the resource down here.
-         *   }
-         * }
-         * ```
-         * @since v13.4.0, v12.16.0
-         */
-        [EventEmitter.captureRejectionSymbol]?(error: Error, event: string | symbol, ...args: any[]): void;
-        /**
-         * Alias for `emitter.on(eventName, listener)`.
-         * @since v0.1.26
-         */
-        addListener<E extends string | symbol>(eventName: EventNames<T, E>, listener: Listener<T, E>): this;
-        /**
-         * Synchronously calls each of the listeners registered for the event named
-         * `eventName`, in the order they were registered, passing the supplied arguments
-         * to each.
-         *
-         * Returns `true` if the event had listeners, `false` otherwise.
-         *
-         * ```js
-         * import { EventEmitter } from 'node:events';
-         * const myEmitter = new EventEmitter();
-         *
-         * // First listener
-         * myEmitter.on('event', function firstListener() {
-         *   console.log('Helloooo! first listener');
-         * });
-         * // Second listener
-         * myEmitter.on('event', function secondListener(arg1, arg2) {
-         *   console.log(`event with parameters ${arg1}, ${arg2} in second listener`);
-         * });
-         * // Third listener
-         * myEmitter.on('event', function thirdListener(...args) {
-         *   const parameters = args.join(', ');
-         *   console.log(`event with parameters ${parameters} in third listener`);
-         * });
-         *
-         * console.log(myEmitter.listeners('event'));
-         *
-         * myEmitter.emit('event', 1, 2, 3, 4, 5);
-         *
-         * // Prints:
-         * // [
-         * //   [Function: firstListener],
-         * //   [Function: secondListener],
-         * //   [Function: thirdListener]
-         * // ]
-         * // Helloooo! first listener
-         * // event with parameters 1, 2 in second listener
-         * // event with parameters 1, 2, 3, 4, 5 in third listener
-         * ```
-         * @since v0.1.26
-         */
-        emit<E extends string | symbol>(eventName: EventNames<T, E>, ...args: Args<T, E>): boolean;
-        /**
-         * Returns an array listing the events for which the emitter has registered
-         * listeners.
-         *
-         * ```js
-         * import { EventEmitter } from 'node:events';
-         *
-         * const myEE = new EventEmitter();
-         * myEE.on('foo', () => {});
-         * myEE.on('bar', () => {});
-         *
-         * const sym = Symbol('symbol');
-         * myEE.on(sym, () => {});
-         *
-         * console.log(myEE.eventNames());
-         * // Prints: [ 'foo', 'bar', Symbol(symbol) ]
-         * ```
-         * @since v6.0.0
-         */
-        eventNames(): (string | symbol)[];
-        /**
-         * Returns the current max listener value for the `EventEmitter` which is either
-         * set by `emitter.setMaxListeners(n)` or defaults to
-         * `events.defaultMaxListeners`.
-         * @since v1.0.0
-         */
-        getMaxListeners(): number;
-        /**
-         * Returns the number of listeners listening for the event named `eventName`.
-         * If `listener` is provided, it will return how many times the listener is found
-         * in the list of the listeners of the event.
-         * @since v3.2.0
-         * @param eventName The name of the event being listened for
-         * @param listener The event handler function
-         */
-        listenerCount<E extends string | symbol>(eventName: EventNames<T, E>, listener?: Listener<T, E>): number;
-        /**
-         * Returns a copy of the array of listeners for the event named `eventName`.
-         *
-         * ```js
-         * server.on('connection', (stream) => {
-         *   console.log('someone connected!');
-         * });
-         * console.log(util.inspect(server.listeners('connection')));
-         * // Prints: [ [Function] ]
-         * ```
-         * @since v0.1.26
-         */
-        listeners<E extends string | symbol>(eventName: EventNames<T, E>): Listener<T, E>[];
-        /**
-         * Alias for `emitter.removeListener()`.
-         * @since v10.0.0
-         */
-        off<E extends string | symbol>(eventName: EventNames<T, E>, listener: Listener<T, E>): this;
-        /**
-         * Adds the `listener` function to the end of the listeners array for the
-         * event named `eventName`. No checks are made to see if the `listener` has
-         * already been added. Multiple calls passing the same combination of `eventName`
-         * and `listener` will result in the `listener` being added, and called, multiple
-         * times.
-         *
-         * ```js
-         * server.on('connection', (stream) => {
-         *   console.log('someone connected!');
-         * });
-         * ```
-         *
-         * Returns a reference to the `EventEmitter`, so that calls can be chained.
-         *
-         * By default, event listeners are invoked in the order they are added. The
-         * `emitter.prependListener()` method can be used as an alternative to add the
-         * event listener to the beginning of the listeners array.
-         *
-         * ```js
-         * import { EventEmitter } from 'node:events';
-         * const myEE = new EventEmitter();
-         * myEE.on('foo', () => console.log('a'));
-         * myEE.prependListener('foo', () => console.log('b'));
-         * myEE.emit('foo');
-         * // Prints:
-         * //   b
-         * //   a
-         * ```
-         * @since v0.1.101
-         * @param eventName The name of the event.
-         * @param listener The callback function
-         */
-        on<E extends string | symbol>(eventName: EventNames<T, E>, listener: Listener<T, E>): this;
-        /**
-         * Adds a **one-time** `listener` function for the event named `eventName`. The
-         * next time `eventName` is triggered, this listener is removed and then invoked.
-         *
-         * ```js
-         * server.once('connection', (stream) => {
-         *   console.log('Ah, we have our first user!');
-         * });
-         * ```
-         *
-         * Returns a reference to the `EventEmitter`, so that calls can be chained.
-         *
-         * By default, event listeners are invoked in the order they are added. The
-         * `emitter.prependOnceListener()` method can be used as an alternative to add the
-         * event listener to the beginning of the listeners array.
-         *
-         * ```js
-         * import { EventEmitter } from 'node:events';
-         * const myEE = new EventEmitter();
-         * myEE.once('foo', () => console.log('a'));
-         * myEE.prependOnceListener('foo', () => console.log('b'));
-         * myEE.emit('foo');
-         * // Prints:
-         * //   b
-         * //   a
-         * ```
-         * @since v0.3.0
-         * @param eventName The name of the event.
-         * @param listener The callback function
-         */
-        once<E extends string | symbol>(eventName: EventNames<T, E>, listener: Listener<T, E>): this;
-        /**
-         * Adds the `listener` function to the _beginning_ of the listeners array for the
-         * event named `eventName`. No checks are made to see if the `listener` has
-         * already been added. Multiple calls passing the same combination of `eventName`
-         * and `listener` will result in the `listener` being added, and called, multiple
-         * times.
-         *
-         * ```js
-         * server.prependListener('connection', (stream) => {
-         *   console.log('someone connected!');
-         * });
-         * ```
-         *
-         * Returns a reference to the `EventEmitter`, so that calls can be chained.
-         * @since v6.0.0
-         * @param eventName The name of the event.
-         * @param listener The callback function
-         */
-        prependListener<E extends string | symbol>(eventName: EventNames<T, E>, listener: Listener<T, E>): this;
-        /**
-         * Adds a **one-time** `listener` function for the event named `eventName` to the
-         * _beginning_ of the listeners array. The next time `eventName` is triggered, this
-         * listener is removed, and then invoked.
-         *
-         * ```js
-         * server.prependOnceListener('connection', (stream) => {
-         *   console.log('Ah, we have our first user!');
-         * });
-         * ```
-         *
-         * Returns a reference to the `EventEmitter`, so that calls can be chained.
-         * @since v6.0.0
-         * @param eventName The name of the event.
-         * @param listener The callback function
-         */
-        prependOnceListener<E extends string | symbol>(eventName: EventNames<T, E>, listener: Listener<T, E>): this;
-        /**
-         * Returns a copy of the array of listeners for the event named `eventName`,
-         * including any wrappers (such as those created by `.once()`).
-         *
-         * ```js
-         * import { EventEmitter } from 'node:events';
-         * const emitter = new EventEmitter();
-         * emitter.once('log', () => console.log('log once'));
-         *
-         * // Returns a new Array with a function `onceWrapper` which has a property
-         * // `listener` which contains the original listener bound above
-         * const listeners = emitter.rawListeners('log');
-         * const logFnWrapper = listeners[0];
-         *
-         * // Logs "log once" to the console and does not unbind the `once` event
-         * logFnWrapper.listener();
-         *
-         * // Logs "log once" to the console and removes the listener
-         * logFnWrapper();
-         *
-         * emitter.on('log', () => console.log('log persistently'));
-         * // Will return a new Array with a single function bound by `.on()` above
-         * const newListeners = emitter.rawListeners('log');
-         *
-         * // Logs "log persistently" twice
-         * newListeners[0]();
-         * emitter.emit('log');
-         * ```
-         * @since v9.4.0
-         */
-        rawListeners<E extends string | symbol>(eventName: EventNames<T, E>): Listener<T, E>[];
-        /**
-         * Removes all listeners, or those of the specified `eventName`.
-         *
-         * It is bad practice to remove listeners added elsewhere in the code,
-         * particularly when the `EventEmitter` instance was created by some other
-         * component or module (e.g. sockets or file streams).
-         *
-         * Returns a reference to the `EventEmitter`, so that calls can be chained.
-         * @since v0.1.26
-         */
-        removeAllListeners<E extends string | symbol>(eventName?: EventNames<T, E>): this;
-        /**
-         * Removes the specified `listener` from the listener array for the event named
-         * `eventName`.
-         *
-         * ```js
-         * const callback = (stream) => {
-         *   console.log('someone connected!');
-         * };
-         * server.on('connection', callback);
-         * // ...
-         * server.removeListener('connection', callback);
-         * ```
-         *
-         * `removeListener()` will remove, at most, one instance of a listener from the
-         * listener array. If any single listener has been added multiple times to the
-         * listener array for the specified `eventName`, then `removeListener()` must be
-         * called multiple times to remove each instance.
-         *
-         * Once an event is emitted, all listeners attached to it at the
-         * time of emitting are called in order. This implies that any
-         * `removeListener()` or `removeAllListeners()` calls _after_ emitting and
-         * _before_ the last listener finishes execution will not remove them from
-         * `emit()` in progress. Subsequent events behave as expected.
-         *
-         * ```js
-         * import { EventEmitter } from 'node:events';
-         * class MyEmitter extends EventEmitter {}
-         * const myEmitter = new MyEmitter();
-         *
-         * const callbackA = () => {
-         *   console.log('A');
-         *   myEmitter.removeListener('event', callbackB);
-         * };
-         *
-         * const callbackB = () => {
-         *   console.log('B');
-         * };
-         *
-         * myEmitter.on('event', callbackA);
-         *
-         * myEmitter.on('event', callbackB);
-         *
-         * // callbackA removes listener callbackB but it will still be called.
-         * // Internal listener array at time of emit [callbackA, callbackB]
-         * myEmitter.emit('event');
-         * // Prints:
-         * //   A
-         * //   B
-         *
-         * // callbackB is now removed.
-         * // Internal listener array [callbackA]
-         * myEmitter.emit('event');
-         * // Prints:
-         * //   A
-         * ```
-         *
-         * Because listeners are managed using an internal array, calling this will
-         * change the position indexes of any listener registered _after_ the listener
-         * being removed. This will not impact the order in which listeners are called,
-         * but it means that any copies of the listener array as returned by
-         * the `emitter.listeners()` method will need to be recreated.
-         *
-         * When a single function has been added as a handler multiple times for a single
-         * event (as in the example below), `removeListener()` will remove the most
-         * recently added instance. In the example the `once('ping')`
-         * listener is removed:
-         *
-         * ```js
-         * import { EventEmitter } from 'node:events';
-         * const ee = new EventEmitter();
-         *
-         * function pong() {
-         *   console.log('pong');
-         * }
-         *
-         * ee.on('ping', pong);
-         * ee.once('ping', pong);
-         * ee.removeListener('ping', pong);
-         *
-         * ee.emit('ping');
-         * ee.emit('ping');
-         * ```
-         *
-         * Returns a reference to the `EventEmitter`, so that calls can be chained.
-         * @since v0.1.26
-         */
-        removeListener<E extends string | symbol>(eventName: EventNames<T, E>, listener: Listener<T, E>): this;
-        /**
-         * By default `EventEmitter`s will print a warning if more than `10` listeners are
-         * added for a particular event. This is a useful default that helps finding
-         * memory leaks. The `emitter.setMaxListeners()` method allows the limit to be
-         * modified for this specific `EventEmitter` instance. The value can be set to
-         * `Infinity` (or `0`) to indicate an unlimited number of listeners.
-         *
-         * Returns a reference to the `EventEmitter`, so that calls can be chained.
-         * @since v0.3.5
-         */
-        setMaxListeners(n: number): this;
+    }
+    interface EventEmitter<T extends EventMap<T> = any> extends NodeJS.EventEmitter<T> {}
+    global {
+        namespace NodeJS {
+            interface EventEmitter<T extends EventMap<T> = any> {
+                /**
+                 * The `Symbol.for('nodejs.rejection')` method is called in case a
+                 * promise rejection happens when emitting an event and
+                 * `captureRejections` is enabled on the emitter.
+                 * It is possible to use `events.captureRejectionSymbol` in
+                 * place of `Symbol.for('nodejs.rejection')`.
+                 *
+                 * ```js
+                 * import { EventEmitter, captureRejectionSymbol } from 'node:events';
+                 *
+                 * class MyClass extends EventEmitter {
+                 *   constructor() {
+                 *     super({ captureRejections: true });
+                 *   }
+                 *
+                 *   [captureRejectionSymbol](err, event, ...args) {
+                 *     console.log('rejection happened for', event, 'with', err, ...args);
+                 *     this.destroy(err);
+                 *   }
+                 *
+                 *   destroy(err) {
+                 *     // Tear the resource down here.
+                 *   }
+                 * }
+                 * ```
+                 * @since v13.4.0, v12.16.0
+                 */
+                [EventEmitter.captureRejectionSymbol]?(error: Error, event: string | symbol, ...args: any[]): void;
+                /**
+                 * Alias for `emitter.on(eventName, listener)`.
+                 * @since v0.1.26
+                 */
+                addListener<E extends string | symbol>(eventName: EventNames<T, E>, listener: Listener<T, E>): this;
+                /**
+                 * Synchronously calls each of the listeners registered for the event named
+                 * `eventName`, in the order they were registered, passing the supplied arguments
+                 * to each.
+                 *
+                 * Returns `true` if the event had listeners, `false` otherwise.
+                 *
+                 * ```js
+                 * import { EventEmitter } from 'node:events';
+                 * const myEmitter = new EventEmitter();
+                 *
+                 * // First listener
+                 * myEmitter.on('event', function firstListener() {
+                 *   console.log('Helloooo! first listener');
+                 * });
+                 * // Second listener
+                 * myEmitter.on('event', function secondListener(arg1, arg2) {
+                 *   console.log(`event with parameters ${arg1}, ${arg2} in second listener`);
+                 * });
+                 * // Third listener
+                 * myEmitter.on('event', function thirdListener(...args) {
+                 *   const parameters = args.join(', ');
+                 *   console.log(`event with parameters ${parameters} in third listener`);
+                 * });
+                 *
+                 * console.log(myEmitter.listeners('event'));
+                 *
+                 * myEmitter.emit('event', 1, 2, 3, 4, 5);
+                 *
+                 * // Prints:
+                 * // [
+                 * //   [Function: firstListener],
+                 * //   [Function: secondListener],
+                 * //   [Function: thirdListener]
+                 * // ]
+                 * // Helloooo! first listener
+                 * // event with parameters 1, 2 in second listener
+                 * // event with parameters 1, 2, 3, 4, 5 in third listener
+                 * ```
+                 * @since v0.1.26
+                 */
+                emit<E extends string | symbol>(eventName: EventNames<T, E>, ...args: Args<T, E>): boolean;
+                /**
+                 * Returns an array listing the events for which the emitter has registered
+                 * listeners.
+                 *
+                 * ```js
+                 * import { EventEmitter } from 'node:events';
+                 *
+                 * const myEE = new EventEmitter();
+                 * myEE.on('foo', () => {});
+                 * myEE.on('bar', () => {});
+                 *
+                 * const sym = Symbol('symbol');
+                 * myEE.on(sym, () => {});
+                 *
+                 * console.log(myEE.eventNames());
+                 * // Prints: [ 'foo', 'bar', Symbol(symbol) ]
+                 * ```
+                 * @since v6.0.0
+                 */
+                eventNames(): (string | symbol)[];
+                /**
+                 * Returns the current max listener value for the `EventEmitter` which is either
+                 * set by `emitter.setMaxListeners(n)` or defaults to
+                 * `events.defaultMaxListeners`.
+                 * @since v1.0.0
+                 */
+                getMaxListeners(): number;
+                /**
+                 * Returns the number of listeners listening for the event named `eventName`.
+                 * If `listener` is provided, it will return how many times the listener is found
+                 * in the list of the listeners of the event.
+                 * @since v3.2.0
+                 * @param eventName The name of the event being listened for
+                 * @param listener The event handler function
+                 */
+                listenerCount<E extends string | symbol>(
+                    eventName: EventNames<T, E>,
+                    listener?: Listener<T, E>,
+                ): number;
+                /**
+                 * Returns a copy of the array of listeners for the event named `eventName`.
+                 *
+                 * ```js
+                 * server.on('connection', (stream) => {
+                 *   console.log('someone connected!');
+                 * });
+                 * console.log(util.inspect(server.listeners('connection')));
+                 * // Prints: [ [Function] ]
+                 * ```
+                 * @since v0.1.26
+                 */
+                listeners<E extends string | symbol>(eventName: EventNames<T, E>): Listener<T, E>[];
+                /**
+                 * Alias for `emitter.removeListener()`.
+                 * @since v10.0.0
+                 */
+                off<E extends string | symbol>(eventName: EventNames<T, E>, listener: Listener<T, E>): this;
+                /**
+                 * Adds the `listener` function to the end of the listeners array for the
+                 * event named `eventName`. No checks are made to see if the `listener` has
+                 * already been added. Multiple calls passing the same combination of `eventName`
+                 * and `listener` will result in the `listener` being added, and called, multiple
+                 * times.
+                 *
+                 * ```js
+                 * server.on('connection', (stream) => {
+                 *   console.log('someone connected!');
+                 * });
+                 * ```
+                 *
+                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
+                 *
+                 * By default, event listeners are invoked in the order they are added. The
+                 * `emitter.prependListener()` method can be used as an alternative to add the
+                 * event listener to the beginning of the listeners array.
+                 *
+                 * ```js
+                 * import { EventEmitter } from 'node:events';
+                 * const myEE = new EventEmitter();
+                 * myEE.on('foo', () => console.log('a'));
+                 * myEE.prependListener('foo', () => console.log('b'));
+                 * myEE.emit('foo');
+                 * // Prints:
+                 * //   b
+                 * //   a
+                 * ```
+                 * @since v0.1.101
+                 * @param eventName The name of the event.
+                 * @param listener The callback function
+                 */
+                on<E extends string | symbol>(eventName: EventNames<T, E>, listener: Listener<T, E>): this;
+                /**
+                 * Adds a **one-time** `listener` function for the event named `eventName`. The
+                 * next time `eventName` is triggered, this listener is removed and then invoked.
+                 *
+                 * ```js
+                 * server.once('connection', (stream) => {
+                 *   console.log('Ah, we have our first user!');
+                 * });
+                 * ```
+                 *
+                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
+                 *
+                 * By default, event listeners are invoked in the order they are added. The
+                 * `emitter.prependOnceListener()` method can be used as an alternative to add the
+                 * event listener to the beginning of the listeners array.
+                 *
+                 * ```js
+                 * import { EventEmitter } from 'node:events';
+                 * const myEE = new EventEmitter();
+                 * myEE.once('foo', () => console.log('a'));
+                 * myEE.prependOnceListener('foo', () => console.log('b'));
+                 * myEE.emit('foo');
+                 * // Prints:
+                 * //   b
+                 * //   a
+                 * ```
+                 * @since v0.3.0
+                 * @param eventName The name of the event.
+                 * @param listener The callback function
+                 */
+                once<E extends string | symbol>(eventName: EventNames<T, E>, listener: Listener<T, E>): this;
+                /**
+                 * Adds the `listener` function to the _beginning_ of the listeners array for the
+                 * event named `eventName`. No checks are made to see if the `listener` has
+                 * already been added. Multiple calls passing the same combination of `eventName`
+                 * and `listener` will result in the `listener` being added, and called, multiple
+                 * times.
+                 *
+                 * ```js
+                 * server.prependListener('connection', (stream) => {
+                 *   console.log('someone connected!');
+                 * });
+                 * ```
+                 *
+                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
+                 * @since v6.0.0
+                 * @param eventName The name of the event.
+                 * @param listener The callback function
+                 */
+                prependListener<E extends string | symbol>(eventName: EventNames<T, E>, listener: Listener<T, E>): this;
+                /**
+                 * Adds a **one-time** `listener` function for the event named `eventName` to the
+                 * _beginning_ of the listeners array. The next time `eventName` is triggered, this
+                 * listener is removed, and then invoked.
+                 *
+                 * ```js
+                 * server.prependOnceListener('connection', (stream) => {
+                 *   console.log('Ah, we have our first user!');
+                 * });
+                 * ```
+                 *
+                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
+                 * @since v6.0.0
+                 * @param eventName The name of the event.
+                 * @param listener The callback function
+                 */
+                prependOnceListener<E extends string | symbol>(
+                    eventName: EventNames<T, E>,
+                    listener: Listener<T, E>,
+                ): this;
+                /**
+                 * Returns a copy of the array of listeners for the event named `eventName`,
+                 * including any wrappers (such as those created by `.once()`).
+                 *
+                 * ```js
+                 * import { EventEmitter } from 'node:events';
+                 * const emitter = new EventEmitter();
+                 * emitter.once('log', () => console.log('log once'));
+                 *
+                 * // Returns a new Array with a function `onceWrapper` which has a property
+                 * // `listener` which contains the original listener bound above
+                 * const listeners = emitter.rawListeners('log');
+                 * const logFnWrapper = listeners[0];
+                 *
+                 * // Logs "log once" to the console and does not unbind the `once` event
+                 * logFnWrapper.listener();
+                 *
+                 * // Logs "log once" to the console and removes the listener
+                 * logFnWrapper();
+                 *
+                 * emitter.on('log', () => console.log('log persistently'));
+                 * // Will return a new Array with a single function bound by `.on()` above
+                 * const newListeners = emitter.rawListeners('log');
+                 *
+                 * // Logs "log persistently" twice
+                 * newListeners[0]();
+                 * emitter.emit('log');
+                 * ```
+                 * @since v9.4.0
+                 */
+                rawListeners<E extends string | symbol>(eventName: EventNames<T, E>): Listener<T, E>[];
+                /**
+                 * Removes all listeners, or those of the specified `eventName`.
+                 *
+                 * It is bad practice to remove listeners added elsewhere in the code,
+                 * particularly when the `EventEmitter` instance was created by some other
+                 * component or module (e.g. sockets or file streams).
+                 *
+                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
+                 * @since v0.1.26
+                 */
+                // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
+                removeAllListeners<E extends string | symbol>(eventName?: EventNames<T, E>): this;
+                /**
+                 * Removes the specified `listener` from the listener array for the event named
+                 * `eventName`.
+                 *
+                 * ```js
+                 * const callback = (stream) => {
+                 *   console.log('someone connected!');
+                 * };
+                 * server.on('connection', callback);
+                 * // ...
+                 * server.removeListener('connection', callback);
+                 * ```
+                 *
+                 * `removeListener()` will remove, at most, one instance of a listener from the
+                 * listener array. If any single listener has been added multiple times to the
+                 * listener array for the specified `eventName`, then `removeListener()` must be
+                 * called multiple times to remove each instance.
+                 *
+                 * Once an event is emitted, all listeners attached to it at the
+                 * time of emitting are called in order. This implies that any
+                 * `removeListener()` or `removeAllListeners()` calls _after_ emitting and
+                 * _before_ the last listener finishes execution will not remove them from
+                 * `emit()` in progress. Subsequent events behave as expected.
+                 *
+                 * ```js
+                 * import { EventEmitter } from 'node:events';
+                 * class MyEmitter extends EventEmitter {}
+                 * const myEmitter = new MyEmitter();
+                 *
+                 * const callbackA = () => {
+                 *   console.log('A');
+                 *   myEmitter.removeListener('event', callbackB);
+                 * };
+                 *
+                 * const callbackB = () => {
+                 *   console.log('B');
+                 * };
+                 *
+                 * myEmitter.on('event', callbackA);
+                 *
+                 * myEmitter.on('event', callbackB);
+                 *
+                 * // callbackA removes listener callbackB but it will still be called.
+                 * // Internal listener array at time of emit [callbackA, callbackB]
+                 * myEmitter.emit('event');
+                 * // Prints:
+                 * //   A
+                 * //   B
+                 *
+                 * // callbackB is now removed.
+                 * // Internal listener array [callbackA]
+                 * myEmitter.emit('event');
+                 * // Prints:
+                 * //   A
+                 * ```
+                 *
+                 * Because listeners are managed using an internal array, calling this will
+                 * change the position indexes of any listener registered _after_ the listener
+                 * being removed. This will not impact the order in which listeners are called,
+                 * but it means that any copies of the listener array as returned by
+                 * the `emitter.listeners()` method will need to be recreated.
+                 *
+                 * When a single function has been added as a handler multiple times for a single
+                 * event (as in the example below), `removeListener()` will remove the most
+                 * recently added instance. In the example the `once('ping')`
+                 * listener is removed:
+                 *
+                 * ```js
+                 * import { EventEmitter } from 'node:events';
+                 * const ee = new EventEmitter();
+                 *
+                 * function pong() {
+                 *   console.log('pong');
+                 * }
+                 *
+                 * ee.on('ping', pong);
+                 * ee.once('ping', pong);
+                 * ee.removeListener('ping', pong);
+                 *
+                 * ee.emit('ping');
+                 * ee.emit('ping');
+                 * ```
+                 *
+                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
+                 * @since v0.1.26
+                 */
+                removeListener<E extends string | symbol>(eventName: EventNames<T, E>, listener: Listener<T, E>): this;
+                /**
+                 * By default `EventEmitter`s will print a warning if more than `10` listeners are
+                 * added for a particular event. This is a useful default that helps finding
+                 * memory leaks. The `emitter.setMaxListeners()` method allows the limit to be
+                 * modified for this specific `EventEmitter` instance. The value can be set to
+                 * `Infinity` (or `0`) to indicate an unlimited number of listeners.
+                 *
+                 * Returns a reference to the `EventEmitter`, so that calls can be chained.
+                 * @since v0.3.5
+                 */
+                setMaxListeners(n: number): this;
+            }
+        }
     }
     namespace EventEmitter {
         export { EventEmitter, EventEmitterEventMap, EventEmitterOptions };
@@ -592,7 +606,7 @@ declare module "node:events" {
          * ```
          * @since v15.2.0, v14.17.0
          */
-        function getEventListeners(emitter: NodeJS.EventEmitter, name: string | symbol): ((...args: any[]) => void)[];
+        function getEventListeners(emitter: EventEmitter, name: string | symbol): ((...args: any[]) => void)[];
         function getEventListeners(emitter: EventTarget, name: string): ((...args: any[]) => void)[];
         /**
          * Returns the currently set max amount of listeners.
@@ -622,7 +636,7 @@ declare module "node:events" {
          * ```
          * @since v19.9.0
          */
-        function getMaxListeners(emitter: NodeJS.EventEmitter | EventTarget): number;
+        function getMaxListeners(emitter: EventEmitter | EventTarget): number;
         /**
          * A class method that returns the number of listeners for the given `eventName`
          * registered on the given `emitter`.
@@ -641,7 +655,7 @@ declare module "node:events" {
          * @param emitter The emitter to query
          * @param eventName The event name
          */
-        function listenerCount(emitter: NodeJS.EventEmitter, eventName: string | symbol): number;
+        function listenerCount(emitter: EventEmitter, eventName: string | symbol): number;
         interface OnOptions extends Abortable {
             /**
              * Names of events that will end the iteration.
@@ -721,7 +735,7 @@ declare module "node:events" {
          * @returns `AsyncIterator` that iterates `eventName` events emitted by the `emitter`
          */
         function on(
-            emitter: NodeJS.EventEmitter,
+            emitter: EventEmitter,
             eventName: string | symbol,
             options?: OnOptions,
         ): NodeJS.AsyncIterator<any[]>;
@@ -812,7 +826,7 @@ declare module "node:events" {
          * @since v11.13.0, v10.16.0
          */
         function once(
-            emitter: NodeJS.EventEmitter,
+            emitter: EventEmitter,
             eventName: string | symbol,
             options?: OnceOptions,
         ): Promise<any[]>;
@@ -833,7 +847,7 @@ declare module "node:events" {
          * max for all newly created `EventTarget` and `EventEmitter` objects.
          * objects.
          */
-        function setMaxListeners(n: number, ...eventTargets: ReadonlyArray<NodeJS.EventEmitter | EventTarget>): void;
+        function setMaxListeners(n: number, ...eventTargets: ReadonlyArray<EventEmitter | EventTarget>): void;
         /**
          * This is the interface from which event-emitting Node.js APIs inherit in the types package.
          * **It is not intended for consumer use.**
@@ -1031,12 +1045,6 @@ declare module "node:events" {
         type InternalEventTargetEventProperties<T> = {
             [K in keyof T & string as `on${K}`]: ((ev: T[K]) => void) | null;
         };
-    }
-    global {
-        import _ = EventEmitter;
-        namespace NodeJS {
-            interface EventEmitter<T extends EventMap<T> = any> extends _<T> {}
-        }
     }
     export = EventEmitter;
 }


### PR DESCRIPTION
Consolidating the class definition seemed sensible, but there's probably still enough third-party augmentation targeted at the `NodeJS.EventEmitter` interface that the previous arrangement (`import("node:events").EventEmitter` inheriting from `NodeJS.EventEmitter`) probably needs to remain.

This also fixes a previously unseen issue where the `import _ = ...` statement raises TS2667 in particular project environments, if the compiler deems @types/node's module definition to be an augmentation rather than the primary declaration.