### PR TITLE
[react] Properly type form-related events

### DIFF
--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -700,3 +700,57 @@ function cacheSignalTest() {
         }
     }
 }
+
+function formrelatedEventTests() {
+    React.createElement("textarea", {
+        value: "5",
+        onChange: event => {
+            // createElement is not inferring props for textarea. JSX works though.
+            // $ExpectType EventTarget & Element
+            event.target;
+            // @ts-expect-error
+            event.target.value;
+        },
+    });
+
+    React.createElement("input", {
+        onChange: event => {
+            // $ExpectType EventTarget & HTMLInputElement
+            event.target;
+            // $ExpectType string
+            event.target.value;
+        },
+    });
+
+    <input
+        onChange={event => {
+            // $ExpectType EventTarget & HTMLInputElement
+            event.target;
+            // $ExpectType string
+            event.target.value;
+        }}
+    />;
+    <select
+        onChange={event => {
+            // $ExpectType EventTarget & HTMLSelectElement
+            event.target;
+            // $ExpectType string
+            event.target.value;
+        }}
+    />;
+    <textarea
+        onChange={event => {
+            // $ExpectType EventTarget & HTMLTextAreaElement
+            event.target;
+            // $ExpectType string
+            event.target.value;
+        }}
+    />;
+
+    <form onSubmit={event => {
+        // @ts-expect-error -- submitter is not yet exposed by React
+        event.submitter;
+        // $ExpectType EventTarget & HTMLFormElement
+        event.target;
+    }} />
+}

--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -706,7 +706,7 @@ function formrelatedEventTests() {
         value: "5",
         onChange: event => {
             // createElement is not inferring props for textarea. JSX works though.
-            // $ExpectType EventTarget & Element
+            // $ExpectType EventTarget & HTMLElement
             event.target;
             // @ts-expect-error
             event.target.value;
@@ -722,6 +722,13 @@ function formrelatedEventTests() {
         },
     });
 
+    <div
+        onChange={event => {
+            // Should be EventTarget since we don't know from where the change event bubbled.
+            // $ExpectType EventTarget & HTMLDivElement
+            event.target;
+        }}
+    />;
     <input
         onChange={event => {
             // $ExpectType EventTarget & HTMLInputElement
@@ -747,10 +754,12 @@ function formrelatedEventTests() {
         }}
     />;
 
-    <form onSubmit={event => {
-        // @ts-expect-error -- submitter is not yet exposed by React
-        event.submitter;
-        // $ExpectType EventTarget & HTMLFormElement
-        event.target;
-    }} />
+    <form
+        onSubmit={event => {
+            // @ts-expect-error -- submitter is not yet exposed by React
+            event.submitter;
+            // $ExpectType EventTarget & HTMLFormElement
+            event.target;
+        }}
+    />;
 }

--- a/types/react/global.d.ts
+++ b/types/react/global.d.ts
@@ -18,6 +18,7 @@ interface KeyboardEvent extends Event {}
 interface MouseEvent extends Event {}
 interface TouchEvent extends Event {}
 interface PointerEvent extends Event {}
+interface SubmitEvent extends Event {}
 interface ToggleEvent extends Event {}
 interface TransitionEvent extends Event {}
 interface UIEvent extends Event {}

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2085,7 +2085,9 @@ declare namespace React {
      * reflect a DOM event. Change events are just fired as standard {@link SyntheticEvent}.
      */
     interface ChangeEvent<CurrentTarget = Element, Target = Element> extends SyntheticEvent<CurrentTarget> {
-        target: EventTarget & Target;
+        // TODO: This is wrong for change event handlers on arbitrary. Should
+        // be EventTarget & Target, but kept for backward compatibility until React 20.
+        target: EventTarget & CurrentTarget;
     }
 
     interface InputEvent<T = Element> extends SyntheticEvent<T, NativeInputEvent> {

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -16,6 +16,7 @@ type NativeKeyboardEvent = KeyboardEvent;
 type NativeMouseEvent = MouseEvent;
 type NativeTouchEvent = TouchEvent;
 type NativePointerEvent = PointerEvent;
+type NativeSubmitEvent = SubmitEvent;
 type NativeToggleEvent = ToggleEvent;
 type NativeTransitionEvent = TransitionEvent;
 type NativeUIEvent = UIEvent;
@@ -2065,15 +2066,26 @@ declare namespace React {
         target: EventTarget & Target;
     }
 
+    /**
+     * @deprecated FormEvent doesn't actually exist.
+     *             You probably meant to use {@link ChangeEvent}, {@link InputEvent}, {@link SubmitEvent}, or just {@link SyntheticEvent} instead
+     *             depending on the event type.
+     */
     interface FormEvent<T = Element> extends SyntheticEvent<T> {
     }
 
     interface InvalidEvent<T = Element> extends SyntheticEvent<T> {
-        target: EventTarget & T;
     }
 
-    interface ChangeEvent<T = Element> extends SyntheticEvent<T> {
-        target: EventTarget & T;
+    /**
+     * change events bubble in React so their target is generally unknown.
+     * Only for form elements we know their target type because form events can't
+     * be nested.
+     * This type exists purely to narrow `target` for form elements. It doesn't
+     * reflect a DOM event. Change events are just fired as standard {@link SyntheticEvent}.
+     */
+    interface ChangeEvent<CurrentTarget = Element, Target = Element> extends SyntheticEvent<CurrentTarget> {
+        target: EventTarget & Target;
     }
 
     interface InputEvent<T = Element> extends SyntheticEvent<T, NativeInputEvent> {
@@ -2143,6 +2155,13 @@ declare namespace React {
         shiftKey: boolean;
     }
 
+    interface SubmitEvent<T = Element> extends SyntheticEvent<T, NativeSubmitEvent> {
+        // Currently not exposed by Reat
+        // submitter: HTMLElement | null;
+        // SubmitEvents are always targetted at HTMLFormElements.
+        target: EventTarget & HTMLFormElement;
+    }
+
     interface TouchEvent<T = Element> extends UIEvent<T, NativeTouchEvent> {
         altKey: boolean;
         changedTouches: TouchList;
@@ -2198,11 +2217,19 @@ declare namespace React {
     type CompositionEventHandler<T = Element> = EventHandler<CompositionEvent<T>>;
     type DragEventHandler<T = Element> = EventHandler<DragEvent<T>>;
     type FocusEventHandler<T = Element> = EventHandler<FocusEvent<T>>;
+    /**
+     * @deprecated FormEventHandler doesn't actually exist.
+     *             You probably meant to use {@link ChangeEventHandler}, {@link InputEventHandler}, {@link SubmitEventHandler}, or just {@link EventHandler} instead
+     *             depending on the event type.
+     */
     type FormEventHandler<T = Element> = EventHandler<FormEvent<T>>;
-    type ChangeEventHandler<T = Element> = EventHandler<ChangeEvent<T>>;
+    type ChangeEventHandler<CurrentTarget = Element, Target = Element> = EventHandler<
+        ChangeEvent<CurrentTarget, Target>
+    >;
     type InputEventHandler<T = Element> = EventHandler<InputEvent<T>>;
     type KeyboardEventHandler<T = Element> = EventHandler<KeyboardEvent<T>>;
     type MouseEventHandler<T = Element> = EventHandler<MouseEvent<T>>;
+    type SubmitEventHandler<T = Element> = EventHandler<SubmitEvent<T>>;
     type TouchEventHandler<T = Element> = EventHandler<TouchEvent<T>>;
     type PointerEventHandler<T = Element> = EventHandler<PointerEvent<T>>;
     type UIEventHandler<T = Element> = EventHandler<UIEvent<T>>;
@@ -2256,19 +2283,19 @@ declare namespace React {
         onBlur?: FocusEventHandler<T> | undefined;
         onBlurCapture?: FocusEventHandler<T> | undefined;
 
-        // Form Events
-        onChange?: FormEventHandler<T> | undefined;
-        onChangeCapture?: FormEventHandler<T> | undefined;
+        // form related Events
+        onChange?: ChangeEventHandler<T> | undefined;
+        onChangeCapture?: ChangeEventHandler<T> | undefined;
         onBeforeInput?: InputEventHandler<T> | undefined;
-        onBeforeInputCapture?: FormEventHandler<T> | undefined;
-        onInput?: FormEventHandler<T> | undefined;
-        onInputCapture?: FormEventHandler<T> | undefined;
-        onReset?: FormEventHandler<T> | undefined;
-        onResetCapture?: FormEventHandler<T> | undefined;
-        onSubmit?: FormEventHandler<T> | undefined;
-        onSubmitCapture?: FormEventHandler<T> | undefined;
-        onInvalid?: FormEventHandler<T> | undefined;
-        onInvalidCapture?: FormEventHandler<T> | undefined;
+        onBeforeInputCapture?: InputEventHandler<T> | undefined;
+        onInput?: InputEventHandler<T> | undefined;
+        onInputCapture?: InputEventHandler<T> | undefined;
+        onReset?: ReactEventHandler<T> | undefined;
+        onResetCapture?: ReactEventHandler<T> | undefined;
+        onSubmit?: SubmitEventHandler<T> | undefined;
+        onSubmitCapture?: SubmitEventHandler<T> | undefined;
+        onInvalid?: ReactEventHandler<T> | undefined;
+        onInvalidCapture?: ReactEventHandler<T> | undefined;
 
         // Image Events
         onLoad?: ReactEventHandler<T> | undefined;
@@ -3275,7 +3302,9 @@ declare namespace React {
         value?: string | readonly string[] | number | undefined;
         width?: number | string | undefined;
 
-        onChange?: ChangeEventHandler<T> | undefined;
+        // No other element dispatching change events can be nested in a <input>
+        // so we know the target will be a HTMLInputElement.
+        onChange?: ChangeEventHandler<T, HTMLInputElement> | undefined;
     }
 
     interface KeygenHTMLAttributes<T> extends HTMLAttributes<T> {
@@ -3440,7 +3469,9 @@ declare namespace React {
         required?: boolean | undefined;
         size?: number | undefined;
         value?: string | readonly string[] | number | undefined;
-        onChange?: ChangeEventHandler<T> | undefined;
+        // No other element dispatching change events can be nested in a <select>
+        // so we know the target will be a HTMLSelectElement.
+        onChange?: ChangeEventHandler<T, HTMLSelectElement> | undefined;
     }
 
     interface SourceHTMLAttributes<T> extends HTMLAttributes<T> {
@@ -3492,7 +3523,9 @@ declare namespace React {
         value?: string | readonly string[] | number | undefined;
         wrap?: string | undefined;
 
-        onChange?: ChangeEventHandler<T> | undefined;
+        // No other element dispatching change events can be nested in a <textare>
+        // so we know the target will be a HTMLTextAreaElement.
+        onChange?: ChangeEventHandler<T, HTMLTextAreaElement> | undefined;
     }
 
     interface TdHTMLAttributes<T> extends HTMLAttributes<T> {

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -633,25 +633,6 @@ function handler(e: React.MouseEvent) {
 
 const keyboardExtendsUI: React.UIEventHandler = (e: React.KeyboardEvent) => {};
 
-//
-// The SyntheticEvent.target.value should be accessible for onChange
-// --------------------------------------------------------------------------
-class SyntheticEventTargetValue extends React.Component<{}, { value: string }> {
-    state: { value: string };
-    constructor(props: {}) {
-        super(props);
-        this.state = { value: "a" };
-    }
-    render() {
-        return React.createElement("textarea", {
-            value: this.state.value,
-            onChange: e => {
-                const target: HTMLTextAreaElement = e.target;
-            },
-        });
-    }
-}
-
 React.createElement("input", {
     onChange: event => {
         // `event.target` is guaranteed to be HTMLInputElement

--- a/types/react/ts5.0/global.d.ts
+++ b/types/react/ts5.0/global.d.ts
@@ -18,6 +18,7 @@ interface KeyboardEvent extends Event {}
 interface MouseEvent extends Event {}
 interface TouchEvent extends Event {}
 interface PointerEvent extends Event {}
+interface SubmitEvent extends Event {}
 interface ToggleEvent extends Event {}
 interface TransitionEvent extends Event {}
 interface UIEvent extends Event {}

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -16,6 +16,7 @@ type NativeKeyboardEvent = KeyboardEvent;
 type NativeMouseEvent = MouseEvent;
 type NativeTouchEvent = TouchEvent;
 type NativePointerEvent = PointerEvent;
+type NativeSubmitEvent = SubmitEvent;
 type NativeToggleEvent = ToggleEvent;
 type NativeTransitionEvent = TransitionEvent;
 type NativeUIEvent = UIEvent;
@@ -2064,15 +2065,26 @@ declare namespace React {
         target: EventTarget & Target;
     }
 
+    /**
+     * @deprecated FormEvent doesn't actually exist.
+     *             You probably meant to use {@link ChangeEvent}, {@link InputEvent}, {@link SubmitEvent}, or just {@link SyntheticEvent} instead
+     *             depending on the event type.
+     */
     interface FormEvent<T = Element> extends SyntheticEvent<T> {
     }
 
     interface InvalidEvent<T = Element> extends SyntheticEvent<T> {
-        target: EventTarget & T;
     }
 
-    interface ChangeEvent<T = Element> extends SyntheticEvent<T> {
-        target: EventTarget & T;
+    /**
+     * change events bubble in React so their target is generally unknown.
+     * Only for form elements we know their target type because form events can't
+     * be nested.
+     * This type exists purely to narrow `target` for form elements. It doesn't
+     * reflect a DOM event. React fires change events as {@link SyntheticEvent}.
+     */
+    interface ChangeEvent<CurrentTarget = Element, Target = Element> extends SyntheticEvent<CurrentTarget> {
+        target: EventTarget & Target;
     }
 
     interface InputEvent<T = Element> extends SyntheticEvent<T, NativeInputEvent> {
@@ -2142,6 +2154,13 @@ declare namespace React {
         shiftKey: boolean;
     }
 
+    interface SubmitEvent<T = Element> extends SyntheticEvent<T, NativeSubmitEvent> {
+        // Currently not exposed by Reat
+        // submitter: HTMLElement | null;
+        // SubmitEvents are always targetted at HTMLFormElements.
+        target: EventTarget & HTMLFormElement;
+    }
+
     interface TouchEvent<T = Element> extends UIEvent<T, NativeTouchEvent> {
         altKey: boolean;
         changedTouches: TouchList;
@@ -2197,11 +2216,19 @@ declare namespace React {
     type CompositionEventHandler<T = Element> = EventHandler<CompositionEvent<T>>;
     type DragEventHandler<T = Element> = EventHandler<DragEvent<T>>;
     type FocusEventHandler<T = Element> = EventHandler<FocusEvent<T>>;
+    /**
+     * @deprecated FormEventHandler doesn't actually exist.
+     *             You probably meant to use {@link ChangeEventHandler}, {@link InputEventHandler}, {@link SubmitEventHandler}, or just {@link EventHandler} instead
+     *             depending on the event type.
+     */
     type FormEventHandler<T = Element> = EventHandler<FormEvent<T>>;
-    type ChangeEventHandler<T = Element> = EventHandler<ChangeEvent<T>>;
+    type ChangeEventHandler<CurrentTarget = Element, Target = Element> = EventHandler<
+        ChangeEvent<CurrentTarget, Target>
+    >;
     type InputEventHandler<T = Element> = EventHandler<InputEvent<T>>;
     type KeyboardEventHandler<T = Element> = EventHandler<KeyboardEvent<T>>;
     type MouseEventHandler<T = Element> = EventHandler<MouseEvent<T>>;
+    type SubmitEventHandler<T = Element> = EventHandler<SubmitEvent<T>>;
     type TouchEventHandler<T = Element> = EventHandler<TouchEvent<T>>;
     type PointerEventHandler<T = Element> = EventHandler<PointerEvent<T>>;
     type UIEventHandler<T = Element> = EventHandler<UIEvent<T>>;
@@ -2255,19 +2282,19 @@ declare namespace React {
         onBlur?: FocusEventHandler<T> | undefined;
         onBlurCapture?: FocusEventHandler<T> | undefined;
 
-        // Form Events
-        onChange?: FormEventHandler<T> | undefined;
-        onChangeCapture?: FormEventHandler<T> | undefined;
+        // form related Events
+        onChange?: ChangeEventHandler<T> | undefined;
+        onChangeCapture?: ChangeEventHandler<T> | undefined;
         onBeforeInput?: InputEventHandler<T> | undefined;
-        onBeforeInputCapture?: FormEventHandler<T> | undefined;
-        onInput?: FormEventHandler<T> | undefined;
-        onInputCapture?: FormEventHandler<T> | undefined;
-        onReset?: FormEventHandler<T> | undefined;
-        onResetCapture?: FormEventHandler<T> | undefined;
-        onSubmit?: FormEventHandler<T> | undefined;
-        onSubmitCapture?: FormEventHandler<T> | undefined;
-        onInvalid?: FormEventHandler<T> | undefined;
-        onInvalidCapture?: FormEventHandler<T> | undefined;
+        onBeforeInputCapture?: InputEventHandler<T> | undefined;
+        onInput?: InputEventHandler<T> | undefined;
+        onInputCapture?: InputEventHandler<T> | undefined;
+        onReset?: ReactEventHandler<T> | undefined;
+        onResetCapture?: ReactEventHandler<T> | undefined;
+        onSubmit?: SubmitEventHandler<T> | undefined;
+        onSubmitCapture?: SubmitEventHandler<T> | undefined;
+        onInvalid?: ReactEventHandler<T> | undefined;
+        onInvalidCapture?: ReactEventHandler<T> | undefined;
 
         // Image Events
         onLoad?: ReactEventHandler<T> | undefined;
@@ -3274,7 +3301,9 @@ declare namespace React {
         value?: string | readonly string[] | number | undefined;
         width?: number | string | undefined;
 
-        onChange?: ChangeEventHandler<T> | undefined;
+        // No other element dispatching change events can be nested in a <input>
+        // so we know the target will be a HTMLInputElement.
+        onChange?: ChangeEventHandler<T, HTMLInputElement> | undefined;
     }
 
     interface KeygenHTMLAttributes<T> extends HTMLAttributes<T> {
@@ -3439,7 +3468,9 @@ declare namespace React {
         required?: boolean | undefined;
         size?: number | undefined;
         value?: string | readonly string[] | number | undefined;
-        onChange?: ChangeEventHandler<T> | undefined;
+        // No other element dispatching change events can be nested in a <select>
+        // so we know the target will be a HTMLSelectElement.
+        onChange?: ChangeEventHandler<T, HTMLSelectElement> | undefined;
     }
 
     interface SourceHTMLAttributes<T> extends HTMLAttributes<T> {
@@ -3491,7 +3522,9 @@ declare namespace React {
         value?: string | readonly string[] | number | undefined;
         wrap?: string | undefined;
 
-        onChange?: ChangeEventHandler<T> | undefined;
+        // No other element dispatching change events can be nested in a <textarea>
+        // so we know the target will be a HTMLTextAreaElement.
+        onChange?: ChangeEventHandler<T, HTMLTextAreaElement> | undefined;
     }
 
     interface TdHTMLAttributes<T> extends HTMLAttributes<T> {

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -2084,7 +2084,9 @@ declare namespace React {
      * reflect a DOM event. React fires change events as {@link SyntheticEvent}.
      */
     interface ChangeEvent<CurrentTarget = Element, Target = Element> extends SyntheticEvent<CurrentTarget> {
-        target: EventTarget & Target;
+        // TODO: This is wrong for change event handlers on arbitrary. Should
+        // be EventTarget & Target, but kept for backward compatibility until React 20.
+        target: EventTarget & CurrentTarget;
     }
 
     interface InputEvent<T = Element> extends SyntheticEvent<T, NativeInputEvent> {

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -636,25 +636,6 @@ function handler(e: React.MouseEvent) {
 
 const keyboardExtendsUI: React.UIEventHandler = (e: React.KeyboardEvent) => {};
 
-//
-// The SyntheticEvent.target.value should be accessible for onChange
-// --------------------------------------------------------------------------
-class SyntheticEventTargetValue extends React.Component<{}, { value: string }> {
-    state: { value: string };
-    constructor(props: {}) {
-        super(props);
-        this.state = { value: "a" };
-    }
-    render() {
-        return React.createElement("textarea", {
-            value: this.state.value,
-            onChange: e => {
-                const target: HTMLTextAreaElement = e.target;
-            },
-        });
-    }
-}
-
 React.createElement("input", {
     onChange: event => {
         // `event.target` is guaranteed to be HTMLInputElement

--- a/types/redux-form/v4/redux-form-tests.tsx
+++ b/types/redux-form/v4/redux-form-tests.tsx
@@ -6,7 +6,7 @@ import { reducer as reduxFormReducer, reduxForm, ReduxFormProps } from "redux-fo
 namespace SimpleForm {
     export const fields = ["firstName", "lastName", "email", "sex", "favoriteColor", "employed", "notes"];
 
-    class SimpleForm extends React.Component<ReduxFormProps<SimpleForm & HTMLFormElement>> {
+    class SimpleForm extends React.Component<ReduxFormProps<HTMLFormElement>> {
         static propTypes = {
             fields: PropTypes.object.isRequired,
             handleSubmit: PropTypes.func.isRequired,
@@ -121,9 +121,7 @@ namespace SynchronousValidation {
         return errors;
     };
 
-    class SynchronousValidationForm
-        extends React.Component<ReduxFormProps<SynchronousValidationForm & HTMLFormElement>>
-    {
+    class SynchronousValidationForm extends React.Component<ReduxFormProps<HTMLFormElement>> {
         static propTypes = {
             fields: PropTypes.object.isRequired,
             handleSubmit: PropTypes.func.isRequired,
@@ -255,7 +253,7 @@ namespace InitializingFromState {
         load(data: any): void;
     }
 
-    class InitializingFromStateForm extends React.Component<Props<InitializingFromStateForm & HTMLFormElement>> {
+    class InitializingFromStateForm extends React.Component<Props<HTMLFormElement>> {
         static propTypes = {
             fields: PropTypes.object.isRequired,
             handleSubmit: PropTypes.func.isRequired,

--- a/types/redux-form/v5/redux-form-tests.tsx
+++ b/types/redux-form/v5/redux-form-tests.tsx
@@ -6,7 +6,7 @@ import { reducer as reduxFormReducer, reduxForm, ReduxFormProps } from "redux-fo
 namespace SimpleForm {
     export const fields = ["firstName", "lastName", "email", "sex", "favoriteColor", "employed", "notes"];
 
-    class SimpleForm extends React.Component<ReduxFormProps<SimpleForm & HTMLFormElement>> {
+    class SimpleForm extends React.Component<ReduxFormProps<HTMLFormElement>> {
         static propTypes = {
             fields: PropTypes.object.isRequired,
             handleSubmit: PropTypes.func.isRequired,
@@ -121,9 +121,7 @@ namespace SynchronousValidation {
         return errors;
     };
 
-    class SynchronousValidationForm
-        extends React.Component<ReduxFormProps<SynchronousValidationForm & HTMLFormElement>>
-    {
+    class SynchronousValidationForm extends React.Component<ReduxFormProps<HTMLFormElement>> {
         static propTypes = {
             fields: PropTypes.object.isRequired,
             handleSubmit: PropTypes.func.isRequired,
@@ -255,7 +253,7 @@ namespace InitializingFromState {
         load(data: any): void;
     }
 
-    class InitializingFromStateForm extends React.Component<Props<InitializingFromStateForm & HTMLFormElement>> {
+    class InitializingFromStateForm extends React.Component<Props<HTMLFormElement>> {
         static propTypes = {
             fields: PropTypes.object.isRequired,
             handleSubmit: PropTypes.func.isRequired,


### PR DESCRIPTION
This deprecates `React.FormEvent` which has no counterpart in the DOM and was equivalent to `React.SyntheticEvent`. Instead we're now adding the correct corresponding events to form-related event handlers (`change`, `input`, `invalid`, `reset`, `submit`).

As with any type change, this may cause type-checks to fail that were relying on bugs. We're only doing this change for the latest types (React 19) to reduce the blast radius. If the change is too disruptive, we may revert and defer to React 20.

This PR adds a second parameter to `ChangeEvent` specifying the `target`. Change events could have bubbled up so for most elements you should just use `ChangeEvent<CurrentTarget>`. Form-related elements like `input` already use `ChangeEvent<CurrentTarget, HTMLInputElement>`. In React 20, arbitrary `onChange` handlers will not get the narrowed `target` (see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69436#discussioncomment-15572952).