### PR TITLE
docs(node): clarify async_hooks warning for AsyncLocalStorage users

### DIFF
--- a/types/node/async_hooks.d.ts
+++ b/types/node/async_hooks.d.ts
@@ -1,9 +1,11 @@
 /**
- * We strongly discourage the use of the `async_hooks` API.
- * Other APIs that can cover most of its use cases include:
+ * We strongly discourage direct use of the low-level `async_hooks` APIs (for example, `createHook`, `executionAsyncId`, and `AsyncResource`).
+ * Use the stable, higher-level APIs where possible:
  *
- * * [`AsyncLocalStorage`](https://nodejs.org/docs/latest-v25.x/api/async_context.html#class-asynclocalstorage) tracks async context
- * * [`process.getActiveResourcesInfo()`](https://nodejs.org/docs/latest-v25.x/api/process.html#processgetactiveresourcesinfo) tracks active resources
+ * * [`AsyncLocalStorage`](https://nodejs.org/docs/latest-v25.x/api/async_context.html#class-asynclocalstorage) for async context tracking
+ * * [`process.getActiveResourcesInfo()`](https://nodejs.org/docs/latest-v25.x/api/process.html#processgetactiveresourcesinfo) for active resource tracking
+ *
+ * Note: `AsyncLocalStorage` itself is exported from `node:async_hooks`.
  *
  * The `node:async_hooks` module provides an API to track asynchronous resources.
  * It can be accessed using:

--- a/types/node/v20/async_hooks.d.ts
+++ b/types/node/v20/async_hooks.d.ts
@@ -1,9 +1,11 @@
 /**
- * We strongly discourage the use of the `async_hooks` API.
- * Other APIs that can cover most of its use cases include:
+ * We strongly discourage direct use of the low-level `async_hooks` APIs (for example, `createHook`, `executionAsyncId`, and `AsyncResource`).
+ * Use the stable, higher-level APIs where possible:
  *
- * * [`AsyncLocalStorage`](https://nodejs.org/docs/latest-v20.x/api/async_context.html#class-asynclocalstorage) tracks async context
- * * [`process.getActiveResourcesInfo()`](https://nodejs.org/docs/latest-v20.x/api/process.html#processgetactiveresourcesinfo) tracks active resources
+ * * [`AsyncLocalStorage`](https://nodejs.org/docs/latest-v20.x/api/async_context.html#class-asynclocalstorage) for async context tracking
+ * * [`process.getActiveResourcesInfo()`](https://nodejs.org/docs/latest-v20.x/api/process.html#processgetactiveresourcesinfo) for active resource tracking
+ *
+ * Note: `AsyncLocalStorage` itself is exported from `node:async_hooks`.
  *
  * The `node:async_hooks` module provides an API to track asynchronous resources.
  * It can be accessed using:

--- a/types/node/v22/async_hooks.d.ts
+++ b/types/node/v22/async_hooks.d.ts
@@ -1,9 +1,11 @@
 /**
- * We strongly discourage the use of the `async_hooks` API.
- * Other APIs that can cover most of its use cases include:
+ * We strongly discourage direct use of the low-level `async_hooks` APIs (for example, `createHook`, `executionAsyncId`, and `AsyncResource`).
+ * Use the stable, higher-level APIs where possible:
  *
- * * [`AsyncLocalStorage`](https://nodejs.org/docs/latest-v22.x/api/async_context.html#class-asynclocalstorage) tracks async context
- * * [`process.getActiveResourcesInfo()`](https://nodejs.org/docs/latest-v22.x/api/process.html#processgetactiveresourcesinfo) tracks active resources
+ * * [`AsyncLocalStorage`](https://nodejs.org/docs/latest-v22.x/api/async_context.html#class-asynclocalstorage) for async context tracking
+ * * [`process.getActiveResourcesInfo()`](https://nodejs.org/docs/latest-v22.x/api/process.html#processgetactiveresourcesinfo) for active resource tracking
+ *
+ * Note: `AsyncLocalStorage` itself is exported from `node:async_hooks`.
  *
  * The `node:async_hooks` module provides an API to track asynchronous resources.
  * It can be accessed using:

--- a/types/node/v24/async_hooks.d.ts
+++ b/types/node/v24/async_hooks.d.ts
@@ -1,9 +1,11 @@
 /**
- * We strongly discourage the use of the `async_hooks` API.
- * Other APIs that can cover most of its use cases include:
+ * We strongly discourage direct use of the low-level `async_hooks` APIs (for example, `createHook`, `executionAsyncId`, and `AsyncResource`).
+ * Use the stable, higher-level APIs where possible:
  *
- * * [`AsyncLocalStorage`](https://nodejs.org/docs/latest-v24.x/api/async_context.html#class-asynclocalstorage) tracks async context
- * * [`process.getActiveResourcesInfo()`](https://nodejs.org/docs/latest-v24.x/api/process.html#processgetactiveresourcesinfo) tracks active resources
+ * * [`AsyncLocalStorage`](https://nodejs.org/docs/latest-v24.x/api/async_context.html#class-asynclocalstorage) for async context tracking
+ * * [`process.getActiveResourcesInfo()`](https://nodejs.org/docs/latest-v24.x/api/process.html#processgetactiveresourcesinfo) for active resource tracking
+ *
+ * Note: `AsyncLocalStorage` itself is exported from `node:async_hooks`.
  *
  * The `node:async_hooks` module provides an API to track asynchronous resources.
  * It can be accessed using:


### PR DESCRIPTION
## Summary
- clarify that the warning is about low-level `async_hooks` APIs (e.g. `createHook`, `executionAsyncId`, `AsyncResource`)
- keep `AsyncLocalStorage` and `process.getActiveResourcesInfo()` as recommended alternatives
- explicitly note that `AsyncLocalStorage` is still exported from `node:async_hooks`
- apply the wording update consistently in `types/node` and versioned files (`v20`, `v22`, `v24`)

## Motivation
The existing header can read as “avoid this entire module”, which is confusing when importing `AsyncLocalStorage` from the same module. This aligns the docs intent discussed in microsoft/TypeScript#62967.

## Validation
- Ran `pnpm test node` in repo root.
- Result: fails in baseline with existing `@definitelytyped/no-bad-reference` errors in `types/node` and `types/node/ts5.6/index.d.ts`, unrelated to this doc-only change.