### PR TITLE
Remove myself as owner of @types/nova-editor-node

### DIFF
--- a/types/nova-editor-node/package.json
+++ b/types/nova-editor-node/package.json
@@ -10,10 +10,5 @@
     "devDependencies": {
         "@types/nova-editor-node": "workspace:."
     },
-    "owners": [
-        {
-            "name": "Cameron Little",
-            "githubUsername": "apexskier"
-        }
-    ]
+    "owners": []
 }


### PR DESCRIPTION
I haven't been working on Nova extensions for a couple years, and won't be managing these types any more. Ideally, Panic would.

Context - https://github.com/apexskier/nova-typescript/commit/fb6b22d528742a0c688cb83b23b683800b5bb887

Select one of these and delete the others:

None of these.