### PR TITLE
Fix packages for TS 6.0 strict=true

### DIFF
--- a/types/activex-adodb/activex-adodb-tests.ts
+++ b/types/activex-adodb/activex-adodb-tests.ts
@@ -96,7 +96,7 @@ const withConnection = (initialCatalog: string, fn: (conn: ADODB.Connection) => 
     try {
         conn.Open(connectionString);
         fn(conn);
-    } catch (e) {
+    } catch (e: any) {
         WScript.Echo(e.message);
     } finally {
         if (conn.State === ADODB.ObjectStateEnum.adStateOpen) {
@@ -134,7 +134,7 @@ const withRs = (
             rs = tableOrCommand.Execute() as ADODB.Recordset;
         }
         fn(rs);
-    } catch (e) {
+    } catch (e: any) {
         WScript.Echo(e.message);
     } finally {
         if (rs && rs.State === ADODB.ObjectStateEnum.adStateOpen) {
@@ -252,7 +252,7 @@ const withEmployees = (fn: (rs: ADODB.Recordset) => void, type: ADODB.CursorType
                 WScript.Echo(rsContact("ContactName"));
                 rsContact.MoveNext();
             }
-        } catch (e) {
+        } catch (e: any) {
             WScript.Echo(e.message);
         } finally {
             if (rsContact && rsContact.State === ADODB.ObjectStateEnum.adStateOpen) {

--- a/types/activex-msxml2/activex-msxml2-tests.ts
+++ b/types/activex-msxml2/activex-msxml2-tests.ts
@@ -23,7 +23,7 @@ const MakeDOM = () => {
         dom.validateOnParse = false;
         dom.resolveExternals = false;
         return dom;
-    } catch (e) {
+    } catch (e: any) {
         WScript.Echo(e.description);
     }
 };
@@ -33,7 +33,7 @@ const LoadDOM = (file: string) => {
         const dom = MakeDOM()!;
         dom.load(file);
         return dom;
-    } catch (e) {
+    } catch (e: any) {
         WScript.Echo(e.description);
     }
 };
@@ -171,7 +171,7 @@ const LoadDOM = (file: string) => {
             if (nextNode == null) continue;
             WScript.Echo(`Node (${i}), <${oNode.nodeName} + ">:\n\t${oNode.xml}`);
         }
-    } catch (e) {
+    } catch (e: any) {
         WScript.Echo(e.description);
     }
 }

--- a/types/angular-es/angular-es-tests.ts
+++ b/types/angular-es/angular-es-tests.ts
@@ -95,7 +95,7 @@ import { InjectAsProperty } from "angular-es";
 
 @InjectAsProperty("fooBar")
 class MyFooBarService {
-    fooBar: Object;
+    fooBar!: Object;
 
     myMethod() {
         this.fooBar !== undefined;

--- a/types/appletvjs/appletvjs-tests.ts
+++ b/types/appletvjs/appletvjs-tests.ts
@@ -31,8 +31,8 @@ function test_FeatureElement() {
         "<menuBar id=\"menuBar\"></menuBar><textField id=\"textField\"></textField>",
         "application/xml",
     );
-    var textField = document.getElementById("textField");
-    textField.addEventListener("change", function() {
+    var textField = document.getElementById("textField") as unknown as AppleTVJS.FeatureElement;
+    textField.addEventListener("change", function(this: AppleTVJS.FeatureElement) {
         change.call(this, textField);
     });
 
@@ -42,8 +42,8 @@ function test_FeatureElement() {
         var text = keyboard.text;
     };
 
-    var menuBar = document.getElementById("menuBar");
-    textField.addEventListener("change", function() {
+    var menuBar = document.getElementById("menuBar") as unknown as AppleTVJS.FeatureElement;
+    textField.addEventListener("change", function(this: AppleTVJS.FeatureElement) {
         change.call(this, textField);
     });
 

--- a/types/arangodb/arangodb-tests.ts
+++ b/types/arangodb/arangodb-tests.ts
@@ -117,7 +117,7 @@ router.put(
                 params: JSON.parse(request.body),
             });
             response.json({ id });
-        } catch (e) {
+        } catch (e: any) {
             e.error = true;
             response.json(e);
         }

--- a/types/ari-client/test/ari-client-tests.externalMedia.ts
+++ b/types/ari-client/test/ari-client-tests.externalMedia.ts
@@ -6,7 +6,7 @@ import { EventEmitter } from "events";
 
 export default class TsgBridge extends EventEmitter {
     ariClient: Client;
-    bridge: Bridge;
+    bridge!: Bridge;
 
     constructor(ariClient: Client, exten: string, log: any) {
         super();

--- a/types/athenajs/test/tetris/grid.ts
+++ b/types/athenajs/test/tetris/grid.ts
@@ -31,23 +31,23 @@ class Grid extends Scene {
 
     // game sprites
     // current tetris shape
-    shape: Shape;
+    shape!: Shape;
     // next tetris shape
-    nextShape: Shape;
+    nextShape!: Shape;
     // next tetris string
-    nextString: SimpleText;
+    nextString!: SimpleText;
     // score
-    scoreString: SimpleText;
+    scoreString!: SimpleText;
     // "line:"
-    linesString: SimpleText;
+    linesString!: SimpleText;
     // "level:"
-    levelString: SimpleText;
+    levelString!: SimpleText;
     // "pause:"
-    pauseString: SimpleText;
+    pauseString!: SimpleText;
     // flashing lines
-    flashLines: FlashLines;
+    flashLines!: FlashLines;
     // ->, <-
-    controls: SimpleText;
+    controls!: SimpleText;
 
     constructor() {
         super({

--- a/types/athenajs/test/tetris/shape.ts
+++ b/types/athenajs/test/tetris/shape.ts
@@ -12,10 +12,10 @@ interface shapeDescription {
 class Shape extends Sprite {
     shapes: shapeDescription[];
     // current shape
-    shape: shapeDescription;
-    shapeName: string;
+    shape!: shapeDescription;
+    shapeName!: string;
     // current shape rotation
-    rotation: number;
+    rotation!: number;
 
     constructor(name: string, options = {}) {
         super(name, {

--- a/types/athenajs/test/tetris/shape_behavior.ts
+++ b/types/athenajs/test/tetris/shape_behavior.ts
@@ -13,10 +13,10 @@ class ShapeBehavior extends Behavior {
     ts: number;
     LONG_DELAY: number;
     SMALL_DELAY: number;
-    delay: number;
-    key: number;
-    timerEnabled: boolean;
-    startTime: number;
+    delay!: number;
+    key!: number;
+    timerEnabled!: boolean;
+    startTime!: number;
 
     constructor(sprite: Shape, options?: any) {
         super(sprite as Drawable, options);

--- a/types/atom/atom-tests.ts
+++ b/types/atom/atom-tests.ts
@@ -654,7 +654,7 @@ function testDecoration() {
 // DeserializerManager ========================================================
 function testDesializerManager() {
     class StorableClass {
-        name: string;
+        name!: string;
 
         constructor() {}
         deserialize() {

--- a/types/backbone.marionette/backbone.marionette-tests.ts
+++ b/types/backbone.marionette/backbone.marionette-tests.ts
@@ -57,8 +57,8 @@ class MyApplication extends Marionette.Application {
         this.layoutView = new AppLayoutView();
     }
 
-    layoutView: AppLayoutView;
-    mainRegion: Marionette.Region;
+    layoutView!: AppLayoutView;
+    mainRegion!: Marionette.Region;
 
     onStart() {
         this.mainRegion = new Marionette.Region({ el: "#main" });

--- a/types/backbone/backbone-tests.ts
+++ b/types/backbone/backbone-tests.ts
@@ -21,16 +21,16 @@ function test_events() {
 }
 
 class PubSub implements Backbone.Events {
-    on: Backbone.Events_On<PubSub>;
-    off: Backbone.Events_Off<PubSub>;
-    trigger: Backbone.Events_Trigger<PubSub>;
-    bind: Backbone.Events_On<PubSub>;
-    unbind: Backbone.Events_Off<PubSub>;
+    on!: Backbone.Events_On<PubSub>;
+    off!: Backbone.Events_Off<PubSub>;
+    trigger!: Backbone.Events_Trigger<PubSub>;
+    bind!: Backbone.Events_On<PubSub>;
+    unbind!: Backbone.Events_Off<PubSub>;
 
-    once: Backbone.Events_On<PubSub>;
-    listenTo: Backbone.Events_Listen<PubSub>;
-    listenToOnce: Backbone.Events_Listen<PubSub>;
-    stopListening: Backbone.Events_Stop<PubSub>;
+    once!: Backbone.Events_On<PubSub>;
+    listenTo!: Backbone.Events_Listen<PubSub>;
+    listenToOnce!: Backbone.Events_Listen<PubSub>;
+    stopListening!: Backbone.Events_Stop<PubSub>;
 }
 
 Object.assign(PubSub.prototype, Backbone.Events);
@@ -156,7 +156,7 @@ class PrivateNote extends Note {
     }
 
     set(attributes: any, options?: any): this {
-        return Backbone.Model.prototype.set.call(this, attributes, options);
+        return super.set(attributes, options);
     }
 }
 
@@ -217,9 +217,9 @@ class EmployeeCollection extends Backbone.Collection<Employee> {
 }
 
 class Book extends Backbone.Model {
-    title: string;
-    author: string;
-    published: boolean;
+    title!: string;
+    author!: string;
+    published!: boolean;
 }
 
 class Library extends Backbone.Collection<Book> {

--- a/types/bardjs/bardjs-tests.ts
+++ b/types/bardjs/bardjs-tests.ts
@@ -23,7 +23,7 @@ namespace myService {
 }
 
 class MyController {
-    myProperty: string;
+    myProperty!: string;
 }
 
 angular

--- a/types/blessed/blessed-tests.ts
+++ b/types/blessed/blessed-tests.ts
@@ -110,7 +110,7 @@ const lorem = readFileSync(__dirname + "/git.diff", "utf8");
 const cleanSides = screen.cleanSides;
 function expectClean(value: any) {
     screen.cleanSides = function(el: blessed.Widgets.BlessedElement) {
-        const ret = cleanSides.apply(this, arguments);
+        const ret = cleanSides.call(this, el);
         if (ret !== value) {
             throw new Error(`Failed. Expected ${value} from cleanSides. Got ${ret}.`);
         }

--- a/types/bluebird/bluebird-tests.ts
+++ b/types/bluebird/bluebird-tests.ts
@@ -366,7 +366,7 @@ fooOrBarProm = fooProm.caught(Bluebird.CancellationError, (reason: any) => {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 class CustomError extends Error {
-    customField: number;
+    customField!: number;
 }
 // $ExpectType Bluebird<void | Foo>
 fooProm.catch(CustomError, reason => {

--- a/types/braintree-web/test/web.ts
+++ b/types/braintree-web/test/web.ts
@@ -668,7 +668,7 @@ braintree.client.create(
                         });
                         payload.nonce;
                         // Submit payload.nonce to your server
-                    } catch (tokenizeErr /*braintree.BraintreeError*/) {
+                    } catch (tokenizeErr: any) {
                         // Handle tokenization errors or premature flow closure
                         switch (tokenizeErr.code) {
                             case "PAYPAL_POPUP_CLOSED":

--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -378,7 +378,7 @@ function deepInclude() {
 }
 
 class FakeArgs {
-    length: number;
+    length!: number;
 }
 
 function empty() {

--- a/types/chai/v4/chai-tests.ts
+++ b/types/chai/v4/chai-tests.ts
@@ -532,7 +532,7 @@ function deepInclude() {
 }
 
 class FakeArgs {
-    length: number;
+    length!: number;
 }
 
 function empty() {

--- a/types/code/code-tests.ts
+++ b/types/code/code-tests.ts
@@ -136,7 +136,7 @@ expect(1).to.match(/^\d$/);
 expect("x").to.satisfy(value => value === "x");
 
 class CustomError extends Error {
-    call: (message: string) => Error;
+    call!: (message: string) => Error;
 }
 
 const throws = () => {

--- a/types/codependency/codependency-tests.ts
+++ b/types/codependency/codependency-tests.ts
@@ -1,9 +1,9 @@
 let requirePeer = codependency.register(module);
-let package: any;
+let pkg: any;
 requirePeer = codependency.register(module, { index: ["dependencies", "devDependencies"] });
 requirePeer = codependency.get("some-middleware");
-package = requirePeer("some-peer-dependency-package");
-package = requirePeer("some-peer-dependency-package", { optional: true });
-package = requirePeer("some-peer-dependency-package", { dontThrow: true });
-package = requirePeer("some-peer-dependency-package", { optional: true, dontThrow: true });
-package = requirePeer.resolve("peer-package-name");
+pkg = requirePeer("some-peer-dependency-package");
+pkg = requirePeer("some-peer-dependency-package", { optional: true });
+pkg = requirePeer("some-peer-dependency-package", { dontThrow: true });
+pkg = requirePeer("some-peer-dependency-package", { optional: true, dontThrow: true });
+pkg = requirePeer.resolve("peer-package-name");

--- a/types/cors/cors-tests.ts
+++ b/types/cors/cors-tests.ts
@@ -44,7 +44,7 @@ app.use(cors({
     origin: (requestOrigin, cb) => {
         try {
             cb(null, true);
-        } catch (err) {
+        } catch (err: any) {
             cb(err);
         }
     },
@@ -53,7 +53,7 @@ app.use(cors({
     origin: (requestOrigin, cb) => {
         try {
             cb(null, "http://example.com");
-        } catch (err) {
+        } catch (err: any) {
             cb(err);
         }
     },
@@ -62,7 +62,7 @@ app.use(cors({
     origin: (requestOrigin, cb) => {
         try {
             cb(null, /example\.com$/);
-        } catch (err) {
+        } catch (err: any) {
             cb(err);
         }
     },
@@ -71,7 +71,7 @@ app.use(cors({
     origin: (requestOrigin, cb) => {
         try {
             cb(null, [/example\.com$/, "http://example.com"]);
-        } catch (err) {
+        } catch (err: any) {
             cb(err);
         }
     },
@@ -80,7 +80,7 @@ app.use(cors({
     origin: (requestOrigin, cb) => {
         try {
             cb(null, ["http://example.com", "http://fakeurl.com"]);
-        } catch (err) {
+        } catch (err: any) {
             cb(err);
         }
     },
@@ -89,7 +89,7 @@ app.use(cors({
     origin: (requestOrigin, cb) => {
         try {
             cb(null, [/example\.com$/, /fakeurl\.com$/]);
-        } catch (err) {
+        } catch (err: any) {
             cb(err);
         }
     },
@@ -101,7 +101,7 @@ app.use(cors({
                 throw new Error("No origin");
             }
             cb(null, requestOrigin);
-        } catch (err) {
+        } catch (err: any) {
             cb(err);
         }
     },
@@ -111,7 +111,7 @@ app.use(cors({
         try {
             const allow = !requestOrigin || requestOrigin.indexOf(".edu") !== -1;
             cb(null, allow);
-        } catch (err) {
+        } catch (err: any) {
             cb(err);
         }
     },

--- a/types/css-tree/css-tree-tests.ts
+++ b/types/css-tree/css-tree-tests.ts
@@ -80,11 +80,11 @@ csstree.generate(ast, {
         },
         node(node) {
             node; // $ExpectType CssNode
-            handlers.node.call(node);
+            handlers.node(node);
         },
         chunk(chunk) {
             chunk; // $ExpectType string
-            handlers.chunk.call(chunk);
+            handlers.chunk(chunk);
         },
         result() {
             return handlers.result.call(handlers);

--- a/types/curtainsjs/curtainsjs-tests.ts
+++ b/types/curtainsjs/curtainsjs-tests.ts
@@ -537,7 +537,7 @@ window.addEventListener("load", () => {
 
 class LocomotiveScroll {
     constructor(options: Record<string, unknown>) {}
-    isMobile: boolean;
+    isMobile!: boolean;
     on(
         event: string,
         callback: (obj: {

--- a/types/custom-functions-runtime/custom-functions-runtime-tests.ts
+++ b/types/custom-functions-runtime/custom-functions-runtime-tests.ts
@@ -56,8 +56,8 @@ function stockPriceStream(ticker: string,
             const response = await fetch(url);
             const data = await response.json();
             invocation.setResult(data.price);
-        } catch (error) {
-            invocation.setResult(error);
+        } catch (error: any) {
+          invocation.setResult(error);
         }
         isPending = false;
     }, updateFrequency);

--- a/types/d/d-tests.ts
+++ b/types/d/d-tests.ts
@@ -42,7 +42,7 @@ d.gs("ce", () => ({})); // $ExpectType PropertyDescriptor
 d.gs("cew", () => ({}));
 
 class Foo {
-    _count: number;
+    _count!: number;
 }
 
 Object.defineProperties(

--- a/types/dashdash/dashdash-tests.ts
+++ b/types/dashdash/dashdash-tests.ts
@@ -36,7 +36,7 @@ console.log("args:", opts._args);
 const parser = dashdash.createParser({ options });
 try {
     opts = parser.parse(process.argv);
-} catch (e) {
+} catch (e: any) {
     console.error("foo: error: %s", e.message);
     process.exit(1);
 }
@@ -83,7 +83,7 @@ ${help}`);
 
     try {
         const opts = dashdash.parse({ options });
-    } catch (e) {
+    } catch (e: any) {
         console.error("%s: error: %s", path.basename(process.argv[1]), e.message);
         process.exit(1);
     }
@@ -130,7 +130,7 @@ ${help}`);
 
     try {
         const opts = dashdash.parse({ options });
-    } catch (e) {
+    } catch (e: any) {
         console.error("%s: error: %s", path.basename(process.argv[1]), e.message);
         process.exit(1);
     }
@@ -169,7 +169,7 @@ ${help}`);
     const parser = dashdash.createParser({ options });
     try {
         const opts = parser.parse(process.argv);
-    } catch (e) {
+    } catch (e: any) {
         console.error("%s: error: %s", path.basename(process.argv[1]), e.message);
         process.exit(1);
     }

--- a/types/deep-freeze/deep-freeze-tests.ts
+++ b/types/deep-freeze/deep-freeze-tests.ts
@@ -1,7 +1,7 @@
 import df = require("deep-freeze");
 
 class Foo {
-    foo: string;
+    foo!: string;
 }
 const foo = df(new Foo());
 const items = df([{ id: 0, name: "first" }]);

--- a/types/director/director-tests.ts
+++ b/types/director/director-tests.ts
@@ -216,7 +216,7 @@ httpRouter.attach(function() {
 // --------------------------------
 
 class MyTtyClass {
-    some_unique_field_name: boolean;
+    some_unique_field_name!: boolean;
 }
 
 let cliRouter: director.cli.Router<MyTtyClass> = new director.cli.Router<MyTtyClass>();

--- a/types/ee-first/ee-first-tests.ts
+++ b/types/ee-first/ee-first-tests.ts
@@ -2,11 +2,11 @@ import first = require("ee-first");
 import { EventEmitter } from "events";
 
 class Foo extends EventEmitter {
-    foo: "foo";
+    foo!: "foo";
 }
 
 class Bar extends EventEmitter {
-    bar: "bar";
+    bar!: "bar";
 }
 
 const ee1 = new Foo();

--- a/types/ember-data/test/transform.ts
+++ b/types/ember-data/test/transform.ts
@@ -3,8 +3,8 @@ import Ember from "ember";
 import DS from "ember-data";
 
 export class Point extends Ember.Object {
-    x: number;
-    y: number;
+    x!: number;
+    y!: number;
 }
 
 class PointTransform extends DS.Transform {

--- a/types/ember-data/v2/test/transform.ts
+++ b/types/ember-data/v2/test/transform.ts
@@ -2,8 +2,8 @@ import Ember from "ember";
 import DS from "ember-data";
 
 class Point extends Ember.Object {
-    x: number;
-    y: number;
+    x!: number;
+    y!: number;
 }
 
 const PointTransform = DS.Transform.extend({

--- a/types/ember-data/v3/test/transform.ts
+++ b/types/ember-data/v3/test/transform.ts
@@ -2,8 +2,8 @@ import Ember from "ember";
 import DS from "ember-data";
 
 export class Point extends Ember.Object {
-    x: number;
-    y: number;
+    x!: number;
+    y!: number;
 }
 
 class PointTransform extends DS.Transform {

--- a/types/ember-data__model/test/model.ts
+++ b/types/ember-data__model/test/model.ts
@@ -40,19 +40,19 @@ const User = Model.extend({
 
 class Human extends Model {
     @attr
-    age: number;
+    age!: number;
     @belongsTo("human")
-    mother: AsyncBelongsTo<Human>;
+    mother!: AsyncBelongsTo<Human>;
     @belongsTo("human", { async: false })
-    motherSync: Human;
+    motherSync!: Human;
     @belongsTo("human")
-    father: AsyncBelongsTo<Human | null>;
+    father!: AsyncBelongsTo<Human | null>;
     @belongsTo("human", { async: false })
-    fatherSync: Human | null;
+    fatherSync!: Human | null;
     @hasMany("person")
-    children: AsyncHasMany<Person>;
+    children!: AsyncHasMany<Person>;
     @hasMany("person", { async: false })
-    childrenSync: SyncHasMany<Person>;
+    childrenSync!: SyncHasMany<Person>;
 }
 
 const user = User.create({ username: "dwickern" });

--- a/types/ember-data__model/v3/test/model.ts
+++ b/types/ember-data__model/v3/test/model.ts
@@ -40,19 +40,19 @@ const User = Model.extend({
 
 class Human extends Model {
     @attr
-    age: number;
+    age!: number;
     @belongsTo("human")
-    mother: AsyncBelongsTo<Human>;
+    mother!: AsyncBelongsTo<Human>;
     @belongsTo("human", { async: false })
-    motherSync: Human;
+    motherSync!: Human;
     @belongsTo("human")
-    father: AsyncBelongsTo<Human | null>;
+    father!: AsyncBelongsTo<Human | null>;
     @belongsTo("human", { async: false })
-    fatherSync: Human | null;
+    fatherSync!: Human | null;
     @hasMany("person")
-    children: AsyncHasMany<Person>;
+    children!: AsyncHasMany<Person>;
     @hasMany("person", { async: false })
-    childrenSync: SyncHasMany<Person>;
+    childrenSync!: SyncHasMany<Person>;
 }
 
 const user = User.create({ username: "dwickern" });

--- a/types/ember/v2/test/array-ext.ts
+++ b/types/ember/v2/test/array-ext.ts
@@ -6,7 +6,7 @@ declare global {
 }
 
 class Person extends Ember.Object {
-    name: string;
+    name!: string;
 }
 
 const person = Person.create({ name: "Joe" });

--- a/types/ember/v2/test/create.ts
+++ b/types/ember/v2/test/create.ts
@@ -17,9 +17,9 @@ export class Person extends Ember.Object.extend({
         return [this.firstName + this.lastName].join(" ");
     }),
 }) {
-    firstName: string;
-    lastName: string;
-    age: number;
+    firstName!: string;
+    lastName!: string;
+    age!: number;
 }
 const p = new Person();
 assertType<string>(p.firstName);

--- a/types/ember/v2/test/detect-instance.ts
+++ b/types/ember/v2/test/detect-instance.ts
@@ -6,7 +6,7 @@ const ExtendClass = Ember.Object.extend({
 });
 
 class ES6Class extends Ember.Object {
-    bar: string;
+    bar!: string;
 }
 
 let testObject: any = null;

--- a/types/ember/v2/test/detect.ts
+++ b/types/ember/v2/test/detect.ts
@@ -6,7 +6,7 @@ const ExtendClass = Ember.Object.extend({
 });
 
 class ES6Class extends Ember.Object {
-    bar: string;
+    bar!: string;
 }
 
 let TestClass = Ember.Object;

--- a/types/ember/v2/test/extend.ts
+++ b/types/ember/v2/test/extend.ts
@@ -23,8 +23,8 @@ assertType<string>(person.getFullName());
 assertType<number>(person.extra);
 
 class ES6Person extends Ember.Object {
-    firstName: string;
-    lastName: string;
+    firstName!: string;
+    lastName!: string;
 
     get fullName() {
         return `${this.firstName} ${this.lastName}`;

--- a/types/ember/v2/test/helper.ts
+++ b/types/ember/v2/test/helper.ts
@@ -7,11 +7,11 @@ const FormatCurrencyHelper = Ember.Helper.helper(function(params, hash: { curren
 });
 
 class User extends Ember.Object {
-    email: string;
+    email!: string;
 }
 
 class SessionService extends Ember.Service {
-    currentUser: User;
+    currentUser!: User;
 }
 
 const CurrentUserEmailHelper = Ember.Helper.extend({

--- a/types/ember/v2/test/inject.ts
+++ b/types/ember/v2/test/inject.ts
@@ -1,12 +1,12 @@
 import Ember from "ember";
 
 class AuthService extends Ember.Service {
-    isAuthenticated: boolean;
+    isAuthenticated!: boolean;
 }
 
 class ApplicationController extends Ember.Controller {
     model = {};
-    string: string;
+    string!: string;
     transitionToLogin() {}
 }
 

--- a/types/ember/v2/test/observable.ts
+++ b/types/ember/v2/test/observable.ts
@@ -5,7 +5,7 @@ class MyComponent extends Ember.Component {
     foo = "bar";
 
     init() {
-        this._super.apply(this, arguments);
+        this._super.apply(this, arguments as unknown as any[]);
         this.addObserver("foo", this, "fooDidChange");
         this.addObserver("foo", this, this.fooDidChange);
         Ember.addObserver(this, "foo", this, "fooDidChange");

--- a/types/ember/v3/test/array-ext.ts
+++ b/types/ember/v3/test/array-ext.ts
@@ -6,7 +6,7 @@ declare global {
 }
 
 class Person extends Ember.Object {
-    name: string;
+    name!: string;
 }
 
 const person = Person.create({ name: "Joe" });

--- a/types/ember/v3/test/create.ts
+++ b/types/ember/v3/test/create.ts
@@ -32,9 +32,9 @@ export class Person extends Ember.Object.extend({
         return [this.firstName + this.lastName].join(" ");
     }),
 }) {
-    firstName: string;
-    lastName: string;
-    age: number;
+    firstName!: string;
+    lastName!: string;
+    age!: number;
 }
 const p = new Person();
 

--- a/types/ember/v3/test/detect-instance.ts
+++ b/types/ember/v3/test/detect-instance.ts
@@ -6,7 +6,7 @@ const ExtendClass = Ember.Object.extend({
 });
 
 class ES6Class extends Ember.Object {
-    bar: string;
+    bar!: string;
 }
 
 const testObject: any = null;

--- a/types/ember/v3/test/detect.ts
+++ b/types/ember/v3/test/detect.ts
@@ -6,7 +6,7 @@ const ExtendClass = Ember.Object.extend({
 });
 
 class ES6Class extends Ember.Object {
-    bar: string;
+    bar!: string;
 }
 
 const TestClass = Ember.Object;

--- a/types/ember/v3/test/extend.ts
+++ b/types/ember/v3/test/extend.ts
@@ -23,8 +23,8 @@ assertType<string>(person.getFullName());
 assertType<number>(person.extra);
 
 class ES6Person extends Ember.Object {
-    firstName: string;
-    lastName: string;
+    firstName!: string;
+    lastName!: string;
 
     get fullName() {
         return `${this.firstName} ${this.lastName}`;

--- a/types/ember/v3/test/helper.ts
+++ b/types/ember/v3/test/helper.ts
@@ -7,11 +7,11 @@ const FormatCurrencyHelper = Ember.Helper.helper((params: [number], hash: { curr
 });
 
 class User extends Ember.Object {
-    email: string;
+    email!: string;
 }
 
 class SessionService extends Ember.Service {
-    currentUser: User;
+    currentUser!: User;
 }
 
 declare module "@ember/service" {

--- a/types/ember/v3/test/inject.ts
+++ b/types/ember/v3/test/inject.ts
@@ -1,12 +1,12 @@
 import Ember from "ember";
 
 class AuthService extends Ember.Service {
-    isAuthenticated: boolean;
+    isAuthenticated!: boolean;
 }
 
 class ApplicationController extends Ember.Controller {
     model = {};
-    string: string;
+    string!: string;
     transitionToLogin() {}
 }
 

--- a/types/ember/v3/test/observable.ts
+++ b/types/ember/v3/test/observable.ts
@@ -5,7 +5,7 @@ class MyComponent extends Ember.Component {
     foo = "bar";
 
     init() {
-        this._super.apply(this, arguments);
+        this._super.apply(this, arguments as unknown as any[]);
         this.addObserver("foo", this, "fooDidChange");
         this.addObserver("foo", this, this.fooDidChange);
         Ember.addObserver(this, "foo", this, "fooDidChange");

--- a/types/ember/v3/test/techniques/properties-from-this.ts
+++ b/types/ember/v3/test/techniques/properties-from-this.ts
@@ -5,8 +5,8 @@
  */
 
 class BoxedProperty<Get, Set = Get> {
-    __getType: Get;
-    __setType: Set;
+    __getType!: Get;
+    __setType!: Set;
 }
 
 type UnboxGetProperty<T> = T extends BoxedProperty<infer V, any> ? V : T;

--- a/types/ember__array/v3/test/array-ext.ts
+++ b/types/ember__array/v3/test/array-ext.ts
@@ -7,7 +7,7 @@ declare global {
 }
 
 class Person extends EmberObject {
-    name: string;
+    name!: string;
 }
 
 const person = Person.create({ name: "Joe" });

--- a/types/ember__controller/v3/test/octane.ts
+++ b/types/ember__controller/v3/test/octane.ts
@@ -3,11 +3,11 @@ import Controller, { inject } from "@ember/controller";
 class FirstController extends Controller {
     foo = "bar";
     @inject
-    second: InstanceType<typeof SecondController>;
+    second!: InstanceType<typeof SecondController>;
     @inject()
-    otherSecond: InstanceType<typeof SecondController>;
+    otherSecond!: InstanceType<typeof SecondController>;
     @inject("second")
-    moreSecond: InstanceType<typeof SecondController>;
+    moreSecond!: InstanceType<typeof SecondController>;
 
     queryParams = [
         "category",

--- a/types/ember__object/v3/test/compat.ts
+++ b/types/ember__object/v3/test/compat.ts
@@ -2,8 +2,8 @@ import { dependentKeyCompat } from "@ember/object/compat";
 
 // Example (without irrelevant details) from https://api.emberjs.com/ember/3.18/functions/@ember%2Fobject%2Fcompat/dependentKeyCompat
 class Person {
-    firstName: string;
-    lastName: string;
+    firstName!: string;
+    lastName!: string;
 
     @dependentKeyCompat
     get fullName() {

--- a/types/ember__object/v3/test/create.ts
+++ b/types/ember__object/v3/test/create.ts
@@ -31,9 +31,9 @@ export class Person extends EmberObject {
     fullName = computed("firstName", "lastName", function() {
         return [this.firstName + this.lastName].join(" ");
     });
-    firstName: string;
-    lastName: string;
-    age: number;
+    firstName!: string;
+    lastName!: string;
+    age!: number;
 }
 const p = new Person();
 

--- a/types/ember__object/v3/test/detect-instance.ts
+++ b/types/ember__object/v3/test/detect-instance.ts
@@ -6,7 +6,7 @@ const ExtendClass = EmberObject.extend({
 });
 
 class ES6Class extends EmberObject {
-    bar: string;
+    bar!: string;
 }
 
 const testObject: any = null;

--- a/types/ember__object/v3/test/detect.ts
+++ b/types/ember__object/v3/test/detect.ts
@@ -6,7 +6,7 @@ const ExtendClass = EmberObject.extend({
 });
 
 class ES6Class extends EmberObject {
-    bar: string;
+    bar!: string;
 }
 
 const TestClass = EmberObject;

--- a/types/ember__object/v3/test/extend.ts
+++ b/types/ember__object/v3/test/extend.ts
@@ -23,8 +23,8 @@ assertType<string>(person.getFullName());
 assertType<number>(person.extra);
 
 class ES6Person extends EmberObject {
-    firstName: string;
-    lastName: string;
+    firstName!: string;
+    lastName!: string;
 
     get fullName() {
         return `${this.firstName} ${this.lastName}`;

--- a/types/ember__object/v3/test/observable.ts
+++ b/types/ember__object/v3/test/observable.ts
@@ -6,7 +6,7 @@ class MyComponent extends EmberObject {
     foo = "bar";
 
     init() {
-        this._super.apply(this, arguments);
+        this._super.apply(this, arguments as unknown as any[]);
         this.addObserver("foo", this, "fooDidChange");
         this.addObserver("foo", this, this.fooDidChange);
         addObserver(this, "foo", this, "fooDidChange");

--- a/types/ember__object/v3/test/octane.ts
+++ b/types/ember__object/v3/test/octane.ts
@@ -42,12 +42,12 @@ function customMacro(message: string) {
 
 // Native class syntax
 class Foo extends EmberObject {
-    firstName: string;
-    lastName: string;
+    firstName!: string;
+    lastName!: string;
 
     // @ts-expect-error
     @action
-    bar: string;
+    bar!: string;
 
     @computed("firstName", "lastName")
     get fullName() {
@@ -56,15 +56,15 @@ class Foo extends EmberObject {
 
     // @ts-expect-error
     @computed("firstName", "lastName")
-    badFullName: string;
+    badFullName!: string;
 
     @computed("fullName", function(this: Foo) {
         return this.fullName.toUpperCase();
     })
-    bigFullName: string;
+    bigFullName!: string;
 
     @customMacro("hi")
-    hiTwice: string[];
+    hiTwice!: string[];
 
     @action
     foo() {}
@@ -73,383 +73,383 @@ class Foo extends EmberObject {
 // Computed property macros
 
 class Bar extends EmberObject {
-    firstName: string;
-    last: string;
+    firstName!: string;
+    last!: string;
 
-    values: number[];
+    values!: number[];
 
     // @ts-expect-error
     @alias
-    aliasTest0: string;
+    aliasTest0!: string;
     // @ts-expect-error
     @alias()
-    aliasTest1: string;
+    aliasTest1!: string;
     @alias("firstName")
-    aliasTest2: string;
+    aliasTest2!: string;
 
     // @ts-expect-error
     @and
-    andTest0: boolean;
+    andTest0!: boolean;
     @and()
-    andTest1: boolean;
+    andTest1!: boolean;
     @and("firstName")
-    andTest2: boolean;
+    andTest2!: boolean;
     @and("firstName", "lastName")
-    andTest3: boolean;
+    andTest3!: boolean;
 
     // @ts-expect-error
     @bool
-    boolTest0: boolean;
+    boolTest0!: boolean;
     // @ts-expect-error
     @bool()
-    boolTest1: boolean;
+    boolTest1!: boolean;
     @bool("firstName")
-    boolTest2: boolean;
+    boolTest2!: boolean;
 
     // @ts-expect-error
     @collect
-    collectTest0: any;
+    collectTest0!: any;
     @collect()
-    collectTest1: any;
+    collectTest1!: any;
     @collect("firstName")
-    collectTest2: any;
+    collectTest2!: any;
 
     // @ts-expect-error
     @deprecatingAlias
-    deprecatingAliasTest0: string;
+    deprecatingAliasTest0!: string;
     // @ts-expect-error
     @deprecatingAlias()
-    deprecatingAliasTest1: string;
+    deprecatingAliasTest1!: string;
     @deprecatingAlias("firstName")
-    deprecatingAliasTest2: string;
+    deprecatingAliasTest2!: string;
 
     // @ts-expect-error
     @empty
-    emptyTest0: boolean;
+    emptyTest0!: boolean;
     // @ts-expect-error
     @empty()
-    emptyTest1: boolean;
+    emptyTest1!: boolean;
     @empty("firstName")
-    emptyTest2: boolean;
+    emptyTest2!: boolean;
 
     // @ts-expect-error
     @equal
-    equalTest0: boolean;
+    equalTest0!: boolean;
     // @ts-expect-error
     @equal()
-    equalTest1: boolean;
+    equalTest1!: boolean;
     // @ts-expect-error
     @equal("firstName")
-    equalTest2: boolean;
+    equalTest2!: boolean;
     @equal("firstName", "lastName")
-    equalTest3: boolean;
+    equalTest3!: boolean;
 
     // @ts-expect-error
     @filter
-    filterTest1: string[];
+    filterTest1!: string[];
     // @ts-expect-error
     @filter()
-    filterTest2: string[];
+    filterTest2!: string[];
     // @ts-expect-error
     @filter("firstName")
-    filterTest3: string[];
+    filterTest3!: string[];
     @filter("firstName", x => x)
-    filterTest4: string[];
+    filterTest4!: string[];
     // @ts-expect-error
     @filter("firstName", "secondName", x => x)
-    filterTest5: string[];
+    filterTest5!: string[];
     @filter("firstName", ["secondName"], x => x)
-    filterTest6: string[];
+    filterTest6!: string[];
 
     // @ts-expect-error
     @filterBy
-    filterByTest1: any[];
+    filterByTest1!: any[];
     // @ts-expect-error
     @filterBy()
-    filterByTest2: any[];
+    filterByTest2!: any[];
     // @ts-expect-error
     @filterBy("firstName")
-    filterByTest3: any[];
+    filterByTest3!: any[];
     @filterBy("firstName", "id")
-    filterByTest4: any[];
+    filterByTest4!: any[];
 
     // @ts-expect-error
     @gt
-    gtTest1: boolean;
+    gtTest1!: boolean;
     // @ts-expect-error
     @gt()
-    gtTest2: boolean;
+    gtTest2!: boolean;
     // @ts-expect-error
     @gt("firstName")
-    gtTest3: boolean;
+    gtTest3!: boolean;
     @gt("firstName", 3)
-    gtTest4: boolean;
+    gtTest4!: boolean;
 
     // @ts-expect-error
     @gte
-    gteTest1: boolean;
+    gteTest1!: boolean;
     // @ts-expect-error
     @gte()
-    gteTest2: boolean;
+    gteTest2!: boolean;
     // @ts-expect-error
     @gte("firstName")
-    gteTest3: boolean;
+    gteTest3!: boolean;
     @gte("firstName", 3)
-    gteTest4: boolean;
+    gteTest4!: boolean;
 
     // @ts-expect-error
     @intersect
-    intersectTest1: any;
+    intersectTest1!: any;
     @intersect()
-    intersectTest2: any;
+    intersectTest2!: any;
     @intersect("firstName")
-    intersectTest3: any;
+    intersectTest3!: any;
     @intersect("firstName", "lastName")
-    intersectTest4: any;
+    intersectTest4!: any;
 
     // @ts-expect-error
     @lt
-    ltTest1: boolean;
+    ltTest1!: boolean;
     // @ts-expect-error
     @lt()
-    ltTest2: boolean;
+    ltTest2!: boolean;
     // @ts-expect-error
     @lt("firstName")
-    ltTest3: boolean;
+    ltTest3!: boolean;
     @lt("firstName", 3)
-    ltTest4: boolean;
+    ltTest4!: boolean;
 
     // @ts-expect-error
     @lte
-    lteTest1: boolean;
+    lteTest1!: boolean;
     // @ts-expect-error
     @lte()
-    lteTest2: boolean;
+    lteTest2!: boolean;
     // @ts-expect-error
     @lte("firstName")
-    lteTest3: boolean;
+    lteTest3!: boolean;
     @lte("firstName", 3)
-    lteTest4: boolean;
+    lteTest4!: boolean;
 
     // @ts-expect-error
     @map
-    mapTest1: string[];
+    mapTest1!: string[];
     // @ts-expect-error
     @map()
-    mapTest2: string[];
+    mapTest2!: string[];
     // @ts-expect-error
     @map("firstName")
-    mapTest3: string[];
+    mapTest3!: string[];
     @map("firstName", x => x)
-    mapTest4: string[];
+    mapTest4!: string[];
 
     // @ts-expect-error
     @mapBy
-    mapByTest1: any[];
+    mapByTest1!: any[];
     // @ts-expect-error
     @mapBy()
-    mapByTest2: any[];
+    mapByTest2!: any[];
     // @ts-expect-error
     @mapBy("firstName")
-    mapByTest3: any[];
+    mapByTest3!: any[];
     @mapBy("firstName", "id")
-    mapByTest4: any[];
+    mapByTest4!: any[];
 
     // @ts-expect-error
     @match
-    matchTest1: boolean;
+    matchTest1!: boolean;
     // @ts-expect-error
     @match()
-    matchTest2: boolean;
+    matchTest2!: boolean;
     // @ts-expect-error
     @match("firstName")
-    matchTest3: boolean;
+    matchTest3!: boolean;
     // @ts-expect-error
     @match("firstName", "abc")
-    matchTest4: boolean;
+    matchTest4!: boolean;
     @match("firstName", /\s+/)
-    matchTest5: boolean;
+    matchTest5!: boolean;
 
     // @ts-expect-error
     @max
-    maxTest1: number;
+    maxTest1!: number;
     // @ts-expect-error
     @max()
-    maxTest2: number;
+    maxTest2!: number;
     @max("values")
-    maxTest3: number;
+    maxTest3!: number;
     // @ts-expect-error
     @max("values", "a")
-    maxTest4: number;
+    maxTest4!: number;
 
     // @ts-expect-error
     @min
-    minTest1: number;
+    minTest1!: number;
     // @ts-expect-error
     @min()
-    minTest2: number;
+    minTest2!: number;
     @min("values")
-    minTest3: number;
+    minTest3!: number;
     // @ts-expect-error
     @min("values", "a")
-    minTest4: number;
+    minTest4!: number;
 
     // @ts-expect-error
     @none
-    noneTest1: number;
+    noneTest1!: number;
     // @ts-expect-error
     @none()
-    noneTest2: number;
+    noneTest2!: number;
     @none("values")
-    noneTest3: number;
+    noneTest3!: number;
     // @ts-expect-error
     @none("values", "a")
-    noneTest4: number;
+    noneTest4!: number;
 
     // @ts-expect-error
     @not
-    notTest1: number;
+    notTest1!: number;
     // @ts-expect-error
     @not()
-    notTest2: number;
+    notTest2!: number;
     @not("values")
-    notTest3: number;
+    notTest3!: number;
     // @ts-expect-error
     @not("values", "a")
-    notTest4: number;
+    notTest4!: number;
 
     // @ts-expect-error
     @notEmpty
-    notEmptyTest1: boolean;
+    notEmptyTest1!: boolean;
     // @ts-expect-error
     @notEmpty()
-    notEmptyTest2: boolean;
+    notEmptyTest2!: boolean;
     @notEmpty("firstName")
-    notEmptyTest3: boolean;
+    notEmptyTest3!: boolean;
     // @ts-expect-error
     @notEmpty("firstName", "a")
-    notEmptyTest4: boolean;
+    notEmptyTest4!: boolean;
 
     // @ts-expect-error
     @oneWay
-    oneWayTest1: boolean;
+    oneWayTest1!: boolean;
     // @ts-expect-error
     @oneWay()
-    oneWayTest2: boolean;
+    oneWayTest2!: boolean;
     @oneWay("firstName")
-    oneWayTest3: boolean;
+    oneWayTest3!: boolean;
     // @ts-expect-error
     @oneWay("firstName", "b")
-    oneWayTest4: boolean;
+    oneWayTest4!: boolean;
 
     // @ts-expect-error
     @or
-    orTest1: boolean;
+    orTest1!: boolean;
     @or()
-    orTest2: boolean;
+    orTest2!: boolean;
     @or("firstName")
-    orTest3: boolean;
+    orTest3!: boolean;
     @or("firstName", "lastName")
-    orTest4: boolean;
+    orTest4!: boolean;
 
     // @ts-expect-error
     @readOnly
-    readOnlyTest1: boolean;
+    readOnlyTest1!: boolean;
     // @ts-expect-error
     @readOnly()
-    readOnlyTest2: boolean;
+    readOnlyTest2!: boolean;
     @readOnly("firstName")
-    readOnlyTest3: boolean;
+    readOnlyTest3!: boolean;
 
     // @ts-expect-error
     @reads
-    readsTest1: boolean;
+    readsTest1!: boolean;
     // @ts-expect-error
     @reads()
-    readsTest2: boolean;
+    readsTest2!: boolean;
     @reads("firstName")
-    readsTest3: boolean;
+    readsTest3!: boolean;
     // @ts-expect-error
     @reads("firstName", "a")
-    readsTest4: boolean;
+    readsTest4!: boolean;
 
     // @ts-expect-error
     @setDiff
-    setDiffTest1: number;
+    setDiffTest1!: number;
     // @ts-expect-error
     @setDiff()
-    setDiffTest2: number;
+    setDiffTest2!: number;
     // @ts-expect-error
     @setDiff("values")
-    setDiffTest3: number;
+    setDiffTest3!: number;
     @setDiff("values", "otherThing")
-    setDiffTest4: number;
+    setDiffTest4!: number;
     // @ts-expect-error
     @setDiff("values", "otherThing", "a")
-    setDiffTest5: number;
+    setDiffTest5!: number;
 
     // @ts-expect-error
     @sort
-    sortTest1: number;
+    sortTest1!: number;
     // @ts-expect-error
     @sort()
-    sortTest2: number;
+    sortTest2!: number;
     // @ts-expect-error
     @sort("values")
-    sortTest3: number;
+    sortTest3!: number;
     @sort("values", "id")
-    sortTest4: number;
+    sortTest4!: number;
     // @ts-expect-error
     @sort("values", "id", "a")
-    sortTest5: number;
+    sortTest5!: number;
     @sort("values", (a, b) => a - b)
-    sortTest6: number;
+    sortTest6!: number;
     @sort("values", ["id"], (a, b) => a - b)
-    sortTest7: number;
+    sortTest7!: number;
     // @ts-expect-error
     @sort("values", "id", (a, b) => a - b)
-    sortTest8: number;
+    sortTest8!: number;
     // @ts-expect-error
     @sort(["id"], (a, b) => a - b)
-    sortTest9: number;
+    sortTest9!: number;
 
     // @ts-expect-error
     @sum
-    sumTest1: number;
+    sumTest1!: number;
     // @ts-expect-error
     @sum()
-    sumTest2: number;
+    sumTest2!: number;
     @sum("values")
-    sumTest3: number;
+    sumTest3!: number;
 
     // @ts-expect-error
     @union
-    unionTest1: any;
+    unionTest1!: any;
     @union()
-    unionTest2: any;
+    unionTest2!: any;
     @union("firstName")
-    unionTest3: any;
+    unionTest3!: any;
     @union("firstName", "lastName")
-    unionTest4: any;
+    unionTest4!: any;
 
     // @ts-expect-error
     @uniq
-    uniqTest1: number;
+    uniqTest1!: number;
     // @ts-expect-error
     @uniq()
-    uniqTest2: number;
+    uniqTest2!: number;
     @uniq("values")
-    uniqTest3: number;
+    uniqTest3!: number;
 
     // @ts-expect-error
     @uniqBy
-    uniqByTest1: number;
+    uniqByTest1!: number;
     // @ts-expect-error
     @uniqBy()
-    uniqByTest2: number;
+    uniqByTest2!: number;
     // @ts-expect-error
     @uniqBy("values")
-    uniqByTest3: number;
+    uniqByTest3!: number;
     @uniqBy("values", "id")
-    uniqByTest4: number;
+    uniqByTest4!: number;
 }

--- a/types/ember__service/v3/test/octane.ts
+++ b/types/ember__service/v3/test/octane.ts
@@ -23,9 +23,9 @@ declare module "@ember/service" {
 
 class Foo extends EmberObject {
     @inject
-    foo: FirstSvc;
+    foo!: FirstSvc;
     @inject("first")
-    baz: FirstSvc;
+    baz!: FirstSvc;
     @inject()
-    bar: FirstSvc;
+    bar!: FirstSvc;
 }

--- a/types/emscripten/emscripten-tests.ts
+++ b/types/emscripten/emscripten-tests.ts
@@ -24,8 +24,8 @@ function ModuleTest(): void {
     Module.onAbort = (what) => console.log("abort");
     Module.onRuntimeInitialized = () => console.log("init");
 
-    const package: ArrayBuffer = Module.getPreloadedPackage("package-name", 100);
-    const exports: WebAssembly.Exports | undefined = Module.instantiateWasm(
+    const pkg: ArrayBuffer = Module.getPreloadedPackage("package-name", 100);
+    const wasmExports: WebAssembly.Exports | undefined = Module.instantiateWasm(
         { a: { n: function __syscall_chmod() {} } },
         (module: WebAssembly.Instance) => {},
     );

--- a/types/es-get-iterator/es-get-iterator-tests.ts
+++ b/types/es-get-iterator/es-get-iterator-tests.ts
@@ -1,21 +1,21 @@
 import getIterator = require("es-get-iterator");
 
-// $ExpectType Iterator<string, any, undefined> || Iterator<string, any, unknown>
+// $ExpectType Iterator<string, any, undefined> || Iterator<string, any, unknown> || Iterator<string, undefined, unknown>
 getIterator("foo");
 
-// $ExpectType Iterator<never, any, undefined> || Iterator<never, any, unknown>
+// $ExpectType Iterator<never, any, undefined> || Iterator<never, any, unknown> || Iterator<never, undefined, unknown>
 getIterator([]);
 
-// $ExpectType Iterator<number, any, undefined> || Iterator<number, any, unknown>
+// $ExpectType Iterator<number, any, undefined> || Iterator<number, any, unknown> || Iterator<number, undefined, unknown>
 getIterator([0, 1, 2, 3, 4]);
 
-// $ExpectType Iterator<string | number | boolean | undefined, any, undefined> || Iterator<string | number | boolean | undefined, any, unknown>
+// $ExpectType Iterator<string | number | boolean | undefined, any, undefined> || Iterator<string | number | boolean | undefined, any, unknown> || Iterator<string | number | boolean | undefined, undefined, unknown>
 getIterator([undefined, true, "bar", 0]);
 
-// $ExpectType Iterator<[symbol, unknown], any, undefined> || Iterator<[symbol, unknown], any, unknown>
+// $ExpectType Iterator<[symbol, unknown], any, undefined> || Iterator<[symbol, unknown], any, unknown> || Iterator<[symbol, unknown], undefined, unknown>
 getIterator(new Map<symbol, unknown>());
 
-// $ExpectType Iterator<boolean, any, undefined> || Iterator<boolean, any, unknown>
+// $ExpectType Iterator<boolean, any, undefined> || Iterator<boolean, any, unknown> || Iterator<boolean, undefined, unknown>
 getIterator(new Set<boolean>());
 
 // $ExpectType Iterator<"foo" | "bar", void, unknown> || Iterator<"foo" | "bar", void, any>
@@ -32,15 +32,15 @@ getIterator((function*() {
 })());
 
 declare const ARGUMENTS: IArguments;
-// $ExpectType Iterator<any, any, undefined> || Iterator<any, any, unknown>
+// $ExpectType Iterator<any, any, undefined> || Iterator<any, any, unknown> || Iterator<any, undefined, unknown>
 getIterator(ARGUMENTS);
 
 declare const ITERABLE_UNION: number[] | Set<Date>;
-// $ExpectType Iterator<number, any, undefined> | Iterator<Date, any, undefined> || Iterator<number, any, unknown> | Iterator<Date, any, unknown>
+// $ExpectType Iterator<number, any, undefined> | Iterator<Date, any, undefined> || Iterator<number, any, unknown> | Iterator<Date, any, unknown> || Iterator<number, undefined, unknown> | Iterator<Date, undefined, unknown>
 getIterator(ITERABLE_UNION);
 
 declare const ITERABLE_OR_OTHERS_UNION: Map<Error, DataView> | ArrayBuffer;
-// $ExpectType Iterator<[Error, DataView], any, undefined> | undefined || Iterator<[Error, DataView], any, unknown> | undefined || Iterator<[Error, DataView<ArrayBuffer>], any, unknown> | undefined
+// $ExpectType Iterator<[Error, DataView], any, undefined> | undefined || Iterator<[Error, DataView], any, unknown> | undefined || Iterator<[Error, DataView<ArrayBuffer>], any, unknown> | undefined || Iterator<[Error, DataView<ArrayBuffer>], undefined, unknown> | undefined
 getIterator(ITERABLE_OR_OTHERS_UNION);
 
 declare const UNKNOWN: unknown;

--- a/types/event-kit/event-kit-tests.ts
+++ b/types/event-kit/event-kit-tests.ts
@@ -8,7 +8,7 @@ declare let emitter: Emitter;
 // NPM Usage Tests ============================================================
 class User {
     private readonly emitter: Emitter;
-    name: string;
+    name!: string;
 
     constructor() {
         this.emitter = new Emitter();

--- a/types/event-stream/event-stream-tests.ts
+++ b/types/event-stream/event-stream-tests.ts
@@ -2,10 +2,11 @@ import gulp = require("gulp");
 import * as es from "event-stream";
 
 gulp.task("es:concat", () => {
-    var streams = gulp.src(["*"])
-        .pipe(gulp.dest("build"));
+    const streams: es.MapStream[] = [
+        gulp.src(["*"]).pipe(gulp.dest("build")) as unknown as es.MapStream,
+    ];
 
-    return es.concat.apply(null, streams);
+    return es.concat(streams);
 });
 
 gulp.task("es:readArray ", () => {

--- a/types/expectations/expectations-tests.ts
+++ b/types/expectations/expectations-tests.ts
@@ -18,7 +18,7 @@ describe("expect", () => {
         it("can expect false not to be true", () => {
             try {
                 expect(false).toEqual(true);
-            } catch (err) {
+            } catch (err: any) {
                 if (err.message !== "expected false to equal true") {
                     throw new Error("Expected error message is not correct: " + err.message);
                 }
@@ -42,7 +42,7 @@ describe("expect", () => {
         it("Can expect undefined to equal an object correctly", () => {
             try {
                 expect(undefined).toEqual("Not undefined");
-            } catch (err) {
+            } catch (err: any) {
                 if (err.message !== "expected undefined to equal \"Not undefined\"") {
                     throw new Error("Expected error message is not correct: " + err.message);
                 }
@@ -57,7 +57,7 @@ describe("expect", () => {
         it("can expect true not to be true", () => {
             try {
                 expect(true).toNotEqual(true);
-            } catch (err) {
+            } catch (err: any) {
                 if (err.message !== "expected true not to equal true") {
                     throw new Error("Expected error message is not correct: " + err.message);
                 }
@@ -74,7 +74,7 @@ describe("expect", () => {
         it("does not expect an object to be a different", () => {
             try {
                 expect(obj1).toBe(obj2);
-            } catch (err) {
+            } catch (err: any) {
                 if (err.message !== "expected {\"abc\": 123} to equal {\"abc\": 123}") {
                     throw new Error("Expected error message is not correct: " + err.message);
                 }
@@ -89,7 +89,7 @@ describe("expect", () => {
         it("can expect string to not match", () => {
             try {
                 expect("abc").toMatch(/d/);
-            } catch (err) {
+            } catch (err: any) {
                 if (err.message !== "expected \"abc\" to match /d/") {
                     throw new Error("Expected error message is not correct: " + err.message);
                 }
@@ -104,7 +104,7 @@ describe("expect", () => {
         it("can expect toBeTruthy when falsey", () => {
             try {
                 expect("").toBeTruthy();
-            } catch (err) {
+            } catch (err: any) {
                 if (err.message !== "expected \"\" to be truthy") {
                     throw new Error("Expected error message is not correct: " + err.message);
                 }
@@ -119,7 +119,7 @@ describe("expect", () => {
         it("can expect array of numbers to contain number (failing)", () => {
             try {
                 expect([1, 2, 3, 4]).toContain(5);
-            } catch (err) {
+            } catch (err: any) {
                 if (err.message !== "expected [1, 2, 3, 4] to contain 5") {
                     throw new Error("Expected error message is not correct: " + err.message);
                 }
@@ -141,7 +141,7 @@ describe("expect", () => {
                     { a: 3 },
                     { a: 4 },
                 ]).toContain({ a: 5 });
-            } catch (err) {
+            } catch (err: any) {
                 if (err.message !== "expected [{\"a\": 1}, {\"a\": 2}, {\"a\": 3}, {\"a\": 4}] to contain {\"a\": 5}") {
                     throw new Error("Expected error message is not correct: " + err.message);
                 }
@@ -156,7 +156,7 @@ describe("expect", () => {
         it("can expect toBeFalsy when truthy", () => {
             try {
                 expect("abc").toBeFalsy();
-            } catch (err) {
+            } catch (err: any) {
                 if (err.message !== "expected \"abc\" to be falsey") {
                     throw new Error("Expected error message is not correct: " + err.message);
                 }
@@ -171,7 +171,7 @@ describe("expect", () => {
         it("can expect 0 toBeGreaterThan 1 throws", () => {
             try {
                 expect(0).toBeGreaterThan(1);
-            } catch (err) {
+            } catch (err: any) {
                 if (err.message !== "expected 0 to be greater than 1") {
                     throw new Error("Expected error message is not correct: " + err.message);
                 }
@@ -186,7 +186,7 @@ describe("expect", () => {
         it("can expect 1 toBeLessThan 0 throws", () => {
             try {
                 expect(1).toBeLessThan(0);
-            } catch (err) {
+            } catch (err: any) {
                 if (err.message !== "expected 1 to be less than 0") {
                     throw new Error("Expected error message is not correct: " + err.message);
                 }
@@ -201,7 +201,7 @@ describe("expect", () => {
         it("throws when expects undefined values toBeDefined", () => {
             try {
                 expect(undefined).toBeDefined();
-            } catch (err) {
+            } catch (err: any) {
                 if (err.message !== "expected undefined to be defined") {
                     throw new Error("Expected error message is not correct: " + err.message);
                 }
@@ -216,7 +216,7 @@ describe("expect", () => {
         it("throws when expects defined values toBeUndefined", () => {
             try {
                 expect({}).toBeUndefined();
-            } catch (err) {
+            } catch (err: any) {
                 if (err.message !== "expected {} to be undefined") {
                     throw new Error("Expected error message is not correct: " + err.message);
                 }
@@ -237,7 +237,7 @@ describe("expect", () => {
                 expect(() => {
                     // All OK
                 }).toThrow();
-            } catch (err) {
+            } catch (err: any) {
                 error = err;
             }
 
@@ -253,7 +253,7 @@ describe("expect", () => {
 
             try {
                 expect("bob").toThrow();
-            } catch (err) {
+            } catch (err: any) {
                 error = err;
             }
 
@@ -273,7 +273,7 @@ describe("expect", () => {
         it("throws when expects non-null values toBeNull", () => {
             try {
                 expect("abc").toBeDefined();
-            } catch (err) {
+            } catch (err: any) {
                 if (err.message !== "expected \"abc\" to be null") {
                     throw new Error("Expected error message is not correct: " + err.message);
                 }
@@ -291,7 +291,7 @@ describe("expect", () => {
         it("can generate correct message for objects", () => {
             try {
                 expect({}).not.toBeDefined();
-            } catch (err) {
+            } catch (err: any) {
                 if (err.message !== "expected {} not to be defined") {
                     throw new Error("Expected error message is not correct: " + err.message);
                 }
@@ -300,7 +300,7 @@ describe("expect", () => {
         it("can generate correct message for arrays", () => {
             try {
                 expect([]).not.toBeDefined();
-            } catch (err) {
+            } catch (err: any) {
                 if (err.message !== "expected [] not to be defined") {
                     throw new Error("Expected error message is not correct: " + err.message);
                 }
@@ -309,7 +309,7 @@ describe("expect", () => {
         it("can generate correct message for arrays of values", () => {
             try {
                 expect([1, { abc: "def" }]).not.toBeDefined();
-            } catch (err) {
+            } catch (err: any) {
                 if (err.message !== "expected [1, {\"abc\": \"def\"}] not to be defined") {
                     throw new Error("Expected error message is not correct: " + err.message);
                 }
@@ -318,7 +318,7 @@ describe("expect", () => {
         it("can generate correct message for nested arrays of values", () => {
             try {
                 expect([1, [2]]).not.toBeDefined();
-            } catch (err) {
+            } catch (err: any) {
                 if (err.message !== "expected [1, [2]] not to be defined") {
                     throw new Error("Expected error message is not correct: " + err.message);
                 }
@@ -333,7 +333,7 @@ describe("expect", () => {
             };
             try {
                 expect(new (<any> Obj)()).not.toBeDefined();
-            } catch (err) {
+            } catch (err: any) {
                 if (err.message !== "expected [testing] not to be defined") {
                     throw new Error("Expected error message is not correct: " + err.message);
                 }
@@ -342,7 +342,7 @@ describe("expect", () => {
         it("can generate correct message for Errors", () => {
             try {
                 expect(new Error("text")).not.toBeDefined();
-            } catch (err) {
+            } catch (err: any) {
                 if (err.message !== "expected [Error: text] not to be defined") {
                     throw new Error("Expected error message is not correct: " + err.message);
                 }
@@ -353,7 +353,7 @@ describe("expect", () => {
                 var obj: any = { abc: "def" };
                 obj.obj = obj;
                 expect(obj).not.toBeDefined();
-            } catch (err) {
+            } catch (err: any) {
                 if (
                     err.message
                         !== "expected {\"abc\": \"def\", \"obj\": {\"abc\": \"def\", \"obj\": [Circular]}} not to be defined"
@@ -376,7 +376,7 @@ describe("expect", () => {
             nested.e = obj;
             try {
                 expect(obj).not.toBeDefined();
-            } catch (err) {
+            } catch (err: any) {
                 if (
                     err.message
                         !== "expected {\"a\": {\"b\": {\"c\": {\"d\": {\"e\": [object Object]}}}}} not to be defined"
@@ -399,7 +399,7 @@ describe("expect", () => {
             nested.e = [obj];
             try {
                 expect(obj).not.toBeDefined();
-            } catch (err) {
+            } catch (err: any) {
                 if (
                     err.message
                         !== "expected {\"a\": {\"b\": {\"c\": {\"d\": {\"e\": [[object Object]]}}}}} not to be defined"
@@ -411,7 +411,7 @@ describe("expect", () => {
         it("can generate correct message for objects with undefined values", () => {
             try {
                 expect({ a: 1, b: undefined }).toEqual({ a: 1 });
-            } catch (err) {
+            } catch (err: any) {
                 if (err.message !== "expected {\"a\": 1, \"b\": undefined} to equal {\"a\": 1}") {
                     throw new Error("Expected error message is not correct: " + err.message);
                 }
@@ -421,7 +421,7 @@ describe("expect", () => {
             try {
                 expect(() => {
                 }).not.toBeDefined();
-            } catch (err) {
+            } catch (err: any) {
                 if (err.message !== "expected function (){} not to be defined") {
                     throw new Error("Expected error message is not correct: " + err.message);
                 }
@@ -431,7 +431,7 @@ describe("expect", () => {
             try {
                 expect(function name() {
                 }).not.toBeDefined();
-            } catch (err) {
+            } catch (err: any) {
                 if (err.message !== "expected function name(){} not to be defined") {
                     throw new Error("Expected error message is not correct: " + err.message);
                 }
@@ -440,7 +440,7 @@ describe("expect", () => {
         it("can generate correct message for Dates", () => {
             try {
                 expect(new Date(2012, 0, 1)).not.toBeDefined();
-            } catch (err) {
+            } catch (err: any) {
                 if (err.message !== "expected [Date Sun, 01 Jan 2012 00:00:00 GMT] not to be defined") {
                     throw new Error("Expected error message is not correct: " + err.message);
                 }
@@ -452,7 +452,7 @@ describe("expect", () => {
 
                 try {
                     expect(el).toBeUndefined();
-                } catch (err) {
+                } catch (err: any) {
                     if (err.message !== "expected <div /> to be undefined") {
                         throw new Error("Expected error message is not correct: " + err.message);
                     }

--- a/types/eyevinn-iaf/eyevinn-iaf-tests.ts
+++ b/types/eyevinn-iaf/eyevinn-iaf-tests.ts
@@ -2,17 +2,17 @@ import { IafFileWatchModule, IafUploadModule, Logger } from "eyevinn-iaf";
 import { Readable } from "stream";
 
 class FileUploader implements IafUploadModule {
-    logger: Logger;
-    playlistName: string;
-    progressDelegate: (result: any) => any;
-    fileUploadedDelegate: (result: any, error?: any) => any;
+    logger!: Logger;
+    playlistName!: string;
+    progressDelegate!: (result: any) => any;
+    fileUploadedDelegate!: (result: any, error?: any) => any;
 
     onFileAdd(filePath: string, readStream: Readable, contentType?: string): void {}
 }
 
 class FileWatcher implements IafFileWatchModule {
-    fileInput: string;
-    logger: Logger;
+    fileInput!: string;
+    logger!: Logger;
 
     onAdd(callback: (filePath: string, readStream: Readable, contentType?: string) => any): void {}
 }

--- a/types/fbemitter/fbemitter-tests.ts
+++ b/types/fbemitter/fbemitter-tests.ts
@@ -74,7 +74,7 @@ describe("EventEmitter", function tests() {
                         assert.deepStrictEqual(Array.prototype.slice.call(arguments), args);
                     });
 
-                    e.emit.apply(e, (["args"] as any[]).concat(args));
+                    e.emit.apply(e, ["args", ...args]);
                 })(i);
             }
         });
@@ -108,7 +108,7 @@ describe("EventEmitter", function tests() {
                         assert.deepStrictEqual(Array.prototype.slice.call(arguments), args);
                     });
 
-                    e.emit.apply(e, (["args"] as any[]).concat(args));
+                    e.emit.apply(e, ["args", ...args]);
                 })(i);
             }
         });

--- a/types/fibers/test/fibers.ts
+++ b/types/fibers/test/fibers.ts
@@ -62,7 +62,7 @@ const fiberErrorTest = () => {
         while (true) {
             fn.run();
         }
-    } catch (e) {
+    } catch (e: any) {
         console.log("safely caught that error!");
         console.log(e.stack);
     }

--- a/types/forge-viewer/forge-viewer-tests.ts
+++ b/types/forge-viewer/forge-viewer-tests.ts
@@ -755,7 +755,7 @@ async function dbIdRemappingTest(viewer: Autodesk.Viewing.GuiViewer3D): Promise<
     const _load = Autodesk.Viewing.Private.PropDbLoader.prototype.load;
     Autodesk.Viewing.Private.PropDbLoader.prototype.load = function() {
         this.needsDbIdRemap = true;
-        _load.call(this);
+        _load.apply(this, arguments as unknown as any[]);
     };
 
     // Override `PropDbLoader#processLoadResult` so that the dbid mapping is stored within all models (by default it is only stored in 2D models).

--- a/types/forge-viewer/forge-viewer-tests.ts
+++ b/types/forge-viewer/forge-viewer-tests.ts
@@ -753,9 +753,9 @@ async function cameraMappingTest(viewer: Autodesk.Viewing.GuiViewer3D): Promise<
 async function dbIdRemappingTest(viewer: Autodesk.Viewing.GuiViewer3D): Promise<void> {
     // Override `PropDbLoader#load` so that the svf1/svf2 dbid mapping is always loaded.
     const _load = Autodesk.Viewing.Private.PropDbLoader.prototype.load;
-    Autodesk.Viewing.Private.PropDbLoader.prototype.load = function() {
+    Autodesk.Viewing.Private.PropDbLoader.prototype.load = function(options) {
         this.needsDbIdRemap = true;
-        _load.apply(this, arguments as unknown as any[]);
+        _load.apply(this, options);
     };
 
     // Override `PropDbLoader#processLoadResult` so that the dbid mapping is stored within all models (by default it is only stored in 2D models).

--- a/types/forge-viewer/tsconfig.json
+++ b/types/forge-viewer/tsconfig.json
@@ -6,10 +6,7 @@
             "dom",
             "ES2020.String"
         ],
-        "noImplicitAny": true,
-        "noImplicitThis": true,
-        "strictNullChecks": true,
-        "strictFunctionTypes": true,
+        "strict": true,
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true

--- a/types/gapi.calendar/gapi.calendar-tests.ts
+++ b/types/gapi.calendar/gapi.calendar-tests.ts
@@ -13,7 +13,6 @@ function appendPre(message: string) {
 
     var SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"];
 
-
     /**
      * Check if current user has authorized this application.
      */
@@ -100,7 +99,6 @@ function appendPre(message: string) {
             }
         });
     }
-
 }
 
 /* Example taken from https://developers.google.com/google-apps/calendar/v3/reference/events/insert#examples */

--- a/types/gapi.calendar/gapi.calendar-tests.ts
+++ b/types/gapi.calendar/gapi.calendar-tests.ts
@@ -1,11 +1,18 @@
 /* Example taken from Google Calendar API JavaScript Quickstart https://developers.google.com/google-apps/calendar/quickstart/js */
 
+function appendPre(message: string) {
+    var pre = document.getElementById("output")!;
+    var textContent = document.createTextNode(message + "\n");
+    pre.appendChild(textContent);
+}
+
 {
     // Your Client ID can be retrieved from your project in the Google
     // Developer Console, https://console.developers.google.com
     var CLIENT_ID = "<YOUR_CLIENT_ID>";
 
     var SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"];
+
 
     /**
      * Check if current user has authorized this application.
@@ -94,17 +101,6 @@
         });
     }
 
-    /**
-     * Append a pre element to the body containing the given message
-     * as its text node.
-     *
-     * @param {string} message Text to be placed in pre element.
-     */
-    function appendPre(message: string) {
-        var pre = document.getElementById("output")!;
-        var textContent = document.createTextNode(message + "\n");
-        pre.appendChild(textContent);
-    }
 }
 
 /* Example taken from https://developers.google.com/google-apps/calendar/v3/reference/events/insert#examples */

--- a/types/google-apps-script/test/google-apps-script-tests.ts
+++ b/types/google-apps-script/test/google-apps-script-tests.ts
@@ -915,7 +915,7 @@ const handleCommonAction = (e: GoogleAppsScript.Addons.EventObject) => {
         props.setProperties(parameters);
 
         console.log(`Processed on ${formattedDate} at ${formattedTime} | ${userLocale}`);
-    } catch ({ name, message }) {
+    } catch ({ name, message }: any) {
         const type = plaformMap[platform];
         console.warn(`Platform: ${type}
         Type: ${name}

--- a/types/gun/gun-tests.ts
+++ b/types/gun/gun-tests.ts
@@ -68,7 +68,7 @@ app.get("chatRoom").time!(msg => {
 app.get("object").time!({ a: 1 });
 
 class X {
-    val: string;
+    val!: string;
     b() {}
 }
 interface BadState {

--- a/types/hapi-decorators/hapi-decorators-tests.ts
+++ b/types/hapi-decorators/hapi-decorators-tests.ts
@@ -3,8 +3,8 @@ import { cache, config, Controller, controller, get, post, put, route, validate 
 
 @controller("/test")
 class TestController implements Controller {
-    baseUrl: string;
-    routes: () => hapi.RouteConfiguration[];
+    baseUrl!: string;
+    routes!: () => hapi.RouteConfiguration[];
 
     @get("/")
     @config({
@@ -48,8 +48,8 @@ class SimpleTestController implements Controller {
         this.foo = foo;
     }
 
-    baseUrl: string;
-    routes: () => hapi.RouteConfiguration[];
+    baseUrl!: string;
+    routes!: () => hapi.RouteConfiguration[];
 }
 
 server.route(new SimpleTestController("bar").routes());

--- a/types/image-to-base64/image-to-base64-tests.ts
+++ b/types/image-to-base64/image-to-base64-tests.ts
@@ -18,7 +18,7 @@ imageToBase64("https://whatever-image/") // Image URL
 (async () => {
     try {
         await imageToBase64("path/to/file.jpg"); // $ExpectType string
-    } catch (error) {
+    } catch (error: any) {
         error; // $ExpectType any
     }
 })();

--- a/types/intro.js/intro.js-tests.ts
+++ b/types/intro.js/intro.js-tests.ts
@@ -128,7 +128,7 @@ introWithQuerySelector
 
 // test: intro.js should expose instance type #41108
 class SomeClass {
-    introJsInstance: introJs.IntroJs;
+    introJsInstance!: introJs.IntroJs;
 
     someMethod() {
         this.introJsInstance = introJs();

--- a/types/is/is-tests.ts
+++ b/types/is/is-tests.ts
@@ -3,12 +3,12 @@
 var getArguments = function() {
     return arguments;
 };
-var arguments = getArguments();
-is.arguments(arguments);
+var args = getArguments();
+is.arguments(args);
 is.not.arguments({ foo: "bar" });
-is.all.arguments(arguments, "bar");
-is.any.arguments(["foo"], arguments);
-is.all.arguments([arguments, "foo", "bar"]);
+is.all.arguments(args, "bar");
+is.any.arguments(["foo"], args);
+is.all.arguments([args, "foo", "bar"]);
 
 is.array(["foo", "bar", "baz"]);
 is.not.array({ foo: "bar" });

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -1132,14 +1132,14 @@ describe("Spy for generic method", () => {
 
 describe("Multiple spies, when created manually", () => {
     class Tape {
-        private rewindTo: number;
+        private rewindTo!: number;
         play(): void {}
         pause(): void {}
         rewind(pos: number): void {
             this.rewindTo = pos;
         }
         stop(): void {}
-        readonly isPlaying: boolean; // spy obj makes this writable
+        readonly isPlaying!: boolean; // spy obj makes this writable
     }
 
     var tape: Tape;

--- a/types/jasmine/v2/jasmine-tests.ts
+++ b/types/jasmine/v2/jasmine-tests.ts
@@ -652,14 +652,14 @@ describe("A spy, when created manually", () => {
 
 describe("Multiple spies, when created manually", () => {
     abstract class Tape {
-        private rewindTo: number;
+        private rewindTo!: number;
         play(): void {}
         pause(): void {}
         rewind(pos: number): void {
             this.rewindTo = pos;
         }
         stop(): void {}
-        readonly isPlaying: boolean; // spy obj makes this writable
+        readonly isPlaying!: boolean; // spy obj makes this writable
     }
 
     var tape: Tape;

--- a/types/jasmine/v3/jasmine-tests.ts
+++ b/types/jasmine/v3/jasmine-tests.ts
@@ -1128,14 +1128,14 @@ describe("Spy for generic method", () => {
 
 describe("Multiple spies, when created manually", () => {
     class Tape {
-        private rewindTo: number;
+        private rewindTo!: number;
         play(): void {}
         pause(): void {}
         rewind(pos: number): void {
             this.rewindTo = pos;
         }
         stop(): void {}
-        readonly isPlaying: boolean; // spy obj makes this writable
+        readonly isPlaying!: boolean; // spy obj makes this writable
     }
 
     var tape: Tape;

--- a/types/jasmine/v4/jasmine-tests.ts
+++ b/types/jasmine/v4/jasmine-tests.ts
@@ -1126,14 +1126,14 @@ describe("Spy for generic method", () => {
 
 describe("Multiple spies, when created manually", () => {
     class Tape {
-        private rewindTo: number;
+        private rewindTo!: number;
         play(): void {}
         pause(): void {}
         rewind(pos: number): void {
             this.rewindTo = pos;
         }
         stop(): void {}
-        readonly isPlaying: boolean; // spy obj makes this writable
+        readonly isPlaying!: boolean; // spy obj makes this writable
     }
 
     var tape: Tape;

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -782,7 +782,7 @@ interface Type2 {
     b: number;
 }
 class TestMocked {
-    field: string;
+    field!: string;
     test1(x: Type1): Promise<Type1> {
         return Promise.resolve(x);
     }

--- a/types/jexl/jexl-tests.ts
+++ b/types/jexl/jexl-tests.ts
@@ -108,7 +108,7 @@ jexl.eval("\"Guest\" _= \"gUeSt\"");
     try {
         const asyncTransform = await jexl.eval("name.last|getStat(\"weight\")", context);
         console.log("9. Async Transform", asyncTransform); // Output: 184
-    } catch (e) {
+    } catch (e: any) {
         console.log("Database Error", e.stack);
     }
 
@@ -128,7 +128,7 @@ jexl.eval("\"Guest\" _= \"gUeSt\"");
     try {
         const asyncFunc = await jexl.eval("age > calculateAge(20, 21)");
         console.log("12. Async Function", asyncFunc); // false
-    } catch (e) {
+    } catch (e: any) {
         console.log("Calculation Error", e.stack);
     }
 })().then(() => console.log("Testing done"));

--- a/types/jfp/jfp-tests.ts
+++ b/types/jfp/jfp-tests.ts
@@ -9,7 +9,7 @@ j.always(true)();
 j.and(true, false) === false;
 j.apply(testFn, [1, 2, 3]);
 j.between([3, 7], 5) === true;
-j.call(testFn, null, 1, 2, 3);
+j.call(testFn, null as any, 1, 2, 3);
 j.clone({});
 j.compact([]);
 j.compose(testFn, testFn)();

--- a/types/jfp/jfp-tests.ts
+++ b/types/jfp/jfp-tests.ts
@@ -9,7 +9,7 @@ j.always(true)();
 j.and(true, false) === false;
 j.apply(testFn, [1, 2, 3]);
 j.between([3, 7], 5) === true;
-j.call(testFn, 1, 2, 3);
+j.call(testFn, null, 1, 2, 3);
 j.clone({});
 j.compact([]);
 j.compose(testFn, testFn)();

--- a/types/jfp/tsconfig.json
+++ b/types/jfp/tsconfig.json
@@ -4,10 +4,7 @@
         "lib": [
             "es6"
         ],
-        "noImplicitAny": true,
-        "noImplicitThis": true,
-        "strictNullChecks": true,
-        "strictFunctionTypes": true,
+        "strict": true,
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true

--- a/types/jquery-mask-plugin/jquery-mask-plugin-tests.ts
+++ b/types/jquery-mask-plugin/jquery-mask-plugin-tests.ts
@@ -96,7 +96,7 @@ let maskBehavior: (value: string) => string = val => {
 
 options = {
     onKeyPress(val: string, e: Event, field: JQuery, options: jQueryMask.Options) {
-        field.mask(maskBehavior.apply({}, arguments), options);
+        field.mask(maskBehavior(val), options);
     },
 };
 

--- a/types/jquery.bbq/jquery.bbq-tests.ts
+++ b/types/jquery.bbq/jquery.bbq-tests.ts
@@ -228,7 +228,10 @@ $(function() { // START CLOSURE
         run_many_tests(
             // execute this for each array item
             function() {
-                current_url = $.param.querystring.apply(this, [current_url].concat(aps.call(arguments)));
+                current_url = $.param.querystring.apply(
+                    this,
+                    [current_url].concat(aps.call(arguments)) as [string?, any?, number?],
+                );
             },
             // tests:
 
@@ -399,7 +402,10 @@ $(function() { // START CLOSURE
         run_many_tests(
             // execute this for each array item
             function() {
-                current_url = $.param.fragment.apply(this, [current_url].concat(aps.call(arguments)));
+                current_url = $.param.fragment.apply(
+                    this,
+                    [current_url].concat(aps.call(arguments)) as [string, any, number?],
+                );
             },
             // tests:
 
@@ -1228,7 +1234,7 @@ $(function() { // START CLOSURE
             // execute this for each array item
             function() {
                 notice(msg += ".");
-                $.bbq.pushState.apply(this, aps.call(arguments));
+                $.bbq.pushState.apply(this, aps.call(arguments) as [any?, number?]);
             },
             // execute this at the end
             function() {

--- a/types/jquery.cookie/jquery.cookie-tests.ts
+++ b/types/jquery.cookie/jquery.cookie-tests.ts
@@ -9,10 +9,10 @@ class TestObject {
 }
 
 class CookieOptions implements JQueryCookieOptions {
-    expires: number;
-    path: string;
-    domain: string;
-    secure: boolean;
+    expires!: number;
+    path!: string;
+    domain!: string;
+    secure!: boolean;
 }
 
 $.cookie("the_cookie", "the_value");

--- a/types/jquery.leanmodal/jquery.leanmodal-tests.ts
+++ b/types/jquery.leanmodal/jquery.leanmodal-tests.ts
@@ -1,7 +1,7 @@
 class LeanModalOptions implements JQueryLeanModalOption {
-    top: number;
-    overlay: number;
-    closeButton: string;
+    top!: number;
+    overlay!: number;
+    closeButton!: string;
 }
 
 $.leanModal();

--- a/types/jquery/test/learn-tests.ts
+++ b/types/jquery/test/learn-tests.ts
@@ -42,7 +42,10 @@ function special() {
 
                 if (targetData.clicks % event.data.clicks === 0) {
                     event.type = handleObj.origType;
-                    ret = handleObj.handler.apply(this, arguments);
+                    ret = handleObj.handler.apply(
+                        this,
+                        arguments as unknown as [JQuery.TriggeredEvent, ...any[]],
+                    );
                     event.type = handleObj.type;
                     return ret;
                 }

--- a/types/jsforce/jsforce-tests.ts
+++ b/types/jsforce/jsforce-tests.ts
@@ -19,7 +19,7 @@ const salesforceConnection: sf.Connection = new sf.Connection({
             if (callback) {
                 callback(null, conn.accessToken, userInfo);
             }
-        } catch (err) {
+        } catch (err: any) {
             if (callback) {
                 callback(err, conn.accessToken);
             }

--- a/types/karma/karma-tests.ts
+++ b/types/karma/karma-tests.ts
@@ -201,7 +201,7 @@ CustomPlugin.prototype = {
     log: () => {},
 };
 class CustomPluginClass {
-    log: () => {};
+    log!: () => void;
 }
 
 const pluginsTests = (config: Config) => {

--- a/types/knockout/test/index.ts
+++ b/types/knockout/test/index.ts
@@ -93,7 +93,7 @@ class GetterViewModel {
         this._selectedRange = ko.observable();
     }
 
-    public range: KnockoutObservable<any>;
+    public range!: KnockoutObservable<any>;
 }
 
 function testToJs() {
@@ -529,7 +529,10 @@ function test_misc() {
                 read: function() {
                     ko.utils.unwrapObservable(valueAccessor());
                     if (ko.bindingHandlers.options.update) {
-                        ko.bindingHandlers.options.update.apply(this, args);
+                        ko.bindingHandlers.options.update.apply(
+                            this,
+                            args as unknown as [any, () => any, KnockoutAllBindingsAccessor, any, KnockoutBindingContext],
+                        );
                     }
                 },
                 owner: this,

--- a/types/knockout/test/index.ts
+++ b/types/knockout/test/index.ts
@@ -531,7 +531,13 @@ function test_misc() {
                     if (ko.bindingHandlers.options.update) {
                         ko.bindingHandlers.options.update.apply(
                             this,
-                            args as unknown as [any, () => any, KnockoutAllBindingsAccessor, any, KnockoutBindingContext],
+                            args as unknown as [
+                                any,
+                                () => any,
+                                KnockoutAllBindingsAccessor,
+                                any,
+                                KnockoutBindingContext,
+                            ],
                         );
                     }
                 },

--- a/types/knockout/test/templatingBehaviors.ts
+++ b/types/knockout/test/templatingBehaviors.ts
@@ -82,7 +82,7 @@ var dummyTemplateEngine = function(templates?) {
                         try {
                             var evalResult = eval(script);
                             return (evalResult === null) || (evalResult === undefined) ? "" : evalResult.toString();
-                        } catch (ex) {
+                        } catch (ex: any) {
                             throw new Error(
                                 "Error evaluating script: [js: " + script + "]\n\nException: " + ex.toString(),
                             );
@@ -107,7 +107,7 @@ var dummyTemplateEngine = function(templates?) {
         // Only rewrite if the template isn't a function (can't rewrite those)
         var templateSource = new ko.templateSources.anonymousTemplate(template); // this.makeTemplateSource(template);
         if (typeof templateSource.text() != "function") {
-            return ko.templateEngine.prototype.rewriteTemplate.call(this, template, rewriterCallback);
+            return ko.templateEngine.prototype.rewriteTemplate.call(this, template, rewriterCallback, document);
         }
     };
     this.createJavaScriptEvaluatorBlock = function(script) {
@@ -135,7 +135,7 @@ describe("Templating", function() {
         ko.setTemplateEngine(undefined);
         try {
             ko.renderTemplate("someTemplate", {});
-        } catch (ex) {
+        } catch (ex: any) {
             threw = true;
         }
         expect(threw).toEqual(true);
@@ -971,7 +971,7 @@ describe("Templating", function() {
         var didThrow = false;
         try {
             ko.applyBindings({ someData: { childProp: "abc" } }, testNode);
-        } catch (ex) {
+        } catch (ex: any) {
             didThrow = true;
             expect(ex.message).toEqual(
                 "This template engine does not support anonymous templates nested within its templates",
@@ -994,7 +994,7 @@ describe("Templating", function() {
             ko.utils.domData.clear(testNode);
             try {
                 ko.applyBindings({ someData: { childProp: "abc" } }, testNode);
-            } catch (ex) {
+            } catch (ex: any) {
                 didThrow = true;
                 expect(ex.message).toEqual(
                     "This template engine does not support the '" + bindingName + "' binding within its templates",

--- a/types/koa/test/index.ts
+++ b/types/koa/test/index.ts
@@ -35,7 +35,7 @@ app.use(async ctx => {
 app.use(async (ctx, next) => {
     try {
         return await next();
-    } catch (ex) {
+    } catch (ex: any) {
         ctx.errors = [ex];
     }
 });

--- a/types/libpq/libpq-tests.ts
+++ b/types/libpq/libpq-tests.ts
@@ -643,7 +643,7 @@ describe("connecting with bad credentials", () => {
     it("throws an error", () => {
         try {
             new PQ().connectSync("asldkfjlasdf");
-        } catch (e) {
+        } catch (e: any) {
             assert.equal(e.toString().indexOf("connection pointer is NULL"), -1);
             return;
         }

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -4419,7 +4419,7 @@ fp.now(); // $ExpectType number
 
     {
         class CustomError extends Error {
-            custom: string;
+            custom!: string;
         }
 
         const value: number | CustomError = anything;

--- a/types/lokijs/lokijs-tests.ts
+++ b/types/lokijs/lokijs-tests.ts
@@ -14,10 +14,10 @@ class Ant {
     static uniqueId = 1;
 
     id: number;
-    dob: Date;
-    health: number; // range [0.0, 1.0]
-    lengthMm: number; // in millimeters
-    weightMg: number; // in milligrams
+    dob!: Date;
+    health!: number; // range [0.0, 1.0]
+    lengthMm!: number; // in millimeters
+    weightMg!: number; // in milligrams
 
     constructor(id: number) {
         this.id = id;
@@ -29,7 +29,7 @@ class Ant {
 }
 
 class QueenAnt extends Ant {
-    eggsBirthed: number;
+    eggsBirthed!: number;
 
     constructor(id: number) {
         super(id);

--- a/types/loopback/loopback-tests.ts
+++ b/types/loopback/loopback-tests.ts
@@ -2,8 +2,8 @@ import loopback = require("loopback");
 import cookieParser = require("cookie-parser");
 
 class TestModel {
-    id: number;
-    name: string;
+    id!: number;
+    name!: string;
 }
 
 class Server {

--- a/types/ltx/ltx-tests.ts
+++ b/types/ltx/ltx-tests.ts
@@ -163,7 +163,7 @@ el.tree(); // $ExpectType Element
 el.up(); // $ExpectType Element
 
 class MyEl extends ltx.Element {
-    foo: "bar";
+    foo!: "bar";
 }
 const myEl = new MyEl("el");
 

--- a/types/mdns/mdns-tests.ts
+++ b/types/mdns/mdns-tests.ts
@@ -64,8 +64,8 @@ function createAdvertisement() {
         ad = mdns.createAdvertisement(mdns.tcp("http"), 1337);
         ad.on("error", handleError);
         ad.start();
-    } catch (ex) {
-        handleError(ex);
+    } catch (ex: any) {
+        handleError(ex as mdns.DnsSdError);
     }
 }
 

--- a/types/microsoft-ajax/microsoft-ajax-tests.ts
+++ b/types/microsoft-ajax/microsoft-ajax-tests.ts
@@ -91,9 +91,9 @@ function BaseClassExtensions_Function_Tests() {
 
     /** Sample code from http://msdn.microsoft.com/en-us/library/dd393712(v=vs.100).aspx */
     var validateParametersTest = function() {
-        var arguments = ["test1", "test2"];
+        var args = ["test1", "test2"];
         var insert = function Array$insert(array: any[], index: number, item: any) {
-            var e = Function.validateParameters(arguments, [
+            var e = Function.validateParameters(args, [
                 { name: "array", type: Array, elementMayBeNull: true },
                 { name: "index", mayBeNull: true },
                 { name: "item", mayBeNull: true },

--- a/types/new-relic-browser/new-relic-browser-tests.ts
+++ b/types/new-relic-browser/new-relic-browser-tests.ts
@@ -29,7 +29,7 @@ newrelic.finished();
 // noticeError()
 try {
     JSON.parse("{ \"bar\"");
-} catch (err) {
+} catch (err: any) {
     newrelic.noticeError(err);
 }
 newrelic.noticeError(new Error("bar"));

--- a/types/node-fibers/node-fibers-tests.ts
+++ b/types/node-fibers/node-fibers-tests.ts
@@ -68,7 +68,7 @@ try {
     while (true) {
         fn.run();
     }
-} catch (e) {
+} catch (e: any) {
     console.log("safely caught that error!");
     console.log(e.stack);
 }

--- a/types/node-mysql-wrapper/node-mysql-wrapper-tests.ts
+++ b/types/node-mysql-wrapper/node-mysql-wrapper-tests.ts
@@ -5,13 +5,13 @@ import wrapper2 = require("node-mysql-wrapper");
 var db = wrapper2.wrap("mysql://kataras:pass@127.0.0.1/taglub?debug=false&charset=utf8");
 
 class User { // or interface
-    userId: number;
-    username: string;
-    mail: string;
-    password: string;
-    comments: Comment[];
-    myComments: Comment[];
-    info: UserInfo;
+    userId!: number;
+    username!: string;
+    mail!: string;
+    password!: string;
+    comments!: Comment[];
+    myComments!: Comment[];
+    info!: UserInfo;
 }
 
 interface Comment {

--- a/types/node/node-tests/http.ts
+++ b/types/node/node-tests/http.ts
@@ -12,13 +12,13 @@ import * as url from "node:url";
     let server: http.Server = new http.Server();
 
     class MyIncomingMessage extends http.IncomingMessage {
-        foo: number;
+        foo!: number;
     }
 
     class MyServerResponse<Request extends http.IncomingMessage = http.IncomingMessage>
         extends http.ServerResponse<Request>
     {
-        foo: string;
+        foo!: string;
     }
 
     server = new http.Server({ IncomingMessage: MyIncomingMessage });
@@ -77,13 +77,13 @@ import * as url from "node:url";
     let bar: "bar";
 
     class MyIncomingMessage extends http.IncomingMessage {
-        foo: typeof foo;
+        foo!: typeof foo;
     }
 
     class MyServerResponse<
         Request extends MyIncomingMessage = MyIncomingMessage,
     > extends http.ServerResponse<Request> {
-        bar: typeof bar;
+        bar!: typeof bar;
 
         getFoo() {
             return this.req.foo;

--- a/types/node/node-tests/http2.ts
+++ b/types/node/node-tests/http2.ts
@@ -439,13 +439,13 @@ import { URL } from "node:url";
 // Http2ServerRequest, Http2ServerResponse,
 {
     class MyHttp2ServerRequest extends Http2ServerRequest {
-        foo: number;
+        foo!: number;
     }
 
     class MyHttp2ServerResponse<Request extends Http2ServerRequest = Http2ServerRequest>
         extends Http2ServerResponse<Request>
     {
-        bar: string;
+        bar!: string;
     }
 
     function reqListener(req: Http2ServerRequest, res: Http2ServerResponse): void {}

--- a/types/node/node-tests/https.ts
+++ b/types/node/node-tests/https.ts
@@ -77,13 +77,13 @@ import * as url from "node:url";
         function reqListener(req: http.IncomingMessage, res: http.ServerResponse): void {}
 
         class MyIncomingMessage extends http.IncomingMessage {
-            foo: number;
+            foo!: number;
         }
 
         class MyServerResponse<Request extends http.IncomingMessage = http.IncomingMessage>
             extends http.ServerResponse<Request>
         {
-            foo: string;
+            foo!: string;
         }
 
         let server: https.Server;
@@ -127,13 +127,13 @@ import * as url from "node:url";
     let bar: "bar";
 
     class MyIncomingMessage extends http.IncomingMessage {
-        foo: typeof foo;
+        foo!: typeof foo;
     }
 
     class MyServerResponse<
         Request extends http.IncomingMessage = http.IncomingMessage,
     > extends http.ServerResponse<Request> {
-        bar: typeof bar;
+        bar!: typeof bar;
     }
 
     function reqListener(req: MyIncomingMessage, res: MyServerResponse): void {}

--- a/types/node/v20/test/http.ts
+++ b/types/node/v20/test/http.ts
@@ -11,13 +11,13 @@ import * as url from "node:url";
     let server: http.Server = new http.Server();
 
     class MyIncomingMessage extends http.IncomingMessage {
-        foo: number;
+        foo!: number;
     }
 
     class MyServerResponse<Request extends http.IncomingMessage = http.IncomingMessage>
         extends http.ServerResponse<Request>
     {
-        foo: string;
+        foo!: string;
     }
 
     server = new http.Server({ IncomingMessage: MyIncomingMessage });
@@ -69,13 +69,13 @@ import * as url from "node:url";
     let bar: "bar";
 
     class MyIncomingMessage extends http.IncomingMessage {
-        foo: typeof foo;
+        foo!: typeof foo;
     }
 
     class MyServerResponse<
         Request extends http.IncomingMessage = http.IncomingMessage,
     > extends http.ServerResponse<Request> {
-        bar: typeof bar;
+        bar!: typeof bar;
     }
 
     function reqListener(req: MyIncomingMessage, res: MyServerResponse): void {}

--- a/types/node/v20/test/http2.ts
+++ b/types/node/v20/test/http2.ts
@@ -434,13 +434,13 @@ import { URL } from "node:url";
 // Http2ServerRequest, Http2ServerResponse,
 {
     class MyHttp2ServerRequest extends Http2ServerRequest {
-        foo: number;
+        foo!: number;
     }
 
     class MyHttp2ServerResponse<Request extends Http2ServerRequest = Http2ServerRequest>
         extends Http2ServerResponse<Request>
     {
-        bar: string;
+        bar!: string;
     }
 
     function reqListener(req: Http2ServerRequest, res: Http2ServerResponse): void {}

--- a/types/node/v20/test/https.ts
+++ b/types/node/v20/test/https.ts
@@ -74,13 +74,13 @@ import * as url from "node:url";
         function reqListener(req: http.IncomingMessage, res: http.ServerResponse): void {}
 
         class MyIncomingMessage extends http.IncomingMessage {
-            foo: number;
+            foo!: number;
         }
 
         class MyServerResponse<Request extends http.IncomingMessage = http.IncomingMessage>
             extends http.ServerResponse<Request>
         {
-            foo: string;
+            foo!: string;
         }
 
         let server: https.Server;
@@ -123,13 +123,13 @@ import * as url from "node:url";
     let bar: "bar";
 
     class MyIncomingMessage extends http.IncomingMessage {
-        foo: typeof foo;
+        foo!: typeof foo;
     }
 
     class MyServerResponse<
         Request extends http.IncomingMessage = http.IncomingMessage,
     > extends http.ServerResponse<Request> {
-        bar: typeof bar;
+        bar!: typeof bar;
     }
 
     function reqListener(req: MyIncomingMessage, res: MyServerResponse): void {}

--- a/types/node/v22/test/http.ts
+++ b/types/node/v22/test/http.ts
@@ -11,13 +11,13 @@ import * as url from "node:url";
     let server: http.Server = new http.Server();
 
     class MyIncomingMessage extends http.IncomingMessage {
-        foo: number;
+        foo!: number;
     }
 
     class MyServerResponse<Request extends http.IncomingMessage = http.IncomingMessage>
         extends http.ServerResponse<Request>
     {
-        foo: string;
+        foo!: string;
     }
 
     server = new http.Server({ IncomingMessage: MyIncomingMessage });
@@ -71,13 +71,13 @@ import * as url from "node:url";
     let bar: "bar";
 
     class MyIncomingMessage extends http.IncomingMessage {
-        foo: typeof foo;
+        foo!: typeof foo;
     }
 
     class MyServerResponse<
         Request extends MyIncomingMessage = MyIncomingMessage,
     > extends http.ServerResponse<Request> {
-        bar: typeof bar;
+        bar!: typeof bar;
 
         getFoo() {
             return this.req.foo;

--- a/types/node/v22/test/http2.ts
+++ b/types/node/v22/test/http2.ts
@@ -436,13 +436,13 @@ import { URL } from "node:url";
 // Http2ServerRequest, Http2ServerResponse,
 {
     class MyHttp2ServerRequest extends Http2ServerRequest {
-        foo: number;
+        foo!: number;
     }
 
     class MyHttp2ServerResponse<Request extends Http2ServerRequest = Http2ServerRequest>
         extends Http2ServerResponse<Request>
     {
-        bar: string;
+        bar!: string;
     }
 
     function reqListener(req: Http2ServerRequest, res: Http2ServerResponse): void {}

--- a/types/node/v22/test/https.ts
+++ b/types/node/v22/test/https.ts
@@ -74,13 +74,13 @@ import * as url from "node:url";
         function reqListener(req: http.IncomingMessage, res: http.ServerResponse): void {}
 
         class MyIncomingMessage extends http.IncomingMessage {
-            foo: number;
+            foo!: number;
         }
 
         class MyServerResponse<Request extends http.IncomingMessage = http.IncomingMessage>
             extends http.ServerResponse<Request>
         {
-            foo: string;
+            foo!: string;
         }
 
         let server: https.Server;
@@ -124,13 +124,13 @@ import * as url from "node:url";
     let bar: "bar";
 
     class MyIncomingMessage extends http.IncomingMessage {
-        foo: typeof foo;
+        foo!: typeof foo;
     }
 
     class MyServerResponse<
         Request extends http.IncomingMessage = http.IncomingMessage,
     > extends http.ServerResponse<Request> {
-        bar: typeof bar;
+        bar!: typeof bar;
     }
 
     function reqListener(req: MyIncomingMessage, res: MyServerResponse): void {}

--- a/types/node/v24/test/http.ts
+++ b/types/node/v24/test/http.ts
@@ -11,13 +11,13 @@ import * as url from "node:url";
     let server: http.Server = new http.Server();
 
     class MyIncomingMessage extends http.IncomingMessage {
-        foo: number;
+        foo!: number;
     }
 
     class MyServerResponse<Request extends http.IncomingMessage = http.IncomingMessage>
         extends http.ServerResponse<Request>
     {
-        foo: string;
+        foo!: string;
     }
 
     server = new http.Server({ IncomingMessage: MyIncomingMessage });
@@ -75,13 +75,13 @@ import * as url from "node:url";
     let bar: "bar";
 
     class MyIncomingMessage extends http.IncomingMessage {
-        foo: typeof foo;
+        foo!: typeof foo;
     }
 
     class MyServerResponse<
         Request extends MyIncomingMessage = MyIncomingMessage,
     > extends http.ServerResponse<Request> {
-        bar: typeof bar;
+        bar!: typeof bar;
 
         getFoo() {
             return this.req.foo;

--- a/types/node/v24/test/http2.ts
+++ b/types/node/v24/test/http2.ts
@@ -439,13 +439,13 @@ import { URL } from "node:url";
 // Http2ServerRequest, Http2ServerResponse,
 {
     class MyHttp2ServerRequest extends Http2ServerRequest {
-        foo: number;
+        foo!: number;
     }
 
     class MyHttp2ServerResponse<Request extends Http2ServerRequest = Http2ServerRequest>
         extends Http2ServerResponse<Request>
     {
-        bar: string;
+        bar!: string;
     }
 
     function reqListener(req: Http2ServerRequest, res: Http2ServerResponse): void {}

--- a/types/node/v24/test/https.ts
+++ b/types/node/v24/test/https.ts
@@ -77,13 +77,13 @@ import * as url from "node:url";
         function reqListener(req: http.IncomingMessage, res: http.ServerResponse): void {}
 
         class MyIncomingMessage extends http.IncomingMessage {
-            foo: number;
+            foo!: number;
         }
 
         class MyServerResponse<Request extends http.IncomingMessage = http.IncomingMessage>
             extends http.ServerResponse<Request>
         {
-            foo: string;
+            foo!: string;
         }
 
         let server: https.Server;
@@ -127,13 +127,13 @@ import * as url from "node:url";
     let bar: "bar";
 
     class MyIncomingMessage extends http.IncomingMessage {
-        foo: typeof foo;
+        foo!: typeof foo;
     }
 
     class MyServerResponse<
         Request extends http.IncomingMessage = http.IncomingMessage,
     > extends http.ServerResponse<Request> {
-        bar: typeof bar;
+        bar!: typeof bar;
     }
 
     function reqListener(req: MyIncomingMessage, res: MyServerResponse): void {}

--- a/types/oauth2-server/oauth2-server-tests.ts
+++ b/types/oauth2-server/oauth2-server-tests.ts
@@ -80,7 +80,7 @@ const authenticate = (authenticateOptions?: {}) => {
             const token = await oauth2Server.authenticate(request, response, options);
             req.user = token;
             next();
-        } catch (err) {
+        } catch (err: any) {
             res.status(err.code || 500).json(err);
         }
     };

--- a/types/oauth2orize/oauth2orize-tests.ts
+++ b/types/oauth2orize/oauth2orize-tests.ts
@@ -100,8 +100,8 @@ class Clients {
     static findOne(id: string, callback: (err: Error, client?: Clients) => void): void {
         callback(new Error(), {} as Clients); // tslint:disable-line no-object-literal-type-assertion
     }
-    id: string;
-    redirectURI: string;
+    id!: string;
+    redirectURI!: string;
 }
 
 declare global {

--- a/types/oracledb/oracledb-tests.ts
+++ b/types/oracledb/oracledb-tests.ts
@@ -298,7 +298,7 @@ const runPromiseTests = async (): Promise<void> => {
         console.log("Testing pool.close()...");
 
         await pool.close(5);
-    } catch (err) {
+    } catch (err: any) {
         console.log(err.message);
     }
 };

--- a/types/oracledb/v3/oracledb-tests.ts
+++ b/types/oracledb/v3/oracledb-tests.ts
@@ -288,7 +288,7 @@ const runPromiseTests = async (): Promise<void> => {
         console.log("Testing pool.close()...");
 
         await pool.close(5);
-    } catch (err) {
+    } catch (err: any) {
         console.log(err.message);
     }
 };

--- a/types/parcel-env/parcel-env-tests.ts
+++ b/types/parcel-env/parcel-env-tests.ts
@@ -13,7 +13,7 @@ otherModule.otherMethod();
 module.exports = null;
 
 class ModuleData {
-    updated: boolean;
+    updated!: boolean;
 }
 
 // check if HMR is enabled

--- a/types/parsimmon/parsimmon-tests.ts
+++ b/types/parsimmon/parsimmon-tests.ts
@@ -4,11 +4,11 @@ import { Index, Language, Mark, Parser, Reply, Result, TypedLanguage } from "par
 // --  --  --  --  --  --  --  --  --  --  --  --  --
 
 class Foo {
-    bar: Bar;
+    bar!: Bar;
 }
 
 class Bar {
-    foo: Foo;
+    foo!: Foo;
 }
 
 // --  --  --  --  --  --  --  --  --  --  --  --  --

--- a/types/passport-auth-token/passport-auth-token-tests.ts
+++ b/types/passport-auth-token/passport-auth-token-tests.ts
@@ -21,8 +21,8 @@ testingAuthTokenStrategy.success = () => {};
 testingAuthTokenStrategy.fail = () => {};
 
 class AccessTokenImpl implements AccessToken {
-    id: string;
-    userId: string;
+    id!: string;
+    userId!: string;
 
     static findOne(token: AccessToken, callback: (token: AccessTokenImpl, err?: Error) => void): void {
         callback(new AccessTokenImpl(), undefined);
@@ -34,7 +34,7 @@ class AccessTokenImpl implements AccessToken {
 }
 
 class UserImpl implements User {
-    id: string;
+    id!: string;
     static findOne(user: User, callback: (user: UserImpl, err?: Error) => void): void {
         callback(new UserImpl(), undefined);
     }

--- a/types/passport-oauth2-client-password/passport-oauth2-client-password-tests.ts
+++ b/types/passport-oauth2-client-password/passport-oauth2-client-password-tests.ts
@@ -13,8 +13,8 @@ interface IClient {
 }
 
 class Client implements IClient {
-    public clientId: string;
-    public clientSecret: string;
+    public clientId!: string;
+    public clientSecret!: string;
 
     static findOne(client: IClient, callback: (err: any, client: Client) => void): void {
         callback(null, new Client());

--- a/types/passport-unique-token/passport-unique-token-tests.ts
+++ b/types/passport-unique-token/passport-unique-token-tests.ts
@@ -13,7 +13,7 @@ interface BaseUser {
 }
 
 class User implements BaseUser {
-    uniqueToken: string;
+    uniqueToken!: string;
 
     static findOne(user: BaseUser & any, callback: (err: Error | null, user: User) => void): void {
         callback(null, new User());

--- a/types/peer-dial/peer-dial-tests.ts
+++ b/types/peer-dial/peer-dial-tests.ts
@@ -2,10 +2,10 @@ import { App, AppInfo, Client, CorsOptions, Delegate, DeviceInfo, DialDevice, Se
 import express = require("express");
 
 class AppImpl implements App {
-    name: string;
-    state: string;
-    allowStop: boolean;
-    pid: string;
+    name!: string;
+    state!: string;
+    allowStop!: boolean;
+    pid!: string;
     launch(launchData: string): void {
     }
 }

--- a/types/pegjs/pegjs-tests.ts
+++ b/types/pegjs/pegjs-tests.ts
@@ -10,7 +10,7 @@ import * as pegjs from "pegjs";
 
     try {
         let result: string = pegparser.parse("abba");
-    } catch (error) {
+    } catch (error: any) {
         if (error instanceof pegparser.SyntaxError) {
         }
     }
@@ -32,7 +32,7 @@ import * as pegjs from "pegjs";
 
 try {
     let source: string = pegjs.generate("A = 'test'", { output: "source" });
-} catch (error) {
+} catch (error: any) {
     if (error instanceof pegjs.GrammarError) {
         let e: pegjs.GrammarError = error;
     } else if (error instanceof pegjs.parser.SyntaxError) {

--- a/types/pendo-io-browser/pendo-io-browser-tests.ts
+++ b/types/pendo-io-browser/pendo-io-browser-tests.ts
@@ -141,7 +141,7 @@ pendo.track("User Registered", {
 
 try {
     throw new Error();
-} catch (error) {
+} catch (error: any) {
     pendo.track("JIRA-12345--error-tripped", {
         message: error.message,
         stack: error.stack,

--- a/types/polymer/polymer-tests.ts
+++ b/types/polymer/polymer-tests.ts
@@ -69,7 +69,7 @@ var el2 = document.createElement("my-element");
 
 // implicit implementation
 class MyElement2 {
-    is: string;
+    is!: string;
 
     beforeRegister() {
         this.is = "my-element2";
@@ -80,7 +80,7 @@ Polymer(MyElement2);
 
 // explicit implementation
 class MyElement3 implements polymer.Base {
-    is: string;
+    is!: string;
 
     beforeRegister() {
         this.is = "my-element3";

--- a/types/qs/qs-tests.ts
+++ b/types/qs/qs-tests.ts
@@ -406,7 +406,7 @@ qs.parse("a=b&c=d", { delimiter: "&" });
 (() => {
     try {
         qs.parse("a[b][c][d][e][f][g][h][i]=j", { depth: 1, strictDepth: true });
-    } catch (err) {
+    } catch (err: any) {
         assert.strictEqual(err.message, "Input depth exceeded depth option of 1 and strictDepth is true");
     }
 });

--- a/types/qunit/v1/qunit-tests.ts
+++ b/types/qunit/v1/qunit-tests.ts
@@ -1596,7 +1596,7 @@ test("Circular reference - test reported by soniciq in #105", function() {
         expect(0);
         QUnit.reset = function() {
             ok(false, "reset should not modify test status");
-            reset.apply(this, arguments);
+            reset.call(this);
         };
     });
     test("reset runs assertions, cleanup", function() {

--- a/types/raven/raven-tests.ts
+++ b/types/raven/raven-tests.ts
@@ -31,7 +31,7 @@ new Raven.Client(dsn);
 
 try {
     throw new Error();
-} catch (e) {
+} catch (e: any) {
     const eventId = Raven.captureException(e, (sendErr, eventId) => {});
 }
 

--- a/types/raygun4js/raygun4js-tests.ts
+++ b/types/raygun4js/raygun4js-tests.ts
@@ -58,7 +58,7 @@ client.send(new Error("a error"), { some: "data" }, ["tag1", "tag2"]);
 
 try {
     throw new Error("oops");
-} catch (e) {
+} catch (e: any) {
     client.send(e);
 }
 

--- a/types/rclone.js/rclone.js-tests.ts
+++ b/types/rclone.js/rclone.js-tests.ts
@@ -20,7 +20,7 @@ async function usingRclonePromiseAPI() {
     try {
         const response = await rclonePromise.ls(rcloneRemoteName, rcloneConfigOptions);
         console.log(response.toString());
-    } catch (error) {
+    } catch (error: any) {
         console.log(error.toString());
     }
 }

--- a/types/rdfjs__fetch-lite/rdfjs__fetch-lite-tests.ts
+++ b/types/rdfjs__fetch-lite/rdfjs__fetch-lite-tests.ts
@@ -95,7 +95,7 @@ async function environmentDatasetFetch(): Promise<TestDataset> {
         dataset(): TestDataset {
             return <any> {};
         }
-        exports: ["dataset"];
+        exports: ["dataset"] = ["dataset"];
     }
     const environmentTest = new Environment([
         FetchFactory,

--- a/types/redux-action-utils/redux-action-utils-tests.ts
+++ b/types/redux-action-utils/redux-action-utils-tests.ts
@@ -21,7 +21,7 @@ var action: Action = ac();
 type = action.type;
 
 class ImportLesson {
-    lessons: string[];
+    lessons!: string[];
 }
 
 const importLessonAction = actionCreator<ImportLesson>(types.IMPORT_LESSONS, "lessons");
@@ -32,8 +32,8 @@ var lessons: string[] = importLesson.lessons;
 type = importLesson.type;
 
 class UpdateLesson {
-    id: number;
-    update: {
+    id!: number;
+    update!: {
         text: string;
     };
 }

--- a/types/redux-api-middleware/redux-api-middleware-tests.ts
+++ b/types/redux-api-middleware/redux-api-middleware-tests.ts
@@ -156,8 +156,8 @@ import {
         bailout(state: State) {
             return state.bailout;
         }
-        method: "GET";
-        types: ["REQ_TYPE", "SUCCESS_TYPE", "FAILURE_TYPE"];
+        method!: "GET";
+        types!: ["REQ_TYPE", "SUCCESS_TYPE", "FAILURE_TYPE"];
     }
 
     class PromiseStateDrivenRSAACall implements RSAACall<State> {
@@ -176,17 +176,17 @@ import {
         bailout(state: State) {
             return Promise.resolve(state.bailout);
         }
-        method: "GET";
-        types: ["REQ_TYPE", "SUCCESS_TYPE", "FAILURE_TYPE"];
+        method!: "GET";
+        types!: ["REQ_TYPE", "SUCCESS_TYPE", "FAILURE_TYPE"];
     }
 
     class NonStateDrivenRSAACall implements RSAACall<State> {
-        endpoint: "/test/endpoint";
-        method: "GET";
-        headers: { "Content-Type": "application/json" };
-        options: { redirect: "follow" };
-        bailout: true;
-        types: ["REQ_TYPE", "SUCCESS_TYPE", "FAILURE_TYPE"];
+        endpoint!: "/test/endpoint";
+        method!: "GET";
+        headers!: { "Content-Type": "application/json" };
+        options!: { redirect: "follow" };
+        bailout!: true;
+        types!: ["REQ_TYPE", "SUCCESS_TYPE", "FAILURE_TYPE"];
     }
 }
 

--- a/types/scaleway-functions/scaleway-functions-tests.ts
+++ b/types/scaleway-functions/scaleway-functions-tests.ts
@@ -28,7 +28,7 @@ const handler2: Handler = (event: Event, context: Context, callback: Callback) =
     try {
         // Successful response
         callback(undefined, response);
-    } catch (err) {
+    } catch (err: any) {
         // Error response
         callback(err);
     }

--- a/types/screeps-profiler/screeps-profiler-tests.ts
+++ b/types/screeps-profiler/screeps-profiler-tests.ts
@@ -4,7 +4,7 @@ function testFunction() {
 }
 
 class TestClass {
-    private readonly dummy: string;
+    private readonly dummy!: string;
 }
 
 const testObj = {

--- a/types/serverless/serverless-tests.ts
+++ b/types/serverless/serverless-tests.ts
@@ -70,13 +70,13 @@ class CustomPlugin implements Plugin {
 // Test a plugin with missing 'hooks' property
 // @ts-expect-error
 class BadPlugin implements Plugin {
-    hoooks: Plugin.Hooks; // emulate a bad 'hooks' definition with a typo
+    hoooks!: Plugin.Hooks; // emulate a bad 'hooks' definition with a typo
     constructor(badArg: number) {}
 }
 
 // Test a plugin that throws an user error exception
 class ThrowUserErrorPlugin implements Plugin {
-    hooks: Plugin.Hooks;
+    hooks!: Plugin.Hooks;
     constructor(serverless: Serverless, options: Serverless.Options, logging: Plugin.Logging) {
         this.hooks = {
             "command:start": () => {},
@@ -100,7 +100,7 @@ manager.addPlugin(ThrowUserErrorPlugin);
 
 // Test a plugin with bad arguments for a variable resolver
 class BadVariablePlugin1 implements Plugin {
-    hooks: Plugin.Hooks;
+    hooks!: Plugin.Hooks;
     // @ts-expect-error
     variableResolvers = {
         badEchoArgs: async (badArg: number) => {},
@@ -109,7 +109,7 @@ class BadVariablePlugin1 implements Plugin {
 
 // Test a plugin with non-async variable resolver
 class BadVariablePlugin implements Plugin {
-    hooks: Plugin.Hooks;
+    hooks!: Plugin.Hooks;
     // @ts-expect-error
     variableResolvers = {
         badEchoNotAsync: (source: string) => {},

--- a/types/simple-mock/simple-mock-tests.ts
+++ b/types/simple-mock/simple-mock-tests.ts
@@ -95,7 +95,7 @@ describe("Simple", function() {
                 let threw: Error;
                 try {
                     spyFn();
-                } catch (e) {
+                } catch (e: any) {
                     threw = e;
                 }
 
@@ -110,17 +110,17 @@ describe("Simple", function() {
                 let threw: Error[] = [];
                 try {
                     spyFn();
-                } catch (e) {
+                } catch (e: any) {
                     threw.push(e);
                 }
                 try {
                     spyFn();
-                } catch (e) {
+                } catch (e: any) {
                     threw.push(e);
                 }
                 try {
                     spyFn();
-                } catch (e) {
+                } catch (e: any) {
                     threw.push(e);
                 }
 
@@ -359,7 +359,7 @@ describe("Simple", function() {
                 let threw: Error;
                 try {
                     stubFn();
-                } catch (e) {
+                } catch (e: any) {
                     threw = e;
                 }
 
@@ -373,12 +373,12 @@ describe("Simple", function() {
                 let threw: Error[] = [];
                 try {
                     stubFn();
-                } catch (e) {
+                } catch (e: any) {
                     threw.push(e);
                 }
                 try {
                     stubFn();
-                } catch (e) {
+                } catch (e: any) {
                     threw.push(e);
                 }
 
@@ -400,7 +400,7 @@ describe("Simple", function() {
                 let threw: Error;
                 try {
                     stubFn();
-                } catch (e) {
+                } catch (e: any) {
                     threw = e;
                 }
 
@@ -414,17 +414,17 @@ describe("Simple", function() {
                 let threw: Error[] = [];
                 try {
                     stubFn();
-                } catch (e) {
+                } catch (e: any) {
                     threw.push(e);
                 }
                 try {
                     stubFn();
-                } catch (e) {
+                } catch (e: any) {
                     threw.push(e);
                 }
                 try {
                     stubFn();
-                } catch (e) {
+                } catch (e: any) {
                     threw.push(e);
                 }
 
@@ -442,17 +442,17 @@ describe("Simple", function() {
                 let threw: Error[] = [];
                 try {
                     stubFn();
-                } catch (e) {
+                } catch (e: any) {
                     threw.push(e);
                 }
                 try {
                     stubFn();
-                } catch (e) {
+                } catch (e: any) {
                     threw.push(e);
                 }
                 try {
                     stubFn();
-                } catch (e) {
+                } catch (e: any) {
                     threw.push(e);
                 }
 
@@ -578,7 +578,7 @@ describe("Simple", function() {
                     let call2Args = arguments;
                     try {
                         stubFn(); // Call 3
-                    } catch (e) {
+                    } catch (e: any) {
                         assert.equal(stubFn.callCount, 3);
 
                         // Verify Call 1: return 'a'
@@ -721,7 +721,7 @@ describe("Simple", function() {
 
                 try {
                     stubFn();
-                } catch (e) {
+                } catch (e: any) {
                     assert(e instanceof Error);
                     assert.equal(e.message, "my message");
                 }

--- a/types/simple-oauth2/simple-oauth2-tests.ts
+++ b/types/simple-oauth2/simple-oauth2-tests.ts
@@ -98,7 +98,7 @@ const oauth2ResourceOwnerPassword = new oauth2lib.ResourceOwnerPassword(
     try {
         const result = await oauth2AuthorizationCode.getToken(tokenConfig);
         const accessToken = oauth2AuthorizationCode.createToken(result.token);
-    } catch (error) {
+    } catch (error: any) {
         console.log("Access Token Error", error.message);
     }
 })();
@@ -129,7 +129,7 @@ const oauth2ResourceOwnerPassword = new oauth2lib.ResourceOwnerPassword(
         result = await oauth2ResourceOwnerPassword.getToken(tokenConfig3);
 
         const accessToken = oauth2ResourceOwnerPassword.createToken(result.token);
-    } catch (error) {
+    } catch (error: any) {
         console.log("Access Token Error", error.message);
     }
 })();
@@ -142,7 +142,7 @@ const oauth2ResourceOwnerPassword = new oauth2lib.ResourceOwnerPassword(
     try {
         const result = await oauth2ClientCredentials.getToken(tokenConfig);
         const accessToken = oauth2ClientCredentials.createToken(result.token);
-    } catch (error) {
+    } catch (error: any) {
         console.log("Access Token error", error.message);
     }
 })();
@@ -186,7 +186,7 @@ async function TestFnAccessTokenObject(
             accessToken = await accessToken.refresh({ scope: ["<scope1>", "<scope2>"] }, httpOptions);
 
             console.log("Token refreshed");
-        } catch (error) {
+        } catch (error: any) {
             console.log("Error refreshing access token: ", error.message);
         }
     }
@@ -204,7 +204,7 @@ async function TestFnAccessTokenObject(
         await accessToken.revoke("refresh_token", httpOptions);
 
         console.log("Token revoked");
-    } catch (error) {
+    } catch (error: any) {
         console.log("Error revoking token: ", error.message);
     }
 
@@ -215,7 +215,7 @@ async function TestFnAccessTokenObject(
         await accessToken.revokeAll();
 
         await accessToken.revokeAll(httpOptions);
-    } catch (error) {
+    } catch (error: any) {
         console.log("Error revoking token: ", error.message);
     }
 }
@@ -250,7 +250,7 @@ TestFnAccessTokenObject(oauth2ResourceOwnerPassword);
     try {
         const result = await oauth2ResourceOwnerPassword.getToken(tokenConfig);
         const accessToken = oauth2ResourceOwnerPassword.createToken(result.token);
-    } catch (error) {
+    } catch (error: any) {
         console.log("Access Token Error", error.message);
     }
 })();

--- a/types/simple-oauth2/v2/simple-oauth2-tests.ts
+++ b/types/simple-oauth2/v2/simple-oauth2-tests.ts
@@ -55,7 +55,7 @@ const oauth2 = oauth2lib.create(credentials);
     try {
         const result = await oauth2.authorizationCode.getToken(tokenConfig);
         const accessToken = oauth2.accessToken.create(result);
-    } catch (error) {
+    } catch (error: any) {
         console.log("Access Token Error", error.message);
     }
 })();
@@ -72,7 +72,7 @@ const oauth2 = oauth2lib.create(credentials);
     try {
         const result = await oauth2.ownerPassword.getToken(tokenConfig);
         const accessToken = oauth2.accessToken.create(result);
-    } catch (error) {
+    } catch (error: any) {
         console.log("Access Token Error", error.message);
     }
 })();
@@ -85,7 +85,7 @@ const oauth2 = oauth2lib.create(credentials);
     try {
         const result = await oauth2.clientCredentials.getToken(tokenConfig);
         const accessToken = oauth2.accessToken.create(result);
-    } catch (error) {
+    } catch (error: any) {
         console.log("Access Token error", error.message);
     }
 })();
@@ -106,7 +106,7 @@ const oauth2 = oauth2lib.create(credentials);
     if (accessToken.expired()) {
         try {
             accessToken = await accessToken.refresh();
-        } catch (error) {
+        } catch (error: any) {
             console.log("Error refreshing access token: ", error.message);
         }
     }
@@ -121,7 +121,7 @@ const oauth2 = oauth2lib.create(credentials);
         await accessToken.revoke("refresh_token");
 
         console.log("Token revoked");
-    } catch (error) {
+    } catch (error: any) {
         console.log("Error revoking token: ", error.message);
     }
 
@@ -130,7 +130,7 @@ const oauth2 = oauth2lib.create(credentials);
     try {
         // Revokes both tokens, refresh token is only revoked if the access_token is properly revoked
         await accessToken.revokeAll();
-    } catch (error) {
+    } catch (error: any) {
         console.log("Error revoking token: ", error.message);
     }
 })();
@@ -160,7 +160,7 @@ const oauth2 = oauth2lib.create(credentials);
     try {
         const result = await oauth2.ownerPassword.getToken(tokenConfig);
         const accessToken = oauth2.accessToken.create(result);
-    } catch (error) {
+    } catch (error: any) {
         console.log("Access Token Error", error.message);
     }
 })();

--- a/types/simple-oauth2/v4/simple-oauth2-tests.ts
+++ b/types/simple-oauth2/v4/simple-oauth2-tests.ts
@@ -59,7 +59,7 @@ const oauth2ResourceOwnerPassword = new oauth2lib.ResourceOwnerPassword(
     try {
         const result = await oauth2AuthorizationCode.getToken(tokenConfig);
         const accessToken = oauth2AuthorizationCode.createToken(result.token);
-    } catch (error) {
+    } catch (error: any) {
         console.log("Access Token Error", error.message);
     }
 })();
@@ -76,7 +76,7 @@ const oauth2ResourceOwnerPassword = new oauth2lib.ResourceOwnerPassword(
     try {
         const result = await oauth2ResourceOwnerPassword.getToken(tokenConfig);
         const accessToken = oauth2ResourceOwnerPassword.createToken(result.token);
-    } catch (error) {
+    } catch (error: any) {
         console.log("Access Token Error", error.message);
     }
 })();
@@ -89,7 +89,7 @@ const oauth2ResourceOwnerPassword = new oauth2lib.ResourceOwnerPassword(
     try {
         const result = await oauth2ClientCredentials.getToken(tokenConfig);
         const accessToken = oauth2ClientCredentials.createToken(result.token);
-    } catch (error) {
+    } catch (error: any) {
         console.log("Access Token error", error.message);
     }
 })();
@@ -115,7 +115,7 @@ async function TestFnAccessTokenObject(
     if (accessToken.expired()) {
         try {
             accessToken = await accessToken.refresh();
-        } catch (error) {
+        } catch (error: any) {
             console.log("Error refreshing access token: ", error.message);
         }
     }
@@ -130,7 +130,7 @@ async function TestFnAccessTokenObject(
         await accessToken.revoke("refresh_token");
 
         console.log("Token revoked");
-    } catch (error) {
+    } catch (error: any) {
         console.log("Error revoking token: ", error.message);
     }
 
@@ -139,7 +139,7 @@ async function TestFnAccessTokenObject(
     try {
         // Revokes both tokens, refresh token is only revoked if the access_token is properly revoked
         await accessToken.revokeAll();
-    } catch (error) {
+    } catch (error: any) {
         console.log("Error revoking token: ", error.message);
     }
 }
@@ -174,7 +174,7 @@ TestFnAccessTokenObject(oauth2ResourceOwnerPassword);
     try {
         const result = await oauth2ResourceOwnerPassword.getToken(tokenConfig);
         const accessToken = oauth2ResourceOwnerPassword.createToken(result.token);
-    } catch (error) {
+    } catch (error: any) {
         console.log("Access Token Error", error.message);
     }
 })();

--- a/types/simpleddp/simpleddp-tests.ts
+++ b/types/simpleddp/simpleddp-tests.ts
@@ -2,10 +2,10 @@ import simpleDDP from "simpleddp";
 
 class simpleSocketProvider {
     constructor(url: string) {}
-    readonly readyState: number;
+    readonly readyState!: number;
     send(data: any) {}
     close(code?: number, reason?: string) {}
-    onopen: null;
+    onopen!: null;
     onmessage(this: any, event: any) {}
     onerror(this: any, event: any) {}
     onclose(this: any, event: any) {}

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -80,12 +80,12 @@ function testSandbox() {
         foo(arg1: string, arg2: number): number {
             return 1;
         }
-        bar: number;
+        bar!: number;
     };
     const PrivateFoo = class {
         private constructor() {}
         foo() {}
-        bar: number;
+        bar!: number;
         static create() {
             return new PrivateFoo();
         }

--- a/types/slickgrid/test/index.ts
+++ b/types/slickgrid/test/index.ts
@@ -72,7 +72,7 @@ grid.setSelectedRows([0, 1, 2]);
 
 class SingleCellSelectionModel extends Slick.SelectionModel<MyData, Slick.Range[]> {
     private readonly self: SingleCellSelectionModel;
-    private _grid: Slick.Grid<MyData>;
+    private _grid!: Slick.Grid<MyData>;
 
     constructor() {
         super();

--- a/types/sortablejs/sortablejs-tests.ts
+++ b/types/sortablejs/sortablejs-tests.ts
@@ -122,7 +122,7 @@ simpleList.innerHTML = Array.apply(null, new Array(100))
 
     if (!console.log) {
         console.log = function() {
-            alert([].join.apply(arguments, " "));
+            alert([...arguments].join(" "));
         };
     }
 

--- a/types/three/test/integration/loaders-gltfloader-plugin.ts
+++ b/types/three/test/integration/loaders-gltfloader-plugin.ts
@@ -18,7 +18,7 @@ init().then(() => {
 });
 
 class ExamplePlugin implements GLTFLoaderPlugin {
-    name: "example-plugin";
+    name = "example-plugin";
 
     parser: GLTFParser;
 

--- a/types/three/test/unit/src/nodes/code/FunctionNode.ts
+++ b/types/three/test/unit/src/nodes/code/FunctionNode.ts
@@ -27,9 +27,9 @@ export const mx_worley_noise_float_call = wgslFn<[Node, Node, Node]>(
 );
 export const ab_call = wgslFn<{ a: Node; b: Node }>("float mx_cell_noise_float( vec3 p )", includes);
 
-mx_cell_noise_float_call.call(uv());
-mx_worley_noise_float_call.call(uv(), 1, 1);
-ab_call.call({ a: 1, b: uv() });
+mx_cell_noise_float_call(uv());
+mx_worley_noise_float_call(uv(), 1, 1);
+ab_call({ a: 1, b: uv() });
 
 export const mx_cell_noise_float = glslFn<[Node]>("float mx_cell_noise_float( vec3 p )", includes);
 export const mx_worley_noise_float = glslFn<[Node, Node, Node]>(

--- a/types/time-limit-promise/time-limit-promise-tests.ts
+++ b/types/time-limit-promise/time-limit-promise-tests.ts
@@ -30,7 +30,7 @@ async function foo(id: number, delay: number): Promise<string> {
 
     try {
         await timeLimit(foo(6, 200), 100, { rejectWith: 200 });
-    } catch (err) {
+    } catch (err: any) {
         // $ExpectType any
         const fooOutRejectedFail = err; // 200
     }

--- a/types/twig/twig-tests.ts
+++ b/types/twig/twig-tests.ts
@@ -93,7 +93,7 @@ twig.extend(Twig => {
             // this is a pattern used heavily in the library itself
             token.stack = Twig.expression.compile({
                 value: expression,
-            }).stack;
+            }).stack!;
 
             return token;
         },
@@ -101,7 +101,7 @@ twig.extend(Twig => {
         // Runs when the template is rendered
         parse(token, context, chain) {
             // parse the tokens into a value with the render context
-            const name = Twig.expression.parse.apply(this, [token.stack, context]);
+            const name = Twig.expression.parse.apply(this, [token.stack!, context]);
             const output = "";
 
             return {

--- a/types/twine-sugarcube/test/macro.ts
+++ b/types/twine-sugarcube/test/macro.ts
@@ -12,7 +12,7 @@ Macro.add("if", {
                     break;
                 }
             }
-        } catch (ex) {
+        } catch (ex: any) {
             return this.error("bad conditional expression: " + ex.message);
         }
     },

--- a/types/w3c-generic-sensor/w3c-generic-sensor-tests.ts
+++ b/types/w3c-generic-sensor/w3c-generic-sensor-tests.ts
@@ -146,9 +146,9 @@ const orientation2 = () => {
 
 const explainer1 = () => {
     class LowPassFilterData {
-        x: number;
-        y: number;
-        z: number;
+        x!: number;
+        y!: number;
+        z!: number;
         bias: number;
 
         constructor(reading: Accelerometer | Gyroscope | Magnetometer, bias: number) {

--- a/types/webpack-env/webpack-env-tests.ts
+++ b/types/webpack-env/webpack-env-tests.ts
@@ -59,7 +59,7 @@ if (module.hot) {
 }
 
 class ModuleData {
-    updated: boolean;
+    updated!: boolean;
 }
 
 if (module.hot) {

--- a/types/winattr/winattr-tests.ts
+++ b/types/winattr/winattr-tests.ts
@@ -14,7 +14,7 @@ function getSync() {
     try {
         const attrs = winattr.getSync("/home/test");
         console.log(attrs.hidden);
-    } catch (ex) {
+    } catch (ex: any) {
         console.error(ex.message);
     }
 }
@@ -33,7 +33,7 @@ function setSync() {
     try {
         winattr.setSync("/home/test", { hidden: true });
         console.log("success");
-    } catch (ex) {
+    } catch (ex: any) {
         console.error(ex.message);
     }
 }

--- a/types/yargs/v15/yargs-tests.ts
+++ b/types/yargs/v15/yargs-tests.ts
@@ -40,13 +40,13 @@ function count() {
     const VERBOSE_LEVEL: number = argv.verbose;
 
     function WARN() {
-        VERBOSE_LEVEL >= 0 && console.log.apply(console, arguments);
+        VERBOSE_LEVEL >= 0 && console.log(...arguments);
     }
     function INFO() {
-        VERBOSE_LEVEL >= 1 && console.log.apply(console, arguments);
+        VERBOSE_LEVEL >= 1 && console.log(...arguments);
     }
     function DEBUG() {
-        VERBOSE_LEVEL >= 2 && console.log.apply(console, arguments);
+        VERBOSE_LEVEL >= 2 && console.log(...arguments);
     }
 }
 
@@ -376,7 +376,7 @@ function Argv$commandModule() {
         handler(args: yargs.Arguments): void {
             console.log("one");
         }
-        deprecated: true;
+        deprecated!: true;
     }
 
     const CommandTwo: yargs.CommandModule<{ a: string }, { b: number }> = {

--- a/types/yargs/v16/yargs-tests.ts
+++ b/types/yargs/v16/yargs-tests.ts
@@ -40,7 +40,7 @@ function count() {
 
     const VERBOSE_LEVEL: number = argv.verbose;
 
-     function WARN() {
+    function WARN() {
         VERBOSE_LEVEL >= 0 && console.log(...arguments);
     }
     function INFO() {

--- a/types/yargs/v16/yargs-tests.ts
+++ b/types/yargs/v16/yargs-tests.ts
@@ -40,14 +40,14 @@ function count() {
 
     const VERBOSE_LEVEL: number = argv.verbose;
 
-    function WARN() {
-        VERBOSE_LEVEL >= 0 && console.log.apply(console, arguments);
+     function WARN() {
+        VERBOSE_LEVEL >= 0 && console.log(...arguments);
     }
     function INFO() {
-        VERBOSE_LEVEL >= 1 && console.log.apply(console, arguments);
+        VERBOSE_LEVEL >= 1 && console.log(...arguments);
     }
     function DEBUG() {
-        VERBOSE_LEVEL >= 2 && console.log.apply(console, arguments);
+        VERBOSE_LEVEL >= 2 && console.log(...arguments);
     }
 }
 
@@ -377,7 +377,7 @@ function Argv$commandModule() {
         handler(args: yargs.Arguments): void {
             console.log("one");
         }
-        deprecated: true;
+        deprecated!: true;
     }
 
     const CommandTwo: yargs.CommandModule<{ a: string }, { b: number }> = {

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -40,13 +40,13 @@ function count() {
     const VERBOSE_LEVEL: number = argv.verbose;
 
     function WARN() {
-        VERBOSE_LEVEL >= 0 && console.log.apply(console, arguments);
+        VERBOSE_LEVEL >= 0 && console.log(...arguments);
     }
     function INFO() {
-        VERBOSE_LEVEL >= 1 && console.log.apply(console, arguments);
+        VERBOSE_LEVEL >= 1 && console.log(...arguments);
     }
     function DEBUG() {
-        VERBOSE_LEVEL >= 2 && console.log.apply(console, arguments);
+        VERBOSE_LEVEL >= 2 && console.log(...arguments);
     }
 }
 
@@ -396,7 +396,7 @@ async function Argv$commandModule() {
         handler(args: yargs.Arguments): void {
             console.log("one");
         }
-        deprecated: true;
+        deprecated!: true;
     }
 
     const CommandTwo: yargs.CommandModule<{ a: string }, { b: number }> = {

--- a/types/yuka/test/core/EventDispatcher.ts
+++ b/types/yuka/test/core/EventDispatcher.ts
@@ -2,7 +2,7 @@ import { EventDispatcher, EventInterface } from "yuka";
 
 class TestEvent implements EventInterface {
     type = "foo";
-    target: EventDispatcher;
+    target!: EventDispatcher;
 }
 
 const handlerFunction = (event: EventInterface) => {};

--- a/types/yuka/test/examples/playground/hideAndSeek/Enemy.ts
+++ b/types/yuka/test/examples/playground/hideAndSeek/Enemy.ts
@@ -10,8 +10,8 @@ import world from "./World";
 
 export class Enemy extends Vehicle {
     geometry: {};
-    deathAnimDuration: number;
-    currentTime: number;
+    deathAnimDuration!: number;
+    currentTime!: number;
     dead: boolean;
     notifiedWorld: boolean;
     spawningPoint: Vector3 | null;


### PR DESCRIPTION
TS 6.0 has `strict=true` by default. This broke a bunch of packages. Fix them.

A lot of these use options that suck. We should do some cleanup one day and make everyone actually have strictNullChecks etc.

This is a test-only PR.