### PR TITLE
[spotify-api] Mark properties as deprecated for Developer Mode apps

### DIFF
--- a/types/spotify-api/index.d.ts
+++ b/types/spotify-api/index.d.ts
@@ -911,6 +911,7 @@ declare namespace SpotifyApi {
         copyrights: CopyrightObject[];
         /**
          * Known external IDs for the album.
+         * @deprecated since February 2026 for Development Mode apps
          */
         external_ids: ExternalIdObject;
         /**
@@ -920,11 +921,13 @@ declare namespace SpotifyApi {
         genres: string[];
         /**
          * The label for the album.
+         * @deprecated since February 2026 for Development Mode apps
          */
         label: string;
         /**
          * The popularity of the album. The value will be between `0` and `100`, with `100` being the most popular.
          * The popularity is calculated from the popularity of the album’s individual tracks;
+         * @deprecated since February 2026 for Development Mode apps
          */
         popularity: number;
         /**
@@ -942,6 +945,7 @@ declare namespace SpotifyApi {
          * The field is present when getting an artist’s albums.
          * Possible values are “album”, “single”, “compilation”, “appears_on”.
          * Compare to album_type this field represents relationship between the artist and the album.
+         * @deprecated since February 2026 for Development Mode apps
          */
         album_group?: "album" | "single" | "compilation" | "appears_on" | undefined;
         /**
@@ -956,6 +960,7 @@ declare namespace SpotifyApi {
         /**
          * The markets in which the album is available: [ISO 3166-1 alpha-2 country codes](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
          * Note that an album is considered available in a market when at least 1 of its tracks is available in that market.
+         * @deprecated since February 2026 for Development Mode apps
          */
         available_markets?: string[] | undefined;
         /**
@@ -1000,6 +1005,7 @@ declare namespace SpotifyApi {
     interface ArtistObjectFull extends ArtistObjectSimplified {
         /**
          * Information about the followers of the artist.
+         * @deprecated since February 2026 for Development Mode apps
          */
         followers: FollowersObject;
         /**
@@ -1015,6 +1021,7 @@ declare namespace SpotifyApi {
         /**
          * The popularity of the artist. The value will be between `0` and `100`, with `100` being the most popular.
          * The artist’s popularity is calculated from the popularity of all the artist’s tracks.
+         * @deprecated since February 2026 for Development Mode apps
          */
         popularity: number;
     }
@@ -1334,8 +1341,14 @@ declare namespace SpotifyApi {
         followers: FollowersObject;
         /**
          * Information about the tracks of the playlist.
+         * @deprecated since February 2026 for Development Mode apps, use `items`
          */
         tracks: PagingObject<PlaylistTrackObject>;
+        /**
+         * Information about the items of the playlist. Only available when retrieving a users own
+         * playlist. Not available for all other playlists.
+         */
+        items?: PagingObject<PlaylistTrackObject>;
     }
 
     /**
@@ -1343,7 +1356,19 @@ declare namespace SpotifyApi {
      * [](https://developer.spotify.com/web-api/object-model/)
      */
     interface PlaylistObjectSimplified extends PlaylistBaseObject {
+        /**
+         * Information about the tracks of the playlist.
+         * @deprecated since February 2026 for Development Mode apps, use `items`
+         */
         tracks: {
+            href: string;
+            total: number;
+        };
+        /**
+         * Information about the items of the playlist. Only available when retrieving a users own
+         * playlist. Not available for all other playlists.
+         */
+        items?: {
             href: string;
             total: number;
         };
@@ -1357,7 +1382,11 @@ declare namespace SpotifyApi {
         added_at: string;
         added_by: UserObjectPublic;
         is_local: boolean;
+        /**
+         * @deprecated since February 2026 for Development Mode apps, use `item`
+         */
         track: TrackObjectFull | null;
+        item: TrackObjectFull | null;
     }
 
     /**
@@ -1461,6 +1490,7 @@ declare namespace SpotifyApi {
         album: AlbumObjectSimplified;
         /**
          * Known external IDs for the track.
+         * @deprecated since February 2026 for Development Mode apps
          */
         external_ids: ExternalIdObject;
         /**
@@ -1468,6 +1498,7 @@ declare namespace SpotifyApi {
          * The popularity of a track is a value between `0` and `100`, with `100` being the most popular.
          * The popularity is calculated by algorithm and is based, in the most part,
          * on the total number of plays the track has had and how recent those plays are.
+         * @deprecated since February 2026 for Development Mode apps
          */
         popularity: number;
         /**
@@ -1488,6 +1519,7 @@ declare namespace SpotifyApi {
         /**
          * A list of the countries in which the track can be played,
          * identified by their [ISO 3166-1 alpha-2 code](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
+         * @deprecated since February 2026 for Development Mode apps
          */
         available_markets?: string[] | undefined;
         /**
@@ -1504,6 +1536,7 @@ declare namespace SpotifyApi {
         explicit: boolean;
         /**
          * Known external URLs for this track.
+         * @deprecated since February 2026 for Development Mode apps
          */
         external_urls: ExternalUrlObject;
         /**
@@ -1686,6 +1719,7 @@ declare namespace SpotifyApi {
     interface ShowObjectSimplified extends ContextObject {
         /**
          * A list of the countries in which the show can be played, identified by their [ISO 3166-1 alpha-2 code](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
+         *  @deprecated since February 2026 for Development Mode apps
          */
         available_markets: string[];
         /**
@@ -1730,6 +1764,7 @@ declare namespace SpotifyApi {
         name: string;
         /**
          * The publisher of the show.
+         * @deprecated since February 2026 for Development Mode apps
          */
         publisher: string;
         /**
@@ -1751,8 +1786,17 @@ declare namespace SpotifyApi {
      */
     interface UserObjectPrivate extends UserObjectPublic {
         birthdate: string;
+        /**
+         * @deprecated since February 2026 for Development Mode apps
+         */
         country: string;
+        /**
+         * @deprecated since February 2026 for Development Mode apps
+         */
         email: string;
+        /**
+         * @deprecated since February 2026 for Development Mode apps
+         */
         product: string;
     }
 
@@ -1763,6 +1807,9 @@ declare namespace SpotifyApi {
     interface UserObjectPublic {
         display_name?: string | undefined;
         external_urls: ExternalUrlObject;
+        /**
+         * @deprecated since February 2026 for Development Mode apps
+         */
         followers?: FollowersObject | undefined;
         href: string;
         id: string;

--- a/types/spotify-api/spotify-api-tests.ts
+++ b/types/spotify-api/spotify-api-tests.ts
@@ -9738,6 +9738,83 @@ const playlist: SpotifyApi.SinglePlaylistResponse = {
                     type: "track",
                     uri: "spotify:track:3bCmDqflFBHijgJfvtqev5",
                 },
+                item: {
+                    album: {
+                        album_type: "album",
+                        total_tracks: 10,
+                        artists: [
+                            {
+                                external_urls: {
+                                    spotify: "https://open.spotify.com/artist/7MSUfLeTdDEoZiJPDSBXgi",
+                                },
+                                href: "https://api.spotify.com/v1/artists/7MSUfLeTdDEoZiJPDSBXgi",
+                                id: "7MSUfLeTdDEoZiJPDSBXgi",
+                                name: "Brian Eno",
+                                type: "artist",
+                                uri: "spotify:artist:7MSUfLeTdDEoZiJPDSBXgi",
+                            },
+                        ],
+                        available_markets: ["AR", "AT", "AU", "BE", "BR", "CL", "CO", "CY", "CZ", "DE"],
+                        external_urls: {
+                            spotify: "https://open.spotify.com/album/063f8Ej8rLVTz9KkjQKEMa",
+                        },
+                        href: "https://api.spotify.com/v1/albums/063f8Ej8rLVTz9KkjQKEMa",
+                        id: "063f8Ej8rLVTz9KkjQKEMa",
+                        images: [
+                            {
+                                height: 640,
+                                url: "https://i.scdn.co/image/ab67616d0000b27369530c204f1fc99c5b9fa7a4",
+                                width: 640,
+                            },
+                            {
+                                height: 300,
+                                url: "https://i.scdn.co/image/ab67616d00001e0269530c204f1fc99c5b9fa7a4",
+                                width: 300,
+                            },
+                            {
+                                height: 64,
+                                url: "https://i.scdn.co/image/ab67616d0000485169530c204f1fc99c5b9fa7a4",
+                                width: 64,
+                            },
+                        ],
+                        name: "Ambient 1/Music For Airports",
+                        release_date: "1978",
+                        release_date_precision: "year",
+                        type: "album",
+                        uri: "spotify:album:063f8Ej8rLVTz9KkjQKEMa",
+                    },
+                    artists: [
+                        {
+                            external_urls: {
+                                spotify: "https://open.spotify.com/artist/7MSUfLeTdDEoZiJPDSBXgi",
+                            },
+                            href: "https://api.spotify.com/v1/artists/7MSUfLeTdDEoZiJPDSBXgi",
+                            id: "7MSUfLeTdDEoZiJPDSBXgi",
+                            name: "Brian Eno",
+                            type: "artist",
+                            uri: "spotify:artist:7MSUfLeTdDEoZiJPDSBXgi",
+                        },
+                    ],
+                    available_markets: ["AR", "AT", "AU", "BE", "BR", "CL", "CO", "CY", "CZ", "DE"],
+                    disc_number: 1,
+                    duration_ms: 1041520,
+                    explicit: false,
+                    external_ids: {
+                        isrc: "GBAAA0400426",
+                    },
+                    external_urls: {
+                        spotify: "https://open.spotify.com/track/3bCmDqflFBHijgJfvtqev5",
+                    },
+                    href: "https://api.spotify.com/v1/tracks/3bCmDqflFBHijgJfvtqev5",
+                    id: "3bCmDqflFBHijgJfvtqev5",
+                    name: "1/1 - Remastered 2004",
+                    popularity: 51,
+                    preview_url:
+                        "https://p.scdn.co/mp3-preview/b7cd7208aa6c68607b492c5298234cbe8b86c39d?cid=774b29d4f13844c495f206cafdad9c86",
+                    track_number: 1,
+                    type: "track",
+                    uri: "spotify:track:3bCmDqflFBHijgJfvtqev5",
+                },
             },
             {
                 added_at: "2015-10-05T06:05:23Z",
@@ -9752,6 +9829,82 @@ const playlist: SpotifyApi.SinglePlaylistResponse = {
                 },
                 is_local: false,
                 track: {
+                    album: {
+                        album_type: "compilation",
+                        total_tracks: 10,
+                        artists: [
+                            {
+                                external_urls: {
+                                    spotify: "https://open.spotify.com/artist/4xls23Ye9WR9yy3yYMpAMm",
+                                },
+                                href: "https://api.spotify.com/v1/artists/4xls23Ye9WR9yy3yYMpAMm",
+                                id: "4xls23Ye9WR9yy3yYMpAMm",
+                                name: "Little Richard",
+                                type: "artist",
+                                uri: "spotify:artist:4xls23Ye9WR9yy3yYMpAMm",
+                            },
+                        ],
+                        available_markets: [],
+                        external_urls: {
+                            spotify: "https://open.spotify.com/album/3LXNSUpx48PQxUn2StRqfu",
+                        },
+                        href: "https://api.spotify.com/v1/albums/3LXNSUpx48PQxUn2StRqfu",
+                        id: "3LXNSUpx48PQxUn2StRqfu",
+                        images: [
+                            {
+                                height: 640,
+                                url: "https://i.scdn.co/image/ab67616d0000b2737d92de948b22c8201f4467c5",
+                                width: 640,
+                            },
+                            {
+                                height: 300,
+                                url: "https://i.scdn.co/image/ab67616d00001e027d92de948b22c8201f4467c5",
+                                width: 300,
+                            },
+                            {
+                                height: 64,
+                                url: "https://i.scdn.co/image/ab67616d000048517d92de948b22c8201f4467c5",
+                                width: 64,
+                            },
+                        ],
+                        name: "The Very Best Of Little Richard",
+                        release_date: "2008-01-01",
+                        release_date_precision: "day",
+                        type: "album",
+                        uri: "spotify:album:3LXNSUpx48PQxUn2StRqfu",
+                    },
+                    artists: [
+                        {
+                            external_urls: {
+                                spotify: "https://open.spotify.com/artist/4xls23Ye9WR9yy3yYMpAMm",
+                            },
+                            href: "https://api.spotify.com/v1/artists/4xls23Ye9WR9yy3yYMpAMm",
+                            id: "4xls23Ye9WR9yy3yYMpAMm",
+                            name: "Little Richard",
+                            type: "artist",
+                            uri: "spotify:artist:4xls23Ye9WR9yy3yYMpAMm",
+                        },
+                    ],
+                    available_markets: [],
+                    disc_number: 1,
+                    duration_ms: 127386,
+                    explicit: false,
+                    external_ids: {
+                        isrc: "USC4R0817279",
+                    },
+                    external_urls: {
+                        spotify: "https://open.spotify.com/track/1fMMRoalpb7E8m5FsAta2y",
+                    },
+                    href: "https://api.spotify.com/v1/tracks/1fMMRoalpb7E8m5FsAta2y",
+                    id: "1fMMRoalpb7E8m5FsAta2y",
+                    name: "Good Golly Miss Molly",
+                    popularity: 11,
+                    preview_url: null,
+                    track_number: 3,
+                    type: "track",
+                    uri: "spotify:track:1fMMRoalpb7E8m5FsAta2y",
+                },
+                item: {
                     album: {
                         album_type: "compilation",
                         total_tracks: 10,
@@ -9926,6 +10079,619 @@ const playlist: SpotifyApi.SinglePlaylistResponse = {
                     type: "track",
                     uri: "spotify:track:3xhXKRGahWzcXF8rD5gUvd",
                 },
+                item: {
+                    album: {
+                        album_type: "album",
+                        total_tracks: 10,
+                        artists: [
+                            {
+                                external_urls: {
+                                    spotify: "https://open.spotify.com/artist/2Mu5NfyYm8n5iTomuKAEHl",
+                                },
+                                href: "https://api.spotify.com/v1/artists/2Mu5NfyYm8n5iTomuKAEHl",
+                                id: "2Mu5NfyYm8n5iTomuKAEHl",
+                                name: "Ms. Lauryn Hill",
+                                type: "artist",
+                                uri: "spotify:artist:2Mu5NfyYm8n5iTomuKAEHl",
+                            },
+                        ],
+                        available_markets: [],
+                        external_urls: {
+                            spotify: "https://open.spotify.com/album/2Uc0HAF0Cj0LAgyzYZX5e3",
+                        },
+                        href: "https://api.spotify.com/v1/albums/2Uc0HAF0Cj0LAgyzYZX5e3",
+                        id: "2Uc0HAF0Cj0LAgyzYZX5e3",
+                        images: [
+                            {
+                                height: 640,
+                                url: "https://i.scdn.co/image/ab67616d0000b2739196fafd1d6160480d3df68a",
+                                width: 640,
+                            },
+                            {
+                                height: 300,
+                                url: "https://i.scdn.co/image/ab67616d00001e029196fafd1d6160480d3df68a",
+                                width: 300,
+                            },
+                            {
+                                height: 64,
+                                url: "https://i.scdn.co/image/ab67616d000048519196fafd1d6160480d3df68a",
+                                width: 64,
+                            },
+                        ],
+                        name: "The Miseducation of Lauryn Hill",
+                        release_date: "1998-08-25",
+                        release_date_precision: "day",
+                        type: "album",
+                        uri: "spotify:album:2Uc0HAF0Cj0LAgyzYZX5e3",
+                    },
+                    artists: [
+                        {
+                            external_urls: {
+                                spotify: "https://open.spotify.com/artist/2Mu5NfyYm8n5iTomuKAEHl",
+                            },
+                            href: "https://api.spotify.com/v1/artists/2Mu5NfyYm8n5iTomuKAEHl",
+                            id: "2Mu5NfyYm8n5iTomuKAEHl",
+                            name: "Ms. Lauryn Hill",
+                            type: "artist",
+                            uri: "spotify:artist:2Mu5NfyYm8n5iTomuKAEHl",
+                        },
+                        {
+                            external_urls: {
+                                spotify: "https://open.spotify.com/artist/336vr2M3Va0FjyvB55lJEd",
+                            },
+                            href: "https://api.spotify.com/v1/artists/336vr2M3Va0FjyvB55lJEd",
+                            id: "336vr2M3Va0FjyvB55lJEd",
+                            name: "D'Angelo",
+                            type: "artist",
+                            uri: "spotify:artist:336vr2M3Va0FjyvB55lJEd",
+                        },
+                    ],
+                    available_markets: [],
+                    disc_number: 1,
+                    duration_ms: 350533,
+                    explicit: false,
+                    external_ids: {
+                        isrc: "USSM19803112",
+                    },
+                    external_urls: {
+                        spotify: "https://open.spotify.com/track/3xhXKRGahWzcXF8rD5gUvd",
+                    },
+                    href: "https://api.spotify.com/v1/tracks/3xhXKRGahWzcXF8rD5gUvd",
+                    id: "3xhXKRGahWzcXF8rD5gUvd",
+                    name: "Nothing Even Matters",
+                    popularity: 8,
+                    preview_url: null,
+                    track_number: 12,
+                    type: "track",
+                    uri: "spotify:track:3xhXKRGahWzcXF8rD5gUvd",
+                },
+            },
+        ],
+        limit: 100,
+        next: null,
+        offset: 0,
+        previous: null,
+        total: 3,
+    },
+    items: {
+        href: "https://api.spotify.com/v1/playlists/0r6srTg2RFfBWba9WZ6Dlq/tracks?offset=0&limit=100",
+        items: [
+            {
+                added_at: "2015-10-05T06:04:05Z",
+                added_by: {
+                    external_urls: {
+                        spotify: "https://open.spotify.com/user/physicaltunes",
+                    },
+                    href: "https://api.spotify.com/v1/users/physicaltunes",
+                    id: "physicaltunes",
+                    type: "user",
+                    uri: "spotify:user:physicaltunes",
+                },
+                is_local: false,
+                track: {
+                    album: {
+                        album_type: "album",
+                        total_tracks: 10,
+                        artists: [
+                            {
+                                external_urls: {
+                                    spotify: "https://open.spotify.com/artist/7MSUfLeTdDEoZiJPDSBXgi",
+                                },
+                                href: "https://api.spotify.com/v1/artists/7MSUfLeTdDEoZiJPDSBXgi",
+                                id: "7MSUfLeTdDEoZiJPDSBXgi",
+                                name: "Brian Eno",
+                                type: "artist",
+                                uri: "spotify:artist:7MSUfLeTdDEoZiJPDSBXgi",
+                            },
+                        ],
+                        available_markets: ["AR", "AT", "AU", "BE", "BR", "CL", "CO", "CY", "CZ", "DE"],
+                        external_urls: {
+                            spotify: "https://open.spotify.com/album/063f8Ej8rLVTz9KkjQKEMa",
+                        },
+                        href: "https://api.spotify.com/v1/albums/063f8Ej8rLVTz9KkjQKEMa",
+                        id: "063f8Ej8rLVTz9KkjQKEMa",
+                        images: [
+                            {
+                                height: 640,
+                                url: "https://i.scdn.co/image/ab67616d0000b27369530c204f1fc99c5b9fa7a4",
+                                width: 640,
+                            },
+                            {
+                                height: 300,
+                                url: "https://i.scdn.co/image/ab67616d00001e0269530c204f1fc99c5b9fa7a4",
+                                width: 300,
+                            },
+                            {
+                                height: 64,
+                                url: "https://i.scdn.co/image/ab67616d0000485169530c204f1fc99c5b9fa7a4",
+                                width: 64,
+                            },
+                        ],
+                        name: "Ambient 1/Music For Airports",
+                        release_date: "1978",
+                        release_date_precision: "year",
+                        type: "album",
+                        uri: "spotify:album:063f8Ej8rLVTz9KkjQKEMa",
+                    },
+                    artists: [
+                        {
+                            external_urls: {
+                                spotify: "https://open.spotify.com/artist/7MSUfLeTdDEoZiJPDSBXgi",
+                            },
+                            href: "https://api.spotify.com/v1/artists/7MSUfLeTdDEoZiJPDSBXgi",
+                            id: "7MSUfLeTdDEoZiJPDSBXgi",
+                            name: "Brian Eno",
+                            type: "artist",
+                            uri: "spotify:artist:7MSUfLeTdDEoZiJPDSBXgi",
+                        },
+                    ],
+                    available_markets: ["AR", "AT", "AU", "BE", "BR", "CL", "CO", "CY", "CZ", "DE"],
+                    disc_number: 1,
+                    duration_ms: 1041520,
+                    explicit: false,
+                    external_ids: {
+                        isrc: "GBAAA0400426",
+                    },
+                    external_urls: {
+                        spotify: "https://open.spotify.com/track/3bCmDqflFBHijgJfvtqev5",
+                    },
+                    href: "https://api.spotify.com/v1/tracks/3bCmDqflFBHijgJfvtqev5",
+                    id: "3bCmDqflFBHijgJfvtqev5",
+                    name: "1/1 - Remastered 2004",
+                    popularity: 51,
+                    preview_url:
+                        "https://p.scdn.co/mp3-preview/b7cd7208aa6c68607b492c5298234cbe8b86c39d?cid=774b29d4f13844c495f206cafdad9c86",
+                    track_number: 1,
+                    type: "track",
+                    uri: "spotify:track:3bCmDqflFBHijgJfvtqev5",
+                },
+                item: {
+                    album: {
+                        album_type: "album",
+                        total_tracks: 10,
+                        artists: [
+                            {
+                                external_urls: {
+                                    spotify: "https://open.spotify.com/artist/7MSUfLeTdDEoZiJPDSBXgi",
+                                },
+                                href: "https://api.spotify.com/v1/artists/7MSUfLeTdDEoZiJPDSBXgi",
+                                id: "7MSUfLeTdDEoZiJPDSBXgi",
+                                name: "Brian Eno",
+                                type: "artist",
+                                uri: "spotify:artist:7MSUfLeTdDEoZiJPDSBXgi",
+                            },
+                        ],
+                        available_markets: ["AR", "AT", "AU", "BE", "BR", "CL", "CO", "CY", "CZ", "DE"],
+                        external_urls: {
+                            spotify: "https://open.spotify.com/album/063f8Ej8rLVTz9KkjQKEMa",
+                        },
+                        href: "https://api.spotify.com/v1/albums/063f8Ej8rLVTz9KkjQKEMa",
+                        id: "063f8Ej8rLVTz9KkjQKEMa",
+                        images: [
+                            {
+                                height: 640,
+                                url: "https://i.scdn.co/image/ab67616d0000b27369530c204f1fc99c5b9fa7a4",
+                                width: 640,
+                            },
+                            {
+                                height: 300,
+                                url: "https://i.scdn.co/image/ab67616d00001e0269530c204f1fc99c5b9fa7a4",
+                                width: 300,
+                            },
+                            {
+                                height: 64,
+                                url: "https://i.scdn.co/image/ab67616d0000485169530c204f1fc99c5b9fa7a4",
+                                width: 64,
+                            },
+                        ],
+                        name: "Ambient 1/Music For Airports",
+                        release_date: "1978",
+                        release_date_precision: "year",
+                        type: "album",
+                        uri: "spotify:album:063f8Ej8rLVTz9KkjQKEMa",
+                    },
+                    artists: [
+                        {
+                            external_urls: {
+                                spotify: "https://open.spotify.com/artist/7MSUfLeTdDEoZiJPDSBXgi",
+                            },
+                            href: "https://api.spotify.com/v1/artists/7MSUfLeTdDEoZiJPDSBXgi",
+                            id: "7MSUfLeTdDEoZiJPDSBXgi",
+                            name: "Brian Eno",
+                            type: "artist",
+                            uri: "spotify:artist:7MSUfLeTdDEoZiJPDSBXgi",
+                        },
+                    ],
+                    available_markets: ["AR", "AT", "AU", "BE", "BR", "CL", "CO", "CY", "CZ", "DE"],
+                    disc_number: 1,
+                    duration_ms: 1041520,
+                    explicit: false,
+                    external_ids: {
+                        isrc: "GBAAA0400426",
+                    },
+                    external_urls: {
+                        spotify: "https://open.spotify.com/track/3bCmDqflFBHijgJfvtqev5",
+                    },
+                    href: "https://api.spotify.com/v1/tracks/3bCmDqflFBHijgJfvtqev5",
+                    id: "3bCmDqflFBHijgJfvtqev5",
+                    name: "1/1 - Remastered 2004",
+                    popularity: 51,
+                    preview_url:
+                        "https://p.scdn.co/mp3-preview/b7cd7208aa6c68607b492c5298234cbe8b86c39d?cid=774b29d4f13844c495f206cafdad9c86",
+                    track_number: 1,
+                    type: "track",
+                    uri: "spotify:track:3bCmDqflFBHijgJfvtqev5",
+                },
+            },
+            {
+                added_at: "2015-10-05T06:05:23Z",
+                added_by: {
+                    external_urls: {
+                        spotify: "https://open.spotify.com/user/physicaltunes",
+                    },
+                    href: "https://api.spotify.com/v1/users/physicaltunes",
+                    id: "physicaltunes",
+                    type: "user",
+                    uri: "spotify:user:physicaltunes",
+                },
+                is_local: false,
+                track: {
+                    album: {
+                        album_type: "compilation",
+                        total_tracks: 10,
+                        artists: [
+                            {
+                                external_urls: {
+                                    spotify: "https://open.spotify.com/artist/4xls23Ye9WR9yy3yYMpAMm",
+                                },
+                                href: "https://api.spotify.com/v1/artists/4xls23Ye9WR9yy3yYMpAMm",
+                                id: "4xls23Ye9WR9yy3yYMpAMm",
+                                name: "Little Richard",
+                                type: "artist",
+                                uri: "spotify:artist:4xls23Ye9WR9yy3yYMpAMm",
+                            },
+                        ],
+                        available_markets: [],
+                        external_urls: {
+                            spotify: "https://open.spotify.com/album/3LXNSUpx48PQxUn2StRqfu",
+                        },
+                        href: "https://api.spotify.com/v1/albums/3LXNSUpx48PQxUn2StRqfu",
+                        id: "3LXNSUpx48PQxUn2StRqfu",
+                        images: [
+                            {
+                                height: 640,
+                                url: "https://i.scdn.co/image/ab67616d0000b2737d92de948b22c8201f4467c5",
+                                width: 640,
+                            },
+                            {
+                                height: 300,
+                                url: "https://i.scdn.co/image/ab67616d00001e027d92de948b22c8201f4467c5",
+                                width: 300,
+                            },
+                            {
+                                height: 64,
+                                url: "https://i.scdn.co/image/ab67616d000048517d92de948b22c8201f4467c5",
+                                width: 64,
+                            },
+                        ],
+                        name: "The Very Best Of Little Richard",
+                        release_date: "2008-01-01",
+                        release_date_precision: "day",
+                        type: "album",
+                        uri: "spotify:album:3LXNSUpx48PQxUn2StRqfu",
+                    },
+                    artists: [
+                        {
+                            external_urls: {
+                                spotify: "https://open.spotify.com/artist/4xls23Ye9WR9yy3yYMpAMm",
+                            },
+                            href: "https://api.spotify.com/v1/artists/4xls23Ye9WR9yy3yYMpAMm",
+                            id: "4xls23Ye9WR9yy3yYMpAMm",
+                            name: "Little Richard",
+                            type: "artist",
+                            uri: "spotify:artist:4xls23Ye9WR9yy3yYMpAMm",
+                        },
+                    ],
+                    available_markets: [],
+                    disc_number: 1,
+                    duration_ms: 127386,
+                    explicit: false,
+                    external_ids: {
+                        isrc: "USC4R0817279",
+                    },
+                    external_urls: {
+                        spotify: "https://open.spotify.com/track/1fMMRoalpb7E8m5FsAta2y",
+                    },
+                    href: "https://api.spotify.com/v1/tracks/1fMMRoalpb7E8m5FsAta2y",
+                    id: "1fMMRoalpb7E8m5FsAta2y",
+                    name: "Good Golly Miss Molly",
+                    popularity: 11,
+                    preview_url: null,
+                    track_number: 3,
+                    type: "track",
+                    uri: "spotify:track:1fMMRoalpb7E8m5FsAta2y",
+                },
+                item: {
+                    album: {
+                        album_type: "compilation",
+                        total_tracks: 10,
+                        artists: [
+                            {
+                                external_urls: {
+                                    spotify: "https://open.spotify.com/artist/4xls23Ye9WR9yy3yYMpAMm",
+                                },
+                                href: "https://api.spotify.com/v1/artists/4xls23Ye9WR9yy3yYMpAMm",
+                                id: "4xls23Ye9WR9yy3yYMpAMm",
+                                name: "Little Richard",
+                                type: "artist",
+                                uri: "spotify:artist:4xls23Ye9WR9yy3yYMpAMm",
+                            },
+                        ],
+                        available_markets: [],
+                        external_urls: {
+                            spotify: "https://open.spotify.com/album/3LXNSUpx48PQxUn2StRqfu",
+                        },
+                        href: "https://api.spotify.com/v1/albums/3LXNSUpx48PQxUn2StRqfu",
+                        id: "3LXNSUpx48PQxUn2StRqfu",
+                        images: [
+                            {
+                                height: 640,
+                                url: "https://i.scdn.co/image/ab67616d0000b2737d92de948b22c8201f4467c5",
+                                width: 640,
+                            },
+                            {
+                                height: 300,
+                                url: "https://i.scdn.co/image/ab67616d00001e027d92de948b22c8201f4467c5",
+                                width: 300,
+                            },
+                            {
+                                height: 64,
+                                url: "https://i.scdn.co/image/ab67616d000048517d92de948b22c8201f4467c5",
+                                width: 64,
+                            },
+                        ],
+                        name: "The Very Best Of Little Richard",
+                        release_date: "2008-01-01",
+                        release_date_precision: "day",
+                        type: "album",
+                        uri: "spotify:album:3LXNSUpx48PQxUn2StRqfu",
+                    },
+                    artists: [
+                        {
+                            external_urls: {
+                                spotify: "https://open.spotify.com/artist/4xls23Ye9WR9yy3yYMpAMm",
+                            },
+                            href: "https://api.spotify.com/v1/artists/4xls23Ye9WR9yy3yYMpAMm",
+                            id: "4xls23Ye9WR9yy3yYMpAMm",
+                            name: "Little Richard",
+                            type: "artist",
+                            uri: "spotify:artist:4xls23Ye9WR9yy3yYMpAMm",
+                        },
+                    ],
+                    available_markets: [],
+                    disc_number: 1,
+                    duration_ms: 127386,
+                    explicit: false,
+                    external_ids: {
+                        isrc: "USC4R0817279",
+                    },
+                    external_urls: {
+                        spotify: "https://open.spotify.com/track/1fMMRoalpb7E8m5FsAta2y",
+                    },
+                    href: "https://api.spotify.com/v1/tracks/1fMMRoalpb7E8m5FsAta2y",
+                    id: "1fMMRoalpb7E8m5FsAta2y",
+                    name: "Good Golly Miss Molly",
+                    popularity: 11,
+                    preview_url: null,
+                    track_number: 3,
+                    type: "track",
+                    uri: "spotify:track:1fMMRoalpb7E8m5FsAta2y",
+                },
+            },
+            {
+                added_at: "2015-10-05T06:03:49Z",
+                added_by: {
+                    external_urls: {
+                        spotify: "https://open.spotify.com/user/physicaltunes",
+                    },
+                    href: "https://api.spotify.com/v1/users/physicaltunes",
+                    id: "physicaltunes",
+                    type: "user",
+                    uri: "spotify:user:physicaltunes",
+                },
+                is_local: false,
+                track: {
+                    album: {
+                        album_type: "album",
+                        total_tracks: 10,
+                        artists: [
+                            {
+                                external_urls: {
+                                    spotify: "https://open.spotify.com/artist/2Mu5NfyYm8n5iTomuKAEHl",
+                                },
+                                href: "https://api.spotify.com/v1/artists/2Mu5NfyYm8n5iTomuKAEHl",
+                                id: "2Mu5NfyYm8n5iTomuKAEHl",
+                                name: "Ms. Lauryn Hill",
+                                type: "artist",
+                                uri: "spotify:artist:2Mu5NfyYm8n5iTomuKAEHl",
+                            },
+                        ],
+                        available_markets: [],
+                        external_urls: {
+                            spotify: "https://open.spotify.com/album/2Uc0HAF0Cj0LAgyzYZX5e3",
+                        },
+                        href: "https://api.spotify.com/v1/albums/2Uc0HAF0Cj0LAgyzYZX5e3",
+                        id: "2Uc0HAF0Cj0LAgyzYZX5e3",
+                        images: [
+                            {
+                                height: 640,
+                                url: "https://i.scdn.co/image/ab67616d0000b2739196fafd1d6160480d3df68a",
+                                width: 640,
+                            },
+                            {
+                                height: 300,
+                                url: "https://i.scdn.co/image/ab67616d00001e029196fafd1d6160480d3df68a",
+                                width: 300,
+                            },
+                            {
+                                height: 64,
+                                url: "https://i.scdn.co/image/ab67616d000048519196fafd1d6160480d3df68a",
+                                width: 64,
+                            },
+                        ],
+                        name: "The Miseducation of Lauryn Hill",
+                        release_date: "1998-08-25",
+                        release_date_precision: "day",
+                        type: "album",
+                        uri: "spotify:album:2Uc0HAF0Cj0LAgyzYZX5e3",
+                    },
+                    artists: [
+                        {
+                            external_urls: {
+                                spotify: "https://open.spotify.com/artist/2Mu5NfyYm8n5iTomuKAEHl",
+                            },
+                            href: "https://api.spotify.com/v1/artists/2Mu5NfyYm8n5iTomuKAEHl",
+                            id: "2Mu5NfyYm8n5iTomuKAEHl",
+                            name: "Ms. Lauryn Hill",
+                            type: "artist",
+                            uri: "spotify:artist:2Mu5NfyYm8n5iTomuKAEHl",
+                        },
+                        {
+                            external_urls: {
+                                spotify: "https://open.spotify.com/artist/336vr2M3Va0FjyvB55lJEd",
+                            },
+                            href: "https://api.spotify.com/v1/artists/336vr2M3Va0FjyvB55lJEd",
+                            id: "336vr2M3Va0FjyvB55lJEd",
+                            name: "D'Angelo",
+                            type: "artist",
+                            uri: "spotify:artist:336vr2M3Va0FjyvB55lJEd",
+                        },
+                    ],
+                    available_markets: [],
+                    disc_number: 1,
+                    duration_ms: 350533,
+                    explicit: false,
+                    external_ids: {
+                        isrc: "USSM19803112",
+                    },
+                    external_urls: {
+                        spotify: "https://open.spotify.com/track/3xhXKRGahWzcXF8rD5gUvd",
+                    },
+                    href: "https://api.spotify.com/v1/tracks/3xhXKRGahWzcXF8rD5gUvd",
+                    id: "3xhXKRGahWzcXF8rD5gUvd",
+                    name: "Nothing Even Matters",
+                    popularity: 8,
+                    preview_url: null,
+                    track_number: 12,
+                    type: "track",
+                    uri: "spotify:track:3xhXKRGahWzcXF8rD5gUvd",
+                },
+                item: {
+                    album: {
+                        album_type: "album",
+                        total_tracks: 10,
+                        artists: [
+                            {
+                                external_urls: {
+                                    spotify: "https://open.spotify.com/artist/2Mu5NfyYm8n5iTomuKAEHl",
+                                },
+                                href: "https://api.spotify.com/v1/artists/2Mu5NfyYm8n5iTomuKAEHl",
+                                id: "2Mu5NfyYm8n5iTomuKAEHl",
+                                name: "Ms. Lauryn Hill",
+                                type: "artist",
+                                uri: "spotify:artist:2Mu5NfyYm8n5iTomuKAEHl",
+                            },
+                        ],
+                        available_markets: [],
+                        external_urls: {
+                            spotify: "https://open.spotify.com/album/2Uc0HAF0Cj0LAgyzYZX5e3",
+                        },
+                        href: "https://api.spotify.com/v1/albums/2Uc0HAF0Cj0LAgyzYZX5e3",
+                        id: "2Uc0HAF0Cj0LAgyzYZX5e3",
+                        images: [
+                            {
+                                height: 640,
+                                url: "https://i.scdn.co/image/ab67616d0000b2739196fafd1d6160480d3df68a",
+                                width: 640,
+                            },
+                            {
+                                height: 300,
+                                url: "https://i.scdn.co/image/ab67616d00001e029196fafd1d6160480d3df68a",
+                                width: 300,
+                            },
+                            {
+                                height: 64,
+                                url: "https://i.scdn.co/image/ab67616d000048519196fafd1d6160480d3df68a",
+                                width: 64,
+                            },
+                        ],
+                        name: "The Miseducation of Lauryn Hill",
+                        release_date: "1998-08-25",
+                        release_date_precision: "day",
+                        type: "album",
+                        uri: "spotify:album:2Uc0HAF0Cj0LAgyzYZX5e3",
+                    },
+                    artists: [
+                        {
+                            external_urls: {
+                                spotify: "https://open.spotify.com/artist/2Mu5NfyYm8n5iTomuKAEHl",
+                            },
+                            href: "https://api.spotify.com/v1/artists/2Mu5NfyYm8n5iTomuKAEHl",
+                            id: "2Mu5NfyYm8n5iTomuKAEHl",
+                            name: "Ms. Lauryn Hill",
+                            type: "artist",
+                            uri: "spotify:artist:2Mu5NfyYm8n5iTomuKAEHl",
+                        },
+                        {
+                            external_urls: {
+                                spotify: "https://open.spotify.com/artist/336vr2M3Va0FjyvB55lJEd",
+                            },
+                            href: "https://api.spotify.com/v1/artists/336vr2M3Va0FjyvB55lJEd",
+                            id: "336vr2M3Va0FjyvB55lJEd",
+                            name: "D'Angelo",
+                            type: "artist",
+                            uri: "spotify:artist:336vr2M3Va0FjyvB55lJEd",
+                        },
+                    ],
+                    available_markets: [],
+                    disc_number: 1,
+                    duration_ms: 350533,
+                    explicit: false,
+                    external_ids: {
+                        isrc: "USSM19803112",
+                    },
+                    external_urls: {
+                        spotify: "https://open.spotify.com/track/3xhXKRGahWzcXF8rD5gUvd",
+                    },
+                    href: "https://api.spotify.com/v1/tracks/3xhXKRGahWzcXF8rD5gUvd",
+                    id: "3xhXKRGahWzcXF8rD5gUvd",
+                    name: "Nothing Even Matters",
+                    popularity: 8,
+                    preview_url: null,
+                    track_number: 12,
+                    type: "track",
+                    uri: "spotify:track:3xhXKRGahWzcXF8rD5gUvd",
+                },
             },
         ],
         limit: 100,
@@ -9960,6 +10726,82 @@ const playlistTracks: SpotifyApi.PlaylistTrackResponse = {
             },
             is_local: false,
             track: {
+                album: {
+                    album_type: "single",
+                    total_tracks: 10,
+                    artists: [
+                        {
+                            external_urls: {
+                                spotify: "https://open.spotify.com/artist/7jVv8c5Fj3E9VhNjxT4snq",
+                            },
+                            href: "https://api.spotify.com/v1/artists/7jVv8c5Fj3E9VhNjxT4snq",
+                            id: "7jVv8c5Fj3E9VhNjxT4snq",
+                            name: "Lil Nas X",
+                            type: "artist",
+                            uri: "spotify:artist:7jVv8c5Fj3E9VhNjxT4snq",
+                        },
+                    ],
+                    available_markets: [],
+                    external_urls: {
+                        spotify: "https://open.spotify.com/album/6sC8l8bVvMckgES0c3VpCZ",
+                    },
+                    href: "https://api.spotify.com/v1/albums/6sC8l8bVvMckgES0c3VpCZ",
+                    id: "6sC8l8bVvMckgES0c3VpCZ",
+                    images: [
+                        {
+                            height: 640,
+                            url: "https://i.scdn.co/image/ab67616d0000b273d792735868f17bae3b6cda31",
+                            width: 640,
+                        },
+                        {
+                            height: 300,
+                            url: "https://i.scdn.co/image/ab67616d00001e02d792735868f17bae3b6cda31",
+                            width: 300,
+                        },
+                        {
+                            height: 64,
+                            url: "https://i.scdn.co/image/ab67616d00004851d792735868f17bae3b6cda31",
+                            width: 64,
+                        },
+                    ],
+                    name: "Old Town Road",
+                    release_date: "2018-12-17",
+                    release_date_precision: "day",
+                    type: "album",
+                    uri: "spotify:album:6sC8l8bVvMckgES0c3VpCZ",
+                },
+                artists: [
+                    {
+                        external_urls: {
+                            spotify: "https://open.spotify.com/artist/7jVv8c5Fj3E9VhNjxT4snq",
+                        },
+                        href: "https://api.spotify.com/v1/artists/7jVv8c5Fj3E9VhNjxT4snq",
+                        id: "7jVv8c5Fj3E9VhNjxT4snq",
+                        name: "Lil Nas X",
+                        type: "artist",
+                        uri: "spotify:artist:7jVv8c5Fj3E9VhNjxT4snq",
+                    },
+                ],
+                available_markets: [],
+                disc_number: 1,
+                duration_ms: 113005,
+                explicit: true,
+                external_ids: {
+                    isrc: "SE6A91836283",
+                },
+                external_urls: {
+                    spotify: "https://open.spotify.com/track/2pMl9Sx4glsuk5ikZtFBtX",
+                },
+                href: "https://api.spotify.com/v1/tracks/2pMl9Sx4glsuk5ikZtFBtX",
+                id: "2pMl9Sx4glsuk5ikZtFBtX",
+                name: "Old Town Road",
+                popularity: 20,
+                preview_url: null,
+                track_number: 1,
+                type: "track",
+                uri: "spotify:track:2pMl9Sx4glsuk5ikZtFBtX",
+            },
+            item: {
                 album: {
                     album_type: "single",
                     total_tracks: 10,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.spotify.com/documentation/web-api/tutorials/february-2026-migration-guide
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

I wasn't able to run `pnpm test spotify-api` and `pnpm run test-all` because I got the errors `Error: Failed to load plugin '@typescript-eslint' declared in '.eslintrc.cjs » plugin:@definitelytyped/all': Cannot find module '@typescript-eslint/eslint-plugin'` and `Error: spawn EINVAL` respectively. I ran `pnpm install -w --filter "{./types/spotify-api}..."` beforehand.