### PR TITLE
[react] Add types for `SubmitEvent.submitter` in `react@canary`

### DIFF
--- a/types/react-dom/test/canary-tests.tsx
+++ b/types/react-dom/test/canary-tests.tsx
@@ -99,3 +99,12 @@ function fragmentRefTest() {
         <div />
     </React.Fragment>;
 }
+
+function formrelatedEventTests() {
+    <form
+        onSubmit={event => {
+            // $ExpectType HTMLElement | null
+            event.submitter;
+        }}
+    />;
+}

--- a/types/react-dom/test/react-dom-tests.tsx
+++ b/types/react-dom/test/react-dom-tests.tsx
@@ -756,7 +756,7 @@ function formrelatedEventTests() {
 
     <form
         onSubmit={event => {
-            // @ts-expect-error -- submitter is not yet exposed by React
+            // Only passes because program includes React Canary types
             event.submitter;
             // $ExpectType EventTarget & HTMLFormElement
             event.target;

--- a/types/react/canary.d.ts
+++ b/types/react/canary.d.ts
@@ -30,6 +30,8 @@ export {};
 declare const UNDEFINED_VOID_ONLY: unique symbol;
 type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 
+type NativeSubmitEvent = SubmitEvent;
+
 declare module "." {
     export function unstable_useCacheRefresh(): () => void;
 
@@ -116,5 +118,12 @@ declare module "." {
 
     export interface FragmentProps {
         ref?: Ref<FragmentInstance> | undefined;
+    }
+
+    interface SubmitEvent<T = Element> extends SyntheticEvent<T, NativeSubmitEvent> {
+        /**
+         * Only available in react@canary
+         */
+        submitter: HTMLElement | null;
     }
 }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2158,7 +2158,7 @@ declare namespace React {
     }
 
     interface SubmitEvent<T = Element> extends SyntheticEvent<T, NativeSubmitEvent> {
-        // Currently not exposed by Reat
+        // `submitter` is available in react@canary
         // submitter: HTMLElement | null;
         // SubmitEvents are always targetted at HTMLFormElements.
         target: EventTarget & HTMLFormElement;
@@ -3525,7 +3525,7 @@ declare namespace React {
         value?: string | readonly string[] | number | undefined;
         wrap?: string | undefined;
 
-        // No other element dispatching change events can be nested in a <textare>
+        // No other element dispatching change events can be nested in a <textarea>
         // so we know the target will be a HTMLTextAreaElement.
         onChange?: ChangeEventHandler<T, HTMLTextAreaElement> | undefined;
     }

--- a/types/react/ts5.0/canary.d.ts
+++ b/types/react/ts5.0/canary.d.ts
@@ -30,6 +30,8 @@ export {};
 declare const UNDEFINED_VOID_ONLY: unique symbol;
 type VoidOrUndefinedOnly = void | { [UNDEFINED_VOID_ONLY]: never };
 
+type NativeSubmitEvent = SubmitEvent;
+
 declare module "." {
     export function unstable_useCacheRefresh(): () => void;
 
@@ -116,5 +118,12 @@ declare module "." {
 
     export interface FragmentProps {
         ref?: Ref<FragmentInstance> | undefined;
+    }
+
+    interface SubmitEvent<T = Element> extends SyntheticEvent<T, NativeSubmitEvent> {
+        /**
+         * Only available in react@canary
+         */
+        submitter: HTMLElement | null;
     }
 }

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -2081,7 +2081,7 @@ declare namespace React {
      * Only for form elements we know their target type because form events can't
      * be nested.
      * This type exists purely to narrow `target` for form elements. It doesn't
-     * reflect a DOM event. React fires change events as {@link SyntheticEvent}.
+     * reflect a DOM event. Change events are just fired as standard {@link SyntheticEvent}.
      */
     interface ChangeEvent<CurrentTarget = Element, Target = Element> extends SyntheticEvent<CurrentTarget> {
         // TODO: This is wrong for change event handlers on arbitrary. Should
@@ -2157,7 +2157,7 @@ declare namespace React {
     }
 
     interface SubmitEvent<T = Element> extends SyntheticEvent<T, NativeSubmitEvent> {
-        // Currently not exposed by Reat
+        // `submitter` is available in react@canary
         // submitter: HTMLElement | null;
         // SubmitEvents are always targetted at HTMLFormElements.
         target: EventTarget & HTMLFormElement;


### PR DESCRIPTION
Types for https://github.com/facebook/react/pull/35590

drive-by sync fixes as a follow-up to https://github.com/DefinitelyTyped/DefinitelyTyped/pull/74383