### PR TITLE
w3c-web-usb: allow strongly-typed event listeners to work with `AddEventListenerOptions`

### DIFF
--- a/types/w3c-web-usb/index.d.ts
+++ b/types/w3c-web-usb/index.d.ts
@@ -119,7 +119,7 @@ declare class USB extends EventTarget {
     removeEventListener(
         type: "connect" | "disconnect",
         callback: (this: this, ev: USBConnectionEvent) => any,
-        useCapture?: EventListenerOptions | boolean,
+        options?: EventListenerOptions | boolean,
     ): void;
     removeEventListener(
         type: string,

--- a/types/w3c-web-usb/index.d.ts
+++ b/types/w3c-web-usb/index.d.ts
@@ -109,7 +109,7 @@ declare class USB extends EventTarget {
     addEventListener(
         type: "connect" | "disconnect",
         listener: (this: this, ev: USBConnectionEvent) => any,
-        useCapture?: boolean,
+        options?: boolean | AddEventListenerOptions,
     ): void;
     addEventListener(
         type: string,
@@ -119,7 +119,7 @@ declare class USB extends EventTarget {
     removeEventListener(
         type: "connect" | "disconnect",
         callback: (this: this, ev: USBConnectionEvent) => any,
-        useCapture?: boolean,
+        useCapture?: EventListenerOptions | boolean,
     ): void;
     removeEventListener(
         type: string,

--- a/types/w3c-web-usb/w3c-web-usb-tests.ts
+++ b/types/w3c-web-usb/w3c-web-usb-tests.ts
@@ -45,6 +45,16 @@ navigator.usb.addEventListener("connect", evt => {
     // Add |device| to the UI.
     handleConnectedDevice(evt.device);
 });
+// `options: boolean`
+navigator.usb.addEventListener("connect", evt => {
+    // Add |device| to the UI.
+    handleConnectedDevice(evt.device);
+}, true);
+// `options: AddEventListenerOptions`
+navigator.usb.addEventListener("connect", evt => {
+    // Add |device| to the UI.
+    handleConnectedDevice(evt.device);
+}, { capture: true });
 
 navigator.usb.addEventListener("disconnect", evt => {
     // Remove |device| from the UI.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener

---

Fix `{add,remove}EventListener`, so when `AddEventListenerOptions` is used, it still select the overload with `USBConnectionEvent`, align it with `lib.dom.d.ts`