### PR TITLE
[headroom] mark as conflicting with npm

### DIFF
--- a/types/headroom/package.json
+++ b/types/headroom/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "name": "@types/headroom",
     "version": "0.12.9999",
-    "nonNpm": true,
+    "nonNpm": "conflict",
     "nonNpmDescription": "headroom",
     "projects": [
         "http://wicky.nillia.ms/headroom.js/"


### PR DESCRIPTION
Someone grabbed this name, yay.

I'll note that there is `@types/headroom` and `@types/headroom.js`, which are sort of duplicative. Not sure what's up there.