### PR TITLE
[xrm] Modifying MultiSelectOptionSetAttribute.controls type

### DIFF
--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -3026,7 +3026,7 @@ declare namespace Xrm {
              * A collection of all the controls on the form that interface with this attribute.
              * @see {@link https://docs.microsoft.com/en-us/dynamics365/customer-engagement/developer/clientapi/reference/collections External Link: Collections (Client API reference)}
              */
-            controls: Collection.ItemCollection<Controls.OptionSetControl>;
+            controls: Collection.ItemCollection<Controls.MultiSelectOptionSetControl>;
         }
 
         /**

--- a/types/xrm/xrm-tests.ts
+++ b/types/xrm/xrm-tests.ts
@@ -206,7 +206,7 @@ if (multiSelectOptionSetAttributeEnum !== null) {
 }
 
 // Demonstrate that controls on a MultiSelectOptionSetAttribute are typed as MultiSelectOptionSetControl
-multiSelectOptionSetAttribute?.controls // $ExpectType ItemCollection<MultiSelectOptionSetControl> | undefined
+multiSelectOptionSetAttribute?.controls; // $ExpectType ItemCollection<MultiSelectOptionSetControl> | undefined
 
 /// Demonstrate setFormNotification
 

--- a/types/xrm/xrm-tests.ts
+++ b/types/xrm/xrm-tests.ts
@@ -205,6 +205,9 @@ if (multiSelectOptionSetAttributeEnum !== null) {
     const multiSelectOptionEnumValue: TestMultiSelectOptionSet[] | null = multiSelectOptionSetAttributeEnum.getValue();
 }
 
+// Demonstrate that controls on a MultiSelectOptionSetAttribute are typed as MultiSelectOptionSetControl
+multiSelectOptionSetAttribute?.controls // $ExpectType MultiSelectOptionSetControl[]
+
 /// Demonstrate setFormNotification
 
 let level: Xrm.FormNotificationLevel;

--- a/types/xrm/xrm-tests.ts
+++ b/types/xrm/xrm-tests.ts
@@ -206,7 +206,7 @@ if (multiSelectOptionSetAttributeEnum !== null) {
 }
 
 // Demonstrate that controls on a MultiSelectOptionSetAttribute are typed as MultiSelectOptionSetControl
-multiSelectOptionSetAttribute?.controls // $ExpectType MultiSelectOptionSetControl[]
+multiSelectOptionSetAttribute?.controls // $ExpectType ItemCollection<MultiSelectOptionSetControl> | undefined
 
 /// Demonstrate setFormNotification
 


### PR DESCRIPTION
 Modifying MultiSelectOptionSetAttribute.controls type to use the proper MultiSelectionOptionSetControl object

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://learn.microsoft.com/en-us/power-apps/developer/model-driven-apps/clientapi/reference/attributes/controls-collection
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
