### PR TITLE
[colorthief] Add static method declaration for Node.js usage

### DIFF
--- a/types/colorthief/colorthief-tests.ts
+++ b/types/colorthief/colorthief-tests.ts
@@ -4,6 +4,17 @@
 // Import the ColorThief class for testing
 import ColorThief from "colorthief";
 
+// Node.js version tests
+const imgPath = "rainbow.png";
+
+// Test getColor method
+const dominantColorNode: Promise<ColorThief.RGBColor> = ColorThief.getColor(imgPath);
+const dominantColorWithQualityNode: Promise<ColorThief.RGBColor> = ColorThief.getColor(imgPath, 5);
+
+// Test getPalette method
+const paletteNode: Promise<ColorThief.RGBColor[]> = ColorThief.getPalette(imgPath);
+const paletteWithOptionsNode: Promise<ColorThief.RGBColor[]> = ColorThief.getPalette(imgPath, 8, 5);
+
 // Browser version tests
 const colorThief = new ColorThief();
 const img = document.createElement("img");

--- a/types/colorthief/index.d.ts
+++ b/types/colorthief/index.d.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference types="node" />
 
 export = ColorThief;
 export as namespace ColorThief;
@@ -41,6 +42,38 @@ declare namespace ColorThief {
  * Color Thief - Extract dominant colors from images
  */
 declare class ColorThief {
+    // --------------------------------------------------------
+    // Node.js usage (Static methods returning Promises)
+    // --------------------------------------------------------
+
+    /**
+     * Extract the dominant color from an image (Node.js)
+     * @param sourceImage - Path to the image file, or Buffer containing image
+     * @param quality - Quality/speed trade-off (1 = highest quality, 10 = default)
+     * @returns Promise resolving to RGB color array [r, g, b] where values are 0-255
+     */
+    static getColor(
+        sourceImage: Buffer | Uint8Array | ArrayBuffer | string,
+        quality?: number,
+    ): Promise<ColorThief.RGBColor>;
+
+    /**
+     * Extract a palette of colors from an image (Node.js)
+     * @param sourceImage - Path to the image file, or Buffer containing image
+     * @param colorCount - Number of colors to extract (2-20, default: 10)
+     * @param quality - Quality/speed trade-off (1 = highest quality, 10 = default)
+     * @returns Promise resolving to Array of RGB color arrays [[r, g, b], ...] where values are 0-255
+     */
+    static getPalette(
+        sourceImage: Buffer | Uint8Array | ArrayBuffer | string,
+        colorCount?: number,
+        quality?: number,
+    ): Promise<ColorThief.RGBColor[]>;
+
+    // --------------------------------------------------------
+    // Browser usage (Instance methods)
+    // --------------------------------------------------------
+
     /**
      * Extract the dominant color from an image
      * @param sourceImage - HTML image element

--- a/types/colorthief/package.json
+++ b/types/colorthief/package.json
@@ -5,6 +5,9 @@
     "projects": [
         "https://github.com/lokesh/color-thief"
     ],
+    "dependencies": {
+        "@types/node": "*"
+    },
     "devDependencies": {
         "@types/colorthief": "workspace:."
     },


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - According to the [documentation](https://lokeshdhakar.com/projects/color-thief/#getting-started) the static method `getColor()` and `getPalette()` should accept image file path and returns Promise.
  - Although it is not mentioned in the documentation, from reading the [source code](https://github.com/lokesh/color-thief/blob/master/src/color-thief-node.js#L42) it seems they also accept Buffer types that [`FileType.fromBuffer()` of file-type@^16](https://github.com/sindresorhus/file-type/blob/16/core.d.ts#L309) supports, so I added Buffer, Uint8Array and ArrayBuffer to the argument types. 
  - related: #63796 
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
