### PR TITLE
[chrome] several fixes

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -346,9 +346,10 @@ declare namespace chrome {
         export function setIcon(details: TabIconDetails, callback: () => void): void;
 
         /**
-         * Sets the html document to be opened as a popup when the user clicks on the action's icon.
+         * Sets the HTML document to be opened as a popup when the user clicks on the action's icon.
          *
          * Can return its result via Promise.
+         * @since Chrome 96
          */
         export function setPopup(details: PopupDetails): Promise<void>;
         export function setPopup(details: PopupDetails, callback: () => void): void;
@@ -1165,6 +1166,7 @@ declare namespace chrome {
          * Clears websites' cache storage data.
          *
          * Can return its result via Promise in Manifest V3 or later since Chrome 96.
+         * @since Chrome 72
          */
         export function removeCacheStorage(options: RemovalOptions): Promise<void>;
         export function removeCacheStorage(options: RemovalOptions, callback: () => void): void;
@@ -2433,7 +2435,17 @@ declare namespace chrome {
          * Exactly one of `imageData` or `path` must be specified. Both are dictionaries mapping a number of pixels to an image representation. The image representation in `imageData` is an `ImageData` object; for example, from a `canvas` element, while the image representation in `path` is the path to an image file relative to the extension's manifest. If `scale` screen pixels fit into a device-independent pixel, the `scale * n` icon is used. If that scale is missing, another image is resized to the required size.
          */
         export class SetIcon {
-            constructor(options?: { imageData?: ImageData | { [size: string]: ImageData } | undefined });
+            constructor(
+                options:
+                    | {
+                        imageData: ImageData | { [index: number]: ImageData };
+                        path?: string | { [index: number]: string } | undefined;
+                    }
+                    | {
+                        imageData?: ImageData | { [index: number]: ImageData } | undefined;
+                        path: string | { [index: number]: string };
+                    },
+            );
         }
 
         /** Provides the Declarative Event API consisting of {@link events.Event.addRules addRules}, {@link events.Event.removeRules removeRules}, and {@link events.Event.getRules getRules}. */
@@ -3330,7 +3342,7 @@ declare namespace chrome {
             /** Indicates the data type of the option. The requested data type must match the real data type of the underlying option. */
             type: `${OptionType}`;
             /** Indicates the value to set. Leave unset to request automatic setting for options that have `autoSettable` enabled. The data type supplied for `value` must match `type`. */
-            value?: string | number | boolean | number;
+            value?: string | number | boolean | number[];
         }
 
         /**
@@ -3560,6 +3572,8 @@ declare namespace chrome {
         /**
          * Performs a document scan and returns a Promise that resolves with a {@link ScanResults} object. If a callback is passed to this function, the returned data is passed to it instead.
          * @param options An object containing scan parameters.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 96.
          */
         export function scan(options: ScanOptions): Promise<ScanResults>;
         export function scan(options: ScanOptions, callback: (result: ScanResults) => void): void;
@@ -4364,9 +4378,12 @@ declare namespace chrome {
         }
 
         /**
-         * Retrieves the network details of the device's default network. If the user is not affiliated or the device is not connected to a network, runtime.lastError will be set with a failure reason.
+         * Retrieves the network details of the device's default network. If the user is not affiliated or the device is not connected to a network, {@link runtime.lastError} will be set with a failure reason.
          * @param callback Called with the device's default network's NetworkDetails.
+         *
+         * Can return its result via Promise in Manifest V3 or later since Chrome 96.
          */
+        export function getNetworkDetails(): Promise<NetworkDetails>;
         export function getNetworkDetails(callback: (networkDetails: NetworkDetails) => void): void;
     }
 
@@ -6308,7 +6325,7 @@ declare namespace chrome {
          * This API is different from identity.getAccounts in two ways. The information returned is available offline, and it only applies to the primary account for the profile.
          * @param details Profile options.
          *
-         * Can return its result via Promise since Chrome 105.
+         * Can return its result via Promise since Chrome 106.
          */
         export function getProfileUserInfo(details?: ProfileDetails): Promise<ProfileUserInfo>;
         export function getProfileUserInfo(
@@ -6323,7 +6340,7 @@ declare namespace chrome {
          * If an access token is discovered to be invalid, it should be passed to removeCachedAuthToken to remove it from the cache. The app may then retrieve a fresh token with `getAuthToken`.
          * @param details Token information.
          *
-         * Can return its result via Promise since Chrome 105.
+         * Can return its result via Promise since Chrome 106.
          */
         export function removeCachedAuthToken(details: InvalidTokenDetails): Promise<void>;
         export function removeCachedAuthToken(details: InvalidTokenDetails, callback: () => void): void;
@@ -7911,7 +7928,7 @@ declare namespace chrome {
 
         export enum ClientCertificateType {
             ECDSA_SIGN = "ecdsaSign",
-            RAS_SIGN = "rasSign",
+            RSA_SIGN = "rsaSign",
         }
 
         export interface SelectDetails {
@@ -8806,7 +8823,7 @@ declare namespace chrome {
         export type QueryInfo =
             & {
                 /** String to query with the default search provider. */
-                text?: string | undefined;
+                text: string;
             }
             & (
                 | {
@@ -12142,7 +12159,7 @@ declare namespace chrome {
          * Called when the list of {@link TtsVoice} that would be returned by getVoices has changed.
          * @since Chrome 124
          */
-        const onVoicesChanged: chrome.events.Event<() => void>;
+        export const onVoicesChanged: chrome.events.Event<() => void>;
     }
 
     ////////////////////
@@ -13094,7 +13111,7 @@ declare namespace chrome {
             EXTRA_HEADERS = "extraHeaders",
         }
 
-        /** @since Chrome 44 */
+        /** @since Chrome 79 */
         export enum OnErrorOccurredOptions {
             /** Specifies that headers can violate Cross-Origin Resource Sharing (CORS). */
             EXTRA_HEADERS = "extraHeaders",
@@ -13286,14 +13303,14 @@ declare namespace chrome {
             extends SetPartial<WebRequestDetails, "documentId" | "documentLifecycle" | "frameType">
         {
             /** Contains the HTTP request body data. Only provided if extraInfoSpec contains 'requestBody'. */
-            requestBody: {
+            requestBody?: {
                 /** Errors when obtaining request body data. */
                 error?: string;
                 /** If the request method is POST and the body is a sequence of key-value pairs encoded in UTF8, encoded as either multipart/form-data, or application/x-www-form-urlencoded, this dictionary is present and for each key contains the list of all values for that key. If the data is of another media type, or if it is malformed, the dictionary is not present. An example value of this dictionary is {'key': \['value1', 'value2'\]}. */
                 formData?: { [key: string]: FormDataItem[] };
                 /** If the request method is PUT or POST, and the body is not already parsed in formData, then the unparsed request body elements are contained in this array. */
                 raw?: UploadData[];
-            } | undefined;
+            };
         }
 
         export interface OnBeforeSendHeadersDetails extends WebRequestDetails {
@@ -14345,7 +14362,7 @@ declare namespace chrome {
              * The headers provided by a hypothetical response if the request does not get blocked or redirected before it is sent. Represented as an object which maps a header name to a list of string values. If not specified, the hypothetical response would return empty response headers, which can match rules which match on the non-existence of headers. E.g. `{"content-type": ["text/html; charset=utf-8", "multipart/form-data"]}`
              * @since Chrome 129
              */
-            responseHeaders?: { [name: string]: unknown };
+            responseHeaders?: { [name: string]: string[] };
             /** The ID of the tab in which the hypothetical request takes place. Does not need to correspond to a real tab ID. Default is -1, meaning that the request isn't related to a tab. */
             tabId?: number;
             /**
@@ -14683,13 +14700,13 @@ declare namespace chrome {
          * Fired when the extension's side panel is closed.
          * @since Chrome 142
          */
-        const onClosed: events.Event<(info: PanelClosedInfo) => void>;
+        export const onClosed: events.Event<(info: PanelClosedInfo) => void>;
 
         /**
          * Fired when the extension's side panel is opened.
          * @since Chrome 141
          */
-        const onOpened: events.Event<(info: PanelOpenedInfo) => void>;
+        export const onOpened: events.Event<(info: PanelOpenedInfo) => void>;
     }
 
     ////////////////////
@@ -14795,7 +14812,7 @@ declare namespace chrome {
             /** Specifies wildcard patterns for pages this user script will be injected into. */
             includeGlobs?: string[] | undefined;
             /** The list of ScriptSource objects defining sources of scripts to be injected into matching pages. This property must be specified for {@link register}, and when specified it must be a non-empty array.*/
-            js: ScriptSource[];
+            js?: ScriptSource[] | undefined;
             /** Specifies which pages this user script will be injected into. See Match Patterns for more details on the syntax of these strings. This property must be specified for {@link register}. */
             matches?: string[] | undefined;
             /** Specifies when JavaScript files are injected into the web page. The preferred and default value is `document_idle` */

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1316,6 +1316,14 @@ function testDeclarativeContent() {
     const imageData = new ImageData(32, 32);
 
     new chrome.declarativeContent.SetIcon({ imageData }); // $ExpectType SetIcon
+    new chrome.declarativeContent.SetIcon({ imageData: { 32: imageData } }); // $ExpectType SetIcon
+    new chrome.declarativeContent.SetIcon({ path: "image.jpg" }); // $ExpectType SetIcon
+    new chrome.declarativeContent.SetIcon({ imageData, path: "image.jpg" }); // $ExpectType SetIcon
+    new chrome.declarativeContent.SetIcon({ imageData, path: { "32": "image.jpg" } }); // $ExpectType SetIcon
+    // @ts-expect-error Cannot use 'in' operator to search for 'iconIndex' in undefined
+    new chrome.declarativeContent.SetIcon();
+    // @ts-expect-error Uncaught Error: Either the path or imageData property must be specified
+    new chrome.declarativeContent.SetIcon({});
 
     const action = new chrome.declarativeContent.ShowAction(); // $ExpectType ShowAction
 
@@ -4528,7 +4536,7 @@ function testDocumentScan() {
     const optionSettings: chrome.documentScan.OptionSetting[] = [{
         name: "name",
         type: "GROUP",
-        value: "value",
+        value: [10],
     }];
     chrome.documentScan.setOptions(scannerHandle, optionSettings); // $ExpectType Promise<SetOptionsResponse<"handle">>
     chrome.documentScan.setOptions(scannerHandle, optionSettings, response => { // $ExpectType void
@@ -4595,6 +4603,18 @@ function testEnterpriseHardwarePlatform() {
     chrome.enterprise.hardwarePlatform.getHardwarePlatformInfo(); // $ExpectType Promise<HardwarePlatformInfo>
     // @ts-expect-error
     chrome.enterprise.hardwarePlatform.getHardwarePlatformInfo((info) => {}).then((info) => {});
+}
+
+// https://developer.chrome.com/docs/extensions/reference/api/enterprise/networkingAttributes
+function testEntrepriseNetworkingAttributes() {
+    chrome.enterprise.networkingAttributes.getNetworkDetails(); // $ExpectType Promise<NetworkDetails>
+    chrome.enterprise.networkingAttributes.getNetworkDetails((networkAddresses) => { // $ExpectType void
+        networkAddresses.ipv4; // $ExpectType string | undefined
+        networkAddresses.ipv6; // $ExpectType string | undefined
+        networkAddresses.macAddress; // $ExpectType string
+    });
+    // @ts-expect-error
+    chrome.enterprise.networkingAttributes.getNetworkDetails((networkAddresses) => {}).then((networkAddresses) => {});
 }
 
 // https://developer.chrome.com/docs/extensions/reference/api/enterprise/login
@@ -6626,7 +6646,7 @@ function testPrinterProvider() {
 // https://developer.chrome.com/docs/extensions/reference/api/platformKeys
 function testPlatformKeys() {
     chrome.platformKeys.ClientCertificateType.ECDSA_SIGN === "ecdsaSign";
-    chrome.platformKeys.ClientCertificateType.RAS_SIGN === "rasSign";
+    chrome.platformKeys.ClientCertificateType.RSA_SIGN === "rsaSign";
 
     const arrayBuffer = new ArrayBuffer(0);
 
@@ -6645,7 +6665,7 @@ function testPlatformKeys() {
         interactive: true,
         request: {
             certificateAuthorities: [],
-            certificateTypes: ["ecdsaSign", chrome.platformKeys.ClientCertificateType.RAS_SIGN],
+            certificateTypes: ["ecdsaSign", chrome.platformKeys.ClientCertificateType.RSA_SIGN],
         },
     };
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://developer.chrome.com/docs/extensions/reference/api/declarativeContent#type-SetIcon
  - https://developer.chrome.com/docs/extensions/reference/api/documentScan#type-OptionSetting
  - https://developer.chrome.com/docs/extensions/reference/api/platformKeys#type-ClientCertificateType
  - https://developer.chrome.com/docs/extensions/reference/api/enterprise/networkingAttributes#method-getNetworkDetails
  - https://developer.chrome.com/docs/extensions/reference/api/search#type-QueryInfo
  - https://developer.chrome.com/docs/extensions/reference/api/webRequest#event-onBeforeRequest
  - https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest#type-TestMatchRequestDetails
  - https://developer.chrome.com/docs/extensions/reference/api/userScripts#type-RegisteredUserScript
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes:
 - Global :
   - Fix JSDoc
   - Add missing export
 - declarativeContent
   - fix `SetIcon` : param is required, with at least the "path" or "imageData" key.
     <img width="972" height="105" alt="SetIcon-1" src="https://github.com/user-attachments/assets/c7533214-3e4b-41f8-bc44-f45cdd4dfaa5" />
     <img width="973" height="107" alt="SetIcon-2" src="https://github.com/user-attachments/assets/ecab061d-5e84-47fd-a524-65c111953d8b" />
 - documentScan
   - fix `OptionSetting` : `value` key accept number array
     <img width="1631" height="167" alt="image" src="https://github.com/user-attachments/assets/98589ca7-0b50-4efc-9460-aafdfe2e16f6" />
 - enterprise.networkingAttributes
   - update `getNetworkDetails()`: can return a promise  
     <img width="1631" height="212" alt="image" src="https://github.com/user-attachments/assets/3c93d3a9-a250-4e52-a24f-0989a42c89a6" />
- platformKeys
   - fix `ClientCertificateType` : `rasSign` -> `rsaSign`
     <img width="1508" height="278" alt="image" src="https://github.com/user-attachments/assets/706592dc-6c8b-497d-9989-9fb6435cff97" />
 - search
   - fix `QueryInfo` : `text` key is required
     <img width="992" height="90" alt="search" src="https://github.com/user-attachments/assets/5195592f-9ef7-4dea-aa56-ac0c8cae4b69" />
 - webRequest
   - fix `OnBeforeRequestDetails`: `requestBody` is optional
 - declarativeNetRequest
    - update `TestMatchRequestDetails`: strengthens the typing of the key `responseHeaders`
 - userScripts
    - fix `RegisteredUserScript`: `js` is optional