### PR TITLE
Add missing methods and properties to selectize types

### DIFF
--- a/types/selectize/index.d.ts
+++ b/types/selectize/index.d.ts
@@ -416,6 +416,16 @@ declare namespace Selectize {
          */
         options: { [value: string]: U };
 
+        /**
+         * The original jQuery object for the input element that was selectized.
+         */
+        $input: JQuery;
+
+        /**
+         * The settings object for this selectize instance.
+         */
+        settings: IOptions<T, U>;
+
         // Dropdown Options
         // ------------------------------------------------------------------------------------------------------------
 
@@ -476,6 +486,11 @@ declare namespace Selectize {
         addItem(value: T, silent?: boolean): void;
 
         /**
+         * "Selects" multiple items at once. Adds them to the list at the current caret position.
+         */
+        addItems(values: T | T[], silent?: boolean): void;
+
+        /**
          * Removes the selected item matching the provided value.
          */
         removeItem(value: T, silent?: boolean): void;
@@ -499,6 +514,16 @@ declare namespace Selectize {
          * The "id" argument refers to a value of the property in option identified by the "optgroupField" setting.
          */
         addOptionGroup(id: string, data: U): void;
+
+        /**
+         * Removes an existing option group.
+         */
+        removeOptionGroup(id: string): void;
+
+        /**
+         * Clears all existing option groups.
+         */
+        clearOptionGroups(): void;
 
         // Events
         // ------------------------------------------------------------------------------------------------------------

--- a/types/selectize/selectize-tests.ts
+++ b/types/selectize/selectize-tests.ts
@@ -459,3 +459,22 @@ $(".demo-code-language").selectize({
         },
     },
 });
+
+// API methods: addItems, removeOptionGroup, clearOptionGroups
+// --------------------------------------------------------------------------------------------------------------------
+
+var apiControl = $select[0].selectize;
+
+// $ExpectType JQuery
+apiControl.$input;
+
+// $ExpectType IOptions<any, any>
+apiControl.settings;
+
+apiControl.addItems(["one", "two"]);
+apiControl.addItems(["one", "two"], true);
+apiControl.addItems("single");
+
+apiControl.addOptionGroup("group1", { label: "Group 1" });
+apiControl.removeOptionGroup("group1");
+apiControl.clearOptionGroups();


### PR DESCRIPTION
Fixes #69377
Fixes #69530

## Summary
Adds missing methods and properties to the `Selectize.IApi` interface that exist in the [selectize.js source](https://github.com/selectize/selectize.js/blob/master/dist/js/selectize.js) and [official documentation](https://selectize.dev/docs/API/selectize).

## Changes

**New methods added to `IApi<T, U>`:**
- `addItems(values: T | T[], silent?: boolean): void` — selects multiple items at once
- `removeOptionGroup(id: string): void` — removes an existing option group
- `clearOptionGroups(): void` — clears all existing option groups

**New properties added to `IApi<T, U>`:**
- `$input: JQuery` — the original jQuery input element
- `settings: IOptions<T, U>` — the configuration settings object

**Tests:** Added test coverage for all new methods and properties.