### PR TITLE
Fix typo: coneito to conceito in Portuguese README

### DIFF
--- a/README.pt.md
+++ b/README.pt.md
@@ -312,7 +312,7 @@ Se um arquivo não for testado nem referenciado no `index.d.ts`, adicione-o em u
 
 ### Donos de definição
 
-O DT tem o coneito de "Donos de definição", que são pessoas que querem manter a qualidade dos tipos de um módulo específico
+O DT tem o conceito de "Donos de definição", que são pessoas que querem manter a qualidade dos tipos de um módulo específico
 
 - Adicionar você mesmo à lista, vai garantir que você seja notificado (pelo seu usuário do GitHub) sempre que qualquer um fizer uma pull request ou um issue sobre o pacote.
 - Suas revisões da PR terão uma precedência de importância maior para [o bot](https://github.com/microsoft/DefinitelyTyped-tools/tree/main/packages/mergebot) que mantém este repositório.


### PR DESCRIPTION
Fixes #60319. Corrects typo in README.pt.md where 'coneito' should be 'conceito' (Portuguese for 'concept').