### PR TITLE
[@types/node] tls.Certificate: widen DN fields to string | string[]

### DIFF
--- a/types/node/node-tests/tls.ts
+++ b/types/node/node-tests/tls.ts
@@ -314,31 +314,31 @@ import {
     const r00ts: readonly string[] = rootCertificates;
 }
 
-// Certificate DN fields can be string or string[] (multi-valued)
+// Certificate DN fields are optional and can be string or string[] (multi-valued)
 {
     const tlsSocket = connect({});
     const peerCert = tlsSocket.getPeerCertificate();
     const subject = peerCert.subject;
 
-    // Single-valued fields (string)
-    const cn: string | string[] = subject.CN;
-    const ou: string | string[] = subject.OU;
-    const o: string | string[] = subject.O;
+    // Fields are optional and may be string or string[]
+    const cn: string | string[] | undefined = subject.CN;
+    const ou: string | string[] | undefined = subject.OU;
+    const o: string | string[] | undefined = subject.O;
 
     // Type narrowing with Array.isArray
     if (Array.isArray(subject.OU)) {
         const ous: string[] = subject.OU;
     } else {
-        const ou: string = subject.OU;
+        const ou: string | undefined = subject.OU;
     }
 
-    // Index signature: arbitrary DN attributes
+    // Arbitrary DN attributes via index signature
     const email: string | string[] | undefined = subject["emailAddress"];
     const dc: string | string[] | undefined = subject["DC"];
 
     // Issuer has the same shape
     const issuer = peerCert.issuer;
-    const issuerCN: string | string[] = issuer.CN;
+    const issuerCN: string | string[] | undefined = issuer.CN;
 }
 
 {

--- a/types/node/node-tests/tls.ts
+++ b/types/node/node-tests/tls.ts
@@ -314,6 +314,33 @@ import {
     const r00ts: readonly string[] = rootCertificates;
 }
 
+// Certificate DN fields can be string or string[] (multi-valued)
+{
+    const tlsSocket = connect({});
+    const peerCert = tlsSocket.getPeerCertificate();
+    const subject = peerCert.subject;
+
+    // Single-valued fields (string)
+    const cn: string | string[] = subject.CN;
+    const ou: string | string[] = subject.OU;
+    const o: string | string[] = subject.O;
+
+    // Type narrowing with Array.isArray
+    if (Array.isArray(subject.OU)) {
+        const ous: string[] = subject.OU;
+    } else {
+        const ou: string = subject.OU;
+    }
+
+    // Index signature: arbitrary DN attributes
+    const email: string | string[] | undefined = subject["emailAddress"];
+    const dc: string | string[] | undefined = subject["DC"];
+
+    // Issuer has the same shape
+    const issuer = peerCert.issuer;
+    const issuerCN: string | string[] = issuer.CN;
+}
+
 {
     const _options: TlsOptions = {};
     const _server = new Server(_options, (socket) => {});

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -15,37 +15,31 @@ declare module "node:tls" {
     import * as stream from "stream";
     const CLIENT_RENEG_LIMIT: number;
     const CLIENT_RENEG_WINDOW: number;
-    interface Certificate {
+    interface Certificate extends NodeJS.Dict<string | string[]> {
         /**
          * Country code.
          */
-        C: string | string[];
+        C?: string | string[];
         /**
          * Street.
          */
-        ST: string | string[];
+        ST?: string | string[];
         /**
          * Locality.
          */
-        L: string | string[];
+        L?: string | string[];
         /**
          * Organization.
          */
-        O: string | string[];
+        O?: string | string[];
         /**
          * Organizational unit.
          */
-        OU: string | string[];
+        OU?: string | string[];
         /**
          * Common name.
          */
-        CN: string | string[];
-        /**
-         * Additional DN attributes (e.g. `emailAddress`, `serialNumber`, `DC`).
-         * Any attribute recognized by OpenSSL can appear, and any attribute
-         * may be an array when the certificate contains multiple values.
-         */
-        [key: string]: string | string[] | undefined;
+        CN?: string | string[];
     }
     interface PeerCertificate {
         /**

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -19,27 +19,33 @@ declare module "node:tls" {
         /**
          * Country code.
          */
-        C: string;
+        C: string | string[];
         /**
          * Street.
          */
-        ST: string;
+        ST: string | string[];
         /**
          * Locality.
          */
-        L: string;
+        L: string | string[];
         /**
          * Organization.
          */
-        O: string;
+        O: string | string[];
         /**
          * Organizational unit.
          */
-        OU: string;
+        OU: string | string[];
         /**
          * Common name.
          */
-        CN: string;
+        CN: string | string[];
+        /**
+         * Additional DN attributes (e.g. `emailAddress`, `serialNumber`, `DC`).
+         * Any attribute recognized by OpenSSL can appear, and any attribute
+         * may be an array when the certificate contains multiple values.
+         */
+        [key: string]: string | string[] | undefined;
     }
     interface PeerCertificate {
         /**

--- a/types/node/v20/test/tls.ts
+++ b/types/node/v20/test/tls.ts
@@ -325,31 +325,31 @@ import {
     const r00ts: readonly string[] = rootCertificates;
 }
 
-// Certificate DN fields can be string or string[] (multi-valued)
+// Certificate DN fields are optional and can be string or string[] (multi-valued)
 {
     const tlsSocket = connect({});
     const peerCert = tlsSocket.getPeerCertificate();
     const subject = peerCert.subject;
 
-    // Single-valued fields (string)
-    const cn: string | string[] = subject.CN;
-    const ou: string | string[] = subject.OU;
-    const o: string | string[] = subject.O;
+    // Fields are optional and may be string or string[]
+    const cn: string | string[] | undefined = subject.CN;
+    const ou: string | string[] | undefined = subject.OU;
+    const o: string | string[] | undefined = subject.O;
 
     // Type narrowing with Array.isArray
     if (Array.isArray(subject.OU)) {
         const ous: string[] = subject.OU;
     } else {
-        const ou: string = subject.OU;
+        const ou: string | undefined = subject.OU;
     }
 
-    // Index signature: arbitrary DN attributes
+    // Arbitrary DN attributes via index signature
     const email: string | string[] | undefined = subject["emailAddress"];
     const dc: string | string[] | undefined = subject["DC"];
 
     // Issuer has the same shape
     const issuer = peerCert.issuer;
-    const issuerCN: string | string[] = issuer.CN;
+    const issuerCN: string | string[] | undefined = issuer.CN;
 }
 
 {

--- a/types/node/v20/test/tls.ts
+++ b/types/node/v20/test/tls.ts
@@ -325,6 +325,33 @@ import {
     const r00ts: readonly string[] = rootCertificates;
 }
 
+// Certificate DN fields can be string or string[] (multi-valued)
+{
+    const tlsSocket = connect({});
+    const peerCert = tlsSocket.getPeerCertificate();
+    const subject = peerCert.subject;
+
+    // Single-valued fields (string)
+    const cn: string | string[] = subject.CN;
+    const ou: string | string[] = subject.OU;
+    const o: string | string[] = subject.O;
+
+    // Type narrowing with Array.isArray
+    if (Array.isArray(subject.OU)) {
+        const ous: string[] = subject.OU;
+    } else {
+        const ou: string = subject.OU;
+    }
+
+    // Index signature: arbitrary DN attributes
+    const email: string | string[] | undefined = subject["emailAddress"];
+    const dc: string | string[] | undefined = subject["DC"];
+
+    // Issuer has the same shape
+    const issuer = peerCert.issuer;
+    const issuerCN: string | string[] = issuer.CN;
+}
+
 {
     const _options: TlsOptions = {};
     const _server = new Server(_options, (socket) => {});

--- a/types/node/v20/tls.d.ts
+++ b/types/node/v20/tls.d.ts
@@ -19,27 +19,33 @@ declare module "tls" {
         /**
          * Country code.
          */
-        C: string;
+        C: string | string[];
         /**
          * Street.
          */
-        ST: string;
+        ST: string | string[];
         /**
          * Locality.
          */
-        L: string;
+        L: string | string[];
         /**
          * Organization.
          */
-        O: string;
+        O: string | string[];
         /**
          * Organizational unit.
          */
-        OU: string;
+        OU: string | string[];
         /**
          * Common name.
          */
-        CN: string;
+        CN: string | string[];
+        /**
+         * Additional DN attributes (e.g. `emailAddress`, `serialNumber`, `DC`).
+         * Any attribute recognized by OpenSSL can appear, and any attribute
+         * may be an array when the certificate contains multiple values.
+         */
+        [key: string]: string | string[] | undefined;
     }
     interface PeerCertificate {
         /**

--- a/types/node/v20/tls.d.ts
+++ b/types/node/v20/tls.d.ts
@@ -15,37 +15,31 @@ declare module "tls" {
     import * as stream from "stream";
     const CLIENT_RENEG_LIMIT: number;
     const CLIENT_RENEG_WINDOW: number;
-    interface Certificate {
+    interface Certificate extends NodeJS.Dict<string | string[]> {
         /**
          * Country code.
          */
-        C: string | string[];
+        C?: string | string[];
         /**
          * Street.
          */
-        ST: string | string[];
+        ST?: string | string[];
         /**
          * Locality.
          */
-        L: string | string[];
+        L?: string | string[];
         /**
          * Organization.
          */
-        O: string | string[];
+        O?: string | string[];
         /**
          * Organizational unit.
          */
-        OU: string | string[];
+        OU?: string | string[];
         /**
          * Common name.
          */
-        CN: string | string[];
-        /**
-         * Additional DN attributes (e.g. `emailAddress`, `serialNumber`, `DC`).
-         * Any attribute recognized by OpenSSL can appear, and any attribute
-         * may be an array when the certificate contains multiple values.
-         */
-        [key: string]: string | string[] | undefined;
+        CN?: string | string[];
     }
     interface PeerCertificate {
         /**

--- a/types/node/v22/test/tls.ts
+++ b/types/node/v22/test/tls.ts
@@ -329,6 +329,33 @@ import {
     const r00ts: readonly string[] = rootCertificates;
 }
 
+// Certificate DN fields can be string or string[] (multi-valued)
+{
+    const tlsSocket = connect({});
+    const peerCert = tlsSocket.getPeerCertificate();
+    const subject = peerCert.subject;
+
+    // Single-valued fields (string)
+    const cn: string | string[] = subject.CN;
+    const ou: string | string[] = subject.OU;
+    const o: string | string[] = subject.O;
+
+    // Type narrowing with Array.isArray
+    if (Array.isArray(subject.OU)) {
+        const ous: string[] = subject.OU;
+    } else {
+        const ou: string = subject.OU;
+    }
+
+    // Index signature: arbitrary DN attributes
+    const email: string | string[] | undefined = subject["emailAddress"];
+    const dc: string | string[] | undefined = subject["DC"];
+
+    // Issuer has the same shape
+    const issuer = peerCert.issuer;
+    const issuerCN: string | string[] = issuer.CN;
+}
+
 {
     const _options: TlsOptions = {};
     const _server = new Server(_options, (socket) => {});

--- a/types/node/v22/test/tls.ts
+++ b/types/node/v22/test/tls.ts
@@ -329,31 +329,31 @@ import {
     const r00ts: readonly string[] = rootCertificates;
 }
 
-// Certificate DN fields can be string or string[] (multi-valued)
+// Certificate DN fields are optional and can be string or string[] (multi-valued)
 {
     const tlsSocket = connect({});
     const peerCert = tlsSocket.getPeerCertificate();
     const subject = peerCert.subject;
 
-    // Single-valued fields (string)
-    const cn: string | string[] = subject.CN;
-    const ou: string | string[] = subject.OU;
-    const o: string | string[] = subject.O;
+    // Fields are optional and may be string or string[]
+    const cn: string | string[] | undefined = subject.CN;
+    const ou: string | string[] | undefined = subject.OU;
+    const o: string | string[] | undefined = subject.O;
 
     // Type narrowing with Array.isArray
     if (Array.isArray(subject.OU)) {
         const ous: string[] = subject.OU;
     } else {
-        const ou: string = subject.OU;
+        const ou: string | undefined = subject.OU;
     }
 
-    // Index signature: arbitrary DN attributes
+    // Arbitrary DN attributes via index signature
     const email: string | string[] | undefined = subject["emailAddress"];
     const dc: string | string[] | undefined = subject["DC"];
 
     // Issuer has the same shape
     const issuer = peerCert.issuer;
-    const issuerCN: string | string[] = issuer.CN;
+    const issuerCN: string | string[] | undefined = issuer.CN;
 }
 
 {

--- a/types/node/v22/tls.d.ts
+++ b/types/node/v22/tls.d.ts
@@ -19,27 +19,33 @@ declare module "tls" {
         /**
          * Country code.
          */
-        C: string;
+        C: string | string[];
         /**
          * Street.
          */
-        ST: string;
+        ST: string | string[];
         /**
          * Locality.
          */
-        L: string;
+        L: string | string[];
         /**
          * Organization.
          */
-        O: string;
+        O: string | string[];
         /**
          * Organizational unit.
          */
-        OU: string;
+        OU: string | string[];
         /**
          * Common name.
          */
-        CN: string;
+        CN: string | string[];
+        /**
+         * Additional DN attributes (e.g. `emailAddress`, `serialNumber`, `DC`).
+         * Any attribute recognized by OpenSSL can appear, and any attribute
+         * may be an array when the certificate contains multiple values.
+         */
+        [key: string]: string | string[] | undefined;
     }
     interface PeerCertificate {
         /**

--- a/types/node/v22/tls.d.ts
+++ b/types/node/v22/tls.d.ts
@@ -15,37 +15,31 @@ declare module "tls" {
     import * as stream from "stream";
     const CLIENT_RENEG_LIMIT: number;
     const CLIENT_RENEG_WINDOW: number;
-    interface Certificate {
+    interface Certificate extends NodeJS.Dict<string | string[]> {
         /**
          * Country code.
          */
-        C: string | string[];
+        C?: string | string[];
         /**
          * Street.
          */
-        ST: string | string[];
+        ST?: string | string[];
         /**
          * Locality.
          */
-        L: string | string[];
+        L?: string | string[];
         /**
          * Organization.
          */
-        O: string | string[];
+        O?: string | string[];
         /**
          * Organizational unit.
          */
-        OU: string | string[];
+        OU?: string | string[];
         /**
          * Common name.
          */
-        CN: string | string[];
-        /**
-         * Additional DN attributes (e.g. `emailAddress`, `serialNumber`, `DC`).
-         * Any attribute recognized by OpenSSL can appear, and any attribute
-         * may be an array when the certificate contains multiple values.
-         */
-        [key: string]: string | string[] | undefined;
+        CN?: string | string[];
     }
     interface PeerCertificate {
         /**

--- a/types/node/v24/test/tls.ts
+++ b/types/node/v24/test/tls.ts
@@ -329,6 +329,33 @@ import {
     const r00ts: readonly string[] = rootCertificates;
 }
 
+// Certificate DN fields can be string or string[] (multi-valued)
+{
+    const tlsSocket = connect({});
+    const peerCert = tlsSocket.getPeerCertificate();
+    const subject = peerCert.subject;
+
+    // Single-valued fields (string)
+    const cn: string | string[] = subject.CN;
+    const ou: string | string[] = subject.OU;
+    const o: string | string[] = subject.O;
+
+    // Type narrowing with Array.isArray
+    if (Array.isArray(subject.OU)) {
+        const ous: string[] = subject.OU;
+    } else {
+        const ou: string = subject.OU;
+    }
+
+    // Index signature: arbitrary DN attributes
+    const email: string | string[] | undefined = subject["emailAddress"];
+    const dc: string | string[] | undefined = subject["DC"];
+
+    // Issuer has the same shape
+    const issuer = peerCert.issuer;
+    const issuerCN: string | string[] = issuer.CN;
+}
+
 {
     const _options: TlsOptions = {};
     const _server = new Server(_options, (socket) => {});

--- a/types/node/v24/test/tls.ts
+++ b/types/node/v24/test/tls.ts
@@ -329,31 +329,31 @@ import {
     const r00ts: readonly string[] = rootCertificates;
 }
 
-// Certificate DN fields can be string or string[] (multi-valued)
+// Certificate DN fields are optional and can be string or string[] (multi-valued)
 {
     const tlsSocket = connect({});
     const peerCert = tlsSocket.getPeerCertificate();
     const subject = peerCert.subject;
 
-    // Single-valued fields (string)
-    const cn: string | string[] = subject.CN;
-    const ou: string | string[] = subject.OU;
-    const o: string | string[] = subject.O;
+    // Fields are optional and may be string or string[]
+    const cn: string | string[] | undefined = subject.CN;
+    const ou: string | string[] | undefined = subject.OU;
+    const o: string | string[] | undefined = subject.O;
 
     // Type narrowing with Array.isArray
     if (Array.isArray(subject.OU)) {
         const ous: string[] = subject.OU;
     } else {
-        const ou: string = subject.OU;
+        const ou: string | undefined = subject.OU;
     }
 
-    // Index signature: arbitrary DN attributes
+    // Arbitrary DN attributes via index signature
     const email: string | string[] | undefined = subject["emailAddress"];
     const dc: string | string[] | undefined = subject["DC"];
 
     // Issuer has the same shape
     const issuer = peerCert.issuer;
-    const issuerCN: string | string[] = issuer.CN;
+    const issuerCN: string | string[] | undefined = issuer.CN;
 }
 
 {

--- a/types/node/v24/tls.d.ts
+++ b/types/node/v24/tls.d.ts
@@ -19,27 +19,33 @@ declare module "tls" {
         /**
          * Country code.
          */
-        C: string;
+        C: string | string[];
         /**
          * Street.
          */
-        ST: string;
+        ST: string | string[];
         /**
          * Locality.
          */
-        L: string;
+        L: string | string[];
         /**
          * Organization.
          */
-        O: string;
+        O: string | string[];
         /**
          * Organizational unit.
          */
-        OU: string;
+        OU: string | string[];
         /**
          * Common name.
          */
-        CN: string;
+        CN: string | string[];
+        /**
+         * Additional DN attributes (e.g. `emailAddress`, `serialNumber`, `DC`).
+         * Any attribute recognized by OpenSSL can appear, and any attribute
+         * may be an array when the certificate contains multiple values.
+         */
+        [key: string]: string | string[] | undefined;
     }
     interface PeerCertificate {
         /**

--- a/types/node/v24/tls.d.ts
+++ b/types/node/v24/tls.d.ts
@@ -15,37 +15,31 @@ declare module "tls" {
     import * as stream from "stream";
     const CLIENT_RENEG_LIMIT: number;
     const CLIENT_RENEG_WINDOW: number;
-    interface Certificate {
+    interface Certificate extends NodeJS.Dict<string | string[]> {
         /**
          * Country code.
          */
-        C: string | string[];
+        C?: string | string[];
         /**
          * Street.
          */
-        ST: string | string[];
+        ST?: string | string[];
         /**
          * Locality.
          */
-        L: string | string[];
+        L?: string | string[];
         /**
          * Organization.
          */
-        O: string | string[];
+        O?: string | string[];
         /**
          * Organizational unit.
          */
-        OU: string | string[];
+        OU?: string | string[];
         /**
          * Common name.
          */
-        CN: string | string[];
-        /**
-         * Additional DN attributes (e.g. `emailAddress`, `serialNumber`, `DC`).
-         * Any attribute recognized by OpenSSL can appear, and any attribute
-         * may be an array when the certificate contains multiple values.
-         */
-        [key: string]: string | string[] | undefined;
+        CN?: string | string[];
     }
     interface PeerCertificate {
         /**


### PR DESCRIPTION
## Summary

`tls.Certificate` types all DN fields (`C`, `ST`, `L`, `O`, `OU`, `CN`) as `string`, but Node.js returns `string[]` when a certificate has multiple values for the same attribute. This is standard X.509 behavior (e.g. multiple
OUs in enterprise PKI).

### Changes

- Widen all six named fields from `string` to `string | string[]`
- Add index signature `[key: string]: string | string[] | undefined` for arbitrary DN attributes (`emailAddress`, `serialNumber`, `DC`, etc.) that OpenSSL can produce
- Add tests exercising scalar and array access, type narrowing, index signature

### Runtime proof

```js
const { X509Certificate } = require('crypto');
const { execSync } = require('child_process');
const pem = execSync(
  'openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 ' +
  '-nodes -keyout /dev/null -days 1 ' +
  '-subj "/CN=test/OU=Engineering/OU=DevTeam" 2>/dev/null'
);
const cert = new X509Certificate(pem).toLegacyObject();
console.log(cert.subject.OU);
// -> [ 'Engineering', 'DevTeam' ]
```

### Source-level evidence

Node's `GetX509NameObject()` in `src/crypto/crypto_x509.cc` mechanically promotes any repeated DN key to an array. There is no allowlist -- any field can repeat. The code itself comments:

> For backward compatibility, we only create arrays if multiple values exist for the same key.

### Breaking change note

This is a type-level breaking change. Downstream code doing `cert.subject.CN.toLowerCase()` will need a type guard

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change.
- [x] Follow the advice from the readme.
- [x] Avoid common mistakes.
- [x] Run `pnpm test node`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Node.js docs showing array output: https://nodejs.org/api/tls.html#certificate-object
  - Node.js source (`GetX509NameObject`): https://github.com/nodejs/node/blob/main/src/crypto/crypto_x509.cc#L622
  - Issue: #74538
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. (N/A -- correctness fix)
