### PR TITLE
mssql: Convert ConnectionPool argument to a union type

### DIFF
--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -236,8 +236,7 @@ export declare class ConnectionPool extends events.EventEmitter {
     public static parseConnectionString(
         connectionString: string,
     ): config & { options: IOptions; pool: Partial<PoolOpts<Connection>> };
-    public constructor(config: config, callback?: (err?: any) => void);
-    public constructor(connectionString: string, callback?: (err?: any) => void);
+    public constructor(configOrConnectionString: config | string, callback?: (err?: any) => void);
     public query(command: string): Promise<IResult<any>>;
     public query(strings: TemplateStringsArray, ...interpolations: any[]): Promise<IResult<any>>;
     public query<Entity>(command: string): Promise<IResult<Entity>>;

--- a/types/mssql/mssql-tests.ts
+++ b/types/mssql/mssql-tests.ts
@@ -36,6 +36,8 @@ var config: sql.config = {
 
 var connectionString = "Server=localhost,1433;Database=database;User Id=username;Password=password;Encrypt=true";
 
+var configOrConnectionString: sql.config | string;
+
 var minimalConfig: sql.config = { server: "ip" };
 
 var connectionStringTest: sql.ConnectionPool = new sql.ConnectionPool("connectionstring", (err) => {
@@ -162,6 +164,8 @@ var connection: sql.ConnectionPool = new sql.ConnectionPool(config, function(err
         });
     }
 });
+
+var connectionUnionTypeTest = new sql.ConnectionPool(configOrConnectionString);
 
 function test_connection_string_parser() {
     var parsedConfig: sql.config = sql.ConnectionPool.parseConnectionString(connectionString);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tediousjs/node-mssql/blob/61fce506ed2f626a5b78108a06932b67d4eb08f1/lib/base/connection-pool.js#L45-L56
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Converts the connection argument when creating ConnectionPool into a union type for when projects want to have a further abstraction without the use of "any".