### PR TITLE
[jsdom] Update parse5 dependency to match jsdom dependency

### DIFF
--- a/types/jsdom/index.d.ts
+++ b/types/jsdom/index.d.ts
@@ -3,7 +3,7 @@
 /// <reference types="node" />
 
 import { EventEmitter } from "events";
-import { Token } from "parse5";
+import type { Token } from "parse5" with { "resolution-mode": "import" };
 import * as tough from "tough-cookie";
 import { Dispatcher } from "undici-types";
 import { Context } from "vm";

--- a/types/jsdom/package.json
+++ b/types/jsdom/package.json
@@ -13,9 +13,10 @@
     "dependencies": {
         "@types/node": "*",
         "@types/tough-cookie": "*",
-        "parse5": "^7.0.0",
+        "parse5": "^8.0.0",
         "undici-types": "^7.21.0"
     },
+    "minimumTypeScriptVersion": "5.3",
     "devDependencies": {
         "@types/jsdom": "workspace:."
     },


### PR DESCRIPTION
Since jsdom v27.0.1, the module has the dependency `parse5@^8.0.0`. See the commit:

https://github.com/jsdom/jsdom/commit/894151baf0603c5d2203261ce9f4748295e6681c

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
