### PR TITLE
Add method `updateHook` on Database in sql.js

### DIFF
--- a/types/sql.js/index.d.ts
+++ b/types/sql.js/index.d.ts
@@ -328,6 +328,7 @@ declare namespace initSqlJs {
         // types
         SqlValue,
         StatementIteratorResult,
+        UpdateHookCallback,
     };
 
     // classes

--- a/types/sql.js/index.d.ts
+++ b/types/sql.js/index.d.ts
@@ -7,6 +7,14 @@ type ParamsCallback = (obj: ParamsObject) => void;
 type SqlJsConfig = Partial<EmscriptenModule>;
 type BindParams = SqlValue[] | ParamsObject | null;
 
+type UpdateHookOperation = 'insert' | 'update' | 'delete';
+type UpdateHookCallback = (
+    operation: UpdateHookOperation,
+    database: string,
+    table: string,
+    rowId: number
+) => void;
+
 interface QueryExecResult {
     columns: string[];
     values: SqlValue[][];
@@ -149,6 +157,36 @@ declare class Database {
      * `;`). This limitation does not apply to params as an object.
      */
     run(sql: string, params?: BindParams): Database;
+
+    /** Registers an update hook with SQLite.
+     *
+     * Every time a row is changed by whatever means, the callback is called
+     * once with the change (`'insert'`, `'update'` or `'delete'`), the database
+     * name and table name where the change happened and the
+     * [rowid](https://www.sqlite.org/rowidtable.html)
+     * of the row that has been changed.
+     *
+     * The rowid is cast to a plain number. If it exceeds
+     * `Number.MAX_SAFE_INTEGER` (2^53 - 1), an error will be thrown.
+     *
+     * **Important notes:**
+     * - The callback **MUST NOT** modify the database in any way
+     * - Only a single callback can be registered at a time
+     * - Unregister the callback by passing `null`
+     * - Not called for some updates like `ON REPLACE CONFLICT` and `TRUNCATE`
+     *   (a `DELETE FROM` without a `WHERE` clause)
+     *
+     * See SQLite documentation on
+     * [sqlite3_update_hook](https://www.sqlite.org/c3ref/update_hook.html)
+     * for more details
+     *
+     * @param callback
+     * - Callback to be executed when a row changes. Takes the type of change,
+     *   the name of the database, the name of the table, and the row id of the
+     *   changed row.
+     * - Set to `null` to unregister.
+     */
+    updateHook(callback: UpdateHookCallback | null): Database;
 }
 
 declare class Statement {

--- a/types/sql.js/index.d.ts
+++ b/types/sql.js/index.d.ts
@@ -7,12 +7,12 @@ type ParamsCallback = (obj: ParamsObject) => void;
 type SqlJsConfig = Partial<EmscriptenModule>;
 type BindParams = SqlValue[] | ParamsObject | null;
 
-type UpdateHookOperation = 'insert' | 'update' | 'delete';
+type UpdateHookOperation = "insert" | "update" | "delete";
 type UpdateHookCallback = (
     operation: UpdateHookOperation,
     database: string,
     table: string,
-    rowId: number
+    rowId: number,
 ) => void;
 
 interface QueryExecResult {

--- a/types/sql.js/sql.js-tests.ts
+++ b/types/sql.js/sql.js-tests.ts
@@ -28,6 +28,11 @@ initSqlJs().then(SqlJs => {
         + "CREATE TABLE test_table (id INTEGER PRIMARY KEY, content TEXT);";
     db.run(createTableStatement);
 
+    // Register handler for database changes
+    db.updateHook((operation, database, table, rowId) => {
+        console.log("SQLite database is updated", { operation, database, table, rowId });
+    });
+
     // Insert 2 records for testing.
     const insertRecordStatement = "INSERT INTO test_table (id, content) VALUES (@id, @content);";
     db.run(insertRecordStatement, {


### PR DESCRIPTION
Add types for update hook operations and callback.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://sql.js.org/documentation/Database.html#updateHook>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.