### PR TITLE
[dom-chromium-ai] disallow `prefix` in `initialPrompts`

### DIFF
--- a/types/dom-chromium-ai/dom-chromium-ai-tests.ts
+++ b/types/dom-chromium-ai/dom-chromium-ai-tests.ts
@@ -2,8 +2,13 @@ async function topLevel() {
     // Language Model
 
     await LanguageModel.create({
-        // @ts-expect-error - System prompt must be first element of the initialPrompt array.
+        // @ts-expect-error - System prompt must be first element of the initialPrompts array.
         initialPrompts: [{ role: "user", content: "foo" }, { role: "system", content: "foo" }],
+    });
+
+    await LanguageModel.create({
+        // @ts-expect-error - Prefixes are not allowed in initialPrompts.
+        initialPrompts: [{ role: "assistant", content: "foo", prefix: true }],
     });
 
     const languageModel = await LanguageModel.create({

--- a/types/dom-chromium-ai/index.d.ts
+++ b/types/dom-chromium-ai/index.d.ts
@@ -146,10 +146,16 @@ interface LanguageModelToolFunction {
     (...args: any[]): Promise<string>;
 }
 
-type LanguageModelPrompt = LanguageModelMessage[] | string;
+type LanguageModelPrompt = (LanguageModelMessage | LanguageModelAssistantMessage)[] | string;
 
 interface LanguageModelMessage {
     role: LanguageModelMessageRole;
+    content: LanguageModelMessageContent[] | string;
+}
+
+// Not in IDL, split up here for allowing assistant messages with prefix in prompt() and promptStreaming() only
+interface LanguageModelAssistantMessage {
+    role: LanguageModelAssistantMessageRole;
     content: LanguageModelMessageContent[] | string;
     prefix?: boolean;
 }
@@ -165,7 +171,9 @@ interface LanguageModelMessageContent {
     value: LanguageModelMessageValue;
 }
 
-type LanguageModelMessageRole = "user" | "assistant";
+type LanguageModelMessageRole = "user" | LanguageModelAssistantMessageRole;
+// Not in IDL, split up here for allowing assistant messages with prefix in prompt() and promptStreaming() only
+type LanguageModelAssistantMessageRole = "assistant";
 // Not in IDL, split up here for enforcing the system message as the first element
 type LanguageModelSystemMessageRole = "system";
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webmachinelearning/prompt-api?tab=readme-ov-file#constraining-responses-by-providing-a-prefix
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.