### PR TITLE
Add tuple overloads to lodash `unzip` to match existing `zip` overloads

### DIFF
--- a/types/lodash/common/array.d.ts
+++ b/types/lodash/common/array.d.ts
@@ -1784,6 +1784,28 @@ declare module "../index" {
          * @param array The array of grouped elements to process.
          * @return Returns the new array of regrouped elements.
          */
+        unzip<T1, T2>(array: Array<[T1, T2]>): [T1[], T2[]];
+        /**
+         * @see _.unzip
+         */
+        unzip<T1, T2, T3>(
+            array: Array<[T1, T2, T3]>,
+        ): [T1[], T2[], T3[]];
+        /**
+         * @see _.unzip
+         */
+        unzip<T1, T2, T3, T4>(
+            array: Array<[T1, T2, T3, T4]>,
+        ): [T1[], T2[], T3[], T4[]];
+        /**
+         * @see _.unzip
+         */
+        unzip<T1, T2, T3, T4, T5>(
+            array: Array<[T1, T2, T3, T4, T5]>,
+        ): [T1[], T2[], T3[], T4[], T5[]];
+        /**
+         * @see _.unzip
+         */
         unzip<T>(array: T[][] | List<List<T>> | null | undefined): T[][];
     }
     interface Collection<T> {

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -1480,6 +1480,10 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType CollectionChain<number>
     _(list).unzip(); // $ExpectType Collection<AbcObject[]>
     _.chain(list).unzip(); // $ExpectType CollectionChain<AbcObject[]>
     fp.unzip(list); // $ExpectType AbcObject[][]
+
+    _.unzip([[1, 'a'], [3, 'b'], [5, 'c']]); // $ExpectType [number[], string[]]
+    _.unzip([['a', 1, true], ['b', 2, false]]); // $ExpectType [string[], number[], boolean[]]
+    _.unzip([[1, undefined], [2, 'a']]); // $ExpectType [number[], (string | undefined)[]]
 }
 
 // _.unzipWith


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test lodash`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/4a6fd83bbd14c6c208a7e666d49e5cb935e760ae/types/lodash/common/array.d.ts#L1976-L2001
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

## Additional Information

This PR adds tuple overloads to Lodash's [`unzip`](https://lodash.com/docs/4.17.23#unzip) to match the existing overloads that are already present in the typings for [`zip`](https://lodash.com/docs/4.17.23#zip):

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/4a6fd83bbd14c6c208a7e666d49e5cb935e760ae/types/lodash/common/array.d.ts#L1976-L2001

`zip` and `unzip` are inverses, so I effectively took the `zip` tuple overload typings and flipped the parameters and the return type to derive the corresponding overload typings for `unzip`. However, we do not need to add `undefined` to the `unzip` return types as `| undefined` would be automatically captured by the generic argument.

> More precisely, `zip` accepts multiple arrays and returns a new array of arrays where the first returned array contains the first element of each input array, the second returned array contains the second element of each input array, etc. If one of the original array arguments has length `n < m` whereas the rest of the arrays have length `m`, the `n+1`th array in the return value will have an `undefined` value at the input position of the shortened input array. On the other hand, the tuple type signature of `unzip` enforces that all input arrays have the same length and subsumes any `undefined` values in the input into the generic `T1`, `T2`, `T3`, etc., so the return value `[T1, T2, T3]` etc. will automatically reflect the fact that the input had an `undefined` value and hence doesn't need an explicit `| undefined`.

Concretely, the Lodash documentation for `unzip` shows an example of how it is an inverse of `zip`: https://lodash.com/docs/4.17.23#unzip

```js
var zipped = _.zip(['a', 'b'], [1, 2], [true, false]);
// => [['a', 1, true], ['b', 2, false]]
 
_.unzip(zipped);
// => [['a', 'b'], [1, 2], [true, false]]
```

In addition to the tests added in this PR, I patched `@types/lodash` with the proposed changes in an existing project and all `unzip` callsites continued to pass type-checking.