### PR TITLE
[google-apps-script-oauth2] Update types for version 43

### DIFF
--- a/types/google-apps-script-oauth2/google-apps-script-oauth2-tests.ts
+++ b/types/google-apps-script-oauth2/google-apps-script-oauth2-tests.ts
@@ -1,4 +1,4 @@
-// Examples from https://github.com/googlesamples/apps-script-oauth2
+// Examples from https://github.com/googleworkspace/apps-script-oauth2
 
 /**
  * Create the OAuth2 service.
@@ -15,6 +15,73 @@ function getDriveService() {
         .setParam("login_hint", Session.getActiveUser().getEmail())
         .setParam("access_type", "offline")
         .setParam("approval_prompt", "force");
+}
+
+/**
+ * Create sample service for Twitter.
+ */
+function getTwitterService() {
+    const userProps = PropertiesService.getUserProperties();
+    const clientId = "sampleClientId";
+    const clientSecret = "sampleClientSecret";
+
+    return OAuth2.createService("Twitter")
+        .setAuthorizationBaseUrl("https://twitter.com/i/oauth2/authorize")
+        .setTokenUrl("https://api.twitter.com/2/oauth2/token")
+        .setClientId(clientId)
+        .setClientSecret(clientSecret)
+        .setCallbackFunction("authCallback")
+        .setPropertyStore(userProps)
+        .setScope("users.read tweet.read offline.access")
+        .generateCodeVerifier()
+        .setTokenHeaders({
+            "Authorization": "Basic " + Utilities.base64Encode(clientId + ":" + clientSecret),
+            "Content-Type": "application/x-www-form-urlencoded",
+        });
+}
+
+/**
+ * Create sample service with custom token method.
+ */
+function getTestClientWithCustomTokenMethod() {
+    return OAuth2.createService("TestService")
+        .setAuthorizationBaseUrl("https://example.com/auth")
+        .setTokenUrl("https://example.com/token")
+        .setClientId("sampleClientId")
+        .setClientSecret("sampleClientSecret")
+        .setCallbackFunction("authCallback")
+        .setPropertyStore(PropertiesService.getUserProperties())
+        .setTokenMethod("PUT");
+}
+
+/**
+ * Create sample service with code verifier and S256 code challenge method.
+ */
+function getTestClientWithAutoCodeVerifierAndS256ChallengeMethod() {
+    return OAuth2.createService("TestService")
+        .setAuthorizationBaseUrl("https://example.com/auth")
+        .setTokenUrl("https://example.com/token")
+        .setClientId("sampleClientId")
+        .setClientSecret("sampleClientSecret")
+        .setCallbackFunction("authCallback")
+        .setPropertyStore(PropertiesService.getUserProperties())
+        .generateCodeVerifier()
+        .setCodeChallengeMethod(GoogleAppsScriptOAuth2.CodeChallengeMethod.S256);
+}
+
+/**
+ * Create sample service with code verifier and S256 code challenge method.
+ */
+function getTestClientWithManualCodeVerifierAndPlainChallengeMethod() {
+    return OAuth2.createService("TestService")
+        .setAuthorizationBaseUrl("https://example.com/auth")
+        .setTokenUrl("https://example.com/token")
+        .setClientId("sampleClientId")
+        .setClientSecret("sampleClientSecret")
+        .setCallbackFunction("authCallback")
+        .setPropertyStore(PropertiesService.getUserProperties())
+        .setCodeVerififer("sampleCodeVerifier")
+        .setCodeChallengeMethod(GoogleAppsScriptOAuth2.CodeChallengeMethod.PLAIN);
 }
 
 /**

--- a/types/google-apps-script-oauth2/index.d.ts
+++ b/types/google-apps-script-oauth2/index.d.ts
@@ -217,6 +217,26 @@ declare namespace GoogleAppsScriptOAuth2 {
          * For Google services this URL should be `https://accounts.google.com/o/oauth2/token`.
          */
         setTokenUrl(tokenUrl: string): OAuth2Service;
+        /**
+         * Sets the HTTP method to use when retrieving or refreshing the access token.
+         * Default: `post`.
+         */
+        setTokenMethod(tokenMethod: string): OAuth2Service;
+        /**
+         * Set the code verifier used for PKCE. For most use cases,
+         * prefer `generateCodeVerifier` to automatically initialize the
+         * value with a generated challenge string.
+         */
+        setCodeVerififer(codeVerifier: string): OAuth2Service;
+        /**
+         * Sets the code verifier to a randomly generated challenge string.
+         */
+        generateCodeVerifier(): OAuth2Service;
+        /**
+         * Set the code challenge method for PKCE. The default value method
+         * when a code verifier is set is `S256`.
+         */
+        setCodeChallengeMethod(method: CodeChallengeMethod): OAuth2Service;
     }
 
     enum TokenFormat {
@@ -228,6 +248,11 @@ declare namespace GoogleAppsScriptOAuth2 {
          * Form URL-encoded, for example `access_token=...`.
          */
         FORM_URL_ENCODED = "application/x-www-form-urlencoded",
+    }
+
+    enum CodeChallengeMethod {
+        S256 = "S256",
+        PLAIN = "plain",
     }
 
     interface TokenPayload {

--- a/types/google-apps-script-oauth2/index.d.ts
+++ b/types/google-apps-script-oauth2/index.d.ts
@@ -17,6 +17,13 @@ declare namespace GoogleAppsScriptOAuth2 {
          * Often this URI needs to be entered into a configuration screen of your OAuth provider.
          */
         getRedirectUri(scriptId?: string): string;
+        /**
+         * Gets the list of services with tokens stored in the given property store.
+         * This is useful if you connect to the same API with multiple accounts and
+         * need to keep track of them. If no stored tokens are found this will return
+         * an empty array.
+         */
+        getServiceNames(propertyStore: GoogleAppsScript.Properties.PropertiesService): string[];
     }
 
     interface Storage {

--- a/types/google-apps-script-oauth2/package.json
+++ b/types/google-apps-script-oauth2/package.json
@@ -5,7 +5,7 @@
     "nonNpm": true,
     "nonNpmDescription": "google-apps-script-oauth2",
     "projects": [
-        "https://github.com/googlesamples/apps-script-oauth2"
+        "https://github.com/googleworkspace/apps-script-oauth2"
     ],
     "dependencies": {
         "@types/google-apps-script": "*"

--- a/types/google-apps-script-oauth2/package.json
+++ b/types/google-apps-script-oauth2/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/google-apps-script-oauth2",
-    "version": "38.0.9999",
+    "version": "43.0.9999",
     "nonNpm": true,
     "nonNpmDescription": "google-apps-script-oauth2",
     "projects": [


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/googleworkspace/apps-script-oauth2
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

This PR updates type definitions to reflect version 43 of the library.

Note that there is a typo in the original library for `setCodeVerififer()`, therefore the type definition also reflects it with typo. This should be adjusted once the library is also fixed.
See source at https://github.com/googleworkspace/apps-script-oauth2/blob/v1.43.0/src/Service.js#L129