### PR TITLE
[w3c-direct-sockets] Mark members of OpenInfo dictionaries as required.

### DIFF
--- a/types/w3c-direct-sockets/index.d.ts
+++ b/types/w3c-direct-sockets/index.d.ts
@@ -73,10 +73,10 @@ export interface TCPServerSocketOptions {
 export interface SocketOpenInfo {
     readable: ReadableStream;
     writable: WritableStream;
-    remoteAddress: string;
-    remotePort: number;
-    localAddress: string;
-    localPort: number;
+    remoteAddress?: string;
+    remotePort?: number;
+    localAddress?: string;
+    localPort?: number;
 }
 
 export type TCPSocketOpenInfo = SocketOpenInfo;
@@ -87,8 +87,8 @@ export interface UDPSocketOpenInfo extends SocketOpenInfo {
 
 export interface TCPServerSocketOpenInfo {
     readable: ReadableStream;
-    localAddress: string;
-    localPort: number;
+    localAddress?: string;
+    localPort?: number;
 }
 
 declare global {

--- a/types/w3c-direct-sockets/index.d.ts
+++ b/types/w3c-direct-sockets/index.d.ts
@@ -71,12 +71,12 @@ export interface TCPServerSocketOptions {
 }
 
 export interface SocketOpenInfo {
-    readable?: ReadableStream;
-    writable?: WritableStream;
-    remoteAddress?: string;
-    remotePort?: number;
-    localAddress?: string;
-    localPort?: number;
+    readable: ReadableStream;
+    writable: WritableStream;
+    remoteAddress: string;
+    remotePort: number;
+    localAddress: string;
+    localPort: number;
 }
 
 export type TCPSocketOpenInfo = SocketOpenInfo;
@@ -86,9 +86,9 @@ export interface UDPSocketOpenInfo extends SocketOpenInfo {
 }
 
 export interface TCPServerSocketOpenInfo {
-    readable?: ReadableStream;
-    localAddress?: string;
-    localPort?: number;
+    readable: ReadableStream;
+    localAddress: string;
+    localPort: number;
 }
 
 declare global {

--- a/types/w3c-direct-sockets/w3c-direct-sockets-tests.ts
+++ b/types/w3c-direct-sockets/w3c-direct-sockets-tests.ts
@@ -89,6 +89,10 @@ async function testDirectSockets() {
     // --------------------------------------------------------------------------------
     // TCPServerSocket
     // --------------------------------------------------------------------------------
+
+    // @ts-expect-error
+    const invalidTcpServerOpenInfo: TCPServerSocketOpenInfo = {};
+
     const tcpServerOptions: TCPServerSocketOptions = {
         localPort: 0,
         backlog: 5,
@@ -113,23 +117,45 @@ async function testDirectSockets() {
     // Open Info Structures
     // --------------------------------------------------------------------------------
 
-    const udpOpenInfo: UDPSocketOpenInfo = {};
+    const udpOpenInfo: UDPSocketOpenInfo = {
+        readable: {} as ReadableStream,
+        writable: {} as WritableStream, // Only include if your d.ts actually requires this
+        remoteAddress: "127.0.0.1",
+        remotePort: 53,
+        localAddress: "0.0.0.0",
+        localPort: 4500,
+    };
     // $ExpectType MulticastController | undefined
     udpOpenInfo.multicastController;
-    // $ExpectType ReadableStream<any> | undefined
+
+    // $ExpectType ReadableStream<any>
     udpOpenInfo.readable;
 
-    const tcpOpenInfo: TCPSocketOpenInfo = {};
-    // @ts-expect-error
-    tcpOpenInfo.multicastController;
-    // $ExpectType WritableStream<any> | undefined
-    tcpOpenInfo.writable;
+    // ============================================================================
+    // TCPSocketOpenInfo (REQUIRED FIELDS TEST)
+    // ============================================================================
 
-    const tcpServerOpenInfo: TCPServerSocketOpenInfo = {};
-    // $ExpectType ReadableStream<any> | undefined
-    tcpServerOpenInfo.readable;
     // @ts-expect-error
-    tcpServerOpenInfo.writable;
+    const invalidTcpOpenInfo: TCPSocketOpenInfo = {};
+
+    const validTcpOpenInfo: TCPSocketOpenInfo = {
+        readable: {} as ReadableStream,
+        writable: {} as WritableStream,
+        remoteAddress: "127.0.0.1",
+        remotePort: 80,
+        localAddress: "192.168.1.5",
+        localPort: 3000,
+    };
+
+    // $ExpectType ReadableStream<any>
+    validTcpOpenInfo.readable;
+    // $ExpectType WritableStream<any>
+    validTcpOpenInfo.writable;
+    // $ExpectType string
+    validTcpOpenInfo.remoteAddress;
+
+    // @ts-expect-error
+    validTcpOpenInfo.multicastController;
 
     // --------------------------------------------------------------------------------
     // MulticastController

--- a/types/w3c-direct-sockets/w3c-direct-sockets-tests.ts
+++ b/types/w3c-direct-sockets/w3c-direct-sockets-tests.ts
@@ -151,7 +151,7 @@ async function testDirectSockets() {
     validTcpOpenInfo.readable;
     // $ExpectType WritableStream<any>
     validTcpOpenInfo.writable;
-    // $ExpectType string
+    // $ExpectType string | undefined
     validTcpOpenInfo.remoteAddress;
 
     // @ts-expect-error


### PR DESCRIPTION
The opened promise for `TCPSocket` and `TCPServerSocket` is guaranteed to resolve only when the socket is successfully connected or bound.

The implementation in `OnTCPSocketOpened` and `OnTcpServerSocketOpened` ensures that all related metadata (local/remote addresses, ports) and I/O streams are populated before the promise resolves.

This CL updates the WebIDL definitions for TCPSocketOpenInfo and TCPServerSocketOpenInfo to mark these members as required, aligning the IDL with the implementation logic and preventing invalid states where an "open" socket lacks necessary fields.