### PR TITLE
[@types/sanitize-html] Update htmlparser2 dependency to ^10.1

### DIFF
--- a/types/sanitize-html/package.json
+++ b/types/sanitize-html/package.json
@@ -6,7 +6,7 @@
         "https://github.com/punkave/sanitize-html"
     ],
     "dependencies": {
-        "htmlparser2": "^8.0.0"
+        "htmlparser2": "^10.1"
     },
     "devDependencies": {
         "@types/sanitize-html": "workspace:."


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/apostrophecms/sanitize-html/pull/721
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

---

Update the `htmlparser2` dependency version from `^8.0.0` to `^10.1` in `@types/sanitize-html`.

This aligns with the upstream change in [apostrophecms/sanitize-html#721](https://github.com/apostrophecms/sanitize-html/pull/721). The `ParserOptions` import used by `@types/sanitize-html` remains compatible with htmlparser2 v10.1. No test changes needed as the types API is unchanged.