### PR TITLE
Change all target=es5 to target=es6

### DIFF
--- a/types/ansi/tsconfig.json
+++ b/types/ansi/tsconfig.json
@@ -5,7 +5,7 @@
     ],
     "compilerOptions": {
         "module": "node16",
-        "target": "es5",
+        "target": "es6",
         "lib": [
             "es6"
         ],

--- a/types/clearbladejs-node/tsconfig.json
+++ b/types/clearbladejs-node/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "ES5",
+        "target": "es6",
         "module": "node16",
         "lib": [
             "es6"

--- a/types/clearbladejs-server/tsconfig.json
+++ b/types/clearbladejs-server/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "ES5",
+        "target": "es6",
         "module": "node16",
         "lib": [
             "es6"

--- a/types/domexception/tsconfig.json
+++ b/types/domexception/tsconfig.json
@@ -11,7 +11,7 @@
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,
-        "target": "ES5"
+        "target": "es6"
     },
     "files": [
         "test/domexception.index.test.ts",

--- a/types/ember-data/v3/tsconfig.json
+++ b/types/ember-data/v3/tsconfig.json
@@ -5,7 +5,7 @@
             "es6",
             "dom"
         ],
-        "target": "es5",
+        "target": "es6",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,

--- a/types/ember/v2/tsconfig.json
+++ b/types/ember/v2/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "es5",
+        "target": "es6",
         "lib": [
             "es6",
             "dom"

--- a/types/ember/v3/tsconfig.json
+++ b/types/ember/v3/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "es5",
+        "target": "es6",
         "lib": [
             "es6",
             "dom"

--- a/types/ember__application/v3/tsconfig.json
+++ b/types/ember__application/v3/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "es5",
+        "target": "es6",
         "lib": [
             "es6",
             "dom"

--- a/types/ember__array/v3/tsconfig.json
+++ b/types/ember__array/v3/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "es5",
+        "target": "es6",
         "lib": [
             "es6",
             "dom"

--- a/types/ember__component/v3/tsconfig.json
+++ b/types/ember__component/v3/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "es5",
+        "target": "es6",
         "lib": [
             "es6",
             "dom"

--- a/types/ember__controller/v3/tsconfig.json
+++ b/types/ember__controller/v3/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "es5",
+        "target": "es6",
         "lib": [
             "es6",
             "dom"

--- a/types/ember__debug/v3/tsconfig.json
+++ b/types/ember__debug/v3/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "es5",
+        "target": "es6",
         "lib": [
             "es6",
             "dom"

--- a/types/ember__destroyable/v3/tsconfig.json
+++ b/types/ember__destroyable/v3/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "es5",
+        "target": "es6",
         "lib": [
             "es6",
             "dom"

--- a/types/ember__engine/v3/tsconfig.json
+++ b/types/ember__engine/v3/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "es5",
+        "target": "es6",
         "lib": [
             "es6",
             "dom"

--- a/types/ember__error/v3/tsconfig.json
+++ b/types/ember__error/v3/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "es5",
+        "target": "es6",
         "lib": [
             "es6",
             "dom"

--- a/types/ember__object/v3/tsconfig.json
+++ b/types/ember__object/v3/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "es5",
+        "target": "es6",
         "lib": [
             "es6",
             "dom"

--- a/types/ember__polyfills/v3/tsconfig.json
+++ b/types/ember__polyfills/v3/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "es5",
+        "target": "es6",
         "lib": [
             "es6",
             "dom"

--- a/types/ember__routing/v3/tsconfig.json
+++ b/types/ember__routing/v3/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "es5",
+        "target": "es6",
         "lib": [
             "es2018",
             "dom"

--- a/types/ember__runloop/v3/tsconfig.json
+++ b/types/ember__runloop/v3/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "es5",
+        "target": "es6",
         "lib": [
             "es6",
             "dom"

--- a/types/ember__service/v3/tsconfig.json
+++ b/types/ember__service/v3/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "es5",
+        "target": "es6",
         "lib": [
             "es6",
             "dom"

--- a/types/ember__string/v2/tsconfig.json
+++ b/types/ember__string/v2/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "es5",
+        "target": "es6",
         "lib": [
             "es6",
             "dom"

--- a/types/ember__template/v3/tsconfig.json
+++ b/types/ember__template/v3/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "es5",
+        "target": "es6",
         "lib": [
             "es6",
             "dom"

--- a/types/ember__test/v3/tsconfig.json
+++ b/types/ember__test/v3/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "es5",
+        "target": "es6",
         "lib": [
             "es6",
             "dom"

--- a/types/ember__utils/v3/tsconfig.json
+++ b/types/ember__utils/v3/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "es5",
+        "target": "es6",
         "lib": [
             "es6",
             "dom"

--- a/types/guacamole-client/tsconfig.json
+++ b/types/guacamole-client/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "es6",
         "module": "node16",
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,

--- a/types/jest/tsconfig.json
+++ b/types/jest/tsconfig.json
@@ -11,7 +11,7 @@
         "noImplicitThis": false,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
-        "target": "es5",
+        "target": "es6",
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true

--- a/types/material__base/tsconfig.json
+++ b/types/material__base/tsconfig.json
@@ -4,7 +4,7 @@
     ],
     "compilerOptions": {
         "module": "node16",
-        "target": "es5",
+        "target": "es6",
         "lib": [
             "es6",
             "dom"

--- a/types/mssql/tsconfig.json
+++ b/types/mssql/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "ES5",
+        "target": "es6",
         "module": "node16",
         "lib": [
             "es6"

--- a/types/openseadragon/tsconfig.json
+++ b/types/openseadragon/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "es6",
         "module": "node16",
         "lib": [
             "es6",

--- a/types/opossum/tsconfig.json
+++ b/types/opossum/tsconfig.json
@@ -4,7 +4,7 @@
         "lib": [
             "es6"
         ],
-        "target": "es5",
+        "target": "es6",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,

--- a/types/oracle__oraclejet/tsconfig.json
+++ b/types/oracle__oraclejet/tsconfig.json
@@ -17,7 +17,7 @@
         "types": [],
         "forceConsistentCasingInFileNames": true,
         "noEmit": true,
-        "target": "es5"
+        "target": "es6"
     },
     "files": [
         "oracle__oraclejet-tests.ts",

--- a/types/postcss-less/tsconfig.json
+++ b/types/postcss-less/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "ES5",
+        "target": "es6",
         "lib": [
             "es6",
             "ES2018.Promise"

--- a/types/react-transition-group/tsconfig.json
+++ b/types/react-transition-group/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "es6",
         "module": "node16",
         "lib": [
             "es6",

--- a/types/react-virtualized/tsconfig.json
+++ b/types/react-virtualized/tsconfig.json
@@ -13,7 +13,7 @@
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,
-        "target": "es5"
+        "target": "es6"
     },
     "files": [
         "index.d.ts",

--- a/types/rsvp/rsvp-tests.ts
+++ b/types/rsvp/rsvp-tests.ts
@@ -24,7 +24,7 @@ async function testAsyncAwait() {
     const awaitedNothing = await RSVP.resolve();
     const awaitedValue = await RSVP.resolve("just a value");
 
-    async function returnsAPromise(): RSVP.Promise<string> {
+    function returnsAPromise(): RSVP.Promise<string> {
         return RSVP.resolve("look, a string");
     }
 

--- a/types/rsvp/tsconfig.json
+++ b/types/rsvp/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "es5",
+        "target": "es6",
         "lib": [
             "es6",
             "dom"

--- a/types/sinon/tsconfig.json
+++ b/types/sinon/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "es6",
         "module": "node16",
         "lib": [
             "es6",

--- a/types/wechat-miniprogram-xmly/tsconfig.json
+++ b/types/wechat-miniprogram-xmly/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "ES5",
+        "target": "es6",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,

--- a/types/wechat-miniprogram/tsconfig.json
+++ b/types/wechat-miniprogram/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "ES5",
+        "target": "es6",
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,

--- a/types/when/tsconfig.json
+++ b/types/when/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "node16",
-        "target": "es5",
+        "target": "es6",
         "lib": [
             "es6"
         ],


### PR DESCRIPTION
`target=es5` is being deprecated in TS 6.0, removed in TS 7.0. See https://github.com/microsoft/TypeScript/pull/63067.

Update these configs to `target=es6` instead.

Only one non-tsconfig change, a test which incorrectly annotated an `async` function with a non-`Promise` type.