### PR TITLE
node: v25.5

### DIFF
--- a/types/node/fs.d.ts
+++ b/types/node/fs.d.ts
@@ -3553,10 +3553,12 @@ declare module "node:fs" {
      */
     function unwatchFile(filename: PathLike, listener?: StatsListener): void;
     function unwatchFile(filename: PathLike, listener?: BigIntStatsListener): void;
+    type WatchIgnorePredicate = string | RegExp | ((filename: string) => boolean);
     interface WatchOptions extends Abortable {
         encoding?: BufferEncoding | "buffer" | undefined;
         persistent?: boolean | undefined;
         recursive?: boolean | undefined;
+        ignore?: WatchIgnorePredicate | readonly WatchIgnorePredicate[] | undefined;
     }
     interface WatchOptionsWithBufferEncoding extends WatchOptions {
         encoding: "buffer";

--- a/types/node/inspector.d.ts
+++ b/types/node/inspector.d.ts
@@ -218,6 +218,51 @@ declare module "node:inspector" {
          */
         function put(url: string, data: string): void;
     }
+    namespace DOMStorage {
+        /**
+         * This feature is only available with the
+         * `--experimental-storage-inspection` flag enabled.
+         *
+         * Broadcasts the `DOMStorage.domStorageItemAdded` event to connected frontends.
+         * This event indicates that a new item has been added to the storage.
+         * @since v25.5.0
+         */
+        function domStorageItemAdded(params: DomStorageItemAddedEventDataType): void;
+        /**
+         * This feature is only available with the
+         * `--experimental-storage-inspection` flag enabled.
+         *
+         * Broadcasts the `DOMStorage.domStorageItemRemoved` event to connected frontends.
+         * This event indicates that an item has been removed from the storage.
+         * @since v25.5.0
+         */
+        function domStorageItemRemoved(params: DomStorageItemRemovedEventDataType): void;
+        /**
+         * This feature is only available with the
+         * `--experimental-storage-inspection` flag enabled.
+
+         * Broadcasts the `DOMStorage.domStorageItemUpdated` event to connected frontends.
+         * This event indicates that a storage item has been updated.
+         * @since v25.5.0
+         */
+        function domStorageItemUpdated(params: DomStorageItemUpdatedEventDataType): void;
+        /**
+         * This feature is only available with the
+         * `--experimental-storage-inspection` flag enabled.
+         *
+         * Broadcasts the `DOMStorage.domStorageItemsCleared` event to connected
+         * frontends. This event indicates that all items have been cleared from the
+         * storage.
+         * @since v25.5.0
+         */
+        function domStorageItemsCleared(params: DomStorageItemsClearedEventDataType): void;
+        /**
+         * This feature is only available with the
+         * `--experimental-storage-inspection` flag enabled.
+         * @since v25.5.0
+         */
+        function registerStorage(params: unknown): void;
+    }
 }
 declare module "inspector" {
     export * from "node:inspector";

--- a/types/node/inspector.generated.d.ts
+++ b/types/node/inspector.generated.d.ts
@@ -2044,6 +2044,75 @@ declare module "node:inspector" {
             waitingForDebugger: boolean;
         }
     }
+    namespace DOMStorage {
+        type SerializedStorageKey = string;
+        /**
+         * DOM Storage identifier.
+         */
+        interface StorageId {
+            /**
+             * Security origin for the storage.
+             */
+            securityOrigin?: string | undefined;
+            /**
+             * Represents a key by which DOM Storage keys its CachedStorageAreas
+             */
+            storageKey?: SerializedStorageKey | undefined;
+            /**
+             * Whether the storage is local storage (not session storage).
+             */
+            isLocalStorage: boolean;
+        }
+        /**
+         * DOM Storage item.
+         */
+        type Item = string[];
+        interface ClearParameterType {
+            storageId: StorageId;
+        }
+        interface GetDOMStorageItemsParameterType {
+            storageId: StorageId;
+        }
+        interface RemoveDOMStorageItemParameterType {
+            storageId: StorageId;
+            key: string;
+        }
+        interface SetDOMStorageItemParameterType {
+            storageId: StorageId;
+            key: string;
+            value: string;
+        }
+        interface GetDOMStorageItemsReturnType {
+            entries: Item[];
+        }
+        interface DomStorageItemAddedEventDataType {
+            storageId: StorageId;
+            key: string;
+            newValue: string;
+        }
+        interface DomStorageItemRemovedEventDataType {
+            storageId: StorageId;
+            key: string;
+        }
+        interface DomStorageItemUpdatedEventDataType {
+            storageId: StorageId;
+            key: string;
+            oldValue: string;
+            newValue: string;
+        }
+        interface DomStorageItemsClearedEventDataType {
+            storageId: StorageId;
+        }
+    }
+    namespace Storage {
+        type SerializedStorageKey = string;
+        interface GetStorageKeyParameterType {
+            frameId?: string | undefined;
+        }
+        interface GetStorageKeyReturnType {
+            storageKey: SerializedStorageKey;
+        }
+    }
     interface Session {
         /**
          * Posts a message to the inspector back-end. `callback` will be notified when
@@ -2439,6 +2508,31 @@ declare module "node:inspector" {
         post(method: "NodeWorker.detach", callback?: (err: Error | null) => void): void;
         post(method: "Target.setAutoAttach", params?: Target.SetAutoAttachParameterType, callback?: (err: Error | null) => void): void;
         post(method: "Target.setAutoAttach", callback?: (err: Error | null) => void): void;
+        post(method: "DOMStorage.clear", params?: DOMStorage.ClearParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "DOMStorage.clear", callback?: (err: Error | null) => void): void;
+        /**
+         * Disables storage tracking, prevents storage events from being sent to the client.
+         */
+        post(method: "DOMStorage.disable", callback?: (err: Error | null) => void): void;
+        /**
+         * Enables storage tracking, storage events will now be delivered to the client.
+         */
+        post(method: "DOMStorage.enable", callback?: (err: Error | null) => void): void;
+        post(
+            method: "DOMStorage.getDOMStorageItems",
+            params?: DOMStorage.GetDOMStorageItemsParameterType,
+            callback?: (err: Error | null, params: DOMStorage.GetDOMStorageItemsReturnType) => void
+        ): void;
+        post(method: "DOMStorage.getDOMStorageItems", callback?: (err: Error | null, params: DOMStorage.GetDOMStorageItemsReturnType) => void): void;
+        post(method: "DOMStorage.removeDOMStorageItem", params?: DOMStorage.RemoveDOMStorageItemParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "DOMStorage.removeDOMStorageItem", callback?: (err: Error | null) => void): void;
+        post(method: "DOMStorage.setDOMStorageItem", params?: DOMStorage.SetDOMStorageItemParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "DOMStorage.setDOMStorageItem", callback?: (err: Error | null) => void): void;
+        /**
+         * @experimental
+         */
+        post(method: "Storage.getStorageKey", params?: Storage.GetStorageKeyParameterType, callback?: (err: Error | null, params: Storage.GetStorageKeyReturnType) => void): void;
+        post(method: "Storage.getStorageKey", callback?: (err: Error | null, params: Storage.GetStorageKeyReturnType) => void): void;
         addListener(event: string, listener: (...args: any[]) => void): this;
         /**
          * Emitted when any notification from the V8 Inspector is received.
@@ -2574,6 +2668,10 @@ declare module "node:inspector" {
         addListener(event: "NodeWorker.receivedMessageFromWorker", listener: (message: InspectorNotification<NodeWorker.ReceivedMessageFromWorkerEventDataType>) => void): this;
         addListener(event: "Target.targetCreated", listener: (message: InspectorNotification<Target.TargetCreatedEventDataType>) => void): this;
         addListener(event: "Target.attachedToTarget", listener: (message: InspectorNotification<Target.AttachedToTargetEventDataType>) => void): this;
+        addListener(event: "DOMStorage.domStorageItemAdded", listener: (message: InspectorNotification<DOMStorage.DomStorageItemAddedEventDataType>) => void): this;
+        addListener(event: "DOMStorage.domStorageItemRemoved", listener: (message: InspectorNotification<DOMStorage.DomStorageItemRemovedEventDataType>) => void): this;
+        addListener(event: "DOMStorage.domStorageItemUpdated", listener: (message: InspectorNotification<DOMStorage.DomStorageItemUpdatedEventDataType>) => void): this;
+        addListener(event: "DOMStorage.domStorageItemsCleared", listener: (message: InspectorNotification<DOMStorage.DomStorageItemsClearedEventDataType>) => void): this;
         emit(event: string | symbol, ...args: any[]): boolean;
         emit(event: "inspectorNotification", message: InspectorNotification<object>): boolean;
         emit(event: "Runtime.executionContextCreated", message: InspectorNotification<Runtime.ExecutionContextCreatedEventDataType>): boolean;
@@ -2613,6 +2711,10 @@ declare module "node:inspector" {
         emit(event: "NodeWorker.receivedMessageFromWorker", message: InspectorNotification<NodeWorker.ReceivedMessageFromWorkerEventDataType>): boolean;
         emit(event: "Target.targetCreated", message: InspectorNotification<Target.TargetCreatedEventDataType>): boolean;
         emit(event: "Target.attachedToTarget", message: InspectorNotification<Target.AttachedToTargetEventDataType>): boolean;
+        emit(event: "DOMStorage.domStorageItemAdded", message: InspectorNotification<DOMStorage.DomStorageItemAddedEventDataType>): boolean;
+        emit(event: "DOMStorage.domStorageItemRemoved", message: InspectorNotification<DOMStorage.DomStorageItemRemovedEventDataType>): boolean;
+        emit(event: "DOMStorage.domStorageItemUpdated", message: InspectorNotification<DOMStorage.DomStorageItemUpdatedEventDataType>): boolean;
+        emit(event: "DOMStorage.domStorageItemsCleared", message: InspectorNotification<DOMStorage.DomStorageItemsClearedEventDataType>): boolean;
         on(event: string, listener: (...args: any[]) => void): this;
         /**
          * Emitted when any notification from the V8 Inspector is received.
@@ -2748,6 +2850,10 @@ declare module "node:inspector" {
         on(event: "NodeWorker.receivedMessageFromWorker", listener: (message: InspectorNotification<NodeWorker.ReceivedMessageFromWorkerEventDataType>) => void): this;
         on(event: "Target.targetCreated", listener: (message: InspectorNotification<Target.TargetCreatedEventDataType>) => void): this;
         on(event: "Target.attachedToTarget", listener: (message: InspectorNotification<Target.AttachedToTargetEventDataType>) => void): this;
+        on(event: "DOMStorage.domStorageItemAdded", listener: (message: InspectorNotification<DOMStorage.DomStorageItemAddedEventDataType>) => void): this;
+        on(event: "DOMStorage.domStorageItemRemoved", listener: (message: InspectorNotification<DOMStorage.DomStorageItemRemovedEventDataType>) => void): this;
+        on(event: "DOMStorage.domStorageItemUpdated", listener: (message: InspectorNotification<DOMStorage.DomStorageItemUpdatedEventDataType>) => void): this;
+        on(event: "DOMStorage.domStorageItemsCleared", listener: (message: InspectorNotification<DOMStorage.DomStorageItemsClearedEventDataType>) => void): this;
         once(event: string, listener: (...args: any[]) => void): this;
         /**
          * Emitted when any notification from the V8 Inspector is received.
@@ -2883,6 +2989,10 @@ declare module "node:inspector" {
         once(event: "NodeWorker.receivedMessageFromWorker", listener: (message: InspectorNotification<NodeWorker.ReceivedMessageFromWorkerEventDataType>) => void): this;
         once(event: "Target.targetCreated", listener: (message: InspectorNotification<Target.TargetCreatedEventDataType>) => void): this;
         once(event: "Target.attachedToTarget", listener: (message: InspectorNotification<Target.AttachedToTargetEventDataType>) => void): this;
+        once(event: "DOMStorage.domStorageItemAdded", listener: (message: InspectorNotification<DOMStorage.DomStorageItemAddedEventDataType>) => void): this;
+        once(event: "DOMStorage.domStorageItemRemoved", listener: (message: InspectorNotification<DOMStorage.DomStorageItemRemovedEventDataType>) => void): this;
+        once(event: "DOMStorage.domStorageItemUpdated", listener: (message: InspectorNotification<DOMStorage.DomStorageItemUpdatedEventDataType>) => void): this;
+        once(event: "DOMStorage.domStorageItemsCleared", listener: (message: InspectorNotification<DOMStorage.DomStorageItemsClearedEventDataType>) => void): this;
         prependListener(event: string, listener: (...args: any[]) => void): this;
         /**
          * Emitted when any notification from the V8 Inspector is received.
@@ -3018,6 +3128,10 @@ declare module "node:inspector" {
         prependListener(event: "NodeWorker.receivedMessageFromWorker", listener: (message: InspectorNotification<NodeWorker.ReceivedMessageFromWorkerEventDataType>) => void): this;
         prependListener(event: "Target.targetCreated", listener: (message: InspectorNotification<Target.TargetCreatedEventDataType>) => void): this;
         prependListener(event: "Target.attachedToTarget", listener: (message: InspectorNotification<Target.AttachedToTargetEventDataType>) => void): this;
+        prependListener(event: "DOMStorage.domStorageItemAdded", listener: (message: InspectorNotification<DOMStorage.DomStorageItemAddedEventDataType>) => void): this;
+        prependListener(event: "DOMStorage.domStorageItemRemoved", listener: (message: InspectorNotification<DOMStorage.DomStorageItemRemovedEventDataType>) => void): this;
+        prependListener(event: "DOMStorage.domStorageItemUpdated", listener: (message: InspectorNotification<DOMStorage.DomStorageItemUpdatedEventDataType>) => void): this;
+        prependListener(event: "DOMStorage.domStorageItemsCleared", listener: (message: InspectorNotification<DOMStorage.DomStorageItemsClearedEventDataType>) => void): this;
         prependOnceListener(event: string, listener: (...args: any[]) => void): this;
         /**
          * Emitted when any notification from the V8 Inspector is received.
@@ -3153,6 +3267,10 @@ declare module "node:inspector" {
         prependOnceListener(event: "NodeWorker.receivedMessageFromWorker", listener: (message: InspectorNotification<NodeWorker.ReceivedMessageFromWorkerEventDataType>) => void): this;
         prependOnceListener(event: "Target.targetCreated", listener: (message: InspectorNotification<Target.TargetCreatedEventDataType>) => void): this;
         prependOnceListener(event: "Target.attachedToTarget", listener: (message: InspectorNotification<Target.AttachedToTargetEventDataType>) => void): this;
+        prependOnceListener(event: "DOMStorage.domStorageItemAdded", listener: (message: InspectorNotification<DOMStorage.DomStorageItemAddedEventDataType>) => void): this;
+        prependOnceListener(event: "DOMStorage.domStorageItemRemoved", listener: (message: InspectorNotification<DOMStorage.DomStorageItemRemovedEventDataType>) => void): this;
+        prependOnceListener(event: "DOMStorage.domStorageItemUpdated", listener: (message: InspectorNotification<DOMStorage.DomStorageItemUpdatedEventDataType>) => void): this;
+        prependOnceListener(event: "DOMStorage.domStorageItemsCleared", listener: (message: InspectorNotification<DOMStorage.DomStorageItemsClearedEventDataType>) => void): this;
     }
 }
 declare module "node:inspector/promises" {
@@ -3169,6 +3287,8 @@ declare module "node:inspector/promises" {
         NodeTracing,
         NodeWorker,
         Target,
+        DOMStorage,
+        Storage,
     } from 'inspector';
 }
 declare module "node:inspector/promises" {
@@ -3186,6 +3306,8 @@ declare module "node:inspector/promises" {
         NodeTracing,
         NodeWorker,
         Target,
+        DOMStorage,
+        Storage,
     } from "inspector";
     /**
      * The `inspector.Session` is used for dispatching messages to the V8 inspector
@@ -3521,6 +3643,22 @@ declare module "node:inspector/promises" {
          */
         post(method: "NodeWorker.detach", params?: NodeWorker.DetachParameterType): Promise<void>;
         post(method: "Target.setAutoAttach", params?: Target.SetAutoAttachParameterType): Promise<void>;
+        post(method: "DOMStorage.clear", params?: DOMStorage.ClearParameterType): Promise<void>;
+        /**
+         * Disables storage tracking, prevents storage events from being sent to the client.
+         */
+        post(method: "DOMStorage.disable"): Promise<void>;
+        /**
+         * Enables storage tracking, storage events will now be delivered to the client.
+         */
+        post(method: "DOMStorage.enable"): Promise<void>;
+        post(method: "DOMStorage.getDOMStorageItems", params?: DOMStorage.GetDOMStorageItemsParameterType): Promise<DOMStorage.GetDOMStorageItemsReturnType>;
+        post(method: "DOMStorage.removeDOMStorageItem", params?: DOMStorage.RemoveDOMStorageItemParameterType): Promise<void>;
+        post(method: "DOMStorage.setDOMStorageItem", params?: DOMStorage.SetDOMStorageItemParameterType): Promise<void>;
+        /**
+         * @experimental
+         */
+        post(method: "Storage.getStorageKey", params?: Storage.GetStorageKeyParameterType): Promise<Storage.GetStorageKeyReturnType>;
         addListener(event: string, listener: (...args: any[]) => void): this;
         /**
          * Emitted when any notification from the V8 Inspector is received.
@@ -3656,6 +3794,10 @@ declare module "node:inspector/promises" {
         addListener(event: "NodeWorker.receivedMessageFromWorker", listener: (message: InspectorNotification<NodeWorker.ReceivedMessageFromWorkerEventDataType>) => void): this;
         addListener(event: "Target.targetCreated", listener: (message: InspectorNotification<Target.TargetCreatedEventDataType>) => void): this;
         addListener(event: "Target.attachedToTarget", listener: (message: InspectorNotification<Target.AttachedToTargetEventDataType>) => void): this;
+        addListener(event: "DOMStorage.domStorageItemAdded", listener: (message: InspectorNotification<DOMStorage.DomStorageItemAddedEventDataType>) => void): this;
+        addListener(event: "DOMStorage.domStorageItemRemoved", listener: (message: InspectorNotification<DOMStorage.DomStorageItemRemovedEventDataType>) => void): this;
+        addListener(event: "DOMStorage.domStorageItemUpdated", listener: (message: InspectorNotification<DOMStorage.DomStorageItemUpdatedEventDataType>) => void): this;
+        addListener(event: "DOMStorage.domStorageItemsCleared", listener: (message: InspectorNotification<DOMStorage.DomStorageItemsClearedEventDataType>) => void): this;
         emit(event: string | symbol, ...args: any[]): boolean;
         emit(event: "inspectorNotification", message: InspectorNotification<object>): boolean;
         emit(event: "Runtime.executionContextCreated", message: InspectorNotification<Runtime.ExecutionContextCreatedEventDataType>): boolean;
@@ -3695,6 +3837,10 @@ declare module "node:inspector/promises" {
         emit(event: "NodeWorker.receivedMessageFromWorker", message: InspectorNotification<NodeWorker.ReceivedMessageFromWorkerEventDataType>): boolean;
         emit(event: "Target.targetCreated", message: InspectorNotification<Target.TargetCreatedEventDataType>): boolean;
         emit(event: "Target.attachedToTarget", message: InspectorNotification<Target.AttachedToTargetEventDataType>): boolean;
+        emit(event: "DOMStorage.domStorageItemAdded", message: InspectorNotification<DOMStorage.DomStorageItemAddedEventDataType>): boolean;
+        emit(event: "DOMStorage.domStorageItemRemoved", message: InspectorNotification<DOMStorage.DomStorageItemRemovedEventDataType>): boolean;
+        emit(event: "DOMStorage.domStorageItemUpdated", message: InspectorNotification<DOMStorage.DomStorageItemUpdatedEventDataType>): boolean;
+        emit(event: "DOMStorage.domStorageItemsCleared", message: InspectorNotification<DOMStorage.DomStorageItemsClearedEventDataType>): boolean;
         on(event: string, listener: (...args: any[]) => void): this;
         /**
          * Emitted when any notification from the V8 Inspector is received.
@@ -3830,6 +3976,10 @@ declare module "node:inspector/promises" {
         on(event: "NodeWorker.receivedMessageFromWorker", listener: (message: InspectorNotification<NodeWorker.ReceivedMessageFromWorkerEventDataType>) => void): this;
         on(event: "Target.targetCreated", listener: (message: InspectorNotification<Target.TargetCreatedEventDataType>) => void): this;
         on(event: "Target.attachedToTarget", listener: (message: InspectorNotification<Target.AttachedToTargetEventDataType>) => void): this;
+        on(event: "DOMStorage.domStorageItemAdded", listener: (message: InspectorNotification<DOMStorage.DomStorageItemAddedEventDataType>) => void): this;
+        on(event: "DOMStorage.domStorageItemRemoved", listener: (message: InspectorNotification<DOMStorage.DomStorageItemRemovedEventDataType>) => void): this;
+        on(event: "DOMStorage.domStorageItemUpdated", listener: (message: InspectorNotification<DOMStorage.DomStorageItemUpdatedEventDataType>) => void): this;
+        on(event: "DOMStorage.domStorageItemsCleared", listener: (message: InspectorNotification<DOMStorage.DomStorageItemsClearedEventDataType>) => void): this;
         once(event: string, listener: (...args: any[]) => void): this;
         /**
          * Emitted when any notification from the V8 Inspector is received.
@@ -3965,6 +4115,10 @@ declare module "node:inspector/promises" {
         once(event: "NodeWorker.receivedMessageFromWorker", listener: (message: InspectorNotification<NodeWorker.ReceivedMessageFromWorkerEventDataType>) => void): this;
         once(event: "Target.targetCreated", listener: (message: InspectorNotification<Target.TargetCreatedEventDataType>) => void): this;
         once(event: "Target.attachedToTarget", listener: (message: InspectorNotification<Target.AttachedToTargetEventDataType>) => void): this;
+        once(event: "DOMStorage.domStorageItemAdded", listener: (message: InspectorNotification<DOMStorage.DomStorageItemAddedEventDataType>) => void): this;
+        once(event: "DOMStorage.domStorageItemRemoved", listener: (message: InspectorNotification<DOMStorage.DomStorageItemRemovedEventDataType>) => void): this;
+        once(event: "DOMStorage.domStorageItemUpdated", listener: (message: InspectorNotification<DOMStorage.DomStorageItemUpdatedEventDataType>) => void): this;
+        once(event: "DOMStorage.domStorageItemsCleared", listener: (message: InspectorNotification<DOMStorage.DomStorageItemsClearedEventDataType>) => void): this;
         prependListener(event: string, listener: (...args: any[]) => void): this;
         /**
          * Emitted when any notification from the V8 Inspector is received.
@@ -4100,6 +4254,10 @@ declare module "node:inspector/promises" {
         prependListener(event: "NodeWorker.receivedMessageFromWorker", listener: (message: InspectorNotification<NodeWorker.ReceivedMessageFromWorkerEventDataType>) => void): this;
         prependListener(event: "Target.targetCreated", listener: (message: InspectorNotification<Target.TargetCreatedEventDataType>) => void): this;
         prependListener(event: "Target.attachedToTarget", listener: (message: InspectorNotification<Target.AttachedToTargetEventDataType>) => void): this;
+        prependListener(event: "DOMStorage.domStorageItemAdded", listener: (message: InspectorNotification<DOMStorage.DomStorageItemAddedEventDataType>) => void): this;
+        prependListener(event: "DOMStorage.domStorageItemRemoved", listener: (message: InspectorNotification<DOMStorage.DomStorageItemRemovedEventDataType>) => void): this;
+        prependListener(event: "DOMStorage.domStorageItemUpdated", listener: (message: InspectorNotification<DOMStorage.DomStorageItemUpdatedEventDataType>) => void): this;
+        prependListener(event: "DOMStorage.domStorageItemsCleared", listener: (message: InspectorNotification<DOMStorage.DomStorageItemsClearedEventDataType>) => void): this;
         prependOnceListener(event: string, listener: (...args: any[]) => void): this;
         /**
          * Emitted when any notification from the V8 Inspector is received.
@@ -4235,5 +4393,9 @@ declare module "node:inspector/promises" {
         prependOnceListener(event: "NodeWorker.receivedMessageFromWorker", listener: (message: InspectorNotification<NodeWorker.ReceivedMessageFromWorkerEventDataType>) => void): this;
         prependOnceListener(event: "Target.targetCreated", listener: (message: InspectorNotification<Target.TargetCreatedEventDataType>) => void): this;
         prependOnceListener(event: "Target.attachedToTarget", listener: (message: InspectorNotification<Target.AttachedToTargetEventDataType>) => void): this;
+        prependOnceListener(event: "DOMStorage.domStorageItemAdded", listener: (message: InspectorNotification<DOMStorage.DomStorageItemAddedEventDataType>) => void): this;
+        prependOnceListener(event: "DOMStorage.domStorageItemRemoved", listener: (message: InspectorNotification<DOMStorage.DomStorageItemRemovedEventDataType>) => void): this;
+        prependOnceListener(event: "DOMStorage.domStorageItemUpdated", listener: (message: InspectorNotification<DOMStorage.DomStorageItemUpdatedEventDataType>) => void): this;
+        prependOnceListener(event: "DOMStorage.domStorageItemsCleared", listener: (message: InspectorNotification<DOMStorage.DomStorageItemsClearedEventDataType>) => void): this;
     }
 }

--- a/types/node/node-tests/fs.ts
+++ b/types/node/node-tests/fs.ts
@@ -267,6 +267,7 @@ async function testPromisify() {
         persistent: true,
         encoding: "utf8",
         signal: new AbortSignal(),
+        ignore: (filename) => filename.startsWith("_"),
     }, (event, filename) => {
         console.log(event, filename);
     });

--- a/types/node/node-tests/sqlite.ts
+++ b/types/node/node-tests/sqlite.ts
@@ -73,13 +73,23 @@ import { TextEncoder } from "node:util";
 }
 
 {
-    new DatabaseSync(":memory:", {
+    const db = new DatabaseSync(":memory:", {
         timeout: 10_000,
         readBigInts: true,
         returnArrays: true,
         allowBareNamedParameters: false,
         allowUnknownNamedParameters: true,
     });
+
+    const stmt = db.prepare("SELECT 1", {
+        readBigInts: true,
+        returnArrays: true,
+        allowBareNamedParameters: false,
+        allowUnknownNamedParameters: true,
+    });
+
+    // $ExpectType SQLOutputValue
+    stmt.get()![0];
 }
 
 {

--- a/types/node/node-tests/test.ts
+++ b/types/node/node-tests/test.ts
@@ -6,6 +6,7 @@ import {
     before,
     beforeEach,
     describe,
+    expectFailure,
     it,
     Mock,
     mock,
@@ -222,6 +223,7 @@ describe("options with values", {
     skip: "reason for skip",
     timeout: Infinity,
     todo: "reason for todo",
+    expectFailure: true,
 });
 
 it("options with values", {
@@ -231,6 +233,7 @@ it("options with values", {
     skip: "reason for skip",
     timeout: Infinity,
     todo: "reason for todo",
+    expectFailure: true,
 });
 
 describe("options with booleans", {
@@ -335,6 +338,39 @@ describe.only("only shorthand", {
     timeout: Infinity,
 });
 it.only("only shorthand", {
+    concurrency: 1,
+    only: true,
+    signal: new AbortController().signal,
+    timeout: Infinity,
+});
+
+expectFailure("x", {
+    concurrency: 1,
+    only: true,
+    signal: new AbortController().signal,
+    timeout: Infinity,
+});
+expectFailure((t, cb) => {
+    // $ExpectType TestContext
+    t;
+    // $ExpectType (result?: any) => void
+    cb;
+    // $ExpectType void
+    cb({ x: "anything" });
+});
+test.expectFailure("x", {
+    concurrency: 1,
+    only: true,
+    signal: new AbortController().signal,
+    timeout: Infinity,
+});
+describe.expectFailure("x", {
+    concurrency: 1,
+    only: true,
+    signal: new AbortController().signal,
+    timeout: Infinity,
+});
+it.expectFailure("x", {
     concurrency: 1,
     only: true,
     signal: new AbortController().signal,

--- a/types/node/node-tests/tls.ts
+++ b/types/node/node-tests/tls.ts
@@ -277,26 +277,31 @@ import {
     socket = socket.addListener("OCSPResponse", (response) => {
         const _response: Buffer = response;
     });
+    socket = socket.addListener("secure", () => {});
     socket = socket.addListener("secureConnect", () => {});
 
     socket = socket.on("OCSPResponse", (response) => {
         const _response: Buffer = response;
     });
+    socket = socket.on("secure", () => {});
     socket = socket.on("secureConnect", () => {});
 
     socket = socket.once("OCSPResponse", (response) => {
         const _response: Buffer = response;
     });
+    socket = socket.once("secure", () => {});
     socket = socket.once("secureConnect", () => {});
 
     socket = socket.prependListener("OCSPResponse", (response) => {
         const _response: Buffer = response;
     });
+    socket = socket.prependListener("secure", () => {});
     socket = socket.prependListener("secureConnect", () => {});
 
     socket = socket.prependOnceListener("OCSPResponse", (response) => {
         const _response: Buffer = response;
     });
+    socket = socket.prependOnceListener("secure", () => {});
     socket = socket.prependOnceListener("secureConnect", () => {});
 
     socket.once("session", (buff: Buffer) => {});

--- a/types/node/node-tests/v8.ts
+++ b/types/node/node-tests/v8.ts
@@ -19,11 +19,9 @@ v8.takeCoverage();
 v8.stopCoverage();
 
 {
-    const profiler = new v8.GCProfiler();
+    using profiler = new v8.GCProfiler();
     profiler.start();
-    setTimeout(() => {
-        console.log(profiler.stop());
-    }, 1000);
+    profiler.stop();
 }
 
 const disable = v8.promiseHooks.createHook({

--- a/types/node/package.json
+++ b/types/node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/node",
-    "version": "25.4.9999",
+    "version": "25.5.9999",
     "nonNpm": "conflict",
     "nonNpmDescription": "Node.js",
     "projects": [

--- a/types/node/process.d.ts
+++ b/types/node/process.d.ts
@@ -729,7 +729,8 @@ declare module "node:process" {
                  * arguments passed when the Node.js process was launched. The first element will
                  * be {@link execPath}. See `process.argv0` if access to the original value
                  * of `argv[0]` is needed. The second element will be the path to the JavaScript
-                 * file being executed. The remaining elements will be any additional command-line
+                 * file being executed. If a [program entry point](https://nodejs.org/docs/latest-v25.x/api/cli.html#program-entry-point) was provided, the second element
+                 * will be the absolute path to it. The remaining elements are additional command-line
                  * arguments.
                  *
                  * For example, assuming the following script for `process-args.js`:

--- a/types/node/sqlite.d.ts
+++ b/types/node/sqlite.d.ts
@@ -128,7 +128,7 @@ declare module "node:sqlite" {
          * language features that allow ordinary SQL to deliberately corrupt the database file are disabled.
          * The defensive flag can also be set using `enableDefensive()`.
          * @since v25.1.0
-         * @default false
+         * @default true
          */
         defensive?: boolean | undefined;
     }

--- a/types/node/sqlite.d.ts
+++ b/types/node/sqlite.d.ts
@@ -233,6 +233,28 @@ declare module "node:sqlite" {
          */
         inverse?: ((accumulator: T, ...args: SQLOutputValue[]) => T) | undefined;
     }
+    interface PrepareOptions {
+        /**
+         * If `true`, integer fields are read as `BigInt`s.
+         * @since v25.5.0
+         */
+        readBigInts?: boolean | undefined;
+        /**
+         * If `true`, results are returned as arrays.
+         * @since v25.5.0
+         */
+        returnArrays?: boolean | undefined;
+        /**
+         * If `true`, allows binding named parameters without the prefix character.
+         * @since v25.5.0
+         */
+        allowBareNamedParameters?: boolean | undefined;
+        /**
+         * If `true`, unknown named parameters are ignored.
+         * @since v25.5.0
+         */
+        allowUnknownNamedParameters?: boolean | undefined;
+    }
     /**
      * This class represents a single [connection](https://www.sqlite.org/c3ref/sqlite3.html) to a SQLite database. All APIs
      * exposed by this class execute synchronously.
@@ -425,9 +447,10 @@ declare module "node:sqlite" {
          * around [`sqlite3_prepare_v2()`](https://www.sqlite.org/c3ref/prepare.html).
          * @since v22.5.0
          * @param sql A SQL string to compile to a prepared statement.
+         * @param options Optional configuration for the prepared statement.
          * @return The prepared statement.
          */
-        prepare(sql: string): StatementSync;
+        prepare(sql: string, options?: PrepareOptions): StatementSync;
         /**
          * Creates a new {@link SQLTagStore}, which is a Least Recently Used (LRU) cache
          * for storing prepared statements. This allows for the efficient reuse of

--- a/types/node/test.d.ts
+++ b/types/node/test.d.ts
@@ -191,6 +191,11 @@ declare module "node:test" {
             function only(name?: string, fn?: SuiteFn): Promise<void>;
             function only(options?: TestOptions, fn?: SuiteFn): Promise<void>;
             function only(fn?: SuiteFn): Promise<void>;
+            // added in v25.5.0, undocumented
+            function expectFailure(name?: string, options?: TestOptions, fn?: SuiteFn): Promise<void>;
+            function expectFailure(name?: string, fn?: SuiteFn): Promise<void>;
+            function expectFailure(options?: TestOptions, fn?: SuiteFn): Promise<void>;
+            function expectFailure(fn?: SuiteFn): Promise<void>;
         }
         /**
          * Shorthand for skipping a test. This is the same as calling {@link test} with `options.skip` set to `true`.
@@ -216,6 +221,11 @@ declare module "node:test" {
         function only(name?: string, fn?: TestFn): Promise<void>;
         function only(options?: TestOptions, fn?: TestFn): Promise<void>;
         function only(fn?: TestFn): Promise<void>;
+        // added in v25.5.0, undocumented
+        function expectFailure(name?: string, options?: TestOptions, fn?: TestFn): Promise<void>;
+        function expectFailure(name?: string, fn?: TestFn): Promise<void>;
+        function expectFailure(options?: TestOptions, fn?: TestFn): Promise<void>;
+        function expectFailure(fn?: TestFn): Promise<void>;
         /**
          * The type of a function passed to {@link test}. The first argument to this function is a {@link TestContext} object.
          * If the test uses callbacks, the callback function is passed as the second argument.
@@ -1364,6 +1374,8 @@ declare module "node:test" {
              * @since v22.2.0
              */
             plan?: number | undefined;
+            // added in v25.5.0, undocumented
+            expectFailure?: boolean | undefined;
         }
         /**
          * This function creates a hook that runs before executing a suite.

--- a/types/node/tls.d.ts
+++ b/types/node/tls.d.ts
@@ -210,6 +210,7 @@ declare module "node:tls" {
     interface TLSSocketEventMap extends net.SocketEventMap {
         "keylog": [line: NonSharedBuffer];
         "OCSPResponse": [response: NonSharedBuffer];
+        "secure": [];
         "secureConnect": [];
         "session": [session: NonSharedBuffer];
     }

--- a/types/node/v8.d.ts
+++ b/types/node/v8.d.ts
@@ -95,7 +95,7 @@ declare module "node:v8" {
      * buffers and external strings.
      *
      * `total_allocated_bytes` The value of total allocated bytes since the Isolate
-     * creation
+     * creation.
      *
      * ```js
      * {
@@ -112,7 +112,8 @@ declare module "node:v8" {
      *   number_of_detached_contexts: 0,
      *   total_global_handles_size: 8192,
      *   used_global_handles_size: 3296,
-     *   external_memory: 318824
+     *   external_memory: 318824,
+     *   total_allocated_bytes: 45224088
      * }
      * ```
      * @since v1.0.0

--- a/types/node/v8.d.ts
+++ b/types/node/v8.d.ts
@@ -736,6 +736,11 @@ declare module "node:v8" {
          * @since v19.6.0, v18.15.0
          */
         stop(): GCProfilerResult;
+        /**
+         * Stop collecting GC data, and discard the profile.
+         * @since v25.5.0
+         */
+        [Symbol.dispose](): void;
     }
     interface GCProfilerResult {
         version: number;


### PR DESCRIPTION
- doc: added 'secure' event to tls.TLSSocket
- fs: add ignore option to fs.watch
- inspector: initial support storage inspection
- sqlite: add sqlite prepare options args
- sqlite: enable defensive mode by default
- test_runner: support expecting a test-case to fail
- v8: add GCProfiler support for erm