### PR TITLE
[react] wrap JSDoc URLs in `@link` tags

### DIFF
--- a/types/react/experimental.d.ts
+++ b/types/react/experimental.d.ts
@@ -106,8 +106,8 @@ declare module "." {
      * However, if you wrap these items in a `SuspenseList`, React will not show an item in the list
      * until previous items have been displayed (this behavior is adjustable).
      *
-     * @see https://reactjs.org/docs/concurrent-mode-reference.html#suspenselist
-     * @see https://reactjs.org/docs/concurrent-mode-patterns.html#suspenselist
+     * @see {@link https://reactjs.org/docs/concurrent-mode-reference.html#suspenselist}
+     * @see {@link https://reactjs.org/docs/concurrent-mode-patterns.html#suspenselist}
      */
     export const unstable_SuspenseList: ExoticComponent<SuspenseListProps>;
 

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1885,7 +1885,7 @@ declare namespace React {
      *
      * @param callback A synchronous, void callback that will execute as a single, complete React commit.
      *
-     * @see https://reactjs.org/blog/2019/02/06/react-v16.8.0.html#testing-hooks
+     * @see {@link https://reactjs.org/blog/2019/02/06/react-v16.8.0.html#testing-hooks}
      */
     // NOTES
     // - the order of these signatures matters - typescript will check the signatures in source order.
@@ -2841,7 +2841,7 @@ declare namespace React {
 
         // Living Standard
         /**
-         * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert
+         * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert}
          */
         inert?: boolean | undefined;
         /**

--- a/types/react/ts5.0/experimental.d.ts
+++ b/types/react/ts5.0/experimental.d.ts
@@ -106,8 +106,8 @@ declare module "." {
      * However, if you wrap these items in a `SuspenseList`, React will not show an item in the list
      * until previous items have been displayed (this behavior is adjustable).
      *
-     * @see https://reactjs.org/docs/concurrent-mode-reference.html#suspenselist
-     * @see https://reactjs.org/docs/concurrent-mode-patterns.html#suspenselist
+     * @see {@link https://reactjs.org/docs/concurrent-mode-reference.html#suspenselist}
+     * @see {@link https://reactjs.org/docs/concurrent-mode-patterns.html#suspenselist}
      */
     export const unstable_SuspenseList: ExoticComponent<SuspenseListProps>;
 

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -1884,7 +1884,7 @@ declare namespace React {
      *
      * @param callback A synchronous, void callback that will execute as a single, complete React commit.
      *
-     * @see https://reactjs.org/blog/2019/02/06/react-v16.8.0.html#testing-hooks
+     * @see {@link https://reactjs.org/blog/2019/02/06/react-v16.8.0.html#testing-hooks}
      */
     // NOTES
     // - the order of these signatures matters - typescript will check the signatures in source order.
@@ -2840,7 +2840,7 @@ declare namespace React {
 
         // Living Standard
         /**
-         * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert
+         * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert}
          */
         inert?: boolean | undefined;
         /**

--- a/types/react/v15/index.d.ts
+++ b/types/react/v15/index.d.ts
@@ -2721,12 +2721,12 @@ declare namespace React {
         // Living Standard
         /**
          * Hints at the type of data that might be entered by the user while editing the element or its contents
-         * @see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute
+         * @see {@link https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute}
          */
         inputMode?: "none" | "text" | "tel" | "url" | "email" | "numeric" | "decimal" | "search" | undefined;
         /**
          * Specify that a standard HTML element should behave like a defined custom built-in element
-         * @see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is
+         * @see {@link https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is}
          */
         is?: string | undefined;
         /**

--- a/types/react/v16/index.d.ts
+++ b/types/react/v16/index.d.ts
@@ -457,7 +457,7 @@ declare namespace React {
          * }
          * ```
          *
-         * @see https://react.dev/reference/react/Component#static-contexttype
+         * @see {@link https://react.dev/reference/react/Component#static-contexttype}
          */
         static contextType?: Context<any> | undefined;
 
@@ -474,7 +474,7 @@ declare namespace React {
          * declare context: React.ContextType<typeof MyContext>
          * ```
          *
-         * @see https://react.dev/reference/react/Component#context
+         * @see {@link https://react.dev/reference/react/Component#context}
          */
         // TODO (TypeScript 3.0): unknown
         context: any;
@@ -482,7 +482,7 @@ declare namespace React {
         constructor(props: Readonly<P> | P);
         /**
          * @deprecated
-         * @see https://legacy.reactjs.org/docs/legacy-context.html
+         * @see {@link https://legacy.reactjs.org/docs/legacy-context.html}
          */
         constructor(props: P, context: any);
 
@@ -698,8 +698,8 @@ declare namespace React {
          * prevents this from being invoked.
          *
          * @deprecated 16.3, use componentDidMount or the constructor instead; will stop working in React 17
-         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state
-         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state}
+         * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path}
          */
         componentWillMount?(): void;
         /**
@@ -712,8 +712,8 @@ declare namespace React {
          * prevents this from being invoked.
          *
          * @deprecated 16.3, use componentDidMount or the constructor instead
-         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state
-         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state}
+         * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path}
          */
         UNSAFE_componentWillMount?(): void;
         /**
@@ -727,8 +727,8 @@ declare namespace React {
          * prevents this from being invoked.
          *
          * @deprecated 16.3, use static getDerivedStateFromProps instead; will stop working in React 17
-         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props
-         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props}
+         * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path}
          */
         componentWillReceiveProps?(nextProps: Readonly<P>, nextContext: any): void;
         /**
@@ -744,8 +744,8 @@ declare namespace React {
          * prevents this from being invoked.
          *
          * @deprecated 16.3, use static getDerivedStateFromProps instead
-         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props
-         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props}
+         * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path}
          */
         UNSAFE_componentWillReceiveProps?(nextProps: Readonly<P>, nextContext: any): void;
         /**
@@ -757,8 +757,8 @@ declare namespace React {
          * prevents this from being invoked.
          *
          * @deprecated 16.3, use getSnapshotBeforeUpdate instead; will stop working in React 17
-         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#reading-dom-properties-before-an-update
-         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#reading-dom-properties-before-an-update}
+         * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path}
          */
         componentWillUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): void;
         /**
@@ -772,8 +772,8 @@ declare namespace React {
          * prevents this from being invoked.
          *
          * @deprecated 16.3, use getSnapshotBeforeUpdate instead
-         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#reading-dom-properties-before-an-update
-         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#reading-dom-properties-before-an-update}
+         * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path}
          */
         UNSAFE_componentWillUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): void;
     }
@@ -915,14 +915,14 @@ declare namespace React {
      * context value, as given by the nearest context provider for the given context.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useContext
+     * @see {@link https://react.dev/reference/react/useContext}
      */
     function useContext<T>(context: Context<T> /*, (not public API) observedBits?: number|boolean */): T;
     /**
      * Returns a stateful value, and a function to update it.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useState
+     * @see {@link https://react.dev/reference/react/useState}
      */
     function useState<S>(initialState: S | (() => S)): [S, Dispatch<SetStateAction<S>>];
     // convenience overload when first argument is omitted
@@ -930,7 +930,7 @@ declare namespace React {
      * Returns a stateful value, and a function to update it.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useState
+     * @see {@link https://react.dev/reference/react/useState}
      */
     function useState<S = undefined>(): [S | undefined, Dispatch<SetStateAction<S | undefined>>];
     /**
@@ -941,7 +941,7 @@ declare namespace React {
      * updates because you can pass `dispatch` down instead of callbacks.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useReducer
+     * @see {@link https://react.dev/reference/react/useReducer}
      */
     // overload where dispatch could accept 0 arguments.
     function useReducer<R extends ReducerWithoutAction<any>, I>(
@@ -957,7 +957,7 @@ declare namespace React {
      * updates because you can pass `dispatch` down instead of callbacks.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useReducer
+     * @see {@link https://react.dev/reference/react/useReducer}
      */
     // overload where dispatch could accept 0 arguments.
     function useReducer<R extends ReducerWithoutAction<any>>(
@@ -973,7 +973,7 @@ declare namespace React {
      * updates because you can pass `dispatch` down instead of callbacks.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useReducer
+     * @see {@link https://react.dev/reference/react/useReducer}
      */
     // overload where "I" may be a subset of ReducerState<R>; used to provide autocompletion.
     // If "I" matches ReducerState<R> exactly then the last overload will allow initializer to be omitted.
@@ -991,7 +991,7 @@ declare namespace React {
      * updates because you can pass `dispatch` down instead of callbacks.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useReducer
+     * @see {@link https://react.dev/reference/react/useReducer}
      */
     // overload for free "I"; all goes as long as initializer converts it into "ReducerState<R>".
     function useReducer<R extends Reducer<any, any>, I>(
@@ -1007,7 +1007,7 @@ declare namespace React {
      * updates because you can pass `dispatch` down instead of callbacks.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useReducer
+     * @see {@link https://react.dev/reference/react/useReducer}
      */
 
     // I'm not sure if I keep this 2-ary or if I make it (2,3)-ary; it's currently (2,3)-ary.
@@ -1032,7 +1032,7 @@ declare namespace React {
      * value around similar to how you’d use instance fields in classes.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useRef
+     * @see {@link https://react.dev/reference/react/useRef}
      */
     function useRef<T>(initialValue: T): MutableRefObject<T>;
     // convenience overload for refs given as a ref prop as they typically start with a null value
@@ -1047,7 +1047,7 @@ declare namespace React {
      * of the generic argument.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useRef
+     * @see {@link https://react.dev/reference/react/useRef}
      */
     function useRef<T>(initialValue: T | null): RefObject<T>;
     // convenience overload for potentially undefined initialValue / call with 0 arguments
@@ -1060,7 +1060,7 @@ declare namespace React {
      * value around similar to how you’d use instance fields in classes.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useRef
+     * @see {@link https://react.dev/reference/react/useRef}
      */
     function useRef<T = undefined>(): MutableRefObject<T | undefined>;
     /**
@@ -1074,7 +1074,7 @@ declare namespace React {
      * `componentDidMount` and `componentDidUpdate`.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useLayoutEffect
+     * @see {@link https://react.dev/reference/react/useLayoutEffect}
      */
     function useLayoutEffect(effect: EffectCallback, deps?: DependencyList): void;
     /**
@@ -1084,7 +1084,7 @@ declare namespace React {
      * @param deps If present, effect will only activate if the values in the list change.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useEffect
+     * @see {@link https://react.dev/reference/react/useEffect}
      */
     function useEffect(effect: EffectCallback, deps?: DependencyList): void;
     // NOTE: this does not accept strings, but this will have to be fixed by removing strings from type Ref<T>
@@ -1095,7 +1095,7 @@ declare namespace React {
      * `useImperativeHandle` should be used with `React.forwardRef`.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useImperativeHandle
+     * @see {@link https://react.dev/reference/react/useImperativeHandle}
      */
     function useImperativeHandle<T, R extends T>(ref: Ref<T> | undefined, init: () => R, deps?: DependencyList): void;
     // I made 'inputs' required here and in useMemo as there's no point to memoizing without the memoization key
@@ -1105,7 +1105,7 @@ declare namespace React {
      * has changed.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useCallback
+     * @see {@link https://react.dev/reference/react/useCallback}
      */
     // TODO (TypeScript 3.0): <T extends (...args: never[]) => unknown>
     function useCallback<T extends (...args: any[]) => any>(callback: T, deps: DependencyList): T;
@@ -1113,7 +1113,7 @@ declare namespace React {
      * `useMemo` will only recompute the memoized value when one of the `deps` has changed.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useMemo
+     * @see {@link https://react.dev/reference/react/useMemo}
      */
     // allow undefined, but don't make it optional as that is very likely a mistake
     function useMemo<T>(factory: () => T, deps: DependencyList | undefined): T;
@@ -1124,7 +1124,7 @@ declare namespace React {
      * It’s most valuable for custom hooks that are part of shared libraries.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useDebugValue
+     * @see {@link https://react.dev/reference/react/useDebugValue}
      */
     // the name of the custom hook is itself derived from the function name at runtime:
     // it's just the function name without the "use" prefix.
@@ -1921,12 +1921,12 @@ declare namespace React {
         // Living Standard
         /**
          * Hints at the type of data that might be entered by the user while editing the element or its contents
-         * @see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute
+         * @see {@link https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute}
          */
         inputMode?: "none" | "text" | "tel" | "url" | "email" | "numeric" | "decimal" | "search" | undefined;
         /**
          * Specify that a standard HTML element should behave like a defined custom built-in element
-         * @see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is
+         * @see {@link https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is}
          */
         is?: string | undefined;
         /**

--- a/types/react/v17/index.d.ts
+++ b/types/react/v17/index.d.ts
@@ -457,7 +457,7 @@ declare namespace React {
          * }
          * ```
          *
-         * @see https://react.dev/reference/react/Component#static-contexttype
+         * @see {@link https://react.dev/reference/react/Component#static-contexttype}
          */
         static contextType?: Context<any> | undefined;
 
@@ -474,7 +474,7 @@ declare namespace React {
          * declare context: React.ContextType<typeof MyContext>
          * ```
          *
-         * @see https://react.dev/reference/react/Component#context
+         * @see {@link https://react.dev/reference/react/Component#context}
          */
         // TODO (TypeScript 3.0): unknown
         context: any;
@@ -482,7 +482,7 @@ declare namespace React {
         constructor(props: Readonly<P> | P);
         /**
          * @deprecated
-         * @see https://legacy.reactjs.org/docs/legacy-context.html
+         * @see {@link https://legacy.reactjs.org/docs/legacy-context.html}
          */
         constructor(props: P, context: any);
 
@@ -698,8 +698,8 @@ declare namespace React {
          * prevents this from being invoked.
          *
          * @deprecated 16.3, use componentDidMount or the constructor instead; will stop working in React 17
-         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state
-         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state}
+         * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path}
          */
         componentWillMount?(): void;
         /**
@@ -712,8 +712,8 @@ declare namespace React {
          * prevents this from being invoked.
          *
          * @deprecated 16.3, use componentDidMount or the constructor instead
-         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state
-         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state}
+         * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path}
          */
         UNSAFE_componentWillMount?(): void;
         /**
@@ -727,8 +727,8 @@ declare namespace React {
          * prevents this from being invoked.
          *
          * @deprecated 16.3, use static getDerivedStateFromProps instead; will stop working in React 17
-         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props
-         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props}
+         * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path}
          */
         componentWillReceiveProps?(nextProps: Readonly<P>, nextContext: any): void;
         /**
@@ -744,8 +744,8 @@ declare namespace React {
          * prevents this from being invoked.
          *
          * @deprecated 16.3, use static getDerivedStateFromProps instead
-         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props
-         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props}
+         * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path}
          */
         UNSAFE_componentWillReceiveProps?(nextProps: Readonly<P>, nextContext: any): void;
         /**
@@ -757,8 +757,8 @@ declare namespace React {
          * prevents this from being invoked.
          *
          * @deprecated 16.3, use getSnapshotBeforeUpdate instead; will stop working in React 17
-         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#reading-dom-properties-before-an-update
-         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#reading-dom-properties-before-an-update}
+         * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path}
          */
         componentWillUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): void;
         /**
@@ -772,8 +772,8 @@ declare namespace React {
          * prevents this from being invoked.
          *
          * @deprecated 16.3, use getSnapshotBeforeUpdate instead
-         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#reading-dom-properties-before-an-update
-         * @see https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#reading-dom-properties-before-an-update}
+         * @see {@link https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path}
          */
         UNSAFE_componentWillUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): void;
     }
@@ -915,14 +915,14 @@ declare namespace React {
      * context value, as given by the nearest context provider for the given context.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useContext
+     * @see {@link https://react.dev/reference/react/useContext}
      */
     function useContext<T>(context: Context<T> /*, (not public API) observedBits?: number|boolean */): T;
     /**
      * Returns a stateful value, and a function to update it.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useState
+     * @see {@link https://react.dev/reference/react/useState}
      */
     function useState<S>(initialState: S | (() => S)): [S, Dispatch<SetStateAction<S>>];
     // convenience overload when first argument is omitted
@@ -930,7 +930,7 @@ declare namespace React {
      * Returns a stateful value, and a function to update it.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useState
+     * @see {@link https://react.dev/reference/react/useState}
      */
     function useState<S = undefined>(): [S | undefined, Dispatch<SetStateAction<S | undefined>>];
     /**
@@ -941,7 +941,7 @@ declare namespace React {
      * updates because you can pass `dispatch` down instead of callbacks.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useReducer
+     * @see {@link https://react.dev/reference/react/useReducer}
      */
     // overload where dispatch could accept 0 arguments.
     function useReducer<R extends ReducerWithoutAction<any>, I>(
@@ -957,7 +957,7 @@ declare namespace React {
      * updates because you can pass `dispatch` down instead of callbacks.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useReducer
+     * @see {@link https://react.dev/reference/react/useReducer}
      */
     // overload where dispatch could accept 0 arguments.
     function useReducer<R extends ReducerWithoutAction<any>>(
@@ -973,7 +973,7 @@ declare namespace React {
      * updates because you can pass `dispatch` down instead of callbacks.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useReducer
+     * @see {@link https://react.dev/reference/react/useReducer}
      */
     // overload where "I" may be a subset of ReducerState<R>; used to provide autocompletion.
     // If "I" matches ReducerState<R> exactly then the last overload will allow initializer to be omitted.
@@ -991,7 +991,7 @@ declare namespace React {
      * updates because you can pass `dispatch` down instead of callbacks.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useReducer
+     * @see {@link https://react.dev/reference/react/useReducer}
      */
     // overload for free "I"; all goes as long as initializer converts it into "ReducerState<R>".
     function useReducer<R extends Reducer<any, any>, I>(
@@ -1007,7 +1007,7 @@ declare namespace React {
      * updates because you can pass `dispatch` down instead of callbacks.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useReducer
+     * @see {@link https://react.dev/reference/react/useReducer}
      */
 
     // I'm not sure if I keep this 2-ary or if I make it (2,3)-ary; it's currently (2,3)-ary.
@@ -1032,7 +1032,7 @@ declare namespace React {
      * value around similar to how you’d use instance fields in classes.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useRef
+     * @see {@link https://react.dev/reference/react/useRef}
      */
     function useRef<T>(initialValue: T): MutableRefObject<T>;
     // convenience overload for refs given as a ref prop as they typically start with a null value
@@ -1047,7 +1047,7 @@ declare namespace React {
      * of the generic argument.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useRef
+     * @see {@link https://react.dev/reference/react/useRef}
      */
     function useRef<T>(initialValue: T | null): RefObject<T>;
     // convenience overload for potentially undefined initialValue / call with 0 arguments
@@ -1060,7 +1060,7 @@ declare namespace React {
      * value around similar to how you’d use instance fields in classes.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useRef
+     * @see {@link https://react.dev/reference/react/useRef}
      */
     function useRef<T = undefined>(): MutableRefObject<T | undefined>;
     /**
@@ -1074,7 +1074,7 @@ declare namespace React {
      * `componentDidMount` and `componentDidUpdate`.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useLayoutEffect
+     * @see {@link https://react.dev/reference/react/useLayoutEffect}
      */
     function useLayoutEffect(effect: EffectCallback, deps?: DependencyList): void;
     /**
@@ -1084,7 +1084,7 @@ declare namespace React {
      * @param deps If present, effect will only activate if the values in the list change.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useEffect
+     * @see {@link https://react.dev/reference/react/useEffect}
      */
     function useEffect(effect: EffectCallback, deps?: DependencyList): void;
     // NOTE: this does not accept strings, but this will have to be fixed by removing strings from type Ref<T>
@@ -1095,7 +1095,7 @@ declare namespace React {
      * `useImperativeHandle` should be used with `React.forwardRef`.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useImperativeHandle
+     * @see {@link https://react.dev/reference/react/useImperativeHandle}
      */
     function useImperativeHandle<T, R extends T>(ref: Ref<T> | undefined, init: () => R, deps?: DependencyList): void;
     // I made 'inputs' required here and in useMemo as there's no point to memoizing without the memoization key
@@ -1105,7 +1105,7 @@ declare namespace React {
      * has changed.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useCallback
+     * @see {@link https://react.dev/reference/react/useCallback}
      */
     // TODO (TypeScript 3.0): <T extends (...args: never[]) => unknown>
     function useCallback<T extends (...args: any[]) => any>(callback: T, deps: DependencyList): T;
@@ -1113,7 +1113,7 @@ declare namespace React {
      * `useMemo` will only recompute the memoized value when one of the `deps` has changed.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useMemo
+     * @see {@link https://react.dev/reference/react/useMemo}
      */
     // allow undefined, but don't make it optional as that is very likely a mistake
     function useMemo<T>(factory: () => T, deps: DependencyList | undefined): T;
@@ -1124,7 +1124,7 @@ declare namespace React {
      * It’s most valuable for custom hooks that are part of shared libraries.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useDebugValue
+     * @see {@link https://react.dev/reference/react/useDebugValue}
      */
     // the name of the custom hook is itself derived from the function name at runtime:
     // it's just the function name without the "use" prefix.
@@ -1947,12 +1947,12 @@ declare namespace React {
         // Living Standard
         /**
          * Hints at the type of data that might be entered by the user while editing the element or its contents
-         * @see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute
+         * @see {@link https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute}
          */
         inputMode?: "none" | "text" | "tel" | "url" | "email" | "numeric" | "decimal" | "search" | undefined;
         /**
          * Specify that a standard HTML element should behave like a defined custom built-in element
-         * @see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is
+         * @see {@link https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is}
          */
         is?: string | undefined;
         /**

--- a/types/react/v18/canary.d.ts
+++ b/types/react/v18/canary.d.ts
@@ -53,7 +53,7 @@ declare module "." {
      * context value, as given by the nearest context provider for the given context.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useContext
+     * @see {@link https://react.dev/reference/react/useContext}
      */
     function useContext<T extends ServerContextJSONValue>(context: ServerContext<T>): T;
     export function createServerContext<T extends ServerContextJSONValue>(

--- a/types/react/v18/experimental.d.ts
+++ b/types/react/v18/experimental.d.ts
@@ -101,8 +101,8 @@ declare module "." {
      * However, if you wrap these items in a `SuspenseList`, React will not show an item in the list
      * until previous items have been displayed (this behavior is adjustable).
      *
-     * @see https://reactjs.org/docs/concurrent-mode-reference.html#suspenselist
-     * @see https://reactjs.org/docs/concurrent-mode-patterns.html#suspenselist
+     * @see {@link https://reactjs.org/docs/concurrent-mode-reference.html#suspenselist}
+     * @see {@link https://reactjs.org/docs/concurrent-mode-patterns.html#suspenselist}
      */
     export const unstable_SuspenseList: ExoticComponent<SuspenseListProps>;
 
@@ -125,7 +125,7 @@ declare module "." {
 
     export interface HTMLAttributes<T> {
         /**
-         * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert
+         * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert}
          */
         inert?: boolean | undefined;
     }

--- a/types/react/v18/index.d.ts
+++ b/types/react/v18/index.d.ts
@@ -2149,7 +2149,7 @@ declare namespace React {
      *
      * @param callback A synchronous, void callback that will execute as a single, complete React commit.
      *
-     * @see https://reactjs.org/blog/2019/02/06/react-v16.8.0.html#testing-hooks
+     * @see {@link https://reactjs.org/blog/2019/02/06/react-v16.8.0.html#testing-hooks}
      */
     // While act does always return Thenable, if a void function is passed, we pretend the return value is also void to not trigger dangling Promise lint rules.
     export function act(callback: () => VoidOrUndefinedOnly): void;

--- a/types/react/v18/ts5.0/canary.d.ts
+++ b/types/react/v18/ts5.0/canary.d.ts
@@ -53,7 +53,7 @@ declare module "." {
      * context value, as given by the nearest context provider for the given context.
      *
      * @version 16.8.0
-     * @see https://react.dev/reference/react/useContext
+     * @see {@link https://react.dev/reference/react/useContext}
      */
     function useContext<T extends ServerContextJSONValue>(context: ServerContext<T>): T;
     export function createServerContext<T extends ServerContextJSONValue>(

--- a/types/react/v18/ts5.0/experimental.d.ts
+++ b/types/react/v18/ts5.0/experimental.d.ts
@@ -101,8 +101,8 @@ declare module "." {
      * However, if you wrap these items in a `SuspenseList`, React will not show an item in the list
      * until previous items have been displayed (this behavior is adjustable).
      *
-     * @see https://reactjs.org/docs/concurrent-mode-reference.html#suspenselist
-     * @see https://reactjs.org/docs/concurrent-mode-patterns.html#suspenselist
+     * @see {@link https://reactjs.org/docs/concurrent-mode-reference.html#suspenselist}
+     * @see {@link https://reactjs.org/docs/concurrent-mode-patterns.html#suspenselist}
      */
     export const unstable_SuspenseList: ExoticComponent<SuspenseListProps>;
 
@@ -125,7 +125,7 @@ declare module "." {
 
     export interface HTMLAttributes<T> {
         /**
-         * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert
+         * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert}
          */
         inert?: boolean | undefined;
     }

--- a/types/react/v18/ts5.0/index.d.ts
+++ b/types/react/v18/ts5.0/index.d.ts
@@ -2150,7 +2150,7 @@ declare namespace React {
      *
      * @param callback A synchronous, void callback that will execute as a single, complete React commit.
      *
-     * @see https://reactjs.org/blog/2019/02/06/react-v16.8.0.html#testing-hooks
+     * @see {@link https://reactjs.org/blog/2019/02/06/react-v16.8.0.html#testing-hooks}
      */
     // While act does always return Thenable, if a void function is passed, we pretend the return value is also void to not trigger dangling Promise lint rules.
     export function act(callback: () => VoidOrUndefinedOnly): void;


### PR DESCRIPTION
see https://github.com/npmx-dev/npmx.dev/issues/955#issuecomment-3850729855:

> But there's still a raw URL text in React docs too:
> 
> - react@19.2.4 docs - npmx - https://npmx.dev/package-docs/react/v/19.2.4#function-act
>   - index.d.ts - @types/react@19.2.4 - npmx - https://npmx.dev/package-code/@types/react/v/19.2.4/index.d.ts#L1878-L1895

There are 420 instances of `@see {@link` in React's types. These 88 instances of `@see https` are in the minority. Wrapping the URLs in `{@link ... }` ([example](https://jsdoc.app/tags-see)) makes the JSDoc comments within React's types more consistent, and aids in generating links when JSDoc comments are turned into HTML (npmx-dev/npmx.dev#955)

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/npmx-dev/npmx.dev/issues/955#issuecomment-3850729855
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
