### PR TITLE
[node] process: restore original overload

### DIFF
--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -1908,6 +1908,8 @@ declare module "node:process" {
                  */
                 send?(
                     message: any,
+                    sendHandle?: SendHandle,
+                    options?: MessageOptions,
                     callback?: (error: Error | null) => void,
                 ): boolean;
                 send?(
@@ -1917,9 +1919,7 @@ declare module "node:process" {
                 ): boolean;
                 send?(
                     message: any,
-                    sendHandle: SendHandle,
-                    options: MessageOptions,
-                    callback?: (error: Error | null) => void,
+                    callback: (error: Error | null) => void,
                 ): boolean;
                 /**
                  * If the Node.js process is spawned with an IPC channel (see the `Child Process` and `Cluster` documentation), the `process.disconnect()` method will close the

--- a/types/node/v20/process.d.ts
+++ b/types/node/v20/process.d.ts
@@ -1714,6 +1714,8 @@ declare module "process" {
                  */
                 send?(
                     message: any,
+                    sendHandle?: SendHandle,
+                    options?: MessageOptions,
                     callback?: (error: Error | null) => void,
                 ): boolean;
                 send?(
@@ -1723,9 +1725,7 @@ declare module "process" {
                 ): boolean;
                 send?(
                     message: any,
-                    sendHandle: SendHandle,
-                    options: MessageOptions,
-                    callback?: (error: Error | null) => void,
+                    callback: (error: Error | null) => void,
                 ): boolean;
                 /**
                  * If the Node.js process is spawned with an IPC channel (see the `Child Process` and `Cluster` documentation), the `process.disconnect()` method will close the

--- a/types/node/v22/process.d.ts
+++ b/types/node/v22/process.d.ts
@@ -1787,6 +1787,8 @@ declare module "process" {
                  */
                 send?(
                     message: any,
+                    sendHandle?: SendHandle,
+                    options?: MessageOptions,
                     callback?: (error: Error | null) => void,
                 ): boolean;
                 send?(
@@ -1796,9 +1798,7 @@ declare module "process" {
                 ): boolean;
                 send?(
                     message: any,
-                    sendHandle: SendHandle,
-                    options: MessageOptions,
-                    callback?: (error: Error | null) => void,
+                    callback: (error: Error | null) => void,
                 ): boolean;
                 /**
                  * If the Node.js process is spawned with an IPC channel (see the `Child Process` and `Cluster` documentation), the `process.disconnect()` method will close the

--- a/types/node/v24/process.d.ts
+++ b/types/node/v24/process.d.ts
@@ -1786,6 +1786,8 @@ declare module "process" {
                  */
                 send?(
                     message: any,
+                    sendHandle?: SendHandle,
+                    options?: MessageOptions,
                     callback?: (error: Error | null) => void,
                 ): boolean;
                 send?(
@@ -1795,9 +1797,7 @@ declare module "process" {
                 ): boolean;
                 send?(
                     message: any,
-                    sendHandle: SendHandle,
-                    options: MessageOptions,
-                    callback?: (error: Error | null) => void,
+                    callback: (error: Error | null) => void,
                 ): boolean;
                 /**
                  * If the Node.js process is spawned with an IPC channel (see the `Child Process` and `Cluster` documentation), the `process.disconnect()` method will close the


### PR DESCRIPTION
Restores the original argument optionality for those that were explicitly relying on it.

refs: #74289