### PR TITLE
[mssql] Use enum for MSSQLError error codes

### DIFF
--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -216,9 +216,32 @@ export interface config {
     beforeConnect?: ((conn: Connection) => void) | undefined;
 }
 
+export declare enum MSSQL_ERROR_CODE {
+    ELOGIN = "ELOGIN",
+    ETIMEOUT = "ETIMEOUT",
+    EDRIVER = "EDRIVER",
+    EALREADYCONNECTED = "EALREADYCONNECTED",
+    EALREADYCONNECTING = "EALREADYCONNECTING",
+    ENOTOPEN = "ENOTOPEN",
+    EINSTLOOKUP = "EINSTLOOKUP",
+    ESOCKET = "ESOCKET",
+    ECONNCLOSED = "ECONNCLOSED",
+    ENOTBEGUN = "ENOTBEGUN",
+    EALREADYBEGUN = "EALREADYBEGUN",
+    EREQINPROG = "EREQINPROG",
+    EABORT = "EABORT",
+    EREQUEST = "EREQUEST",
+    ECANCEL = "ECANCEL",
+    EARGS = "EARGS",
+    EINJECT = "EINJECT",
+    ENOCONN = "ENOCONN",
+    EALREADYPREPARED = "EALREADYPREPARED",
+    ENOTPREPARED = "ENOTPREPARED",
+}
+
 export declare class MSSQLError extends Error {
-    constructor(message: Error | string, code?: string);
-    public code: string;
+    constructor(message: Error | string, code?: MSSQL_ERROR_CODE);
+    public code: MSSQL_ERROR_CODE;
     public name: string;
     public originalError?: Error | undefined;
 }

--- a/types/mssql/mssql-tests.ts
+++ b/types/mssql/mssql-tests.ts
@@ -320,11 +320,11 @@ function test_mssql_errors() {
     // Test constructors
     const sqlDriverError = new Error("mock error");
     const mssqlStringError = new sql.MSSQLError("Something went wrong");
-    const baseMSSQLError = new sql.MSSQLError(sqlDriverError, "EREQUEST");
-    const connectionError = new sql.ConnectionError(sqlDriverError, "ELOGIN");
-    const requestError = new sql.RequestError(sqlDriverError, "EREQUEST");
-    const preparedStatementError = new sql.PreparedStatementError(sqlDriverError, "EINJECT");
-    const transactionError = new sql.TransactionError(sqlDriverError, "EABORT");
+    const baseMSSQLError = new sql.MSSQLError(sqlDriverError, sql.MSSQL_ERROR_CODE.EREQUEST);
+    const connectionError = new sql.ConnectionError(sqlDriverError, sql.MSSQL_ERROR_CODE.ELOGIN);
+    const requestError = new sql.RequestError(sqlDriverError, sql.MSSQL_ERROR_CODE.EREQUEST);
+    const preparedStatementError = new sql.PreparedStatementError(sqlDriverError, sql.MSSQL_ERROR_CODE.EINJECT);
+    const transactionError = new sql.TransactionError(sqlDriverError, sql.MSSQL_ERROR_CODE.EABORT);
 
     // Test inheritance
     if (


### PR DESCRIPTION
This PR changes the type of MSSQLError code from plain `string` to its own `enum`. This is based on the `mssql` package [documentation](https://www.npmjs.com/package/mssql#errors) about the errors: 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/mssql#errors
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
