### PR TITLE
[@wordpress/block-editor] Add definitions for the HeadingLevelDropdown component

### DIFF
--- a/types/wordpress__block-editor/components/block-heading-level-dropdown.d.ts
+++ b/types/wordpress__block-editor/components/block-heading-level-dropdown.d.ts
@@ -1,11 +1,11 @@
-import {JSX} from "react";
+import { JSX } from "react";
 
 declare namespace HeadingLevelDropdown {
-    type HeadingLevel = 1|2|3|4|5|6;
+    type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
     interface Props {
-        options?: HeadingLevel[]|(readonly HeadingLevel[])|undefined;
-        value?: HeadingLevel|undefined;
-        onChange?: (value?: HeadingLevel|undefined) => void;
+        options?: HeadingLevel[] | (readonly HeadingLevel[]) | undefined;
+        value?: HeadingLevel | undefined;
+        onChange?: (value?: HeadingLevel | undefined) => void;
     }
 }
 declare const HeadingLevelDropdown: {

--- a/types/wordpress__block-editor/components/block-heading-level-dropdown.d.ts
+++ b/types/wordpress__block-editor/components/block-heading-level-dropdown.d.ts
@@ -1,0 +1,15 @@
+import {JSX} from "react";
+
+declare namespace HeadingLevelDropdown {
+    type HeadingLevel = 1|2|3|4|5|6;
+    interface Props {
+        options?: HeadingLevel[]|(readonly HeadingLevel[])|undefined;
+        value?: HeadingLevel|undefined;
+        onChange?: (value?: HeadingLevel|undefined) => void;
+    }
+}
+declare const HeadingLevelDropdown: {
+    (props: HeadingLevelDropdown.Props): JSX.Element;
+};
+
+export default HeadingLevelDropdown;

--- a/types/wordpress__block-editor/components/index.d.ts
+++ b/types/wordpress__block-editor/components/index.d.ts
@@ -7,6 +7,7 @@ export { default as BlockAlignmentToolbar } from "./block-alignment-toolbar";
 export { default as BlockControls } from "./block-controls";
 export { default as BlockEdit } from "./block-edit";
 export { default as BlockFormatControls } from "./block-format-controls";
+export { default as HeadingLevelDropdown } from "./block-heading-level-dropdown";
 export { default as BlockIcon } from "./block-icon";
 export { default as BlockNavigationDropdown } from "./block-navigation/dropdown";
 export { default as BlockVerticalAlignmentToolbar } from "./block-vertical-alignment-toolbar";

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -217,6 +217,13 @@ be.getFontSizeClass("foo");
 be.withFontSizes("fontSize")(() => <h1>Hello World</h1>);
 
 //
+// heading-level-dropdown
+//
+<be.HeadingLevelDropdown value={5} />;
+<be.HeadingLevelDropdown value={5} options={[4]} />;
+<be.HeadingLevelDropdown value={5} options={[4]} onChange={v => console.log(v)} />;
+
+//
 // inner-blocks
 //
 <be.InnerBlocks />;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Heading Level Dropdown's source](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/block-heading-level-dropdown/index.js)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

These definitions are a quick translation of the JSDoc from the repo. The component has been kicking around for a while, so bumping the version is unnecessary.