### PR TITLE
[node-notifier] Align type definitions with v10 API surface

### DIFF
--- a/types/node-notifier/index.d.ts
+++ b/types/node-notifier/index.d.ts
@@ -7,6 +7,13 @@ import WindowsBalloon = require("./notifiers/balloon");
 import Growl = require("./notifiers/growl");
 
 declare namespace nodeNotifier {
+    type NotificationConstructor =
+        | typeof NotificationCenter
+        | typeof NotifySend
+        | typeof WindowsToaster
+        | typeof WindowsBalloon
+        | typeof Growl;
+
     interface NodeNotifier extends NodeJS.EventEmitter {
         notify(notification?: NotificationCenter.Notification, callback?: NotificationCallback): NotificationCenter;
         notify(notification?: WindowsToaster.Notification, callback?: NotificationCallback): WindowsToaster;
@@ -19,6 +26,7 @@ declare namespace nodeNotifier {
         WindowsToaster: typeof WindowsToaster;
         WindowsBalloon: typeof WindowsBalloon;
         Growl: typeof Growl;
+        Notification: NotificationConstructor;
     }
 
     interface Notification {

--- a/types/node-notifier/node-notifier-tests.ts
+++ b/types/node-notifier/node-notifier-tests.ts
@@ -48,6 +48,11 @@ new notifier.WindowsToaster(options).notify(options);
 new notifier.WindowsBalloon(options).notify(options);
 new notifier.Growl(options).notify(options);
 
+const Notification = notifier.Notification;
+const platformNotifier = new Notification(options);
+platformNotifier.notify();
+platformNotifier.on("click", () => {});
+
 //
 // All notification options with their defaults:
 //
@@ -87,6 +92,8 @@ const notifier3 = new notifier.WindowsToaster({
     customPath: void 0, // Relative path if you want to use your fork of toast.exe
 });
 
+notifier3.on("click", () => {});
+
 notifier3.notify(
     {
         title: void 0,
@@ -95,7 +102,9 @@ notifier3.notify(
         sound: false, // true | false.
         wait: false, // if wait for notification to end
         appID: "",
+        appName: "com.example.app",
         id: 1,
+        actions: ["Open"],
         install: "/",
         remove: 1,
     },
@@ -113,6 +122,8 @@ const notifier4 = new notifier.Growl({
     host: "localhost",
     port: 23053,
 });
+
+notifier4.on("click", () => {});
 
 notifier4.notify({
     title: "Foo",
@@ -152,7 +163,11 @@ notifier5.notify(
 // Usage NotifySend
 //
 
-const notifier6 = new notifier.NotifySend();
+const notifier6 = new notifier.NotifySend({
+    suppressOsdCheck: true,
+});
+
+notifier6.on("timeout", () => {});
 
 notifier6.notify({
     title: "Foo",
@@ -163,6 +178,7 @@ notifier6.notify({
     timeout: void 0,
     category: void 0,
     hint: void 0,
+    "app-name": "node-notifier",
 });
 
 notifier6.notify({
@@ -185,4 +201,25 @@ notifier6.notify({
     urgency: void 0,
     category: void 0,
     hint: void 0,
+});
+
+notifier2.on("replied", () => {});
+
+notifier2.notify({
+    list: "ALL",
+});
+
+notifier2.notify({
+    group: "demo",
+    remove: "demo",
+});
+
+notifier2.notify({
+    title: "Foo",
+    message: "Hello World",
+    activate: "com.apple.Terminal",
+    sender: "com.apple.Terminal",
+    execute: "/usr/bin/open",
+    appIcon: path.join(__dirname, "coulson.jpg"),
+    ignoreDnD: true,
 });

--- a/types/node-notifier/notifiers/balloon.d.ts
+++ b/types/node-notifier/notifiers/balloon.d.ts
@@ -1,6 +1,7 @@
+import events = require("events");
 import notifier = require("../");
 
-declare class WindowsBalloon {
+declare class WindowsBalloon extends events.EventEmitter {
     constructor(option?: notifier.Option);
     notify(notification?: WindowsBalloon.Notification, callback?: notifier.NotificationCallback): WindowsBalloon;
 }

--- a/types/node-notifier/notifiers/growl.d.ts
+++ b/types/node-notifier/notifiers/growl.d.ts
@@ -1,6 +1,7 @@
+import events = require("events");
 import notifier = require("../");
 
-declare class Growl {
+declare class Growl extends events.EventEmitter {
     constructor(option?: Growl.Option);
     notify(notification?: Growl.Notification, callback?: notifier.NotificationCallback): Growl;
 }

--- a/types/node-notifier/notifiers/notificationcenter.d.ts
+++ b/types/node-notifier/notifiers/notificationcenter.d.ts
@@ -1,6 +1,7 @@
+import events = require("events");
 import notifier = require("../");
 
-declare class NotificationCenter {
+declare class NotificationCenter extends events.EventEmitter {
     constructor(option?: notifier.Option);
     notify(
         notification?: NotificationCenter.Notification,
@@ -19,6 +20,22 @@ declare namespace NotificationCenter {
         contentImage?: string | undefined;
         /** URL to open on click */
         open?: string | undefined;
+        /** Bundle identifier of the application to activate on click. */
+        activate?: string | undefined;
+        /** Bundle identifier of the application that sends the notification. */
+        sender?: string | undefined;
+        /** Command to execute when the notification is clicked. */
+        execute?: string | undefined;
+        /** Path to an image to display as the application icon. */
+        appIcon?: string | undefined;
+        /** Deliver even if Do Not Disturb is enabled. */
+        ignoreDnD?: boolean | undefined;
+        /** Group notifications under a specific identifier. */
+        group?: string | undefined;
+        /** List notifications by group or use ALL to list every notification. */
+        list?: string | undefined;
+        /** Remove a previously delivered notification by group or id. */
+        remove?: string | number | undefined;
         /**
          * The amount of seconds before the notification closes.
          * Takes precedence over wait if both are defined.

--- a/types/node-notifier/notifiers/notifysend.d.ts
+++ b/types/node-notifier/notifiers/notifysend.d.ts
@@ -1,17 +1,17 @@
+import events = require("events");
 import notifier = require("../");
 
-declare class NotifySend {
-    constructor(option?: notifier.Option);
+declare class NotifySend extends events.EventEmitter {
+    constructor(option?: NotifySend.Option);
     notify(notification?: NotifySend.Notification, callback?: notifier.NotificationCallback): NotifySend;
 }
 
 declare namespace NotifySend {
-    interface Notification {
-        title?: string | undefined;
-        message?: string | undefined;
-        icon?: string | undefined;
-        /** Shorthand for timeout 5 seconds if true. Timeout option overrides wait */
-        wait?: boolean | undefined;
+    interface Option extends notifier.Option {
+        suppressOsdCheck?: boolean | undefined;
+    }
+
+    interface Notification extends notifier.Notification {
         /** Specifies the urgency level  (low,  normal,  critical). */
         urgency?: string | undefined;
         /** Specifies  the  timeout  in  seconds at which to expire the notification. Defaults to 10 seconds */
@@ -20,6 +20,8 @@ declare namespace NotifySend {
         category?: string | undefined;
         /** Specifies basic extra data to pass. Valid types are int, double, string and byte. */
         hint?: string | undefined;
+        /** Specifies the application name to show in the notification. */
+        "app-name"?: string | undefined;
     }
 }
 

--- a/types/node-notifier/notifiers/toaster.d.ts
+++ b/types/node-notifier/notifiers/toaster.d.ts
@@ -1,6 +1,7 @@
+import events = require("events");
 import notifier = require("../");
 
-declare class WindowsToaster {
+declare class WindowsToaster extends events.EventEmitter {
     constructor(option?: notifier.Option);
     notify(notification?: WindowsToaster.Notification, callback?: notifier.NotificationCallback): WindowsToaster;
 }
@@ -15,8 +16,12 @@ declare namespace WindowsToaster {
         id?: number | undefined;
         /** App.ID and app Name. Defaults to no value, causing SnoreToast text to be visible. */
         appID?: string | undefined;
+        /** Alias for appID. */
+        appName?: string | undefined;
         /** Refer to previously created notification to close. */
         remove?: number | undefined;
+        /** Action buttons to show in the toast. */
+        actions?: string[] | undefined;
         /**
          * Creates a shortcut <path> in the start menu which point to the
          * executable <application>, appID used for the notifications.


### PR DESCRIPTION
Aligns @types/node-notifier with the v10.0.1 npm package:

- Add root Notification constructor alias
- Add EventEmitter inheritance to all 5 notifier classes
- Add missing NotifySend options (app-name, suppressOsdCheck)
- Add missing WindowsToaster options (appName, actions)
- Add missing NotificationCenter passthrough flags (list, group, remove, etc.)
- Updated tests to cover all changes
- dtslint passes
