### PR TITLE
[node] Fix ReadableStreamReadDoneResult.value optionality

### DIFF
--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -30,6 +30,7 @@ import "./node-tests/repl";
 import "./node-tests/sea";
 import "./node-tests/sqlite";
 import "./node-tests/stream";
+import "./node-tests/stream-web";
 import "./node-tests/string_decoder";
 import "./node-tests/test";
 import "./node-tests/timers_promises";

--- a/types/node/node-tests/stream-web.ts
+++ b/types/node/node-tests/stream-web.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert";
+import { ReadableStream } from "node:stream/web";
+
+async function readResultHasRequiredValueProperty() {
+    const stream = ReadableStream.from(["test"]);
+    const reader = stream.getReader();
+    {
+        const result = await reader.read();
+        assert(!result.done, "Expected a non-done result");
+        // $ExpectType string
+        result.value;
+        assert.strictEqual(result.value, "test");
+    }
+    {
+        const result = await reader.read();
+        assert(result.done, "Expected a done result");
+        // $ExpectType string | undefined
+        result.value;
+
+        assert.strictEqual(Object.prototype.hasOwnProperty.call(result, "value"), true);
+        assert.strictEqual(result.value, undefined);
+    }
+}

--- a/types/node/v20/node-tests.ts
+++ b/types/node/v20/node-tests.ts
@@ -28,6 +28,7 @@ import "./test/readline";
 import "./test/repl";
 import "./test/sea";
 import "./test/stream";
+import "./test/stream-web";
 import "./test/string_decoder";
 import "./test/test";
 import "./test/timers_promises";

--- a/types/node/v20/stream/web.d.ts
+++ b/types/node/v20/stream/web.d.ts
@@ -109,7 +109,7 @@ declare module "stream/web" {
     }
     interface ReadableStreamReadDoneResult<T> {
         done: true;
-        value?: T;
+        value: T | undefined;
     }
     type ReadableStreamReadResult<T> = ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult<T>;
     interface ReadableByteStreamControllerCallback {

--- a/types/node/v20/test/stream-web.ts
+++ b/types/node/v20/test/stream-web.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert";
+import { ReadableStream } from "node:stream/web";
+
+async function readResultHasRequiredValueProperty() {
+    const stream = ReadableStream.from(["test"]);
+    const reader = stream.getReader();
+    {
+        const result = await reader.read();
+        assert(!result.done, "Expected a non-done result");
+        // $ExpectType string
+        result.value;
+        assert.strictEqual(result.value, "test");
+    }
+    {
+        const result = await reader.read();
+        assert(result.done, "Expected a done result");
+        // $ExpectType string | undefined
+        result.value;
+
+        assert.strictEqual(Object.prototype.hasOwnProperty.call(result, "value"), true);
+        assert.strictEqual(result.value, undefined);
+    }
+}

--- a/types/node/v22/node-tests.ts
+++ b/types/node/v22/node-tests.ts
@@ -29,6 +29,7 @@ import "./test/repl";
 import "./test/sea";
 import "./test/sqlite";
 import "./test/stream";
+import "./test/stream-web";
 import "./test/string_decoder";
 import "./test/test";
 import "./test/timers_promises";

--- a/types/node/v22/stream/web.d.ts
+++ b/types/node/v22/stream/web.d.ts
@@ -109,7 +109,7 @@ declare module "stream/web" {
     }
     interface ReadableStreamReadDoneResult<T> {
         done: true;
-        value?: T;
+        value: T | undefined;
     }
     type ReadableStreamReadResult<T> = ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult<T>;
     interface ReadableByteStreamControllerCallback {

--- a/types/node/v22/test/stream-web.ts
+++ b/types/node/v22/test/stream-web.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert";
+import { ReadableStream } from "node:stream/web";
+
+async function readResultHasRequiredValueProperty() {
+    const stream = ReadableStream.from(["test"]);
+    const reader = stream.getReader();
+    {
+        const result = await reader.read();
+        assert(!result.done, "Expected a non-done result");
+        // $ExpectType string
+        result.value;
+        assert.strictEqual(result.value, "test");
+    }
+    {
+        const result = await reader.read();
+        assert(result.done, "Expected a done result");
+        // $ExpectType string | undefined
+        result.value;
+
+        assert.strictEqual(Object.prototype.hasOwnProperty.call(result, "value"), true);
+        assert.strictEqual(result.value, undefined);
+    }
+}

--- a/types/node/v24/node-tests.ts
+++ b/types/node/v24/node-tests.ts
@@ -29,6 +29,7 @@ import "./test/repl";
 import "./test/sea";
 import "./test/sqlite";
 import "./test/stream";
+import "./test/stream-web";
 import "./test/string_decoder";
 import "./test/test";
 import "./test/timers_promises";

--- a/types/node/v24/stream/web.d.ts
+++ b/types/node/v24/stream/web.d.ts
@@ -105,7 +105,7 @@ declare module "stream/web" {
     }
     interface ReadableStreamReadDoneResult<T> {
         done: true;
-        value?: T;
+        value: T | undefined;
     }
     type ReadableStreamReadResult<T> = ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult<T>;
     interface ReadableByteStreamControllerCallback {

--- a/types/node/v24/test/stream-web.ts
+++ b/types/node/v24/test/stream-web.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert";
+import { ReadableStream } from "node:stream/web";
+
+async function readResultHasRequiredValueProperty() {
+    const stream = ReadableStream.from(["test"]);
+    const reader = stream.getReader();
+    {
+        const result = await reader.read();
+        assert(!result.done, "Expected a non-done result");
+        // $ExpectType string
+        result.value;
+        assert.strictEqual(result.value, "test");
+    }
+    {
+        const result = await reader.read();
+        assert(result.done, "Expected a done result");
+        // $ExpectType string | undefined
+        result.value;
+
+        assert.strictEqual(Object.prototype.hasOwnProperty.call(result, "value"), true);
+        assert.strictEqual(result.value, undefined);
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - ReadableStreamDefaultReader -> https://github.com/nodejs/node/blob/ac6375417a5305433c735c781d0f6d1eaec9f2ba/lib/internal/webstreams/readablestream.js#L798
  - ReadableStreamBYOBReader -> https://github.com/nodejs/node/blob/ac6375417a5305433c735c781d0f6d1eaec9f2ba/lib/internal/webstreams/readablestream.js#L818
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

## Summary

Follow microsoft/TypeScript-DOM-lib-generator#1914 (`7545a90156aa82c8ef5c804ea9a9846c5de3ee67`) for the `ReadableStreamReadDoneResult<T>.value` change in `@types/web` and `lib.dom.d.ts`.

The root `types/node/stream/web.d.ts` already matches the upstream Web Streams shape, but the versioned packages still model `value` as optional. That difference is observable to consumers through assignability and property-presence checks such as the `in` operator.

## Validation

```
const stream = ReadableStream.from([]);
const result = await stream.getReader().read();

assert.strictEqual(result.done, true);
assert.strictEqual(Object.prototype.hasOwnProperty.call(result, "value"), true);
assert.strictEqual(result.value, undefined);
```
