### PR TITLE
Remove wordpress override

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,6 +48,3 @@ hoistWorkspacePackages: false
 # Remove once https://github.com/pnpm/pnpm/issues/6457 is fixed
 # and we can set a hoisting limit of "workspaces" like in Yarn.
 sharedWorkspaceLockfile: false
-
-overrides:
-  '@wordpress/vips': '-'


### PR DESCRIPTION
This is no longer needed, as the upstream package has been fixed.