### PR TITLE
fix(formidable): FormidableError became a default export in v3, add missing erorr codes, add emitting 'error' event

### DIFF
--- a/types/formidable/Formidable.d.ts
+++ b/types/formidable/Formidable.d.ts
@@ -35,6 +35,7 @@ declare class IncomingForm extends EventEmitter {
     on(eventName: string, listener: () => void): this;
 
     emit(eventName: "data", data: EmitData): boolean;
+    emit(eventName: "error", error: any): boolean;
 
     /**
      * A method that allows you to extend the Formidable library. By default we include 4 plugins,

--- a/types/formidable/FormidableError.d.ts
+++ b/types/formidable/FormidableError.d.ts
@@ -6,7 +6,7 @@ declare class FormidableError extends Error {
 
 declare const errors:
     & {
-        FormidableError: typeof FormidableError;
+        default: typeof FormidableError;
     }
     & Record<
         | "missingPlugin"
@@ -17,14 +17,20 @@ declare const errors:
         | "filenameNotString"
         | "maxFieldsSizeExceeded"
         | "maxFieldsExceeded"
+        | "maxFilesExceeded"
         | "smallerThanMinFileSize"
         | "biggerThanMaxFileSize"
         | "noEmptyFiles"
         | "missingContentType"
         | "malformedMultipart"
         | "missingMultipartBoundary"
-        | "unknownTransferEncoding",
+        | "unknownTransferEncoding"
+        | "biggerThanTotalMaxFileSize"
+        | "pluginFailed"
+        | "cannotCreateDir",
         number
     >;
 
 export = errors;
+
+

--- a/types/formidable/FormidableError.d.ts
+++ b/types/formidable/FormidableError.d.ts
@@ -32,5 +32,3 @@ declare const errors:
     >;
 
 export = errors;
-
-

--- a/types/formidable/formidable-tests.ts
+++ b/types/formidable/formidable-tests.ts
@@ -2,9 +2,11 @@ import formidable = require("formidable");
 import {
     defaultOptions,
     enabledPlugins,
+    errors as formidableErrors,
     File,
     Formidable,
     formidable as formidableAlias,
+    FormidableError,
     IncomingForm,
     json,
     multipart,
@@ -17,8 +19,6 @@ import {
     plugins,
     querystring,
     VolatileFile,
-    errors as formidableErrors,
-    FormidableError
 } from "formidable";
 import * as http from "http";
 
@@ -148,7 +148,10 @@ form.on("data", data => {
         // $ExpectType number
         bytesExpected;
 
-        form.emit("error", new formidableErrors.default('bytes received exceeded', formidableErrors.biggerThanTotalMaxFileSize, 400))
+        form.emit(
+            "error",
+            new formidableErrors.default("bytes received exceeded", formidableErrors.biggerThanTotalMaxFileSize, 400),
+        );
     })
     .on("field", (name, value) => {
         // $ExpectType string
@@ -277,4 +280,4 @@ formidableErrors.pluginFailed;
 formidableErrors.cannotCreateDir;
 
 // $ExpectType FormidableError
-new formidableErrors.default('invalid type', 0, 400);
+new formidableErrors.default("invalid type", 0, 400);

--- a/types/formidable/formidable-tests.ts
+++ b/types/formidable/formidable-tests.ts
@@ -17,6 +17,8 @@ import {
     plugins,
     querystring,
     VolatileFile,
+    errors as formidableErrors,
+    FormidableError
 } from "formidable";
 import * as http from "http";
 
@@ -145,6 +147,8 @@ form.on("data", data => {
         bytesReceived;
         // $ExpectType number
         bytesExpected;
+
+        form.emit("error", new formidableErrors.default('bytes received exceeded', formidableErrors.biggerThanTotalMaxFileSize, 400))
     })
     .on("field", (name, value) => {
         // $ExpectType string
@@ -233,3 +237,44 @@ querystring;
 multipart;
 // $ExpectType PluginFunction
 json;
+// $ExpectType number
+formidableErrors.missingPlugin;
+// $ExpectType number
+formidableErrors.pluginFunction;
+// $ExpectType number
+formidableErrors.aborted;
+// $ExpectType number
+formidableErrors.noParser;
+// $ExpectType number
+formidableErrors.uninitializedParser;
+// $ExpectType number
+formidableErrors.filenameNotString;
+// $ExpectType number
+formidableErrors.maxFieldsSizeExceeded;
+// $ExpectType number
+formidableErrors.maxFieldsExceeded;
+// $ExpectType number
+formidableErrors.maxFilesExceeded;
+// $ExpectType number
+formidableErrors.smallerThanMinFileSize;
+// $ExpectType number
+formidableErrors.biggerThanMaxFileSize;
+// $ExpectType number
+formidableErrors.noEmptyFiles;
+// $ExpectType number
+formidableErrors.missingContentType;
+// $ExpectType number
+formidableErrors.malformedMultipart;
+// $ExpectType number
+formidableErrors.missingMultipartBoundary;
+// $ExpectType number
+formidableErrors.unknownTransferEncoding;
+// $ExpectType number
+formidableErrors.biggerThanTotalMaxFileSize;
+// $ExpectType number
+formidableErrors.pluginFailed;
+// $ExpectType number
+formidableErrors.cannotCreateDir;
+
+// $ExpectType FormidableError
+new formidableErrors.default('invalid type', 0, 400);

--- a/types/formidable/index.d.ts
+++ b/types/formidable/index.d.ts
@@ -309,6 +309,8 @@ declare namespace formidable {
     type EnabledPlugins = {
         [P in Plugin]: PluginFunction;
     };
+
+    type FormidableError = InstanceType<typeof errors.default>;
 }
 
 declare const formidable: {

--- a/types/formidable/package.json
+++ b/types/formidable/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/formidable",
-    "version": "3.5.4",
+    "version": "3.5.9999",
     "projects": [
         "https://github.com/node-formidable/formidable"
     ],

--- a/types/formidable/package.json
+++ b/types/formidable/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/formidable",
-    "version": "3.4.9999",
+    "version": "3.5.4",
     "projects": [
         "https://github.com/node-formidable/formidable"
     ],


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/node-formidable/formidable/blob/master/src/FormidableError.js#L51 - FormidableError is a default export,
https://github.com/node-formidable/formidable/blob/master/src/FormidableError.js#L38 and other missing codes,
https://github.com/node-formidable/formidable/blob/master/README.md?plain=1#L396 - form can emit 'error' event
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Since `formidable` v3 the `FormidableError` class became a default export from `errors`  "sub-module" and is no longer accessible via `errors.FormidableError` (first link). Also I added a type export for the `FormidableError` class for convenience.

Also there are some new error codes (`maxFilesExceeded`, `biggerThanTotalMaxFileSize`, `pluginFailed` and `cannotCreateDir` for instance), that were missing in `erros` definition (second link).

And the last but not least, the README for the package states, that the `form` object can emit an `"error"` event, but there were no type definition for that, which caused `TS2345: Argument of type "error" is not assignable to parameter of type "data"` (third link).