### PR TITLE
[@types/superagent] Accept global Blob in attach() and field()

### DIFF
--- a/types/superagent/lib/node/index.d.ts
+++ b/types/superagent/lib/node/index.d.ts
@@ -14,6 +14,10 @@ import { AppendOptions } from "form-data";
 import { AgentOptions as SAgentOptions, CBHandler, URLType } from "../../types";
 import { Request as Http2Request } from "./http2wrapper";
 
+type GlobalBlob = typeof globalThis extends { Blob: infer T } ? T extends abstract new(...args: any) => infer I ? I
+    : never
+    : never;
+
 type HttpMethod<Req extends request.Request> =
     | ((url: URLType, callback?: CBHandler) => Req)
     | ((url: URLType, data?: string | Record<string, any>, callback?: CBHandler) => Req);
@@ -57,15 +61,15 @@ declare class SARequest extends Stream implements RequestBase {
     field(
         fields: {
             [fieldName: string]:
-                | (string | number | boolean | Blob | Buffer | ReadStream)
-                | Array<string | number | boolean | Blob | Buffer | ReadStream>;
+                | request.MultipartValueSingle
+                | Array<request.MultipartValueSingle>;
         },
     ): this;
     field(
         name: string,
         val:
-            | (string | number | boolean | Blob | Buffer | ReadStream)
-            | Array<string | number | boolean | Blob | Buffer | ReadStream>,
+            | request.MultipartValueSingle
+            | Array<request.MultipartValueSingle>,
         options?: AppendOptions | string,
     ): this;
     finally(onfinally?: (() => void) | null): Promise<ResponseBase>;
@@ -119,7 +123,7 @@ declare namespace request {
 
     type CallbackHandler = CBHandler;
 
-    type MultipartValueSingle = Blob | Buffer | ReadStream | string | boolean | number;
+    type MultipartValueSingle = GlobalBlob | Blob | Buffer | ReadStream | string | boolean | number;
 
     interface ProgressEvent {
         direction: "download" | "upload";

--- a/types/superagent/superagent-tests.ts
+++ b/types/superagent/superagent-tests.ts
@@ -206,6 +206,7 @@ request.get("http://example.com/search").retry(2, callback).end(callback);
 
 // Attaching files
 const blob = new Blob([]);
+const globalBlob = new globalThis.Blob([]);
 request
     .post("/upload")
     .attach("avatar", "path/to/tobi.png", "user.png")
@@ -213,6 +214,7 @@ request
     .attach("file", "path/to/jane.png")
     .attach("fileWithOptions", "path/to/file.png", { filename: "filename", contentType: "contentType" })
     .attach("blob", blob)
+    .attach("globalBlob", globalBlob)
     .end(callback);
 
 // Field values


### PR DESCRIPTION
`.attach()` and `.field()` reject the browser/DOM `Blob` (e.g. `new Blob(...)` in projects with `lib: ["DOM"]`) because the typings only accept `import("buffer").Blob`.

This adds a conditional `GlobalBlob` type that picks up `globalThis.Blob` when it exists, or `never` when it doesn't, so in older environments without a global `Blob` the resulting union is unchanged. It also updates `field()` to reuse `request.MultipartValueSingle`, like `attach()`.

  - [x] Use a meaningful title for the pull request. Include the name of the package modified.
  - [x] Test the change in your own code. (Compile and run.)
  - [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
  - [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
  - [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
  - [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

  If changing an existing definition:

  - [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - superagent source documenting Blob support: https://github.com/forwardemail/superagent/blob/master/src/request-base.js#L404-L466
    - DOM Blob vs buffer.Blob type identity incompatibility: https://github.com/microsoft/TypeScript/issues/53668
  - [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.