### PR TITLE
[@wordpress/block-editor] Add definitions for useDispatch, useSelect, and useBlockEditingMode

### DIFF
--- a/types/wordpress__block-editor/components/index.d.ts
+++ b/types/wordpress__block-editor/components/index.d.ts
@@ -64,5 +64,6 @@ export { default as BlockEditorProvider } from "./provider";
  */
 export { useBlockBindingsUtils } from "./use-block-bindings-utils";
 export { useBlockEditContext } from "./use-block-edit-context";
+export { useBlockEditingMode } from "./use-block-editing-mode";
 export { useBlockProps } from "./use-block-props";
 export { useSettings } from "./use-settings";

--- a/types/wordpress__block-editor/components/use-block-editing-mode.d.ts
+++ b/types/wordpress__block-editor/components/use-block-editing-mode.d.ts
@@ -1,0 +1,35 @@
+export namespace useBlockEditingMode {
+    type BlockEditingMode = "disabled" | "contentOnly" | "default";
+}
+
+/**
+ * Allows a block to restrict the user interface that is displayed for editing
+ * that block and its inner blocks.
+ *
+ * @example
+ * ```js
+ * function MyBlock( { attributes, setAttributes } ) {
+ *     useBlockEditingMode( 'disabled' );
+ *     return <div { ...useBlockProps() }></div>;
+ * }
+ * ```
+ *
+ * `mode` can be one of three options:
+ *
+ * - `'disabled'`: Prevents editing the block entirely, i.e. it cannot be
+ *   selected.
+ * - `'contentOnly'`: Hides all non-content UI, e.g. auxiliary controls in the
+ *   toolbar, the block movers, block settings.
+ * - `'default'`: Allows editing the block as normal.
+ *
+ * The mode is inherited by all of the block's inner blocks, unless they have
+ * their own mode.
+ *
+ * If called outside of a block context, the mode is applied to all blocks.
+ *
+ * @param {?useBlockEditingMode.BlockEditingMode} mode The editing mode to apply. If undefined, the
+ *                                 current editing mode is not changed.
+ *
+ * @return {useBlockEditingMode.BlockEditingMode} The current editing mode.
+ */
+export function useBlockEditingMode(mode?: useBlockEditingMode.BlockEditingMode): useBlockEditingMode.BlockEditingMode;

--- a/types/wordpress__block-editor/index.d.ts
+++ b/types/wordpress__block-editor/index.d.ts
@@ -10,6 +10,9 @@ export * from "./utils";
 declare module "@wordpress/data" {
     function dispatch(key: "core/block-editor"): typeof import("./store/actions");
     function select(key: "core/block-editor"): typeof import("./store/selectors");
+
+    function useDispatch(key: "core/block-editor"): typeof import("./store/actions");
+    function useSelect(key: "core/block-editor"): typeof import("./store/selectors");
 }
 
 export interface BlockEditorStoreDescriptor extends StoreDescriptor {

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -1,7 +1,7 @@
 import be from "@wordpress/block-editor";
 import * as UseBlockProps from "@wordpress/block-editor/components/use-block-props";
 import { BlockInstance, createBlock } from "@wordpress/blocks";
-import { dispatch, select } from "@wordpress/data";
+import { dispatch, select, useDispatch, useSelect } from "@wordpress/data";
 import { useRef } from "react";
 
 declare const BLOCK_INSTANCE: BlockInstance;
@@ -464,119 +464,125 @@ be.transformStyles(STYLES, ".foobar");
 // $ExpectType BlockEditorStoreDescriptor
 be.store;
 
-// $ExpectType void
-dispatch("core/block-editor").insertBlock(BLOCK_INSTANCE);
-dispatch("core/block-editor").insertBlock(BLOCK_INSTANCE, 4);
-dispatch("core/block-editor").insertBlock(BLOCK_INSTANCE, 4, "foo");
-dispatch("core/block-editor").insertBlock(BLOCK_INSTANCE, 4, "foo", false);
+for (const dispatchOrUseDispatch of [dispatch, useDispatch]) {
+    // $ExpectType void
+    dispatchOrUseDispatch("core/block-editor").insertBlock(BLOCK_INSTANCE);
+    dispatchOrUseDispatch("core/block-editor").insertBlock(BLOCK_INSTANCE, 4);
+    dispatchOrUseDispatch("core/block-editor").insertBlock(BLOCK_INSTANCE, 4, "foo");
+    dispatchOrUseDispatch("core/block-editor").insertBlock(BLOCK_INSTANCE, 4, "foo", false);
 
-// $ExpectType IterableIterator<void>
-dispatch("core/block-editor").insertBlocks([BLOCK_INSTANCE]);
-dispatch("core/block-editor").insertBlocks([BLOCK_INSTANCE], 5);
-dispatch("core/block-editor").insertBlocks([BLOCK_INSTANCE], 5, "foo");
-dispatch("core/block-editor").insertBlocks([BLOCK_INSTANCE], 5, "foo", false);
+    // $ExpectType IterableIterator<void>
+    dispatchOrUseDispatch("core/block-editor").insertBlocks([BLOCK_INSTANCE]);
+    dispatchOrUseDispatch("core/block-editor").insertBlocks([BLOCK_INSTANCE], 5);
+    dispatchOrUseDispatch("core/block-editor").insertBlocks([BLOCK_INSTANCE], 5, "foo");
+    dispatchOrUseDispatch("core/block-editor").insertBlocks([BLOCK_INSTANCE], 5, "foo", false);
 
-// $ExpectType void
-dispatch("core/block-editor").insertDefaultBlock();
-dispatch("core/block-editor").insertDefaultBlock({ foo: "bar" });
-dispatch("core/block-editor").insertDefaultBlock({ foo: "bar" }, "foo");
-dispatch("core/block-editor").insertDefaultBlock({ foo: "bar" }, "foo", 5);
+    // $ExpectType void
+    dispatchOrUseDispatch("core/block-editor").insertDefaultBlock();
+    dispatchOrUseDispatch("core/block-editor").insertDefaultBlock({ foo: "bar" });
+    dispatchOrUseDispatch("core/block-editor").insertDefaultBlock({ foo: "bar" }, "foo");
+    dispatchOrUseDispatch("core/block-editor").insertDefaultBlock({ foo: "bar" }, "foo", 5);
 
-// $ExpectType void
-dispatch("core/block-editor").mergeBlocks("foo", "bar");
+    // $ExpectType void
+    dispatchOrUseDispatch("core/block-editor").mergeBlocks("foo", "bar");
 
-// $ExpectType void
-dispatch("core/block-editor").moveBlocksUp("foo", "bar");
-dispatch("core/block-editor").moveBlocksUp(["foo", "baz"], "bar");
+    // $ExpectType void
+    dispatchOrUseDispatch("core/block-editor").moveBlocksUp("foo", "bar");
+    dispatchOrUseDispatch("core/block-editor").moveBlocksUp(["foo", "baz"], "bar");
 
-// $ExpectType IterableIterator<void>
-dispatch("core/block-editor").moveBlockToPosition("foo", "bar", "baz", 1);
-dispatch("core/block-editor").moveBlockToPosition(undefined, "foo", undefined, 5);
-dispatch("core/block-editor").moveBlockToPosition(undefined, undefined, undefined, 5);
+    // $ExpectType IterableIterator<void>
+    dispatchOrUseDispatch("core/block-editor").moveBlockToPosition("foo", "bar", "baz", 1);
+    dispatchOrUseDispatch("core/block-editor").moveBlockToPosition(undefined, "foo", undefined, 5);
+    dispatchOrUseDispatch("core/block-editor").moveBlockToPosition(undefined, undefined, undefined, 5);
 
-// $ExpectType void
-dispatch("core/block-editor").multiSelect("foo", "bar");
+    // $ExpectType void
+    dispatchOrUseDispatch("core/block-editor").multiSelect("foo", "bar");
 
-// $ExpectType void
-dispatch("core/block-editor").receiveBlocks([BLOCK_INSTANCE]);
+    // $ExpectType void
+    dispatchOrUseDispatch("core/block-editor").receiveBlocks([BLOCK_INSTANCE]);
 
-// $ExpectType void
-dispatch("core/block-editor").removeBlock("foo");
-dispatch("core/block-editor").removeBlock("foo", true);
+    // $ExpectType void
+    dispatchOrUseDispatch("core/block-editor").removeBlock("foo");
+    dispatchOrUseDispatch("core/block-editor").removeBlock("foo", true);
 
-// $ExpectType IterableIterator<void>
-dispatch("core/block-editor").removeBlocks("foo");
-dispatch("core/block-editor").removeBlocks("foo", false);
-dispatch("core/block-editor").removeBlocks(["foo"]);
-dispatch("core/block-editor").removeBlocks(["foo"], false);
+    // $ExpectType IterableIterator<void>
+    dispatchOrUseDispatch("core/block-editor").removeBlocks("foo");
+    dispatchOrUseDispatch("core/block-editor").removeBlocks("foo", false);
+    dispatchOrUseDispatch("core/block-editor").removeBlocks(["foo"]);
+    dispatchOrUseDispatch("core/block-editor").removeBlocks(["foo"], false);
 
-// $ExpectType void
-dispatch("core/block-editor").replaceBlock("foo", BLOCK_INSTANCE);
-dispatch("core/block-editor").replaceBlock("foo", [BLOCK_INSTANCE]);
-dispatch("core/block-editor").replaceBlock(["foo"], BLOCK_INSTANCE);
-dispatch("core/block-editor").replaceBlock(["foo"], [BLOCK_INSTANCE]);
+    // $ExpectType void
+    dispatchOrUseDispatch("core/block-editor").replaceBlock("foo", BLOCK_INSTANCE);
+    dispatchOrUseDispatch("core/block-editor").replaceBlock("foo", [BLOCK_INSTANCE]);
+    dispatchOrUseDispatch("core/block-editor").replaceBlock(["foo"], BLOCK_INSTANCE);
+    dispatchOrUseDispatch("core/block-editor").replaceBlock(["foo"], [BLOCK_INSTANCE]);
 
-// $ExpectType IterableIterator<void>
-dispatch("core/block-editor").replaceBlocks("foo", BLOCK_INSTANCE);
-dispatch("core/block-editor").replaceBlocks("foo", [BLOCK_INSTANCE], 3);
-dispatch("core/block-editor").replaceBlocks(["foo"], BLOCK_INSTANCE);
-dispatch("core/block-editor").replaceBlocks(["foo"], [BLOCK_INSTANCE], 0);
+    // $ExpectType IterableIterator<void>
+    dispatchOrUseDispatch("core/block-editor").replaceBlocks("foo", BLOCK_INSTANCE);
+    dispatchOrUseDispatch("core/block-editor").replaceBlocks("foo", [BLOCK_INSTANCE], 3);
+    dispatchOrUseDispatch("core/block-editor").replaceBlocks(["foo"], BLOCK_INSTANCE);
+    dispatchOrUseDispatch("core/block-editor").replaceBlocks(["foo"], [BLOCK_INSTANCE], 0);
 
-// $ExpectType void
-dispatch("core/block-editor").replaceInnerBlocks("foo", [BLOCK_INSTANCE]);
-dispatch("core/block-editor").replaceInnerBlocks("foo", [BLOCK_INSTANCE], true);
+    // $ExpectType void
+    dispatchOrUseDispatch("core/block-editor").replaceInnerBlocks("foo", [BLOCK_INSTANCE]);
+    dispatchOrUseDispatch("core/block-editor").replaceInnerBlocks("foo", [BLOCK_INSTANCE], true);
 
-// $ExpectType void
-dispatch("core/block-editor").resetBlocks([BLOCK_INSTANCE]);
+    // $ExpectType void
+    dispatchOrUseDispatch("core/block-editor").resetBlocks([BLOCK_INSTANCE]);
 
-// $ExpectType void
-dispatch("core/block-editor").selectBlock("foo");
-dispatch("core/block-editor").selectBlock("foo", 5);
+    // $ExpectType void
+    dispatchOrUseDispatch("core/block-editor").selectBlock("foo");
+    dispatchOrUseDispatch("core/block-editor").selectBlock("foo", 5);
 
-// $ExpectType void
-dispatch("core/block-editor").selectionChange("foo", "bar", 0, 5);
+    // $ExpectType void
+    dispatchOrUseDispatch("core/block-editor").selectionChange("foo", "bar", 0, 5);
 
-// $ExpectType IterableIterator<void>
-dispatch("core/block-editor").selectNextBlock("foo");
+    // $ExpectType IterableIterator<void>
+    dispatchOrUseDispatch("core/block-editor").selectNextBlock("foo");
 
-// $ExpectType IterableIterator<void>
-dispatch("core/block-editor").selectPreviousBlock("foo");
+    // $ExpectType IterableIterator<void>
+    dispatchOrUseDispatch("core/block-editor").selectPreviousBlock("foo");
 
-// $ExpectType void
-dispatch("core/block-editor").setTemplateValidity(false);
+    // $ExpectType void
+    dispatchOrUseDispatch("core/block-editor").setTemplateValidity(false);
 
-// $ExpectType void
-dispatch("core/block-editor").showInsertionPoint();
-dispatch("core/block-editor").showInsertionPoint("foo");
-dispatch("core/block-editor").showInsertionPoint("foo", 5);
+    // $ExpectType void
+    dispatchOrUseDispatch("core/block-editor").showInsertionPoint();
+    dispatchOrUseDispatch("core/block-editor").showInsertionPoint("foo");
+    dispatchOrUseDispatch("core/block-editor").showInsertionPoint("foo", 5);
 
-// $ExpectType void
-dispatch("core/block-editor").toggleBlockMode("foo");
+    // $ExpectType void
+    dispatchOrUseDispatch("core/block-editor").toggleBlockMode("foo");
 
-// $ExpectType void
-dispatch("core/block-editor").toggleSelection();
-dispatch("core/block-editor").toggleSelection(true);
+    // $ExpectType void
+    dispatchOrUseDispatch("core/block-editor").toggleSelection();
+    dispatchOrUseDispatch("core/block-editor").toggleSelection(true);
 
-// $ExpectType void
-dispatch("core/block-editor").updateBlock("foo", { attributes: { foo: "bar" }, innerBlocks: [] });
+    // $ExpectType void
+    dispatchOrUseDispatch("core/block-editor").updateBlock("foo", { attributes: { foo: "bar" }, innerBlocks: [] });
 
-// $ExpectType void
-dispatch("core/block-editor").updateBlockAttributes("foo", { foo: "bar" });
+    // $ExpectType void
+    dispatchOrUseDispatch("core/block-editor").updateBlockAttributes("foo", { foo: "bar" });
 
-// $ExpectType void
-dispatch("core/block-editor").updateBlockListSettings("foo", { allowedBlocks: ["core/paragraph"] });
+    // $ExpectType void
+    dispatchOrUseDispatch("core/block-editor").updateBlockListSettings("foo", { allowedBlocks: ["core/paragraph"] });
 
-// $ExpectType void
-dispatch("core/block-editor").updateSettings({
-    focusMode: true,
-    codeEditingEnabled: false,
-    maxUploadFileSize: 500,
-    richEditingEnabled: false,
-});
+    // $ExpectType void
+    dispatchOrUseDispatch("core/block-editor").updateSettings({
+        focusMode: true,
+        codeEditingEnabled: false,
+        maxUploadFileSize: 500,
+        richEditingEnabled: false,
+    });
+}
 
 // $ExpectType boolean
 select("core/block-editor").canInsertBlockType("core/paragraph");
 select("core/block-editor").canInsertBlockType("core/paragraph", "foo");
+
+// $ExpectType boolean
+useSelect("core/block-editor").canInsertBlockType("core/paragraph");
+useSelect("core/block-editor").canInsertBlockType("core/paragraph", "foo");
 
 // $ExpectType string | null
 select("core/block-editor").getAdjacentBlockClientId();
@@ -584,11 +590,23 @@ select("core/block-editor").getAdjacentBlockClientId("foo");
 select("core/block-editor").getAdjacentBlockClientId("foo", -1);
 select("core/block-editor").getAdjacentBlockClientId("foo", 1);
 
+// $ExpectType string | null
+useSelect("core/block-editor").getAdjacentBlockClientId();
+useSelect("core/block-editor").getAdjacentBlockClientId("foo");
+useSelect("core/block-editor").getAdjacentBlockClientId("foo", -1);
+useSelect("core/block-editor").getAdjacentBlockClientId("foo", 1);
+
 // $ExpectType string[]
 select("core/block-editor").getBlockParents("foo");
 select("core/block-editor").getBlockParentsByBlockName("foo", ["core/query"]);
 select("core/block-editor").getBlockParents("foo", true);
 select("core/block-editor").getBlockParentsByBlockName("foo", ["core/query"], true);
+
+// $ExpectType string[]
+useSelect("core/block-editor").getBlockParents("foo");
+useSelect("core/block-editor").getBlockParentsByBlockName("foo", ["core/query"]);
+useSelect("core/block-editor").getBlockParents("foo", true);
+useSelect("core/block-editor").getBlockParentsByBlockName("foo", ["core/query"], true);
 
 {
     const blockProps: UseBlockProps.Merged & UseBlockProps.Reserved = be.useBlockProps();

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -690,3 +690,6 @@ be.useBlockBindingsUtils();
 
 // $ExpectType { name: string; isSelected?: boolean | undefined; clientId: string; layout: unknown; }
 be.useBlockEditContext();
+
+// $ExpectType BlockEditingMode
+be.useBlockEditingMode();


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [WordPress data package docs](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-data) and the [useBlockEditingMode source code](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/block-editing-mode/index.js)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

This copies the preexisting convenience definitions for `select` and `dispatch` to `useSelect` and `useDispatch` and adds a definition for the useBlockEditingMode hook.

While it looks like there are a lot of changes to the tests, that's just due to applying the tests for the `select` and `dispatch` calls to `useSelect` and `useDispatch`