### PR TITLE
Disable dangerbot CI job for now

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -124,39 +124,38 @@ jobs:
           retention-days: 1
         if: ${{ github.event_name == 'pull_request' }}
 
-  dangerbot:
-    runs-on: ubuntu-latest
-    # if: github.repository == 'DefinitelyTyped/DefinitelyTyped' && github.event_name == 'pull_request'
-    if: false
+  # dangerbot:
+  #   runs-on: ubuntu-latest
+  #   if: github.repository == 'DefinitelyTyped/DefinitelyTyped' && github.event_name == 'pull_request'
 
-    needs:
-      - test
+  #   needs:
+  #     - test
 
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ./.github/actions/setup-for-scripts
+  #   steps:
+  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  #     - uses: ./.github/actions/setup-for-scripts
 
-      - name: Get suggestions dir
-        id: suggestions-dir
-        run: echo "path=$(node ./scripts/get-suggestions-dir.js)" >> "$GITHUB_OUTPUT"
+  #     - name: Get suggestions dir
+  #       id: suggestions-dir
+  #       run: echo "path=$(node ./scripts/get-suggestions-dir.js)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          path: ${{ steps.suggestions-dir.outputs.path }}
-          merge-multiple: true
+  #     - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+  #       with:
+  #         path: ${{ steps.suggestions-dir.outputs.path }}
+  #         merge-multiple: true
 
-      - name: 'Run Danger'
-        env:
-          # See https://github.com/danger/danger-js/issues/1042
-          DANGER_GITHUB_API_BASE_URL: 'https://api.github.com'
+  #     - name: 'Run Danger'
+  #       env:
+  #         # See https://github.com/danger/danger-js/issues/1042
+  #         DANGER_GITHUB_API_BASE_URL: 'https://api.github.com'
 
-        # Danger failing (for example through rate-limiting) shouldn't fail the build
-        run: |
-          # Exposing this token is safe because the user of it has no other public repositories
-          # and has no permission to modify this repository. See #62638 for the discussion.
-          TOKEN='ghp_i5wtj1l2AbpFv3OU96w6R'
-          TOKEN+='On3bHOkcV2AmVY6'
-          DANGER_GITHUB_API_TOKEN=$TOKEN pnpm danger ci || $( exit 0 )
+  #       # Danger failing (for example through rate-limiting) shouldn't fail the build
+  #       run: |
+  #         # Exposing this token is safe because the user of it has no other public repositories
+  #         # and has no permission to modify this repository. See #62638 for the discussion.
+  #         TOKEN='ghp_i5wtj1l2AbpFv3OU96w6R'
+  #         TOKEN+='On3bHOkcV2AmVY6'
+  #         DANGER_GITHUB_API_TOKEN=$TOKEN pnpm danger ci || $( exit 0 )
 
   scripts:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -126,7 +126,8 @@ jobs:
 
   dangerbot:
     runs-on: ubuntu-latest
-    if: github.repository == 'DefinitelyTyped/DefinitelyTyped' && github.event_name == 'pull_request'
+    # if: github.repository == 'DefinitelyTyped/DefinitelyTyped' && github.event_name == 'pull_request'
+    if: ${{ false }}
 
     needs:
       - test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -127,7 +127,7 @@ jobs:
   dangerbot:
     runs-on: ubuntu-latest
     # if: github.repository == 'DefinitelyTyped/DefinitelyTyped' && github.event_name == 'pull_request'
-    if: ${{ false }}
+    if: false
 
     needs:
       - test


### PR DESCRIPTION
This job is no longer working:

```
Unable to evaluate the Dangerfile
 TypeError: Cannot read properties of null (reading 'filename')
    at shouldUseGitHubOverride (/home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/.pnpm/danger@11.3.1_encoding@0.1.13/node_modules/danger/distribution/platforms/github/customGitHubRequire.js:131:16)
    at _module2.default._load (/home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/.pnpm/override-require@1.1.1/node_modules/override-require/dist/overrideRequire.js:38:9)
    at node:internal/modules/esm/translators:273:15
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:240:7)
    at ModuleJobSync.runSync (node:internal/modules/esm/module_job:437:37)
    at ModuleLoader.importSyncForRequire (node:internal/modules/esm/loader:389:47)
    at loadESMFromCJS (node:internal/modules/cjs/loader:1363:24)
    at Module._compile (node:internal/modules/cjs/loader:1503:5)
    at requireFromString (/home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/.pnpm/require-from-string@2.0.2/node_modules/require-from-string/index.js:28:4)
    at /home/runner/work/DefinitelyTyped/DefinitelyTyped/node_modules/.pnpm/danger@11.3.1_encoding@0.1.13/node_modules/danger/distribution/runner/runners/inline.js:161:68


Failing the build, there is 1 fail.
Feedback: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/74440#issuecomment-3830306797
Could not add a commit status, the GitHub token for Danger does not have access rights.
If the build fails, then danger will use a failing exit code.
```

This message is getting spammed onto all PRs.

I have no idea what would have changed to cause this, but I want to stop the spam for now.

This will stop PRs from being told to format, and also the thing that says which exports seem to be obviously missing, plus other misc checks.