### PR TITLE
Updated @types/pdfkit definition for TableOptions

### DIFF
--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -466,14 +466,14 @@ declare namespace PDFKit.Mixins {
         /** Column definitions of the table. (default auto) */
         columnStyles?:
             | number
-            | Array<number | string>
+            | Array<number | string | ColumnStyle>
             | ColumnStyle
             | ((row: number) => number | ColumnStyle | undefined);
         /** Row definitions of the table. (default *) */
-        rowStyles?: number | Array<number | string> | RowStyle | ((row: number) => number | RowStyle | undefined);
+        rowStyles?: number | Array<number | string | RowStyle> | RowStyle | ((row: number) => number | RowStyle | undefined);
         /** Defaults to apply to every cell */
         defaultStyle?:
-            & (number | Array<number | string> | CellStyle | ((row: number) => number | CellStyle | undefined))
+            & (number | Array<number | string | CellStyle> | CellStyle | ((row: number) => number | CellStyle | undefined))
             & { width?: number };
         /** Whether to show the debug lines for all the cells (default false) */
         debug?: boolean;

--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -470,10 +470,19 @@ declare namespace PDFKit.Mixins {
             | ColumnStyle
             | ((row: number) => number | ColumnStyle | undefined);
         /** Row definitions of the table. (default *) */
-        rowStyles?: number | Array<number | string | RowStyle> | RowStyle | ((row: number) => number | RowStyle | undefined);
+        rowStyles?:
+            | number
+            | Array<number | string | RowStyle>
+            | RowStyle
+            | ((row: number) => number | RowStyle | undefined);
         /** Defaults to apply to every cell */
         defaultStyle?:
-            & (number | Array<number | string | CellStyle> | CellStyle | ((row: number) => number | CellStyle | undefined))
+            & (
+                | number
+                | Array<number | string | CellStyle>
+                | CellStyle
+                | ((row: number) => number | CellStyle | undefined)
+            )
             & { width?: number };
         /** Whether to show the debug lines for all the cells (default false) */
         debug?: boolean;

--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -479,7 +479,7 @@ declare namespace PDFKit.Mixins {
         defaultStyle?:
             & (
                 | number
-                | Array<number | string | CellStyle>
+                | Array<number | string>
                 | CellStyle
                 | ((row: number) => number | CellStyle | undefined)
             )

--- a/types/pdfkit/pdfkit-tests.ts
+++ b/types/pdfkit/pdfkit-tests.ts
@@ -466,6 +466,28 @@ doc.table({
     ],
 });
 
+// Alternative way to define the same styles as above using arrays
+doc.table({
+    // Set the style for all cells
+    defaultStyle: { border: 1, borderColor: "gray" },
+    // Set the style for cells based on their column
+    columnStyles: [{ border: { left: 2 }, borderColor: { left: "black" } }, {
+        border: { right: 2 },
+        borderColor: { right: "black" },
+    }],
+    // Set the style for cells based on their row
+    rowStyles: [{ border: { top: 2 }, borderColor: { top: "black" } }, {
+        border: { bottom: 2 },
+        borderColor: { bottom: "black" },
+    }],
+    data: [
+        ["Header 1", "Header 2", "Header 3"],
+        ["Sample value 1", "Sample value 2", "Sample value 3"],
+        ["Sample value 1", "Sample value 2", "Sample value 3"],
+        ["Sample value 1", "Sample value 2", "Sample value 3"],
+    ],
+});
+
 doc.table({
     rowStyles: (i) => {
         if (i % 2 === 0) return { backgroundColor: "#ccc" };


### PR DESCRIPTION
-  Allows ColumnStyle and RowStyle in arrays for columnStyles and rowStyles respectively

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/foliojs/pdfkit/blob/75b978c713720d24cd63133974dad2e568657f2b/lib/table/normalize.js#L92
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
