### PR TITLE
Rename group to bingeGroup in index.d.ts in stremio-addon-sdk

### DIFF
--- a/types/stremio-addon-sdk/index.d.ts
+++ b/types/stremio-addon-sdk/index.d.ts
@@ -398,13 +398,13 @@ export interface Stream {
          */
         notWebReady?: boolean | undefined;
         /**
-         * If defined, addons with the same behaviorHints.group will be chosen automatically for binge watching.
+         * If defined, addons with the same behaviorHints.bingeGroup will be chosen automatically for binge watching.
          *
          * This should be something that identifies the stream's nature within your addon.
-         * For example, if your addon is called "gobsAddon", and the stream is 720p, the group should be "gobsAddon-720p".
-         * If the next episode has a stream with the same group, stremio should select that stream implicitly.
+         * For example, if your addon is called "gobsAddon", and the stream is 720p, the bingeGroup should be "gobsAddon-720p".
+         * If the next episode has a stream with the same bingeGroup, stremio should select that stream implicitly.
          */
-        group?: string | undefined;
+        bingeGroup?: string | undefined;
         /**
          * **Not implemented yet!**
          *


### PR DESCRIPTION
The old group parameter does not work as intended in current stremio version. Stremio autoplay only work with the bingeGroup in the Stream response. I have tested the change myself and bingeGroup work while group does not. The new document is described at https://github.com/Stremio/stremio-addon-sdk/blob/master/docs/api/responses/stream.md

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Stremio/stremio-addon-sdk/blob/master/docs/api/responses/stream.md
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
