### PR TITLE
[postcss-fail-on-warn] Update postcss dependency to match upstream package

### DIFF
--- a/types/postcss-fail-on-warn/index.d.ts
+++ b/types/postcss-fail-on-warn/index.d.ts
@@ -1,5 +1,5 @@
-import { Plugin } from "postcss";
+import { PluginCreator } from "postcss";
 
-declare const postcssFailOnWarn: Plugin<{}>;
+declare const postcssFailOnWarn: PluginCreator<{}>;
 
 export = postcssFailOnWarn;

--- a/types/postcss-fail-on-warn/package.json
+++ b/types/postcss-fail-on-warn/package.json
@@ -6,7 +6,7 @@
         "https://github.com/postcss/postcss-fail-on-warn#readme"
     ],
     "dependencies": {
-        "postcss": "^6.0.17"
+        "postcss": "^8.2.14"
     },
     "devDependencies": {
         "@types/postcss-fail-on-warn": "workspace:."


### PR DESCRIPTION
The package dependency now matches:

https://github.com/postcss/postcss-fail-on-warn/blob/9d283b3c353d89d4a0e8c253b04d4074b3052928/package.json#L21

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

