### PR TITLE
Update @aws-sdk/client-sesv2 version to ^3.985.0 for nodemailer development dependencies

### DIFF
--- a/types/nodemailer/package.json
+++ b/types/nodemailer/package.json
@@ -10,7 +10,7 @@
         "@types/node": "*"
     },
     "devDependencies": {
-        "@aws-sdk/client-sesv2": "^3.839.0",
+        "@aws-sdk/client-sesv2": "^3.985.0",
         "@types/nodemailer": "workspace:."
     },
     "owners": [


### PR DESCRIPTION
Prevents annoying dependency vulnerability

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

Very simple bump!!! Just shifting the version to remove downstream security warnings about the fast-xml-parser vulnerability. This has already been updated in the actual code here:
https://github.com/nodemailer/nodemailer/commit/b7872f9959e199a460b068adef4afdb6a8933a73
<img width="1193" height="223" alt="image" src="https://github.com/user-attachments/assets/a081eb49-99ea-4a63-9fdf-3cde6c6bc15f" />
CVE-2026-25128
https://github.com/advisories/GHSA-37qj-frw5-hhjh