### PR TITLE
Temporarily remove @wordpress/vips dep via pnpm override

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,10 @@
         "remark-validate-links": "^13.0.0",
         "typescript": "next"
     },
+    "pnpm": {
+        "overrides": {
+            "@wordpress/vips": "-"
+        }
+    },
     "type": "module"
 }


### PR DESCRIPTION
https://github.com/WordPress/gutenberg/issues/75718

At least until this is fixed; we need the repo to be working again.