### PR TITLE
Fix fabric tests for TS 6.0

### DIFF
--- a/types/fabric/test/index.ts
+++ b/types/fabric/test/index.ts
@@ -102,7 +102,8 @@ function sample3() {
     function applyFilter(index: number, filter: any) {
         const obj: fabric.Image = <fabric.Image> canvas.getActiveObject();
         obj.filters[index] = filter;
-        obj.applyFilters(canvas.renderAll.bind(canvas));
+        obj.applyFilters();
+        canvas.renderAll();
     }
 
     function getFilter(index: number) {
@@ -113,7 +114,8 @@ function sample3() {
     function applyFilterValue(index: number, prop: string, value: any) {
         const obj: fabric.Image = <fabric.Image> canvas.getActiveObject();
         if (obj.filters[index]) {
-            obj.applyFilters(canvas.renderAll.bind(canvas));
+            obj.applyFilters();
+            canvas.renderAll();
         }
     }
 


### PR DESCRIPTION
Missed this in #74479

strict=true in 6.0, which means `strictBindCallApply` is on, despite strictNullChecks being off here, etc.

Searching for examples in fabric, I think this code was just incorrect and only worked due to `any`.