### PR TITLE
Enable `hooker` to infer the parameter and return value types of function

### DIFF
--- a/types/hooker/index.d.ts
+++ b/types/hooker/index.d.ts
@@ -9,23 +9,79 @@ declare type HookerPostHookFunction<F extends (...args: any[]) => any = (...args
 /* eslint-enable @typescript-eslint/no-invalid-void-type */
 
 declare module "hooker" {
+    /**
+     * Monkey-patch (hook) one or more methods of an object. Returns an array of hooked method names.
+     *
+     * @param object
+     * @param props Can be a method name, array of method names or null. If null (or omitted), all enumerable methods of `object` will be hooked.
+     * @param options
+     */
     function hook<T, K extends keyof T>(
         object: T,
         props: K,
         options: IHookerOptions<T[K] extends (...args: any[]) => any ? T[K] : never>,
-    ): void;
+    ): string[];
+    /**
+     * Monkey-patch (hook) one or more methods of an object. Returns an array of hooked method names.
+     *
+     * @param object
+     * @param props Can be a method name, array of method names or null. If null (or omitted), all enumerable methods of `object` will be hooked.
+     * @param prehookFunction A pre-hook function to be executed before the original function. Arguments passed into the method will be passed into the pre-hook function as well.
+     */
     function hook<T, K extends keyof T>(
         object: T,
         props: K,
         prehookFunction: HookerPreHookFunction<T[K] extends (...args: any[]) => any ? T[K] : never>,
-    ): void;
-    function hook(object: any, props: string[], options: IHookerOptions): void;
-    function hook(object: any, props: string[], prehookFunction: HookerPreHookFunction): void;
+    ): string[];
+    /**
+     * Monkey-patch (hook) one or more methods of an object. Returns an array of hooked method names.
+     *
+     * @param object
+     * @param props Can be a method name, array of method names or null. If null (or omitted), all enumerable methods of `object` will be hooked.
+     * @param options
+     */
+    function hook(object: any, props: string[], options: IHookerOptions): string[];
+    /**
+     * Monkey-patch (hook) one or more methods of an object. Returns an array of hooked method names.
+     *
+     * @param object
+     * @param props Can be a method name, array of method names or null. If null (or omitted), all enumerable methods of `object` will be hooked.
+     * @param prehookFunction A pre-hook function to be executed before the original function. Arguments passed into the method will be passed into the pre-hook function as well.
+     */
+    function hook(object: any, props: string[], prehookFunction: HookerPreHookFunction): string[];
+    /**
+     * Un-monkey-patch (unhook) one or more methods of an object.
+     *
+     * @param object
+     * @param props Can be a method name, array of method names or null. If null (or omitted), all methods of object will be unhooked.
+     */
     function unhook(object: any, props?: string | string[]): string[];
+    /**
+     * Get a reference to the original method from a hooked function.
+     *
+     * @param object
+     * @param prop
+     */
     function orig<T, K extends keyof T>(object: T, prop: K): T[K] extends (...args: any[]) => any ? T[K] : never;
     function orig(object: any, prop: string): Function;
+    /**
+     * When a pre- or post-hook returns the result of this function, the value passed will be used in place of the original function's return value. Any post-hook override value will take precedence over a pre-hook override value.
+     *
+     * @param value
+     */
     function override<T>(value: T): HookerOverride<T>;
+    /**
+     * When a pre-hook returns the result of this function, the value passed will be used in place of the original function's return value, and the original function will **NOT** be executed.
+     *
+     * @param value
+     */
     function preempt<T>(value: T): HookerPreempt<T>;
+    /**
+     * When a pre-hook returns the result of this function, the context and arguments passed will be applied into the original function.
+     *
+     * @param context
+     * @param args
+     */
     function filter<T>(context: any, args: T): HookerFilter<T>;
 }
 
@@ -43,8 +99,20 @@ declare class HookerFilter<T> {
 }
 
 interface IHookerOptions<F extends (...args: any[]) => any = (...args: any[]) => any> {
+    /**
+     * A pre-hook function to be executed before the original function. Arguments passed into the method will be passed into the pre-hook function as well.
+     */
     pre?: HookerPreHookFunction<F>;
+    /**
+     * A post-hook function to be executed after the original function. The original function's result is passed into the post-hook function as its first argument, followed by the method arguments.
+     */
     post?: HookerPostHookFunction<F>;
+    /**
+     * If true, auto-unhook the function after the first execution.
+     */
     once?: boolean;
+    /**
+     * If true, pass the name of the method into the pre-hook function as its first arg (preceding all other arguments), and into the post-hook function as the second arg (after result but preceding all other arguments).
+     */
     passName?: boolean;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/hooker#documentation
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

This PR enables `hooker` to infer the parameter and return value types of function when adding hooks to function with `hook(object: any, props: string)`. This allows you to get type hints when writing hooks and avoid calling the original function or overriding the return value with wrong types.

Before:

![](https://github.com/user-attachments/assets/c7d1c8a5-ace9-4b02-84bc-dedef20c9093)
![](https://github.com/user-attachments/assets/1ec3d520-c3d0-4fdb-981d-afba86dfd0ba)

After:

![](https://github.com/user-attachments/assets/23eb6657-7cdb-4e07-a9f1-4b8226096a05)
![](https://github.com/user-attachments/assets/e0c9685c-b641-4534-a291-1a71d176b956)
![](https://github.com/user-attachments/assets/54b8485d-d6c6-4d6f-99eb-8288984e4277)

(No more AnyScript, should get an error with wrong overriding return value type)

I completely rewrote the test because the original one was strange.

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0cc4d1e1371be64cda8884304f6ffd63e452d6a0/types/hooker/hooker-tests.ts#L4-L11

Why hook something that isn't a function or is undefined? Although the hooker [won't do anything](https://github.com/cowboy/javascript-hooker/blob/4b49d9e5078fe7b632f8cde30a79b21495e03163/lib/hooker.js#L63-L69) in this case.

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0cc4d1e1371be64cda8884304f6ffd63e452d6a0/types/hooker/hooker-tests.ts#L47-L51

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0cc4d1e1371be64cda8884304f6ffd63e452d6a0/types/hooker/hooker-tests.ts#L58-L65

`hooker.filter` can only be used in [pre-hook](https://www.npmjs.com/package/hooker#hookerfilter).

Additionally I fixed these issues:

* In `orig(object, props)`, the type of `props` can only be `string`, not `string[]`. [(Source)](https://github.com/cowboy/javascript-hooker/blob/4b49d9e5078fe7b632f8cde30a79b21495e03163/lib/hooker.js#L158-L161)
* In `hook(object, props, options)`, the return type should be `string[]` (hooked method names) instead of `void`. [(Source)](https://github.com/cowboy/javascript-hooker/blob/4b49d9e5078fe7b632f8cde30a79b21495e03163/lib/hooker.js#L71-L72)
* Added documentation.

