### PR TITLE
[debug] Fix names and skips to use string patterns

### DIFF
--- a/types/debug/debug-tests.ts
+++ b/types/debug/debug-tests.ts
@@ -8,7 +8,7 @@ log2("Formatted test (%d arg)", 1);
 log2("Formatted %s (%d args)", "test", 2);
 
 debug1.disable();
-debug1.enable("DefinitelyTyped:*");
+debug1.enable("DefinitelyTyped:*,-DefinitelyTyped:skip");
 
 const log: debug1.Debugger = debug1("DefinitelyTyped:log");
 
@@ -17,7 +17,8 @@ log("Formatted test (%d arg)", 1);
 log("Formatted %s (%d args)", "test", 2);
 
 log("Enabled?: %s", debug1.enabled("DefinitelyTyped:log"));
-log("Name Enabled: %s", debug1.names.some(name => name.test("DefinitelyTyped:log")));
+log("Name Enabled: %s", debug1.names.some(name => name === "DefinitelyTyped:*"));
+log("Skip Enabled: %s", debug1.skips.some(name => name === "DefinitelyTyped:skip"));
 log("Namespace: %s", log.namespace);
 
 const error: debug1.Debugger = debug1("DefinitelyTyped:error");

--- a/types/debug/index.d.ts
+++ b/types/debug/index.d.ts
@@ -15,8 +15,8 @@ declare namespace debug {
         selectColor: (namespace: string) => string | number;
         humanize: typeof import("ms");
 
-        names: RegExp[];
-        skips: RegExp[];
+        names: string[];
+        skips: string[];
 
         formatters: Formatters;
 


### PR DESCRIPTION

  - [x] Use a meaningful title for the pull request. Include the name of the package
  modified.
  - [x] Test the change in your own code. (Compile and run.)
  - [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/
  master/README.md#my-package-teststs) to reflect the change.
  - [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/
  DefinitelyTyped/blob/master/README.md#make-a-pull-request).
  - [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/
  master/README.md#common-mistakes).
  - [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/
  DefinitelyTyped/blob/master/README.md#running-tests).

  If changing an existing definition:

  - [x] Provide a URL to documentation or source code which provides context for the
  suggested changes:
    - https://github.com/debug-js/debug/blob/master/src/common.js
    - https://github.com/debug-js/debug/blob/master/src/common.js#L162-L180
    - Testing also shows that they are strings https://github.com/debug-js/debug/blob/master/test.js

  `debug.enable()` stores namespace filters in `debug.names` and `debug.skips` as string
  patterns like `"namespace:*"` and `"skip:this"`, but `@types/debug` currently declares
  both as `RegExp[]`.

  This updates those exposed types to `string[]` and adjusts the package test to reflect
  the current runtime behavior.

  Validation:
  - `corepack pnpm install -w --filter "{./types/debug}..."`
  - `corepack pnpm test debug