### PR TITLE
serviceworker-webpack-plugin: use lib.webworker

### DIFF
--- a/types/serviceworker-webpack-plugin/tsconfig.json
+++ b/types/serviceworker-webpack-plugin/tsconfig.json
@@ -2,8 +2,8 @@
     "compilerOptions": {
         "module": "node16",
         "lib": [
-            "dom",
-            "es6"
+            "es6",
+            "webworker"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
In the latest DOM update, one of the mixins referenced in the tests is now worker-only.