### PR TITLE
[node/tls] Add/remove options of tls functions {connect,createServer,createSecureContext} and `new TLSSocket`

### DIFF
--- a/types/node/node-tests/tls.ts
+++ b/types/node/node-tests/tls.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as net from "node:net";
 import * as stream from "node:stream";
 import {
     connect,
@@ -348,4 +349,15 @@ import {
             cb(null, ctx);
         },
     };
+}
+
+{
+    // server mode
+    ((socket: net.Socket, server: net.Server | undefined) => new TLSSocket(socket, { isServer: true, server: server }));
+    ((duplex: stream.Duplex, server: net.Server | undefined) =>
+        new TLSSocket(duplex, { isServer: true, server: server }));
+    // client mode
+    ((socket: net.Socket) => new TLSSocket(socket, { isServer: false }));
+    // backward compatibility with mixed options
+    ((duplex: stream.Duplex) => new TLSSocket(duplex, { isServer: false, ALPNCallback: undefined, requestOCSP: true }));
 }

--- a/types/node/node-tests/tls.ts
+++ b/types/node/node-tests/tls.ts
@@ -40,6 +40,7 @@ import {
                 psk: Buffer.from("asd"),
             };
         },
+        requestOCSP: true,
     };
     const tlsSocket = connect(connOpts);
 
@@ -85,7 +86,7 @@ import {
 }
 
 {
-    const _server = createServer({
+    const options: TlsOptions = {
         enableTrace: true,
         pskCallback(socket, ident) {
             if (ident === "something") {
@@ -93,7 +94,8 @@ import {
             }
             return Buffer.from("asdasd");
         },
-    });
+    };
+    const _server = createServer(options);
 
     _server.addContext("example", {
         cert: fs.readFileSync("cert_filepath"),
@@ -159,6 +161,17 @@ import {
     _server = _server.addListener("secureConnection", (tlsSocket) => {
         const _tlsSocket: TLSSocket = tlsSocket;
     });
+
+    const _err: Error = new Error();
+    const _tlsSocket: TLSSocket = connect(1);
+    const _any: Buffer = Buffer.from("asd");
+    const _func: Function = () => {};
+    const _buffer: Buffer = Buffer.from("a");
+    _boolean = _server.emit("tlsClientError", _err, _tlsSocket);
+    _boolean = _server.emit("newSession", _any, _any, _func1);
+    _boolean = _server.emit("OCSPRequest", _buffer, _buffer, _func);
+    _boolean = _server.emit("resumeSession", _any, _func2);
+    _boolean = _server.emit("secureConnection", _tlsSocket);
 
     _server = _server.on("tlsClientError", (err, tlsSocket) => {
         const _err: Error = err;
@@ -277,6 +290,10 @@ import {
         const _response: Buffer = response;
     });
     socket = socket.addListener("secureConnect", () => {});
+
+    const _buffer: Buffer = Buffer.from("");
+    _boolean = socket.emit("OCSPResponse", _buffer);
+    _boolean = socket.emit("secureConnect");
 
     socket = socket.on("OCSPResponse", (response) => {
         const _response: Buffer = response;

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -186,17 +186,25 @@ declare module "node:tls" {
          */
         passphrase?: string | undefined;
     }
-    interface TLSSocketOptions extends SecureContextOptions, ServerConnectionOptions, ClientConnectionOptions {
+    interface ServerModeTLSSocketOptions extends SecureContextOptions, ServerConnectionOptions {
         /**
          * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
          * If true the TLS socket will be instantiated as a server.
          * @default false
          */
-        isServer?: boolean | undefined;
+        isServer: true;
         /**
          * An optional net.Server instance.
          */
         server?: net.Server | undefined;
+    }
+    interface ClientModeTLSSocketOptions extends SecureContextOptions, ClientConnectionOptions {
+        /**
+         * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
+         * If true the TLS socket will be instantiated as a server.
+         * @default false
+         */
+        isServer?: false | undefined;
     }
     interface TLSSocketEventMap extends net.SocketEventMap {
         "keylog": [line: NonSharedBuffer];
@@ -216,9 +224,13 @@ declare module "node:tls" {
      */
     class TLSSocket extends net.Socket {
         /**
-         * Construct a new tls.TLSSocket object from an existing TCP socket.
+         * Construct a new tls.TLSSocket object in server mode from an existing stream.Duplex.
          */
-        constructor(socket: net.Socket | stream.Duplex, options?: TLSSocketOptions);
+        constructor(socket: stream.Duplex, options: ServerModeTLSSocketOptions);
+        /**
+         * Construct a new tls.TLSSocket object in client mode from an existing TCP socket.
+         */
+        constructor(socket: net.Socket, options?: ClientModeTLSSocketOptions);
         /**
          * This property is `true` if the peer certificate was signed by one of the CAs
          * specified when creating the `tls.TLSSocket` instance, otherwise `false`.

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -216,9 +216,9 @@ declare module "node:tls" {
      */
     class TLSSocket extends net.Socket {
         /**
-         * Construct a new tls.TLSSocket object from an existing stream.Duplex.
+         * Construct a new tls.TLSSocket object from an existing TCP socket or a stream.Duplex.
          */
-        constructor(socket: stream.Duplex, options?: TLSSocketOptions);
+        constructor(socket: net.Socket | stream.Duplex, options?: TLSSocketOptions);
         /**
          * This property is `true` if the peer certificate was signed by one of the CAs
          * specified when creating the `tls.TLSSocket` instance, otherwise `false`.

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -580,7 +580,7 @@ declare module "node:tls" {
          * the client's ALPN protocols, an error will be thrown.
          * This option cannot be used with the `ALPNProtocols` option, and setting both options will throw an error.
          */
-        ALPNCallback?: ((arg: { servername: string; protocols: string[] }) => string | undefined) | undefined;
+        ALPNCallback?: ((arg: { servername: string | false; protocols: string[] }) => string | undefined) | undefined;
         /**
          * SNICallback(servername, cb) <Function> A function that will be
          * called if the client supports SNI TLS extension. Two arguments

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -198,26 +198,6 @@ declare module "node:tls" {
          */
         server?: net.Server | undefined;
     }
-    interface ServerModeTLSSocketOptions extends SecureContextOptions, ServerConnectionOptions {
-        /**
-         * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
-         * If true the TLS socket will be instantiated as a server.
-         * @default false
-         */
-        isServer: true;
-        /**
-         * An optional net.Server instance.
-         */
-        server?: net.Server | undefined;
-    }
-    interface ClientModeTLSSocketOptions extends SecureContextOptions, ClientConnectionOptions {
-        /**
-         * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
-         * If true the TLS socket will be instantiated as a server.
-         * @default false
-         */
-        isServer?: false | undefined;
-    }
     interface TLSSocketEventMap extends net.SocketEventMap {
         "keylog": [line: NonSharedBuffer];
         "OCSPResponse": [response: NonSharedBuffer];
@@ -235,14 +215,6 @@ declare module "node:tls" {
      * @since v0.11.4
      */
     class TLSSocket extends net.Socket {
-        /**
-         * Construct a new tls.TLSSocket object in server mode from an existing stream.Duplex.
-         */
-        constructor(socket: stream.Duplex, options: ServerModeTLSSocketOptions);
-        /**
-         * Construct a new tls.TLSSocket object in client mode from an existing TCP socket.
-         */
-        constructor(socket: net.Socket, options?: ClientModeTLSSocketOptions);
         /**
          * Construct a new tls.TLSSocket object from an existing stream.Duplex.
          */

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -186,6 +186,18 @@ declare module "node:tls" {
          */
         passphrase?: string | undefined;
     }
+    interface TLSSocketOptions extends SecureContextOptions, ServerConnectionOptions, ClientConnectionOptions {
+        /**
+         * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
+         * If true the TLS socket will be instantiated as a server.
+         * @default false
+         */
+        isServer?: boolean | undefined;
+        /**
+         * An optional net.Server instance.
+         */
+        server?: net.Server | undefined;
+    }
     interface ServerModeTLSSocketOptions extends SecureContextOptions, ServerConnectionOptions {
         /**
          * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
@@ -231,6 +243,10 @@ declare module "node:tls" {
          * Construct a new tls.TLSSocket object in client mode from an existing TCP socket.
          */
         constructor(socket: net.Socket, options?: ClientModeTLSSocketOptions);
+        /**
+         * Construct a new tls.TLSSocket object from an existing stream.Duplex.
+         */
+        constructor(socket: stream.Duplex, options?: TLSSocketOptions);
         /**
          * This property is `true` if the peer certificate was signed by one of the CAs
          * specified when creating the `tls.TLSSocket` instance, otherwise `false`.

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -534,6 +534,13 @@ declare module "node:tls" {
     }
     interface CommonConnectionOptions {
         /**
+         * If not `false`, the peer certificate is verified against the list of
+         * supplied CAs. An `'error'` event is emitted if verification fails;
+         * `err.code` contains the OpenSSL error code.
+         * @default true
+         */
+        rejectUnauthorized?: boolean | undefined;
+        /**
          * When enabled, TLS packet trace information is written to `stderr`. This can be
          * used to debug TLS connection problems.
          * @default false

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -186,7 +186,7 @@ declare module "node:tls" {
          */
         passphrase?: string | undefined;
     }
-    interface TLSSocketOptions extends SecureContextOptions, ServerConnectionOptions, ClientConnectionOptions {
+    interface TLSSocketOptions extends SecureContextOptions, CommonConnectionOptions {
         /**
          * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
          * If true the TLS socket will be instantiated as a server.
@@ -522,12 +522,9 @@ declare module "node:tls" {
     }
     interface CommonConnectionOptions {
         /**
-         * If not `false`, the peer certificate is verified against the list of
-         * supplied CAs. An `'error'` event is emitted if verification fails;
-         * `err.code` contains the OpenSSL error code.
-         * @default true
+         * An optional TLS context object from tls.createSecureContext()
          */
-        rejectUnauthorized?: boolean | undefined;
+        secureContext?: SecureContext | undefined;
         /**
          * When enabled, TLS packet trace information is written to `stderr`. This can be
          * used to debug TLS connection problems.
@@ -535,48 +532,43 @@ declare module "node:tls" {
          */
         enableTrace?: boolean | undefined;
         /**
-         * An array of strings or a Buffer naming possible ALPN protocols.
-         * (Protocols should be ordered by their priority.)
-         */
-        ALPNProtocols?: readonly string[] | NodeJS.ArrayBufferView | undefined;
-    }
-    interface ClientConnectionOptions extends CommonConnectionOptions {
-        /**
-         * If not `false`, the server certificate is verified against the list of
-         * supplied CAs. An `'error'` event is emitted if verification fails;
-         * `err.code` contains the OpenSSL error code.
-         * @default true
-         */
-        rejectUnauthorized?: boolean | undefined;
-        /**
-         * If true, specifies that the OCSP status request extension will be
-         * added to the client hello and an 'OCSPResponse' event will be
-         * emitted on the socket before establishing a secure communication
-         */
-        requestOCSP?: boolean | undefined;
-        /**
-         * An optional Buffer instance containing a TLS session.
-         */
-        session?: Buffer | undefined;
-        /**
-         * An optional TLS context object from tls.createSecureContext()
-         */
-        secureContext?: SecureContext | undefined;
-    }
-    interface ServerConnectionOptions extends CommonConnectionOptions {
-        /**
          * If true the server will request a certificate from clients that
          * connect and attempt to verify that certificate. Defaults to
          * false.
          */
         requestCert?: boolean | undefined;
         /**
-         * If true the server will reject any connection which is not
-         * authorized with the list of supplied CAs. This option only has an
-         * effect if requestCert is true.
+         * An array of strings or a Buffer naming possible ALPN protocols.
+         * (Protocols should be ordered by their priority.)
+         */
+        ALPNProtocols?: readonly string[] | NodeJS.ArrayBufferView | undefined;
+        /**
+         * SNICallback(servername, cb) <Function> A function that will be
+         * called if the client supports SNI TLS extension. Two arguments
+         * will be passed when called: servername and cb. SNICallback should
+         * invoke cb(null, ctx), where ctx is a SecureContext instance.
+         * (tls.createSecureContext(...) can be used to get a proper
+         * SecureContext.) If SNICallback wasn't provided the default callback
+         * with high-level API will be used (see below).
+         */
+        SNICallback?: ((servername: string, cb: (err: Error | null, ctx?: SecureContext) => void) => void) | undefined;
+        /**
+         * If not `false`, the peer certificate is verified against the list of
+         * supplied CAs. An `'error'` event is emitted if verification fails;
+         * `err.code` contains the OpenSSL error code.
          * @default true
          */
         rejectUnauthorized?: boolean | undefined;
+        /**
+         * An optional Buffer instance containing a TLS session.
+         */
+        session?: Buffer | undefined;
+        /**
+         * If true, specifies that the OCSP status request extension will be
+         * added to the client hello and an 'OCSPResponse' event will be
+         * emitted on the socket before establishing a secure communication
+         */
+        requestOCSP?: boolean | undefined;
         /**
          * If set, this will be called when a client opens a connection using the ALPN extension.
          * One argument will be passed to the callback: an object containing `servername` and `protocols` fields,
@@ -588,16 +580,44 @@ declare module "node:tls" {
          * This option cannot be used with the `ALPNProtocols` option, and setting both options will throw an error.
          */
         ALPNCallback?: ((arg: { servername: string | false; protocols: string[] }) => string | undefined) | undefined;
+    }
+    interface ClientConnectionOptions extends
+        Pick<
+            CommonConnectionOptions,
+            | "secureContext"
+            | "enableTrace"
+            | "ALPNProtocols"
+            | "rejectUnauthorized"
+            | "session"
+            | "requestOCSP"
+        >
+    {
         /**
-         * SNICallback(servername, cb) <Function> A function that will be
-         * called if the client supports SNI TLS extension. Two arguments
-         * will be passed when called: servername and cb. SNICallback should
-         * invoke cb(null, ctx), where ctx is a SecureContext instance.
-         * (tls.createSecureContext(...) can be used to get a proper
-         * SecureContext.) If SNICallback wasn't provided the default callback
-         * with high-level API will be used (see below).
+         * If not `false`, the server certificate is verified against the list of
+         * supplied CAs. An `'error'` event is emitted if verification fails;
+         * `err.code` contains the OpenSSL error code.
+         * @default true
          */
-        SNICallback?: ((servername: string, cb: (err: Error | null, ctx?: SecureContext) => void) => void) | undefined;
+        rejectUnauthorized?: boolean | undefined;
+    }
+    interface ServerConnectionOptions extends
+        Pick<
+            CommonConnectionOptions,
+            | "enableTrace"
+            | "requestCert"
+            | "ALPNProtocols"
+            | "SNICallback"
+            | "rejectUnauthorized"
+            | "ALPNCallback"
+        >
+    {
+        /**
+         * If true the server will reject any connection which is not
+         * authorized with the list of supplied CAs. This option only has an
+         * effect if requestCert is true.
+         * @default true
+         */
+        rejectUnauthorized?: boolean | undefined;
     }
     interface TlsOptions extends SecureContextOptions, ServerConnectionOptions, net.ServerOpts {
         /**

--- a/types/node/v20/test/tls.ts
+++ b/types/node/v20/test/tls.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as net from "node:net";
 import * as stream from "node:stream";
 import {
     connect,
@@ -344,4 +345,15 @@ import {
             cb(null, ctx);
         },
     };
+}
+
+{
+    // server mode
+    ((socket: net.Socket, server: net.Server | undefined) => new TLSSocket(socket, { isServer: true, server: server }));
+    ((duplex: stream.Duplex, server: net.Server | undefined) =>
+        new TLSSocket(duplex, { isServer: true, server: server }));
+    // client mode
+    ((socket: net.Socket) => new TLSSocket(socket, { isServer: false }));
+    // backward compatibility with mixed options
+    ((duplex: stream.Duplex) => new TLSSocket(duplex, { isServer: false, ALPNCallback: undefined, requestOCSP: true }));
 }

--- a/types/node/v20/test/tls.ts
+++ b/types/node/v20/test/tls.ts
@@ -38,6 +38,7 @@ import {
                 psk: Buffer.from("asd"),
             };
         },
+        requestOCSP: true,
     };
     const tlsSocket = connect(connOpts);
 
@@ -81,7 +82,7 @@ import {
 }
 
 {
-    const _server = createServer({
+    const options: TlsOptions = {
         enableTrace: true,
         pskCallback(socket, ident) {
             if (ident === "something") {
@@ -89,7 +90,8 @@ import {
             }
             return Buffer.from("asdasd");
         },
-    });
+    };
+    const _server = createServer(options);
 
     _server.addContext("example", {
         cert: fs.readFileSync("cert_filepath"),

--- a/types/node/v20/tls.d.ts
+++ b/types/node/v20/tls.d.ts
@@ -186,7 +186,7 @@ declare module "tls" {
          */
         passphrase?: string | undefined;
     }
-    interface TLSSocketOptions extends SecureContextOptions, ServerConnectionOptions, ClientConnectionOptions {
+    interface TLSSocketOptions extends SecureContextOptions, CommonConnectionOptions {
         /**
          * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
          * If true the TLS socket will be instantiated as a server.
@@ -504,12 +504,9 @@ declare module "tls" {
     }
     interface CommonConnectionOptions {
         /**
-         * If not `false`, the peer certificate is verified against the list of
-         * supplied CAs. An `'error'` event is emitted if verification fails;
-         * `err.code` contains the OpenSSL error code.
-         * @default true
+         * An optional TLS context object from tls.createSecureContext()
          */
-        rejectUnauthorized?: boolean | undefined;
+        secureContext?: SecureContext | undefined;
         /**
          * When enabled, TLS packet trace information is written to `stderr`. This can be
          * used to debug TLS connection problems.
@@ -517,48 +514,43 @@ declare module "tls" {
          */
         enableTrace?: boolean | undefined;
         /**
-         * An array of strings or a Buffer naming possible ALPN protocols.
-         * (Protocols should be ordered by their priority.)
-         */
-        ALPNProtocols?: readonly string[] | NodeJS.ArrayBufferView | undefined;
-    }
-    interface ClientConnectionOptions extends CommonConnectionOptions {
-        /**
-         * If not `false`, the server certificate is verified against the list of
-         * supplied CAs. An `'error'` event is emitted if verification fails;
-         * `err.code` contains the OpenSSL error code.
-         * @default true
-         */
-        rejectUnauthorized?: boolean | undefined;
-        /**
-         * If true, specifies that the OCSP status request extension will be
-         * added to the client hello and an 'OCSPResponse' event will be
-         * emitted on the socket before establishing a secure communication
-         */
-        requestOCSP?: boolean | undefined;
-        /**
-         * An optional Buffer instance containing a TLS session.
-         */
-        session?: Buffer | undefined;
-        /**
-         * An optional TLS context object from tls.createSecureContext()
-         */
-        secureContext?: SecureContext | undefined;
-    }
-    interface ServerConnectionOptions extends CommonConnectionOptions {
-        /**
          * If true the server will request a certificate from clients that
          * connect and attempt to verify that certificate. Defaults to
          * false.
          */
         requestCert?: boolean | undefined;
         /**
-         * If true the server will reject any connection which is not
-         * authorized with the list of supplied CAs. This option only has an
-         * effect if requestCert is true.
+         * An array of strings or a Buffer naming possible ALPN protocols.
+         * (Protocols should be ordered by their priority.)
+         */
+        ALPNProtocols?: readonly string[] | NodeJS.ArrayBufferView | undefined;
+        /**
+         * SNICallback(servername, cb) <Function> A function that will be
+         * called if the client supports SNI TLS extension. Two arguments
+         * will be passed when called: servername and cb. SNICallback should
+         * invoke cb(null, ctx), where ctx is a SecureContext instance.
+         * (tls.createSecureContext(...) can be used to get a proper
+         * SecureContext.) If SNICallback wasn't provided the default callback
+         * with high-level API will be used (see below).
+         */
+        SNICallback?: ((servername: string, cb: (err: Error | null, ctx?: SecureContext) => void) => void) | undefined;
+        /**
+         * If not `false`, the peer certificate is verified against the list of
+         * supplied CAs. An `'error'` event is emitted if verification fails;
+         * `err.code` contains the OpenSSL error code.
          * @default true
          */
         rejectUnauthorized?: boolean | undefined;
+        /**
+         * An optional Buffer instance containing a TLS session.
+         */
+        session?: Buffer | undefined;
+        /**
+         * If true, specifies that the OCSP status request extension will be
+         * added to the client hello and an 'OCSPResponse' event will be
+         * emitted on the socket before establishing a secure communication
+         */
+        requestOCSP?: boolean | undefined;
         /**
          * If set, this will be called when a client opens a connection using the ALPN extension.
          * One argument will be passed to the callback: an object containing `servername` and `protocols` fields,
@@ -570,16 +562,44 @@ declare module "tls" {
          * This option cannot be used with the `ALPNProtocols` option, and setting both options will throw an error.
          */
         ALPNCallback?: ((arg: { servername: string | false; protocols: string[] }) => string | undefined) | undefined;
+    }
+    interface ClientConnectionOptions extends
+        Pick<
+            CommonConnectionOptions,
+            | "secureContext"
+            | "enableTrace"
+            | "ALPNProtocols"
+            | "rejectUnauthorized"
+            | "session"
+            | "requestOCSP"
+        >
+    {
         /**
-         * SNICallback(servername, cb) <Function> A function that will be
-         * called if the client supports SNI TLS extension. Two arguments
-         * will be passed when called: servername and cb. SNICallback should
-         * invoke cb(null, ctx), where ctx is a SecureContext instance.
-         * (tls.createSecureContext(...) can be used to get a proper
-         * SecureContext.) If SNICallback wasn't provided the default callback
-         * with high-level API will be used (see below).
+         * If not `false`, the server certificate is verified against the list of
+         * supplied CAs. An `'error'` event is emitted if verification fails;
+         * `err.code` contains the OpenSSL error code.
+         * @default true
          */
-        SNICallback?: ((servername: string, cb: (err: Error | null, ctx?: SecureContext) => void) => void) | undefined;
+        rejectUnauthorized?: boolean | undefined;
+    }
+    interface ServerConnectionOptions extends
+        Pick<
+            CommonConnectionOptions,
+            | "enableTrace"
+            | "requestCert"
+            | "ALPNProtocols"
+            | "SNICallback"
+            | "rejectUnauthorized"
+            | "ALPNCallback"
+        >
+    {
+        /**
+         * If true the server will reject any connection which is not
+         * authorized with the list of supplied CAs. This option only has an
+         * effect if requestCert is true.
+         * @default true
+         */
+        rejectUnauthorized?: boolean | undefined;
     }
     interface TlsOptions extends SecureContextOptions, ServerConnectionOptions, net.ServerOpts {
         /**

--- a/types/node/v20/tls.d.ts
+++ b/types/node/v20/tls.d.ts
@@ -562,7 +562,7 @@ declare module "tls" {
          * the client's ALPN protocols, an error will be thrown.
          * This option cannot be used with the `ALPNProtocols` option, and setting both options will throw an error.
          */
-        ALPNCallback?: ((arg: { servername: string; protocols: string[] }) => string | undefined) | undefined;
+        ALPNCallback?: ((arg: { servername: string | false; protocols: string[] }) => string | undefined) | undefined;
         /**
          * SNICallback(servername, cb) <Function> A function that will be
          * called if the client supports SNI TLS extension. Two arguments

--- a/types/node/v20/tls.d.ts
+++ b/types/node/v20/tls.d.ts
@@ -210,9 +210,9 @@ declare module "tls" {
      */
     class TLSSocket extends net.Socket {
         /**
-         * Construct a new tls.TLSSocket object from an existing stream.Duplex.
+         * Construct a new tls.TLSSocket object from an existing TCP socket or a stream.Duplex.
          */
-        constructor(socket: stream.Duplex, options?: TLSSocketOptions);
+        constructor(socket: net.Socket | stream.Duplex, options?: TLSSocketOptions);
         /**
          * This property is `true` if the peer certificate was signed by one of the CAs
          * specified when creating the `tls.TLSSocket` instance, otherwise `false`.

--- a/types/node/v20/tls.d.ts
+++ b/types/node/v20/tls.d.ts
@@ -198,26 +198,6 @@ declare module "tls" {
          */
         server?: net.Server | undefined;
     }
-    interface ServerModeTLSSocketOptions extends SecureContextOptions, ServerConnectionOptions {
-        /**
-         * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
-         * If true the TLS socket will be instantiated as a server.
-         * @default false
-         */
-        isServer: true;
-        /**
-         * An optional net.Server instance.
-         */
-        server?: net.Server | undefined;
-    }
-    interface ClientModeTLSSocketOptions extends SecureContextOptions, ClientConnectionOptions {
-        /**
-         * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
-         * If true the TLS socket will be instantiated as a server.
-         * @default false
-         */
-        isServer?: false | undefined;
-    }
     /**
      * Performs transparent encryption of written data and all required TLS
      * negotiation.
@@ -229,14 +209,6 @@ declare module "tls" {
      * @since v0.11.4
      */
     class TLSSocket extends net.Socket {
-        /**
-         * Construct a new tls.TLSSocket object in server mode from an existing stream.Duplex.
-         */
-        constructor(socket: stream.Duplex, options: ServerModeTLSSocketOptions);
-        /**
-         * Construct a new tls.TLSSocket object in client mode from an existing TCP socket.
-         */
-        constructor(socket: net.Socket, options?: ClientModeTLSSocketOptions);
         /**
          * Construct a new tls.TLSSocket object from an existing stream.Duplex.
          */

--- a/types/node/v20/tls.d.ts
+++ b/types/node/v20/tls.d.ts
@@ -516,6 +516,13 @@ declare module "tls" {
     }
     interface CommonConnectionOptions {
         /**
+         * If not `false`, the peer certificate is verified against the list of
+         * supplied CAs. An `'error'` event is emitted if verification fails;
+         * `err.code` contains the OpenSSL error code.
+         * @default true
+         */
+        rejectUnauthorized?: boolean | undefined;
+        /**
          * When enabled, TLS packet trace information is written to `stderr`. This can be
          * used to debug TLS connection problems.
          * @default false

--- a/types/node/v20/tls.d.ts
+++ b/types/node/v20/tls.d.ts
@@ -186,6 +186,18 @@ declare module "tls" {
          */
         passphrase?: string | undefined;
     }
+    interface TLSSocketOptions extends SecureContextOptions, ServerConnectionOptions, ClientConnectionOptions {
+        /**
+         * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
+         * If true the TLS socket will be instantiated as a server.
+         * @default false
+         */
+        isServer?: boolean | undefined;
+        /**
+         * An optional net.Server instance.
+         */
+        server?: net.Server | undefined;
+    }
     interface ServerModeTLSSocketOptions extends SecureContextOptions, ServerConnectionOptions {
         /**
          * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
@@ -225,6 +237,10 @@ declare module "tls" {
          * Construct a new tls.TLSSocket object in client mode from an existing TCP socket.
          */
         constructor(socket: net.Socket, options?: ClientModeTLSSocketOptions);
+        /**
+         * Construct a new tls.TLSSocket object from an existing stream.Duplex.
+         */
+        constructor(socket: stream.Duplex, options?: TLSSocketOptions);
         /**
          * This property is `true` if the peer certificate was signed by one of the CAs
          * specified when creating the `tls.TLSSocket` instance, otherwise `false`.

--- a/types/node/v20/tls.d.ts
+++ b/types/node/v20/tls.d.ts
@@ -186,17 +186,25 @@ declare module "tls" {
          */
         passphrase?: string | undefined;
     }
-    interface TLSSocketOptions extends SecureContextOptions, ServerConnectionOptions, ClientConnectionOptions {
+    interface ServerModeTLSSocketOptions extends SecureContextOptions, ServerConnectionOptions {
         /**
          * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
          * If true the TLS socket will be instantiated as a server.
          * @default false
          */
-        isServer?: boolean | undefined;
+        isServer: true;
         /**
          * An optional net.Server instance.
          */
         server?: net.Server | undefined;
+    }
+    interface ClientModeTLSSocketOptions extends SecureContextOptions, ClientConnectionOptions {
+        /**
+         * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
+         * If true the TLS socket will be instantiated as a server.
+         * @default false
+         */
+        isServer?: false | undefined;
     }
     /**
      * Performs transparent encryption of written data and all required TLS
@@ -210,9 +218,13 @@ declare module "tls" {
      */
     class TLSSocket extends net.Socket {
         /**
-         * Construct a new tls.TLSSocket object from an existing TCP socket.
+         * Construct a new tls.TLSSocket object in server mode from an existing stream.Duplex.
          */
-        constructor(socket: net.Socket | stream.Duplex, options?: TLSSocketOptions);
+        constructor(socket: stream.Duplex, options: ServerModeTLSSocketOptions);
+        /**
+         * Construct a new tls.TLSSocket object in client mode from an existing TCP socket.
+         */
+        constructor(socket: net.Socket, options?: ClientModeTLSSocketOptions);
         /**
          * This property is `true` if the peer certificate was signed by one of the CAs
          * specified when creating the `tls.TLSSocket` instance, otherwise `false`.

--- a/types/node/v20/tls.d.ts
+++ b/types/node/v20/tls.d.ts
@@ -186,26 +186,17 @@ declare module "tls" {
          */
         passphrase?: string | undefined;
     }
-    interface TLSSocketOptions extends SecureContextOptions, CommonConnectionOptions {
+    interface TLSSocketOptions extends SecureContextOptions, ServerConnectionOptions, ClientConnectionOptions {
         /**
-         * If true the TLS socket will be instantiated in server-mode.
-         * Defaults to false.
+         * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
+         * If true the TLS socket will be instantiated as a server.
+         * @default false
          */
         isServer?: boolean | undefined;
         /**
          * An optional net.Server instance.
          */
         server?: net.Server | undefined;
-        /**
-         * An optional Buffer instance containing a TLS session.
-         */
-        session?: Buffer | undefined;
-        /**
-         * If true, specifies that the OCSP status request extension will be
-         * added to the client hello and an 'OCSPResponse' event will be
-         * emitted on the socket before establishing a secure communication
-         */
-        requestOCSP?: boolean | undefined;
     }
     /**
      * Performs transparent encryption of written data and all required TLS
@@ -513,15 +504,41 @@ declare module "tls" {
     }
     interface CommonConnectionOptions {
         /**
-         * An optional TLS context object from tls.createSecureContext()
-         */
-        secureContext?: SecureContext | undefined;
-        /**
          * When enabled, TLS packet trace information is written to `stderr`. This can be
          * used to debug TLS connection problems.
          * @default false
          */
         enableTrace?: boolean | undefined;
+        /**
+         * An array of strings or a Buffer naming possible ALPN protocols.
+         * (Protocols should be ordered by their priority.)
+         */
+        ALPNProtocols?: readonly string[] | NodeJS.ArrayBufferView | undefined;
+    }
+    interface ClientConnectionOptions extends CommonConnectionOptions {
+        /**
+         * If not `false`, the server certificate is verified against the list of
+         * supplied CAs. An `'error'` event is emitted if verification fails;
+         * `err.code` contains the OpenSSL error code.
+         * @default true
+         */
+        rejectUnauthorized?: boolean | undefined;
+        /**
+         * If true, specifies that the OCSP status request extension will be
+         * added to the client hello and an 'OCSPResponse' event will be
+         * emitted on the socket before establishing a secure communication
+         */
+        requestOCSP?: boolean | undefined;
+        /**
+         * An optional Buffer instance containing a TLS session.
+         */
+        session?: Buffer | undefined;
+        /**
+         * An optional TLS context object from tls.createSecureContext()
+         */
+        secureContext?: SecureContext | undefined;
+    }
+    interface ServerConnectionOptions extends CommonConnectionOptions {
         /**
          * If true the server will request a certificate from clients that
          * connect and attempt to verify that certificate. Defaults to
@@ -529,10 +546,23 @@ declare module "tls" {
          */
         requestCert?: boolean | undefined;
         /**
-         * An array of strings or a Buffer naming possible ALPN protocols.
-         * (Protocols should be ordered by their priority.)
+         * If true the server will reject any connection which is not
+         * authorized with the list of supplied CAs. This option only has an
+         * effect if requestCert is true.
+         * @default true
          */
-        ALPNProtocols?: readonly string[] | NodeJS.ArrayBufferView | undefined;
+        rejectUnauthorized?: boolean | undefined;
+        /**
+         * If set, this will be called when a client opens a connection using the ALPN extension.
+         * One argument will be passed to the callback: an object containing `servername` and `protocols` fields,
+         * respectively containing the server name from the SNI extension (if any) and an array of
+         * ALPN protocol name strings. The callback must return either one of the strings listed in `protocols`,
+         * which will be returned to the client as the selected ALPN protocol, or `undefined`,
+         * to reject the connection with a fatal alert. If a string is returned that does not match one of
+         * the client's ALPN protocols, an error will be thrown.
+         * This option cannot be used with the `ALPNProtocols` option, and setting both options will throw an error.
+         */
+        ALPNCallback?: ((arg: { servername: string; protocols: string[] }) => string | undefined) | undefined;
         /**
          * SNICallback(servername, cb) <Function> A function that will be
          * called if the client supports SNI TLS extension. Two arguments
@@ -543,15 +573,8 @@ declare module "tls" {
          * with high-level API will be used (see below).
          */
         SNICallback?: ((servername: string, cb: (err: Error | null, ctx?: SecureContext) => void) => void) | undefined;
-        /**
-         * If true the server will reject any connection which is not
-         * authorized with the list of supplied CAs. This option only has an
-         * effect if requestCert is true.
-         * @default true
-         */
-        rejectUnauthorized?: boolean | undefined;
     }
-    interface TlsOptions extends SecureContextOptions, CommonConnectionOptions, net.ServerOpts {
+    interface TlsOptions extends SecureContextOptions, ServerConnectionOptions, net.ServerOpts {
         /**
          * Abort the connection if the SSL/TLS handshake does not finish in the
          * specified number of milliseconds. A 'tlsClientError' is emitted on
@@ -600,14 +623,13 @@ declare module "tls" {
         psk: NodeJS.ArrayBufferView;
         identity: string;
     }
-    interface ConnectionOptions extends SecureContextOptions, CommonConnectionOptions {
+    interface ConnectionOptions extends SecureContextOptions, ClientConnectionOptions {
         host?: string | undefined;
         port?: number | undefined;
         path?: string | undefined; // Creates unix socket connection to path. If this option is specified, `host` and `port` are ignored.
         socket?: stream.Duplex | undefined; // Establish secure connection on a given socket rather than creating a new socket
         checkServerIdentity?: typeof checkServerIdentity | undefined;
         servername?: string | undefined; // SNI TLS Extension
-        session?: Buffer | undefined;
         minDHSize?: number | undefined;
         lookup?: net.LookupFunction | undefined;
         timeout?: number | undefined;
@@ -830,17 +852,6 @@ declare module "tls" {
     }
     type SecureVersion = "TLSv1.3" | "TLSv1.2" | "TLSv1.1" | "TLSv1";
     interface SecureContextOptions {
-        /**
-         * If set, this will be called when a client opens a connection using the ALPN extension.
-         * One argument will be passed to the callback: an object containing `servername` and `protocols` fields,
-         * respectively containing the server name from the SNI extension (if any) and an array of
-         * ALPN protocol name strings. The callback must return either one of the strings listed in `protocols`,
-         * which will be returned to the client as the selected ALPN protocol, or `undefined`,
-         * to reject the connection with a fatal alert. If a string is returned that does not match one of
-         * the client's ALPN protocols, an error will be thrown.
-         * This option cannot be used with the `ALPNProtocols` option, and setting both options will throw an error.
-         */
-        ALPNCallback?: ((arg: { servername: string; protocols: string[] }) => string | undefined) | undefined;
         /**
          * Treat intermediate (non-self-signed)
          * certificates in the trust CA certificate list as trusted.

--- a/types/node/v22/test/tls.ts
+++ b/types/node/v22/test/tls.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as net from "node:net";
 import * as stream from "node:stream";
 import {
     connect,
@@ -348,4 +349,15 @@ import {
             cb(null, ctx);
         },
     };
+}
+
+{
+    // server mode
+    ((socket: net.Socket, server: net.Server | undefined) => new TLSSocket(socket, { isServer: true, server: server }));
+    ((duplex: stream.Duplex, server: net.Server | undefined) =>
+        new TLSSocket(duplex, { isServer: true, server: server }));
+    // client mode
+    ((socket: net.Socket) => new TLSSocket(socket, { isServer: false }));
+    // backward compatibility with mixed options
+    ((duplex: stream.Duplex) => new TLSSocket(duplex, { isServer: false, ALPNCallback: undefined, requestOCSP: true }));
 }

--- a/types/node/v22/test/tls.ts
+++ b/types/node/v22/test/tls.ts
@@ -40,6 +40,7 @@ import {
                 psk: Buffer.from("asd"),
             };
         },
+        requestOCSP: true,
     };
     const tlsSocket = connect(connOpts);
 
@@ -85,7 +86,7 @@ import {
 }
 
 {
-    const _server = createServer({
+    const options: TlsOptions = {
         enableTrace: true,
         pskCallback(socket, ident) {
             if (ident === "something") {
@@ -93,7 +94,8 @@ import {
             }
             return Buffer.from("asdasd");
         },
-    });
+    };
+    const _server = createServer(options);
 
     _server.addContext("example", {
         cert: fs.readFileSync("cert_filepath"),

--- a/types/node/v22/tls.d.ts
+++ b/types/node/v22/tls.d.ts
@@ -186,7 +186,7 @@ declare module "tls" {
          */
         passphrase?: string | undefined;
     }
-    interface TLSSocketOptions extends SecureContextOptions, ServerConnectionOptions, ClientConnectionOptions {
+    interface TLSSocketOptions extends SecureContextOptions, CommonConnectionOptions {
         /**
          * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
          * If true the TLS socket will be instantiated as a server.
@@ -504,12 +504,9 @@ declare module "tls" {
     }
     interface CommonConnectionOptions {
         /**
-         * If not `false`, the peer certificate is verified against the list of
-         * supplied CAs. An `'error'` event is emitted if verification fails;
-         * `err.code` contains the OpenSSL error code.
-         * @default true
+         * An optional TLS context object from tls.createSecureContext()
          */
-        rejectUnauthorized?: boolean | undefined;
+        secureContext?: SecureContext | undefined;
         /**
          * When enabled, TLS packet trace information is written to `stderr`. This can be
          * used to debug TLS connection problems.
@@ -517,48 +514,43 @@ declare module "tls" {
          */
         enableTrace?: boolean | undefined;
         /**
-         * An array of strings or a Buffer naming possible ALPN protocols.
-         * (Protocols should be ordered by their priority.)
-         */
-        ALPNProtocols?: readonly string[] | NodeJS.ArrayBufferView | undefined;
-    }
-    interface ClientConnectionOptions extends CommonConnectionOptions {
-        /**
-         * If not `false`, the server certificate is verified against the list of
-         * supplied CAs. An `'error'` event is emitted if verification fails;
-         * `err.code` contains the OpenSSL error code.
-         * @default true
-         */
-        rejectUnauthorized?: boolean | undefined;
-        /**
-         * If true, specifies that the OCSP status request extension will be
-         * added to the client hello and an 'OCSPResponse' event will be
-         * emitted on the socket before establishing a secure communication
-         */
-        requestOCSP?: boolean | undefined;
-        /**
-         * An optional Buffer instance containing a TLS session.
-         */
-        session?: Buffer | undefined;
-        /**
-         * An optional TLS context object from tls.createSecureContext()
-         */
-        secureContext?: SecureContext | undefined;
-    }
-    interface ServerConnectionOptions extends CommonConnectionOptions {
-        /**
          * If true the server will request a certificate from clients that
          * connect and attempt to verify that certificate. Defaults to
          * false.
          */
         requestCert?: boolean | undefined;
         /**
-         * If true the server will reject any connection which is not
-         * authorized with the list of supplied CAs. This option only has an
-         * effect if requestCert is true.
+         * An array of strings or a Buffer naming possible ALPN protocols.
+         * (Protocols should be ordered by their priority.)
+         */
+        ALPNProtocols?: readonly string[] | NodeJS.ArrayBufferView | undefined;
+        /**
+         * SNICallback(servername, cb) <Function> A function that will be
+         * called if the client supports SNI TLS extension. Two arguments
+         * will be passed when called: servername and cb. SNICallback should
+         * invoke cb(null, ctx), where ctx is a SecureContext instance.
+         * (tls.createSecureContext(...) can be used to get a proper
+         * SecureContext.) If SNICallback wasn't provided the default callback
+         * with high-level API will be used (see below).
+         */
+        SNICallback?: ((servername: string, cb: (err: Error | null, ctx?: SecureContext) => void) => void) | undefined;
+        /**
+         * If not `false`, the peer certificate is verified against the list of
+         * supplied CAs. An `'error'` event is emitted if verification fails;
+         * `err.code` contains the OpenSSL error code.
          * @default true
          */
         rejectUnauthorized?: boolean | undefined;
+        /**
+         * An optional Buffer instance containing a TLS session.
+         */
+        session?: Buffer | undefined;
+        /**
+         * If true, specifies that the OCSP status request extension will be
+         * added to the client hello and an 'OCSPResponse' event will be
+         * emitted on the socket before establishing a secure communication
+         */
+        requestOCSP?: boolean | undefined;
         /**
          * If set, this will be called when a client opens a connection using the ALPN extension.
          * One argument will be passed to the callback: an object containing `servername` and `protocols` fields,
@@ -570,16 +562,44 @@ declare module "tls" {
          * This option cannot be used with the `ALPNProtocols` option, and setting both options will throw an error.
          */
         ALPNCallback?: ((arg: { servername: string | false; protocols: string[] }) => string | undefined) | undefined;
+    }
+    interface ClientConnectionOptions extends
+        Pick<
+            CommonConnectionOptions,
+            | "secureContext"
+            | "enableTrace"
+            | "ALPNProtocols"
+            | "rejectUnauthorized"
+            | "session"
+            | "requestOCSP"
+        >
+    {
         /**
-         * SNICallback(servername, cb) <Function> A function that will be
-         * called if the client supports SNI TLS extension. Two arguments
-         * will be passed when called: servername and cb. SNICallback should
-         * invoke cb(null, ctx), where ctx is a SecureContext instance.
-         * (tls.createSecureContext(...) can be used to get a proper
-         * SecureContext.) If SNICallback wasn't provided the default callback
-         * with high-level API will be used (see below).
+         * If not `false`, the server certificate is verified against the list of
+         * supplied CAs. An `'error'` event is emitted if verification fails;
+         * `err.code` contains the OpenSSL error code.
+         * @default true
          */
-        SNICallback?: ((servername: string, cb: (err: Error | null, ctx?: SecureContext) => void) => void) | undefined;
+        rejectUnauthorized?: boolean | undefined;
+    }
+    interface ServerConnectionOptions extends
+        Pick<
+            CommonConnectionOptions,
+            | "enableTrace"
+            | "requestCert"
+            | "ALPNProtocols"
+            | "SNICallback"
+            | "rejectUnauthorized"
+            | "ALPNCallback"
+        >
+    {
+        /**
+         * If true the server will reject any connection which is not
+         * authorized with the list of supplied CAs. This option only has an
+         * effect if requestCert is true.
+         * @default true
+         */
+        rejectUnauthorized?: boolean | undefined;
     }
     interface TlsOptions extends SecureContextOptions, ServerConnectionOptions, net.ServerOpts {
         /**

--- a/types/node/v22/tls.d.ts
+++ b/types/node/v22/tls.d.ts
@@ -562,7 +562,7 @@ declare module "tls" {
          * the client's ALPN protocols, an error will be thrown.
          * This option cannot be used with the `ALPNProtocols` option, and setting both options will throw an error.
          */
-        ALPNCallback?: ((arg: { servername: string; protocols: string[] }) => string | undefined) | undefined;
+        ALPNCallback?: ((arg: { servername: string | false; protocols: string[] }) => string | undefined) | undefined;
         /**
          * SNICallback(servername, cb) <Function> A function that will be
          * called if the client supports SNI TLS extension. Two arguments

--- a/types/node/v22/tls.d.ts
+++ b/types/node/v22/tls.d.ts
@@ -210,9 +210,9 @@ declare module "tls" {
      */
     class TLSSocket extends net.Socket {
         /**
-         * Construct a new tls.TLSSocket object from an existing stream.Duplex.
+         * Construct a new tls.TLSSocket object from an existing TCP socket or a stream.Duplex.
          */
-        constructor(socket: stream.Duplex, options?: TLSSocketOptions);
+        constructor(socket: net.Socket | stream.Duplex, options?: TLSSocketOptions);
         /**
          * This property is `true` if the peer certificate was signed by one of the CAs
          * specified when creating the `tls.TLSSocket` instance, otherwise `false`.

--- a/types/node/v22/tls.d.ts
+++ b/types/node/v22/tls.d.ts
@@ -198,26 +198,6 @@ declare module "tls" {
          */
         server?: net.Server | undefined;
     }
-    interface ServerModeTLSSocketOptions extends SecureContextOptions, ServerConnectionOptions {
-        /**
-         * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
-         * If true the TLS socket will be instantiated as a server.
-         * @default false
-         */
-        isServer: true;
-        /**
-         * An optional net.Server instance.
-         */
-        server?: net.Server | undefined;
-    }
-    interface ClientModeTLSSocketOptions extends SecureContextOptions, ClientConnectionOptions {
-        /**
-         * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
-         * If true the TLS socket will be instantiated as a server.
-         * @default false
-         */
-        isServer?: false | undefined;
-    }
     /**
      * Performs transparent encryption of written data and all required TLS
      * negotiation.
@@ -229,14 +209,6 @@ declare module "tls" {
      * @since v0.11.4
      */
     class TLSSocket extends net.Socket {
-        /**
-         * Construct a new tls.TLSSocket object in server mode from an existing stream.Duplex.
-         */
-        constructor(socket: stream.Duplex, options: ServerModeTLSSocketOptions);
-        /**
-         * Construct a new tls.TLSSocket object in client mode from an existing TCP socket.
-         */
-        constructor(socket: net.Socket, options?: ClientModeTLSSocketOptions);
         /**
          * Construct a new tls.TLSSocket object from an existing stream.Duplex.
          */

--- a/types/node/v22/tls.d.ts
+++ b/types/node/v22/tls.d.ts
@@ -516,6 +516,13 @@ declare module "tls" {
     }
     interface CommonConnectionOptions {
         /**
+         * If not `false`, the peer certificate is verified against the list of
+         * supplied CAs. An `'error'` event is emitted if verification fails;
+         * `err.code` contains the OpenSSL error code.
+         * @default true
+         */
+        rejectUnauthorized?: boolean | undefined;
+        /**
          * When enabled, TLS packet trace information is written to `stderr`. This can be
          * used to debug TLS connection problems.
          * @default false

--- a/types/node/v22/tls.d.ts
+++ b/types/node/v22/tls.d.ts
@@ -186,6 +186,18 @@ declare module "tls" {
          */
         passphrase?: string | undefined;
     }
+    interface TLSSocketOptions extends SecureContextOptions, ServerConnectionOptions, ClientConnectionOptions {
+        /**
+         * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
+         * If true the TLS socket will be instantiated as a server.
+         * @default false
+         */
+        isServer?: boolean | undefined;
+        /**
+         * An optional net.Server instance.
+         */
+        server?: net.Server | undefined;
+    }
     interface ServerModeTLSSocketOptions extends SecureContextOptions, ServerConnectionOptions {
         /**
          * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
@@ -225,6 +237,10 @@ declare module "tls" {
          * Construct a new tls.TLSSocket object in client mode from an existing TCP socket.
          */
         constructor(socket: net.Socket, options?: ClientModeTLSSocketOptions);
+        /**
+         * Construct a new tls.TLSSocket object from an existing stream.Duplex.
+         */
+        constructor(socket: stream.Duplex, options?: TLSSocketOptions);
         /**
          * This property is `true` if the peer certificate was signed by one of the CAs
          * specified when creating the `tls.TLSSocket` instance, otherwise `false`.

--- a/types/node/v22/tls.d.ts
+++ b/types/node/v22/tls.d.ts
@@ -186,17 +186,25 @@ declare module "tls" {
          */
         passphrase?: string | undefined;
     }
-    interface TLSSocketOptions extends SecureContextOptions, ServerConnectionOptions, ClientConnectionOptions {
+    interface ServerModeTLSSocketOptions extends SecureContextOptions, ServerConnectionOptions {
         /**
          * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
          * If true the TLS socket will be instantiated as a server.
          * @default false
          */
-        isServer?: boolean | undefined;
+        isServer: true;
         /**
          * An optional net.Server instance.
          */
         server?: net.Server | undefined;
+    }
+    interface ClientModeTLSSocketOptions extends SecureContextOptions, ClientConnectionOptions {
+        /**
+         * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
+         * If true the TLS socket will be instantiated as a server.
+         * @default false
+         */
+        isServer?: false | undefined;
     }
     /**
      * Performs transparent encryption of written data and all required TLS
@@ -210,9 +218,13 @@ declare module "tls" {
      */
     class TLSSocket extends net.Socket {
         /**
-         * Construct a new tls.TLSSocket object from an existing TCP socket.
+         * Construct a new tls.TLSSocket object in server mode from an existing stream.Duplex.
          */
-        constructor(socket: net.Socket | stream.Duplex, options?: TLSSocketOptions);
+        constructor(socket: stream.Duplex, options: ServerModeTLSSocketOptions);
+        /**
+         * Construct a new tls.TLSSocket object in client mode from an existing TCP socket.
+         */
+        constructor(socket: net.Socket, options?: ClientModeTLSSocketOptions);
         /**
          * This property is `true` if the peer certificate was signed by one of the CAs
          * specified when creating the `tls.TLSSocket` instance, otherwise `false`.

--- a/types/node/v22/tls.d.ts
+++ b/types/node/v22/tls.d.ts
@@ -186,26 +186,17 @@ declare module "tls" {
          */
         passphrase?: string | undefined;
     }
-    interface TLSSocketOptions extends SecureContextOptions, CommonConnectionOptions {
+    interface TLSSocketOptions extends SecureContextOptions, ServerConnectionOptions, ClientConnectionOptions {
         /**
-         * If true the TLS socket will be instantiated in server-mode.
-         * Defaults to false.
+         * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
+         * If true the TLS socket will be instantiated as a server.
+         * @default false
          */
         isServer?: boolean | undefined;
         /**
          * An optional net.Server instance.
          */
         server?: net.Server | undefined;
-        /**
-         * An optional Buffer instance containing a TLS session.
-         */
-        session?: Buffer | undefined;
-        /**
-         * If true, specifies that the OCSP status request extension will be
-         * added to the client hello and an 'OCSPResponse' event will be
-         * emitted on the socket before establishing a secure communication
-         */
-        requestOCSP?: boolean | undefined;
     }
     /**
      * Performs transparent encryption of written data and all required TLS
@@ -513,15 +504,41 @@ declare module "tls" {
     }
     interface CommonConnectionOptions {
         /**
-         * An optional TLS context object from tls.createSecureContext()
-         */
-        secureContext?: SecureContext | undefined;
-        /**
          * When enabled, TLS packet trace information is written to `stderr`. This can be
          * used to debug TLS connection problems.
          * @default false
          */
         enableTrace?: boolean | undefined;
+        /**
+         * An array of strings or a Buffer naming possible ALPN protocols.
+         * (Protocols should be ordered by their priority.)
+         */
+        ALPNProtocols?: readonly string[] | NodeJS.ArrayBufferView | undefined;
+    }
+    interface ClientConnectionOptions extends CommonConnectionOptions {
+        /**
+         * If not `false`, the server certificate is verified against the list of
+         * supplied CAs. An `'error'` event is emitted if verification fails;
+         * `err.code` contains the OpenSSL error code.
+         * @default true
+         */
+        rejectUnauthorized?: boolean | undefined;
+        /**
+         * If true, specifies that the OCSP status request extension will be
+         * added to the client hello and an 'OCSPResponse' event will be
+         * emitted on the socket before establishing a secure communication
+         */
+        requestOCSP?: boolean | undefined;
+        /**
+         * An optional Buffer instance containing a TLS session.
+         */
+        session?: Buffer | undefined;
+        /**
+         * An optional TLS context object from tls.createSecureContext()
+         */
+        secureContext?: SecureContext | undefined;
+    }
+    interface ServerConnectionOptions extends CommonConnectionOptions {
         /**
          * If true the server will request a certificate from clients that
          * connect and attempt to verify that certificate. Defaults to
@@ -529,10 +546,23 @@ declare module "tls" {
          */
         requestCert?: boolean | undefined;
         /**
-         * An array of strings or a Buffer naming possible ALPN protocols.
-         * (Protocols should be ordered by their priority.)
+         * If true the server will reject any connection which is not
+         * authorized with the list of supplied CAs. This option only has an
+         * effect if requestCert is true.
+         * @default true
          */
-        ALPNProtocols?: readonly string[] | NodeJS.ArrayBufferView | undefined;
+        rejectUnauthorized?: boolean | undefined;
+        /**
+         * If set, this will be called when a client opens a connection using the ALPN extension.
+         * One argument will be passed to the callback: an object containing `servername` and `protocols` fields,
+         * respectively containing the server name from the SNI extension (if any) and an array of
+         * ALPN protocol name strings. The callback must return either one of the strings listed in `protocols`,
+         * which will be returned to the client as the selected ALPN protocol, or `undefined`,
+         * to reject the connection with a fatal alert. If a string is returned that does not match one of
+         * the client's ALPN protocols, an error will be thrown.
+         * This option cannot be used with the `ALPNProtocols` option, and setting both options will throw an error.
+         */
+        ALPNCallback?: ((arg: { servername: string; protocols: string[] }) => string | undefined) | undefined;
         /**
          * SNICallback(servername, cb) <Function> A function that will be
          * called if the client supports SNI TLS extension. Two arguments
@@ -543,15 +573,8 @@ declare module "tls" {
          * with high-level API will be used (see below).
          */
         SNICallback?: ((servername: string, cb: (err: Error | null, ctx?: SecureContext) => void) => void) | undefined;
-        /**
-         * If true the server will reject any connection which is not
-         * authorized with the list of supplied CAs. This option only has an
-         * effect if requestCert is true.
-         * @default true
-         */
-        rejectUnauthorized?: boolean | undefined;
     }
-    interface TlsOptions extends SecureContextOptions, CommonConnectionOptions, net.ServerOpts {
+    interface TlsOptions extends SecureContextOptions, ServerConnectionOptions, net.ServerOpts {
         /**
          * Abort the connection if the SSL/TLS handshake does not finish in the
          * specified number of milliseconds. A 'tlsClientError' is emitted on
@@ -600,14 +623,13 @@ declare module "tls" {
         psk: NodeJS.ArrayBufferView;
         identity: string;
     }
-    interface ConnectionOptions extends SecureContextOptions, CommonConnectionOptions {
+    interface ConnectionOptions extends SecureContextOptions, ClientConnectionOptions {
         host?: string | undefined;
         port?: number | undefined;
         path?: string | undefined; // Creates unix socket connection to path. If this option is specified, `host` and `port` are ignored.
         socket?: stream.Duplex | undefined; // Establish secure connection on a given socket rather than creating a new socket
         checkServerIdentity?: typeof checkServerIdentity | undefined;
         servername?: string | undefined; // SNI TLS Extension
-        session?: Buffer | undefined;
         minDHSize?: number | undefined;
         lookup?: net.LookupFunction | undefined;
         timeout?: number | undefined;
@@ -830,17 +852,6 @@ declare module "tls" {
     }
     type SecureVersion = "TLSv1.3" | "TLSv1.2" | "TLSv1.1" | "TLSv1";
     interface SecureContextOptions {
-        /**
-         * If set, this will be called when a client opens a connection using the ALPN extension.
-         * One argument will be passed to the callback: an object containing `servername` and `protocols` fields,
-         * respectively containing the server name from the SNI extension (if any) and an array of
-         * ALPN protocol name strings. The callback must return either one of the strings listed in `protocols`,
-         * which will be returned to the client as the selected ALPN protocol, or `undefined`,
-         * to reject the connection with a fatal alert. If a string is returned that does not match one of
-         * the client's ALPN protocols, an error will be thrown.
-         * This option cannot be used with the `ALPNProtocols` option, and setting both options will throw an error.
-         */
-        ALPNCallback?: ((arg: { servername: string; protocols: string[] }) => string | undefined) | undefined;
         /**
          * Treat intermediate (non-self-signed)
          * certificates in the trust CA certificate list as trusted.

--- a/types/node/v24/test/tls.ts
+++ b/types/node/v24/test/tls.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as net from "node:net";
 import * as stream from "node:stream";
 import {
     connect,
@@ -348,4 +349,15 @@ import {
             cb(null, ctx);
         },
     };
+}
+
+{
+    // server mode
+    ((socket: net.Socket, server: net.Server | undefined) => new TLSSocket(socket, { isServer: true, server: server }));
+    ((duplex: stream.Duplex, server: net.Server | undefined) =>
+        new TLSSocket(duplex, { isServer: true, server: server }));
+    // client mode
+    ((socket: net.Socket) => new TLSSocket(socket, { isServer: false }));
+    // backward compatibility with mixed options
+    ((duplex: stream.Duplex) => new TLSSocket(duplex, { isServer: false, ALPNCallback: undefined, requestOCSP: true }));
 }

--- a/types/node/v24/test/tls.ts
+++ b/types/node/v24/test/tls.ts
@@ -40,6 +40,7 @@ import {
                 psk: Buffer.from("asd"),
             };
         },
+        requestOCSP: true,
     };
     const tlsSocket = connect(connOpts);
 
@@ -85,7 +86,7 @@ import {
 }
 
 {
-    const _server = createServer({
+    const options: TlsOptions = {
         enableTrace: true,
         pskCallback(socket, ident) {
             if (ident === "something") {
@@ -93,7 +94,8 @@ import {
             }
             return Buffer.from("asdasd");
         },
-    });
+    };
+    const _server = createServer(options);
 
     _server.addContext("example", {
         cert: fs.readFileSync("cert_filepath"),

--- a/types/node/v24/tls.d.ts
+++ b/types/node/v24/tls.d.ts
@@ -186,7 +186,7 @@ declare module "tls" {
          */
         passphrase?: string | undefined;
     }
-    interface TLSSocketOptions extends SecureContextOptions, ServerConnectionOptions, ClientConnectionOptions {
+    interface TLSSocketOptions extends SecureContextOptions, CommonConnectionOptions {
         /**
          * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
          * If true the TLS socket will be instantiated as a server.
@@ -504,12 +504,9 @@ declare module "tls" {
     }
     interface CommonConnectionOptions {
         /**
-         * If not `false`, the peer certificate is verified against the list of
-         * supplied CAs. An `'error'` event is emitted if verification fails;
-         * `err.code` contains the OpenSSL error code.
-         * @default true
+         * An optional TLS context object from tls.createSecureContext()
          */
-        rejectUnauthorized?: boolean | undefined;
+        secureContext?: SecureContext | undefined;
         /**
          * When enabled, TLS packet trace information is written to `stderr`. This can be
          * used to debug TLS connection problems.
@@ -517,48 +514,43 @@ declare module "tls" {
          */
         enableTrace?: boolean | undefined;
         /**
-         * An array of strings or a Buffer naming possible ALPN protocols.
-         * (Protocols should be ordered by their priority.)
-         */
-        ALPNProtocols?: readonly string[] | NodeJS.ArrayBufferView | undefined;
-    }
-    interface ClientConnectionOptions extends CommonConnectionOptions {
-        /**
-         * If not `false`, the server certificate is verified against the list of
-         * supplied CAs. An `'error'` event is emitted if verification fails;
-         * `err.code` contains the OpenSSL error code.
-         * @default true
-         */
-        rejectUnauthorized?: boolean | undefined;
-        /**
-         * If true, specifies that the OCSP status request extension will be
-         * added to the client hello and an 'OCSPResponse' event will be
-         * emitted on the socket before establishing a secure communication
-         */
-        requestOCSP?: boolean | undefined;
-        /**
-         * An optional Buffer instance containing a TLS session.
-         */
-        session?: Buffer | undefined;
-        /**
-         * An optional TLS context object from tls.createSecureContext()
-         */
-        secureContext?: SecureContext | undefined;
-    }
-    interface ServerConnectionOptions extends CommonConnectionOptions {
-        /**
          * If true the server will request a certificate from clients that
          * connect and attempt to verify that certificate. Defaults to
          * false.
          */
         requestCert?: boolean | undefined;
         /**
-         * If true the server will reject any connection which is not
-         * authorized with the list of supplied CAs. This option only has an
-         * effect if requestCert is true.
+         * An array of strings or a Buffer naming possible ALPN protocols.
+         * (Protocols should be ordered by their priority.)
+         */
+        ALPNProtocols?: readonly string[] | NodeJS.ArrayBufferView | undefined;
+        /**
+         * SNICallback(servername, cb) <Function> A function that will be
+         * called if the client supports SNI TLS extension. Two arguments
+         * will be passed when called: servername and cb. SNICallback should
+         * invoke cb(null, ctx), where ctx is a SecureContext instance.
+         * (tls.createSecureContext(...) can be used to get a proper
+         * SecureContext.) If SNICallback wasn't provided the default callback
+         * with high-level API will be used (see below).
+         */
+        SNICallback?: ((servername: string, cb: (err: Error | null, ctx?: SecureContext) => void) => void) | undefined;
+        /**
+         * If not `false`, the peer certificate is verified against the list of
+         * supplied CAs. An `'error'` event is emitted if verification fails;
+         * `err.code` contains the OpenSSL error code.
          * @default true
          */
         rejectUnauthorized?: boolean | undefined;
+        /**
+         * An optional Buffer instance containing a TLS session.
+         */
+        session?: Buffer | undefined;
+        /**
+         * If true, specifies that the OCSP status request extension will be
+         * added to the client hello and an 'OCSPResponse' event will be
+         * emitted on the socket before establishing a secure communication
+         */
+        requestOCSP?: boolean | undefined;
         /**
          * If set, this will be called when a client opens a connection using the ALPN extension.
          * One argument will be passed to the callback: an object containing `servername` and `protocols` fields,
@@ -570,16 +562,44 @@ declare module "tls" {
          * This option cannot be used with the `ALPNProtocols` option, and setting both options will throw an error.
          */
         ALPNCallback?: ((arg: { servername: string | false; protocols: string[] }) => string | undefined) | undefined;
+    }
+    interface ClientConnectionOptions extends
+        Pick<
+            CommonConnectionOptions,
+            | "secureContext"
+            | "enableTrace"
+            | "ALPNProtocols"
+            | "rejectUnauthorized"
+            | "session"
+            | "requestOCSP"
+        >
+    {
         /**
-         * SNICallback(servername, cb) <Function> A function that will be
-         * called if the client supports SNI TLS extension. Two arguments
-         * will be passed when called: servername and cb. SNICallback should
-         * invoke cb(null, ctx), where ctx is a SecureContext instance.
-         * (tls.createSecureContext(...) can be used to get a proper
-         * SecureContext.) If SNICallback wasn't provided the default callback
-         * with high-level API will be used (see below).
+         * If not `false`, the server certificate is verified against the list of
+         * supplied CAs. An `'error'` event is emitted if verification fails;
+         * `err.code` contains the OpenSSL error code.
+         * @default true
          */
-        SNICallback?: ((servername: string, cb: (err: Error | null, ctx?: SecureContext) => void) => void) | undefined;
+        rejectUnauthorized?: boolean | undefined;
+    }
+    interface ServerConnectionOptions extends
+        Pick<
+            CommonConnectionOptions,
+            | "enableTrace"
+            | "requestCert"
+            | "ALPNProtocols"
+            | "SNICallback"
+            | "rejectUnauthorized"
+            | "ALPNCallback"
+        >
+    {
+        /**
+         * If true the server will reject any connection which is not
+         * authorized with the list of supplied CAs. This option only has an
+         * effect if requestCert is true.
+         * @default true
+         */
+        rejectUnauthorized?: boolean | undefined;
     }
     interface TlsOptions extends SecureContextOptions, ServerConnectionOptions, net.ServerOpts {
         /**

--- a/types/node/v24/tls.d.ts
+++ b/types/node/v24/tls.d.ts
@@ -562,7 +562,7 @@ declare module "tls" {
          * the client's ALPN protocols, an error will be thrown.
          * This option cannot be used with the `ALPNProtocols` option, and setting both options will throw an error.
          */
-        ALPNCallback?: ((arg: { servername: string; protocols: string[] }) => string | undefined) | undefined;
+        ALPNCallback?: ((arg: { servername: string | false; protocols: string[] }) => string | undefined) | undefined;
         /**
          * SNICallback(servername, cb) <Function> A function that will be
          * called if the client supports SNI TLS extension. Two arguments

--- a/types/node/v24/tls.d.ts
+++ b/types/node/v24/tls.d.ts
@@ -210,9 +210,9 @@ declare module "tls" {
      */
     class TLSSocket extends net.Socket {
         /**
-         * Construct a new tls.TLSSocket object from an existing stream.Duplex.
+         * Construct a new tls.TLSSocket object from an existing TCP socket or a stream.Duplex.
          */
-        constructor(socket: stream.Duplex, options?: TLSSocketOptions);
+        constructor(socket: net.Socket | stream.Duplex, options?: TLSSocketOptions);
         /**
          * This property is `true` if the peer certificate was signed by one of the CAs
          * specified when creating the `tls.TLSSocket` instance, otherwise `false`.

--- a/types/node/v24/tls.d.ts
+++ b/types/node/v24/tls.d.ts
@@ -198,26 +198,6 @@ declare module "tls" {
          */
         server?: net.Server | undefined;
     }
-    interface ServerModeTLSSocketOptions extends SecureContextOptions, ServerConnectionOptions {
-        /**
-         * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
-         * If true the TLS socket will be instantiated as a server.
-         * @default false
-         */
-        isServer: true;
-        /**
-         * An optional net.Server instance.
-         */
-        server?: net.Server | undefined;
-    }
-    interface ClientModeTLSSocketOptions extends SecureContextOptions, ClientConnectionOptions {
-        /**
-         * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
-         * If true the TLS socket will be instantiated as a server.
-         * @default false
-         */
-        isServer?: false | undefined;
-    }
     /**
      * Performs transparent encryption of written data and all required TLS
      * negotiation.
@@ -229,14 +209,6 @@ declare module "tls" {
      * @since v0.11.4
      */
     class TLSSocket extends net.Socket {
-        /**
-         * Construct a new tls.TLSSocket object in server mode from an existing stream.Duplex.
-         */
-        constructor(socket: stream.Duplex, options: ServerModeTLSSocketOptions);
-        /**
-         * Construct a new tls.TLSSocket object in client mode from an existing TCP socket.
-         */
-        constructor(socket: net.Socket, options?: ClientModeTLSSocketOptions);
         /**
          * Construct a new tls.TLSSocket object from an existing stream.Duplex.
          */

--- a/types/node/v24/tls.d.ts
+++ b/types/node/v24/tls.d.ts
@@ -516,6 +516,13 @@ declare module "tls" {
     }
     interface CommonConnectionOptions {
         /**
+         * If not `false`, the peer certificate is verified against the list of
+         * supplied CAs. An `'error'` event is emitted if verification fails;
+         * `err.code` contains the OpenSSL error code.
+         * @default true
+         */
+        rejectUnauthorized?: boolean | undefined;
+        /**
          * When enabled, TLS packet trace information is written to `stderr`. This can be
          * used to debug TLS connection problems.
          * @default false

--- a/types/node/v24/tls.d.ts
+++ b/types/node/v24/tls.d.ts
@@ -186,6 +186,18 @@ declare module "tls" {
          */
         passphrase?: string | undefined;
     }
+    interface TLSSocketOptions extends SecureContextOptions, ServerConnectionOptions, ClientConnectionOptions {
+        /**
+         * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
+         * If true the TLS socket will be instantiated as a server.
+         * @default false
+         */
+        isServer?: boolean | undefined;
+        /**
+         * An optional net.Server instance.
+         */
+        server?: net.Server | undefined;
+    }
     interface ServerModeTLSSocketOptions extends SecureContextOptions, ServerConnectionOptions {
         /**
          * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
@@ -225,6 +237,10 @@ declare module "tls" {
          * Construct a new tls.TLSSocket object in client mode from an existing TCP socket.
          */
         constructor(socket: net.Socket, options?: ClientModeTLSSocketOptions);
+        /**
+         * Construct a new tls.TLSSocket object from an existing stream.Duplex.
+         */
+        constructor(socket: stream.Duplex, options?: TLSSocketOptions);
         /**
          * This property is `true` if the peer certificate was signed by one of the CAs
          * specified when creating the `tls.TLSSocket` instance, otherwise `false`.

--- a/types/node/v24/tls.d.ts
+++ b/types/node/v24/tls.d.ts
@@ -186,17 +186,25 @@ declare module "tls" {
          */
         passphrase?: string | undefined;
     }
-    interface TLSSocketOptions extends SecureContextOptions, ServerConnectionOptions, ClientConnectionOptions {
+    interface ServerModeTLSSocketOptions extends SecureContextOptions, ServerConnectionOptions {
         /**
          * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
          * If true the TLS socket will be instantiated as a server.
          * @default false
          */
-        isServer?: boolean | undefined;
+        isServer: true;
         /**
          * An optional net.Server instance.
          */
         server?: net.Server | undefined;
+    }
+    interface ClientModeTLSSocketOptions extends SecureContextOptions, ClientConnectionOptions {
+        /**
+         * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
+         * If true the TLS socket will be instantiated as a server.
+         * @default false
+         */
+        isServer?: false | undefined;
     }
     /**
      * Performs transparent encryption of written data and all required TLS
@@ -210,9 +218,13 @@ declare module "tls" {
      */
     class TLSSocket extends net.Socket {
         /**
-         * Construct a new tls.TLSSocket object from an existing TCP socket.
+         * Construct a new tls.TLSSocket object in server mode from an existing stream.Duplex.
          */
-        constructor(socket: net.Socket | stream.Duplex, options?: TLSSocketOptions);
+        constructor(socket: stream.Duplex, options: ServerModeTLSSocketOptions);
+        /**
+         * Construct a new tls.TLSSocket object in client mode from an existing TCP socket.
+         */
+        constructor(socket: net.Socket, options?: ClientModeTLSSocketOptions);
         /**
          * This property is `true` if the peer certificate was signed by one of the CAs
          * specified when creating the `tls.TLSSocket` instance, otherwise `false`.

--- a/types/node/v24/tls.d.ts
+++ b/types/node/v24/tls.d.ts
@@ -186,26 +186,17 @@ declare module "tls" {
          */
         passphrase?: string | undefined;
     }
-    interface TLSSocketOptions extends SecureContextOptions, CommonConnectionOptions {
+    interface TLSSocketOptions extends SecureContextOptions, ServerConnectionOptions, ClientConnectionOptions {
         /**
-         * If true the TLS socket will be instantiated in server-mode.
-         * Defaults to false.
+         * The SSL/TLS protocol is asymmetrical, TLSSockets must know if they are to behave as a server or a client.
+         * If true the TLS socket will be instantiated as a server.
+         * @default false
          */
         isServer?: boolean | undefined;
         /**
          * An optional net.Server instance.
          */
         server?: net.Server | undefined;
-        /**
-         * An optional Buffer instance containing a TLS session.
-         */
-        session?: Buffer | undefined;
-        /**
-         * If true, specifies that the OCSP status request extension will be
-         * added to the client hello and an 'OCSPResponse' event will be
-         * emitted on the socket before establishing a secure communication
-         */
-        requestOCSP?: boolean | undefined;
     }
     /**
      * Performs transparent encryption of written data and all required TLS
@@ -513,15 +504,41 @@ declare module "tls" {
     }
     interface CommonConnectionOptions {
         /**
-         * An optional TLS context object from tls.createSecureContext()
-         */
-        secureContext?: SecureContext | undefined;
-        /**
          * When enabled, TLS packet trace information is written to `stderr`. This can be
          * used to debug TLS connection problems.
          * @default false
          */
         enableTrace?: boolean | undefined;
+        /**
+         * An array of strings or a Buffer naming possible ALPN protocols.
+         * (Protocols should be ordered by their priority.)
+         */
+        ALPNProtocols?: readonly string[] | NodeJS.ArrayBufferView | undefined;
+    }
+    interface ClientConnectionOptions extends CommonConnectionOptions {
+        /**
+         * If not `false`, the server certificate is verified against the list of
+         * supplied CAs. An `'error'` event is emitted if verification fails;
+         * `err.code` contains the OpenSSL error code.
+         * @default true
+         */
+        rejectUnauthorized?: boolean | undefined;
+        /**
+         * If true, specifies that the OCSP status request extension will be
+         * added to the client hello and an 'OCSPResponse' event will be
+         * emitted on the socket before establishing a secure communication
+         */
+        requestOCSP?: boolean | undefined;
+        /**
+         * An optional Buffer instance containing a TLS session.
+         */
+        session?: Buffer | undefined;
+        /**
+         * An optional TLS context object from tls.createSecureContext()
+         */
+        secureContext?: SecureContext | undefined;
+    }
+    interface ServerConnectionOptions extends CommonConnectionOptions {
         /**
          * If true the server will request a certificate from clients that
          * connect and attempt to verify that certificate. Defaults to
@@ -529,10 +546,23 @@ declare module "tls" {
          */
         requestCert?: boolean | undefined;
         /**
-         * An array of strings or a Buffer naming possible ALPN protocols.
-         * (Protocols should be ordered by their priority.)
+         * If true the server will reject any connection which is not
+         * authorized with the list of supplied CAs. This option only has an
+         * effect if requestCert is true.
+         * @default true
          */
-        ALPNProtocols?: readonly string[] | NodeJS.ArrayBufferView | undefined;
+        rejectUnauthorized?: boolean | undefined;
+        /**
+         * If set, this will be called when a client opens a connection using the ALPN extension.
+         * One argument will be passed to the callback: an object containing `servername` and `protocols` fields,
+         * respectively containing the server name from the SNI extension (if any) and an array of
+         * ALPN protocol name strings. The callback must return either one of the strings listed in `protocols`,
+         * which will be returned to the client as the selected ALPN protocol, or `undefined`,
+         * to reject the connection with a fatal alert. If a string is returned that does not match one of
+         * the client's ALPN protocols, an error will be thrown.
+         * This option cannot be used with the `ALPNProtocols` option, and setting both options will throw an error.
+         */
+        ALPNCallback?: ((arg: { servername: string; protocols: string[] }) => string | undefined) | undefined;
         /**
          * SNICallback(servername, cb) <Function> A function that will be
          * called if the client supports SNI TLS extension. Two arguments
@@ -543,15 +573,8 @@ declare module "tls" {
          * with high-level API will be used (see below).
          */
         SNICallback?: ((servername: string, cb: (err: Error | null, ctx?: SecureContext) => void) => void) | undefined;
-        /**
-         * If true the server will reject any connection which is not
-         * authorized with the list of supplied CAs. This option only has an
-         * effect if requestCert is true.
-         * @default true
-         */
-        rejectUnauthorized?: boolean | undefined;
     }
-    interface TlsOptions extends SecureContextOptions, CommonConnectionOptions, net.ServerOpts {
+    interface TlsOptions extends SecureContextOptions, ServerConnectionOptions, net.ServerOpts {
         /**
          * Abort the connection if the SSL/TLS handshake does not finish in the
          * specified number of milliseconds. A 'tlsClientError' is emitted on
@@ -600,14 +623,13 @@ declare module "tls" {
         psk: NodeJS.ArrayBufferView;
         identity: string;
     }
-    interface ConnectionOptions extends SecureContextOptions, CommonConnectionOptions {
+    interface ConnectionOptions extends SecureContextOptions, ClientConnectionOptions {
         host?: string | undefined;
         port?: number | undefined;
         path?: string | undefined; // Creates unix socket connection to path. If this option is specified, `host` and `port` are ignored.
         socket?: stream.Duplex | undefined; // Establish secure connection on a given socket rather than creating a new socket
         checkServerIdentity?: typeof checkServerIdentity | undefined;
         servername?: string | undefined; // SNI TLS Extension
-        session?: Buffer | undefined;
         minDHSize?: number | undefined;
         lookup?: net.LookupFunction | undefined;
         timeout?: number | undefined;
@@ -823,17 +845,6 @@ declare module "tls" {
     }
     type SecureVersion = "TLSv1.3" | "TLSv1.2" | "TLSv1.1" | "TLSv1";
     interface SecureContextOptions {
-        /**
-         * If set, this will be called when a client opens a connection using the ALPN extension.
-         * One argument will be passed to the callback: an object containing `servername` and `protocols` fields,
-         * respectively containing the server name from the SNI extension (if any) and an array of
-         * ALPN protocol name strings. The callback must return either one of the strings listed in `protocols`,
-         * which will be returned to the client as the selected ALPN protocol, or `undefined`,
-         * to reject the connection with a fatal alert. If a string is returned that does not match one of
-         * the client's ALPN protocols, an error will be thrown.
-         * This option cannot be used with the `ALPNProtocols` option, and setting both options will throw an error.
-         */
-        ALPNCallback?: ((arg: { servername: string; protocols: string[] }) => string | undefined) | undefined;
         /**
          * Treat intermediate (non-self-signed)
          * certificates in the trust CA certificate list as trusted.


### PR DESCRIPTION
options of tls.connect:
- Added requestOCSP (https://github.com/nodejs/node/issues/61042)
- Removed ALPNCallback, requestCert, SNICallback ([according to nodejs doc](https://nodejs.org/api/tls.html#tlsconnectoptions-callback))

options of (tls.createServer and new tls.Server):
- Removed secureContext ([according to nodejs doc](https://nodejs.org/api/tls.html#tlscreateserveroptions-secureconnectionlistener))
- Changed the type of `servername` argument in `ALPNCallback` option to allow for `false`

  <details><summary>test of ALPNCallback</summary>

  ```ts
  import * as assert from "node:assert";
  import * as fs from "node:fs";
  import * as net from "node:net";
  import { describe, it } from "node:test";
  import * as tls from "node:tls";
  import { createSecureContext } from "node:tls";
  
  const domain = "ocsp.example.test";
  
  const certPem = fs.readFileSync("server.crt");
  const keyPem = fs.readFileSync("server.key");
  
  async function listen(server: net.Server) {
      await new Promise<void>((resolve, reject) => {
          server.once("error", reject);
          server.listen(0, "127.0.0.1", resolve);
      });
      const addr = server.address();
      assert.ok(addr && typeof addr === "object");
      return addr.port;
  }
  
  function connectClient(
      port: number,
      alpnProtocols: string[],
      servername: string | undefined,
  ): Promise<string | false | null> {
      return new Promise<string | false | null>((resolve, reject) => {
          const s = tls.connect(
              {
                  host: "127.0.0.1",
                  port,
                  servername,
                  rejectUnauthorized: false,
                  ALPNProtocols: alpnProtocols,
                  minVersion: "TLSv1.2",
                  maxVersion: "TLSv1.2",
              },
              () => {
                  console.log("client negotiated protocol:", s.alpnProtocol);
                  console.log("client servername:", s.servername);
                  const selected = s.alpnProtocol;
                  s.end();
                  resolve(selected);
              },
          );
          s.once("error", reject);
          s.setTimeout(3_000, () => s.destroy(new Error("TLS handshake timeout")));
      });
  }
  
  describe("undocumented TLSSocket option: ALPNCallback", () => {
      it("new tls.TLSSocket({ isServer:true, ALPNCallback }) negotiates ALPN and calls callback", async () => {
          const calledAlpnOptions: Array<{ servername: string | false; protocols: string[] }> = [];
  
          await using server = net.createServer((raw) => {
              // ★ここが検証対象：TLSSocket の options に ALPNCallback を渡す
              const tlsSocket = new tls.TLSSocket(raw, {
                  isServer: true,
                  cert: certPem,
                  key: keyPem,
                  minVersion: "TLSv1.2",
                  maxVersion: "TLSv1.2",
  
                  // Undocumented (hypothesis): should be called with { servername, protocols }
                  ALPNCallback: ({ servername, protocols }) => {
                      calledAlpnOptions.push({ servername, protocols });
  
                      // offered list includes "h2" → choose it
                      return protocols.includes("h2") ? "h2" : undefined;
                  },
                  SNICallback(servername, cb) {
                      console.log('SNICallback', servername);
  
                      cb(null, createSecureContext({
                          cert: certPem,
                          key: keyPem,
                          minVersion: "TLSv1.2",
                          maxVersion: "TLSv1.2",
                      }));
                  },
              });
  
              tlsSocket.once("secure", () => {
                  console.log("server servername:", tlsSocket.servername);
                  console.log("server negotiated protocol:", tlsSocket.alpnProtocol);
                  // server side should also see negotiated protocol
                  assert.strictEqual(tlsSocket.alpnProtocol, "h2");
                  tlsSocket.end();
              });
  
              tlsSocket.once("error", (e) => {
                  // surface errors clearly
                  raw.destroy(e);
              });
          });
  
          const port = await listen(server);
  
          const clientSelected = await connectClient(port, ["h2", "http/1.1"], domain);
          assert.strictEqual(clientSelected, "h2");
          assert.deepStrictEqual(calledAlpnOptions, [{
              servername: domain,
              protocols: ["h2", "http/1.1"],
          }]);
      });
  
      it("control: without ALPNCallback, negotiated protocol is false (no selection)", async () => {
          await using server = net.createServer((raw) => {
              const tlsSocket = new tls.TLSSocket(raw, {
                  isServer: true,
                  cert: certPem,
                  key: keyPem,
                  minVersion: "TLSv1.2",
                  maxVersion: "TLSv1.2",
              });
  
              tlsSocket.once("secure", () => {
                  console.log("server servername:", tlsSocket.servername);
                  tlsSocket.end();
              });
              tlsSocket.once("error", (e) => raw.destroy(e));
          });
  
          const port = await listen(server);
  
          const clientSelected = await connectClient(port, ["h2", "http/1.1"], domain);
          assert.strictEqual(clientSelected, false);
      });
  
      it("ALPNCallback is called even if client does not send SNI", async () => {
          await using server = net.createServer((raw) => {
              const tlsSocket = new tls.TLSSocket(raw, {
                  isServer: true,
                  cert: certPem,
                  key: keyPem,
                  minVersion: "TLSv1.2",
                  maxVersion: "TLSv1.2",
  
                  ALPNCallback: ({ servername, protocols }) => {
                      // should be called even if client did not send SNI
                      console.log("ALPNCallback servername:", servername);
                      console.log("ALPNCallback protocols:", protocols);
                      assert.strictEqual(servername, false);
                      assert.deepStrictEqual(protocols, ["h2", "http/1.1"]);
                      return protocols.includes("h2") ? "h2" : undefined;
                  },
              });
  
              tlsSocket.once("secure", () => {
                  console.log("server servername:", tlsSocket.servername);
                  tlsSocket.end();
              });
              tlsSocket.once("error", (e) => {
                  console.log("server error:", e);
                  return raw.destroy(e);
              });
          });
  
          const port = await listen(server);
  
          const clientSelected = await connectClient(port, ["h2", "http/1.1"], undefined);
          assert.strictEqual(clientSelected, "h2");
      });
  });
  ```
  </details>

options of tls.createSecureContext:
- Removed ALPNCallback ([according to nodejs doc](https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions))

options of new tls.TLSSocket:
- Changed the type of `servername` argument in `ALPNCallback` option to allow for `false`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/tls.html
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
