### PR TITLE
[@wordpress/block-editor] Added 0 into the valid HeadingLevel values

### DIFF
--- a/types/wordpress__block-editor/components/block-heading-level-dropdown.d.ts
+++ b/types/wordpress__block-editor/components/block-heading-level-dropdown.d.ts
@@ -1,7 +1,7 @@
 import { JSX } from "react";
 
 declare namespace HeadingLevelDropdown {
-    type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+    type HeadingLevel = 0 | 1 | 2 | 3 | 4 | 5 | 6;
     interface Props {
         options?: HeadingLevel[] | (readonly HeadingLevel[]) | undefined;
         value?: HeadingLevel | undefined;

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -219,6 +219,7 @@ be.withFontSizes("fontSize")(() => <h1>Hello World</h1>);
 //
 // heading-level-dropdown
 //
+<be.HeadingLevelDropdown value={0} />;
 <be.HeadingLevelDropdown value={5} />;
 <be.HeadingLevelDropdown value={5} options={[4]} />;
 <be.HeadingLevelDropdown value={5} options={[4]} onChange={v => console.log(v)} />;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Heading Level Dropdown's source](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/block-heading-level-dropdown/index.js)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

I misread the code when adding types in #74261. I treated 0 as "invalid/falsey" when it was actually being used to mean "paragraph"