### PR TITLE
[chrome] update since Chrome 144 + update sidePanel namespace

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -1029,7 +1029,7 @@ declare namespace chrome {
             cookies?: boolean | undefined;
             /**
              * Stored passwords.
-             * @deprecated Support for password deletion through extensions has been removed. This data type will be ignored.
+             * @deprecated since Chrome 144. Support for password deletion through extensions has been removed. This data type will be ignored.
              */
             passwords?: boolean | undefined;
             /**
@@ -1125,7 +1125,7 @@ declare namespace chrome {
          * Clears the browser's stored passwords.
          *
          * Can return its result via Promise in Manifest V3 or later since Chrome 96.
-         * @deprecated Support for password deletion through extensions has been removed. This function has no effect.
+         * @deprecated since Chrome 144. Support for password deletion through extensions has been removed. This function has no effect.
          */
         export function removePasswords(options: RemovalOptions): Promise<void>;
         export function removePasswords(options: RemovalOptions, callback: () => void): void;
@@ -3779,6 +3779,8 @@ declare namespace chrome {
             BLOCKED_SCAN_FAILED = "blockedScanFailed",
             /** For use by the Secure Enterprise Browser extension. When required, Chrome will block the download to disc and download the file directly to Google Drive. */
             FORCE_SAVE_TO_GDRIVE = "forceSaveToGdrive",
+            /** For use by the Secure Enterprise Browser extension. When required, Chrome will block the download to disc and download the file directly to OneDrive. */
+            FORCE_SAVE_TO_ONEDRIVE = "forceSaveToOnedrive",
         }
 
         export interface DownloadItem {
@@ -13085,6 +13087,10 @@ declare namespace chrome {
             EXTRA_HEADERS = "extraHeaders",
             /** Specifies that the response headers should be included in the event. */
             RESPONSE_HEADERS = "responseHeaders",
+            /** Specifies that the SecurityInfo should be included in the event. */
+            SECURITY_INFO = "securityInfo",
+            /** Specifies that the SecurityInfo with raw bytes of certificates should be included in the event. */
+            SECURITY_INFO_RAW_DER = "securityInfoRawDer",
         }
 
         /** @since Chrome 44 */
@@ -13143,6 +13149,23 @@ declare namespace chrome {
             WEBBUNDLE = "webbundle",
             /** Specifies the resource as a type not included in the listed types. */
             OTHER = "other",
+        }
+
+        /** @since Chrome 144 */
+        export interface SecurityInfo {
+            /** A list of certificates */
+            certificates: {
+                /** Fingerprints of the certificate. */
+                fingerprint: {
+                    /** sha256 fingerprint of the certificate. */
+                    sha256: string;
+                };
+                /** Raw bytes of DER encoded server certificate */
+                rawDER?: ArrayBuffer;
+            }[];
+
+            /** State of the connection. One of secure, insecure, broken. */
+            state: string;
         }
 
         /** Contains data uploaded in a URL request. */
@@ -13282,6 +13305,11 @@ declare namespace chrome {
         export interface OnHeadersReceivedDetails extends WebRequestDetails {
             /** The HTTP response headers that have been received with this response. */
             responseHeaders?: HttpHeader[];
+            /**
+             * Information about the TLS/QUIC connection used for the underlying connection. Only provided if `securityInfo` is specified in the `extraInfoSpec` parameter.
+             * @since Chrome 144
+             */
+            securityInfo?: SecurityInfo;
             /** Standard HTTP status code returned by the server. */
             statusCode: number;
             /** HTTP status line of the response or the 'HTTP/0.9 200 OK' string for HTTP/0.9 responses (i.e., responses that lack a status line) or an empty string if there are no headers.*/
@@ -14516,6 +14544,14 @@ declare namespace chrome {
         }
 
         /**
+         * Closes the extension's side panel. This is a no-op if the panel is already closed.
+         * @param options Specifies the context in which to close the side panel.
+         * @since Chrome 141
+         */
+        export function close(options: CloseOptions): Promise<void>;
+        export function close(options: CloseOptions, callback: () => void): void;
+
+        /**
          * Returns the side panel's current layout.
          * @since Chrome 140
          */
@@ -14566,6 +14602,12 @@ declare namespace chrome {
          */
         export function setPanelBehavior(behavior: PanelBehavior): Promise<void>;
         export function setPanelBehavior(behavior: PanelBehavior, callback: () => void): void;
+
+        /**
+         * Fired when the extension's side panel is closed.
+         * @since Chrome 142
+         */
+        const onClosed: events.Event<(info: PanelClosedInfo) => void>;
 
         /**
          * Fired when the extension's side panel is opened.

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -4918,6 +4918,7 @@ function testDownloads() {
     chrome.downloads.DangerType.DEEP_SCANNED_SAFE === "deepScannedSafe";
     chrome.downloads.DangerType.FILE === "file";
     chrome.downloads.DangerType.FORCE_SAVE_TO_GDRIVE === "forceSaveToGdrive";
+    chrome.downloads.DangerType.FORCE_SAVE_TO_ONEDRIVE === "forceSaveToOnedrive";
     chrome.downloads.DangerType.HOST === "host";
     chrome.downloads.DangerType.PASSWORD_PROTECTED === "passwordProtected";
     chrome.downloads.DangerType.PROMPT_FOR_LOCAL_PASSWORD_SCANNING === "promptForLocalPasswordScanning";
@@ -5078,7 +5079,7 @@ function testDownloads() {
         result.byExtensionName; // $ExpectType string | undefined
         result.bytesReceived; // $ExpectType number
         result.canResume; // $ExpectType boolean
-        result.danger; // $ExpectType "file" | "url" | "content" | "uncommon" | "host" | "unwanted" | "safe" | "accepted" | "allowlistedByPolicy" | "asyncScanning" | "asyncLocalPasswordScanning" | "passwordProtected" | "blockedTooLarge" | "sensitiveContentWarning" | "sensitiveContentBlock" | "deepScannedFailed" | "deepScannedSafe" | "deepScannedOpenedDangerous" | "promptForScanning" | "promptForLocalPasswordScanning" | "accountCompromise" | "blockedScanFailed" | "forceSaveToGdrive"
+        result.danger; // $ExpectType "file" | "url" | "content" | "uncommon" | "host" | "unwanted" | "safe" | "accepted" | "allowlistedByPolicy" | "asyncScanning" | "asyncLocalPasswordScanning" | "passwordProtected" | "blockedTooLarge" | "sensitiveContentWarning" | "sensitiveContentBlock" | "deepScannedFailed" | "deepScannedSafe" | "deepScannedOpenedDangerous" | "promptForScanning" | "promptForLocalPasswordScanning" | "accountCompromise" | "blockedScanFailed" | "forceSaveToGdrive" | "forceSaveToOnedrive"
         result.endTime; // $ExpectType string | undefined
         result.error; // $ExpectType "CRASH" | "FILE_ACCESS_DENIED" | "FILE_BLOCKED" | "FILE_FAILED" | "FILE_HASH_MISMATCH" | "FILE_NAME_TOO_LONG" | "FILE_NO_SPACE" | "FILE_SAME_AS_SOURCE" | "FILE_SECURITY_CHECK_FAILED" | "FILE_TOO_LARGE" | "FILE_TOO_SHORT" | "FILE_TRANSIENT_ERROR" | "FILE_VIRUS_INFECTED" | "NETWORK_DISCONNECTED" | "NETWORK_FAILED" | "NETWORK_INVALID_REQUEST" | "NETWORK_SERVER_DOWN" | "NETWORK_TIMEOUT" | "SERVER_BAD_CONTENT" | "SERVER_CERT_PROBLEM" | "SERVER_CONTENT_LENGTH_MISMATCH" | "SERVER_CROSS_ORIGIN_REDIRECT" | "SERVER_FAILED" | "SERVER_FORBIDDEN" | "SERVER_NO_RANGE" | "SERVER_UNAUTHORIZED" | "SERVER_UNREACHABLE" | "USER_CANCELED" | "USER_SHUTDOWN" | undefined
         result.estimatedEndTime; // $ExpectType string | undefined
@@ -5136,7 +5137,7 @@ function testDownloads() {
         downloadItem.byExtensionName; // $ExpectType string | undefined
         downloadItem.bytesReceived; // $ExpectType number
         downloadItem.canResume; // $ExpectType boolean
-        downloadItem.danger; // $ExpectType "file" | "url" | "content" | "uncommon" | "host" | "unwanted" | "safe" | "accepted" | "allowlistedByPolicy" | "asyncScanning" | "asyncLocalPasswordScanning" | "passwordProtected" | "blockedTooLarge" | "sensitiveContentWarning" | "sensitiveContentBlock" | "deepScannedFailed" | "deepScannedSafe" | "deepScannedOpenedDangerous" | "promptForScanning" | "promptForLocalPasswordScanning" | "accountCompromise" | "blockedScanFailed" | "forceSaveToGdrive"
+        downloadItem.danger; // $ExpectType "file" | "url" | "content" | "uncommon" | "host" | "unwanted" | "safe" | "accepted" | "allowlistedByPolicy" | "asyncScanning" | "asyncLocalPasswordScanning" | "passwordProtected" | "blockedTooLarge" | "sensitiveContentWarning" | "sensitiveContentBlock" | "deepScannedFailed" | "deepScannedSafe" | "deepScannedOpenedDangerous" | "promptForScanning" | "promptForLocalPasswordScanning" | "accountCompromise" | "blockedScanFailed" | "forceSaveToGdrive" | "forceSaveToOnedrive"
         downloadItem.endTime; // $ExpectType string | undefined
         downloadItem.error; // $ExpectType "CRASH" | "FILE_ACCESS_DENIED" | "FILE_BLOCKED" | "FILE_FAILED" | "FILE_HASH_MISMATCH" | "FILE_NAME_TOO_LONG" | "FILE_NO_SPACE" | "FILE_SAME_AS_SOURCE" | "FILE_SECURITY_CHECK_FAILED" | "FILE_TOO_LARGE" | "FILE_TOO_SHORT" | "FILE_TRANSIENT_ERROR" | "FILE_VIRUS_INFECTED" | "NETWORK_DISCONNECTED" | "NETWORK_FAILED" | "NETWORK_INVALID_REQUEST" | "NETWORK_SERVER_DOWN" | "NETWORK_TIMEOUT" | "SERVER_BAD_CONTENT" | "SERVER_CERT_PROBLEM" | "SERVER_CONTENT_LENGTH_MISMATCH" | "SERVER_CROSS_ORIGIN_REDIRECT" | "SERVER_FAILED" | "SERVER_FORBIDDEN" | "SERVER_NO_RANGE" | "SERVER_UNAUTHORIZED" | "SERVER_UNREACHABLE" | "USER_CANCELED" | "USER_SHUTDOWN" | undefined
         downloadItem.estimatedEndTime; // $ExpectType string | undefined
@@ -6196,6 +6197,15 @@ function testSidePanel() {
     chrome.sidePanel.Side.LEFT === "left";
     chrome.sidePanel.Side.RIGHT === "right";
 
+    const closeOptions: chrome.sidePanel.CloseOptions = {
+        tabId: 123,
+    };
+
+    chrome.sidePanel.close(closeOptions); // $ExpectType Promise<void>
+    chrome.sidePanel.close(closeOptions, () => void 0); // $ExpectType void
+    // @ts-expect-error
+    chrome.sidePanel.close(closeOptions, () => {}).then(() => {});
+
     chrome.sidePanel.getLayout(); // $ExpectType Promise<PanelLayout>
     chrome.sidePanel.getLayout((layout) => { // $ExpectType void
         layout.side; // $ExpectType "left" | "right"
@@ -6262,6 +6272,12 @@ function testSidePanel() {
     chrome.sidePanel.setPanelBehavior(setPanelBehavior, () => void 0); // $ExpectType void
     // @ts-expect-error
     chrome.sidePanel.setPanelBehavior(setPanelBehavior, () => {}).then(() => {});
+
+    checkChromeEvent(chrome.sidePanel.onClosed, (info) => {
+        info.path; // $ExpectType string
+        info.tabId; // $ExpectType number | undefined
+        info.windowId; // $ExpectType number
+    });
 
     checkChromeEvent(chrome.sidePanel.onOpened, (info) => {
         info.path; // $ExpectType string
@@ -6855,6 +6871,8 @@ function testWebRequest() {
     chrome.webRequest.OnHeadersReceivedOptions.BLOCKING === "blocking";
     chrome.webRequest.OnHeadersReceivedOptions.EXTRA_HEADERS === "extraHeaders";
     chrome.webRequest.OnHeadersReceivedOptions.RESPONSE_HEADERS === "responseHeaders";
+    chrome.webRequest.OnHeadersReceivedOptions.SECURITY_INFO === "securityInfo";
+    chrome.webRequest.OnHeadersReceivedOptions.SECURITY_INFO_RAW_DER === "securityInfoRawDer";
 
     chrome.webRequest.OnResponseStartedOptions.EXTRA_HEADERS === "extraHeaders";
     chrome.webRequest.OnResponseStartedOptions.RESPONSE_HEADERS === "responseHeaders";
@@ -7062,6 +7080,10 @@ function testWebRequest() {
         details.responseHeaders?.[0].name; // $ExpectType string | undefined
         details.responseHeaders?.[0].value; // $ExpectType string | undefined
         details.responseHeaders?.[0].binaryValue; // $ExpectType ArrayBuffer | undefined
+        details.securityInfo; // $ExpectType SecurityInfo | undefined
+        details.securityInfo!.certificates![0].fingerprint.sha256; // $ExpectType string
+        details.securityInfo!.certificates![0].rawDER; // $ExpectType ArrayBuffer | undefined
+        details.securityInfo!.state; // $ExpectType string
         details.statusCode; // $ExpectType number
         details.statusLine; // $ExpectType string
         details.tabId; // $ExpectType number


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://developer.chrome.com/docs/extensions/reference/api/downloads
  - https://developer.chrome.com/docs/extensions/reference/api/webRequest
  - https://developer.chrome.com/docs/extensions/reference/api/sidePanel
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes:
- update `chrome.downloads.DangerType`: add key `FORCE_SAVE_TO_ONEDRIVE`
- update `chrome.webRequest.OnHeadersReceivedOptions`: add keys `SECURITY_INFO` and `SECURITY_INFO_RAW_DER`
- update `chrome.webRequest.OnHeadersReceivedDetails`: add key `securityInfo`
- add `chrome.webRequest.SecurityInfo`
- add `chrome.sidePanel.close`
- add `chrome.sidePanel.onClosed`
- update JSDocs

Runtime:
<img width="782" height="321" alt="image" src="https://github.com/user-attachments/assets/2819bc3d-d0c0-41d5-a977-62306b3e9dc0" />
