### PR TITLE
Fix node telegram bot api 9 4 types

### DIFF
--- a/types/node-telegram-bot-api/index.d.ts
+++ b/types/node-telegram-bot-api/index.d.ts
@@ -882,6 +882,8 @@ declare namespace TelegramBot {
 
     interface KeyboardButton {
         text: string;
+        style?: 'primary' | 'danger' | 'success' | undefined;
+        icon_custom_emoji_id?: string | undefined;
         request_user?: KeyboardButtonRequestUser | undefined;
         request_chat?: KeyboardButtonRequestChat | undefined;
         request_contact?: boolean | undefined;
@@ -922,6 +924,8 @@ declare namespace TelegramBot {
 
     interface InlineKeyboardButton {
         text: string;
+        style?: 'primary' | 'danger' | 'success' | undefined;
+        icon_custom_emoji_id?: string | undefined;
         url?: string | undefined;
         callback_data?: string | undefined;
         web_app?: WebAppInfo;

--- a/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
+++ b/types/node-telegram-bot-api/node-telegram-bot-api-tests.ts
@@ -548,3 +548,32 @@ MyTelegramBot.setStickerSetThumb(1234, "my_set_thumb", "thumb_file");
 MyTelegramBot.setMessageReaction(1234, 1234, {
     reaction: [{ type: "emoji", emoji: "👍" }],
 });
+MyTelegramBot.sendMessage(1234, "test-InlineKeyboardButton", {
+    reply_markup: {
+        inline_keyboard: [
+            [
+                {
+                    text: "Registration",
+                    callback_data: "reg",
+                    icon_custom_emoji_id: "5179278706941624825",
+                    style: "primary",
+                },
+            ],
+        ],
+    },
+});
+MyTelegramBot.sendMessage(1234, "test-KeyboardButton", {
+    reply_markup: {
+        keyboard: [
+            [
+                {
+                    text: "Button",
+                    request_contact: false,
+                    icon_custom_emoji_id: "5179278706941624825",
+                    style: "success",
+                },
+            ],
+        ],
+    },
+});
+


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change.
- [x] Follow the advice from the readme.
- [x] Avoid common mistakes.
- [x] Run `pnpm test node-telegram-bot-api`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - Bot API 9.4+ release notes: [KeyboardButton and InlineKeyboardButton](https://core.telegram.org/bots/api)
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

**Changes:**
- Added `icon_custom_emoji_id?: string` to `KeyboardButton` and `InlineKeyboardButton`
- Added `style?: 'primary' | 'secondary' | 'success' | 'danger'` to `KeyboardButton` and `InlineKeyboardButton`
- This allows bots to display custom emoji and styled buttons if supported by the client and Bot API.