### PR TITLE
[nodemailer] Remove AWS SDK from dependencies, use structural types

### DIFF
--- a/types/nodemailer/lib/ses-transport/index.d.ts
+++ b/types/nodemailer/lib/ses-transport/index.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="node" />
 
-import * as aws from "@aws-sdk/client-sesv2";
 import { EventEmitter } from "node:events";
 
 import { Transport, TransportOptions } from "../..";
@@ -12,25 +11,63 @@ import MailMessage = require("../mailer/mail-message");
 import MimeNode = require("../mime-node");
 
 declare namespace SESTransport {
+    /**
+     * Minimal structural shape of SESv2 SendEmail input.
+     * This is intentionally structural so @types/nodemailer does not require
+     * installing @aws-sdk/client-sesv2.
+     *
+     * If you want the full, exact type, install @aws-sdk/client-sesv2 in your
+     * app and use its types directly in your own code.
+     */
+    interface SendEmailRequestLike {
+        FromEmailAddress?: string;
+        Destination?: {
+            ToAddresses?: string[];
+            CcAddresses?: string[];
+            BccAddresses?: string[];
+        };
+        ReplyToAddresses?: string[];
+        Content?: unknown;
+        EmailTags?: Array<{ Name?: string; Value?: string }>;
+        ConfigurationSetName?: string;
+        ListManagementOptions?: unknown;
+        FeedbackForwardingEmailAddress?: string;
+        // Allow extra fields without forcing the SDK type package
+        [key: string]: unknown;
+    }
+
+    /** Structural type matching SESv2Client from @aws-sdk/client-sesv2 */
+    interface SESv2ClientLike {
+        send(command: unknown, options?: unknown): Promise<{ MessageId?: string }>;
+    }
+
+    /**
+     * Constructor type for SendEmailCommand from @aws-sdk/client-sesv2.
+     * The real type is: new(input: SendEmailCommandInput) => SendEmailCommand
+     * Contravariance prevents typing this more strictly without pulling in aws-sdk as a dependency.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    type SendEmailCommandConstructorLike = new(input: any) => unknown;
+
     interface MailOptions extends Mail.Options {
-        /** list of keys that SendRawEmail method can take */
+        /** Options passed to AWS SESv2 SendEmailCommand */
         ses?: MailSesOptions | undefined;
     }
 
     // Keep it as an interface for backward-compatibility
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface MailSesOptions extends Partial<aws.SendEmailRequest> {}
+    interface MailSesOptions extends Partial<SendEmailRequestLike> {}
 
     interface Options extends MailOptions, TransportOptions {
-        /** is an option that expects an instantiated aws.SES object */
+        /** An object containing an instantiated SESv2Client and the SendEmailCommand class */
         SES: {
-            sesClient: aws.SESv2Client;
-            SendEmailCommand: typeof aws.SendEmailCommand;
+            sesClient: SESv2ClientLike;
+            SendEmailCommand: SendEmailCommandConstructorLike;
         };
     }
 
     interface SentMessageInfo {
-        /** an envelope object {from:‘address’, to:[‘address’]} */
+        /** an envelope object {from:'address', to:['address']} */
         envelope: MimeNode.Envelope;
         /** the Message-ID header value. This value is derived from the response of SES API, so it differs from the Message-ID values used in logging. */
         messageId: string;

--- a/types/nodemailer/lib/ses-transport/index.d.ts
+++ b/types/nodemailer/lib/ses-transport/index.d.ts
@@ -39,6 +39,9 @@ declare namespace SESTransport {
     /** Structural type matching SESv2Client from @aws-sdk/client-sesv2 */
     interface SESv2ClientLike {
         send(command: unknown, options?: unknown): Promise<{ MessageId?: string }>;
+        config?: {
+            region?: string | (() => Promise<string>);
+        };
     }
 
     /**

--- a/types/nodemailer/package.json
+++ b/types/nodemailer/package.json
@@ -7,10 +7,10 @@
         "https://nodemailer.com"
     ],
     "dependencies": {
-        "@aws-sdk/client-sesv2": "^3.839.0",
         "@types/node": "*"
     },
     "devDependencies": {
+        "@aws-sdk/client-sesv2": "^3.839.0",
         "@types/nodemailer": "workspace:."
     },
     "owners": [

--- a/types/nodemailer/v6/lib/ses-transport/index.d.ts
+++ b/types/nodemailer/v6/lib/ses-transport/index.d.ts
@@ -37,8 +37,13 @@ declare namespace SESTransport {
 
     /** Structural type matching SES client from @aws-sdk/client-ses */
     interface SESClientLike {
-        sendEmail(params: unknown, options?: unknown): Promise<{ MessageId?: string }>;
-        sendRawEmail(params: unknown, options?: unknown): Promise<{ MessageId?: string }>;
+        /** Used with v3 low-level client + SendRawEmailCommand */
+        send?(command: unknown): Promise<{ MessageId?: string }>;
+        /** Used with v3 high-level SES class or v2 SDK */
+        sendRawEmail?(params: unknown, options?: unknown): Promise<{ MessageId?: string }>;
+        config?: {
+            region?: string | (() => Promise<string>);
+        };
     }
 
     /** Structural type matching the aws module shape */

--- a/types/nodemailer/v6/package.json
+++ b/types/nodemailer/v6/package.json
@@ -7,10 +7,10 @@
         "https://nodemailer.com"
     ],
     "dependencies": {
-        "@aws-sdk/client-ses": "^3.731.1",
         "@types/node": "*"
     },
     "devDependencies": {
+        "@aws-sdk/client-ses": "^3.731.1",
         "@types/nodemailer": "workspace:."
     },
     "owners": [


### PR DESCRIPTION
Move @aws-sdk/client-sesv2 (v7) and @aws-sdk/client-ses (v6) from dependencies to devDependencies so users who install @types/nodemailer don't pull in the large AWS SDK dependency tree.

Replace AWS SDK type imports with structural "like" types that match the shape nodemailer actually needs. This works because TypeScript uses structural typing - the real AWS SDK types will still be accepted when users install the SDK themselves for SES transport.

Fixes discussion #74080

Note: this is largely in line with how `nodemailer` itself treats aws-sdk - it's not a direct dep.  See [docs](https://nodemailer.com/transports/ses/):

> The AWS SES SDK is not included with Nodemailer, so you need to install it separately:
> ```npm install @aws-sdk/client-sesv2```

---

Template:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
    - N/A - my code doesn't use the ses bits
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
    - I didn't add tests, but I kept the existing ones the same to ensure these are still compatible with the AWS lib
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test nodemailer`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/74080
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. (N/A)
