### PR TITLE
[chrome] documentId is optional in webRequest namespace

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -13162,7 +13162,7 @@ declare namespace chrome {
              * The UUID of the document making the request.
              * @since Chrome 106
              */
-            documentId: string;
+            documentId?: string;
             /**
              * The lifecycle the document is in.
              * @since Chrome 106

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -6910,7 +6910,7 @@ function testWebRequest() {
     checkWebRequestEvent(chrome.webRequest.onAuthRequired, (details, asyncCallback) => {
         details.challenger.host; // $ExpectType string
         details.challenger.port; // $ExpectType number
-        details.documentId; // $ExpectType string
+        details.documentId; // $ExpectType string | undefined
         details.documentLifecycle; // $ExpectType DocumentLifecycle
         details.frameId; // $ExpectType number
         details.frameType; // $ExpectType FrameType
@@ -6937,7 +6937,7 @@ function testWebRequest() {
     }, ["responseHeaders", "blocking", "asyncBlocking", "extraHeaders"]);
 
     checkWebRequestEvent(chrome.webRequest.onBeforeRedirect, (details) => {
-        details.documentId; // $ExpectType string
+        details.documentId; // $ExpectType string | undefined
         details.documentLifecycle; // $ExpectType DocumentLifecycle
         details.frameId; // $ExpectType number
         details.frameType; // $ExpectType FrameType
@@ -6985,7 +6985,7 @@ function testWebRequest() {
     checkWebRequestEvent(
         chrome.webRequest.onBeforeSendHeaders,
         (details) => {
-            details.documentId; // $ExpectType string
+            details.documentId; // $ExpectType string | undefined
             details.documentLifecycle; // $ExpectType DocumentLifecycle
             details.frameId; // $ExpectType number
             details.frameType; // $ExpectType FrameType
@@ -7008,7 +7008,7 @@ function testWebRequest() {
     );
 
     checkWebRequestEvent(chrome.webRequest.onCompleted, (details) => {
-        details.documentId; // $ExpectType string
+        details.documentId; // $ExpectType string | undefined
         details.documentLifecycle; // $ExpectType DocumentLifecycle
         details.frameId; // $ExpectType number
         details.frameType; // $ExpectType FrameType
@@ -7031,7 +7031,7 @@ function testWebRequest() {
     }, ["responseHeaders", "extraHeaders"]);
 
     checkWebRequestEvent(chrome.webRequest.onErrorOccurred, (details) => {
-        details.documentId; // $ExpectType string
+        details.documentId; // $ExpectType string | undefined
         details.documentLifecycle; // $ExpectType DocumentLifecycle
         details.error; // $ExpectType string
         details.frameId; // $ExpectType number
@@ -7050,7 +7050,7 @@ function testWebRequest() {
     }, ["extraHeaders"]);
 
     checkWebRequestEvent(chrome.webRequest.onHeadersReceived, (details) => {
-        details.documentId; // $ExpectType string
+        details.documentId; // $ExpectType string | undefined
         details.documentLifecycle; // $ExpectType DocumentLifecycle
         details.frameId; // $ExpectType number
         details.frameType; // $ExpectType FrameType
@@ -7073,7 +7073,7 @@ function testWebRequest() {
     }, ["blocking", "responseHeaders", "extraHeaders"]);
 
     checkWebRequestEvent(chrome.webRequest.onResponseStarted, (details) => {
-        details.documentId; // $ExpectType string
+        details.documentId; // $ExpectType string | undefined
         details.documentLifecycle; // $ExpectType DocumentLifecycle
         details.frameId; // $ExpectType number
         details.frameType; // $ExpectType FrameType
@@ -7096,7 +7096,7 @@ function testWebRequest() {
     }, ["responseHeaders", "extraHeaders"]);
 
     checkWebRequestEvent(chrome.webRequest.onSendHeaders, (details) => {
-        details.documentId; // $ExpectType string
+        details.documentId; // $ExpectType string | undefined
         details.documentLifecycle; // $ExpectType DocumentLifecycle
         details.frameId; // $ExpectType number
         details.frameType; // $ExpectType FrameType


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/docs/extensions/reference/api/webRequest
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

[Doc diff](https://github.com/erwanjugand/chrome-extension-docs-checker/commit/cfe4fbaed1a93fd0b9f96e6cf2220f8a95c0ee12#diff-7a812c59b08457f2509b039ee69eb494e1a54d6475ac8f1275874dc075ae2607)