### PR TITLE
[@hotwired/turbo] Add `drive` to `TurboSession` type

### DIFF
--- a/types/hotwired__turbo/hotwired__turbo-tests.ts
+++ b/types/hotwired__turbo/hotwired__turbo-tests.ts
@@ -73,6 +73,7 @@ Turbo.visit("my-location", { frame: "mine" });
 
 // $ExpectType TurboSession
 Turbo.session;
+Turbo.session.drive = false;
 
 StreamActions.log = function() {
     // $ExpectType StreamElement

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -93,6 +93,7 @@ export interface TurboSession {
     connectStreamSource(source: unknown): void;
     disconnectStreamSource(source: unknown): void;
     renderStreamMessage(message: unknown): void;
+    drive: boolean;
 }
 
 export const StreamActions: {


### PR DESCRIPTION
As per [the docs][td], which allow you to disable it.

[td]: https://turbo.hotwired.dev/handbook/drive#disabling-turbo-drive-on-specific-links-or-forms

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://turbo.hotwired.dev/handbook/drive#disabling-turbo-drive-on-specific-links-or-forms