### PR TITLE
[node] ProcessEnv: remove TZ property, fall back to index signature

### DIFF
--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -465,12 +465,7 @@ declare module "node:process" {
                 isTTY?: true | undefined;
             }
             // Alias for compatibility
-            interface ProcessEnv extends Dict<string> {
-                /**
-                 * Can be used to change the default timezone at runtime
-                 */
-                TZ?: string | undefined;
-            }
+            interface ProcessEnv extends Dict<string> {}
             interface HRTime {
                 /**
                  * This is the legacy version of {@link process.hrtime.bigint()}

--- a/types/node/v20/process.d.ts
+++ b/types/node/v20/process.d.ts
@@ -321,12 +321,7 @@ declare module "process" {
                 isTTY?: true | undefined;
             }
             // Alias for compatibility
-            interface ProcessEnv extends Dict<string> {
-                /**
-                 * Can be used to change the default timezone at runtime
-                 */
-                TZ?: string | undefined;
-            }
+            interface ProcessEnv extends Dict<string> {}
             interface HRTime {
                 /**
                  * This is the legacy version of {@link process.hrtime.bigint()}

--- a/types/node/v22/process.d.ts
+++ b/types/node/v22/process.d.ts
@@ -346,12 +346,7 @@ declare module "process" {
                 isTTY?: true | undefined;
             }
             // Alias for compatibility
-            interface ProcessEnv extends Dict<string> {
-                /**
-                 * Can be used to change the default timezone at runtime
-                 */
-                TZ?: string | undefined;
-            }
+            interface ProcessEnv extends Dict<string> {}
             interface HRTime {
                 /**
                  * This is the legacy version of {@link process.hrtime.bigint()}

--- a/types/node/v24/process.d.ts
+++ b/types/node/v24/process.d.ts
@@ -344,12 +344,7 @@ declare module "process" {
                 isTTY?: true | undefined;
             }
             // Alias for compatibility
-            interface ProcessEnv extends Dict<string> {
-                /**
-                 * Can be used to change the default timezone at runtime
-                 */
-                TZ?: string | undefined;
-            }
+            interface ProcessEnv extends Dict<string> {}
             interface HRTime {
                 /**
                  * This is the legacy version of {@link process.hrtime.bigint()}


### PR DESCRIPTION
Remove the `TZ` property from `ProcessEnv` across all Node.js version types (latest, v20, v22, v24), falling back to the index signature.

### Problem

Under `exactOptionalPropertyTypes: true`, the named `TZ?: string | undefined` property conflicts when `NodeJS.ProcessEnv` is intersected with other runtime types (e.g., `bun-types`) that declare `TZ?: string`, producing TS2412.

### Solution

Remove the `TZ` property entirely from `ProcessEnv`, as [suggested by @Renegade334](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/74581#issuecomment-3953955385). `process.env.TZ` falls back to the index signature `[key: string]: string | undefined`, which:

- Preserves the same read type (`string | undefined`)
- Preserves the same write type (`string | undefined`)
- Eliminates the intersection conflict with other runtimes

### Not a breaking change

The index signature already provides the exact same type for `process.env.TZ`. The only difference is the loss of IntelliSense autocomplete for `TZ`, which is a minor tradeoff.