### PR TITLE
Fix `MusicKit.configure()` return type to `Promise<MusicKitInstance>`

### DIFF
--- a/types/musickit-js/MusicKit.d.ts
+++ b/types/musickit-js/MusicKit.d.ts
@@ -79,7 +79,7 @@ declare namespace MusicKit {
     /**
      * Configure a MusicKit instance.
      */
-    function configure(configuration: Configuration): MusicKitInstance;
+    function configure(configuration: Configuration): Promise<MusicKitInstance>;
     /**
      * Returns the configured MusicKit instance.
      */

--- a/types/musickit-js/test/musickit-js-tests.ts
+++ b/types/musickit-js/test/musickit-js-tests.ts
@@ -1,10 +1,13 @@
-MusicKit.configure({
-    app: {
-        build: "1.0",
-        name: "PLAYER_NAME",
-    },
-    developerToken: "devToken",
-});
+async function testConfigure() {
+    // $ExpectType MusicKitInstance
+    const instance = await MusicKit.configure({
+        app: {
+            build: "1.0",
+            name: "PLAYER_NAME",
+        },
+        developerToken: "devToken",
+    });
+}
 
 const player = MusicKit.getInstance();
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://js-cdn.music.apple.com/musickit/v3/docs/index.html?path=/story/reference-javascript-musickit--page#configure

<img width="1294" height="750" alt="CleanShot 2026-01-06 at 21 04 54@2x" src="https://github.com/user-attachments/assets/4deb02a3-a6ae-4cc9-90d3-1d7a460fae2f" />


