### PR TITLE
svg-to-pdfkit: Update types

### DIFF
--- a/types/svg-to-pdfkit/index.d.ts
+++ b/types/svg-to-pdfkit/index.d.ts
@@ -1,31 +1,64 @@
 import PDFDocument = require("pdfkit");
 
+/**
+ * Insert SVG into a PDF document created with PDFKit.
+ *
+ * @param doc the PDF document created with PDFKit
+ * @param svg the SVG object or XML code
+ * @param x the x position where the SVG will be added
+ * @param y the y position where the SVG will be added
+ * @param options See {@link SVGtoPDF.Options}
+ */
 declare function SVGtoPDF(
     doc: typeof PDFDocument,
     svg: SVGElement | string,
-    x?: number,
-    y?: number,
-    options?: SVGtoPDF.SVGtoPDFOptions,
-): void;
+    x: number,
+    y: number,
+    options: SVGtoPDF.Options,
+): void
 
 declare namespace SVGtoPDF {
-    interface SVGtoPDFOptions {
-        width?: number;
-        height?: number;
-        preserveAspectRatio?: string;
-        useCSS?: boolean;
+    type Color = [[number, number, number], number]
+    interface Options {
+        // initial viewport width, by default it's the page width
+        width?: number
+
+        // initial viewport width, by default it's the page height
+        height?: number
+
+        // override alignment of the SVG content inside its viewport
+        preserveAspectRatio?: string
+
+        // use the CSS styles computed by the browser (for SVGElement only)
+        useCSS?: boolean
+
+        // function called to get the fonts, see source code
         fontCallback?: (
             family: string,
             bold: boolean,
             italic: boolean,
             fontOptions: { fauxItalic: boolean; fauxBold: boolean },
-        ) => string;
-        imageCallback?: (link: string) => string;
-        documentCallback?: (file: string) => string;
-        colorCallback?: (result: string, raw: string) => [[number, number, number], number];
-        warningCallback?: (str: string) => void;
-        assumePt?: boolean;
-        precision?: number;
+        ) => string
+
+        // same as above for the images (for Node.js)
+        imageCallback?: (link: string) => string
+
+        // same as above for the external SVG documents
+        documentCallback?: (
+            file: string,
+        ) => SVGElement | string | (SVGElement | string)[]
+
+        // function called to get color, making mapping to CMYK possible
+        colorCallback?: (color: Color) => Color
+
+        // function called when there is a warning
+        warningCallback?: (warning: string) => void
+
+        // assume that units are PDF points instead of SVG pixels
+        assumePt?: boolean
+
+        // precision factor for approximate calculations (default = 3)
+        precision?: number
     }
 }
 

--- a/types/svg-to-pdfkit/index.d.ts
+++ b/types/svg-to-pdfkit/index.d.ts
@@ -20,19 +20,19 @@ declare function SVGtoPDF(
 declare namespace SVGtoPDF {
     type Color = [[number, number, number], number]
     interface Options {
-        // initial viewport width, by default it's the page width
+        /** initial viewport width, by default it's the page width */
         width?: number
 
-        // initial viewport width, by default it's the page height
+        /** initial viewport width, by default it's the page height */
         height?: number
 
-        // override alignment of the SVG content inside its viewport
+        /** override alignment of the SVG content inside its viewport */
         preserveAspectRatio?: string
 
-        // use the CSS styles computed by the browser (for SVGElement only)
+        /** use the CSS styles computed by the browser (for SVGElement only) */
         useCSS?: boolean
 
-        // function called to get the fonts, see source code
+        /** function called to get the fonts, see source code */
         fontCallback?: (
             family: string,
             bold: boolean,
@@ -40,24 +40,24 @@ declare namespace SVGtoPDF {
             fontOptions: { fauxItalic: boolean; fauxBold: boolean },
         ) => string
 
-        // same as above for the images (for Node.js)
+        /** same as above for the images (for Node.js) */
         imageCallback?: (link: string) => string
 
-        // same as above for the external SVG documents
+        /** same as above for the external SVG documents */
         documentCallback?: (
             file: string,
         ) => SVGElement | string | (SVGElement | string)[]
 
-        // function called to get color, making mapping to CMYK possible
+        /** function called to get color, making mapping to CMYK possible */
         colorCallback?: (color: Color) => Color
 
-        // function called when there is a warning
+        /** function called when there is a warning */
         warningCallback?: (warning: string) => void
 
-        // assume that units are PDF points instead of SVG pixels
+        /** assume that units are PDF points instead of SVG pixels */
         assumePt?: boolean
 
-        // precision factor for approximate calculations (default = 3)
+        /** precision factor for approximate calculations (default = 3) */
         precision?: number
     }
 }

--- a/types/svg-to-pdfkit/index.d.ts
+++ b/types/svg-to-pdfkit/index.d.ts
@@ -15,22 +15,22 @@ declare function SVGtoPDF(
     x?: number,
     y?: number,
     options?: SVGtoPDF.Options,
-): void
+): void;
 
 declare namespace SVGtoPDF {
-    type Color = [[number, number, number], number]
+    type Color = [[number, number, number], number];
     interface Options {
         /** initial viewport width, by default it's the page width */
-        width?: number
+        width?: number;
 
         /** initial viewport width, by default it's the page height */
-        height?: number
+        height?: number;
 
         /** override alignment of the SVG content inside its viewport */
-        preserveAspectRatio?: string
+        preserveAspectRatio?: string;
 
         /** use the CSS styles computed by the browser (for SVGElement only) */
-        useCSS?: boolean
+        useCSS?: boolean;
 
         /** function called to get the fonts, see source code */
         fontCallback?: (
@@ -38,27 +38,27 @@ declare namespace SVGtoPDF {
             bold: boolean,
             italic: boolean,
             fontOptions: { fauxItalic: boolean; fauxBold: boolean },
-        ) => string
+        ) => string;
 
         /** same as above for the images (for Node.js) */
-        imageCallback?: (link: string) => string
+        imageCallback?: (link: string) => string;
 
         /** same as above for the external SVG documents */
         documentCallback?: (
             file: string,
-        ) => SVGElement | string | (SVGElement | string)[]
+        ) => SVGElement | string | (SVGElement | string)[];
 
         /** function called to get color, making mapping to CMYK possible */
-        colorCallback?: (color: Color) => Color
+        colorCallback?: (color: Color) => Color;
 
         /** function called when there is a warning */
-        warningCallback?: (warning: string) => void
+        warningCallback?: (warning: string) => void;
 
         /** assume that units are PDF points instead of SVG pixels */
-        assumePt?: boolean
+        assumePt?: boolean;
 
         /** precision factor for approximate calculations (default = 3) */
-        precision?: number
+        precision?: number;
     }
 }
 

--- a/types/svg-to-pdfkit/index.d.ts
+++ b/types/svg-to-pdfkit/index.d.ts
@@ -12,9 +12,9 @@ import PDFDocument = require("pdfkit");
 declare function SVGtoPDF(
     doc: typeof PDFDocument,
     svg: SVGElement | string,
-    x: number,
-    y: number,
-    options: SVGtoPDF.Options,
+    x?: number,
+    y?: number,
+    options?: SVGtoPDF.Options,
 ): void
 
 declare namespace SVGtoPDF {

--- a/types/svg-to-pdfkit/package.json
+++ b/types/svg-to-pdfkit/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/svg-to-pdfkit",
-    "version": "0.1.9999",
+    "version": "1.0.9999",
     "projects": [
         "https://github.com/alafr/SVG-to-PDFKit"
     ],

--- a/types/svg-to-pdfkit/package.json
+++ b/types/svg-to-pdfkit/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/svg-to-pdfkit",
-    "version": "1.0.9999",
+    "version": "0.1.9999",
     "projects": [
         "https://github.com/alafr/SVG-to-PDFKit"
     ],

--- a/types/svg-to-pdfkit/svg-to-pdfkit-tests.ts
+++ b/types/svg-to-pdfkit/svg-to-pdfkit-tests.ts
@@ -9,13 +9,13 @@ SvgToPdf(doc, "<svg>", 100, 100); // $ExpectType void
 
 SvgToPdf(doc, "<svg>", 100, 100, {}); // $ExpectType void
 
-// https://github.com/alafr/SVG-to-PDFKit/blob/4d2d8746bda1e9335c47bbe9ad91277c51fd5a07/source.js#L2477
-const options: SvgToPdf.SVGtoPDFOptions = {
+// https://github.com/alafr/SVG-to-PDFKit/blob/b091ebd4e7b7d2310eb1003511cd5de480f7e0e1/source.js#L2617
+const options: SvgToPdf.Options = {
     width: 100,
     height: 100,
     preserveAspectRatio: "xMinYMin",
     useCSS: true,
-    // https://github.com/alafr/SVG-to-PDFKit/blob/4d2d8746bda1e9335c47bbe9ad91277c51fd5a07/source.js#L2500
+    // https://github.com/alafr/SVG-to-PDFKit/blob/b091ebd4e7b7d2310eb1003511cd5de480f7e0e1/source.js#L2640
     fontCallback: (family, bold, italic, fontOptions) => {
         family; // $ExpectType string
         bold; // $ExpectType boolean
@@ -24,18 +24,17 @@ const options: SvgToPdf.SVGtoPDFOptions = {
         fontOptions.fauxItalic; // $ExpectType boolean
         return family;
     },
-    // https://github.com/alafr/SVG-to-PDFKit/blob/4d2d8746bda1e9335c47bbe9ad91277c51fd5a07/source.js#L2558
+    // https://github.com/alafr/SVG-to-PDFKit/blob/b091ebd4e7b7d2310eb1003511cd5de480f7e0e1/source.js#L2698
     imageCallback: link => {
         link; // $ExpectType string
         return link;
     },
-    // https://github.com/alafr/SVG-to-PDFKit/blob/4d2d8746bda1e9335c47bbe9ad91277c51fd5a07/source.js#L2562
-    colorCallback: (result, row) => {
-        result; // $ExpectType string
-        row; // $ExpectType string
+    // https://github.com/alafr/SVG-to-PDFKit/blob/b091ebd4e7b7d2310eb1003511cd5de480f7e0e1/source.js#L2703
+    colorCallback: (color) => {
+        color; // $ExpectType Color
         return [[255, 255, 255], 1];
     },
-    // https://github.com/alafr/SVG-to-PDFKit/blob/4d2d8746bda1e9335c47bbe9ad91277c51fd5a07/source.js#L2494
+    // https://github.com/alafr/SVG-to-PDFKit/blob/b091ebd4e7b7d2310eb1003511cd5de480f7e0e1/source.js#L2635
     warningCallback: str => {
         str; // $ExpectType string
         console.log(str);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/alafr/SVG-to-PDFKit/blob/master/index.d.ts
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

The types in this repo did not match the types of `svg-to-pdfkit`, namely the `colorCallback` function. The types in `svg-to-pdfkit` were also slightly wrong because `x`, `y`, and `options` are optional arguments for the main function but were not marked as such (I confirmed they are optional in the source code).