### PR TITLE
[@wordpress/blocks] Bump versions and add self as maintainer

### DIFF
--- a/types/wordpress__blocks/package.json
+++ b/types/wordpress__blocks/package.json
@@ -1,16 +1,16 @@
 {
     "private": true,
     "name": "@types/wordpress__blocks",
-    "version": "12.5.9999",
+    "version": "15.10.9999",
     "projects": [
         "https://github.com/WordPress/gutenberg/tree/master/packages/blocks/README.md"
     ],
     "dependencies": {
         "@types/react": "^18",
-        "@wordpress/components": "^27.2.0",
-        "@wordpress/data": "^9.13.0",
-        "@wordpress/element": "^5.0.0",
-        "@wordpress/shortcode": "^4.14.0"
+        "@wordpress/components": "^30.9.0",
+        "@wordpress/data": "^10.37.0",
+        "@wordpress/element": "^6.37.0",
+        "@wordpress/shortcode": "^4.37.0"
     },
     "devDependencies": {
         "@types/wordpress__blocks": "workspace:."
@@ -39,6 +39,10 @@
         {
             "name": "Bas Tolen",
             "githubUsername": "bastolen"
+        },
+        {
+            "name": "Joshua Lipstone",
+            "githubUsername": "joshualip-plaudit"
         }
     ]
 }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [package.json](https://github.com/WordPress/gutenberg/blob/trunk/packages/blocks/package.json)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.


This change doesn't add or edit any new type definitions - it just updates the dependencies, so the existing tests should be sufficient. It also adds me as an owner, but that's unrelated to testing.