### PR TITLE
Fix incorrect getSession return type in node-media-server

### DIFF
--- a/types/node-media-server/index.d.ts
+++ b/types/node-media-server/index.d.ts
@@ -96,7 +96,7 @@ declare class NodeMediaServer {
     run(): void;
     on(eventName: string, listener: (id: string, StreamPath: string, args: object) => void): void;
     stop(): void;
-    getSession(id: string): Map<string, unknown>;
+    getSession(id: string): unknown;
 }
 
 export = NodeMediaServer;

--- a/types/node-media-server/node-media-server-tests.ts
+++ b/types/node-media-server/node-media-server-tests.ts
@@ -49,7 +49,7 @@ nms.on("test");
 // $ExpectType void
 nms.on("test", () => {});
 
-// $ExpectType Map<string, unknown>
+// $ExpectType unknown
 nms.getSession("1");
 
 // $ExpectType void


### PR DESCRIPTION
Fixes #69760

## Summary
`NodeMediaServer.getSession(id)` was typed as returning `Map<string, unknown>`, but the actual implementation returns the result of `context.sessions.get(id)` — a single session value from the Map, not the Map itself.

**Source:** [node_media_server.js#L110](https://github.com/illuspas/Node-Media-Server/blob/abcacc3b9274cfa6df8aab874df2c255379f710c/src/node_media_server.js#L110)

```javascript
getSession(id) {
    return context.sessions.get(id);
}
```

Since the session classes (`NodeRelaySession`, `NodeFlvSession`, `NodeRtmpSession`) aren't typed in this package, the return type is changed to `unknown`.

## Changes
- `index.d.ts`: Changed `getSession` return type from `Map<string, unknown>` to `unknown`
- `node-media-server-tests.ts`: Updated `$ExpectType` assertion to match