### PR TITLE
Add named plugin exports to formidable types

### DIFF
--- a/types/formidable/formidable-tests.ts
+++ b/types/formidable/formidable-tests.ts
@@ -12,6 +12,11 @@ import {
     PersistentFile,
     plugins,
     VolatileFile,
+    PluginFunction,
+    octetstream,
+    querystring,
+    multipart,
+    json,
 } from "formidable";
 import * as http from "http";
 
@@ -219,3 +224,12 @@ new IncomingForm();
 
 // $ExpectType IncomingForm
 formidable();
+
+// $ExpectType PluginFunction
+octetstream;
+// $ExpectType PluginFunction
+querystring;
+// $ExpectType PluginFunction
+multipart;
+// $ExpectType PluginFunction
+json;

--- a/types/formidable/index.d.ts
+++ b/types/formidable/index.d.ts
@@ -326,6 +326,11 @@ declare const formidable: {
     IncomingForm: typeof Formidable;
     // parsers and mapped parsers
     parsers: typeof parsers;
+    // add named plugin exports
+    octetstream: formidable.PluginFunction;
+    querystring: formidable.PluginFunction;
+    multipart: formidable.PluginFunction;
+    json: formidable.PluginFunction;
 } & formidable.MappedParsers;
 
 export = formidable;


### PR DESCRIPTION
Added named plugin exports for octetstream, querystring, multipart, and json.

To match how plugins are used on [README](https://github.com/node-formidable/formidable?tab=readme-ov-file#useplugin-plugin):

```ts
import formidable, {octetstream, querystring, multipart, json} from "formidable";
```

Plugins exported by name and works well at runtime: [main file exports all plugins](https://github.com/node-formidable/formidable/blob/d0fbec13edc8add54a1afb9ce1a8d3db803f8d47/src/index.js#L31) and [plugins/index.js exports plugins by name](https://github.com/node-formidable/formidable/blob/d0fbec13edc8add54a1afb9ce1a8d3db803f8d47/src/plugins/index.js#L6)