### PR TITLE
feat(m3u8-parser): make Stream's methods public

### DIFF
--- a/types/m3u8-parser/index.d.ts
+++ b/types/m3u8-parser/index.d.ts
@@ -1,10 +1,15 @@
+export type PreservedStreamEventType = "info" | "warn" | "error";
+
 export abstract class Stream {
-    private listeners: Record<string, unknown>;
-    private on(type: string, listener: () => void): void;
-    private off(type: string, listener: () => void): void;
-    private trigger(type: string, ...args: unknown[]): void;
-    private dispose(): void;
-    private pipe(destination: Stream): void;
+    listeners: Record<string, unknown>;
+    on(type: PreservedStreamEventType, listener: (data: { message: string }) => void): void;
+    on(type: string, listener: (...data: unknown[]) => void): void;
+    off(type: PreservedStreamEventType, listener: (data: { message: string }) => void): boolean;
+    off(type: string, listener: (...data: unknown[]) => void): boolean;
+    trigger(type: PreservedStreamEventType, listener: (data: { message: string }) => void): void;
+    trigger(type: string, listener: (...data: unknown[]) => void): void;
+    dispose(): void;
+    pipe(destination: Stream): void;
 }
 
 export interface RawAttributes {

--- a/types/m3u8-parser/m3u8-parser-tests.ts
+++ b/types/m3u8-parser/m3u8-parser-tests.ts
@@ -2,10 +2,49 @@ import { Manifest, Parser } from "m3u8-parser";
 
 const manifest = "#EXTM3U\n#EXT-X-VERSION:3";
 
-var parser = new Parser();
+const parser = new Parser();
+
+// $ExpectType void
+parser.on("info", (args) => {
+    args.message; // $ExpectType string
+});
+// $ExpectType void
+parser.on("info", (args) => {
+    args.message; // $ExpectType string
+});
+// $ExpectType void
+parser.on("info", (args) => {
+    args.message; // $ExpectType string
+});
+// $ExpectType boolean
+parser.off("info", (args) => {
+    args.message; // $ExpectType string
+});
+// $ExpectType boolean
+parser.off("info", (args) => {
+    args.message; // $ExpectType string
+});
+// $ExpectType boolean
+parser.off("info", (args) => {
+    args.message; // $ExpectType string
+});
+// $ExpectType void
+parser.trigger("info", (args) => {
+    args.message; // $ExpectType string
+});
+// $ExpectType void
+parser.trigger("info", (args) => {
+    args.message; // $ExpectType string
+});
+// $ExpectType void
+parser.trigger("info", (args) => {
+    args.message; // $ExpectType string
+});
 
 parser.push(manifest);
 parser.end();
+
+parser.dispose();
 
 const parsedManifest = parser.manifest.playlists?.[0].contentProtection?.["com.apple.fps.1_0"]?.attributes.resolution;
 


### PR DESCRIPTION
See https://github.com/videojs/vhs-utils/blob/main/src/stream.js. 

In particular,
- `.on()` & `.off()` can be useful for logging and manual event cleanup.
- `.dispose()` is in favor of `tc39/proposal-explicit-resource-management`.
- `PreservedStreamEventType` is factored out since these are special events from js source code.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
