### PR TITLE
Fix dagre graph successors type to return a string array

### DIFF
--- a/types/dagre/index.d.ts
+++ b/types/dagre/index.d.ts
@@ -39,7 +39,7 @@ export namespace graphlib {
         setParent(childName: string, parentName: string): void;
         sinks(): string[];
         sources(): string[];
-        successors(name: string): Array<Node<T>> | undefined;
+        successors(name: string): string[] | undefined;
     }
 
     namespace json {


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Fix dagre graph successors type to return a string array.
  - It currently incorrectly returns `Array<Node<T>>`, but the underlying `graphlib` call is returning an array of string keys w/ lodash `keys` https://github.com/dagrejs/graphlib/blob/master/lib/graph.js#L348
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.