### PR TITLE
[hotwired__turbo] Fix `fetchOptions.headers` type

### DIFF
--- a/types/hotwired__turbo/hotwired__turbo-tests.ts
+++ b/types/hotwired__turbo/hotwired__turbo-tests.ts
@@ -94,6 +94,14 @@ StreamActions.log = function() {
     console.log(this.getAttribute("message"));
 };
 
+document.addEventListener("turbo:before-fetch-request", function(event) {
+    // $ExpectType FetchRequestHeaders
+    const headers = event.detail.fetchOptions.headers;
+    headers["Turbo-Referrer"] = window.location.href;
+    // $ExpectType string | undefined
+    headers.Accept;
+});
+
 document.addEventListener("turbo:before-fetch-response", function(e) {
     let { fetchResponse } = e.detail;
     fetchResponse.header("foo");

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -495,7 +495,7 @@ export type TurboFrameMissingEvent = CustomEvent<{
 export type TurboBeforeFetchRequestEvent = CustomEvent<{
     fetchOptions: Omit<RequestInit, "headers"> & { headers: FetchRequestHeaders };
     url: URL;
-    resume: (value: any) => void;
+    resume: (value?: unknown) => void;
 }>;
 
 export type TurboBeforeFetchResponseEvent = CustomEvent<{

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -78,11 +78,15 @@ export class StreamMessage {
     constructor(fragment: DocumentFragment);
 }
 
+export interface FetchRequestHeaders {
+    [header: string]: string | undefined;
+}
+
 export class FetchRequest {
     body: FormData | URLSearchParams;
     enctype: "application/x-www-form-urlencoded" | "multipart/form-data" | "text/plain";
     fetchOptions: RequestInit;
-    headers: Headers | { [k: string]: any };
+    headers: FetchRequestHeaders;
     method: "get" | "post" | "put" | "patch" | "delete";
     params: URLSearchParams;
     target: HTMLFormElement | HTMLAnchorElement | FrameElement | null;
@@ -489,7 +493,7 @@ export type TurboFrameMissingEvent = CustomEvent<{
 }>;
 
 export type TurboBeforeFetchRequestEvent = CustomEvent<{
-    fetchOptions: RequestInit;
+    fetchOptions: Omit<RequestInit, "headers"> & { headers: FetchRequestHeaders };
     url: URL;
     resume: (value: any) => void;
 }>;


### PR DESCRIPTION

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: this change fixes an issue found in downstream code.

`fetchOptions.headers` is currently typed as `HeadersInit | undefined`, which requires a cast for most use cases.

```ts
  // Append turbo nonce for drive requests
  document.addEventListener('turbo:before-fetch-request', (event) => {
    const headers = event.detail.fetchOptions.headers as Record<string, string>;
    headers['Turbo-Referrer'] = window.location.href;
    headers['X-Turbo-Nonce'] = document.getElementsByName('csp-nonce')[0]?.getAttribute('content') || '';
  });
```

This PR narrows the typing to `Record<string, string>` reflecting the fact `FetchRequest` initializes `fetchOptions.headers` with this type. Since `FetchRequest.fetchOptions` is mutable and not checked at runtime, it is conceivable that implementing code clobbers this value with some other type, however in this case I have chosen to optimize for typical usage.
