### PR TITLE
Fix: localAddress / localPort for TCPServerSocket should be always defined.

### DIFF
--- a/types/w3c-direct-sockets/index.d.ts
+++ b/types/w3c-direct-sockets/index.d.ts
@@ -87,8 +87,8 @@ export interface UDPSocketOpenInfo extends SocketOpenInfo {
 
 export interface TCPServerSocketOpenInfo {
     readable: ReadableStream;
-    localAddress?: string;
-    localPort?: number;
+    localAddress: string;
+    localPort: number;
 }
 
 declare global {


### PR DESCRIPTION
`localAddress` / `localPort` for `TCPServerSocket` are always defined.