### PR TITLE
fix(@types/node): accept ArrayBufferView in webcrypto SubtleCrypto methods

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -3963,7 +3963,10 @@ declare module "node:crypto" {
                 extractable: boolean,
                 keyUsages: readonly KeyUsage[],
             ): Promise<CryptoKey>;
-            digest(algorithm: AlgorithmIdentifier | CShakeParams, data: NodeJS.BufferSource | NodeJS.ArrayBufferView): Promise<ArrayBuffer>;
+            digest(
+                algorithm: AlgorithmIdentifier | CShakeParams,
+                data: NodeJS.BufferSource | NodeJS.ArrayBufferView,
+            ): Promise<ArrayBuffer>;
             encapsulateBits(
                 encapsulationAlgorithm: AlgorithmIdentifier,
                 encapsulationKey: CryptoKey,

--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -3949,7 +3949,7 @@ declare module "node:crypto" {
             decrypt(
                 algorithm: AlgorithmIdentifier | RsaOaepParams | AesCtrParams | AesCbcParams | AeadParams,
                 key: CryptoKey,
-                data: NodeJS.BufferSource,
+                data: NodeJS.BufferSource | NodeJS.ArrayBufferView,
             ): Promise<ArrayBuffer>;
             deriveBits(
                 algorithm: AlgorithmIdentifier | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params | Argon2Params,
@@ -3963,7 +3963,7 @@ declare module "node:crypto" {
                 extractable: boolean,
                 keyUsages: readonly KeyUsage[],
             ): Promise<CryptoKey>;
-            digest(algorithm: AlgorithmIdentifier | CShakeParams, data: NodeJS.BufferSource): Promise<ArrayBuffer>;
+            digest(algorithm: AlgorithmIdentifier | CShakeParams, data: NodeJS.BufferSource | NodeJS.ArrayBufferView): Promise<ArrayBuffer>;
             encapsulateBits(
                 encapsulationAlgorithm: AlgorithmIdentifier,
                 encapsulationKey: CryptoKey,
@@ -3978,7 +3978,7 @@ declare module "node:crypto" {
             encrypt(
                 algorithm: AlgorithmIdentifier | RsaOaepParams | AesCtrParams | AesCbcParams | AeadParams,
                 key: CryptoKey,
-                data: NodeJS.BufferSource,
+                data: NodeJS.BufferSource | NodeJS.ArrayBufferView,
             ): Promise<ArrayBuffer>;
             exportKey(format: "jwk", key: CryptoKey): Promise<JsonWebKey>;
             exportKey(format: Exclude<KeyFormat, "jwk">, key: CryptoKey): Promise<ArrayBuffer>;
@@ -4014,7 +4014,7 @@ declare module "node:crypto" {
             ): Promise<CryptoKey>;
             importKey(
                 format: Exclude<KeyFormat, "jwk">,
-                keyData: NodeJS.BufferSource,
+                keyData: NodeJS.BufferSource | NodeJS.ArrayBufferView,
                 algorithm:
                     | AlgorithmIdentifier
                     | RsaHashedImportParams
@@ -4028,11 +4028,11 @@ declare module "node:crypto" {
             sign(
                 algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams | ContextParams | KmacParams,
                 key: CryptoKey,
-                data: NodeJS.BufferSource,
+                data: NodeJS.BufferSource | NodeJS.ArrayBufferView,
             ): Promise<ArrayBuffer>;
             unwrapKey(
                 format: KeyFormat,
-                wrappedKey: NodeJS.BufferSource,
+                wrappedKey: NodeJS.BufferSource | NodeJS.ArrayBufferView,
                 unwrappingKey: CryptoKey,
                 unwrapAlgorithm: AlgorithmIdentifier | RsaOaepParams | AesCtrParams | AesCbcParams | AeadParams,
                 unwrappedKeyAlgorithm:
@@ -4048,8 +4048,8 @@ declare module "node:crypto" {
             verify(
                 algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams | ContextParams | KmacParams,
                 key: CryptoKey,
-                signature: NodeJS.BufferSource,
-                data: NodeJS.BufferSource,
+                signature: NodeJS.BufferSource | NodeJS.ArrayBufferView,
+                data: NodeJS.BufferSource | NodeJS.ArrayBufferView,
             ): Promise<boolean>;
             wrapKey(
                 format: KeyFormat,

--- a/types/node/node-tests/crypto.ts
+++ b/types/node/node-tests/crypto.ts
@@ -1911,6 +1911,22 @@ import { promisify } from "node:util";
     );
     subtle.verify({ name: "RSASSA-PKCS1-v1_5" }, key, buf, buf); // $ExpectType Promise<boolean>
     subtle.wrapKey("spki", key, key, { name: "AES-GCM", tagLength: 104, iv: buf }); // $ExpectType Promise<ArrayBuffer>
+
+    // Test: SubtleCrypto methods accept Uint8Array created via new Uint8Array(n).
+    // In TS 5.7+, new Uint8Array(n) infers Uint8Array<ArrayBufferLike> (not Uint8Array<ArrayBuffer>).
+    // These tests verify that the widened types (BufferSource | ArrayBufferView) work.
+    const rawKey = new Uint8Array(32);
+    const iv = new Uint8Array(12);
+    const data = new Uint8Array(64);
+    subtle.importKey("raw", rawKey, "AES-GCM", false, ["encrypt"]); // $ExpectType Promise<CryptoKey>
+    subtle.importKey("raw", rawKey, { name: "HKDF" }, false, ["deriveBits"]); // $ExpectType Promise<CryptoKey>
+    subtle.importKey("raw", rawKey, { name: "HMAC", hash: "SHA-256" }, false, ["sign", "verify"]); // $ExpectType Promise<CryptoKey>
+    subtle.encrypt({ name: "AES-GCM", iv }, key, data); // $ExpectType Promise<ArrayBuffer>
+    subtle.decrypt({ name: "AES-GCM", iv }, key, data); // $ExpectType Promise<ArrayBuffer>
+    subtle.sign("HMAC", key, data); // $ExpectType Promise<ArrayBuffer>
+    subtle.verify("HMAC", key, data, data); // $ExpectType Promise<boolean>
+    subtle.digest("SHA-256", data); // $ExpectType Promise<ArrayBuffer>
+    subtle.unwrapKey("raw", rawKey, key, "AES-KW", "AES-GCM", true, ["encrypt"]); // $ExpectType Promise<CryptoKey>
 }
 
 {


### PR DESCRIPTION
## Summary

Add `| NodeJS.ArrayBufferView` to data parameters in `webcrypto.SubtleCrypto` methods (`importKey`, `encrypt`, `decrypt`, `sign`, `verify`, `digest`, `unwrapKey`).

## Problem

TypeScript 5.7+ infers `Uint8Array<ArrayBufferLike>` for `new Uint8Array(n)`, which is not assignable to `NodeJS.BufferSource` (= `NonSharedArrayBufferView | ArrayBuffer`).

This causes type errors on all `SubtleCrypto` methods when passing a `Uint8Array` created via `new Uint8Array(n)` — a very common pattern:

\`\`\`typescript
const key = new Uint8Array(32);
// ERROR: Argument of type 'Uint8Array<ArrayBufferLike>' is not assignable to parameter of type 'BufferSource'
await webcrypto.subtle.importKey("raw", key, "AES-GCM", false, ["encrypt"]);
\`\`\`

## Root Cause

1. TS 5.7 made \`Uint8Array\` generic: \`Uint8Array<TArrayBuffer extends ArrayBufferLike>\`
2. \`new Uint8Array(32)\` produces \`Uint8Array<ArrayBufferLike>\` (default generic)
3. \`NodeJS.BufferSource\` requires \`NonSharedArrayBufferView\` = \`ArrayBufferView<ArrayBuffer>\`
4. \`Uint8Array<ArrayBufferLike>\` is NOT assignable to \`Uint8Array<ArrayBuffer>\`

At runtime, \`new Uint8Array(32)\` always creates a view over a regular \`ArrayBuffer\`, and Node.js's \`SubtleCrypto\` accepts it without issue.

## Solution

Add \`NodeJS.ArrayBufferView\` as an accepted type alongside \`NodeJS.BufferSource\` for data parameters. This matches Node.js's runtime behavior without modifying the \`BufferSource\` type itself (which follows the WebIDL spec).

**Additive change** — no existing signatures modified. All previously-compiling code continues to compile.

## Methods Updated

- \`importKey\` (raw format overload) — \`keyData\`
- \`encrypt\` — \`data\`
- \`decrypt\` — \`data\`
- \`sign\` — \`data\`
- \`verify\` — \`signature\` + \`data\`
- \`digest\` — \`data\`
- \`unwrapKey\` — \`wrappedKey\`

## Impact

Every Node.js + TypeScript developer using \`webcrypto\` in strict mode. Eliminates the need for \`as any\` or \`as unknown as BufferSource\` workarounds.

---

*Contributed by [Continuum Identity](https://continuum-identity.com) — maintainers of [2FApi](https://gitlab.continuum-identity.com/continuum-identity/2fapi), a zero-knowledge proof authentication protocol for APIs.*