### PR TITLE
[react] Add commandFor and command attributes to ButtonHTMLAttributes (#74664)

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3050,6 +3050,8 @@ declare namespace React {
     }
 
     interface ButtonHTMLAttributes<T> extends HTMLAttributes<T> {
+        command?: string | undefined;
+        commandFor?: string | undefined;
         disabled?: boolean | undefined;
         form?: string | undefined;
         formAction?:

--- a/types/react/test/elementAttributes.tsx
+++ b/types/react/test/elementAttributes.tsx
@@ -162,6 +162,15 @@ const testCases = [
         <button popoverTarget="popover-target" popoverTargetAction="toggle">Toggle</button>
         <button popoverTarget="popover-target" popoverTargetAction="show">Show</button>
         <button popoverTarget="popover-target" popoverTargetAction="hide">Hide</button>
+        <button commandFor="command-target" command="toggle-popover">Toggle</button>
+        <button commandFor="command-target" command="--custom-command">Custom</button>
+        <button
+            commandFor="command-target"
+            // @ts-expect-error accidental boolean
+            command
+        >
+            Invalid
+        </button>
         <button
             popoverTarget="popover-target"
             // @ts-expect-error

--- a/types/react/ts5.0/index.d.ts
+++ b/types/react/ts5.0/index.d.ts
@@ -3049,6 +3049,8 @@ declare namespace React {
     }
 
     interface ButtonHTMLAttributes<T> extends HTMLAttributes<T> {
+        command?: string | undefined;
+        commandFor?: string | undefined;
         disabled?: boolean | undefined;
         form?: string | undefined;
         formAction?:

--- a/types/react/ts5.0/test/elementAttributes.tsx
+++ b/types/react/ts5.0/test/elementAttributes.tsx
@@ -162,6 +162,15 @@ const testCases = [
         <button popoverTarget="popover-target" popoverTargetAction="toggle">Toggle</button>
         <button popoverTarget="popover-target" popoverTargetAction="show">Show</button>
         <button popoverTarget="popover-target" popoverTargetAction="hide">Hide</button>
+        <button commandFor="command-target" command="toggle-popover">Toggle</button>
+        <button commandFor="command-target" command="--custom-command">Custom</button>
+        <button
+            commandFor="command-target"
+            // @ts-expect-error accidental boolean
+            command
+        >
+            Invalid
+        </button>
         <button
             popoverTarget="popover-target"
             // @ts-expect-error


### PR DESCRIPTION
## Summary

Adds the `command` and `commandFor` attributes to `ButtonHTMLAttributes` in `@types/react`, reflecting the new [Invoker Commands API](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API) from the HTML spec.

These attributes allow `<button>` elements to declaratively invoke actions on other elements (e.g., toggling a `<dialog>` or `<popover>`) without JavaScript.

- **`command`** — Specifies the action to perform on the target element (e.g., `"show-modal"`, `"toggle-popover"`, `"show"`, `"hide"`, or a custom `--` prefixed command).
- **`commandFor`** — References the `id` of the target element to invoke the command on.

Both attributes are typed as `string | undefined`, consistent with existing HTML attribute patterns in `@types/react`.

## Changes

- Added `command` and `commandFor` to `ButtonHTMLAttributes` in `types/react/index.d.ts`
- Added `command` and `commandFor` to `ButtonHTMLAttributes` in `types/react/ts5.0/index.d.ts`
- No changes to `tsconfig.json`, `package.json`, or any other configuration files

## References

- Fixes #74664
- [MDN: Invoker Commands API](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API)
- [MDN: HTMLButtonElement.command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command)
- [MDN: HTMLButtonElement.commandfor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor)

## Validation

- `pnpm test react` — passes
- `pnpm dprint check -- 'types/react/**/*.ts'` — passes
- Both main (`index.d.ts`) and TS 5.0 (`ts5.0/index.d.ts`) type surfaces updated