### PR TITLE
Smooch: Add `off` method

### DIFF
--- a/types/smooch/index.d.ts
+++ b/types/smooch/index.d.ts
@@ -288,6 +288,104 @@ declare namespace Smooch {
      */
     function on(event: "typing:stop", callback: (data: ConversationData) => void): void;
     // tslint:enable:unified-signatures
+
+    // tslint:disable:unified-signatures
+    /**
+     * Removes a specific handler for the "ready" event, or all handlers if no callback is provided.
+     */
+    function off(event: "ready", callback?: () => void): void;
+    /**
+     * Removes a specific handler for the "destroy" event, or all handlers if no callback is provided.
+     */
+    function off(event: "destroy", callback?: () => void): void;
+    /**
+     * Removes a specific handler for the "participant:added" event, or all handlers if no callback is provided.
+     */
+    function off(
+        event: "participant:added",
+        callback?: (participant: ConversationParticipant, data: ConversationData) => void,
+    ): void;
+    /**
+     * Removes a specific handler for the "participant:removed" event, or all handlers if no callback is provided.
+     */
+    function off(
+        event: "participant:removed",
+        callback?: (participant: ConversationParticipant, data: ConversationData) => void,
+    ): void;
+    /**
+     * Removes a specific handler for the "conversation:added" event, or all handlers if no callback is provided.
+     */
+    function off(
+        event: "conversation:added",
+        callback?: (participants: ConversationParticipant[], data: ConversationData) => void,
+    ): void;
+    /**
+     * Removes a specific handler for the "conversation:read" event, or all handlers if no callback is provided.
+     */
+    function off(
+        event: "conversation:read",
+        callback?: (payload: ConversationReadEventPayload, data: ConversationData) => void,
+    ): void;
+    /**
+     * Removes a specific handler for the "conversation:removed" event, or all handlers if no callback is provided.
+     */
+    function off(event: "conversation:removed", callback?: (data: ConversationData) => void): void;
+    /**
+     * Removes a specific handler for the "message:received" event, or all handlers if no callback is provided.
+     */
+    function off(event: "message:received", callback?: (message: Message, data: ConversationData) => void): void;
+    /**
+     * Removes a specific handler for the "message:sent" event, or all handlers if no callback is provided.
+     */
+    function off(event: "message:sent", callback?: (message: Message, data: ConversationData) => void): void;
+    /**
+     * Removes a specific handler for the "message" event, or all handlers if no callback is provided.
+     */
+    function off(event: "message", callback?: (message: Message, data: ConversationData) => void): void;
+    /**
+     * Removes a specific handler for the "unreadCount" event, or all handlers if no callback is provided.
+     */
+    function off(event: "unreadCount", callback?: (unreadCount: number, data: ConversationData) => void): void;
+    /**
+     * Removes a specific handler for the "widget:opened" event, or all handlers if no callback is provided.
+     */
+    function off(event: "widget:opened", callback?: () => void): void;
+    /**
+     * Removes a specific handler for the "widget:closed" event, or all handlers if no callback is provided.
+     */
+    function off(event: "widget:closed", callback?: () => void): void;
+    /**
+     * Removes a specific handler for the "log:debug" event, or all handlers if no callback is provided.
+     */
+    function off(event: "log:debug", callback?: (e: DebugLog) => void): void;
+    /**
+     * Removes a specific handler for the "connected" event, or all handlers if no callback is provided.
+     */
+    function off(event: "connected", callback?: (data: ConversationData) => void): void;
+    /**
+     * Removes a specific handler for the "disconnected" event, or all handlers if no callback is provided.
+     */
+    function off(event: "disconnected", callback?: (data: ConversationData) => void): void;
+    /**
+     * Removes a specific handler for the "reconnecting" event, or all handlers if no callback is provided.
+     */
+    function off(event: "reconnecting", callback?: (data: ConversationData) => void): void;
+    /**
+     * Removes a specific handler for the "typing:start" event, or all handlers if no callback is provided.
+     */
+    function off(
+        event: "typing:start",
+        callback?: (data: ConversationData & { avatarUrl: string; name: string }) => void,
+    ): void;
+    /**
+     * Removes a specific handler for the "typing:stop" event, or all handlers if no callback is provided.
+     */
+    function off(event: "typing:stop", callback?: (data: ConversationData) => void): void;
+    /**
+     * Removes all handlers for all events.
+     */
+    function off(): void;
+    // tslint:enable:unified-signatures
 }
 
 type Nullable<T> = { [P in keyof T]: T[P] | null };

--- a/types/smooch/package.json
+++ b/types/smooch/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/smooch",
-    "version": "5.7.17",
+    "version": "5.6.9999",
     "projects": [
         "https://github.com/zendesk/sunshine-conversations-web"
     ],

--- a/types/smooch/package.json
+++ b/types/smooch/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/smooch",
-    "version": "5.3.9999",
+    "version": "5.7.17",
     "projects": [
         "https://github.com/zendesk/sunshine-conversations-web"
     ],

--- a/types/smooch/smooch-tests.ts
+++ b/types/smooch/smooch-tests.ts
@@ -21,6 +21,51 @@ Smooch.on("reconnecting", (data: ConversationData) => {});
 Smooch.on("typing:start", (data: ConversationData) => {});
 Smooch.on("typing:stop", (data: ConversationData) => {});
 
+// off - remove a specific handler
+Smooch.off("ready", () => {});
+Smooch.off("destroy", () => {});
+Smooch.off("participant:added", (participant: ConversationParticipant, data: ConversationData) => {});
+Smooch.off("participant:removed", (participant: ConversationParticipant, data: ConversationData) => {});
+Smooch.off("conversation:added", (participants: ConversationParticipant[], data: ConversationData) => {});
+Smooch.off("conversation:read", (payload: ConversationReadEventPayload, data: ConversationData) => {});
+Smooch.off("conversation:removed", (data: ConversationData) => {});
+Smooch.off("message:received", (message: Message, data: ConversationData) => {});
+Smooch.off("message:sent", (message: Message, data: ConversationData) => {});
+Smooch.off("message", (message: Message, data: ConversationData) => {});
+Smooch.off("unreadCount", (unreadCount: number, data: ConversationData) => {});
+Smooch.off("widget:opened", () => {});
+Smooch.off("widget:closed", () => {});
+Smooch.off("log:debug", (e: DebugLog) => {});
+Smooch.off("connected", (data: ConversationData) => {});
+Smooch.off("disconnected", (data: ConversationData) => {});
+Smooch.off("reconnecting", (data: ConversationData) => {});
+Smooch.off("typing:start", (data: ConversationData) => {});
+Smooch.off("typing:stop", (data: ConversationData) => {});
+
+// off - remove all handlers for a specific event
+Smooch.off("ready");
+Smooch.off("destroy");
+Smooch.off("participant:added");
+Smooch.off("participant:removed");
+Smooch.off("conversation:added");
+Smooch.off("conversation:read");
+Smooch.off("conversation:removed");
+Smooch.off("message:received");
+Smooch.off("message:sent");
+Smooch.off("message");
+Smooch.off("unreadCount");
+Smooch.off("widget:opened");
+Smooch.off("widget:closed");
+Smooch.off("log:debug");
+Smooch.off("connected");
+Smooch.off("disconnected");
+Smooch.off("reconnecting");
+Smooch.off("typing:start");
+Smooch.off("typing:stop");
+
+// off - remove all handlers for all events
+Smooch.off();
+
 // InitOptions must always have integrationId
 // @ts-expect-error
 Smooch.init({});


### PR DESCRIPTION
Add signatures for the `off` method, as described on https://github.com/zendesk/sunshine-conversations-web?tab=readme-ov-file#events

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/zendesk/sunshine-conversations-web?tab=readme-ov-file#events
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
