### PR TITLE
Add overloads for add_argument to support multiple strings with options

### DIFF
--- a/types/argparse/argparse-tests.ts
+++ b/types/argparse/argparse-tests.ts
@@ -68,6 +68,9 @@ const constantExample = new ArgumentParser({
     description: "Argparse examples: constant",
 });
 
+constantExample.add_argument('--multiple', '-m', '--alias1', '--alias2', '--alias3', '--alias4',
+    '--alias5', '--alias6', {dest: 'arg'});
+
 constantExample.add_argument("-a", {
     action: "store_const",
     dest: "answer",

--- a/types/argparse/index.d.ts
+++ b/types/argparse/index.d.ts
@@ -24,9 +24,37 @@ export class SubParser {
     add_parser(name: string, options?: SubArgumentParserOptions): ArgumentParser;
 }
 
+type StrOrOptions = string | ArgumentOptions;
+
 export class ArgumentGroup {
-    add_argument(arg: string, options?: ArgumentOptions): void;
-    add_argument(arg1: string, arg2: string, options?: ArgumentOptions): void;
+    /**
+     * One argument
+     */
+    add_argument(name: string, options?: ArgumentOptions): void;
+
+    /**
+     * Arguments array
+     */
+    add_argument(args: string[], options?: ArgumentOptions): void;
+
+    /** 2-9 arguments with options */
+    add_argument(arg1: string, arg2: string, options: ArgumentOptions): void;
+    add_argument(arg1: string, arg2: string, arg3: string, options: ArgumentOptions): void;
+    add_argument(arg1: string, arg2: string, arg3: string, arg4: string, options: ArgumentOptions): void;
+    add_argument(arg1: string, arg2: string, arg3: string, arg4: string, arg5: string, options: ArgumentOptions): void;
+    add_argument(arg1: string, arg2: string, arg3: string, arg4: string, arg5: string, arg6: string, options: ArgumentOptions): void;
+    add_argument(arg1: string, arg2: string, arg3: string, arg4: string, arg5: string, arg6: string, arg7: string, options: ArgumentOptions): void;
+    add_argument(arg1: string, arg2: string, arg3: string, arg4: string, arg5: string, arg6: string, arg7: string, arg8: string, options: ArgumentOptions): void;
+    add_argument(arg1: string, arg2: string, arg3: string, arg4: string, arg5: string, arg6: string, arg7: string, arg8: string, arg9: string, options: ArgumentOptions): void;
+
+    /**
+     * More than one argument without options
+     */
+    add_argument(...args: string[]): void;
+
+    /** More than 9 arguments with options (not recommended) */
+    add_argument(...args_and_options: StrOrOptions[]): void;
+
     add_argument_group(options?: ArgumentGroupOptions): ArgumentGroup;
     add_mutually_exclusive_group(options?: { required: boolean }): ArgumentGroup;
     set_defaults(options?: {}): void;

--- a/types/argparse/package.json
+++ b/types/argparse/package.json
@@ -32,6 +32,10 @@
         {
             "name": "Dieter Oberkofler",
             "githubUsername": "doberkofler"
+        },
+        {
+            "name": "Маг Ильяс DOMA",
+            "githubUsername": "MagIlyasDOMA"
         }
     ]
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#user-content-my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#user-content-run-tests).
- [x] The change is not breaking, or if it is breaking, the downstream impact is clearly explained.
- [x] I've added myself to the package's `package.json` `"owners"` field.

---

### 📝 Summary of changes

The `add_argument` method in `argparse` supports two calling conventions:

1. `add_argument(arg: string, options?: ArgumentOptions)` — for a single argument with optional options.
2. `add_argument('--arg1', '--arg2', {dest: 'arg'})` — for multiple arguments with a final options object.
3. `add_argument(...args: string[])` — for multiple arguments without options.

Previously, the TypeScript definitions did not correctly handle the third case. When passing multiple strings followed by an `ArgumentOptions` object, the last argument was incorrectly interpreted as a string, causing type errors.

This PR adds explicit overloads to support up to 9 string arguments followed by an `ArgumentOptions` object, and a fallback for longer argument lists using a union type. This matches the actual runtime behavior of the library.

### 🔍 Example usage that now works

```typescript
import { ArgumentParser } from 'argparse';

const parser = new ArgumentParser();
parser.add_argument('--arg1', '--arg2', '--arg3', '-a', { dest: 'arg' });
// Previously: TypeScript error
// Now: correctly typed
```