### PR TITLE
node: v25.2

### DIFF
--- a/types/node/child_process.d.ts
+++ b/types/node/child_process.d.ts
@@ -5,6 +5,7 @@
  *
  * ```js
  * import { spawn } from 'node:child_process';
+ * import { once } from 'node:events';
  * const ls = spawn('ls', ['-lh', '/usr']);
  *
  * ls.stdout.on('data', (data) => {
@@ -15,9 +16,8 @@
  *   console.error(`stderr: ${data}`);
  * });
  *
- * ls.on('close', (code) => {
- *   console.log(`child process exited with code ${code}`);
- * });
+ * const [code] = await once(ls, 'close');
+ * console.log(`child process exited with code ${code}`);
  * ```
  *
  * By default, pipes for `stdin`, `stdout`, and `stderr` are established between
@@ -671,6 +671,7 @@ declare module "node:child_process" {
      *
      * ```js
      * import { spawn } from 'node:child_process';
+     * import { once } from 'node:events';
      * const ls = spawn('ls', ['-lh', '/usr']);
      *
      * ls.stdout.on('data', (data) => {
@@ -681,9 +682,8 @@ declare module "node:child_process" {
      *   console.error(`stderr: ${data}`);
      * });
      *
-     * ls.on('close', (code) => {
-     *   console.log(`child process exited with code ${code}`);
-     * });
+     * const [code] = await once(ls, 'close');
+     * console.log(`child process exited with code ${code}`);
      * ```
      *
      * Example: A very elaborate way to run `ps ax | grep ssh`

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -2582,8 +2582,8 @@ declare module "node:crypto" {
     interface X25519KeyPairOptions extends KeyPairExportOptions<"spki", "pkcs8"> {}
     interface X448KeyPairOptions extends KeyPairExportOptions<"spki", "pkcs8"> {}
     /**
-     * Generates a new asymmetric key pair of the given `type`. RSA, RSA-PSS, DSA, EC,
-     * Ed25519, Ed448, X25519, X448, DH, and ML-DSA are currently supported.
+     * Generates a new asymmetric key pair of the given `type`. See the
+     * supported [asymmetric key types](https://nodejs.org/docs/latest-v25.x/api/crypto.html#asymmetric-key-types).
      *
      * If a `publicKeyEncoding` or `privateKeyEncoding` was specified, this function
      * behaves as if `keyObject.export()` had been called on its result. Otherwise,
@@ -2672,8 +2672,8 @@ declare module "node:crypto" {
         options?: T,
     ): KeyPairExportResult<T>;
     /**
-     * Generates a new asymmetric key pair of the given `type`. RSA, RSA-PSS, DSA, EC,
-     * Ed25519, Ed448, X25519, X448, and DH are currently supported.
+     * Generates a new asymmetric key pair of the given `type`. See the
+     * supported [asymmetric key types](https://nodejs.org/docs/latest-v25.x/api/crypto.html#asymmetric-key-types).
      *
      * If a `publicKeyEncoding` or `privateKeyEncoding` was specified, this function
      * behaves as if `keyObject.export()` had been called on its result. Otherwise,

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -1680,20 +1680,34 @@ declare module "node:http" {
         /**
          * Produces a socket/stream to be used for HTTP requests.
          *
-         * By default, this function is the same as `net.createConnection()`. However,
-         * custom agents may override this method in case greater flexibility is desired.
+         * By default, this function behaves identically to `net.createConnection()`,
+         * synchronously returning the created socket. The optional `callback` parameter in the
+         * signature is **not** used by this default implementation.
          *
-         * A socket/stream can be supplied in one of two ways: by returning the
-         * socket/stream from this function, or by passing the socket/stream to `callback`.
+         * However, custom agents may override this method to provide greater flexibility,
+         * for example, to create sockets asynchronously. When overriding `createConnection`:
          *
-         * This method is guaranteed to return an instance of the `net.Socket` class,
-         * a subclass of `stream.Duplex`, unless the user specifies a socket
-         * type other than `net.Socket`.
+         * 1. **Synchronous socket creation**: The overriding method can return the
+         *    socket/stream directly.
+         * 2. **Asynchronous socket creation**: The overriding method can accept the `callback`
+         *    and pass the created socket/stream to it (e.g., `callback(null, newSocket)`).
+         *    If an error occurs during socket creation, it should be passed as the first
+         *    argument to the `callback` (e.g., `callback(err)`).
          *
-         * `callback` has a signature of `(err, stream)`.
+         * The agent will call the provided `createConnection` function with `options` and
+         * this internal `callback`. The `callback` provided by the agent has a signature
+         * of `(err, stream)`.
          * @since v0.11.4
-         * @param options Options containing connection details. Check `createConnection` for the format of the options
-         * @param callback Callback function that receives the created socket
+         * @param options Options containing connection details. Check
+         * `net.createConnection` for the format of the options. For custom agents,
+         * this object is passed to the custom `createConnection` function.
+         * @param callback (Optional, primarily for custom agents) A function to be
+         * called by a custom `createConnection` implementation when the socket is
+         * created, especially for asynchronous operations.
+         * @returns The created socket. This is returned by the default
+         * implementation or by a custom synchronous `createConnection` implementation.
+         * If a custom `createConnection` uses the `callback` for asynchronous
+         * operation, this return value might not be the primary way to obtain the socket.
          */
         createConnection(
             options: ClientRequestArgs,

--- a/types/node/http.d.ts
+++ b/types/node/http.d.ts
@@ -1046,6 +1046,7 @@ declare module "node:http" {
          *
          * ```js
          * import http from 'node:http';
+         * const agent = new http.Agent({ keepAlive: true });
          *
          * // Server has a 5 seconds keep-alive timeout by default
          * http

--- a/types/node/https.d.ts
+++ b/types/node/https.d.ts
@@ -24,6 +24,12 @@ declare module "node:https" {
     }
     /**
      * An `Agent` object for HTTPS similar to `http.Agent`. See {@link request} for more information.
+     *
+     * Like `http.Agent`, the `createConnection(options[, callback])` method can be overridden
+     * to customize how TLS connections are established.
+     *
+     * > See `agent.createConnection()` for details on overriding this method,
+     * > including asynchronous socket creation with a callback.
      * @since v0.4.5
      */
     class Agent extends http.Agent {

--- a/types/node/net.d.ts
+++ b/types/node/net.d.ts
@@ -825,7 +825,7 @@ declare module "node:net" {
     function setDefaultAutoSelectFamily(value: boolean): void;
     /**
      * Gets the current default value of the `autoSelectFamilyAttemptTimeout` option of `socket.connect(options)`.
-     * The initial default value is `250` or the value specified via the command line option `--network-family-autoselection-attempt-timeout`.
+     * The initial default value is `500` or the value specified via the command line option `--network-family-autoselection-attempt-timeout`.
      * @returns The current default value of the `autoSelectFamilyAttemptTimeout` option.
      * @since v19.8.0, v18.8.0
      */

--- a/types/node/node-tests-dom.ts
+++ b/types/node/node-tests-dom.ts
@@ -1,3 +1,2 @@
 import "./node-tests/events-dom";
 import "./node-tests/globals-dom";
-import "./node-tests/perf_hooks-dom";

--- a/types/node/node-tests-non-dom.ts
+++ b/types/node/node-tests-non-dom.ts
@@ -1,3 +1,2 @@
 import "./node-tests/events-non-dom";
 import "./node-tests/globals-non-dom";
-import "./node-tests/perf_hooks-non-dom";

--- a/types/node/node-tests-webworker.ts
+++ b/types/node/node-tests-webworker.ts
@@ -2,4 +2,3 @@
 // If this changes, and it's necessary to create a WebWorker-specific test script, then the import should be updated here.
 import "./node-tests/events-dom";
 import "./node-tests/globals-dom";
-import "./node-tests/perf_hooks-dom";

--- a/types/node/node-tests/perf_hooks-dom.ts
+++ b/types/node/node-tests/perf_hooks-dom.ts
@@ -1,2 +1,0 @@
-// @ts-expect-error - Node API isn't available in DOM environment
-performance.eventLoopUtilization();

--- a/types/node/node-tests/perf_hooks-non-dom.ts
+++ b/types/node/node-tests/perf_hooks-non-dom.ts
@@ -1,1 +1,0 @@
-performance.eventLoopUtilization();

--- a/types/node/node-tests/perf_hooks.ts
+++ b/types/node/node-tests/perf_hooks.ts
@@ -1,6 +1,7 @@
 import {
     createHistogram,
     EntryType,
+    eventLoopUtilization,
     IntervalHistogram,
     monitorEventLoopDelay,
     performance as NodePerf,
@@ -9,6 +10,7 @@ import {
     PerformanceObserver,
     PerformanceObserverCallback,
     RecordableHistogram,
+    timerify,
 } from "node:perf_hooks";
 
 // Test module import once, the rest use global
@@ -154,4 +156,23 @@ resource; // $ExpectType PerformanceResourceTiming
     uvMetrics.loopCount; // $ExpectType number
     uvMetrics.events; // $ExpectType number
     uvMetrics.eventsWaiting; // $ExpectType number
+}
+
+{
+    let elu = eventLoopUtilization();
+    elu.active; // $ExpectType number
+    elu.idle; // $ExpectType number
+    elu.utilization; // $ExpectType number
+
+    elu = eventLoopUtilization(elu);
+    elu = eventLoopUtilization(elu, elu);
+}
+
+{
+    const fn = (a: number, b: number) => a + b;
+
+    // $ExpectType (a: number, b: number) => number
+    timerify(fn);
+    // $ExpectType (a: number, b: number) => number
+    timerify(fn, { histogram: createHistogram() });
 }

--- a/types/node/node-tests/util.ts
+++ b/types/node/node-tests/util.ts
@@ -217,14 +217,19 @@ const cbOptionalError: () => Promise<void | {}> = util.promisify((cb: (err?: Err
     cb();
 });
 assert(typeof util.promisify.custom === "symbol");
-// util.deprecate
-const foo = () => {};
-// $ExpectType () => void
-util.deprecate(foo, "foo() is deprecated, use bar() instead");
-// $ExpectType <T extends Function>(fn: T, msg: string, code?: string | undefined) => T
-util.deprecate(util.deprecate, "deprecate() is deprecated, use bar() instead");
-// $ExpectType <T extends Function>(fn: T, msg: string, code?: string | undefined) => T
-util.deprecate(util.deprecate, "deprecate() is deprecated, use bar() instead", "DEP0001");
+
+{
+    const foo = () => {};
+
+    // $ExpectType () => void
+    util.deprecate(foo, "foo() is deprecated, use bar() instead");
+    // $ExpectType () => void
+    util.deprecate(foo, "foo() is deprecated, use bar() instead", "DEP0001");
+    // $ExpectType () => void
+    util.deprecate(foo, "foo() is deprecated, use bar() instead", "DEP0001", { modifyPrototype: false });
+    // $ExpectType <T extends Function>(fn: T, msg: string, code?: string | undefined, options?: DeprecateOptions | undefined) => T
+    util.deprecate(util.deprecate, "pass-through return type");
+}
 
 // util.isDeepStrictEqual
 util.isDeepStrictEqual({ foo: "bar" }, { foo: "bar" }); // $ExpectType boolean

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "25.1.9999",
+    "version": "25.2.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [

--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -253,7 +253,7 @@ declare module "node:process" {
                 /**
                  * A value that is `"strip"` by default,
                  * `"transform"` if Node.js is run with `--experimental-transform-types`, and `false` if
-                 * Node.js is run with `--no-experimental-strip-types`.
+                 * Node.js is run with `--no-strip-types`.
                  * @since v22.10.0
                  */
                 readonly typescript: "strip" | "transform" | false;

--- a/types/node/sqlite.d.ts
+++ b/types/node/sqlite.d.ts
@@ -484,6 +484,8 @@ declare module "node:sqlite" {
          * [`sqlite3changeset_apply()`](https://www.sqlite.org/session/sqlite3changeset_apply.html).
          *
          * ```js
+         * import { DatabaseSync } from 'node:sqlite';
+         *
          * const sourceDb = new DatabaseSync(':memory:');
          * const targetDb = new DatabaseSync(':memory:');
          *

--- a/types/node/util.d.ts
+++ b/types/node/util.d.ts
@@ -838,6 +838,15 @@ declare module "node:util" {
      */
     export function debuglog(section: string, callback?: (fn: DebugLoggerFunction) => void): DebugLogger;
     export { debuglog as debug };
+    export interface DeprecateOptions {
+        /**
+         * When false do not change the prototype of object
+         * while emitting the deprecation warning.
+         * @since v25.2.0
+         * @default true
+         */
+        modifyPrototype?: boolean | undefined;
+    }
     /**
      * The `util.deprecate()` method wraps `fn` (which may be a function or class) in
      * such a way that it is marked as deprecated.
@@ -898,7 +907,7 @@ declare module "node:util" {
      * @param code A deprecation code. See the `list of deprecated APIs` for a list of codes.
      * @return The deprecated function wrapped to emit a warning.
      */
-    export function deprecate<T extends Function>(fn: T, msg: string, code?: string): T;
+    export function deprecate<T extends Function>(fn: T, msg: string, code?: string, options?: DeprecateOptions): T;
     export interface IsDeepStrictEqualOptions {
         /**
          * If `true`, prototype and constructor

--- a/types/node/v8.d.ts
+++ b/types/node/v8.d.ts
@@ -33,6 +33,7 @@ declare module "node:v8" {
         total_global_handles_size: number;
         used_global_handles_size: number;
         external_memory: number;
+        total_allocated_bytes: number;
     }
     interface HeapCodeStatistics {
         code_and_metadata_size: number;
@@ -92,6 +93,9 @@ declare module "node:v8" {
      *
      * `external_memory` The value of external\_memory is the memory size of array
      * buffers and external strings.
+     *
+     * `total_allocated_bytes` The value of total allocated bytes since the Isolate
+     * creation
      *
      * ```js
      * {


### PR DESCRIPTION
- lib: add options to util.deprecate
- perf_hooks: move non-standard performance properties to perf_hooks
- v8: adding total_allocated_bytes to HeapStatistics

As the non-webstandard `eventLoopUtilization()` and `timerify()` are canonically moving off the web Performance interface, there's not a lot of benefit from testing the non-DOMiness in bespoke test files, so these have been removed.