### PR TITLE
fix(formidable): Change options.enabledPlugins type from string to PluginFunction

### DIFF
--- a/types/formidable/formidable-tests.ts
+++ b/types/formidable/formidable-tests.ts
@@ -25,7 +25,7 @@ import * as http from "http";
 // arrange
 const options: Options = {
     allowEmptyFiles: true,
-    enabledPlugins: [],
+    enabledPlugins: [json, querystring],
     encoding: "utf-8",
     fileWriteStreamHandler: undefined,
     hashAlgorithm: false,

--- a/types/formidable/index.d.ts
+++ b/types/formidable/index.d.ts
@@ -193,7 +193,7 @@ declare namespace formidable {
          */
         filename?: (name: string, ext: string, part: Part, form: Formidable) => string;
 
-        enabledPlugins?: string[] | undefined;
+        enabledPlugins?: formidable.PluginFunction[] | undefined;
 
         filter?: (part: Part) => boolean;
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [enabledPlugins should be themselves](https://github.com/node-formidable/formidable/blob/44768be861499a8c0a159afd632733e3e82088f6/CHANGELOG.md?plain=1#L109)
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Options.enabledPlugins accepts the plugin functions themselves instead of their names. That's also metioned in the [docs](https://github.com/node-formidable/formidable/blob/44768be861499a8c0a159afd632733e3e82088f6/README.md?plain=1#L572)