### PR TITLE
[pdfmake] Add properties for 0.3.3

### DIFF
--- a/types/pdfmake/interfaces.d.ts
+++ b/types/pdfmake/interfaces.d.ts
@@ -727,10 +727,20 @@ export interface Style {
     decorationColor?: string | undefined;
 
     /**
+     * Line thickness of the {@link decoration} in `pt`.
+     *
+     * If used in combination with a {@link decorationStyle}, this value is only used as a baseline
+     * for the computation of the actual line width.
+     *
+     * Defaults to a value derived from the {@link fontSize}.
+     */
+    decorationThickness?: number | undefined;
+
+    /**
      * Margins to apply.
      *
      * Overrides the single-side `marginXXX` properties, unless this value is inherited
-     * from a style and they are set directly on the content object.
+     * from another style.
      *
      * Ignored for content within an inline text array
      * (`{ text: [{ ... }] }`).
@@ -741,7 +751,7 @@ export interface Style {
      * Margin in `pt` to apply above the content.
      *
      * If {@link margin} is set, this value is ignored, unless the margin was inherited
-     * from a style and the value is set directly on the content object.
+     * from another style.
      */
     marginTop?: number | undefined;
 
@@ -749,7 +759,7 @@ export interface Style {
      * Margin in `pt` to apply to the right of the content.
      *
      * If {@link margin} is set, this value is ignored, unless the margin was inherited
-     * from a style and the value is set directly on the content object.
+     * from another style.
      */
     marginRight?: number | undefined;
 
@@ -757,7 +767,7 @@ export interface Style {
      * Margin in `pt` to apply below the content.
      *
      * If {@link margin} is set, this value is ignored, unless the margin was inherited
-     * from a style and the value is set directly on the content object.
+     * from another style.
      */
     marginBottom?: number | undefined;
 
@@ -765,7 +775,7 @@ export interface Style {
      * Margin in `pt` to apply to the left of the content.
      *
      * If {@link margin} is set, this value is ignored, unless the margin was inherited
-     * from a style and the value is set directly on the content object.
+     * from another style.
      */
     marginLeft?: number | undefined;
 
@@ -870,6 +880,21 @@ export interface Style {
      * Defaults to `0`.
      */
     columnGap?: number | undefined;
+}
+
+/**
+ * Named style defined in {@link TDocumentDefinitions.styles}.
+ */
+export interface NamedStyle extends Style {
+    /**
+     * Names of other styles in {@link TDocumentDefinitions.styles} to extend.
+     *
+     * An array applies the styles in the given order, later styles overriding
+     * properties from the earlier ones.
+     *
+     * Extended styles are overridden by the properties on this style.
+     */
+    extends?: string | string[] | undefined;
 }
 
 /**
@@ -1623,6 +1648,27 @@ export interface TableOfContent {
      *   {@link ContentTocItem.tocItem} to its ID
      */
     id?: string | undefined;
+
+    /**
+     * If set to `true`, the table of contents is hidden when it contains no items.
+     */
+    hideEmpty?: boolean | undefined;
+
+    /**
+     * Controls how the items are sorted.
+     *
+     * Defaults to `page`.
+     */
+    sortBy?: "page" | "title" | undefined;
+
+    /**
+     * Specifies the locale used for sorting as BCP 47 language tag, e.g. `en-US`.
+     *
+     * Only relevant if {@link sortBy} is set to `title`.
+     *
+     * Defaults to the system locale.
+     */
+    sortLocale?: string | undefined;
 }
 
 /**
@@ -1990,7 +2036,7 @@ export interface ImageCover {
  * Dictionary of reusable style definitions that can be referenced by their key.
  */
 export interface StyleDictionary {
-    [name: string]: Style;
+    [name: string]: NamedStyle;
 }
 
 /**
@@ -2264,7 +2310,7 @@ export interface TDocumentDefinitions {
     /**
      * Dictionary for reusable styles to be referenced by their key throughout the document.
      *
-     * To define styles that should apply by default, use {@link defaultStyles} instead.
+     * To define styles that should apply by default, use {@link defaultStyle} instead.
      */
     styles?: StyleDictionary | undefined;
 

--- a/types/pdfmake/test/pdfmake-examples-tests.ts
+++ b/types/pdfmake/test/pdfmake-examples-tests.ts
@@ -912,6 +912,50 @@ const margins: TDocumentDefinitions = {
     },
 };
 
+const namedStylesWithExtends: TDocumentDefinitions = {
+    content: [
+        {
+            text: "This is a header, using header style",
+            style: "header",
+        },
+        "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Confectum ponit legam, perferendis nomine miserum, animi. Moveat nesciunt triari naturam.\n\n",
+        {
+            text: "Subheader 1 - using subheader style",
+            style: "subheader",
+        },
+        "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Confectum ponit legam, perferendis nomine miserum, animi. Moveat nesciunt triari naturam posset, eveniunt specie deorsus efficiat sermone instituendarum fuisse veniat, eademque mutat debeo. Delectet plerique protervi diogenem dixerit logikh levius probabo adipiscuntur afficitur, factis magistra inprobitatem aliquo andriam obiecta, religionis, imitarentur studiis quam, clamat intereant vulgo admonitionem operis iudex stabilitas vacillare scriptum nixam, reperiri inveniri maestitiam istius eaque dissentias idcirco gravis, refert suscipiet recte sapiens oportet ipsam terentianus, perpauca sedatio aliena video.",
+        "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Confectum ponit legam, perferendis nomine miserum, animi. Moveat nesciunt triari naturam posset, eveniunt specie deorsus efficiat sermone instituendarum fuisse veniat, eademque mutat debeo. Delectet plerique protervi diogenem dixerit logikh levius probabo adipiscuntur afficitur, factis magistra inprobitatem aliquo andriam obiecta, religionis, imitarentur studiis quam, clamat intereant vulgo admonitionem operis iudex stabilitas vacillare scriptum nixam, reperiri inveniri maestitiam istius eaque dissentias idcirco gravis, refert suscipiet recte sapiens oportet ipsam terentianus, perpauca sedatio aliena video.",
+        "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Confectum ponit legam, perferendis nomine miserum, animi. Moveat nesciunt triari naturam posset, eveniunt specie deorsus efficiat sermone instituendarum fuisse veniat, eademque mutat debeo. Delectet plerique protervi diogenem dixerit logikh levius probabo adipiscuntur afficitur, factis magistra inprobitatem aliquo andriam obiecta, religionis, imitarentur studiis quam, clamat intereant vulgo admonitionem operis iudex stabilitas vacillare scriptum nixam, reperiri inveniri maestitiam istius eaque dissentias idcirco gravis, refert suscipiet recte sapiens oportet ipsam terentianus, perpauca sedatio aliena video.\n\n",
+        {
+            text: "Subheader 2 - using subheader style",
+            style: "subheader",
+        },
+        "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Confectum ponit legam, perferendis nomine miserum, animi. Moveat nesciunt triari naturam posset, eveniunt specie deorsus efficiat sermone instituendarum fuisse veniat, eademque mutat debeo. Delectet plerique protervi diogenem dixerit logikh levius probabo adipiscuntur afficitur, factis magistra inprobitatem aliquo andriam obiecta, religionis, imitarentur studiis quam, clamat intereant vulgo admonitionem operis iudex stabilitas vacillare scriptum nixam, reperiri inveniri maestitiam istius eaque dissentias idcirco gravis, refert suscipiet recte sapiens oportet ipsam terentianus, perpauca sedatio aliena video.",
+        "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Confectum ponit legam, perferendis nomine miserum, animi. Moveat nesciunt triari naturam posset, eveniunt specie deorsus efficiat sermone instituendarum fuisse veniat, eademque mutat debeo. Delectet plerique protervi diogenem dixerit logikh levius probabo adipiscuntur afficitur, factis magistra inprobitatem aliquo andriam obiecta, religionis, imitarentur studiis quam, clamat intereant vulgo admonitionem operis iudex stabilitas vacillare scriptum nixam, reperiri inveniri maestitiam istius eaque dissentias idcirco gravis, refert suscipiet recte sapiens oportet ipsam terentianus, perpauca sedatio aliena video.\n\n",
+        {
+            text:
+                "It is possible to apply multiple styles, by passing an array. This paragraph uses two styles: quote and small. When multiple styles are provided, they are evaluated in the specified order which is important in case they define the same properties",
+            style: ["quote", "small"],
+        },
+    ],
+    styles: {
+        header: {
+            fontSize: 18,
+            bold: true,
+        },
+        subheader: {
+            fontSize: 15,
+            extends: "header",
+        },
+        quote: {
+            italics: true,
+        },
+        small: {
+            fontSize: 8,
+        },
+    },
+};
+
 const pageReference: TDocumentDefinitions = {
     content: [
         {
@@ -2467,6 +2511,15 @@ const textDecorations: TDocumentDefinitions = {
                 },
             ],
         },
+        " ",
+        {
+            columns: [
+                { text: "Dashed style", decoration: "underline", decorationStyle: "dashed", decorationThickness: 3 },
+                { text: "Dotted style", decoration: "underline", decorationStyle: "dotted", decorationThickness: 3 },
+                { text: "Double style", decoration: "underline", decorationStyle: "double", decorationThickness: 3 },
+                { text: "Wavy style", decoration: "underline", decorationStyle: "wavy", decorationThickness: 3 },
+            ],
+        },
     ],
 };
 
@@ -2483,6 +2536,8 @@ const toc: TDocumentDefinitions = {
                 textMargin: [0, 0, 0, 0],
                 textStyle: { italics: true },
                 numberStyle: { bold: true },
+                sortBy: "page",
+                sortLocale: "cs",
             },
         },
         {

--- a/types/pdfmake/test/pdfmake-interfaces-tests.ts
+++ b/types/pdfmake/test/pdfmake-interfaces-tests.ts
@@ -5,8 +5,10 @@ import {
     ContentImage,
     ContentOrderedList,
     ContentSvg,
+    ContentToc,
     ContentUnorderedList,
     CustomTableLayout,
+    StyleDictionary,
     Table,
     TableCell,
     TDocumentDefinitions,
@@ -403,3 +405,27 @@ const svgWithLink: Content = [
         link: "http://foo.bar",
     },
 ];
+
+const hideEmptyToC: ContentToc = {
+    toc: {
+        hideEmpty: true,
+    },
+};
+
+const styleExtends: StyleDictionary = {
+    header: {
+        fontSize: 18,
+        bold: true,
+    },
+    subheader: {
+        fontSize: 15,
+        extends: "header",
+    },
+    smallheader: {
+        italics: true,
+        extends: ["subheader", "small"],
+    },
+    small: {
+        fontSize: 8,
+    },
+};


### PR DESCRIPTION
- ToC: `hideEmpty`, `sortBy`, `sortLocale`
- `decorationThickness`
- Style `extends`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - ToC `hideEmpty` https://github.com/bpampuch/pdfmake/commit/6634ed480ace1fe5bc1cf5d9228dc10741a42fba
  - ToC `sortBy`, `sortLocale` https://github.com/bpampuch/pdfmake/commit/00ed454abd41d1f47b9a22e3d904f93bbc3e10ae
  - `decorationThickness` https://github.com/bpampuch/pdfmake/commit/3f25593645ef38cf3574376128e6385af769ae5f
  - Style `extends` https://github.com/bpampuch/pdfmake/commit/79c8e0b5cd8a935b458691e94d09cc4a440b6e9e
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
