### PR TITLE
[@wordpress/block-editor] Add definitions for getBlocksByName and some missing props on RichText

### DIFF
--- a/types/wordpress__block-editor/components/rich-text.d.ts
+++ b/types/wordpress__block-editor/components/rich-text.d.ts
@@ -17,6 +17,10 @@ declare namespace RichText {
         autocompleters?: ComponentProps<typeof Autocomplete>["completers"] | undefined;
         children?: never | undefined;
         className?: string | undefined;
+        /**
+         * Disables inserting line breaks on Enter when it is set to true
+         */
+        disableLineBreaks?: boolean | undefined;
         identifier?: string | undefined;
         inlineToolbar?: boolean | undefined;
         /**
@@ -66,6 +70,10 @@ declare namespace RichText {
          * if provided.
          */
         value: string;
+        /**
+         * By default, all formatting controls are present. This setting can be used to remove formatting controls that would make content interactive. This is useful if you want to make content that is already interactive editable.
+         */
+        withoutInteractiveFormatting?: boolean | undefined;
         wrapperClassName?: string | undefined;
     }
     interface ContentProps<T extends keyof HTMLElementTagNameMap> extends HTMLProps<T> {

--- a/types/wordpress__block-editor/store/selectors.d.ts
+++ b/types/wordpress__block-editor/store/selectors.d.ts
@@ -192,6 +192,15 @@ export function getBlocks(rootClientId?: string): BlockInstance[];
 export function getBlocksByClientId(clientIds: string | string[]): Array<BlockInstance | null>;
 
 /**
+ * Returns all blocks that match a blockName. Results include nested blocks.
+ *
+ * @param blockName - Block name(s) for which clientIds are to be returned.
+ *
+ * @returns Array of clientIds of blocks with name equal to blockName.
+ */
+export function getBlocksByName(blockName: string | string[]): string[];
+
+/**
  * Returns an array containing the clientIds of all descendants of the blocks given.
  *
  * @param clientIds - Array of block ids to inspect.

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -370,6 +370,8 @@ be.withFontSizes("fontSize")(() => <h1>Hello World</h1>);
     onReplace={blocks => blocks.forEach(b => console.log(b.clientId))}
     allowedFormats={["core/bold", "core/italic"]}
     onSplit={(value, isOriginal) => createBlock("core/paragraph", { content: value })}
+    disableLineBreaks
+    withoutInteractiveFormatting
 />;
 <be.RichText.Content value="foo" />;
 <be.RichText.Content tagName="p" style={{ color: "blue" }} className="foo" value="Hello World" dir="rtl" />;
@@ -607,6 +609,10 @@ useSelect("core/block-editor").getBlockParents("foo");
 useSelect("core/block-editor").getBlockParentsByBlockName("foo", ["core/query"]);
 useSelect("core/block-editor").getBlockParents("foo", true);
 useSelect("core/block-editor").getBlockParentsByBlockName("foo", ["core/query"], true);
+
+// $ExpectType string[]
+useSelect("core/block-editor").getBlocksByName("core/group");
+useSelect("core/block-editor").getBlocksByName(["core/group", "core/paragraph"]);
 
 {
     const blockProps: UseBlockProps.Merged & UseBlockProps.Reserved = be.useBlockProps();


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [getBlocksByName](https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/data/data-core-block-editor.md#getblocksbyname) and [RichText](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/rich-text/README.md)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

This is another batch of missing stuff that I encountered while trying to fix up some accordion issues.