### PR TITLE
Update webextension-polyfill with latest definitions and a fix for Promise<void> returns

### DIFF
--- a/types/webextension-polyfill/namespaces/action.d.ts
+++ b/types/webextension-polyfill/namespaces/action.d.ts
@@ -228,8 +228,10 @@ export namespace Action {
 
         /**
          * Checks whether the browser action is enabled.
+         *
+         * @param details Optional.
          */
-        isEnabled(details: Details): Promise<boolean>;
+        isEnabled(details?: Details | number): Promise<boolean>;
 
         /**
          * Opens the extension popup window in the specified window.

--- a/types/webextension-polyfill/namespaces/commands.d.ts
+++ b/types/webextension-polyfill/namespaces/commands.d.ts
@@ -92,7 +92,7 @@ export namespace Commands {
         /**
          * Open extension shortcuts configuration page.
          */
-        openShortcutSettings(): void;
+        openShortcutSettings(): Promise<void>;
 
         /**
          * Fired when a registered command is activated using a keyboard shortcut.

--- a/types/webextension-polyfill/namespaces/geckoProfiler.d.ts
+++ b/types/webextension-polyfill/namespaces/geckoProfiler.d.ts
@@ -37,7 +37,8 @@ export namespace GeckoProfiler {
         | "memory"
         | "tracing"
         | "sandbox"
-        | "flows";
+        | "flows"
+        | "jssources";
 
     type supports = "windowLength";
 
@@ -77,22 +78,22 @@ export namespace GeckoProfiler {
         /**
          * Starts the profiler with the specified settings.
          */
-        start(settings: StartSettingsType): void;
+        start(settings: StartSettingsType): Promise<void>;
 
         /**
          * Stops the profiler and discards any captured profile data.
          */
-        stop(): void;
+        stop(): Promise<void>;
 
         /**
          * Pauses the profiler, keeping any profile data that is already written.
          */
-        pause(): void;
+        pause(): Promise<void>;
 
         /**
          * Resumes the profiler with the settings that were initially used to start it.
          */
-        resume(): void;
+        resume(): Promise<void>;
 
         /**
          * Gathers the profile data from the current profiling session, and writes it to disk.
@@ -100,24 +101,24 @@ export namespace GeckoProfiler {
          *
          * @param fileName The name of the file inside the profile/profiler directory
          */
-        dumpProfileToFile(fileName: string): void;
+        dumpProfileToFile(fileName: string): Promise<void>;
 
         /**
          * Gathers the profile data from the current profiling session.
          */
-        getProfile(): void;
+        getProfile(): Promise<void>;
 
         /**
          * Gathers the profile data from the current profiling session. The returned promise resolves to an array buffer that
          * contains a JSON string.
          */
-        getProfileAsArrayBuffer(): void;
+        getProfileAsArrayBuffer(): Promise<void>;
 
         /**
          * Gathers the profile data from the current profiling session. The returned promise resolves to an array buffer that
          * contains a gzipped JSON string.
          */
-        getProfileAsGzippedArrayBuffer(): void;
+        getProfileAsGzippedArrayBuffer(): Promise<void>;
 
         /**
          * Gets the debug symbols for a particular library.
@@ -125,7 +126,7 @@ export namespace GeckoProfiler {
          * @param debugName The name of the library's debug file. For example, 'xul.pdb
          * @param breakpadId The Breakpad ID of the library
          */
-        getSymbols(debugName: string, breakpadId: string): void;
+        getSymbols(debugName: string, breakpadId: string): Promise<void>;
 
         /**
          * Fires when the profiler starts/stops running.

--- a/types/webextension-polyfill/namespaces/management.d.ts
+++ b/types/webextension-polyfill/namespaces/management.d.ts
@@ -37,10 +37,10 @@ export namespace Management {
     type ExtensionType = "extension" | "theme";
 
     /**
-     * How the extension was installed. One of<br><var>development</var>: The extension was loaded unpacked in developer mode,
-     * <br><var>normal</var>: The extension was installed normally via an .xpi file,<br><var>sideload</var>
-     * : The extension was installed by other software on the machine,<br><var>admin</var>
-     * : The extension was installed by policy,<br><var>other</var>: The extension was installed by other means.
+     * How the extension was installed.<dl><dt>development</dt><dd>The extension was loaded unpacked in developer mode,</dd><dt>
+     * normal</dt><dd>The extension was installed normally via an .xpi file</dd><dt>sideload</dt><dd>
+     * The extension was installed by other software on the machine</dd><dt>admin</dt><dd>
+     * The extension was installed by policy</dd><dt>other</dt><dd>The extension was installed by other means.</dd></dl>
      */
     type ExtensionInstallType = "development" | "normal" | "sideload" | "admin" | "other";
 

--- a/types/webextension-polyfill/namespaces/networkStatus.d.ts
+++ b/types/webextension-polyfill/namespaces/networkStatus.d.ts
@@ -40,7 +40,7 @@ export namespace NetworkStatus {
         /**
          * Returns the $(ref:NetworkLinkInfo) of the current network connection.
          */
-        getLinkInfo(): void;
+        getLinkInfo(): Promise<void>;
 
         /**
          * Fired when the network connection state changes.

--- a/types/webextension-polyfill/namespaces/normandyAddonStudy.d.ts
+++ b/types/webextension-polyfill/namespaces/normandyAddonStudy.d.ts
@@ -85,19 +85,19 @@ export namespace NormandyAddonStudy {
         /**
          * Returns a study object for the current study.
          */
-        getStudy(): void;
+        getStudy(): Promise<void>;
 
         /**
          * Marks the study as ended and then uninstalls the addon.
          *
          * @param reason The reason why the study is ending.
          */
-        endStudy(reason: string): void;
+        endStudy(reason: string): Promise<void>;
 
         /**
          * Returns an object with metadata about the client which may be required for constructing survey URLs.
          */
-        getClientMetadata(): void;
+        getClientMetadata(): Promise<void>;
 
         /**
          * Fired when a user unenrolls from a study but before the addon is uninstalled.

--- a/types/webextension-polyfill/namespaces/runtime.d.ts
+++ b/types/webextension-polyfill/namespaces/runtime.d.ts
@@ -463,7 +463,7 @@ export namespace Runtime {
          * a connection will be attempted with your own extension. Required if sending messages from a web page for
          * $(topic:manifest/externally_connectable)[web messaging].
          * @param connectInfo Optional.
-         * @returns Port through which messages can be sent and received. The port's $(ref:runtime.Port onDisconnect)
+         * @returns Port through which messages can be sent and received. The port's $(ref:runtime.Port.onDisconnect)
          * event is fired if the extension/app does not exist.
          */
         connect(extensionId?: string, connectInfo?: ConnectConnectInfoType): Port;
@@ -475,7 +475,7 @@ export namespace Runtime {
          * content script. Extensions may connect to content scripts embedded in tabs via $(ref:tabs.connect).
          *
          * @param connectInfo Optional.
-         * @returns Port through which messages can be sent and received. The port's $(ref:runtime.Port onDisconnect)
+         * @returns Port through which messages can be sent and received. The port's $(ref:runtime.Port.onDisconnect)
          * event is fired if the extension/app does not exist.
          */
         connect(connectInfo?: ConnectConnectInfoType): Port;

--- a/types/webextension-polyfill/namespaces/storage.d.ts
+++ b/types/webextension-polyfill/namespaces/storage.d.ts
@@ -98,8 +98,8 @@ export namespace Storage {
          * Fired when one or more items change.
          *
          * @param changes Object mapping each key that changed to its corresponding $(ref:storage.StorageChange) for that item.
-         * @param areaName The name of the storage area (<code>"sync"</code>, <code>"local"</code> or <code>"managed"</code>)
-         * the changes are for.
+         * @param areaName The name of the storage area (<code>"session"</code>, <code>"sync"</code>, <code>"local"</code> or <code>
+         * "managed"</code>) the changes are for.
          */
         onChanged: Events.Event<(changes: Record<string, StorageChange>, areaName: string) => void>;
 

--- a/types/webextension-polyfill/namespaces/tabs.d.ts
+++ b/types/webextension-polyfill/namespaces/tabs.d.ts
@@ -1387,7 +1387,7 @@ export namespace Tabs {
          * first tab in the array instead.
          * @param options Optional.
          */
-        moveInSuccession(tabIds: number[], tabId?: number, options?: MoveInSuccessionOptionsType): void;
+        moveInSuccession(tabIds: number[], tabId?: number, options?: MoveInSuccessionOptionsType): Promise<void>;
 
         /**
          * Navigate to next page in tab's history, if available
@@ -1413,7 +1413,7 @@ export namespace Tabs {
          *
          * @param tabIds The tab ID or list of tab IDs to remove from their respective groups.
          */
-        ungroup(tabIds: number | number[]): void;
+        ungroup(tabIds: number | number[]): Promise<void>;
 
         /**
          * Fired when a tab is created. Note that the tab's URL may not be set at the time this event fired,

--- a/types/webextension-polyfill/namespaces/trial_ml.d.ts
+++ b/types/webextension-polyfill/namespaces/trial_ml.d.ts
@@ -27,17 +27,17 @@ export namespace TrialMl {
         /**
          * Prepare the inference engine
          */
-        createEngine(CreateEngineRequest: CreateEngineRequest): void;
+        createEngine(CreateEngineRequest: CreateEngineRequest): Promise<void>;
 
         /**
          * Call the inference engine
          */
-        runEngine(RunEngineRequest: RunEngineRequest): void;
+        runEngine(RunEngineRequest: RunEngineRequest): Promise<void>;
 
         /**
          * Delete the models the extension downloaded.
          */
-        deleteCachedModels(): void;
+        deleteCachedModels(): Promise<void>;
 
         /**
          * Events from the inference engine.

--- a/types/webextension-polyfill/namespaces/userScripts.d.ts
+++ b/types/webextension-polyfill/namespaces/userScripts.d.ts
@@ -219,21 +219,21 @@ export namespace UserScripts {
          *
          * @param scripts List of user scripts to be registered.
          */
-        register(scripts: RegisteredUserScript[]): void;
+        register(scripts: RegisteredUserScript[]): Promise<void>;
 
         /**
          * Updates one or more user scripts for this extension.
          *
          * @param scripts List of user scripts to be updated.
          */
-        update(scripts: UpdateScriptsItemType[]): void;
+        update(scripts: UpdateScriptsItemType[]): Promise<void>;
 
         /**
          * Unregisters all dynamically-registered user scripts for this extension.
          *
          * @param filter Optional. If specified, this method unregisters only the user scripts that match it.
          */
-        unregister(filter?: UserScriptFilter): void;
+        unregister(filter?: UserScriptFilter): Promise<void>;
 
         /**
          * Returns all dynamically-registered user scripts for this extension.
@@ -247,7 +247,7 @@ export namespace UserScripts {
          *
          * @param properties The desired configuration for a USER_SCRIPT world.
          */
-        configureWorld(properties: WorldProperties): void;
+        configureWorld(properties: WorldProperties): Promise<void>;
 
         /**
          * Resets the configuration for a given world. That world will fall back to the default world's configuration.
@@ -255,7 +255,7 @@ export namespace UserScripts {
          * @param worldId Optional. The ID of the USER_SCRIPT world to reset. If omitted or empty,
          * resets the default world's configuration.
          */
-        resetWorldConfiguration(worldId?: string): void;
+        resetWorldConfiguration(worldId?: string): Promise<void>;
 
         /**
          * Returns all registered USER_SCRIPT world configurations.

--- a/types/webextension-polyfill/webextension-polyfill-tests.ts
+++ b/types/webextension-polyfill/webextension-polyfill-tests.ts
@@ -5,3 +5,5 @@ import { Browser, Tabs } from "webextension-polyfill";
 const x: Browser = browser;
 
 const promise: Promise<Tabs.Tab> = browser.tabs.create({});
+
+const void_p: Promise<void> = browser.tabs.ungroup([1, 2, 3, 4]);


### PR DESCRIPTION
- Handle `Promise<void>` types correctly in the generated definitions.
- Update to the latest schema from Firefox.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.) - Manually tested against `josh-berry/tab-stash`
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Lusito/webextension-polyfill-ts/pull/118
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

