### PR TITLE
[cacache] fix types and update version

### DIFF
--- a/types/cacache/cacache-tests.ts
+++ b/types/cacache/cacache-tests.ts
@@ -6,7 +6,7 @@ const cachePath = "";
 cacache.ls(cachePath).then(() => {});
 
 cacache.ls.stream(cachePath).on("data", data => {
-    data; // $ExpectType any
+    data; // $ExpectType Cache
 });
 
 cacache.get(cachePath, "my-thing", { memoize: true }).then(() => {});
@@ -21,7 +21,10 @@ cacache.get
         metadata; // $ExpectType any
     })
     .on("integrity", integrity => {
-        integrity; // $ExpectType any
+        integrity; // $ExpectType string
+    })
+    .on("size", size => {
+        size; // $ExpectType number
     })
     .pipe(fs.createWriteStream("./x.tgz"));
 
@@ -29,7 +32,9 @@ cacache.get.stream.byDigest(cachePath, "sha512-SoMeDIGest+64==").pipe(fs.createW
 
 cacache.get.info(cachePath, "my-thing").then(() => {});
 
-cacache.get.hasContent(cachePath, "sha521-NOT+IN/CACHE==").then(() => {});
+cacache.get.hasContent(cachePath, "sha521-NOT+IN/CACHE==").then((res) => {
+    res; // $ExpectType HasContentObject | false
+});
 
 cacache
     .put(cachePath, "registry.npmjs.org|cacache@1.0.0", Buffer.from([]), {
@@ -43,7 +48,12 @@ cacache
 fs.createReadStream("").pipe(
     cacache.put
         .stream(cachePath, "registry.npmjs.org|cacache@1.0.0")
-        .on("integrity", d => console.log(`integrity digest is ${d}`)),
+        .on("integrity", integrity => {
+            integrity; // $ExpectType string
+        })
+        .on("size", size => {
+            size; // $ExpectType number
+        }),
 );
 
 cacache.rm.all(cachePath).then(() => {

--- a/types/cacache/package.json
+++ b/types/cacache/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/cacache",
-    "version": "19.0.9999",
+    "version": "20.0.9999",
     "projects": [
         "https://github.com/npm/cacache#readme"
     ],

--- a/types/cacache/package.json
+++ b/types/cacache/package.json
@@ -6,7 +6,8 @@
         "https://github.com/npm/cacache#readme"
     ],
     "dependencies": {
-        "@types/node": "*"
+        "@types/node": "*",
+        "minipass": "*"
     },
     "devDependencies": {
         "@types/cacache": "workspace:."


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/npm/cacache
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Some notes:

- The `Minipass` stream API is a bit different from `NodeJS.ReadableStream` and neither fully covers the other ([ts playground](https://www.typescriptlang.org/play/?target=99&module=102&declaration=false#code/JYWwDg9gTgLgBAbzgWWAO2GAhgZx3AXzgDMoIQ4ByEdTXHSgbgChmATAUwGMAbLKDnB4d4WAFwpa2PC069+g4fABGEgHIROAKQDKAOgBKHLGyzLhOmAKwgWzLHAC8cZXeVO4WRkA)). This PR changed all returned streams to use `Minipass` with the correct type parameters. This also fixes the types of the event `'integrity'`, `'size'` and `'metadata'`.
- Changed the return value type of `get.copy`.
- Added missing `get.HasContentObject.stat`.
- Added missing `put.Options.integrityEmitter`.
- Updated package version.