### PR TITLE
[dom-chromium-ai] Reflect breaking Prompt API changes in TypeScript types

### DIFF
--- a/types/dom-chromium-ai/dom-chromium-ai-tests.ts
+++ b/types/dom-chromium-ai/dom-chromium-ai-tests.ts
@@ -122,36 +122,47 @@ async function topLevel() {
     await languageModel.append("foo", { signal: (new AbortController()).signal });
     await languageModel.append([{ role: "assistant", content: "foo" }], { signal: (new AbortController()).signal });
 
-    const languageModelInputUsage1: number = await languageModel.measureInputUsage("foo", {
+    const languageModelContextUsage1: number = await languageModel.measureContextUsage("foo", {
         signal: (new AbortController()).signal,
     });
-    console.log(languageModelInputUsage1);
+    console.log(languageModelContextUsage1);
 
-    const languageModelInputUsage2: number = await languageModel.measureInputUsage([{
+    const languageModelContextUsage2: number = await languageModel.measureContextUsage([{
         role: "assistant",
         content: "foo",
     }], {
         signal: (new AbortController()).signal,
     });
-    console.log(languageModelInputUsage2);
+    console.log(languageModelContextUsage2);
 
-    const languageModelInputUsage3: number = await languageModel.measureInputUsage([
+    const languageModelContextUsage3: number = await languageModel.measureContextUsage([
         { role: "assistant", content: "foo" },
         { role: "user", content: "bar" },
     ], { signal: (new AbortController()).signal });
-    console.log(languageModelInputUsage3);
+    console.log(languageModelContextUsage3);
 
+    console.log(
+        languageModel.contextUsage,
+        languageModel.contextWindow,
+    );
+
+    // Legacy names (Deprecated in extensions, removed in web)
     console.log(
         languageModel.inputUsage,
         languageModel.inputQuota,
     );
 
-    const quotaOverflowListener = (e: Event) => {
+    const contextOverflowListener = (e: Event) => {
         console.log(e);
     };
-    languageModel.onquotaoverflow = quotaOverflowListener;
-    languageModel.addEventListener("quotaoverflow", quotaOverflowListener);
-    languageModel.removeEventListener("quotaoverflow", quotaOverflowListener);
+    languageModel.oncontextoverflow = contextOverflowListener;
+    languageModel.addEventListener("contextoverflow", contextOverflowListener);
+    languageModel.removeEventListener("contextoverflow", contextOverflowListener);
+
+    // Legacy (Deprecated in extensions, removed in web)
+    languageModel.onquotaoverflow = contextOverflowListener;
+    languageModel.addEventListener("quotaoverflow", contextOverflowListener);
+    languageModel.removeEventListener("quotaoverflow", contextOverflowListener);
 
     console.log(
         languageModel.topK,

--- a/types/dom-chromium-ai/index.d.ts
+++ b/types/dom-chromium-ai/index.d.ts
@@ -44,6 +44,7 @@ interface DestroyableModel {
 declare abstract class LanguageModel extends EventTarget implements DestroyableModel {
     static create(options?: LanguageModelCreateOptions): Promise<LanguageModel>;
     static availability(options?: LanguageModelCreateCoreOptions): Promise<Availability>;
+    /** @deprecated Restricted to web extension contexts only. */
     static params(): Promise<LanguageModelParams>;
 
     prompt(input: LanguageModelPrompt, options?: LanguageModelPromptOptions): Promise<string>;
@@ -52,11 +53,20 @@ declare abstract class LanguageModel extends EventTarget implements DestroyableM
 
     append(input: LanguageModelPrompt, options?: LanguageModelAppendOptions): Promise<undefined>;
 
+    measureContextUsage(input: LanguageModelPrompt, options?: LanguageModelPromptOptions): Promise<number>;
+    /** @deprecated Use measureContextUsage instead. Deprecated in extensions, removed in web. */
     measureInputUsage(input: LanguageModelPrompt, options?: LanguageModelPromptOptions): Promise<number>;
 
+    readonly contextUsage: number;
+    /** @deprecated Use contextUsage instead. Deprecated in extensions, removed in web. */
     readonly inputUsage: number;
+
+    readonly contextWindow: number;
+    /** @deprecated Use contextWindow instead. Deprecated in extensions, removed in web. */
     readonly inputQuota: number;
 
+    oncontextoverflow: ((this: LanguageModel, ev: Event) => any) | null;
+    /** @deprecated Use oncontextoverflow instead. Deprecated in extensions, removed in web. */
     onquotaoverflow: ((this: LanguageModel, ev: Event) => any) | null;
 
     addEventListener<K extends keyof LanguageModelEventMap>(
@@ -80,7 +90,9 @@ declare abstract class LanguageModel extends EventTarget implements DestroyableM
         options?: boolean | EventListenerOptions,
     ): void;
 
+    /** @deprecated Restricted to web extension contexts only. */
     readonly topK: number;
+    /** @deprecated Restricted to web extension contexts only. */
     readonly temperature: number;
 
     clone(options?: LanguageModelCloneOptions): Promise<LanguageModel>;
@@ -88,18 +100,26 @@ declare abstract class LanguageModel extends EventTarget implements DestroyableM
 }
 
 interface LanguageModelEventMap {
+    contextoverflow: Event;
+    /** @deprecated Use contextoverflow instead. Deprecated in extensions, removed in web. */
     quotaoverflow: Event;
 }
 
 interface LanguageModelParams {
+    /** @deprecated Restricted to web extension contexts only. */
     readonly defaultTopK: number;
+    /** @deprecated Restricted to web extension contexts only. */
     readonly maxTopK: number;
+    /** @deprecated Restricted to web extension contexts only. */
     readonly defaultTemperature: number;
+    /** @deprecated Restricted to web extension contexts only. */
     readonly maxTemperature: number;
 }
 
 interface LanguageModelCreateCoreOptions {
+    /** @deprecated Restricted to web extension contexts only. Use the topK option within LanguageModel.create() is now restricted to web extensions. */
     topK?: number;
+    /** @deprecated Restricted to web extension contexts only. Use the temperature option within LanguageModel.create() is now restricted to web extensions. */
     temperature?: number;
 
     expectedInputs?: LanguageModelExpected[];


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webmachinelearning/prompt-api?tab=readme-ov-file#api-updates-deprecations-and-renaming
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
