### PR TITLE
[jsdom] Fix Node.js type pollution

### DIFF
--- a/types/jsdom/base.d.ts
+++ b/types/jsdom/base.d.ts
@@ -1,7 +1,3 @@
-/// <reference lib="dom" />
-/// <reference lib="dom.iterable" />
-/// <reference types="node" />
-
 import { EventEmitter } from "events";
 import { Token } from "parse5";
 import * as tough from "tough-cookie";

--- a/types/jsdom/jsdom-tests.ts
+++ b/types/jsdom/jsdom-tests.ts
@@ -30,3 +30,7 @@ domWindow.WeakRef; // $ExpectType WeakRefConstructor
 dom.nodeLocation(domWindow.document.createElement("br")); // $ExpectType Location | null | undefined
 
 const childNodesArray = [...(domWindow.document.getElementById("parent")?.childNodes || [])]; // $ExpectType ChildNode[]
+
+// DOM types (lib "dom") and iterable DOM collections (lib "dom.iterable") are
+// provided via tsconfig.json.
+const allDivs = [...domWindow.document.querySelectorAll("div")]; // $ExpectType HTMLDivElement[]

--- a/types/jsdom/tsconfig.json
+++ b/types/jsdom/tsconfig.json
@@ -2,7 +2,9 @@
     "compilerOptions": {
         "module": "node16",
         "lib": [
-            "ESNext"
+            "ESNext",
+            "dom",
+            "dom.iterable"
         ],
         "target": "ES2015",
         "noImplicitAny": true,


### PR DESCRIPTION
Replace `/// <reference types="node" />` and friends with imports.
[Triple-slash directives] cause typings to appear in all TypeScript
environment IDE import suggestions even if their tsconfigs explicitly
configure empty `types` and sources have no jsdom dependencies.

For testing, I removed the directive and no longer saw Node.js import
suggestions in VSCode. I'm not sure how to unit test available imports.

[Triple-slash directives]: https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change. I'm not sure how to unit test available imports.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [<<url here>>](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
