### PR TITLE
[eslint-scope] correct scope type incompatibility

### DIFF
--- a/types/eslint-scope/eslint-scope-tests.ts
+++ b/types/eslint-scope/eslint-scope-tests.ts
@@ -58,6 +58,10 @@ if (scope) {
     scope.functionExpressionScope;
     // $ExpectType Reference[]
     scope.implicit.left;
+    // $ExpectType Map<string, Variable<Reference>>
+    scope.implicit.set;
+    // $ExpectType Variable<Reference>[]
+    scope.implicit.variables;
     // $ExpectType  Map<string, Variable>
     scope.set;
     // $ExpectType Reference[]
@@ -196,7 +200,7 @@ scopeInstance.childScopes;
 scopeInstance.block;
 // $ExpectType boolean
 scopeInstance.functionExpressionScope;
-// $ExpectType { left: Reference[]; set: Map<string, Variable<Reference>>; }
+// $ExpectType { left: Reference[]; set: Map<string, Variable<Reference>>; variables: Variable<Reference>[]; }
 scopeInstance.implicit;
 // $ExpectType Map<string, Variable>
 scopeInstance.set;

--- a/types/eslint-scope/index.d.cts
+++ b/types/eslint-scope/index.d.cts
@@ -201,7 +201,7 @@ export class Scope<TVariable extends Variable = Variable, TReference extends Ref
     /**
      * Implicit references (e.g., 'arguments' in functions).
      */
-    implicit: { left: TReference[]; set: Map<string, Variable> };
+    implicit: { left: TReference[]; set: Map<string, Variable>; variables: Variable[] };
 
     /**
      * Map of variable names to variables.

--- a/types/eslint-scope/package.json
+++ b/types/eslint-scope/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/eslint-scope",
-    "version": "8.3.9999",
+    "version": "8.4.9999",
     "type": "module",
     "projects": [
         "https://github.com/eslint/eslint-scope"


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/eslint/js/blob/main/packages/eslint-scope/README.md#properties-1
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Updated Scope["implicit"] to match the documented interface. Backporting changes that were abandoned in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/74066 to v8
Bug that raised this issue: https://github.com/eslint-community/eslint-plugin-eslint-plugin/issues/582