### PR TITLE
[aws-lambda] Add Cognito InboundFederation trigger types

### DIFF
--- a/types/aws-lambda/test/cognito-tests.ts
+++ b/types/aws-lambda/test/cognito-tests.ts
@@ -9,6 +9,8 @@ import {
     DefineAuthChallengeTriggerEvent,
     DefineAuthChallengeTriggerHandler,
     Handler,
+    InboundFederationTriggerEvent,
+    InboundFederationTriggerHandler,
     PostAuthenticationTriggerEvent,
     PostAuthenticationTriggerHandler,
     PostConfirmationTriggerEvent,
@@ -42,7 +44,8 @@ type CognitoTriggerEvent =
     | PreTokenGenerationV3TriggerEvent
     | UserMigrationTriggerEvent
     | CustomMessageTriggerEvent
-    | CustomEmailSenderTriggerEvent;
+    | CustomEmailSenderTriggerEvent
+    | InboundFederationTriggerEvent;
 
 const baseTest: Handler<CognitoTriggerEvent> = async (event: CognitoTriggerEvent, _, callback) => {
     str = event.version;
@@ -398,4 +401,31 @@ const customSmsSender: CustomSMSSenderTriggerHandler = async (event, _, callback
     triggerSource === "CustomSMSSender_ResendCode";
     triggerSource === "CustomSMSSender_SignUp";
     triggerSource === "CustomSMSSender_Authentication";
+};
+
+const inboundFederation: InboundFederationTriggerHandler = async (event, _, callback) => {
+    const { request, response, triggerSource } = event;
+
+    str = request.providerName;
+    str = request.providerType;
+    request.providerType === "OIDC";
+    request.providerType === "SAML";
+    request.providerType === "Facebook";
+    request.providerType === "Google";
+    request.providerType === "SignInWithApple";
+    request.providerType === "LoginWithAmazon";
+
+    objectOrUndefined = request.attributes.tokenResponse;
+    objectOrUndefined = request.attributes.idToken;
+    objectOrUndefined = request.attributes.userInfo;
+    objectOrUndefined = request.attributes.samlResponse;
+    strOrUndefined = request.attributes.idToken?.["email"];
+    strOrUndefined = request.attributes.samlResponse?.["given_name"];
+
+    obj = response.userAttributesToMap;
+    str = response.userAttributesToMap["email"];
+    response.userAttributesToMap = {};
+    response.userAttributesToMap = { email: "user@example.com", given_name: "Jane" };
+
+    triggerSource === "InboundFederation_ExternalProvider";
 };

--- a/types/aws-lambda/trigger/cognito-user-pool-trigger/inbound-federation.d.ts
+++ b/types/aws-lambda/trigger/cognito-user-pool-trigger/inbound-federation.d.ts
@@ -1,0 +1,40 @@
+import { Handler } from "../../handler";
+import { BaseTriggerEvent, StringMap } from "./_common";
+
+export type InboundFederationProviderType =
+    | "OIDC"
+    | "SAML"
+    | "Facebook"
+    | "Google"
+    | "SignInWithApple"
+    | "LoginWithAmazon";
+
+/**
+ * @see https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-inbound-federation.html
+ */
+export interface InboundFederationTriggerEvent extends BaseTriggerEvent<"InboundFederation_ExternalProvider"> {
+    request: {
+        providerName: string;
+        providerType: InboundFederationProviderType;
+        attributes: {
+            /** OAuth token response. Present for OIDC and social providers. */
+            tokenResponse?: StringMap | undefined;
+            /** Decoded JWT claims. Present for OIDC and social providers. */
+            idToken?: StringMap | undefined;
+            /** Extended profile info. Present for OIDC and social providers. */
+            userInfo?: StringMap | undefined;
+            /** SAML assertion attributes. Present for SAML providers. */
+            samlResponse?: StringMap | undefined;
+        };
+    };
+    response: {
+        /**
+         * User attributes to apply to the user profile.
+         * All attributes to be retained must be included; omitted attributes are dropped.
+         * Return an empty object `{}` to retain all original attributes unchanged.
+         */
+        userAttributesToMap: StringMap;
+    };
+}
+
+export type InboundFederationTriggerHandler = Handler<InboundFederationTriggerEvent>;

--- a/types/aws-lambda/trigger/cognito-user-pool-trigger/index.d.ts
+++ b/types/aws-lambda/trigger/cognito-user-pool-trigger/index.d.ts
@@ -32,7 +32,8 @@ export interface CognitoUserPoolTriggerEvent {
         | "TokenGeneration_RefreshTokens"
         | "TokenGeneration_ClientCredentials"
         | "UserMigration_Authentication"
-        | "UserMigration_ForgotPassword";
+        | "UserMigration_ForgotPassword"
+        | "InboundFederation_ExternalProvider";
     region: string;
     userPoolId: string;
     userName?: string | undefined;
@@ -119,6 +120,7 @@ export * from "./custom-email-sender";
 export * from "./custom-message";
 export * from "./custom-sms-sender";
 export * from "./define-auth-challenge";
+export * from "./inbound-federation";
 export * from "./post-authentication";
 export * from "./post-confirmation";
 export * from "./pre-authentication";


### PR DESCRIPTION
## Description

Adds type definitions for the new AWS Cognito **Inbound Federation Lambda Trigger** (`InboundFederation_ExternalProvider`), which was recently released. This trigger allows transforming federated user attributes during authentication with external identity providers (SAML, OIDC, and social providers).

### New exports

- `InboundFederationProviderType` — union type of supported provider types (`"OIDC" | "SAML" | "Facebook" | "Google" | "SignInWithApple" | "LoginWithAmazon"`)
- `InboundFederationTriggerEvent` — the full event shape including request (providerName, providerType, attributes) and response (userAttributesToMap)
- `InboundFederationTriggerHandler` — handler type alias

### Changes

- Added `types/aws-lambda/trigger/cognito-user-pool-trigger/inbound-federation.d.ts`
- Updated `types/aws-lambda/trigger/cognito-user-pool-trigger/index.d.ts` to export the new file and add `"InboundFederation_ExternalProvider"` to the deprecated `CognitoUserPoolTriggerEvent` trigger source union
- Updated `types/aws-lambda/test/cognito-tests.ts` with a full test handler

## Documentation

https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-inbound-federation.html

## Checklist

My suggestion meets these guidelines:

* [x] I use `type` for non-callable types and `interface` for callable/constructable types.
* [x] Provide a URL to documentation or source code providing context for the suggested changes.
* [x] If this is a `breaking change` to a type definition, I contacted the author and provided a migration path.
* [x] I've verified the change by building and running tests locally.