### PR TITLE
[pdfmake] Fixes and new properties for 0.2

### DIFF
--- a/types/pdfmake/build/vfs_fonts.d.ts
+++ b/types/pdfmake/build/vfs_fonts.d.ts
@@ -1,1 +1,3 @@
-export let vfs: { [file: string]: string };
+declare const vfs: { [file: string]: string };
+
+export = vfs;

--- a/types/pdfmake/interfaces.d.ts
+++ b/types/pdfmake/interfaces.d.ts
@@ -837,6 +837,16 @@ export interface Style {
     noWrap?: boolean | undefined;
 
     /**
+     * Controls the line breaking behavior.
+     *
+     * - `normal` breaks lines at spaces
+     * - `break-all` breaks lines anywhere
+     *
+     * Defaults to `normal`.
+     */
+    wordBreak?: "normal" | "break-all" | undefined;
+
+    /**
      * Space between columns in `pt`.
      *
      * Only applies to {@link ContentColumns} elements.
@@ -1043,13 +1053,13 @@ export interface ContentCanvas extends ContentBase, ForbidOtherElementProperties
  */
 export interface ContentSvg extends ContentBase, ContentLink, ForbidOtherElementProperties<"svg"> {
     /**
-     * Renders the given SVG content string as an image.
+     * Renders the given SVG element or content string as an image.
      *
      * For images other than SVG, use the `image` property instead.
      *
      * Simple vectors can also be rendered using the `canvas` property instead.
      */
-    svg: string;
+    svg: string | SVGElement;
 
     /**
      * Width of the image in `pt`.
@@ -1563,6 +1573,15 @@ export interface OrderedListElementProperties {
      * Defaults to the list's {@link ContentOrderedList.type}.
      */
     listType?: OrderedListType | undefined;
+
+    /**
+     * Color of the list marker (i.e. number).
+     *
+     * Supports well-known color names like `blue` or hexadecimal color strings like `#ccffcc`.
+     *
+     * Defaults to the list's marker color.
+     */
+    markerColor?: string | undefined;
 }
 
 /**
@@ -1590,6 +1609,15 @@ export interface UnorderedListElementProperties {
      * Defaults to the list's {@link ContentUnorderedList.type}.
      */
     listType?: UnorderedListType | undefined;
+
+    /**
+     * Color of the list marker (i.e. bullet point).
+     *
+     * Supports well-known color names like `blue` or hexadecimal color strings like `#ccffcc`.
+     *
+     * Defaults to the list's marker color.
+     */
+    markerColor?: string | undefined;
 }
 
 /**
@@ -2069,7 +2097,7 @@ export interface TDocumentDefinitions {
      *
      * @param currentNode - The current content node to check.
      * @param followingNodesOnPage - The content nodes defined after the current node on the same page.
-     * @param nodesOnNextPage - The content nodes on the page after the current node's page.
+     * @param nodesOnNextPage - The content nodes on the next page.
      * @param previousNodesOnPage - The content nodes defined before the current node on the same page.
      *
      * @returns whether to insert a page break before the current node.

--- a/types/pdfmake/test/pdfmake-examples-tests.ts
+++ b/types/pdfmake/test/pdfmake-examples-tests.ts
@@ -684,7 +684,7 @@ const lists: TDocumentDefinitions = {
         {
             color: "blue",
             markerColor: "red",
-            ul: ["item 1", "item 2", "item 3"],
+            ul: ["item 1", "item 2", { text: "item 3 with custom marker color", markerColor: "lime" }],
         },
         { text: "\n\nColored ordered list", style: "header" },
         {
@@ -698,7 +698,7 @@ const lists: TDocumentDefinitions = {
         {
             color: "blue",
             markerColor: "red",
-            ol: ["item 1", "item 2", "item 3"],
+            ol: ["item 1", "item 2", { text: "item 3 with custom marker color", markerColor: "lime" }],
         },
         { text: "\n\nOrdered list - type: lower-alpha", style: "header" },
         {
@@ -1447,7 +1447,37 @@ const stylingProperties: TDocumentDefinitions = {
                 " World",
             ],
         },
+        "\n\n",
+        {
+            text: "Text background pattern",
+            background: ["stripe45d", "gray"],
+        },
+        {
+            text: "Customize word break:",
+            pageBreak: "before",
+        },
+        {
+            text: "DefaultLine\n\"BreakBehaviour\" \"ForATextWithVeryVery\" \"LongLongWords\"",
+            fontSize: 30,
+        },
+        {
+            text: "\n\n",
+            fontSize: 30,
+        },
+        {
+            text: "BreakAll\n\"LineBreakBehaviour\" \"ForATextWithVeryVery\" \"LongLongWords\"",
+            fontSize: 30,
+            wordBreak: "break-all",
+        },
     ],
+    patterns: {
+        stripe45d: {
+            boundingBox: [1, 1, 4, 4],
+            xStep: 3,
+            yStep: 3,
+            pattern: "1 w 0 1 m 4 5 l s 2 0 m 5 3 l s",
+        },
+    },
 };
 
 const svgs: TDocumentDefinitions = {

--- a/types/pdfmake/test/pdfmake-import-default-tests.ts
+++ b/types/pdfmake/test/pdfmake-import-default-tests.ts
@@ -1,7 +1,7 @@
 import pdfMake from "pdfmake/build/pdfmake";
 import pdfFonts from "pdfmake/build/vfs_fonts";
 
-pdfMake.vfs = pdfFonts.vfs;
+pdfMake.vfs = pdfFonts;
 
 const dd = {
     content: "Hello world!",

--- a/types/pdfmake/test/pdfmake-module-browser-min-tests.ts
+++ b/types/pdfmake/test/pdfmake-module-browser-min-tests.ts
@@ -2,7 +2,7 @@ import pdfFonts = require("pdfmake/build/vfs_fonts");
 import pdfMake = require("pdfmake/build/pdfmake.min");
 import { BufferOptions, CustomTableLayout, TFontDictionary } from "pdfmake/interfaces";
 
-pdfMake.vfs = pdfFonts.vfs;
+pdfMake.vfs = pdfFonts;
 
 const dd = {
     content: "Hello world!",

--- a/types/pdfmake/test/pdfmake-module-browser-tests.ts
+++ b/types/pdfmake/test/pdfmake-module-browser-tests.ts
@@ -1,11 +1,14 @@
 import pdfFonts = require("pdfmake/build/vfs_fonts");
 import pdfMake = require("pdfmake/build/pdfmake");
-import { BufferOptions, CustomTableLayout, TFontDictionary } from "pdfmake/interfaces";
+import { BufferOptions, CustomTableLayout, TDocumentDefinitions, TFontDictionary } from "pdfmake/interfaces";
 
-pdfMake.vfs = pdfFonts.vfs;
+pdfMake.vfs = pdfFonts;
 
-const dd = {
-    content: "Hello world!",
+const dd: TDocumentDefinitions = {
+    content: [
+        "Hello world!",
+        { svg: new SVGElement() },
+    ],
 };
 
 const options: BufferOptions = {


### PR DESCRIPTION
Extracted from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/74337 to avoid duplicating the types for v0.2

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - wordBreak: https://github.com/bpampuch/pdfmake/commit/4ebb69a5bb5075447e370096da874390dade24dc
  - markerColor for list items: https://github.com/bpampuch/pdfmake/commit/4fc1315da5cd0ea51ad62d4130dda99a9454d36c
  - support for SVGElement: https://github.com/bpampuch/pdfmake/commit/c5a1732af8df9a13dac179de1a73567bbf86f891
  - Fix vfs_fonts export: https://github.com/bpampuch/pdfmake/blob/0.2/build/vfs_fonts.js
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

