### PR TITLE
[vscode] Update CommentRule.lineComment to support LineCommentConfig

### DIFF
--- a/types/vscode/index.d.ts
+++ b/types/vscode/index.d.ts
@@ -6482,6 +6482,21 @@ declare module 'vscode' {
 	 */
 	export type CharacterPair = [string, string];
 
+    /**
+     * Describes the configuration for a line comment.
+     */
+    export interface LineCommentConfig {
+        /**
+         * The line comment token, like `// this is a comment`
+         */
+        comment: string;
+
+        /**
+         * If true, the line comment token will not be indented.
+         */
+        noIndent?: boolean;
+    }
+
 	/**
 	 * Describes how comments for a language work.
 	 */
@@ -6490,7 +6505,7 @@ declare module 'vscode' {
 		/**
 		 * The line comment token, like `// this is a comment`
 		 */
-		lineComment?: string;
+		lineComment?: string | LineCommentConfig;
 
 		/**
 		 * The block comment character pair, like `/* block comment *&#47;`

--- a/types/vscode/index.d.ts
+++ b/types/vscode/index.d.ts
@@ -6505,7 +6505,7 @@ declare module 'vscode' {
 		/**
 		 * The line comment token, like `// this is a comment`
 		 */
-		lineComment?: string | LineCommentConfig;
+		lineComment?: string | LineCommentConfig | null;
 
 		/**
 		 * The block comment character pair, like `/* block comment *&#47;`


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/microsoft/vscode/pull/243283
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

**Context:**
As of VS Code 1.91 (via microsoft/vscode#243283), the `lineComment` property in `CommentRule` can be an object (`LineCommentConfig`) in addition to a string. This PR updates the interface to `string | LineCommentConfig` to match the runtime behavior and prevent type errors for consumers.

Fixes #74372