### PR TITLE
[@wordpress/block-editor] Updated the useTypographyProps definition to allow newer options

### DIFF
--- a/types/wordpress__block-editor/hooks/use-typography-props.d.ts
+++ b/types/wordpress__block-editor/hooks/use-typography-props.d.ts
@@ -7,7 +7,7 @@ import { GlobalStylesSettings } from "@wordpress/global-styles-engine";
  *
  * @param attributes              Block attributes.
  * @param fluidTypographySettings If boolean, whether the function should try to convert font sizes to fluid values,
- *                                                 otherwise an object containing theme settings.
+ *                                                 otherwise an object containing theme (typography) settings.
  *
  * @return Typography block support derived CSS classes & styles.
  */

--- a/types/wordpress__block-editor/hooks/use-typography-props.d.ts
+++ b/types/wordpress__block-editor/hooks/use-typography-props.d.ts
@@ -1,4 +1,5 @@
 import { BlockAttributes } from "@wordpress/blocks";
+import { GlobalStylesSettings } from "@wordpress/global-styles-engine";
 
 /**
  * Provides the CSS class names and inline styles for a block's typography support
@@ -6,11 +7,11 @@ import { BlockAttributes } from "@wordpress/blocks";
  *
  * @param attributes              Block attributes.
  * @param fluidTypographySettings If boolean, whether the function should try to convert font sizes to fluid values,
- *                                                 otherwise an object containing theme fluid typography settings.
+ *                                                 otherwise an object containing theme settings.
  *
  * @return Typography block support derived CSS classes & styles.
  */
 export function getTypographyClassesAndStyles(
     attributes: BlockAttributes,
-    fluidTypographySettings: { minFontSize?: string } | boolean,
+    fluidTypographySettings?: { minFontSize?: string } | GlobalStylesSettings | boolean,
 ): { className: string; style: Record<string, string> };

--- a/types/wordpress__block-editor/package.json
+++ b/types/wordpress__block-editor/package.json
@@ -11,6 +11,7 @@
         "@wordpress/components": "^29.12.0",
         "@wordpress/data": "^10.26.0",
         "@wordpress/element": "^6.26.0",
+        "@wordpress/global-styles-engine": "^1.4.0",
         "@wordpress/keycodes": "^4.26.0",
         "react-autosize-textarea": "^7.1.0"
     },

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -683,6 +683,9 @@ be.getTypographyClassesAndStyles({}, false).style;
 be.getTypographyClassesAndStyles({}, {}).style;
 be.getTypographyClassesAndStyles({}, { minFontSize: "33" }).style;
 
+// $ExpectType string
+be.getTypographyClassesAndStyles({}).className;
+
 // $ExpectType "HELLO"
 be.useCachedTruthy("HELLO");
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Usage here](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/accordion-heading/edit.js#L47)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

This addition is based on the hook's usage in the Accordion Heading block. While I'm fairly certain that the original `minFontSize` object won't work anymore, I'm retaining it to avoid breaking existing code.