### PR TITLE
[w3c-web-hid] Preserve event types when using EventListenerOptions

### DIFF
--- a/types/w3c-web-hid/index.d.ts
+++ b/types/w3c-web-hid/index.d.ts
@@ -23,7 +23,7 @@ declare class HID extends EventTarget {
     addEventListener(
         type: "connect" | "disconnect",
         listener: (this: this, ev: HIDConnectionEvent) => any,
-        useCapture?: boolean,
+        options?: boolean | AddEventListenerOptions,
     ): void;
     addEventListener(
         type: string,
@@ -34,7 +34,7 @@ declare class HID extends EventTarget {
     removeEventListener(
         type: "connect" | "disconnect",
         callback: (this: this, ev: HIDConnectionEvent) => any,
-        useCapture?: boolean,
+        options?: boolean | AddEventListenerOptions,
     ): void;
     removeEventListener(
         type: string,
@@ -156,14 +156,22 @@ declare class HIDDevice extends EventTarget {
 
     receiveFeatureReport(reportId: number): Promise<DataView>;
 
-    addEventListener(type: "inputreport", listener: (this: this, ev: HIDInputReportEvent) => any): void;
+    addEventListener(
+        type: "inputreport",
+        listener: (this: this, ev: HIDInputReportEvent) => any,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
     addEventListener(
         type: string,
         listener: EventListenerOrEventListenerObject | null,
         options?: boolean | AddEventListenerOptions,
     ): void;
 
-    removeEventListener(type: "inputreport", callback: (this: this, ev: HIDInputReportEvent) => any): void;
+    removeEventListener(
+        type: "inputreport",
+        callback: (this: this, ev: HIDInputReportEvent) => any,
+        options?: boolean | AddEventListenerOptions,
+    ): void;
     removeEventListener(
         type: string,
         callback: EventListenerOrEventListenerObject | null,

--- a/types/w3c-web-hid/w3c-web-hid-tests.ts
+++ b/types/w3c-web-hid/w3c-web-hid-tests.ts
@@ -14,7 +14,7 @@ async function example_1() {
 
     navigator.hid.addEventListener("connect", ({ device }) => {
         console.log(`HID connected: ${device.productName}`);
-    });
+    }, {});
 
     navigator.hid.addEventListener("disconnect", ({ device }) => {
         console.log(`HID disconnected: ${device.productName}`);

--- a/types/w3c-web-hid/w3c-web-hid-tests.ts
+++ b/types/w3c-web-hid/w3c-web-hid-tests.ts
@@ -14,7 +14,7 @@ async function example_1() {
 
     navigator.hid.addEventListener("connect", ({ device }) => {
         console.log(`HID connected: ${device.productName}`);
-    }, {});
+    }, { signal: AbortSignal.timeout(1000) });
 
     navigator.hid.addEventListener("disconnect", ({ device }) => {
         console.log(`HID disconnected: ${device.productName}`);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: n/a
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

<hr>

The overrides provided for `addEventListener`/`removeEventListener` that provide more specific types for the event object did not allow callers to use the modern EventListenerOptions object for things like an AbortSignal.

Before:
```ts
// event is a HIDConnectionEvent
navigator.hid.addEventListener("connect", (event) => {});
// event is a generic Event
navigator.hid.addEventListener("connect", (event) => {}, { signal });
```