### PR TITLE
[telegram-web-app] correct msg_id parameter type for shareMessage method

### DIFF
--- a/types/telegram-web-app/index.d.ts
+++ b/types/telegram-web-app/index.d.ts
@@ -500,7 +500,7 @@ export interface WebApp {
      *
      * @since Bot API 8.0+
      */
-    shareMessage(msg_id: number, callback?: (success: boolean) => void): void;
+    shareMessage(msg_id: string, callback?: (success: boolean) => void): void;
 
     /**
      * A method that opens a dialog allowing the user to set the specified custom emoji as their status.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: The message id passed to `shareMessage` must belong to a [PreparedInlineMessage](https://core.telegram.org/bots/api#preparedinlinemessage) which can be obtained via the Bot API method [savePreparedInlineMessage](https://core.telegram.org/bots/api#savepreparedinlinemessage) and type of `PreparedInlineMessage.id` is a string
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
