### PR TITLE
[oracledb] Add missing poolPingTimeout to PoolAttributes and Statistics

### DIFF
--- a/types/oracledb/index.d.ts
+++ b/types/oracledb/index.d.ts
@@ -2760,6 +2760,7 @@ declare namespace OracleDB {
         poolIncrement: number;
         poolTimeout: number;
         poolPingInterval: number;
+        poolPingTimeout: number;
         poolMaxPerShard: number;
         stmtCacheSize: number;
         sodaMetaDataCache: boolean;
@@ -3245,6 +3246,13 @@ declare namespace OracleDB {
          * @default 60
          */
         poolPingInterval?: number | undefined;
+        /**
+         * The number of milliseconds that a connection should wait for a response from connection.ping().
+         * This optional property overrides the oracledb.poolPingTimeout property.
+         *
+         * @default 5000
+         */
+        poolPingTimeout?: number | undefined;
         /**
          * The number of seconds after which idle connections (unused in the pool) may be terminated.
          * Idle connections are terminated only when the pool is accessed.

--- a/types/oracledb/oracledb-tests.ts
+++ b/types/oracledb/oracledb-tests.ts
@@ -205,6 +205,7 @@ const runPromiseTests = async (): Promise<void> => {
             queueTimeout: 60000,
             sessionCallback: initSession,
             stmtCacheSize: 5,
+            poolPingTimeout: 5000,
             user: DB_USER,
         });
 


### PR DESCRIPTION
For some reason, `poolPingTimeout` property was missing from `PoolAttributes` and it couldn't be passed to `createPool` when using these typings. It was also missing in `Statistics`, so added it there too while at it.

Please fill in this template.

- [ x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x ] Test the change in your own code. (Compile and run.)
- [ x ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [ x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).

If changing an existing definition:

- [ x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://node-oracledb.readthedocs.io/en/latest/api_manual/oracledb.html#createpoolpoolattrspoolpingtimeout


