### PR TITLE
feat(node/util): make promisify() able to infer optional arguments

### DIFF
--- a/types/bluebird/bluebird-tests.ts
+++ b/types/bluebird/bluebird-tests.ts
@@ -909,6 +909,317 @@ voidProm = Bluebird.delay(num);
 asyncfunc = Bluebird.promisify(f);
 asyncfunc = Bluebird.promisify(f, obj);
 
+declare function fn1WithOptionalArg1(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn1WithOptionalArg1(cb: (err: Error | null, result: number) => void): void;
+declare function fn1WithFullArgs(arg1: string, cb: (err: Error | null, result: number) => void): void;
+
+// $ExpectType (arg1?: string | undefined) => Bluebird<number>
+Bluebird.promisify<number, string>(fn1WithOptionalArg1);
+// $ExpectType (arg1: string) => Bluebird<number>
+Bluebird.promisify<number, string>(fn1WithFullArgs);
+
+declare function fn2WithOptionalArg12(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn2WithOptionalArg12(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn2WithOptionalArg12(cb: (err: Error | null, result: number) => void): void;
+declare function fn2WithOptionalArg2(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn2WithOptionalArg2(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn2WithFullArgs(arg1: string, arg2: boolean, cb: (err: Error | null, result: number) => void): void;
+
+// $ExpectType (arg1?: string | undefined, arg2?: boolean | undefined) => Bluebird<number>
+Bluebird.promisify<number, string, boolean>(fn2WithOptionalArg12);
+// $ExpectType (arg1: string, arg2?: boolean | undefined) => Bluebird<number>
+Bluebird.promisify<number, string, boolean>(fn2WithOptionalArg2);
+// $ExpectType (arg1: string, arg2: boolean) => Bluebird<number>
+Bluebird.promisify<number, string, boolean>(fn2WithFullArgs);
+
+declare function fn3WithOptionalArg123(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg123(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg123(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn3WithOptionalArg123(cb: (err: Error | null, result: number) => void): void;
+declare function fn3WithOptionalArg23(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg23(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg23(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn3WithOptionalArg3(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg3(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithFullArgs(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+
+// $ExpectType (arg1?: string | undefined, arg2?: boolean | undefined, arg3?: number | undefined) => Bluebird<number>
+Bluebird.promisify<number, string, boolean, number>(fn3WithOptionalArg123);
+// $ExpectType (arg1: string, arg2?: boolean | undefined, arg3?: number | undefined) => Bluebird<number>
+Bluebird.promisify<number, string, boolean, number>(fn3WithOptionalArg23);
+// $ExpectType (arg1: string, arg2: boolean, arg3?: number | undefined) => Bluebird<number>
+Bluebird.promisify<number, string, boolean, number>(fn3WithOptionalArg3);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number) => Bluebird<number>
+Bluebird.promisify<number, string, boolean, number>(fn3WithFullArgs);
+
+declare function fn4WithOptionalArg1234(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg1234(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg1234(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg1234(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn4WithOptionalArg1234(cb: (err: Error | null, result: number) => void): void;
+declare function fn4WithOptionalArg234(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg234(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg234(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg234(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn4WithOptionalArg34(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg34(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg34(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg4(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg4(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithFullArgs(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+
+// $ExpectType (arg1?: string | undefined, arg2?: boolean | undefined, arg3?: number | undefined, arg4?: string | undefined) => Bluebird<number>
+Bluebird.promisify<number, string, boolean, number, string>(fn4WithOptionalArg1234);
+// $ExpectType (arg1: string, arg2?: boolean | undefined, arg3?: number | undefined, arg4?: string | undefined) => Bluebird<number>
+Bluebird.promisify<number, string, boolean, number, string>(fn4WithOptionalArg234);
+// $ExpectType (arg1: string, arg2: boolean, arg3?: number | undefined, arg4?: string | undefined) => Bluebird<number>
+Bluebird.promisify<number, string, boolean, number, string>(fn4WithOptionalArg34);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4?: string | undefined) => Bluebird<number>
+Bluebird.promisify<number, string, boolean, number, string>(fn4WithOptionalArg4);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4: string) => Bluebird<number>
+Bluebird.promisify<number, string, boolean, number, string>(fn4WithFullArgs);
+
+declare function fn5WithOptionalArg12345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg12345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg12345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg12345(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg12345(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn5WithOptionalArg12345(cb: (err: Error | null, result: number) => void): void;
+declare function fn5WithOptionalArg2345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg2345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg2345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg2345(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg2345(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn5WithOptionalArg345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg345(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg45(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg45(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg45(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg5(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg5(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithFullArgs(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+
+// $ExpectType (arg1?: string | undefined, arg2?: boolean | undefined, arg3?: number | undefined, arg4?: string | undefined, arg5?: boolean | undefined) => Bluebird<number>
+Bluebird.promisify<number, string, boolean, number, string, boolean>(fn5WithOptionalArg12345);
+// $ExpectType (arg1: string, arg2?: boolean | undefined, arg3?: number | undefined, arg4?: string | undefined, arg5?: boolean | undefined) => Bluebird<number>
+Bluebird.promisify<number, string, boolean, number, string, boolean>(fn5WithOptionalArg2345);
+// $ExpectType (arg1: string, arg2: boolean, arg3?: number | undefined, arg4?: string | undefined, arg5?: boolean | undefined) => Bluebird<number>
+Bluebird.promisify<number, string, boolean, number, string, boolean>(fn5WithOptionalArg345);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4?: string | undefined, arg5?: boolean | undefined) => Bluebird<number>
+Bluebird.promisify<number, string, boolean, number, string, boolean>(fn5WithOptionalArg45);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4: string, arg5?: boolean | undefined) => Bluebird<number>
+Bluebird.promisify<number, string, boolean, number, string, boolean>(fn5WithOptionalArg5);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4: string, arg5: boolean) => Bluebird<number>
+Bluebird.promisify<number, string, boolean, number, string, boolean>(fn5WithFullArgs);
+
 const emtpyFn = () => {};
 
 const promiseModule = Bluebird.promisifyAll({

--- a/types/bluebird/index.d.ts
+++ b/types/bluebird/index.d.ts
@@ -793,21 +793,126 @@ declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
         options?: Bluebird.PromisifyOptions,
     ): () => Bluebird<T>;
     static promisify<T, A1>(
+        func: {
+            (arg1: A1, callback: (err: any, result?: T) => void): void;
+            (callback: (err: any, result?: T) => void): void;
+        },
+        options?: Bluebird.PromisifyOptions,
+    ): (arg1?: A1) => Bluebird<T>;
+    static promisify<T, A1>(
         func: (arg1: A1, callback: (err: any, result?: T) => void) => void,
         options?: Bluebird.PromisifyOptions,
     ): (arg1: A1) => Bluebird<T>;
+    static promisify<T, A1, A2>(
+        func: {
+            (arg1: A1, arg2: A2, callback: (err: any, result?: T) => void): void;
+            (callback: (err: any, result?: T) => void): void;
+        },
+        options?: Bluebird.PromisifyOptions,
+    ): (arg1?: A1, arg2?: A2) => Bluebird<T>;
+    static promisify<T, A1, A2>(
+        func: {
+            (arg1: A1, arg2: A2, callback: (err: any, result?: T) => void): void;
+            (arg1: A1, callback: (err: any, result?: T) => void): void;
+        },
+        options?: Bluebird.PromisifyOptions,
+    ): (arg1: A1, arg2?: A2) => Bluebird<T>;
     static promisify<T, A1, A2>(
         func: (arg1: A1, arg2: A2, callback: (err: any, result?: T) => void) => void,
         options?: Bluebird.PromisifyOptions,
     ): (arg1: A1, arg2: A2) => Bluebird<T>;
     static promisify<T, A1, A2, A3>(
+        func: {
+            (arg1: A1, arg2: A2, arg3: A3, callback: (err: any, result?: T) => void): void;
+            (callback: (err: any, result?: T) => void): void;
+        },
+        options?: Bluebird.PromisifyOptions,
+    ): (arg1?: A1, arg2?: A2, arg3?: A3) => Bluebird<T>;
+    static promisify<T, A1, A2, A3>(
+        func: {
+            (arg1: A1, arg2: A2, arg3: A3, callback: (err: any, result?: T) => void): void;
+            (arg1: A1, callback: (err: any, result?: T) => void): void;
+        },
+        options?: Bluebird.PromisifyOptions,
+    ): (arg1: A1, arg2?: A2, arg3?: A3) => Bluebird<T>;
+    static promisify<T, A1, A2, A3>(
+        func: {
+            (arg1: A1, arg2: A2, arg3: A3, callback: (err: any, result?: T) => void): void;
+            (arg1: A1, arg2: A2, callback: (err: any, result?: T) => void): void;
+        },
+        options?: Bluebird.PromisifyOptions,
+    ): (arg1: A1, arg2: A2, arg3?: A3) => Bluebird<T>;
+    static promisify<T, A1, A2, A3>(
         func: (arg1: A1, arg2: A2, arg3: A3, callback: (err: any, result?: T) => void) => void,
         options?: Bluebird.PromisifyOptions,
     ): (arg1: A1, arg2: A2, arg3: A3) => Bluebird<T>;
     static promisify<T, A1, A2, A3, A4>(
+        func: {
+            (arg1: A1, arg2: A2, arg3: A3, arg4: A4, callback: (err: any, result?: T) => void): void;
+            (callback: (err: any, result?: T) => void): void;
+        },
+        options?: Bluebird.PromisifyOptions,
+    ): (arg1?: A1, arg2?: A2, arg3?: A3, arg4?: A4) => Bluebird<T>;
+    static promisify<T, A1, A2, A3, A4>(
+        func: {
+            (arg1: A1, arg2: A2, arg3: A3, arg4: A4, callback: (err: any, result?: T) => void): void;
+            (arg1: A1, callback: (err: any, result?: T) => void): void;
+        },
+        options?: Bluebird.PromisifyOptions,
+    ): (arg1: A1, arg2?: A2, arg3?: A3, arg4?: A4) => Bluebird<T>;
+    static promisify<T, A1, A2, A3, A4>(
+        func: {
+            (arg1: A1, arg2: A2, arg3: A3, arg4: A4, callback: (err: any, result?: T) => void): void;
+            (arg1: A1, arg2: A2, callback: (err: any, result?: T) => void): void;
+        },
+        options?: Bluebird.PromisifyOptions,
+    ): (arg1: A1, arg2: A2, arg3?: A3, arg4?: A4) => Bluebird<T>;
+    static promisify<T, A1, A2, A3, A4>(
+        func: {
+            (arg1: A1, arg2: A2, arg3: A3, arg4: A4, callback: (err: any, result?: T) => void): void;
+            (arg1: A1, arg2: A2, arg3: A3, callback: (err: any, result?: T) => void): void;
+        },
+        options?: Bluebird.PromisifyOptions,
+    ): (arg1: A1, arg2: A2, arg3: A3, arg4?: A4) => Bluebird<T>;
+    static promisify<T, A1, A2, A3, A4>(
         func: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, callback: (err: any, result?: T) => void) => void,
         options?: Bluebird.PromisifyOptions,
     ): (arg1: A1, arg2: A2, arg3: A3, arg4: A4) => Bluebird<T>;
+    static promisify<T, A1, A2, A3, A4, A5>(
+        func: {
+            (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: (err: any, result?: T) => void): void;
+            (callback: (err: any, result?: T) => void): void;
+        },
+        options?: Bluebird.PromisifyOptions,
+    ): (arg1?: A1, arg2?: A2, arg3?: A3, arg4?: A4, arg5?: A5) => Bluebird<T>;
+    static promisify<T, A1, A2, A3, A4, A5>(
+        func: {
+            (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: (err: any, result?: T) => void): void;
+            (arg1: A1, callback: (err: any, result?: T) => void): void;
+        },
+        options?: Bluebird.PromisifyOptions,
+    ): (arg1: A1, arg2?: A2, arg3?: A3, arg4?: A4, arg5?: A5) => Bluebird<T>;
+    static promisify<T, A1, A2, A3, A4, A5>(
+        func: {
+            (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: (err: any, result?: T) => void): void;
+            (arg1: A1, arg2: A2, callback: (err: any, result?: T) => void): void;
+        },
+        options?: Bluebird.PromisifyOptions,
+    ): (arg1: A1, arg2: A2, arg3?: A3, arg4?: A4, arg5?: A5) => Bluebird<T>;
+    static promisify<T, A1, A2, A3, A4, A5>(
+        func: {
+            (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: (err: any, result?: T) => void): void;
+            (arg1: A1, arg2: A2, arg3: A3, callback: (err: any, result?: T) => void): void;
+        },
+        options?: Bluebird.PromisifyOptions,
+    ): (arg1: A1, arg2: A2, arg3: A3, arg4?: A4, arg5?: A5) => Bluebird<T>;
+    static promisify<T, A1, A2, A3, A4, A5>(
+        func: {
+            (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: (err: any, result?: T) => void): void;
+            (arg1: A1, arg2: A2, arg3: A3, arg4: A4, callback: (err: any, result?: T) => void): void;
+        },
+        options?: Bluebird.PromisifyOptions,
+    ): (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5?: A5) => Bluebird<T>;
     static promisify<T, A1, A2, A3, A4, A5>(
         func: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: (err: any, result?: T) => void) => void,
         options?: Bluebird.PromisifyOptions,

--- a/types/cldr/cldr-tests.ts
+++ b/types/cldr/cldr-tests.ts
@@ -88,7 +88,7 @@ Cldr.preload(["localeid"], (error: Error | undefined) => {});
 // $ExpectType () => Promise<void>
 promisify(Cldr.preload);
 
-// $ExpectType (arg1: string[]) => Promise<void>
+// $ExpectType (arg1?: string[] | undefined) => Promise<void>
 promisify<string[]>(Cldr.preload);
 
 // $ExpectType Finder

--- a/types/node/node-tests/util.ts
+++ b/types/node/node-tests/util.ts
@@ -197,6 +197,318 @@ class callbackifyTest {
 callbackifyTest.test();
 
 // util.promisify
+
+declare function fn1WithOptionalArg1(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn1WithOptionalArg1(cb: (err: Error | null, result: number) => void): void;
+declare function fn1WithFullArgs(arg1: string, cb: (err: Error | null, result: number) => void): void;
+
+// $ExpectType (arg1?: string | undefined) => Promise<number>
+util.promisify<string, number>(fn1WithOptionalArg1);
+// $ExpectType (arg1: string) => Promise<number>
+util.promisify<string, number>(fn1WithFullArgs);
+
+declare function fn2WithOptionalArg12(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn2WithOptionalArg12(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn2WithOptionalArg12(cb: (err: Error | null, result: number) => void): void;
+declare function fn2WithOptionalArg2(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn2WithOptionalArg2(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn2WithFullArgs(arg1: string, arg2: boolean, cb: (err: Error | null, result: number) => void): void;
+
+// $ExpectType (arg1?: string | undefined, arg2?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number>(fn2WithOptionalArg12);
+// $ExpectType (arg1: string, arg2?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number>(fn2WithOptionalArg2);
+// $ExpectType (arg1: string, arg2: boolean) => Promise<number>
+util.promisify<string, boolean, number>(fn2WithFullArgs);
+
+declare function fn3WithOptionalArg123(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg123(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg123(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn3WithOptionalArg123(cb: (err: Error | null, result: number) => void): void;
+declare function fn3WithOptionalArg23(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg23(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg23(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn3WithOptionalArg3(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg3(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithFullArgs(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+
+// $ExpectType (arg1?: string | undefined, arg2?: boolean | undefined, arg3?: number | undefined) => Promise<number>
+util.promisify<string, boolean, number, number>(fn3WithOptionalArg123);
+// $ExpectType (arg1: string, arg2?: boolean | undefined, arg3?: number | undefined) => Promise<number>
+util.promisify<string, boolean, number, number>(fn3WithOptionalArg23);
+// $ExpectType (arg1: string, arg2: boolean, arg3?: number | undefined) => Promise<number>
+util.promisify<string, boolean, number, number>(fn3WithOptionalArg3);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number) => Promise<number>
+util.promisify<string, boolean, number, number>(fn3WithFullArgs);
+
+declare function fn4WithOptionalArg1234(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg1234(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg1234(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg1234(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn4WithOptionalArg1234(cb: (err: Error | null, result: number) => void): void;
+declare function fn4WithOptionalArg234(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg234(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg234(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg234(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn4WithOptionalArg34(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg34(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg34(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg4(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg4(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithFullArgs(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+
+// $ExpectType (arg1?: string | undefined, arg2?: boolean | undefined, arg3?: number | undefined, arg4?: string | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, number>(fn4WithOptionalArg1234);
+// $ExpectType (arg1: string, arg2?: boolean | undefined, arg3?: number | undefined, arg4?: string | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, number>(fn4WithOptionalArg234);
+// $ExpectType (arg1: string, arg2: boolean, arg3?: number | undefined, arg4?: string | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, number>(fn4WithOptionalArg34);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4?: string | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, number>(fn4WithOptionalArg4);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4: string) => Promise<number>
+util.promisify<string, boolean, number, string, number>(fn4WithFullArgs);
+
+declare function fn5WithOptionalArg12345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg12345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg12345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg12345(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg12345(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn5WithOptionalArg12345(cb: (err: Error | null, result: number) => void): void;
+declare function fn5WithOptionalArg2345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg2345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg2345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg2345(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg2345(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn5WithOptionalArg345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg345(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg45(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg45(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg45(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg5(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg5(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithFullArgs(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+
+// $ExpectType (arg1?: string | undefined, arg2?: boolean | undefined, arg3?: number | undefined, arg4?: string | undefined, arg5?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, boolean, number>(fn5WithOptionalArg12345);
+// $ExpectType (arg1: string, arg2?: boolean | undefined, arg3?: number | undefined, arg4?: string | undefined, arg5?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, boolean, number>(fn5WithOptionalArg2345);
+// $ExpectType (arg1: string, arg2: boolean, arg3?: number | undefined, arg4?: string | undefined, arg5?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, boolean, number>(fn5WithOptionalArg345);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4?: string | undefined, arg5?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, boolean, number>(fn5WithOptionalArg45);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4: string, arg5?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, boolean, number>(fn5WithOptionalArg5);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4: string, arg5: boolean) => Promise<number>
+util.promisify<string, boolean, number, string, boolean, number>(fn5WithFullArgs);
+
 const readPromised = util.promisify(readFile);
 const sampleRead: Promise<any> = readPromised(__filename).then((data: Buffer): void => {}).catch(
     (error: Error): void => {},

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -1134,30 +1134,210 @@ declare module "node:util" {
     ): () => Promise<TResult>;
     export function promisify(fn: (callback: (err?: any) => void) => void): () => Promise<void>;
     export function promisify<T1, TResult>(
+        fn: {
+            (arg1: T1, callback: (err: any, result: TResult) => void): void;
+            (callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1?: T1) => Promise<TResult>;
+    export function promisify<T1, TResult>(
         fn: (arg1: T1, callback: (err: any, result: TResult) => void) => void,
     ): (arg1: T1) => Promise<TResult>;
+    export function promisify<T1>(
+        fn: {
+            (arg1: T1, callback: (err: any) => void): void;
+            (callback: (err: any) => void): void;
+        },
+    ): (arg1?: T1) => Promise<void>;
     export function promisify<T1>(fn: (arg1: T1, callback: (err?: any) => void) => void): (arg1: T1) => Promise<void>;
+    export function promisify<T1, T2, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void): void;
+            (callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2) => Promise<TResult>;
+    export function promisify<T1, T2, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2) => Promise<TResult>;
     export function promisify<T1, T2, TResult>(
         fn: (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void) => void,
     ): (arg1: T1, arg2: T2) => Promise<TResult>;
     export function promisify<T1, T2>(
+        fn: {
+            (arg1: T1, arg2: T2, callback: (err: any) => void): void;
+            (callback: (err: any) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2) => Promise<void>;
+    export function promisify<T1, T2>(
+        fn: {
+            (arg1: T1, arg2: T2, callback: (err: any) => void): void;
+            (arg1: T1, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2) => Promise<void>;
+    export function promisify<T1, T2>(
         fn: (arg1: T1, arg2: T2, callback: (err?: any) => void) => void,
     ): (arg1: T1, arg2: T2) => Promise<void>;
+    export function promisify<T1, T2, T3, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void): void;
+            (callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2, arg3?: T3) => Promise<TResult>;
+    export function promisify<T1, T2, T3, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2, arg3?: T3) => Promise<TResult>;
+    export function promisify<T1, T2, T3, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3?: T3) => Promise<TResult>;
     export function promisify<T1, T2, T3, TResult>(
         fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>;
     export function promisify<T1, T2, T3>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any) => void): void;
+            (callback: (err: any) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2, arg3?: T3) => Promise<void>;
+    export function promisify<T1, T2, T3>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any) => void): void;
+            (arg1: T1, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2, arg3?: T3) => Promise<void>;
+    export function promisify<T1, T2, T3>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any) => void): void;
+            (arg1: T1, arg2: T2, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3?: T3) => Promise<void>;
+    export function promisify<T1, T2, T3>(
         fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err?: any) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3) => Promise<void>;
+    export function promisify<T1, T2, T3, T4, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void): void;
+            (callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2, arg3?: T3, arg4?: T4) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2, arg3?: T3, arg4?: T4) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3?: T3, arg4?: T4) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4?: T4) => Promise<TResult>;
     export function promisify<T1, T2, T3, T4, TResult>(
         fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<TResult>;
     export function promisify<T1, T2, T3, T4>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any) => void): void;
+            (callback: (err: any) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2, arg3?: T3, arg4?: T4) => Promise<void>;
+    export function promisify<T1, T2, T3, T4>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any) => void): void;
+            (arg1: T1, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2, arg3?: T3, arg4?: T4) => Promise<void>;
+    export function promisify<T1, T2, T3, T4>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any) => void): void;
+            (arg1: T1, arg2: T2, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3?: T3, arg4?: T4) => Promise<void>;
+    export function promisify<T1, T2, T3, T4>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any) => void): void;
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4?: T4) => Promise<void>;
+    export function promisify<T1, T2, T3, T4>(
         fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err?: any) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>;
     export function promisify<T1, T2, T3, T4, T5, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void): void;
+            (callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2, arg3?: T3, arg4?: T4, arg5?: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2, arg3?: T3, arg4?: T4, arg5?: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3?: T3, arg4?: T4, arg5?: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4?: T4, arg5?: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5?: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5, TResult>(
         fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any) => void): void;
+            (callback: (err: any) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2, arg3?: T3, arg4?: T4, arg5?: T5) => Promise<void>;
+    export function promisify<T1, T2, T3, T4, T5>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any) => void): void;
+            (arg1: T1, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2, arg3?: T3, arg4?: T4, arg5?: T5) => Promise<void>;
+    export function promisify<T1, T2, T3, T4, T5>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any) => void): void;
+            (arg1: T1, arg2: T2, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3?: T3, arg4?: T4, arg5?: T5) => Promise<void>;
+    export function promisify<T1, T2, T3, T4, T5>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any) => void): void;
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4?: T4, arg5?: T5) => Promise<void>;
+    export function promisify<T1, T2, T3, T4, T5>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any) => void): void;
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5?: T5) => Promise<void>;
     export function promisify<T1, T2, T3, T4, T5>(
         fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err?: any) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<void>;

--- a/types/node/v20/test/util.ts
+++ b/types/node/v20/test/util.ts
@@ -174,6 +174,318 @@ class callbackifyTest {
 callbackifyTest.test();
 
 // util.promisify
+
+declare function fn1WithOptionalArg1(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn1WithOptionalArg1(cb: (err: Error | null, result: number) => void): void;
+declare function fn1WithFullArgs(arg1: string, cb: (err: Error | null, result: number) => void): void;
+
+// $ExpectType (arg1?: string | undefined) => Promise<number>
+util.promisify<string, number>(fn1WithOptionalArg1);
+// $ExpectType (arg1: string) => Promise<number>
+util.promisify<string, number>(fn1WithFullArgs);
+
+declare function fn2WithOptionalArg12(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn2WithOptionalArg12(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn2WithOptionalArg12(cb: (err: Error | null, result: number) => void): void;
+declare function fn2WithOptionalArg2(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn2WithOptionalArg2(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn2WithFullArgs(arg1: string, arg2: boolean, cb: (err: Error | null, result: number) => void): void;
+
+// $ExpectType (arg1?: string | undefined, arg2?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number>(fn2WithOptionalArg12);
+// $ExpectType (arg1: string, arg2?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number>(fn2WithOptionalArg2);
+// $ExpectType (arg1: string, arg2: boolean) => Promise<number>
+util.promisify<string, boolean, number>(fn2WithFullArgs);
+
+declare function fn3WithOptionalArg123(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg123(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg123(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn3WithOptionalArg123(cb: (err: Error | null, result: number) => void): void;
+declare function fn3WithOptionalArg23(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg23(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg23(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn3WithOptionalArg3(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg3(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithFullArgs(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+
+// $ExpectType (arg1?: string | undefined, arg2?: boolean | undefined, arg3?: number | undefined) => Promise<number>
+util.promisify<string, boolean, number, number>(fn3WithOptionalArg123);
+// $ExpectType (arg1: string, arg2?: boolean | undefined, arg3?: number | undefined) => Promise<number>
+util.promisify<string, boolean, number, number>(fn3WithOptionalArg23);
+// $ExpectType (arg1: string, arg2: boolean, arg3?: number | undefined) => Promise<number>
+util.promisify<string, boolean, number, number>(fn3WithOptionalArg3);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number) => Promise<number>
+util.promisify<string, boolean, number, number>(fn3WithFullArgs);
+
+declare function fn4WithOptionalArg1234(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg1234(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg1234(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg1234(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn4WithOptionalArg1234(cb: (err: Error | null, result: number) => void): void;
+declare function fn4WithOptionalArg234(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg234(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg234(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg234(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn4WithOptionalArg34(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg34(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg34(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg4(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg4(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithFullArgs(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+
+// $ExpectType (arg1?: string | undefined, arg2?: boolean | undefined, arg3?: number | undefined, arg4?: string | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, number>(fn4WithOptionalArg1234);
+// $ExpectType (arg1: string, arg2?: boolean | undefined, arg3?: number | undefined, arg4?: string | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, number>(fn4WithOptionalArg234);
+// $ExpectType (arg1: string, arg2: boolean, arg3?: number | undefined, arg4?: string | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, number>(fn4WithOptionalArg34);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4?: string | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, number>(fn4WithOptionalArg4);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4: string) => Promise<number>
+util.promisify<string, boolean, number, string, number>(fn4WithFullArgs);
+
+declare function fn5WithOptionalArg12345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg12345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg12345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg12345(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg12345(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn5WithOptionalArg12345(cb: (err: Error | null, result: number) => void): void;
+declare function fn5WithOptionalArg2345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg2345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg2345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg2345(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg2345(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn5WithOptionalArg345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg345(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg45(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg45(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg45(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg5(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg5(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithFullArgs(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+
+// $ExpectType (arg1?: string | undefined, arg2?: boolean | undefined, arg3?: number | undefined, arg4?: string | undefined, arg5?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, boolean, number>(fn5WithOptionalArg12345);
+// $ExpectType (arg1: string, arg2?: boolean | undefined, arg3?: number | undefined, arg4?: string | undefined, arg5?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, boolean, number>(fn5WithOptionalArg2345);
+// $ExpectType (arg1: string, arg2: boolean, arg3?: number | undefined, arg4?: string | undefined, arg5?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, boolean, number>(fn5WithOptionalArg345);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4?: string | undefined, arg5?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, boolean, number>(fn5WithOptionalArg45);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4: string, arg5?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, boolean, number>(fn5WithOptionalArg5);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4: string, arg5: boolean) => Promise<number>
+util.promisify<string, boolean, number, string, boolean, number>(fn5WithFullArgs);
+
 const readPromised = util.promisify(readFile);
 const sampleRead: Promise<any> = readPromised(__filename).then((data: Buffer): void => {}).catch(
     (error: Error): void => {},

--- a/types/node/v20/util.d.ts
+++ b/types/node/v20/util.d.ts
@@ -1139,30 +1139,210 @@ declare module "util" {
     ): () => Promise<TResult>;
     export function promisify(fn: (callback: (err?: any) => void) => void): () => Promise<void>;
     export function promisify<T1, TResult>(
+        fn: {
+            (arg1: T1, callback: (err: any, result: TResult) => void): void;
+            (callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1?: T1) => Promise<TResult>;
+    export function promisify<T1, TResult>(
         fn: (arg1: T1, callback: (err: any, result: TResult) => void) => void,
     ): (arg1: T1) => Promise<TResult>;
+    export function promisify<T1>(
+        fn: {
+            (arg1: T1, callback: (err: any) => void): void;
+            (callback: (err: any) => void): void;
+        },
+    ): (arg1?: T1) => Promise<void>;
     export function promisify<T1>(fn: (arg1: T1, callback: (err?: any) => void) => void): (arg1: T1) => Promise<void>;
+    export function promisify<T1, T2, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void): void;
+            (callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2) => Promise<TResult>;
+    export function promisify<T1, T2, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2) => Promise<TResult>;
     export function promisify<T1, T2, TResult>(
         fn: (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void) => void,
     ): (arg1: T1, arg2: T2) => Promise<TResult>;
     export function promisify<T1, T2>(
+        fn: {
+            (arg1: T1, arg2: T2, callback: (err: any) => void): void;
+            (callback: (err: any) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2) => Promise<void>;
+    export function promisify<T1, T2>(
+        fn: {
+            (arg1: T1, arg2: T2, callback: (err: any) => void): void;
+            (arg1: T1, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2) => Promise<void>;
+    export function promisify<T1, T2>(
         fn: (arg1: T1, arg2: T2, callback: (err?: any) => void) => void,
     ): (arg1: T1, arg2: T2) => Promise<void>;
+    export function promisify<T1, T2, T3, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void): void;
+            (callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2, arg3?: T3) => Promise<TResult>;
+    export function promisify<T1, T2, T3, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2, arg3?: T3) => Promise<TResult>;
+    export function promisify<T1, T2, T3, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3?: T3) => Promise<TResult>;
     export function promisify<T1, T2, T3, TResult>(
         fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>;
     export function promisify<T1, T2, T3>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any) => void): void;
+            (callback: (err: any) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2, arg3?: T3) => Promise<void>;
+    export function promisify<T1, T2, T3>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any) => void): void;
+            (arg1: T1, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2, arg3?: T3) => Promise<void>;
+    export function promisify<T1, T2, T3>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any) => void): void;
+            (arg1: T1, arg2: T2, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3?: T3) => Promise<void>;
+    export function promisify<T1, T2, T3>(
         fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err?: any) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3) => Promise<void>;
+    export function promisify<T1, T2, T3, T4, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void): void;
+            (callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2, arg3?: T3, arg4?: T4) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2, arg3?: T3, arg4?: T4) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3?: T3, arg4?: T4) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4?: T4) => Promise<TResult>;
     export function promisify<T1, T2, T3, T4, TResult>(
         fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<TResult>;
     export function promisify<T1, T2, T3, T4>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any) => void): void;
+            (callback: (err: any) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2, arg3?: T3, arg4?: T4) => Promise<void>;
+    export function promisify<T1, T2, T3, T4>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any) => void): void;
+            (arg1: T1, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2, arg3?: T3, arg4?: T4) => Promise<void>;
+    export function promisify<T1, T2, T3, T4>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any) => void): void;
+            (arg1: T1, arg2: T2, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3?: T3, arg4?: T4) => Promise<void>;
+    export function promisify<T1, T2, T3, T4>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any) => void): void;
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4?: T4) => Promise<void>;
+    export function promisify<T1, T2, T3, T4>(
         fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err?: any) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>;
     export function promisify<T1, T2, T3, T4, T5, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void): void;
+            (callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2, arg3?: T3, arg4?: T4, arg5?: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2, arg3?: T3, arg4?: T4, arg5?: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3?: T3, arg4?: T4, arg5?: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4?: T4, arg5?: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5?: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5, TResult>(
         fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any) => void): void;
+            (callback: (err: any) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2, arg3?: T3, arg4?: T4, arg5?: T5) => Promise<void>;
+    export function promisify<T1, T2, T3, T4, T5>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any) => void): void;
+            (arg1: T1, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2, arg3?: T3, arg4?: T4, arg5?: T5) => Promise<void>;
+    export function promisify<T1, T2, T3, T4, T5>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any) => void): void;
+            (arg1: T1, arg2: T2, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3?: T3, arg4?: T4, arg5?: T5) => Promise<void>;
+    export function promisify<T1, T2, T3, T4, T5>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any) => void): void;
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4?: T4, arg5?: T5) => Promise<void>;
+    export function promisify<T1, T2, T3, T4, T5>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any) => void): void;
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5?: T5) => Promise<void>;
     export function promisify<T1, T2, T3, T4, T5>(
         fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err?: any) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<void>;

--- a/types/node/v22/test/util.ts
+++ b/types/node/v22/test/util.ts
@@ -183,6 +183,318 @@ class callbackifyTest {
 callbackifyTest.test();
 
 // util.promisify
+
+declare function fn1WithOptionalArg1(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn1WithOptionalArg1(cb: (err: Error | null, result: number) => void): void;
+declare function fn1WithFullArgs(arg1: string, cb: (err: Error | null, result: number) => void): void;
+
+// $ExpectType (arg1?: string | undefined) => Promise<number>
+util.promisify<string, number>(fn1WithOptionalArg1);
+// $ExpectType (arg1: string) => Promise<number>
+util.promisify<string, number>(fn1WithFullArgs);
+
+declare function fn2WithOptionalArg12(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn2WithOptionalArg12(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn2WithOptionalArg12(cb: (err: Error | null, result: number) => void): void;
+declare function fn2WithOptionalArg2(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn2WithOptionalArg2(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn2WithFullArgs(arg1: string, arg2: boolean, cb: (err: Error | null, result: number) => void): void;
+
+// $ExpectType (arg1?: string | undefined, arg2?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number>(fn2WithOptionalArg12);
+// $ExpectType (arg1: string, arg2?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number>(fn2WithOptionalArg2);
+// $ExpectType (arg1: string, arg2: boolean) => Promise<number>
+util.promisify<string, boolean, number>(fn2WithFullArgs);
+
+declare function fn3WithOptionalArg123(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg123(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg123(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn3WithOptionalArg123(cb: (err: Error | null, result: number) => void): void;
+declare function fn3WithOptionalArg23(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg23(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg23(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn3WithOptionalArg3(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg3(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithFullArgs(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+
+// $ExpectType (arg1?: string | undefined, arg2?: boolean | undefined, arg3?: number | undefined) => Promise<number>
+util.promisify<string, boolean, number, number>(fn3WithOptionalArg123);
+// $ExpectType (arg1: string, arg2?: boolean | undefined, arg3?: number | undefined) => Promise<number>
+util.promisify<string, boolean, number, number>(fn3WithOptionalArg23);
+// $ExpectType (arg1: string, arg2: boolean, arg3?: number | undefined) => Promise<number>
+util.promisify<string, boolean, number, number>(fn3WithOptionalArg3);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number) => Promise<number>
+util.promisify<string, boolean, number, number>(fn3WithFullArgs);
+
+declare function fn4WithOptionalArg1234(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg1234(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg1234(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg1234(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn4WithOptionalArg1234(cb: (err: Error | null, result: number) => void): void;
+declare function fn4WithOptionalArg234(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg234(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg234(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg234(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn4WithOptionalArg34(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg34(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg34(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg4(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg4(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithFullArgs(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+
+// $ExpectType (arg1?: string | undefined, arg2?: boolean | undefined, arg3?: number | undefined, arg4?: string | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, number>(fn4WithOptionalArg1234);
+// $ExpectType (arg1: string, arg2?: boolean | undefined, arg3?: number | undefined, arg4?: string | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, number>(fn4WithOptionalArg234);
+// $ExpectType (arg1: string, arg2: boolean, arg3?: number | undefined, arg4?: string | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, number>(fn4WithOptionalArg34);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4?: string | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, number>(fn4WithOptionalArg4);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4: string) => Promise<number>
+util.promisify<string, boolean, number, string, number>(fn4WithFullArgs);
+
+declare function fn5WithOptionalArg12345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg12345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg12345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg12345(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg12345(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn5WithOptionalArg12345(cb: (err: Error | null, result: number) => void): void;
+declare function fn5WithOptionalArg2345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg2345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg2345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg2345(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg2345(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn5WithOptionalArg345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg345(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg45(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg45(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg45(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg5(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg5(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithFullArgs(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+
+// $ExpectType (arg1?: string | undefined, arg2?: boolean | undefined, arg3?: number | undefined, arg4?: string | undefined, arg5?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, boolean, number>(fn5WithOptionalArg12345);
+// $ExpectType (arg1: string, arg2?: boolean | undefined, arg3?: number | undefined, arg4?: string | undefined, arg5?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, boolean, number>(fn5WithOptionalArg2345);
+// $ExpectType (arg1: string, arg2: boolean, arg3?: number | undefined, arg4?: string | undefined, arg5?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, boolean, number>(fn5WithOptionalArg345);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4?: string | undefined, arg5?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, boolean, number>(fn5WithOptionalArg45);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4: string, arg5?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, boolean, number>(fn5WithOptionalArg5);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4: string, arg5: boolean) => Promise<number>
+util.promisify<string, boolean, number, string, boolean, number>(fn5WithFullArgs);
+
 const readPromised = util.promisify(readFile);
 const sampleRead: Promise<any> = readPromised(__filename).then((data: Buffer): void => {}).catch(
     (error: Error): void => {},

--- a/types/node/v22/util.d.ts
+++ b/types/node/v22/util.d.ts
@@ -1368,30 +1368,210 @@ declare module "util" {
     ): () => Promise<TResult>;
     export function promisify(fn: (callback: (err?: any) => void) => void): () => Promise<void>;
     export function promisify<T1, TResult>(
+        fn: {
+            (arg1: T1, callback: (err: any, result: TResult) => void): void;
+            (callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1?: T1) => Promise<TResult>;
+    export function promisify<T1, TResult>(
         fn: (arg1: T1, callback: (err: any, result: TResult) => void) => void,
     ): (arg1: T1) => Promise<TResult>;
+    export function promisify<T1>(
+        fn: {
+            (arg1: T1, callback: (err: any) => void): void;
+            (callback: (err: any) => void): void;
+        },
+    ): (arg1?: T1) => Promise<void>;
     export function promisify<T1>(fn: (arg1: T1, callback: (err?: any) => void) => void): (arg1: T1) => Promise<void>;
+    export function promisify<T1, T2, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void): void;
+            (callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2) => Promise<TResult>;
+    export function promisify<T1, T2, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2) => Promise<TResult>;
     export function promisify<T1, T2, TResult>(
         fn: (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void) => void,
     ): (arg1: T1, arg2: T2) => Promise<TResult>;
     export function promisify<T1, T2>(
+        fn: {
+            (arg1: T1, arg2: T2, callback: (err: any) => void): void;
+            (callback: (err: any) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2) => Promise<void>;
+    export function promisify<T1, T2>(
+        fn: {
+            (arg1: T1, arg2: T2, callback: (err: any) => void): void;
+            (arg1: T1, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2) => Promise<void>;
+    export function promisify<T1, T2>(
         fn: (arg1: T1, arg2: T2, callback: (err?: any) => void) => void,
     ): (arg1: T1, arg2: T2) => Promise<void>;
+    export function promisify<T1, T2, T3, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void): void;
+            (callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2, arg3?: T3) => Promise<TResult>;
+    export function promisify<T1, T2, T3, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2, arg3?: T3) => Promise<TResult>;
+    export function promisify<T1, T2, T3, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3?: T3) => Promise<TResult>;
     export function promisify<T1, T2, T3, TResult>(
         fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>;
     export function promisify<T1, T2, T3>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any) => void): void;
+            (callback: (err: any) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2, arg3?: T3) => Promise<void>;
+    export function promisify<T1, T2, T3>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any) => void): void;
+            (arg1: T1, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2, arg3?: T3) => Promise<void>;
+    export function promisify<T1, T2, T3>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any) => void): void;
+            (arg1: T1, arg2: T2, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3?: T3) => Promise<void>;
+    export function promisify<T1, T2, T3>(
         fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err?: any) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3) => Promise<void>;
+    export function promisify<T1, T2, T3, T4, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void): void;
+            (callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2, arg3?: T3, arg4?: T4) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2, arg3?: T3, arg4?: T4) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3?: T3, arg4?: T4) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4?: T4) => Promise<TResult>;
     export function promisify<T1, T2, T3, T4, TResult>(
         fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<TResult>;
     export function promisify<T1, T2, T3, T4>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any) => void): void;
+            (callback: (err: any) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2, arg3?: T3, arg4?: T4) => Promise<void>;
+    export function promisify<T1, T2, T3, T4>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any) => void): void;
+            (arg1: T1, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2, arg3?: T3, arg4?: T4) => Promise<void>;
+    export function promisify<T1, T2, T3, T4>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any) => void): void;
+            (arg1: T1, arg2: T2, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3?: T3, arg4?: T4) => Promise<void>;
+    export function promisify<T1, T2, T3, T4>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any) => void): void;
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4?: T4) => Promise<void>;
+    export function promisify<T1, T2, T3, T4>(
         fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err?: any) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>;
     export function promisify<T1, T2, T3, T4, T5, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void): void;
+            (callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2, arg3?: T3, arg4?: T4, arg5?: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2, arg3?: T3, arg4?: T4, arg5?: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3?: T3, arg4?: T4, arg5?: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4?: T4, arg5?: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5?: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5, TResult>(
         fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any) => void): void;
+            (callback: (err: any) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2, arg3?: T3, arg4?: T4, arg5?: T5) => Promise<void>;
+    export function promisify<T1, T2, T3, T4, T5>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any) => void): void;
+            (arg1: T1, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2, arg3?: T3, arg4?: T4, arg5?: T5) => Promise<void>;
+    export function promisify<T1, T2, T3, T4, T5>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any) => void): void;
+            (arg1: T1, arg2: T2, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3?: T3, arg4?: T4, arg5?: T5) => Promise<void>;
+    export function promisify<T1, T2, T3, T4, T5>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any) => void): void;
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4?: T4, arg5?: T5) => Promise<void>;
+    export function promisify<T1, T2, T3, T4, T5>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any) => void): void;
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5?: T5) => Promise<void>;
     export function promisify<T1, T2, T3, T4, T5>(
         fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err?: any) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<void>;

--- a/types/node/v24/test/util.ts
+++ b/types/node/v24/test/util.ts
@@ -183,6 +183,318 @@ class callbackifyTest {
 callbackifyTest.test();
 
 // util.promisify
+
+declare function fn1WithOptionalArg1(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn1WithOptionalArg1(cb: (err: Error | null, result: number) => void): void;
+declare function fn1WithFullArgs(arg1: string, cb: (err: Error | null, result: number) => void): void;
+
+// $ExpectType (arg1?: string | undefined) => Promise<number>
+util.promisify<string, number>(fn1WithOptionalArg1);
+// $ExpectType (arg1: string) => Promise<number>
+util.promisify<string, number>(fn1WithFullArgs);
+
+declare function fn2WithOptionalArg12(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn2WithOptionalArg12(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn2WithOptionalArg12(cb: (err: Error | null, result: number) => void): void;
+declare function fn2WithOptionalArg2(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn2WithOptionalArg2(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn2WithFullArgs(arg1: string, arg2: boolean, cb: (err: Error | null, result: number) => void): void;
+
+// $ExpectType (arg1?: string | undefined, arg2?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number>(fn2WithOptionalArg12);
+// $ExpectType (arg1: string, arg2?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number>(fn2WithOptionalArg2);
+// $ExpectType (arg1: string, arg2: boolean) => Promise<number>
+util.promisify<string, boolean, number>(fn2WithFullArgs);
+
+declare function fn3WithOptionalArg123(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg123(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg123(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn3WithOptionalArg123(cb: (err: Error | null, result: number) => void): void;
+declare function fn3WithOptionalArg23(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg23(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg23(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn3WithOptionalArg3(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithOptionalArg3(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn3WithFullArgs(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+
+// $ExpectType (arg1?: string | undefined, arg2?: boolean | undefined, arg3?: number | undefined) => Promise<number>
+util.promisify<string, boolean, number, number>(fn3WithOptionalArg123);
+// $ExpectType (arg1: string, arg2?: boolean | undefined, arg3?: number | undefined) => Promise<number>
+util.promisify<string, boolean, number, number>(fn3WithOptionalArg23);
+// $ExpectType (arg1: string, arg2: boolean, arg3?: number | undefined) => Promise<number>
+util.promisify<string, boolean, number, number>(fn3WithOptionalArg3);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number) => Promise<number>
+util.promisify<string, boolean, number, number>(fn3WithFullArgs);
+
+declare function fn4WithOptionalArg1234(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg1234(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg1234(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg1234(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn4WithOptionalArg1234(cb: (err: Error | null, result: number) => void): void;
+declare function fn4WithOptionalArg234(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg234(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg234(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg234(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn4WithOptionalArg34(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg34(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg34(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg4(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithOptionalArg4(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn4WithFullArgs(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+
+// $ExpectType (arg1?: string | undefined, arg2?: boolean | undefined, arg3?: number | undefined, arg4?: string | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, number>(fn4WithOptionalArg1234);
+// $ExpectType (arg1: string, arg2?: boolean | undefined, arg3?: number | undefined, arg4?: string | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, number>(fn4WithOptionalArg234);
+// $ExpectType (arg1: string, arg2: boolean, arg3?: number | undefined, arg4?: string | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, number>(fn4WithOptionalArg34);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4?: string | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, number>(fn4WithOptionalArg4);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4: string) => Promise<number>
+util.promisify<string, boolean, number, string, number>(fn4WithFullArgs);
+
+declare function fn5WithOptionalArg12345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg12345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg12345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg12345(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg12345(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn5WithOptionalArg12345(cb: (err: Error | null, result: number) => void): void;
+declare function fn5WithOptionalArg2345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg2345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg2345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg2345(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg2345(arg1: string, cb: (err: Error | null, result: number) => void): void;
+declare function fn5WithOptionalArg345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg345(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg345(
+    arg1: string,
+    arg2: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg45(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg45(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg45(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg5(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithOptionalArg5(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    cb: (err: Error | null, result: number) => void,
+): void;
+declare function fn5WithFullArgs(
+    arg1: string,
+    arg2: boolean,
+    arg3: number,
+    arg4: string,
+    arg5: boolean,
+    cb: (err: Error | null, result: number) => void,
+): void;
+
+// $ExpectType (arg1?: string | undefined, arg2?: boolean | undefined, arg3?: number | undefined, arg4?: string | undefined, arg5?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, boolean, number>(fn5WithOptionalArg12345);
+// $ExpectType (arg1: string, arg2?: boolean | undefined, arg3?: number | undefined, arg4?: string | undefined, arg5?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, boolean, number>(fn5WithOptionalArg2345);
+// $ExpectType (arg1: string, arg2: boolean, arg3?: number | undefined, arg4?: string | undefined, arg5?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, boolean, number>(fn5WithOptionalArg345);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4?: string | undefined, arg5?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, boolean, number>(fn5WithOptionalArg45);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4: string, arg5?: boolean | undefined) => Promise<number>
+util.promisify<string, boolean, number, string, boolean, number>(fn5WithOptionalArg5);
+// $ExpectType (arg1: string, arg2: boolean, arg3: number, arg4: string, arg5: boolean) => Promise<number>
+util.promisify<string, boolean, number, string, boolean, number>(fn5WithFullArgs);
+
 const readPromised = util.promisify(readFile);
 const sampleRead: Promise<any> = readPromised(__filename).then((data: Buffer): void => {}).catch(
     (error: Error): void => {},

--- a/types/node/v24/util.d.ts
+++ b/types/node/v24/util.d.ts
@@ -1088,30 +1088,210 @@ declare module "util" {
     ): () => Promise<TResult>;
     export function promisify(fn: (callback: (err?: any) => void) => void): () => Promise<void>;
     export function promisify<T1, TResult>(
+        fn: {
+            (arg1: T1, callback: (err: any, result: TResult) => void): void;
+            (callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1?: T1) => Promise<TResult>;
+    export function promisify<T1, TResult>(
         fn: (arg1: T1, callback: (err: any, result: TResult) => void) => void,
     ): (arg1: T1) => Promise<TResult>;
+    export function promisify<T1>(
+        fn: {
+            (arg1: T1, callback: (err: any) => void): void;
+            (callback: (err: any) => void): void;
+        },
+    ): (arg1?: T1) => Promise<void>;
     export function promisify<T1>(fn: (arg1: T1, callback: (err?: any) => void) => void): (arg1: T1) => Promise<void>;
+    export function promisify<T1, T2, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void): void;
+            (callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2) => Promise<TResult>;
+    export function promisify<T1, T2, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2) => Promise<TResult>;
     export function promisify<T1, T2, TResult>(
         fn: (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void) => void,
     ): (arg1: T1, arg2: T2) => Promise<TResult>;
     export function promisify<T1, T2>(
+        fn: {
+            (arg1: T1, arg2: T2, callback: (err: any) => void): void;
+            (callback: (err: any) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2) => Promise<void>;
+    export function promisify<T1, T2>(
+        fn: {
+            (arg1: T1, arg2: T2, callback: (err: any) => void): void;
+            (arg1: T1, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2) => Promise<void>;
+    export function promisify<T1, T2>(
         fn: (arg1: T1, arg2: T2, callback: (err?: any) => void) => void,
     ): (arg1: T1, arg2: T2) => Promise<void>;
+    export function promisify<T1, T2, T3, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void): void;
+            (callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2, arg3?: T3) => Promise<TResult>;
+    export function promisify<T1, T2, T3, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2, arg3?: T3) => Promise<TResult>;
+    export function promisify<T1, T2, T3, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3?: T3) => Promise<TResult>;
     export function promisify<T1, T2, T3, TResult>(
         fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>;
     export function promisify<T1, T2, T3>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any) => void): void;
+            (callback: (err: any) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2, arg3?: T3) => Promise<void>;
+    export function promisify<T1, T2, T3>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any) => void): void;
+            (arg1: T1, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2, arg3?: T3) => Promise<void>;
+    export function promisify<T1, T2, T3>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any) => void): void;
+            (arg1: T1, arg2: T2, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3?: T3) => Promise<void>;
+    export function promisify<T1, T2, T3>(
         fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err?: any) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3) => Promise<void>;
+    export function promisify<T1, T2, T3, T4, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void): void;
+            (callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2, arg3?: T3, arg4?: T4) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2, arg3?: T3, arg4?: T4) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3?: T3, arg4?: T4) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4?: T4) => Promise<TResult>;
     export function promisify<T1, T2, T3, T4, TResult>(
         fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<TResult>;
     export function promisify<T1, T2, T3, T4>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any) => void): void;
+            (callback: (err: any) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2, arg3?: T3, arg4?: T4) => Promise<void>;
+    export function promisify<T1, T2, T3, T4>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any) => void): void;
+            (arg1: T1, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2, arg3?: T3, arg4?: T4) => Promise<void>;
+    export function promisify<T1, T2, T3, T4>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any) => void): void;
+            (arg1: T1, arg2: T2, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3?: T3, arg4?: T4) => Promise<void>;
+    export function promisify<T1, T2, T3, T4>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any) => void): void;
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4?: T4) => Promise<void>;
+    export function promisify<T1, T2, T3, T4>(
         fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err?: any) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>;
     export function promisify<T1, T2, T3, T4, T5, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void): void;
+            (callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2, arg3?: T3, arg4?: T4, arg5?: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2, arg3?: T3, arg4?: T4, arg5?: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, arg2: T2, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3?: T3, arg4?: T4, arg5?: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4?: T4, arg5?: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5, TResult>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void): void;
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any, result: TResult) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5?: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5, TResult>(
         fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any, result: TResult) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<TResult>;
+    export function promisify<T1, T2, T3, T4, T5>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any) => void): void;
+            (callback: (err: any) => void): void;
+        },
+    ): (arg1?: T1, arg2?: T2, arg3?: T3, arg4?: T4, arg5?: T5) => Promise<void>;
+    export function promisify<T1, T2, T3, T4, T5>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any) => void): void;
+            (arg1: T1, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2?: T2, arg3?: T3, arg4?: T4, arg5?: T5) => Promise<void>;
+    export function promisify<T1, T2, T3, T4, T5>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any) => void): void;
+            (arg1: T1, arg2: T2, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3?: T3, arg4?: T4, arg5?: T5) => Promise<void>;
+    export function promisify<T1, T2, T3, T4, T5>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any) => void): void;
+            (arg1: T1, arg2: T2, arg3: T3, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4?: T4, arg5?: T5) => Promise<void>;
+    export function promisify<T1, T2, T3, T4, T5>(
+        fn: {
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: any) => void): void;
+            (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: any) => void): void;
+        },
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5?: T5) => Promise<void>;
     export function promisify<T1, T2, T3, T4, T5>(
         fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err?: any) => void) => void,
     ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<void>;


### PR DESCRIPTION
The PR is motivated by my recent attempt on the popular `tmp` package. 

Since `util.promisify(...)` only cares about the last argument, and the remaining argument will remain effective in its original order, I would expect a series of properly-positioned overloads on the same callback-first function will be turned into an ES6 async function with optional arguments.

For example, given this signature,
```ts
export function tmpName(options: TmpNameOptions, cb: TmpNameCallback): void;
export function tmpName(cb: TmpNameCallback): void;
```

the update made by this PR will properly denote the promisified result as an ES6 async function with an optional `TmpNameOptions`.
```patch
- // (arg1: tmp.TmpNameOptions) => Promise<string>
+ // (arg1?: tmp.TmpNameOptions | undefined) => Promise<string>
nodeUtil.promisify<tmp.TmpNameOptions, string>(tmp.tmpName)
```

Here is the full playground code for illustration: https://tsplay.dev/NrAvVw

For completeness, I am making updates on both `node/util` & `bluebird`, from `<T1(, TResult)>` up to `<T1, ..., T5(, TResult)>` *(since `T5` seems to be the "stopping point" in the existing implementation)*.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
