### PR TITLE
[hotwired__turbo] Introduce Adapter interface

### DIFF
--- a/types/hotwired__turbo/hotwired__turbo-tests.ts
+++ b/types/hotwired__turbo/hotwired__turbo-tests.ts
@@ -1,10 +1,13 @@
 import {
     Adapter,
+    BrowserAdapter,
     cache,
     config,
     connectStreamSource,
     disconnectStreamSource,
     navigator,
+    NavigatorDelegate,
+    ProgressBar,
     registerAdapter,
     renderStreamMessage,
     session,
@@ -179,6 +182,26 @@ navigator.submitForm(form);
 navigator.submitForm(form, document.querySelector("button")!);
 Turbo.navigator.submitForm(form);
 Turbo.navigator.submitForm(form, document.querySelector("button")!);
+
+// Test navigator.delegate
+// $ExpectType NavigatorDelegate
+navigator.delegate;
+// $ExpectType Adapter
+navigator.delegate.adapter;
+
+// Test ProgressBar via BrowserAdapter cast
+const browserAdapter = navigator.delegate.adapter as BrowserAdapter;
+// $ExpectType ProgressBar
+browserAdapter.progressBar;
+browserAdapter.progressBar.setValue(0);
+browserAdapter.progressBar.show();
+browserAdapter.progressBar.hide();
+// $ExpectType number
+browserAdapter.progressBar.value;
+// $ExpectType boolean
+browserAdapter.progressBar.visible;
+// $ExpectType boolean
+browserAdapter.progressBar.hiding;
 
 // Test cache methods
 cache.clear();

--- a/types/hotwired__turbo/hotwired__turbo-tests.ts
+++ b/types/hotwired__turbo/hotwired__turbo-tests.ts
@@ -1,16 +1,20 @@
 import {
+    Adapter,
     cache,
     config,
     connectStreamSource,
     disconnectStreamSource,
     navigator,
+    registerAdapter,
     renderStreamMessage,
     session,
     start,
     StreamActions,
     StreamMessage,
     StreamSource,
+    Visit,
     visit,
+    VisitOptions,
 } from "@hotwired/turbo";
 
 const turboFrame = document.querySelector("turbo-frame")!;
@@ -145,15 +149,29 @@ document.addEventListener("turbo:submit-end", function(event) {
 
 // Test start() function
 start();
+
+const customAdapter: Adapter = {
+    visitProposedToLocation(_location: URL, _options?: VisitOptions): void {},
+    visitStarted(_visit: Visit): void {},
+    visitCompleted(_visit: Visit): void {},
+    visitFailed(_visit: Visit): void {},
+    visitRequestStarted(_visit: Visit): void {},
+    visitRequestCompleted(_visit: Visit): void {},
+    visitRequestFailedWithStatusCode(_visit: Visit, _statusCode: number): void {},
+    visitRequestFinished(_visit: Visit): void {},
+    visitRendered(_visit: Visit): void {},
+    pageInvalidated(_reason: { reason: string }): void {},
+};
+registerAdapter(customAdapter);
+Turbo.registerAdapter(customAdapter);
+
 Turbo.start();
 
 // Test session.adapter
-// $ExpectType BrowserAdapter
+// $ExpectType Adapter
 session.adapter;
-session.adapter.formSubmissionStarted();
-session.adapter.formSubmissionFinished();
-Turbo.session.adapter.formSubmissionStarted();
-Turbo.session.adapter.formSubmissionFinished();
+// $ExpectType Adapter
+Turbo.session.adapter;
 
 // Test navigator.submitForm
 const form = document.querySelector("form")!;

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -109,13 +109,44 @@ export class FetchResponse {
     succeeded: boolean;
 }
 
-/**
- * Interface for accessing the browser adapter.
- * The adapter handles form submission lifecycle events.
- */
-export interface BrowserAdapter {
-    formSubmissionStarted(formSubmission?: FormSubmission): void;
-    formSubmissionFinished(formSubmission?: FormSubmission): void;
+export interface Visit {
+    readonly action: Action;
+    readonly location: URL;
+    hasCachedSnapshot(): boolean;
+    complete(): void;
+    cancel(): void;
+}
+
+export interface Adapter {
+    visitProposedToLocation(location: URL, options?: VisitOptions): void;
+    visitStarted(visit: Visit): void;
+    visitCompleted(visit: Visit): void;
+    visitFailed(visit: Visit): void;
+    visitRequestStarted(visit: Visit): void;
+    visitRequestCompleted(visit: Visit): void;
+    visitRequestFailedWithStatusCode(visit: Visit, statusCode: number): void;
+    visitRequestFinished(visit: Visit): void;
+    visitRendered(visit: Visit): void;
+    pageInvalidated(reason: { reason: string }): void;
+    formSubmissionStarted?(formSubmission: FormSubmission): void;
+    formSubmissionFinished?(formSubmission: FormSubmission): void;
+    linkPrefetchingIsEnabledForLocation?(location: URL): boolean;
+}
+
+export class BrowserAdapter implements Adapter {
+    visitProposedToLocation(location: URL, options?: VisitOptions): void;
+    visitStarted(visit: Visit): void;
+    visitCompleted(visit: Visit): void;
+    visitFailed(visit: Visit): void;
+    visitRequestStarted(visit: Visit): void;
+    visitRequestCompleted(visit: Visit): void;
+    visitRequestFailedWithStatusCode(visit: Visit, statusCode: number): void;
+    visitRequestFinished(visit: Visit): void;
+    visitRendered(visit: Visit): void;
+    pageInvalidated(reason: { reason: string }): void;
+    formSubmissionStarted(formSubmission: FormSubmission): void;
+    formSubmissionFinished(formSubmission: FormSubmission): void;
+    linkPrefetchingIsEnabledForLocation(location: URL): boolean;
 }
 
 /**
@@ -231,7 +262,7 @@ export interface TurboSession {
     disconnectStreamSource(source: StreamSource): void;
     renderStreamMessage(message: StreamMessage | string): void;
     drive: boolean;
-    adapter: BrowserAdapter;
+    adapter: Adapter;
 }
 
 export const StreamActions: {
@@ -256,7 +287,7 @@ export function start(): void;
  *
  * @param adapter Adapter to register
  */
-export function registerAdapter(adapter: unknown): void;
+export function registerAdapter(adapter: Adapter): void;
 
 /**
  * Sets the form mode for Turbo Drive.

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -134,6 +134,7 @@ export interface Adapter {
 }
 
 export class BrowserAdapter implements Adapter {
+    progressBar: ProgressBar;
     visitProposedToLocation(location: URL, options?: VisitOptions): void;
     visitStarted(visit: Visit): void;
     visitCompleted(visit: Visit): void;
@@ -149,11 +150,30 @@ export class BrowserAdapter implements Adapter {
     linkPrefetchingIsEnabledForLocation(location: URL): boolean;
 }
 
+export interface ProgressBar {
+    hiding: boolean;
+    value: number;
+    visible: boolean;
+    show(): void;
+    hide(): void;
+    setValue(value: number): void;
+}
+
+/**
+ * The delegate for the Turbo navigator — in practice, the active session.
+ * Provides access to the current adapter.
+ */
+export interface NavigatorDelegate {
+    adapter: Adapter;
+}
+
 /**
  * Interface for the Turbo navigator.
  * Provides methods for programmatic navigation and form submission.
  */
 export interface Navigator {
+    /** The delegate for this navigator (the active Turbo session). */
+    delegate: NavigatorDelegate;
     /**
      * Submits a form programmatically through Turbo Drive.
      *


### PR DESCRIPTION

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Replaces the narrow `BrowserAdapter` interface (form submission only) with a full Adapter interface reflecting the real turbo adapter contract, 
    - makes `BrowserAdapter` implement it
    - types `session.adapter` as `Adapter`
    - strengthens `registerAdapter`'s parameter type accordingly.
  - Exposes `Navigator#delegate` and `BrowserAdapter#progressBar`, thereby
facilitating control of the Progress Bar in client code ([similar to example provided by Rails Request.JS](https://github.com/rails/request.js?tab=readme-ov-file#before-and-after-hooks))