### PR TITLE
google-apps-script: widen Console method parameter from `object | string` to `any`

### DIFF
--- a/types/google-apps-script/google-apps-script.base.d.ts
+++ b/types/google-apps-script/google-apps-script.base.d.ts
@@ -2,15 +2,15 @@
 
 interface Console {
     error(): void;
-    error(formatOrObject: object | string, ...values: any[]): void;
+    error(formatOrObject: any, ...values: any[]): void;
     info(): void;
-    info(formatOrObject: object | string, ...values: any[]): void;
+    info(formatOrObject: any, ...values: any[]): void;
     log(): void;
-    log(formatOrObject: object | string, ...values: any[]): void;
+    log(formatOrObject: any, ...values: any[]): void;
     time(label: string): void;
     timeEnd(label: string): void;
     warn(): void;
-    warn(formatOrObject: object | string, ...values: any[]): void;
+    warn(formatOrObject: any, ...values: any[]): void;
 }
 
 declare namespace GoogleAppsScript {

--- a/types/google-apps-script/test/google-apps-script-tests.ts
+++ b/types/google-apps-script/test/google-apps-script-tests.ts
@@ -332,6 +332,10 @@ console.info("info");
 console.warn("warn");
 console.error("error");
 console.log("Console can use %s and %d format string.", "hello", 2);
+console.log(42);
+console.info(true);
+console.warn(null);
+console.error(undefined);
 
 // Data Studio Request
 const request: GoogleAppsScript.Data_Studio.Request<any> = {


### PR DESCRIPTION
The Console interface methods (error, info, log, warn) previously typed their first argument as `object | string`, which incorrectly rejects primitive values like numbers and booleans. The Google Apps Script documentation specifies the parameter as Object, which in JS/GAS accepts any value. This aligns with standard TS console typings in lib.dom.d.ts and @types/node which use `any`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests). — Ran locally; all 118 errors are pre-existing `no-bad-reference` lint issues on `master`, none introduced by this change.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/apps-script/reference/base/console
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.