### PR TITLE
[react-dom] Inline ReferrerPolicy and RequestDestination types

### DIFF
--- a/types/react-dom/index.d.ts
+++ b/types/react-dom/index.d.ts
@@ -88,13 +88,44 @@ export interface PreloadOptions {
     integrity?: string | undefined;
     type?: string | undefined;
     nonce?: string | undefined;
-    referrerPolicy?: ReferrerPolicy | undefined;
+    referrerPolicy?:
+        | ""
+        | "no-referrer"
+        | "no-referrer-when-downgrade"
+        | "origin"
+        | "origin-when-cross-origin"
+        | "same-origin"
+        | "strict-origin"
+        | "strict-origin-when-cross-origin"
+        | "unsafe-url"
+        | undefined;
     media?: string | undefined;
 }
 export function preload(href: string, options?: PreloadOptions): void;
 
 // https://html.spec.whatwg.org/multipage/links.html#link-type-modulepreload
-export type PreloadModuleAs = RequestDestination;
+export type PreloadModuleAs =
+    | ""
+    | "audio"
+    | "audioworklet"
+    | "document"
+    | "embed"
+    | "font"
+    | "frame"
+    | "iframe"
+    | "image"
+    | "json"
+    | "manifest"
+    | "object"
+    | "paintworklet"
+    | "report"
+    | "script"
+    | "sharedworker"
+    | "style"
+    | "track"
+    | "video"
+    | "worker"
+    | "xslt";
 export interface PreloadModuleOptions {
     /**
      * @default "script"


### PR DESCRIPTION
## Summary

`PreloadOptions.referrerPolicy` and `PreloadModuleAs` reference the DOM globals `ReferrerPolicy` and `RequestDestination` from `lib.dom.d.ts`. This causes TS2304 errors in projects that don't include `lib: ["DOM"]` — such as monorepo backend workspaces, React Native projects, or SSR servers — when `skipLibCheck: false`.

This PR inlines both string unions directly, following the existing pattern in the same file where `PreloadAs`, `crossOrigin`, and `fetchPriority` are already inlined rather than referencing DOM globals.

## Problem

```
node_modules/@types/react-dom/index.d.ts(91,22): error TS2304: Cannot find name 'ReferrerPolicy'.
node_modules/@types/react-dom/index.d.ts(97,31): error TS2304: Cannot find name 'RequestDestination'.
```

The `preload()` and `preloadModule()` APIs are designed for React Server Components (SSR), where `lib: ["DOM"]` is typically not configured. Their type declarations should be self-contained.

## Fix

Inline the unions at the usage site (no new module-scope types), consistent with the comment at line 59-63 ("Don't create a helper type... it becomes part of the public API"):

- `referrerPolicy?: ReferrerPolicy | undefined` → inline 9-value union per [W3C Referrer Policy spec](https://w3c.github.io/webappsec-referrer-policy/#referrer-policy)
- `export type PreloadModuleAs = RequestDestination` → inline 21-value union per [WHATWG Fetch spec](https://fetch.spec.whatwg.org/#concept-request-destination)

## Precedent

- **Same file:** `PreloadAs` (line 68), `crossOrigin` (line 64), `fetchPriority` (line 84) — all inline their unions instead of referencing DOM globals
- **@types/react:** Defines `HTMLAttributeReferrerPolicy` as its own inline union (line 2904) rather than referencing the DOM `ReferrerPolicy` global

## Scope

The file references other DOM globals too (`Element`, `DocumentFragment`, `FormData`, `HTMLFormElement`, `AbortSignal`), but those are complex class/interface types used by APIs that genuinely require a DOM environment (`createPortal` needs an `Element`, `requestFormReset` needs an `HTMLFormElement`). They can't be inlined as string unions.

`ReferrerPolicy` and `RequestDestination` are the only DOM references that are simple string literal unions — exactly the kind the file already inlines everywhere else. This PR completes that pattern.

## Tests

Existing tests (`referrerPolicy: "unknown-policy"` @ts-expect-error, `as: "serviceworker"` @ts-expect-error) pass unchanged — the inlined unions have identical members to the DOM globals.
