### PR TITLE
[@wordpress/block-editor] Dependency versions bump

### DIFF
--- a/types/wordpress__block-editor/package.json
+++ b/types/wordpress__block-editor/package.json
@@ -1,18 +1,18 @@
 {
     "private": true,
     "name": "@types/wordpress__block-editor",
-    "version": "14.21.9999",
+    "version": "15.0.9999",
     "projects": [
         "https://github.com/WordPress/gutenberg/tree/master/packages/block-editor/README.md"
     ],
     "dependencies": {
         "@types/react": "^18",
         "@types/wordpress__blocks": "*",
-        "@wordpress/components": "^29.12.0",
-        "@wordpress/data": "^10.26.0",
-        "@wordpress/element": "^6.26.0",
+        "@wordpress/components": "^30.9.0",
+        "@wordpress/data": "^10.36.0",
+        "@wordpress/element": "^6.36.0",
         "@wordpress/global-styles-engine": "^1.4.0",
-        "@wordpress/keycodes": "^4.26.0",
+        "@wordpress/keycodes": "^4.36.0",
         "react-autosize-textarea": "^7.1.0"
     },
     "devDependencies": {


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Block-Editor's package.json file](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/package.json)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

This bumps the dependency versions to allow for Redux 5 uses to percolate through. It is, unfortunately, a major version bump for backwards-compatibility protection.
It doesn't include any code changes due to time constraints on my end, so test updates aren't necessary.