### PR TITLE
[@wordpress/block-editor] Added types for BlockContextProvider and AlignmentControl

### DIFF
--- a/types/wordpress__block-editor/components/alignment-control.d.ts
+++ b/types/wordpress__block-editor/components/alignment-control.d.ts
@@ -12,7 +12,7 @@ declare namespace AlignmentControl {
             | undefined;
         children?: never | undefined;
         value?: string | undefined;
-        onChange?(newValue: string | undefined): void;
+        onChange(newValue: string | undefined): void;
         label?: string | undefined;
         description?: string | undefined;
         isCollapsed?: boolean | undefined;

--- a/types/wordpress__block-editor/components/alignment-control.d.ts
+++ b/types/wordpress__block-editor/components/alignment-control.d.ts
@@ -1,7 +1,7 @@
 import { IconType } from "@wordpress/components";
 import { ComponentType } from "react";
 
-declare namespace AlignmentToolbar {
+declare namespace AlignmentControl {
     interface Props {
         alignmentControls?:
             | Array<{
@@ -19,6 +19,6 @@ declare namespace AlignmentToolbar {
     }
 }
 
-declare const AlignmentToolbar: ComponentType<AlignmentToolbar.Props>;
+declare const AlignmentControl: ComponentType<AlignmentControl.Props>;
 
-export default AlignmentToolbar;
+export default AlignmentControl;

--- a/types/wordpress__block-editor/components/alignment-toolbar.d.ts
+++ b/types/wordpress__block-editor/components/alignment-toolbar.d.ts
@@ -12,7 +12,7 @@ declare namespace AlignmentToolbar {
             | undefined;
         children?: never | undefined;
         value?: string | undefined;
-        onChange?(newValue: string | undefined): void;
+        onChange(newValue: string | undefined): void;
         label?: string | undefined;
         description?: string | undefined;
         isCollapsed?: boolean | undefined;

--- a/types/wordpress__block-editor/components/block-context.d.ts
+++ b/types/wordpress__block-editor/components/block-context.d.ts
@@ -1,0 +1,24 @@
+import { JSX, ReactNode } from "react";
+
+declare namespace BlockContextProvider {
+    /**
+     * Component which merges passed value with current consumed block context.
+     *
+     * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/block-context/README.md
+     */
+    interface Props {
+        /**
+         * Context value to merge with current value.
+         */
+        value?: Record<string, any>|undefined;
+        /**
+         * Component children.
+         */
+        children?: ReactNode;
+    }
+}
+declare const BlockContextProvider: {
+    (props: BlockContextProvider.Props): JSX.Element;
+}
+
+export default BlockContextProvider;

--- a/types/wordpress__block-editor/components/block-context.d.ts
+++ b/types/wordpress__block-editor/components/block-context.d.ts
@@ -10,7 +10,7 @@ declare namespace BlockContextProvider {
         /**
          * Context value to merge with current value.
          */
-        value?: Record<string, any>|undefined;
+        value?: Record<string, any> | undefined;
         /**
          * Component children.
          */
@@ -19,6 +19,6 @@ declare namespace BlockContextProvider {
 }
 declare const BlockContextProvider: {
     (props: BlockContextProvider.Props): JSX.Element;
-}
+};
 
 export default BlockContextProvider;

--- a/types/wordpress__block-editor/components/index.d.ts
+++ b/types/wordpress__block-editor/components/index.d.ts
@@ -1,9 +1,11 @@
 /**
  * Block Creation Components
  */
+export { default as AlignmentControl } from "./alignment-control";
 export { default as AlignmentToolbar } from "./alignment-toolbar";
 export { default as Autocomplete } from "./autocomplete";
 export { default as BlockAlignmentToolbar } from "./block-alignment-toolbar";
+export { default as BlockContext } from "./block-context";
 export { default as BlockControls } from "./block-controls";
 export { default as BlockEdit } from "./block-edit";
 export { default as BlockFormatControls } from "./block-format-controls";

--- a/types/wordpress__block-editor/components/index.d.ts
+++ b/types/wordpress__block-editor/components/index.d.ts
@@ -5,7 +5,7 @@ export { default as AlignmentControl } from "./alignment-control";
 export { default as AlignmentToolbar } from "./alignment-toolbar";
 export { default as Autocomplete } from "./autocomplete";
 export { default as BlockAlignmentToolbar } from "./block-alignment-toolbar";
-export { default as BlockContext } from "./block-context";
+export { default as BlockContextProvider } from "./block-context";
 export { default as BlockControls } from "./block-controls";
 export { default as BlockEdit } from "./block-edit";
 export { default as BlockFormatControls } from "./block-format-controls";

--- a/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
+++ b/types/wordpress__block-editor/wordpress__block-editor-tests.tsx
@@ -26,6 +26,17 @@ const STYLES = [{ css: ".foo { color: red; }" }, { css: ".bar { color: blue; }",
 />;
 
 //
+// alignment-control
+//
+<be.AlignmentControl value={undefined} onChange={newValue => newValue && console.log(newValue.toUpperCase())} />;
+<be.AlignmentControl value="left" onChange={newValue => newValue && console.log(newValue.toUpperCase())} />;
+<be.AlignmentControl
+    alignmentControls={[{ align: "center", icon: "carrot", title: "Center" }]}
+    value="left"
+    onChange={newValue => newValue && console.log(newValue.toUpperCase())}
+/>;
+
+//
 // block-alignment-toolbar
 //
 <be.BlockAlignmentToolbar value={undefined} onChange={newValue => newValue && console.log(newValue.toUpperCase())} />;
@@ -86,6 +97,13 @@ const STYLES = [{ css: ".foo { color: red; }" }, { css: ".bar { color: blue; }",
 >
     Hello World
 </be.BlockControls>;
+
+//
+// BlockContextProvider
+//
+<be.BlockContextProvider value={{}}>
+    <div />
+</be.BlockContextProvider>;
 
 //
 // BlockEditorProvider


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [BlockContextProvider](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/block-context/index.js#L27) and [AlignmentControl](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/alignment-control/index.js#L6)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Another batch of type additions that I put together while working.