### PR TITLE
cacache: add missing options argument for cacache.get.info

### DIFF
--- a/types/cacache/cacache-tests.ts
+++ b/types/cacache/cacache-tests.ts
@@ -32,6 +32,10 @@ cacache.get.stream.byDigest(cachePath, "sha512-SoMeDIGest+64==").pipe(fs.createW
 
 cacache.get.info(cachePath, "my-thing").then(() => {});
 
+cacache.get.info(cachePath, "my-thing", { memoize: true }).then(() => {});
+
+cacache.get.info(cachePath, "my-thing", { memoize: new Map() }).then(() => {});
+
 cacache.get.hasContent(cachePath, "sha521-NOT+IN/CACHE==").then((res) => {
     res; // $ExpectType HasContentObject | false
 });

--- a/types/cacache/index.d.ts
+++ b/types/cacache/index.d.ts
@@ -79,6 +79,8 @@ export namespace get {
         size?: number | undefined;
     }
 
+    type InfoOptions = Pick<Options, "memoize">;
+
     interface GetStreamEvents extends Minipass.Events<Buffer> {
         // eslint-disable-next-line @definitelytyped/no-single-element-tuple-type
         integrity: [integrity: string];
@@ -116,7 +118,7 @@ export namespace get {
      * Looks up `key` in the cache index, returning information about the entry
      * if one exists.
      */
-    function info(cachePath: string, key: string): Promise<CacheObject>;
+    function info(cachePath: string, key: string, opts?: InfoOptions): Promise<CacheObject | null>;
 
     /**
      * Returns a Readable Stream of the cached data identified by `key`.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/npm/cacache/blob/v20.0.3/lib/get.js#L137
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

