### PR TITLE
[@wordpress/blocks] Updating the Store object to match official maintainer commentary

### DIFF
--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -1,5 +1,5 @@
 import { IconType } from "@wordpress/components";
-import { StoreDescriptor } from "@wordpress/data";
+import { ReduxStoreConfig, StoreDescriptor } from "@wordpress/data";
 import { ShortcodeMatch } from "@wordpress/shortcode";
 import { ComponentType, ReactElement } from "react";
 
@@ -11,7 +11,8 @@ declare module "@wordpress/data" {
     function select(key: "core/blocks"): typeof import("./store/selectors");
 }
 
-export interface BlocksStoreDescriptor extends StoreDescriptor {
+type Decurry<S extends {[key: string]: (...args: any[]) => any}> = { [key in keyof S]: (state: any, ...args: Parameters<S[key]>) => ReturnType<S[key]> };
+export interface BlocksStoreDescriptor extends StoreDescriptor<ReduxStoreConfig<any, typeof import("./store/actions"), Decurry<typeof import("./store/selectors")>>> {
     name: "core/blocks";
 }
 

--- a/types/wordpress__blocks/index.d.ts
+++ b/types/wordpress__blocks/index.d.ts
@@ -7,7 +7,13 @@ export * from "./api";
 export { withBlockContentContext } from "./block-content-provider";
 
 declare module "@wordpress/data" {
+    /**
+     * @deprecated Use the version that takes a store descriptor object instead
+     */
     function dispatch(key: "core/blocks"): typeof import("./store/actions");
+    /**
+     * @deprecated Use the version that takes a store descriptor object instead
+     */
     function select(key: "core/blocks"): typeof import("./store/selectors");
 }
 

--- a/types/wordpress__blocks/wordpress__blocks-tests.tsx
+++ b/types/wordpress__blocks/wordpress__blocks-tests.tsx
@@ -721,3 +721,28 @@ dispatch("core/blocks").addBlockStyles("my/foo", { name: "foo__bar", label: "Foo
 
 // $ExpectType void
 dispatch("core/blocks").setDefaultBlockName("my/foo");
+
+//
+// store objects
+// ----------------------------------------------------------------------------
+
+// $ExpectType readonly BlockStyle[] | undefined
+select(blocks.store).getBlockStyles("my/foo");
+
+// $ExpectType string | undefined
+select(blocks.store).getFreeformFallbackBlockName();
+
+// $ExpectType string | undefined
+select(blocks.store).getUnregisteredFallbackBlockName();
+
+// $ExpectType boolean
+select(blocks.store).isMatchingSearchTerm("my/foo", "foo");
+
+// $ExpectType boolean
+select(blocks.store).isMatchingSearchTerm(BLOCK, "foo");
+
+// $ExpectType Promise<void>
+dispatch(blocks.store).addBlockStyles("my/foo", { name: "foo__bar", label: "Foobar" });
+
+// $ExpectType Promise<void>
+dispatch(blocks.store).setDefaultBlockName("my/foo");


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Official Maintainer Commentary](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/74262#discussion_r2844747639)
- [X] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

I'm leaving the "broken" version of the dispatch function in place but marking them as deprecated in order to avoid breaking changes until its time to push a major version update