### PR TITLE
[mapbox__mapbox-sdk] Fix GeocodeV6Request.proximity type

### DIFF
--- a/types/mapbox__mapbox-sdk/index.d.ts
+++ b/types/mapbox__mapbox-sdk/index.d.ts
@@ -919,7 +919,7 @@ declare module "@mapbox/mapbox-sdk/services/geocoding-v6" {
          * Bias local results based on a provided coordinate location or a
          * user's IP address.
          */
-        proximity?: Coordinates | "ip";
+        proximity?: MapiRequestCoordinates | "ip";
         /**
          * Filter results by feature types.
          */

--- a/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
+++ b/types/mapbox__mapbox-sdk/mapbox__mapbox-sdk-tests.ts
@@ -301,6 +301,22 @@ geocodeServiceV6
         });
     });
 
+geocodeServiceV6.forwardGeocode({
+    query: "Berlin",
+    proximity: [13.405, 52.52],
+});
+
+geocodeServiceV6.forwardGeocode({
+    query: "Berlin",
+    proximity: "ip",
+});
+
+geocodeServiceV6.forwardGeocode({
+    query: "Berlin",
+    // @ts-expect-error - object form should not be accepted for request proximity
+    proximity: { longitude: 13.405, latitude: 52.52 },
+});
+
 const optimizationService: OptimizationService = Optimization(config);
 optimizationService.getOptimization({
     profile: "driving",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change.
- [x] Follow the advice from the readme.
- [x] Avoid common mistakes.
- [x] Run `pnpm test mapbox__mapbox-sdk`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://docs.mapbox.com/api/search/geocoding/#forward-geocoding
  - https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/mapbox__mapbox-sdk/index.d.ts#L874
  - https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/mapbox__mapbox-sdk/index.d.ts#L922
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

## Summary

In `@mapbox/mapbox-sdk/services/geocoding-v6`, `GeocodeV6Request.proximity` is currently typed as `Coordinates | "ip"` where `Coordinates` resolves to an object shape (`{ longitude, latitude, ... }`) in this module.

At runtime, `proximity` accepts coordinate tuples (`[longitude, latitude]`) or `"ip"`. This mismatch causes incorrect TypeScript errors for valid usage and forces downstream casts.

This PR updates the type to use `MapiRequestCoordinates | "ip"` for `GeocodeV6Request.proximity`, aligning the v6 request type with runtime behavior and the existing imported tuple coordinate type.