### PR TITLE
[react] Backport recent changes to TS 5.0 fork

### DIFF
--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 
 const { useSyncExternalStore } = React;
 

--- a/types/react/test/managedAttributes.tsx
+++ b/types/react/test/managedAttributes.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 
 interface Props {
     bool?: boolean;

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -3598,6 +3598,9 @@ declare namespace React {
         method?: string | undefined;
         min?: number | string | undefined;
         name?: string | undefined;
+        nonce?: string | undefined;
+        part?: string | undefined;
+        slot?: string | undefined;
         style?: CSSProperties | undefined;
         target?: string | undefined;
         type?: string | undefined;

--- a/types/react/ts5.0/test/elementAttributes.tsx
+++ b/types/react/ts5.0/test/elementAttributes.tsx
@@ -29,6 +29,7 @@ const testCases = [
     <span lang="art-x-tokipona" />,
     <input placeholder="placeholder" />,
     <span slot="my-text" />,
+    <svg slot="my-svg" />,
     <span spellCheck />,
     <span tabIndex={0} />,
     <span title="title" />,
@@ -101,6 +102,7 @@ const testCases = [
         open
     />,
     <link nonce="8IBTHwOdqNKAWeKl7plt8g==" />,
+    <svg nonce="8IBTHwOdqNKAWeKl7plt8g==" />,
     <center></center>,
     // Float
     <>
@@ -171,6 +173,7 @@ const testCases = [
     <>
         <template>
             <div part="base" />
+            <svg part="svg" />
             <custom-element exportparts="nested" />
         </template>
     </>,

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -135,16 +135,15 @@ class ModernComponent extends React.Component<Props, State, Snapshot> implements
     static propTypes = {};
 
     static contextType = SomeContext;
-    context: Context;
+    declare context: Context;
 
     constructor(props: Props, context: Context) {
         super(props, context);
+        this.state = {
+            inputValue: this.context.someValue,
+            seconds: this.props.foo,
+        };
     }
-
-    state = {
-        inputValue: this.context.someValue,
-        seconds: this.props.foo,
-    };
 
     reset() {
         this._myComponent.reset();

--- a/types/react/ts5.0/test/index.ts
+++ b/types/react/ts5.0/test/index.ts
@@ -153,8 +153,8 @@ class ModernComponent extends React.Component<Props, State, Snapshot> implements
         });
     }
 
-    private readonly _myComponent: MyComponent;
-    private _input: HTMLInputElement | null;
+    private readonly _myComponent!: MyComponent;
+    private _input: HTMLInputElement | null = null;
 
     render() {
         return React.createElement(

--- a/types/react/ts5.0/tsconfig.json
+++ b/types/react/ts5.0/tsconfig.json
@@ -25,6 +25,7 @@
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,
-        "jsx": "preserve"
+        "jsx": "preserve",
+        "esModuleInterop": true
     }
 }


### PR DESCRIPTION
Stacked on https://github.com/DefinitelyTyped/DefinitelyTyped/pull/74451

Backports
- https://github.com/DefinitelyTyped/DefinitelyTyped/issues/74430
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/74250
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/74479

Consistently uses `import * as React`. I don't understand why this got changed in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/73954 when it also enabled `esModuleInterop`