### PR TITLE
[tabulator-tables] align validator and EditorParams typings with actual Tabulator behavior

### DIFF
--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -1253,7 +1253,7 @@ export interface ColumnDefinition extends ColumnLayout, CellCallbacks {
      *
      * Validators can be applied by using the validator property in a columns definition object (see Define Columns for more details).
      */
-    validator?: StandardValidatorType | StandardValidatorType[] | Validator | Validator[] | string | undefined;
+    validator?: StandardValidatorType | StandardValidatorType[] | Validator | Validator[] | string | undefined | ((cell: CellComponent, value: any) => boolean);
 
     /**
      * Mutators are used to alter data as it is parsed into  For example if you wanted to convert a numeric column into a boolean based on its value, before the data is used to build the table.
@@ -1657,7 +1657,7 @@ export type Editor =
         onRendered: EmptyCallback,
         success: ValueBooleanCallback,
         cancel: ValueVoidCallback,
-        editorParams: {},
+        editorParams: Record<string, unknown>,
     ) => HTMLElement | false);
 
 export type EditorParams =
@@ -1669,7 +1669,7 @@ export type EditorParams =
     | DateParams
     | TimeParams
     | DateTimeEditorParams
-    | ((cell: CellComponent) => {});
+    | ((cell: CellComponent) => Record<string, unknown>);
 
 export type ScrollToRowPosition = "top" | "center" | "bottom" | "nearest";
 export type PopupPosition = ColumnDefinitionAlign | "top" | "bottom";

--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -1253,7 +1253,14 @@ export interface ColumnDefinition extends ColumnLayout, CellCallbacks {
      *
      * Validators can be applied by using the validator property in a columns definition object (see Define Columns for more details).
      */
-    validator?: StandardValidatorType | StandardValidatorType[] | Validator | Validator[] | string | undefined | ((cell: CellComponent, value: any) => boolean);
+    validator?:
+        | StandardValidatorType
+        | StandardValidatorType[]
+        | Validator
+        | Validator[]
+        | string
+        | undefined
+        | ((cell: CellComponent, value: any) => boolean);
 
     /**
      * Mutators are used to alter data as it is parsed into  For example if you wanted to convert a numeric column into a boolean based on its value, before the data is used to build the table.

--- a/types/tabulator-tables/tabulator-tables-tests.ts
+++ b/types/tabulator-tables/tabulator-tables-tests.ts
@@ -385,6 +385,7 @@ colDef.validator = {
 };
 colDef.validator = "float";
 colDef.validator = { type: "float", parameters: {} };
+colDef.validator = (cell, value) => true;
 
 let validators: Validator[] = [
     { type: "integer", parameters: {} },


### PR DESCRIPTION
This PR updates the TypeScript definitions to more accurately reflect Tabulator’s runtime behavior.

Validator typing:
- Allows passing a validator directly as a function ` (cell, value) => boolean`
- While the docs primarily show custom validators wrapped in an object (`{ type, parameters }`), the documentation explicitly states that “you can pass a function to the validator property”, which implies direct function support. This change aligns the typings with that documented intent and existing usage.
https://tabulator.info/docs/6.3/validate#func-custom

EditorParams typing:
- Replaces `{}` with `Record<string, unknown>` for editor parameter objects
- `{}` allows non-object values and prevents safe property access, which breaks valid usage
- `object` is too weak for configuration objects and disallows property access entirely
- `any` would be overly permissive for a public types package

https://tabulator.info/docs/6.3/edit#overview

Although the README recommends avoiding `Object`-like types, `Record<string, unknown>` is used here to model “an object with arbitrary keys” while still preventing primitives and preserving type safety. The actual shape of editor params is editor-specific and user-defined, so a more specific object type is not possible in this case.
