### PR TITLE
[@hotwired/turbo] Add missing types, update for 8.0.23

### DIFF
--- a/types/hotwired__turbo/hotwired__turbo-tests.ts
+++ b/types/hotwired__turbo/hotwired__turbo-tests.ts
@@ -1,4 +1,4 @@
-import { StreamActions, visit } from "@hotwired/turbo";
+import { cache, config, navigator, session, start, StreamActions, visit } from "@hotwired/turbo";
 
 const turboFrame = document.querySelector("turbo-frame")!;
 
@@ -114,3 +114,65 @@ document.addEventListener("turbo:submit-end", function(event) {
         event.detail.fetchResponse;
     }
 });
+
+// Test start() function
+start();
+Turbo.start();
+
+// Test session.adapter
+// $ExpectType BrowserAdapter
+session.adapter;
+session.adapter.formSubmissionStarted();
+session.adapter.formSubmissionFinished();
+Turbo.session.adapter.formSubmissionStarted();
+Turbo.session.adapter.formSubmissionFinished();
+
+// Test navigator.submitForm
+const form = document.querySelector("form")!;
+navigator.submitForm(form);
+navigator.submitForm(form, document.querySelector("button")!);
+Turbo.navigator.submitForm(form);
+Turbo.navigator.submitForm(form, document.querySelector("button")!);
+
+// Test cache methods
+cache.clear();
+cache.resetCacheControl();
+cache.exemptPageFromCache();
+cache.exemptPageFromPreview();
+Turbo.cache.clear();
+Turbo.cache.resetCacheControl();
+Turbo.cache.exemptPageFromCache();
+Turbo.cache.exemptPageFromPreview();
+
+// Test config.drive
+// $ExpectType boolean
+config.drive.enabled;
+// $ExpectType number
+config.drive.progressBarDelay;
+config.drive.progressBarDelay = 1000;
+// $ExpectType Set<string>
+config.drive.unvisitableExtensions;
+
+// Test config.forms
+// $ExpectType "on" | "off" | "optin"
+config.forms.mode;
+config.forms.mode = "optin";
+config.forms.mode = "on";
+config.forms.mode = "off";
+// @ts-expect-error
+config.forms.mode = "invalid";
+
+// Test Turbo.config
+Turbo.config.drive.progressBarDelay = 300;
+Turbo.config.forms.mode = "optin";
+
+// Test StreamElement.templateElement and templateContent
+// $ExpectType HTMLTemplateElement
+turboStream.templateElement;
+// $ExpectType DocumentFragment
+turboStream.templateContent;
+
+// @ts-expect-error - templateElement is readonly
+turboStream.templateElement = document.createElement("template");
+// @ts-expect-error - templateContent is readonly
+turboStream.templateContent = document.createDocumentFragment();

--- a/types/hotwired__turbo/hotwired__turbo-tests.ts
+++ b/types/hotwired__turbo/hotwired__turbo-tests.ts
@@ -1,4 +1,17 @@
-import { cache, config, navigator, session, start, StreamActions, visit } from "@hotwired/turbo";
+import {
+    cache,
+    config,
+    connectStreamSource,
+    disconnectStreamSource,
+    navigator,
+    renderStreamMessage,
+    session,
+    start,
+    StreamActions,
+    StreamMessage,
+    StreamSource,
+    visit,
+} from "@hotwired/turbo";
 
 const turboFrame = document.querySelector("turbo-frame")!;
 
@@ -194,3 +207,29 @@ turboStream.templateContent;
 turboStream.templateElement = document.createElement("template");
 // @ts-expect-error - templateContent is readonly
 turboStream.templateContent = document.createDocumentFragment();
+
+const eventSource = new EventSource("https://example.com/stream");
+const webSocket = new WebSocket("wss://example.com/stream");
+
+const streamSource: StreamSource = eventSource;
+connectStreamSource(streamSource);
+disconnectStreamSource(streamSource);
+connectStreamSource(eventSource);
+disconnectStreamSource(eventSource);
+connectStreamSource(webSocket);
+disconnectStreamSource(webSocket);
+
+// @ts-expect-error
+connectStreamSource({});
+
+const streamMessage = new StreamMessage(document.createDocumentFragment());
+renderStreamMessage("<turbo-stream></turbo-stream>");
+renderStreamMessage(streamMessage);
+Turbo.renderStreamMessage("<turbo-stream></turbo-stream>");
+Turbo.renderStreamMessage(streamMessage);
+
+// $ExpectType "text/vnd.turbo-stream.html"
+StreamMessage.contentType;
+
+// $ExpectType StreamMessage
+StreamMessage.wrap("<turbo-stream></turbo-stream>");

--- a/types/hotwired__turbo/hotwired__turbo-tests.ts
+++ b/types/hotwired__turbo/hotwired__turbo-tests.ts
@@ -174,6 +174,11 @@ config.forms.mode = "invalid";
 Turbo.config.drive.progressBarDelay = 300;
 Turbo.config.forms.mode = "optin";
 
+// Test config.forms.confirm is optional (undefined by default, can be set to undefined)
+// $ExpectType ((message: string, element: HTMLFormElement, submitter: HTMLElement | null) => Promise<boolean>) | undefined
+config.forms.confirm;
+config.forms.confirm = undefined;
+
 // Test config.forms.confirm assignment
 config.forms.confirm = async (message, element, submitter) => {
     return window.confirm(message);

--- a/types/hotwired__turbo/hotwired__turbo-tests.ts
+++ b/types/hotwired__turbo/hotwired__turbo-tests.ts
@@ -153,6 +153,14 @@ config.drive.progressBarDelay = 1000;
 // $ExpectType Set<string>
 config.drive.unvisitableExtensions;
 
+// Test config.drive.enabled assignment
+config.drive.enabled = false;
+config.drive.enabled = true;
+
+// Test config.drive.unvisitableExtensions Set modification
+config.drive.unvisitableExtensions.add(".custom");
+config.drive.unvisitableExtensions.delete(".pdf");
+
 // Test config.forms
 // $ExpectType "on" | "off" | "optin"
 config.forms.mode;
@@ -165,6 +173,11 @@ config.forms.mode = "invalid";
 // Test Turbo.config
 Turbo.config.drive.progressBarDelay = 300;
 Turbo.config.forms.mode = "optin";
+
+// Test config.forms.confirm assignment
+config.forms.confirm = async (message, element, submitter) => {
+    return window.confirm(message);
+};
 
 // Test StreamElement.templateElement and templateContent
 // $ExpectType HTMLTemplateElement

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -163,7 +163,7 @@ export interface SubmitterConfig {
 export interface FormsConfig {
     /** Form handling mode: "on" (default), "off", or "optin". */
     mode: "on" | "off" | "optin";
-    /** Custom confirmation method. Replaces window.confirm. */
+    /** Custom confirmation method. Defaults to window.confirm. */
     confirm: (message: string, element: HTMLFormElement, submitter: HTMLElement | null) => Promise<boolean>;
     /**
      * Controls how submitters are disabled during form submission.

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -163,7 +163,7 @@ export interface SubmitterConfig {
 export interface FormsConfig {
     /** Form handling mode: "on" (default), "off", or "optin". */
     mode: "on" | "off" | "optin";
-    /** Custom confirmation method. Defaults to window.confirm. */
+    /** Custom confirmation method. Falls back to window.confirm if not defined. */
     confirm: (message: string, element: HTMLFormElement, submitter: HTMLElement | null) => Promise<boolean>;
     /**
      * Controls how submitters are disabled during form submission.

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -58,6 +58,26 @@ export class StreamSourceElement extends HTMLElement {
     readonly src: string;
 }
 
+export interface StreamSource {
+    addEventListener(
+        type: "message",
+        listener: (event: MessageEvent) => void,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
+    removeEventListener(
+        type: "message",
+        listener: (event: MessageEvent) => void,
+        options?: boolean | EventListenerOptions,
+    ): void;
+}
+
+export class StreamMessage {
+    static readonly contentType: "text/vnd.turbo-stream.html";
+    readonly fragment: DocumentFragment;
+    static wrap(message: StreamMessage | string): StreamMessage;
+    constructor(fragment: DocumentFragment);
+}
+
 export class FetchRequest {
     body: FormData | URLSearchParams;
     enctype: "application/x-www-form-urlencoded" | "multipart/form-data" | "text/plain";
@@ -185,14 +205,14 @@ export interface TurboConfig {
  *
  * @param source Stream source to connect
  */
-export function connectStreamSource(source: unknown): void;
+export function connectStreamSource(source: StreamSource): void;
 
 /**
  * Disconnects a stream source from the main session.
  *
  * @param source Stream source to disconnect
  */
-export function disconnectStreamSource(source: unknown): void;
+export function disconnectStreamSource(source: StreamSource): void;
 
 /**
  * Renders a stream message to the main session by appending it to the
@@ -200,12 +220,12 @@ export function disconnectStreamSource(source: unknown): void;
  *
  * @param message Message to render
  */
-export function renderStreamMessage(message: unknown): void;
+export function renderStreamMessage(message: StreamMessage | string): void;
 
 export interface TurboSession {
-    connectStreamSource(source: unknown): void;
-    disconnectStreamSource(source: unknown): void;
-    renderStreamMessage(message: unknown): void;
+    connectStreamSource(source: StreamSource): void;
+    disconnectStreamSource(source: StreamSource): void;
+    renderStreamMessage(message: StreamMessage | string): void;
     drive: boolean;
     adapter: BrowserAdapter;
 }
@@ -355,9 +375,9 @@ export interface TurboGlobal {
      */
     start(): void;
 
-    connectStreamSource(source: unknown): void;
-    disconnectStreamSource(source: unknown): void;
-    renderStreamMessage(message: unknown): void;
+    connectStreamSource(source: StreamSource): void;
+    disconnectStreamSource(source: StreamSource): void;
+    renderStreamMessage(message: StreamMessage | string): void;
 
     morphElements(currentElement: Element, newElement: Element | ChildNode[], options?: MorphOptions): void;
     morphChildren(currentElement: Element, newElement: Element, options?: MorphOptions): void;

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -164,7 +164,7 @@ export interface FormsConfig {
     /** Form handling mode: "on" (default), "off", or "optin". */
     mode: "on" | "off" | "optin";
     /** Custom confirmation method. Falls back to window.confirm if not defined. */
-    confirm: (message: string, element: HTMLFormElement, submitter: HTMLElement | null) => Promise<boolean>;
+    confirm?: (message: string, element: HTMLFormElement, submitter: HTMLElement | null) => Promise<boolean>;
     /**
      * Controls how submitters are disabled during form submission.
      * Can be "disabled" (default), "aria-disabled", or a custom SubmitterConfig.


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [X] adds support for `Turbo.config` object, added in [Turbo 8.0.6](https://github.com/hotwired/turbo/releases/tag/8.0.6). Adds deprecation warnings accordingly.
  - [x] adds support for morphing functions, exposed as public API in [Turbo 8.0.19](https://github.com/hotwired/turbo/releases/tag/v8.0.19).
- [X] ~~If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`~~ Unfortunately, Turbo doesn't seem to use semantic versioning, introducing breaking API changes in patch versions.
  - [x] Tested with Turbo 8.0.21.
  - [X] Tested with Turbo 8.0.23.

-----

This pull request expands the test coverage for the Turbo TypeScript types, ensuring that more of the public API is exercised and type-checked. The changes include importing additional Turbo modules, adding tests for various Turbo features and configuration options, and verifying correct type inference and error handling.

**Expanded Turbo API coverage:**

* Added imports for more Turbo modules, including `cache`, `config`, `connectStreamSource`, `disconnectStreamSource`, `navigator`, `renderStreamMessage`, `session`, `start`, `StreamMessage`, and `StreamSource` to `hotwired__turbo-tests.ts`.
* Added tests for `start()`, `session.adapter` methods, `navigator.submitForm`, and `cache` methods to verify correct usage and type inference.
* Added comprehensive tests for `config.drive` and `config.forms`, including assignments, type checks, and error scenarios for configuration options.

**Stream handling and message rendering:**

* Added tests for stream source connection/disconnection, stream message creation, and rendering, including type checks and error handling.
* Verified type inference and readonly status of `StreamElement.templateElement` and `templateContent` properties.