### PR TITLE
[scriptable-ios] fix `UITableRow.onSelect` type: add `index` param, m…

### DIFF
--- a/types/scriptable-ios/index.d.ts
+++ b/types/scriptable-ios/index.d.ts
@@ -6077,12 +6077,14 @@ declare class UITableRow {
     /**
      * _Called when the row is selected._
      *
-     * Called when the row is selected when the table is presented. If this has no value, the row cannot be selected. Defaults to null.
+     * Called when the row is selected when the table is presented. If this has no value, the row cannot be selected. Defaults to `undefined`.
+     *
+     * The `index` parameter starts from 1.
      *
      * Rows cannot be tapped when the tables is presented in Siri.
      * @see https://docs.scriptable.app/uitablerow/#onselect
      */
-    onSelect: () => void;
+    onSelect: ((index: number) => void) | undefined;
 }
 
 /**

--- a/types/scriptable-ios/scriptable-ios-tests.ts
+++ b/types/scriptable-ios/scriptable-ios-tests.ts
@@ -1031,7 +1031,9 @@
 }
 
 {
-    // TODO: UITableRow
+    const row = new UITableRow();
+    // $ExpectType ((index: number) => void) | undefined
+    row.onSelect;
 }
 
 {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see below
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.


Cross-posting prior discussion from https://talk.automators.fm/t/scriptable-json-is-gone/19108/4 for `UITableRow.onSelect`, basically this PR is patching some upstream upstream issues in Scriptable docs (https://docs.scriptable.app/uitablerow/#onselect)

- defined as `onSelect: () => void`, but actually it has 1 argument - `index`, so it should be `onSelect: (index: number) => void`
- docs state `Defaults to null`, but it's not reflected in the type; docs are not entirely correct here - it actually defaults to `undefined`, so the definition should be `onSelect: ((index: number) => void) | undefined`
- noted that  `index` in `onSelect` starts from `1`, since it seems a bit unexpected until you stumble upon it