### PR TITLE
Fix react test for TS 6.0

### DIFF
--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -135,7 +135,7 @@ class ModernComponent extends React.Component<Props, State, Snapshot> implements
     static propTypes = {};
 
     static contextType = SomeContext;
-    declare context: React.ContextType<typeof SomeContext>;
+    declare context: Context;
 
     constructor(props: Props, context: Context) {
         super(props, context);

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -135,7 +135,7 @@ class ModernComponent extends React.Component<Props, State, Snapshot> implements
     static propTypes = {};
 
     static contextType = SomeContext;
-    context: Context;
+    declare context: React.ContextType<typeof SomeContext>;
 
     constructor(props: Props, context: Context) {
         super(props, context);


### PR DESCRIPTION
The default target for TS 6.0+ is changing to "the latest standardized spec version".

Update this test to pass with 6.0, per the note on `context` in the base class:

```ts
        /**
         * If using React Context, re-declare this in your class to be the
         * `React.ContextType` of your `static contextType`.
         * Should be used with type annotation or static contextType.
         *
         * @example
         * ```ts
         * static contextType = MyContext
         * // For TS pre-3.7:
         * context!: React.ContextType<typeof MyContext>
         * // For TS 3.7 and above:
         * declare context: React.ContextType<typeof MyContext>
         * ```
         *
         * @see {@link https://react.dev/reference/react/Component#context React Docs}
         */
```