### PR TITLE
[slickgrid] Use generic subclass of SlickData for the `dataContext` paramter of `Formatter`

### DIFF
--- a/types/slickgrid/index.d.ts
+++ b/types/slickgrid/index.d.ts
@@ -1496,7 +1496,7 @@ declare namespace Slick {
     }
 
     export interface Formatter<T extends SlickData> {
-        (row: number, cell: number, value: any, columnDef: Column<T>, dataContext: SlickData): string;
+        (row: number, cell: number, value: any, columnDef: Column<T>, dataContext: T): string;
     }
 
     export namespace Formatters {


### PR DESCRIPTION
The `Formatter` interface has a parameter `dataContext` that is called with an object corresponding with the generic parameter `T`. Currently if `T` has extra properties, these are flagged as errors when type-checking.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [This is a most recent version of the library which is in Typescript, and here you can see the parameter rightly typed](https://github.com/6pac/SlickGrid/blob/master/src/models/formatter.interface.ts)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.