### PR TITLE
[node] Fix Web Streams chunk parameter optionality

### DIFF
--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -30,6 +30,7 @@ import "./node-tests/repl";
 import "./node-tests/sea";
 import "./node-tests/sqlite";
 import "./node-tests/stream";
+import "./node-tests/stream-web";
 import "./node-tests/string_decoder";
 import "./node-tests/test";
 import "./node-tests/timers_promises";

--- a/types/node/node-tests/stream-web.ts
+++ b/types/node/node-tests/stream-web.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert";
+import { ReadableStream } from "node:stream/web";
+
+async function readResultHasRequiredValueProperty() {
+    const stream = ReadableStream.from(["test"]);
+    const reader = stream.getReader();
+    {
+        const result = await reader.read();
+        assert(!result.done, "Expected a non-done result");
+        // $ExpectType string
+        result.value;
+        assert.strictEqual(result.value, "test");
+    }
+    {
+        const result = await reader.read();
+        assert(result.done, "Expected a done result");
+        // $ExpectType string | undefined
+        result.value;
+
+        assert.strictEqual(Object.prototype.hasOwnProperty.call(result, "value"), true);
+        assert.strictEqual(result.value, undefined);
+    }
+}

--- a/types/node/node-tests/stream-web.ts
+++ b/types/node/node-tests/stream-web.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert";
-import { ReadableStream } from "node:stream/web";
+import { ReadableStream, TransformStream, WritableStream } from "node:stream/web";
+import type { QueuingStrategySize } from "node:stream/web";
 
 async function readResultHasRequiredValueProperty() {
     const stream = ReadableStream.from(["test"]);
@@ -20,4 +21,83 @@ async function readResultHasRequiredValueProperty() {
         assert.strictEqual(Object.prototype.hasOwnProperty.call(result, "value"), true);
         assert.strictEqual(result.value, undefined);
     }
+}
+
+async function readableStreamControllerTreatsExplicitUndefinedAsAChunk() {
+    const stream = new ReadableStream<string | undefined>({
+        start(controller) {
+            // @ts-expect-error `chunk` is required; pass `undefined` explicitly when it is part of the chunk type.
+            controller.enqueue();
+            controller.enqueue(undefined);
+            controller.close();
+        },
+    });
+    const values: (string | undefined)[] = [];
+    for await (const chunk of stream) {
+        values.push(chunk);
+    }
+    // enqueue() and enqueue(undefined) should have the same effect
+    assert.deepStrictEqual(values, [undefined, undefined]);
+}
+
+async function transformStreamControllerTreatsExplicitUndefinedAsAChunk() {
+    const stream = new TransformStream<string, string | undefined>({
+        transform(chunk, controller) {
+            assert.strictEqual(chunk, "input");
+
+            // @ts-expect-error `chunk` is required; pass `undefined` explicitly when it is part of the chunk type.
+            controller.enqueue();
+            controller.enqueue(undefined);
+        },
+    });
+    const values: (string | undefined)[] = [];
+    for await (const chunk of ReadableStream.from(["input"]).pipeThrough(stream)) {
+        values.push(chunk);
+    }
+    // enqueue() and enqueue(undefined) should have the same effect
+    assert.deepStrictEqual(values, [undefined, undefined]);
+}
+
+async function writableStreamWriterTreatsExplicitUndefinedAsAChunk() {
+    const writtenChunks: (string | undefined)[] = [];
+
+    const stream = new WritableStream<string | undefined>({
+        write(chunk) {
+            writtenChunks.push(chunk);
+        },
+    });
+    const writer = stream.getWriter();
+    // @ts-expect-error `chunk` is required; pass `undefined` explicitly when it is part of the chunk type.
+    await writer.write();
+    await writer.write(undefined);
+    await writer.close();
+
+    assert.deepStrictEqual(writtenChunks, [undefined, undefined]);
+}
+
+async function queuingStrategySizeReceivesTheChunk() {
+    const sizeChunks: string[] = [];
+
+    const size: QueuingStrategySize<string> = (chunk) => {
+        // $ExpectType string
+        chunk;
+        sizeChunks.push(chunk);
+        return chunk.length;
+    };
+
+    const stream = new ReadableStream<string>(
+        {
+            start(controller) {
+                controller.enqueue("size");
+                controller.close();
+            },
+        },
+        {
+            highWaterMark: 10,
+            size,
+        },
+    );
+    const result = await stream.getReader().read();
+    assert.deepStrictEqual(result, { done: false, value: "size" });
+    assert.deepStrictEqual(sizeChunks, ["size"]);
 }

--- a/types/node/stream/web.d.ts
+++ b/types/node/stream/web.d.ts
@@ -206,7 +206,7 @@ declare module "node:stream/web" {
     interface ReadableStreamDefaultController<R = any> {
         readonly desiredSize: number | null;
         close(): void;
-        enqueue(chunk?: R): void;
+        enqueue(chunk: R): void;
         error(e?: any): void;
     }
     var ReadableStreamDefaultController: {
@@ -251,7 +251,7 @@ declare module "node:stream/web" {
     };
     interface TransformStreamDefaultController<O = any> {
         readonly desiredSize: number | null;
-        enqueue(chunk?: O): void;
+        enqueue(chunk: O): void;
         error(reason?: any): void;
         terminate(): void;
     }
@@ -284,7 +284,7 @@ declare module "node:stream/web" {
         abort(reason?: any): Promise<void>;
         close(): Promise<void>;
         releaseLock(): void;
-        write(chunk?: W): Promise<void>;
+        write(chunk: W): Promise<void>;
     }
     var WritableStreamDefaultWriter: {
         prototype: WritableStreamDefaultWriter;

--- a/types/node/v20/node-tests.ts
+++ b/types/node/v20/node-tests.ts
@@ -28,6 +28,7 @@ import "./test/readline";
 import "./test/repl";
 import "./test/sea";
 import "./test/stream";
+import "./test/stream-web";
 import "./test/string_decoder";
 import "./test/test";
 import "./test/timers_promises";

--- a/types/node/v20/stream/web.d.ts
+++ b/types/node/v20/stream/web.d.ts
@@ -251,7 +251,7 @@ declare module "stream/web" {
     interface ReadableStreamDefaultController<R = any> {
         readonly desiredSize: number | null;
         close(): void;
-        enqueue(chunk?: R): void;
+        enqueue(chunk: R): void;
         error(e?: any): void;
     }
     const ReadableStreamDefaultController: {
@@ -279,7 +279,7 @@ declare module "stream/web" {
     };
     interface TransformStreamDefaultController<O = any> {
         readonly desiredSize: number | null;
-        enqueue(chunk?: O): void;
+        enqueue(chunk: O): void;
         error(reason?: any): void;
         terminate(): void;
     }
@@ -315,7 +315,7 @@ declare module "stream/web" {
         abort(reason?: any): Promise<void>;
         close(): Promise<void>;
         releaseLock(): void;
-        write(chunk?: W): Promise<void>;
+        write(chunk: W): Promise<void>;
     }
     const WritableStreamDefaultWriter: {
         prototype: WritableStreamDefaultWriter;
@@ -339,7 +339,7 @@ declare module "stream/web" {
         size?: QueuingStrategySize<T>;
     }
     interface QueuingStrategySize<T = any> {
-        (chunk?: T): number;
+        (chunk: T): number;
     }
     interface QueuingStrategyInit {
         /**

--- a/types/node/v20/stream/web.d.ts
+++ b/types/node/v20/stream/web.d.ts
@@ -109,7 +109,7 @@ declare module "stream/web" {
     }
     interface ReadableStreamReadDoneResult<T> {
         done: true;
-        value?: T;
+        value: T | undefined;
     }
     type ReadableStreamReadResult<T> = ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult<T>;
     interface ReadableByteStreamControllerCallback {

--- a/types/node/v20/test/stream-web.ts
+++ b/types/node/v20/test/stream-web.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert";
+import { ReadableStream } from "node:stream/web";
+
+async function readResultHasRequiredValueProperty() {
+    const stream = ReadableStream.from(["test"]);
+    const reader = stream.getReader();
+    {
+        const result = await reader.read();
+        assert(!result.done, "Expected a non-done result");
+        // $ExpectType string
+        result.value;
+        assert.strictEqual(result.value, "test");
+    }
+    {
+        const result = await reader.read();
+        assert(result.done, "Expected a done result");
+        // $ExpectType string | undefined
+        result.value;
+
+        assert.strictEqual(Object.prototype.hasOwnProperty.call(result, "value"), true);
+        assert.strictEqual(result.value, undefined);
+    }
+}

--- a/types/node/v20/test/stream-web.ts
+++ b/types/node/v20/test/stream-web.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert";
-import { ReadableStream } from "node:stream/web";
+import { ReadableStream, TransformStream, WritableStream } from "node:stream/web";
+import type { QueuingStrategySize } from "node:stream/web";
 
 async function readResultHasRequiredValueProperty() {
     const stream = ReadableStream.from(["test"]);
@@ -20,4 +21,83 @@ async function readResultHasRequiredValueProperty() {
         assert.strictEqual(Object.prototype.hasOwnProperty.call(result, "value"), true);
         assert.strictEqual(result.value, undefined);
     }
+}
+
+async function readableStreamControllerTreatsExplicitUndefinedAsAChunk() {
+    const stream = new ReadableStream<string | undefined>({
+        start(controller) {
+            // @ts-expect-error `chunk` is required; pass `undefined` explicitly when it is part of the chunk type.
+            controller.enqueue();
+            controller.enqueue(undefined);
+            controller.close();
+        },
+    });
+    const values: (string | undefined)[] = [];
+    for await (const chunk of stream) {
+        values.push(chunk);
+    }
+    // enqueue() and enqueue(undefined) should have the same effect
+    assert.deepStrictEqual(values, [undefined, undefined]);
+}
+
+async function transformStreamControllerTreatsExplicitUndefinedAsAChunk() {
+    const stream = new TransformStream<string, string | undefined>({
+        transform(chunk, controller) {
+            assert.strictEqual(chunk, "input");
+
+            // @ts-expect-error `chunk` is required; pass `undefined` explicitly when it is part of the chunk type.
+            controller.enqueue();
+            controller.enqueue(undefined);
+        },
+    });
+    const values: (string | undefined)[] = [];
+    for await (const chunk of ReadableStream.from(["input"]).pipeThrough(stream)) {
+        values.push(chunk);
+    }
+    // enqueue() and enqueue(undefined) should have the same effect
+    assert.deepStrictEqual(values, [undefined, undefined]);
+}
+
+async function writableStreamWriterTreatsExplicitUndefinedAsAChunk() {
+    const writtenChunks: (string | undefined)[] = [];
+
+    const stream = new WritableStream<string | undefined>({
+        write(chunk) {
+            writtenChunks.push(chunk);
+        },
+    });
+    const writer = stream.getWriter();
+    // @ts-expect-error `chunk` is required; pass `undefined` explicitly when it is part of the chunk type.
+    await writer.write();
+    await writer.write(undefined);
+    await writer.close();
+
+    assert.deepStrictEqual(writtenChunks, [undefined, undefined]);
+}
+
+async function queuingStrategySizeReceivesTheChunk() {
+    const sizeChunks: string[] = [];
+
+    const size: QueuingStrategySize<string> = (chunk) => {
+        // $ExpectType string
+        chunk;
+        sizeChunks.push(chunk);
+        return chunk.length;
+    };
+
+    const stream = new ReadableStream<string>(
+        {
+            start(controller) {
+                controller.enqueue("size");
+                controller.close();
+            },
+        },
+        {
+            highWaterMark: 10,
+            size,
+        },
+    );
+    const result = await stream.getReader().read();
+    assert.deepStrictEqual(result, { done: false, value: "size" });
+    assert.deepStrictEqual(sizeChunks, ["size"]);
 }

--- a/types/node/v22/node-tests.ts
+++ b/types/node/v22/node-tests.ts
@@ -29,6 +29,7 @@ import "./test/repl";
 import "./test/sea";
 import "./test/sqlite";
 import "./test/stream";
+import "./test/stream-web";
 import "./test/string_decoder";
 import "./test/test";
 import "./test/timers_promises";

--- a/types/node/v22/stream/web.d.ts
+++ b/types/node/v22/stream/web.d.ts
@@ -254,7 +254,7 @@ declare module "stream/web" {
     interface ReadableStreamDefaultController<R = any> {
         readonly desiredSize: number | null;
         close(): void;
-        enqueue(chunk?: R): void;
+        enqueue(chunk: R): void;
         error(e?: any): void;
     }
     const ReadableStreamDefaultController: {
@@ -283,7 +283,7 @@ declare module "stream/web" {
     };
     interface TransformStreamDefaultController<O = any> {
         readonly desiredSize: number | null;
-        enqueue(chunk?: O): void;
+        enqueue(chunk: O): void;
         error(reason?: any): void;
         terminate(): void;
     }
@@ -319,7 +319,7 @@ declare module "stream/web" {
         abort(reason?: any): Promise<void>;
         close(): Promise<void>;
         releaseLock(): void;
-        write(chunk?: W): Promise<void>;
+        write(chunk: W): Promise<void>;
     }
     const WritableStreamDefaultWriter: {
         prototype: WritableStreamDefaultWriter;
@@ -343,7 +343,7 @@ declare module "stream/web" {
         size?: QueuingStrategySize<T>;
     }
     interface QueuingStrategySize<T = any> {
-        (chunk?: T): number;
+        (chunk: T): number;
     }
     interface QueuingStrategyInit {
         /**

--- a/types/node/v22/stream/web.d.ts
+++ b/types/node/v22/stream/web.d.ts
@@ -109,7 +109,7 @@ declare module "stream/web" {
     }
     interface ReadableStreamReadDoneResult<T> {
         done: true;
-        value?: T;
+        value: T | undefined;
     }
     type ReadableStreamReadResult<T> = ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult<T>;
     interface ReadableByteStreamControllerCallback {

--- a/types/node/v22/test/stream-web.ts
+++ b/types/node/v22/test/stream-web.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert";
+import { ReadableStream } from "node:stream/web";
+
+async function readResultHasRequiredValueProperty() {
+    const stream = ReadableStream.from(["test"]);
+    const reader = stream.getReader();
+    {
+        const result = await reader.read();
+        assert(!result.done, "Expected a non-done result");
+        // $ExpectType string
+        result.value;
+        assert.strictEqual(result.value, "test");
+    }
+    {
+        const result = await reader.read();
+        assert(result.done, "Expected a done result");
+        // $ExpectType string | undefined
+        result.value;
+
+        assert.strictEqual(Object.prototype.hasOwnProperty.call(result, "value"), true);
+        assert.strictEqual(result.value, undefined);
+    }
+}

--- a/types/node/v22/test/stream-web.ts
+++ b/types/node/v22/test/stream-web.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert";
-import { ReadableStream } from "node:stream/web";
+import { ReadableStream, TransformStream, WritableStream } from "node:stream/web";
+import type { QueuingStrategySize } from "node:stream/web";
 
 async function readResultHasRequiredValueProperty() {
     const stream = ReadableStream.from(["test"]);
@@ -20,4 +21,83 @@ async function readResultHasRequiredValueProperty() {
         assert.strictEqual(Object.prototype.hasOwnProperty.call(result, "value"), true);
         assert.strictEqual(result.value, undefined);
     }
+}
+
+async function readableStreamControllerTreatsExplicitUndefinedAsAChunk() {
+    const stream = new ReadableStream<string | undefined>({
+        start(controller) {
+            // @ts-expect-error `chunk` is required; pass `undefined` explicitly when it is part of the chunk type.
+            controller.enqueue();
+            controller.enqueue(undefined);
+            controller.close();
+        },
+    });
+    const values: (string | undefined)[] = [];
+    for await (const chunk of stream) {
+        values.push(chunk);
+    }
+    // enqueue() and enqueue(undefined) should have the same effect
+    assert.deepStrictEqual(values, [undefined, undefined]);
+}
+
+async function transformStreamControllerTreatsExplicitUndefinedAsAChunk() {
+    const stream = new TransformStream<string, string | undefined>({
+        transform(chunk, controller) {
+            assert.strictEqual(chunk, "input");
+
+            // @ts-expect-error `chunk` is required; pass `undefined` explicitly when it is part of the chunk type.
+            controller.enqueue();
+            controller.enqueue(undefined);
+        },
+    });
+    const values: (string | undefined)[] = [];
+    for await (const chunk of ReadableStream.from(["input"]).pipeThrough(stream)) {
+        values.push(chunk);
+    }
+    // enqueue() and enqueue(undefined) should have the same effect
+    assert.deepStrictEqual(values, [undefined, undefined]);
+}
+
+async function writableStreamWriterTreatsExplicitUndefinedAsAChunk() {
+    const writtenChunks: (string | undefined)[] = [];
+
+    const stream = new WritableStream<string | undefined>({
+        write(chunk) {
+            writtenChunks.push(chunk);
+        },
+    });
+    const writer = stream.getWriter();
+    // @ts-expect-error `chunk` is required; pass `undefined` explicitly when it is part of the chunk type.
+    await writer.write();
+    await writer.write(undefined);
+    await writer.close();
+
+    assert.deepStrictEqual(writtenChunks, [undefined, undefined]);
+}
+
+async function queuingStrategySizeReceivesTheChunk() {
+    const sizeChunks: string[] = [];
+
+    const size: QueuingStrategySize<string> = (chunk) => {
+        // $ExpectType string
+        chunk;
+        sizeChunks.push(chunk);
+        return chunk.length;
+    };
+
+    const stream = new ReadableStream<string>(
+        {
+            start(controller) {
+                controller.enqueue("size");
+                controller.close();
+            },
+        },
+        {
+            highWaterMark: 10,
+            size,
+        },
+    );
+    const result = await stream.getReader().read();
+    assert.deepStrictEqual(result, { done: false, value: "size" });
+    assert.deepStrictEqual(sizeChunks, ["size"]);
 }

--- a/types/node/v24/node-tests.ts
+++ b/types/node/v24/node-tests.ts
@@ -29,6 +29,7 @@ import "./test/repl";
 import "./test/sea";
 import "./test/sqlite";
 import "./test/stream";
+import "./test/stream-web";
 import "./test/string_decoder";
 import "./test/test";
 import "./test/timers_promises";

--- a/types/node/v24/stream/web.d.ts
+++ b/types/node/v24/stream/web.d.ts
@@ -250,7 +250,7 @@ declare module "stream/web" {
     interface ReadableStreamDefaultController<R = any> {
         readonly desiredSize: number | null;
         close(): void;
-        enqueue(chunk?: R): void;
+        enqueue(chunk: R): void;
         error(e?: any): void;
     }
     const ReadableStreamDefaultController: {
@@ -279,7 +279,7 @@ declare module "stream/web" {
     };
     interface TransformStreamDefaultController<O = any> {
         readonly desiredSize: number | null;
-        enqueue(chunk?: O): void;
+        enqueue(chunk: O): void;
         error(reason?: any): void;
         terminate(): void;
     }
@@ -315,7 +315,7 @@ declare module "stream/web" {
         abort(reason?: any): Promise<void>;
         close(): Promise<void>;
         releaseLock(): void;
-        write(chunk?: W): Promise<void>;
+        write(chunk: W): Promise<void>;
     }
     const WritableStreamDefaultWriter: {
         prototype: WritableStreamDefaultWriter;
@@ -339,7 +339,7 @@ declare module "stream/web" {
         size?: QueuingStrategySize<T>;
     }
     interface QueuingStrategySize<T = any> {
-        (chunk?: T): number;
+        (chunk: T): number;
     }
     interface QueuingStrategyInit {
         /**

--- a/types/node/v24/stream/web.d.ts
+++ b/types/node/v24/stream/web.d.ts
@@ -105,7 +105,7 @@ declare module "stream/web" {
     }
     interface ReadableStreamReadDoneResult<T> {
         done: true;
-        value?: T;
+        value: T | undefined;
     }
     type ReadableStreamReadResult<T> = ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult<T>;
     interface ReadableByteStreamControllerCallback {

--- a/types/node/v24/test/stream-web.ts
+++ b/types/node/v24/test/stream-web.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert";
+import { ReadableStream } from "node:stream/web";
+
+async function readResultHasRequiredValueProperty() {
+    const stream = ReadableStream.from(["test"]);
+    const reader = stream.getReader();
+    {
+        const result = await reader.read();
+        assert(!result.done, "Expected a non-done result");
+        // $ExpectType string
+        result.value;
+        assert.strictEqual(result.value, "test");
+    }
+    {
+        const result = await reader.read();
+        assert(result.done, "Expected a done result");
+        // $ExpectType string | undefined
+        result.value;
+
+        assert.strictEqual(Object.prototype.hasOwnProperty.call(result, "value"), true);
+        assert.strictEqual(result.value, undefined);
+    }
+}

--- a/types/node/v24/test/stream-web.ts
+++ b/types/node/v24/test/stream-web.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert";
-import { ReadableStream } from "node:stream/web";
+import { ReadableStream, TransformStream, WritableStream } from "node:stream/web";
+import type { QueuingStrategySize } from "node:stream/web";
 
 async function readResultHasRequiredValueProperty() {
     const stream = ReadableStream.from(["test"]);
@@ -20,4 +21,83 @@ async function readResultHasRequiredValueProperty() {
         assert.strictEqual(Object.prototype.hasOwnProperty.call(result, "value"), true);
         assert.strictEqual(result.value, undefined);
     }
+}
+
+async function readableStreamControllerTreatsExplicitUndefinedAsAChunk() {
+    const stream = new ReadableStream<string | undefined>({
+        start(controller) {
+            // @ts-expect-error `chunk` is required; pass `undefined` explicitly when it is part of the chunk type.
+            controller.enqueue();
+            controller.enqueue(undefined);
+            controller.close();
+        },
+    });
+    const values: (string | undefined)[] = [];
+    for await (const chunk of stream) {
+        values.push(chunk);
+    }
+    // enqueue() and enqueue(undefined) should have the same effect
+    assert.deepStrictEqual(values, [undefined, undefined]);
+}
+
+async function transformStreamControllerTreatsExplicitUndefinedAsAChunk() {
+    const stream = new TransformStream<string, string | undefined>({
+        transform(chunk, controller) {
+            assert.strictEqual(chunk, "input");
+
+            // @ts-expect-error `chunk` is required; pass `undefined` explicitly when it is part of the chunk type.
+            controller.enqueue();
+            controller.enqueue(undefined);
+        },
+    });
+    const values: (string | undefined)[] = [];
+    for await (const chunk of ReadableStream.from(["input"]).pipeThrough(stream)) {
+        values.push(chunk);
+    }
+    // enqueue() and enqueue(undefined) should have the same effect
+    assert.deepStrictEqual(values, [undefined, undefined]);
+}
+
+async function writableStreamWriterTreatsExplicitUndefinedAsAChunk() {
+    const writtenChunks: (string | undefined)[] = [];
+
+    const stream = new WritableStream<string | undefined>({
+        write(chunk) {
+            writtenChunks.push(chunk);
+        },
+    });
+    const writer = stream.getWriter();
+    // @ts-expect-error `chunk` is required; pass `undefined` explicitly when it is part of the chunk type.
+    await writer.write();
+    await writer.write(undefined);
+    await writer.close();
+
+    assert.deepStrictEqual(writtenChunks, [undefined, undefined]);
+}
+
+async function queuingStrategySizeReceivesTheChunk() {
+    const sizeChunks: string[] = [];
+
+    const size: QueuingStrategySize<string> = (chunk) => {
+        // $ExpectType string
+        chunk;
+        sizeChunks.push(chunk);
+        return chunk.length;
+    };
+
+    const stream = new ReadableStream<string>(
+        {
+            start(controller) {
+                controller.enqueue("size");
+                controller.close();
+            },
+        },
+        {
+            highWaterMark: 10,
+            size,
+        },
+    );
+    const result = await stream.getReader().read();
+    assert.deepStrictEqual(result, { done: false, value: "size" });
+    assert.deepStrictEqual(sizeChunks, ["size"]);
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - ReadableStreamDefaultController.enqueue:
    - https://github.com/nodejs/node/blob/ac6375417a5305433c735c781d0f6d1eaec9f2ba/lib/internal/webstreams/readablestream.js#L1194
  - TransformStreamDefaultController.enqueue:
    - https://github.com/nodejs/node/blob/ac6375417a5305433c735c781d0f6d1eaec9f2ba/lib/internal/webstreams/transformstream.js#L320
  - WritableStreamDefaultWriter.write:
    - https://github.com/nodejs/node/blob/ac6375417a5305433c735c781d0f6d1eaec9f2ba/lib/internal/webstreams/writablestream.js#L445
  - QueuingStrategySize:
    - https://github.com/nodejs/node/blob/ac6375417a5305433c735c781d0f6d1eaec9f2ba/lib/internal/webstreams/readablestream.js#L2396-L2400
    - https://github.com/nodejs/node/blob/06a8240384419a072be5a73e75d7a153da8d51e4/lib/internal/webstreams/writablestream.js#L1201-L1204
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

This PR makes the `chunk` parameter required for:

- `ReadableStreamDefaultController<R>.enqueue(chunk: R)`
- `TransformStreamDefaultController<O>.enqueue(chunk: O)`
- `WritableStreamDefaultWriter<W>.write(chunk: W)`

In Node.js, omitting these arguments and passing `undefined` produce the same runtime behavior.
Making the parameter optional is therefore unsound whenever the stream type does not include `undefined` or `void`.

This PR also makes `chunk` in `QueuingStrategySize<T>` non-optional in the versioned `stream/web` definitions. Node's readable stream implementation always calls the size algorithm with the enqueued chunk.

Additional context:

- This branch was created on top of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/74770 rather than directly on DefinitelyTyped master, because `stream-web.ts` conflicts with that PR.
  - [compare](https://github.com/ikeyan/DefinitelyTyped/compare/fix-ReadableStreamReadDoneResult-value...fix-stream-web-chunk-params)
- This change is related to the corresponding `TypeScript-DOM-lib-generator` work for `@types/web` / `lib.dom.d.ts`:
  - https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/2425
  - https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/2452
  - The intention is to keep the DefinitelyTyped `stream/web` types aligned with those `@types/web` changes.
