### PR TITLE
expressjs_multer/support-for-unicode-headers

### DIFF
--- a/types/multer/index.d.ts
+++ b/types/multer/index.d.ts
@@ -211,8 +211,11 @@ declare namespace multer {
         } | undefined;
         /** Preserve the full path of the original filename rather than the basename. (Default: false) */
         preservePath?: boolean | undefined;
-        /** For multipart forms, the default character set to use for values of part header parameters (e.g. filename)
-         * that are not extended parameters (that contain an explicit charset). (Default: latin1) */
+        /**
+         * For multipart forms, the default character set to use for values of
+         * part header parameters (e.g. filename) that are not extended
+         * parameters (that contain an explicit charset). (Default: latin1)
+         */
         defParamCharset?: string | undefined;
         /**
          * Optional function to control which files are uploaded. This is called

--- a/types/multer/index.d.ts
+++ b/types/multer/index.d.ts
@@ -211,6 +211,9 @@ declare namespace multer {
         } | undefined;
         /** Preserve the full path of the original filename rather than the basename. (Default: false) */
         preservePath?: boolean | undefined;
+        /** For multipart forms, the default character set to use for values of part header parameters (e.g. filename)
+         * that are not extended parameters (that contain an explicit charset). (Default: latin1) */
+        defParamCharset?: string | undefined;
         /**
          * Optional function to control which files are uploaded. This is called
          * for every file that is processed.

--- a/types/multer/multer-tests.ts
+++ b/types/multer/multer-tests.ts
@@ -16,17 +16,17 @@ upload; // $ExpectType Multer
 assert.strictEqual(upload.constructor.name, "Multer");
 
 const upload_with_defParamCharset = multer({
-    dest: 'uploads/',
+    dest: "uploads/",
     fileFilter: (req, file, cb) => {
         cb(null, false);
         cb(null, true);
         cb(new Error(`I don't have a clue!`));
     },
-    defParamCharset: 'utf8',
+    defParamCharset: "utf8",
 });
 
 upload_with_defParamCharset; // $ExpectType Multer
-assert.strictEqual(upload_with_defParamCharset.constructor.name, 'Multer');
+assert.strictEqual(upload_with_defParamCharset.constructor.name, "Multer");
 
 const app = express();
 

--- a/types/multer/multer-tests.ts
+++ b/types/multer/multer-tests.ts
@@ -15,6 +15,19 @@ const upload = multer({
 upload; // $ExpectType Multer
 assert.strictEqual(upload.constructor.name, "Multer");
 
+const upload_with_defParamCharset = multer({
+    dest: 'uploads/',
+    fileFilter: (req, file, cb) => {
+        cb(null, false);
+        cb(null, true);
+        cb(new Error(`I don't have a clue!`));
+    },
+    defParamCharset: 'utf8',
+});
+
+upload_with_defParamCharset; // $ExpectType Multer
+assert.strictEqual(upload_with_defParamCharset.constructor.name, 'Multer');
+
 const app = express();
 
 app.post(

--- a/types/multer/package.json
+++ b/types/multer/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/multer",
-    "version": "2.0.9999",
+    "version": "2.1.9999",
     "projects": [
         "https://github.com/expressjs/multer"
     ],


### PR DESCRIPTION
Please fill in this template.

reopening #65578

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <[PR](https://github.com/expressjs/multer/pull/1210)>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
