### PR TITLE
[node] test: `mock.module` can take a `URL`

### DIFF
--- a/types/node/node-tests/test.ts
+++ b/types/node/node-tests/test.ts
@@ -20,6 +20,7 @@ import {
     todo,
 } from "node:test";
 import { dot, junit, lcov, spec, tap, TestEvent } from "node:test/reporters";
+import { URL } from "node:url";
 
 // top-level export
 test satisfies typeof import("node:test");
@@ -795,6 +796,7 @@ test("mocks a setter", (t) => {
 });
 
 test("mocks a module", (t) => {
+    // module specifier as a string
     // $ExpectType MockModuleContext
     const mock = t.mock.module("node:readline", {
         namedExports: {
@@ -811,6 +813,16 @@ test("mocks a module", (t) => {
     });
     // $ExpectType void
     mock.restore();
+
+    // module specifier as a URL
+    // $ExpectType MockModuleContext
+    t.mock.module(new URL("someUrl"), {
+        namedExports: {
+            fn() {
+                return 42;
+            },
+        },
+    });
 });
 
 test("mocks a property", (t) => {

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -82,6 +82,7 @@ declare module "node:test" {
     import { AssertMethodNames } from "node:assert";
     import { Readable, ReadableEventMap } from "node:stream";
     import { TestEvent } from "node:test/reporters";
+    import { URL } from "node:url";
     import TestFn = test.TestFn;
     import TestOptions = test.TestOptions;
     /**
@@ -1692,7 +1693,7 @@ declare module "node:test" {
              * @param specifier A string identifying the module to mock.
              * @param options Optional configuration options for the mock module.
              */
-            module(specifier: string, options?: MockModuleOptions): MockModuleContext;
+            module(specifier: string | URL, options?: MockModuleOptions): MockModuleContext;
             /**
              * Creates a mock for a property value on an object. This allows you to track and control access to a specific property,
              * including how many times it is read (getter) or written (setter), and to restore the original value after mocking.

--- a/types/node/v22/test.d.ts
+++ b/types/node/v22/test.d.ts
@@ -81,6 +81,7 @@
 declare module "node:test" {
     import { AssertMethodNames } from "node:assert";
     import { Readable } from "node:stream";
+    import { URL } from "node:url";
     import TestFn = test.TestFn;
     import TestOptions = test.TestOptions;
     /**
@@ -1638,7 +1639,7 @@ declare module "node:test" {
              * @param specifier A string identifying the module to mock.
              * @param options Optional configuration options for the mock module.
              */
-            module(specifier: string, options?: MockModuleOptions): MockModuleContext;
+            module(specifier: string | URL, options?: MockModuleOptions): MockModuleContext;
             /**
              * This function restores the default behavior of all mocks that were previously
              * created by this `MockTracker` and disassociates the mocks from the `MockTracker` instance. Once disassociated, the mocks can still be used, but the `MockTracker` instance can no longer be

--- a/types/node/v22/test/test.ts
+++ b/types/node/v22/test/test.ts
@@ -20,6 +20,7 @@ import {
     todo,
 } from "node:test";
 import { dot, junit, lcov, spec, tap, TestEvent } from "node:test/reporters";
+import { URL } from "node:url";
 
 // top-level export
 test satisfies typeof import("node:test");
@@ -791,6 +792,7 @@ test("mocks a setter", (t) => {
 });
 
 test("mocks a module", (t) => {
+    // module specifier as a string
     // $ExpectType MockModuleContext
     const mock = t.mock.module("node:readline", {
         namedExports: {
@@ -807,6 +809,16 @@ test("mocks a module", (t) => {
     });
     // $ExpectType void
     mock.restore();
+
+    // module specifier as a URL
+    // $ExpectType MockModuleContext
+    t.mock.module(new URL("someUrl"), {
+        namedExports: {
+            fn() {
+                return 42;
+            },
+        },
+    });
 });
 
 // @ts-expect-error

--- a/types/node/v24/test.d.ts
+++ b/types/node/v24/test.d.ts
@@ -81,6 +81,7 @@
 declare module "node:test" {
     import { AssertMethodNames } from "node:assert";
     import { Readable } from "node:stream";
+    import { URL } from "node:url";
     import TestFn = test.TestFn;
     import TestOptions = test.TestOptions;
     /**
@@ -1711,7 +1712,7 @@ declare module "node:test" {
              * @param specifier A string identifying the module to mock.
              * @param options Optional configuration options for the mock module.
              */
-            module(specifier: string, options?: MockModuleOptions): MockModuleContext;
+            module(specifier: string | URL, options?: MockModuleOptions): MockModuleContext;
             /**
              * Creates a mock for a property value on an object. This allows you to track and control access to a specific property,
              * including how many times it is read (getter) or written (setter), and to restore the original value after mocking.

--- a/types/node/v24/test/test.ts
+++ b/types/node/v24/test/test.ts
@@ -20,6 +20,7 @@ import {
     todo,
 } from "node:test";
 import { dot, junit, lcov, spec, tap, TestEvent } from "node:test/reporters";
+import { URL } from "node:url";
 
 // top-level export
 test satisfies typeof import("node:test");
@@ -795,6 +796,7 @@ test("mocks a setter", (t) => {
 });
 
 test("mocks a module", (t) => {
+    // module specifier as a string
     // $ExpectType MockModuleContext
     const mock = t.mock.module("node:readline", {
         namedExports: {
@@ -811,6 +813,16 @@ test("mocks a module", (t) => {
     });
     // $ExpectType void
     mock.restore();
+
+    // module specifier as a URL
+    // $ExpectType MockModuleContext
+    t.mock.module(new URL("someUrl"), {
+        namedExports: {
+            fn() {
+                return 42;
+            },
+        },
+    });
 });
 
 test("mocks a property", (t) => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see below
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

This behavior is since nodejs/node#54416. It is in v22 since v22.8.0 (nodejs/node#54560), v24 since v24.0.0, and v25 since v25.0.0. It's not in v22.

Relevant Nodejs docs: https://nodejs.org/docs/latest-v25.x/api/test.html#mockmodulespecifier-options

Relevant Nodejs code: https://github.com/nodejs/node/blob/ae2ffce5f3d5ac5ad153d98839d5a19a70e073b2/lib/internal/test_runner/mock/mock.js#L619-L625

Relevant Nodejs test: https://github.com/nodejs/node/blob/ae2ffce5f3d5ac5ad153d98839d5a19a70e073b2/test/parallel/test-runner-module-mocking.js#L158-L160