### PR TITLE
[chrome] update since Chrome 145

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -692,8 +692,15 @@ declare namespace chrome {
 
         /** @deprecated Bookmark write operations are no longer limited by Chrome. */
         export const MAX_WRITE_OPERATIONS_PER_HOUR: 1000000;
+
         /** @deprecated Bookmark write operations are no longer limited by Chrome. */
         export const MAX_SUSTAINED_WRITE_OPERATIONS_PER_MINUTE: 1000000;
+
+        /**
+         * The `id` associated with the root level node.
+         * @since Chrome 145
+         */
+        export const ROOT_NODE_ID = "0";
 
         /**
          * Creates a bookmark or folder under the specified parentId. If url is NULL or missing, it will be a folder.
@@ -11048,6 +11055,11 @@ declare namespace chrome {
             /** The session ID used to uniquely identify a tab obtained from the {@link sessions} API. */
             sessionId?: string | undefined;
             /**
+             * The ID of the Split View that the tab belongs to.
+             * @since Chrome 145
+             */
+            splitViewId?: number | undefined;
+            /**
              * The ID of the group that the tab belongs to.
              * @since Chrome 88
              */
@@ -11117,6 +11129,12 @@ declare namespace chrome {
          * @since Chrome 92
          */
         export const MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND = 2;
+
+        /**
+         * An ID that represents the absence of a split tab.
+         * @since Chrome 145
+         */
+        export const SPLIT_VIEW_ID_NONE: -1;
 
         /**
          * An ID that represents the absence of a browser tab.
@@ -14083,6 +14101,30 @@ declare namespace chrome {
             responseHeaders?: HeaderInfo[];
         }
 
+        /** @since Chrome 145 */
+        export enum RuleConditionKeys {
+            URL_FILTER = "urlFilter",
+            REGEX_FILTER = "regexFilter",
+            IS_URL_FILTER_CASE_SENSITIVE = "isUrlFilterCaseSensitive",
+            INITIATOR_DOMAINS = "initiatorDomains",
+            EXCLUDED_INITIATOR_DOMAINS = "excludedInitiatorDomains",
+            REQUEST_DOMAINS = "requestDomains",
+            EXCLUDED_REQUEST_DOMAINS = "excludedRequestDomains",
+            TOP_DOMAINS = "topDomains",
+            EXCLUDED_TOP_DOMAINS = "excludedTopDomains",
+            DOMAINS = "domains",
+            EXCLUDED_DOMAINS = "excludedDomains",
+            RESOURCE_TYPES = "resourceTypes",
+            EXCLUDED_RESOURCE_TYPES = "excludedResourceTypes",
+            REQUEST_METHODS = "requestMethods",
+            EXCLUDED_REQUEST_METHODS = "excludedRequestMethods",
+            DOMAIN_TYPE = "domainType",
+            TAB_IDS = "tabIds",
+            EXCLUDED_TAB_IDS = "excludedTabIds",
+            RESPONSE_HEADERS = "responseHeaders",
+            EXCLUDED_RESPONSE_HEADERS = "excludedResponseHeaders",
+        }
+
         export interface MatchedRule {
             /** A matching rule's ID. */
             ruleId: number;
@@ -14303,6 +14345,11 @@ declare namespace chrome {
             responseHeaders?: { [name: string]: unknown };
             /** The ID of the tab in which the hypothetical request takes place. Does not need to correspond to a real tab ID. Default is -1, meaning that the request isn't related to a tab. */
             tabId?: number;
+            /**
+             * The associated top-level frame URL (if any) for the request.
+             * @since Chrome 145
+             */
+            topUrl?: string;
             /** The resource type of the hypothetical request. */
             type: `${ResourceType}`;
             /** The URL of the hypothetical request. */

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -26,6 +26,8 @@ function testBookmarks() {
 
     chrome.bookmarks.MAX_WRITE_OPERATIONS_PER_HOUR === 1000000;
 
+    chrome.bookmarks.ROOT_NODE_ID === "0";
+
     const bookmarkDetails: chrome.bookmarks.CreateDetails = {
         index: 0,
         parentId: "1",
@@ -3214,6 +3216,8 @@ async function testTabs() {
     chrome.tabs.MutedInfoReason.EXTENSION === "extension";
     chrome.tabs.MutedInfoReason.USER === "user";
 
+    chrome.tabs.SPLIT_VIEW_ID_NONE === -1;
+
     chrome.tabs.TAB_ID_NONE === -1;
 
     chrome.tabs.TAB_INDEX_NONE === -1;
@@ -4021,6 +4025,27 @@ async function testDeclarativeNetRequest() {
     chrome.declarativeNetRequest.RuleActionType.REDIRECT === "redirect";
     chrome.declarativeNetRequest.RuleActionType.UPGRADE_SCHEME === "upgradeScheme";
 
+    chrome.declarativeNetRequest.RuleConditionKeys.DOMAINS === "domains";
+    chrome.declarativeNetRequest.RuleConditionKeys.DOMAIN_TYPE === "domainType";
+    chrome.declarativeNetRequest.RuleConditionKeys.EXCLUDED_DOMAINS === "excludedDomains";
+    chrome.declarativeNetRequest.RuleConditionKeys.EXCLUDED_INITIATOR_DOMAINS === "excludedInitiatorDomains";
+    chrome.declarativeNetRequest.RuleConditionKeys.EXCLUDED_REQUEST_DOMAINS === "excludedRequestDomains";
+    chrome.declarativeNetRequest.RuleConditionKeys.EXCLUDED_REQUEST_METHODS === "excludedRequestMethods";
+    chrome.declarativeNetRequest.RuleConditionKeys.EXCLUDED_RESOURCE_TYPES === "excludedResourceTypes";
+    chrome.declarativeNetRequest.RuleConditionKeys.EXCLUDED_RESPONSE_HEADERS === "excludedResponseHeaders";
+    chrome.declarativeNetRequest.RuleConditionKeys.EXCLUDED_TAB_IDS === "excludedTabIds";
+    chrome.declarativeNetRequest.RuleConditionKeys.EXCLUDED_TOP_DOMAINS === "excludedTopDomains";
+    chrome.declarativeNetRequest.RuleConditionKeys.INITIATOR_DOMAINS === "initiatorDomains";
+    chrome.declarativeNetRequest.RuleConditionKeys.IS_URL_FILTER_CASE_SENSITIVE === "isUrlFilterCaseSensitive";
+    chrome.declarativeNetRequest.RuleConditionKeys.REGEX_FILTER === "regexFilter";
+    chrome.declarativeNetRequest.RuleConditionKeys.REQUEST_DOMAINS === "requestDomains";
+    chrome.declarativeNetRequest.RuleConditionKeys.REQUEST_METHODS === "requestMethods";
+    chrome.declarativeNetRequest.RuleConditionKeys.RESOURCE_TYPES === "resourceTypes";
+    chrome.declarativeNetRequest.RuleConditionKeys.RESPONSE_HEADERS === "responseHeaders";
+    chrome.declarativeNetRequest.RuleConditionKeys.TAB_IDS === "tabIds";
+    chrome.declarativeNetRequest.RuleConditionKeys.TOP_DOMAINS === "topDomains";
+    chrome.declarativeNetRequest.RuleConditionKeys.URL_FILTER === "urlFilter";
+
     chrome.declarativeNetRequest.SESSION_RULESET_ID === "_session";
 
     chrome.declarativeNetRequest.UnsupportedRegexReason.MEMORY_LIMIT_EXCEEDED === "memoryLimitExceeded";
@@ -4131,6 +4156,7 @@ async function testDeclarativeNetRequest() {
         tabId: 1,
         initiator: "https://example.com",
         method: "get",
+        topUrl: "https://example.com",
         responseHeaders: {},
     };
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  -  https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest
  - https://developer.chrome.com/docs/extensions/reference/api/tabs
  - https://developer.chrome.com/docs/extensions/reference/api/bookmarks
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes:
- add `bookmarks.ROOT_NODE_ID` const
- update `tabs.Tab`: add `splitViewId` key
- add `tabs.SPLIT_VIEW_ID_NONE` const
- add `declarativeNetRequest.RuleConditionKeys` enum
- update `declarativeNetRequest.TestMatchRequestDetails`: add `topUrl` key
- update tests

Runtime: 
<img width="602" height="631" alt="image" src="https://github.com/user-attachments/assets/f1c92610-1a98-4c22-ae16-a29e11313e65" />
