### PR TITLE
[@types/ioredis-mock] Use export = for CJS module compatibility

### DIFF
--- a/attw.json
+++ b/attw.json
@@ -148,7 +148,6 @@
         "input-moment",
         "inputmask",
         "intl-unofficial-duration-unit-format",
-        "ioredis-mock",
         "iput",
         "itemsjs",
         "itowns",

--- a/types/ioredis-mock/index.d.ts
+++ b/types/ioredis-mock/index.d.ts
@@ -1,29 +1,31 @@
 import ioredis = require("ioredis");
 
-export type RedisOptions = { data?: Record<string, unknown> } & ioredis.RedisOptions;
+declare namespace redisMock {
+    type RedisOptions = { data?: Record<string, unknown> } & ioredis.RedisOptions;
 
-export type RedisClusterOptions = {
-    redisOptions: Omit<
-        RedisOptions,
-        "port" | "host" | "path" | "sentinels" | "retryStrategy" | "enableOfflineQueue" | "readOnly"
-    >;
-} & ioredis.ClusterOptions;
+    type RedisClusterOptions = {
+        redisOptions: Omit<
+            RedisOptions,
+            "port" | "host" | "path" | "sentinels" | "retryStrategy" | "enableOfflineQueue" | "readOnly"
+        >;
+    } & ioredis.ClusterOptions;
 
-export interface ClusterConstructor {
-    new(startupNodes: ioredis.ClusterNode[], options?: RedisClusterOptions): ioredis.Cluster;
+    interface ClusterConstructor {
+        new(startupNodes: ioredis.ClusterNode[], options?: RedisClusterOptions): ioredis.Cluster;
+    }
+
+    interface Constructor {
+        new(port: number, host: string, options: RedisOptions): ioredis.Redis;
+        new(path: string, options: RedisOptions): ioredis.Redis;
+        new(port: number, options: RedisOptions): ioredis.Redis;
+        new(port: number, host: string): ioredis.Redis;
+        new(options: RedisOptions): ioredis.Redis;
+        new(port: number): ioredis.Redis;
+        new(path: string): ioredis.Redis;
+        new(): ioredis.Redis;
+        Cluster: ClusterConstructor;
+    }
 }
 
-export interface Constructor {
-    new(port: number, host: string, options: RedisOptions): ioredis.Redis;
-    new(path: string, options: RedisOptions): ioredis.Redis;
-    new(port: number, options: RedisOptions): ioredis.Redis;
-    new(port: number, host: string): ioredis.Redis;
-    new(options: RedisOptions): ioredis.Redis;
-    new(port: number): ioredis.Redis;
-    new(path: string): ioredis.Redis;
-    new(): ioredis.Redis;
-    Cluster: ClusterConstructor;
-}
-
-export const redisMock: Constructor;
-export { redisMock as default };
+declare const redisMock: redisMock.Constructor;
+export = redisMock;

--- a/types/ioredis-mock/ioredis-mock-tests.ts
+++ b/types/ioredis-mock/ioredis-mock-tests.ts
@@ -1,4 +1,4 @@
-import IORedis, { RedisOptions } from "ioredis-mock";
+import IORedis = require("ioredis-mock");
 
 // see https://www.npmjs.com/package/ioredis-mock for MockRedisInput input
 // see https://github.com/luin/ioredis/tree/master/examples
@@ -61,7 +61,7 @@ redis.hgetall("myhash").then(res => console.log(res));
 // All arguments are passed directly to the redis server:
 redis.set("key", 100, "EX", 10); // set's key to value 100 and expires it after 10 seconds
 
-const options: RedisOptions = {};
+const options: IORedis.RedisOptions = {};
 console.log(options.port);
 
 const f = async () => {


### PR DESCRIPTION
## Summary

`ioredis-mock` is a CJS package (no `"type": "module"`) but `@types/ioredis-mock` uses ESM-style exports (`export const redisMock; export { redisMock as default }`). Under `verbatimModuleSyntax: true` + `module: "nodenext"` (the standard modern TS config from `@tsconfig/node24` + `@tsconfig/node-ts`), the default import resolves to the **module namespace type** instead of `Constructor`, so `new Redis()` fails type checking.

## The Fix

- Switch from ESM-style named/default exports to `export =` with namespace declaration merging
- This correctly models the CJS module shape (`module.exports = redisMock`)
- Types (`RedisOptions`, `ClusterConstructor`, etc.) remain accessible via the namespace (e.g., `IORedis.RedisOptions`)
- Remove `ioredis-mock` from `attw.json` `failingPackages` since the types now pass all resolution checks

## Compatibility

- **`esModuleInterop` users**: `import Redis from "ioredis-mock"` continues to work — TS synthesizes the default from `export =`
- **`verbatimModuleSyntax` / `nodenext` users**: `import Redis = require("ioredis-mock")` now works correctly, and `new Redis()` resolves to `Constructor`
- **Named type imports**: Change from `import { RedisOptions } from "ioredis-mock"` to `import Redis = require("ioredis-mock"); type Opts = Redis.RedisOptions`

## Test plan

- [x] `pnpm test ioredis-mock` passes in DefinitelyTyped
- [x] `attw` shows all green (node10, node16 CJS/ESM, bundler)