### PR TITLE
chore(vscode): add a readme to refer contribution back to vscode source repo

### DIFF
--- a/types/vscode/README.md
+++ b/types/vscode/README.md
@@ -1,0 +1,7 @@
+# @types/vscode
+
+## Contributing
+
+`@types/vscode/index.d.ts` is an idential re-export of `src/vscode-dts/vscode.d.ts` in https://github.com/microsoft/vscode. See https://github.com/microsoft/vscode/tree/main/build/azure-pipelines/publish-types for how these types are updated.
+
+If you would like to contribute, please open an issue or a pull request there. Any code changes on `@types/vscode` without going through `microsoft/vscode` repo will risk being eliminated by microsoft's pipeline.


### PR DESCRIPTION
The type-reexport situation should at least be revealed in a standalone readme _(like `@types/ramda`)_, so that type owners and DT maintainers can be more aware and can then devise community contributor to the right place; Or else community contribution like https://github.com/DefinitelyTyped/DefinitelyTyped/pull/74140 would risk getting eliminated upon microsoft's pipeline triggering.

Fyr, I have helped ported back the change  to `microsoft/vscode` repo via https://github.com/microsoft/vscode/pull/289071.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
