### PR TITLE
feat(smtp-server): add hideDSN option and message param to onData cal…

### DIFF
--- a/types/smtp-server/index.d.ts
+++ b/types/smtp-server/index.d.ts
@@ -299,7 +299,11 @@ export interface SMTPServerOptions extends tls.TlsOptions {
     /**
      * the callback to handle incoming messages ([see details](https://nodemailer.com/extras/smtp-server#processing-incoming-messages-ondata))
      */
-    onData?(stream: SMTPServerDataStream, session: SMTPServerSession, callback: (err?: Error | null, message?: string) => void): void;    
+    onData?(
+        stream: SMTPServerDataStream,
+        session: SMTPServerSession,
+        callback: (err?: Error | null, message?: string) => void,
+    ): void;
     /**
      * the callback that informs about closed client connection
      */
@@ -343,7 +347,11 @@ export class SMTPServer extends EventEmitter {
     /** Override this */
     onConnect(session: SMTPServerSession, callback: (err?: Error | null) => void): void;
     /** Override this */
-    onData(stream: SMTPServerDataStream, session: SMTPServerSession, callback: (err?: Error | null, message?: string) => void): void;
+    onData(
+        stream: SMTPServerDataStream,
+        session: SMTPServerSession,
+        callback: (err?: Error | null, message?: string) => void,
+    ): void;
     /** Override this */
     onMailFrom(address: SMTPServerAddress, session: SMTPServerSession, callback: (err?: Error | null) => void): void;
     /** Override this */

--- a/types/smtp-server/index.d.ts
+++ b/types/smtp-server/index.d.ts
@@ -210,6 +210,10 @@ export interface SMTPServerOptions extends tls.TlsOptions {
      */
     hideENHANCEDSTATUSCODES?: boolean | undefined;
     /**
+     * optional boolean, if set to true then does not show DSN in features list, by default DSN is disabled
+     */
+    hideDSN?: boolean;
+    /**
      * optional boolean, if set to true allows authentication even if connection is not secured first
      */
     allowInsecureAuth?: boolean | undefined;
@@ -295,7 +299,7 @@ export interface SMTPServerOptions extends tls.TlsOptions {
     /**
      * the callback to handle incoming messages ([see details](https://nodemailer.com/extras/smtp-server#processing-incoming-messages-ondata))
      */
-    onData?(stream: SMTPServerDataStream, session: SMTPServerSession, callback: (err?: Error | null) => void): void;
+    onData?(stream: SMTPServerDataStream, session: SMTPServerSession, callback: (err?: Error | null, message?: string) => void): void;    
     /**
      * the callback that informs about closed client connection
      */
@@ -339,7 +343,7 @@ export class SMTPServer extends EventEmitter {
     /** Override this */
     onConnect(session: SMTPServerSession, callback: (err?: Error | null) => void): void;
     /** Override this */
-    onData(stream: SMTPServerDataStream, session: SMTPServerSession, callback: (err?: Error | null) => void): void;
+    onData(stream: SMTPServerDataStream, session: SMTPServerSession, callback: (err?: Error | null, message?: string) => void): void;
     /** Override this */
     onMailFrom(address: SMTPServerAddress, session: SMTPServerSession, callback: (err?: Error | null) => void): void;
     /** Override this */

--- a/types/smtp-server/smtp-server-tests.ts
+++ b/types/smtp-server/smtp-server-tests.ts
@@ -190,3 +190,17 @@ function test_newly_added_options() {
         },
     });
 }
+
+function test_hideDSN_option() {
+    const smtpServerInstance = new SMTPServer({
+        hideDSN: true,
+    });
+}
+
+function test_onData_with_message() {
+    const smtpServerInstance = new SMTPServer({
+        onData(stream, session, callback) {
+            callback(null, "Message queued");
+        },
+    });
+}


### PR DESCRIPTION
 
This pull request adds new test functions to the SMTP server test suite to cover additional configuration options and callback behaviors.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodemailer/smtp-server
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

### Changes

1. Added `hideDSN?: boolean` option to `SMTPServerOptions` - controls whether DSN is shown in the features list.
2. Added optional `message?: string` parameter to the `onData` callback - allows returning a custom message after processing incoming data.
3. Added corresponding tests for both changes.