### PR TITLE
[react] Add missing SVG attributes: nonce, part, and slot

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3564,6 +3564,9 @@ declare namespace React {
         method?: string | undefined;
         min?: number | string | undefined;
         name?: string | undefined;
+        nonce?: string | undefined;
+        part?: string | undefined;
+        slot?: string | undefined;
         style?: CSSProperties | undefined;
         target?: string | undefined;
         type?: string | undefined;

--- a/types/react/test/elementAttributes.tsx
+++ b/types/react/test/elementAttributes.tsx
@@ -29,6 +29,7 @@ const testCases = [
     <span lang="art-x-tokipona" />,
     <input placeholder="placeholder" />,
     <span slot="my-text" />,
+    <svg slot="my-svg" />,
     <span spellCheck />,
     <span tabIndex={0} />,
     <span title="title" />,
@@ -101,6 +102,7 @@ const testCases = [
         open
     />,
     <link nonce="8IBTHwOdqNKAWeKl7plt8g==" />,
+    <svg nonce="8IBTHwOdqNKAWeKl7plt8g==" />,
     <center></center>,
     // Float
     <>
@@ -171,6 +173,7 @@ const testCases = [
     <>
         <template>
             <div part="base" />
+            <svg part="svg" />
             <custom-element exportparts="nested" />
         </template>
     </>,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/docs/Web/API/Element/slot, https://developer.mozilla.org/docs/Web/API/Element/part, https://developer.mozilla.org/docs/Web/API/SVGElement/nonce
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

# Description

## Background

While working with SVG elements in React, I noticed that the slot attribute could not be specified on SVG elements, even though it is included in `HTMLAttributes` but not in `SVGAttributes`.

## Investigation

To identify other potentially missing attributes, I created [a script (stackblitz)](https://stackblitz.com/~/github.com/okathira/typescript-react-additional-svg-attributes?file=scripts/html-svg-attr-diff.js) to compare `HTMLAttributes` and `SVGAttributes` against the DOM Element and SVGElement interfaces. The script identified the following candidates:

- autoFocus
- nonce
- part
- prefix
- slot

## Verification

I created a comprehensive demo to test each attribute's behavior in React and browsers: https://stackblitz.com/~/github.com/okathira/typescript-react-additional-svg-attributes?file=src/App.tsx

<img width="1080" height="1750" alt="image" src="https://github.com/user-attachments/assets/5dd086a8-b9e9-451e-9ff5-e1e59ff264e7" />


Results: 
- ✅ nonce: Works correctly on SVG elements
- ✅ part: Works correctly - SVG elements can expose parts for external styling via ::part
- ✅ slot: Works correctly - SVG elements can be provided to named slots
- ❌ autoFocus: React does not support autoFocus on non-form controls, though `HTMLAttributes` does have the type definition.
  - [HTML Spec: autofocus attribute](https://html.spec.whatwg.org/multipage/interaction.html#the-autofocus-attribute)
  - https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64881
  - https://github.com/facebook/react/issues/6868
  - https://github.com/facebook/react/issues/23301
- ❌ prefix: The prefix in `HTMLAttributes` refers to the RDFa attribute, while Element.prefix is a different read-only DOM property.
  - [RDFa 1.1 Primer - Third Edition](https://www.w3.org/TR/2015/NOTE-rdfa-primer-20150317/#using-multiple-vocabularies)
  - [Element: prefix property - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/prefix)

For details and test results, please see the comments in the demo.

## Changes

This PR adds the following attributes to `SVGAttributes`

- `nonce?: string | undefined;`
- `part?: string | undefined;`
- `slot?: string | undefined;`

All three are attributes that work on both HTML and SVG elements in modern browsers and React.

## Related links

- https://github.com/facebook/react/issues/32406
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/72000


(Note: While AI assistance was used for codes and English texts, all functionality and behavior verification was performed manually by the author.)
