### PR TITLE
[@types/knockout] allow constructor view models

### DIFF
--- a/types/knockout/index.d.ts
+++ b/types/knockout/index.d.ts
@@ -1082,7 +1082,13 @@ declare namespace KnockoutComponentTypes {
     }
 
     // viewmodel types
-    interface ViewModelFunction {
+    type ViewModelFunction = ViewModelConstructor | ViewModelFactory;
+
+    interface ViewModelConstructor {
+        new (params?: any): any;
+    }
+
+    interface ViewModelFactory {
         (params?: any): any;
     }
 


### PR DESCRIPTION
Knockout view models can be class constructors OR callable but not constructible functions. See the condition in the `resolveViewModel` function in the Knockout code. This commit modifies the appropriate type here, taking into consideration that these options exist.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/knockout/knockout/blob/45e86bf0347cf742ca359bab051ea82fdfae7a5d/src/components/defaultLoader.js#L133
