### PR TITLE
[@types/html-to-docx]: fix typo in footer property

### DIFF
--- a/types/html-to-docx/html-to-docx-tests.ts
+++ b/types/html-to-docx/html-to-docx-tests.ts
@@ -42,6 +42,23 @@ HtmlToDocx(
     "footer",
 );
 
+// $ExpectType Promise<Blob> | Promise<ArrayBuffer>
+HtmlToDocx(
+    htmlString,
+    null,
+    {
+        margins: {
+            top: 720,
+            right: 900,
+            bottom: 720,
+            left: 900,
+            header: 360,
+            footer: 360,
+            gutter: 0,
+        },
+    },
+);
+
 // @ts-expect-error
 HtmlToDocx(htmlString, {
     orientation: "landscape",

--- a/types/html-to-docx/index.d.ts
+++ b/types/html-to-docx/index.d.ts
@@ -7,7 +7,7 @@ declare namespace HtmlToDocx {
         bottom?: number;
         left?: number;
         header?: number;
-        fotter?: number;
+        footer?: number;
         gutter?: number;
     }
 


### PR DESCRIPTION
Fixes: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/74055

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test html-to-docx`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/privateOmega/html-to-docx?tab=readme-ov-file#parameters>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.