### PR TITLE
[hotwired__turbo] Tighten resume type in render events

### DIFF
--- a/types/hotwired__turbo/hotwired__turbo-tests.ts
+++ b/types/hotwired__turbo/hotwired__turbo-tests.ts
@@ -114,6 +114,13 @@ document.addEventListener("turbo:before-render", function(e) {
         // $ExpectType HTMLBodyElement
         newElement;
     };
+    // $ExpectType (value?: unknown) => void
+    e.detail.resume;
+});
+
+document.addEventListener("turbo:before-frame-render", function(e) {
+    // $ExpectType (value?: unknown) => void
+    e.detail.resume;
 });
 
 document.addEventListener("turbo:frame-missing", function(event) {

--- a/types/hotwired__turbo/index.d.ts
+++ b/types/hotwired__turbo/index.d.ts
@@ -411,7 +411,7 @@ export type TurboBeforeRenderEvent = CustomEvent<{
     newBody: HTMLBodyElement;
     renderMethod: "replace" | "morph";
     isPreview: boolean;
-    resume: (value?: any) => void;
+    resume: (value?: unknown) => void;
     render: (currentBody: HTMLBodyElement, newBody: HTMLBodyElement) => void;
 }>;
 export type TurboBeforeVisitEvent = CustomEvent<{ url: string }>;
@@ -422,7 +422,7 @@ export type TurboClickEvent = CustomEvent<{
 export type TurboFrameLoadEvent = CustomEvent;
 export type TurboBeforeFrameRenderEvent = CustomEvent<{
     newFrame: FrameElement;
-    resume: (value?: any) => void;
+    resume: (value?: unknown) => void;
     render: (currentFrame: FrameElement, newFrame: FrameElement) => void;
 }>;
 export type TurboFrameRenderEvent = CustomEvent<{


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - Applies the same `(value?: unknown) => void` fix to `TurboBeforeRenderEvent` and `TurboBeforeFrameRenderEvent`, missed in 38e7a6f / #74614.
