### PR TITLE
Add @types/chartmogul-node for Invoice updateStatus/disable/enable, SubscriptionEvent disable/enable, and error fields

### DIFF
--- a/types/chartmogul-node/chartmogul-node-tests.ts
+++ b/types/chartmogul-node/chartmogul-node-tests.ts
@@ -68,10 +68,32 @@ ChartMogul.JsonImport.create(config, "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba", 
     external_id: "ds_import_1",
     customers: [{ external_id: "cus_001", name: "Test Customer" }],
     plans: [{ name: "Gold", external_id: "gold", interval_count: 1, interval_unit: "month" }],
-    invoices: [{ external_id: "inv_001", date: "2023-04-02", currency: "USD", customer_external_id: "cus_001" }],
-    line_items: [{ type: "subscription", amount_in_cents: 1000, invoice_external_id: "inv_001" }],
-    transactions: [{ type: "payment", result: "successful", date: "2023-04-02", invoice_external_id: "inv_001" }],
-    subscription_events: [{ event_type: "subscription_start", event_date: "2023-04-02" }],
+    invoices: [{
+        external_id: "inv_001",
+        date: "2023-04-02",
+        currency: "USD",
+        customer_external_id: "cus_001",
+    }],
+    line_items: [{
+        type: "subscription",
+        amount_in_cents: 1000,
+        invoice_external_id: "inv_001",
+        subscription_external_id: "sub_001",
+        plan_external_id: "gold",
+    }],
+    transactions: [{
+        type: "payment",
+        result: "successful",
+        date: "2023-04-02",
+        invoice_external_id: "inv_001",
+    }],
+    subscription_events: [{
+        customer_external_id: "cus_001",
+        event_type: "subscription_start",
+        event_date: "2023-04-02",
+        effective_date: "2023-04-02",
+        subscription_external_id: "sub_001",
+    }],
 });
 
 // $ExpectType Promise<JsonImportStatus>
@@ -1605,7 +1627,13 @@ ChartMogul.SubscriptionEvent.deleteWithParams(config, {
 ChartMogul.SubscriptionEvent.disable(config, 12345);
 
 // $ExpectType Promise<SubscriptionEvent>
+ChartMogul.SubscriptionEvent.disable(config, "12345");
+
+// $ExpectType Promise<SubscriptionEvent>
 ChartMogul.SubscriptionEvent.enable(config, 12345);
+
+// $ExpectType Promise<SubscriptionEvent>
+ChartMogul.SubscriptionEvent.enable(config, "12345");
 
 // Metrics.ActivitiesExport.create
 

--- a/types/chartmogul-node/chartmogul-node-tests.ts
+++ b/types/chartmogul-node/chartmogul-node-tests.ts
@@ -1156,6 +1156,31 @@ ChartMogul.Invoice.disable(config, "inv_565c73b2-85b9-49c9-a25e-2b7df6a677c9", {
 // $ExpectType Promise<Invoice>
 ChartMogul.Invoice.enable(config, "inv_565c73b2-85b9-49c9-a25e-2b7df6a677c9");
 
+// Invoice query-param methods (PIP-306)
+
+// $ExpectType Promise<Invoice>
+ChartMogul.Invoice.update(config, {
+    qs: { data_source_uuid: "ds_uuid", external_id: "INV0001" },
+    currency: "EUR",
+});
+
+// $ExpectType Promise<ResourceDestroyed>
+ChartMogul.Invoice.destroyByExternalId(config, {
+    qs: { data_source_uuid: "ds_uuid", external_id: "INV0001" },
+});
+
+// $ExpectType Promise<Invoice>
+ChartMogul.Invoice.disableByExternalId(config, {
+    data_source_uuid: "ds_uuid",
+    external_id: "INV0001",
+});
+
+// $ExpectType Promise<Invoice>
+ChartMogul.Invoice.enableByExternalId(config, {
+    data_source_uuid: "ds_uuid",
+    external_id: "INV0001",
+});
+
 ChartMogul.Invoice.all(config, "", {
     page: 1,
 });
@@ -1192,6 +1217,68 @@ ChartMogul.Transaction.create(config, "inv_565c73b2-85b9-49c9-a25e-2b7df6a677c9"
     amount_in_cents: 1000,
     transaction_fees_in_cents: 350,
     transaction_fees_currency: "EUR",
+});
+
+// LineItem query-param methods (PIP-306)
+
+// $ExpectType Promise<LineItems>
+ChartMogul.LineItem.all(config, {
+    data_source_uuid: "ds_uuid",
+    external_id: "li_ext_001",
+});
+
+// $ExpectType Promise<LineItem>
+ChartMogul.LineItem.update(config, {
+    qs: { data_source_uuid: "ds_uuid", external_id: "li_ext_001" },
+    amount_in_cents: 20000,
+});
+
+// $ExpectType Promise<ResourceDestroyed>
+ChartMogul.LineItem.destroy(config, {
+    qs: { data_source_uuid: "ds_uuid", external_id: "li_ext_001" },
+});
+
+// $ExpectType Promise<LineItem>
+ChartMogul.LineItem.disable(config, {
+    data_source_uuid: "ds_uuid",
+    external_id: "li_ext_001",
+});
+
+// $ExpectType Promise<LineItem>
+ChartMogul.LineItem.enable(config, {
+    data_source_uuid: "ds_uuid",
+    external_id: "li_ext_001",
+});
+
+// Transaction query-param methods (PIP-306)
+
+// $ExpectType Promise<Transactions>
+ChartMogul.Transaction.all(config, {
+    data_source_uuid: "ds_uuid",
+    external_id: "tr_ext_001",
+});
+
+// $ExpectType Promise<Transaction>
+ChartMogul.Transaction.update(config, {
+    qs: { data_source_uuid: "ds_uuid", external_id: "tr_ext_001" },
+    result: "failed",
+});
+
+// $ExpectType Promise<ResourceDestroyed>
+ChartMogul.Transaction.destroy(config, {
+    qs: { data_source_uuid: "ds_uuid", external_id: "tr_ext_001" },
+});
+
+// $ExpectType Promise<Transaction>
+ChartMogul.Transaction.disable(config, {
+    data_source_uuid: "ds_uuid",
+    external_id: "tr_ext_001",
+});
+
+// $ExpectType Promise<Transaction>
+ChartMogul.Transaction.enable(config, {
+    data_source_uuid: "ds_uuid",
+    external_id: "tr_ext_001",
 });
 
 ChartMogul.Subscription.cancel(config, "", {

--- a/types/chartmogul-node/chartmogul-node-tests.ts
+++ b/types/chartmogul-node/chartmogul-node-tests.ts
@@ -1337,6 +1337,25 @@ ChartMogul.LineItem.enableByExternalId(config, {
     external_id: "li_ext_001",
 });
 
+// Transaction UUID-based methods
+
+// $ExpectType Promise<Transaction>
+ChartMogul.Transaction.retrieve(config, "tr_592f4699-107b-41b9-b7bc-a2aa2ca7a67b");
+
+// $ExpectType Promise<Transaction>
+ChartMogul.Transaction.modify(config, "tr_592f4699-107b-41b9-b7bc-a2aa2ca7a67b", {
+    result: "failed",
+});
+
+// $ExpectType Promise<ResourceDestroyed>
+ChartMogul.Transaction.destroy(config, "tr_592f4699-107b-41b9-b7bc-a2aa2ca7a67b");
+
+// $ExpectType Promise<Transaction>
+ChartMogul.Transaction.disable(config, "tr_592f4699-107b-41b9-b7bc-a2aa2ca7a67b");
+
+// $ExpectType Promise<Transaction>
+ChartMogul.Transaction.enable(config, "tr_592f4699-107b-41b9-b7bc-a2aa2ca7a67b");
+
 // Transaction query-param methods (PIP-306)
 
 // $ExpectType Promise<Transactions>
@@ -1352,7 +1371,7 @@ ChartMogul.Transaction.update(config, {
 });
 
 // $ExpectType Promise<ResourceDestroyed>
-ChartMogul.Transaction.destroy(config, {
+ChartMogul.Transaction.destroyByExternalId(config, {
     qs: { data_source_uuid: "ds_uuid", external_id: "tr_ext_001" },
 });
 
@@ -1364,6 +1383,18 @@ ChartMogul.Transaction.disable(config, {
 
 // $ExpectType Promise<Transaction>
 ChartMogul.Transaction.enable(config, {
+    data_source_uuid: "ds_uuid",
+    external_id: "tr_ext_001",
+});
+
+// $ExpectType Promise<Transaction>
+ChartMogul.Transaction.disableByExternalId(config, {
+    data_source_uuid: "ds_uuid",
+    external_id: "tr_ext_001",
+});
+
+// $ExpectType Promise<Transaction>
+ChartMogul.Transaction.enableByExternalId(config, {
     data_source_uuid: "ds_uuid",
     external_id: "tr_ext_001",
 });

--- a/types/chartmogul-node/chartmogul-node-tests.ts
+++ b/types/chartmogul-node/chartmogul-node-tests.ts
@@ -1325,6 +1325,10 @@ ChartMogul.Transaction.enable(config, {
     external_id: "tr_ext_001",
 });
 
+const txnWithError: ChartMogul.Transaction.Transaction = {};
+// $ExpectType string | null | undefined
+txnWithError.error;
+
 ChartMogul.Subscription.cancel(config, "", {
     cancelled_at: "",
 });

--- a/types/chartmogul-node/chartmogul-node-tests.ts
+++ b/types/chartmogul-node/chartmogul-node-tests.ts
@@ -1180,7 +1180,10 @@ ChartMogul.Invoice.modify(config, "inv_f466e33d-ff2b-4a11-8f85-417eb02157a7", {
 ChartMogul.Invoice.destroy(config, "");
 
 // $ExpectType Promise<ResourceDestroyed>
-ChartMogul.Invoice.destroy_all(config, "ds_uuid", "cus_uuid");
+ChartMogul.Invoice.destroyAll(config, "ds_uuid", "cus_uuid");
+
+// $ExpectType Promise<ResourceDestroyed>
+ChartMogul.Invoice.destroy_all(config, "ds_uuid", "cus_uuid"); // deprecated alias
 
 // $ExpectType Promise<UpdateStatusResponse>
 ChartMogul.Invoice.updateStatus(config, "ds_uuid", "INV0001", { status: "voided" });

--- a/types/chartmogul-node/chartmogul-node-tests.ts
+++ b/types/chartmogul-node/chartmogul-node-tests.ts
@@ -1179,9 +1179,6 @@ ChartMogul.Invoice.modify(config, "inv_f466e33d-ff2b-4a11-8f85-417eb02157a7", {
 // $ExpectType Promise<ResourceDestroyed>
 ChartMogul.Invoice.destroy(config, "");
 
-// $ExpectType Promise<ResourceDestroyed>
-ChartMogul.Invoice.destroy_all(config, "ds_uuid", "cus_uuid");
-
 // $ExpectType Promise<UpdateStatusResponse>
 ChartMogul.Invoice.updateStatus(config, "ds_uuid", "INV0001", { status: "voided" });
 

--- a/types/chartmogul-node/chartmogul-node-tests.ts
+++ b/types/chartmogul-node/chartmogul-node-tests.ts
@@ -1138,6 +1138,24 @@ ChartMogul.Invoice.modify(config, "inv_f466e33d-ff2b-4a11-8f85-417eb02157a7", {
 // $ExpectType Promise<ResourceDestroyed>
 ChartMogul.Invoice.destroy(config, "");
 
+// $ExpectType Promise<ResourceDestroyed>
+ChartMogul.Invoice.destroy_all(config, "ds_uuid", "cus_uuid");
+
+// $ExpectType Promise<UpdateStatusResponse>
+ChartMogul.Invoice.updateStatus(config, "ds_uuid", "INV0001", { status: "voided" });
+
+// $ExpectType Promise<UpdateStatusResponse>
+ChartMogul.Invoice.updateStatus(config, "ds_uuid", "INV0001", { status: "written_off" });
+
+// $ExpectType Promise<Invoice>
+ChartMogul.Invoice.disable(config, "inv_565c73b2-85b9-49c9-a25e-2b7df6a677c9");
+
+// $ExpectType Promise<Invoice>
+ChartMogul.Invoice.disable(config, "inv_565c73b2-85b9-49c9-a25e-2b7df6a677c9", { reason: "duplicate" });
+
+// $ExpectType Promise<Invoice>
+ChartMogul.Invoice.enable(config, "inv_565c73b2-85b9-49c9-a25e-2b7df6a677c9");
+
 ChartMogul.Invoice.all(config, "", {
     page: 1,
 });
@@ -1453,6 +1471,35 @@ ChartMogul.SubscriptionEvent.deleteWithParams(config, {
         id: 23223966,
     },
 });
+
+// SubscriptionEvent flat params (auto-wrapped)
+
+// $ExpectType Promise<SubscriptionEvent>
+ChartMogul.SubscriptionEvent.create(config, {
+    data_source_uuid: "ds_14336c0c-ab0b-11ec-8c55-c3902af70e1c",
+    customer_external_id: "cus_001",
+    event_type: "subscription_cancelled",
+    event_date: "2022-04-09T12:30:00.000Z",
+    effective_date: "2022-04-09T12:30:00.000Z",
+    subscription_external_id: "sub_001",
+});
+
+// $ExpectType Promise<SubscriptionEvent>
+ChartMogul.SubscriptionEvent.updateWithParams(config, {
+    id: 12345,
+    event_type: "subscription_cancelled",
+});
+
+// $ExpectType Promise<ResourceDestroyed>
+ChartMogul.SubscriptionEvent.deleteWithParams(config, {
+    id: 12345,
+});
+
+// $ExpectType Promise<SubscriptionEvent>
+ChartMogul.SubscriptionEvent.disable(config, 12345);
+
+// $ExpectType Promise<SubscriptionEvent>
+ChartMogul.SubscriptionEvent.enable(config, 12345);
 
 // Metrics.ActivitiesExport.create
 

--- a/types/chartmogul-node/chartmogul-node-tests.ts
+++ b/types/chartmogul-node/chartmogul-node-tests.ts
@@ -1263,6 +1263,37 @@ ChartMogul.Transaction.create(config, "inv_565c73b2-85b9-49c9-a25e-2b7df6a677c9"
     transaction_fees_currency: "EUR",
 });
 
+// LineItem UUID-based methods
+
+// $ExpectType Promise<LineItem>
+ChartMogul.LineItem.create(config, "inv_79eaad44-3379-4239-af83-2e0047dbebe6", {
+    type: "subscription",
+    amount_in_cents: 10000,
+    quantity: 1,
+    external_id: "li_ext_id_00762",
+    subscription_external_id: "sub_added_line_item_via_api_1",
+    plan_uuid: "pl_3eb4efb2-d101-4dce-a664-be271b0da4de",
+    service_period_start: "2022-11-01T00:00:00.000Z",
+    service_period_end: "2022-12-01T00:00:00.000Z",
+});
+
+// $ExpectType Promise<LineItem>
+ChartMogul.LineItem.retrieve(config, "li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b");
+
+// $ExpectType Promise<LineItem>
+ChartMogul.LineItem.modify(config, "li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b", {
+    amount_in_cents: 20000,
+});
+
+// $ExpectType Promise<ResourceDestroyed>
+ChartMogul.LineItem.destroy(config, "li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b");
+
+// $ExpectType Promise<LineItem>
+ChartMogul.LineItem.disable(config, "li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b");
+
+// $ExpectType Promise<LineItem>
+ChartMogul.LineItem.enable(config, "li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b");
+
 // LineItem query-param methods (PIP-306)
 
 // $ExpectType Promise<LineItems>
@@ -1278,7 +1309,7 @@ ChartMogul.LineItem.update(config, {
 });
 
 // $ExpectType Promise<ResourceDestroyed>
-ChartMogul.LineItem.destroy(config, {
+ChartMogul.LineItem.destroyByExternalId(config, {
     qs: { data_source_uuid: "ds_uuid", external_id: "li_ext_001" },
 });
 
@@ -1290,6 +1321,18 @@ ChartMogul.LineItem.disable(config, {
 
 // $ExpectType Promise<LineItem>
 ChartMogul.LineItem.enable(config, {
+    data_source_uuid: "ds_uuid",
+    external_id: "li_ext_001",
+});
+
+// $ExpectType Promise<LineItem>
+ChartMogul.LineItem.disableByExternalId(config, {
+    data_source_uuid: "ds_uuid",
+    external_id: "li_ext_001",
+});
+
+// $ExpectType Promise<LineItem>
+ChartMogul.LineItem.enableByExternalId(config, {
     data_source_uuid: "ds_uuid",
     external_id: "li_ext_001",
 });

--- a/types/chartmogul-node/chartmogul-node-tests.ts
+++ b/types/chartmogul-node/chartmogul-node-tests.ts
@@ -63,6 +63,25 @@ ChartMogul.DataSource.all(config, {
     with_invoice_handling_setting: true,
 });
 
+// $ExpectType Promise<JsonImportStatus>
+ChartMogul.JsonImport.create(config, "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba", {
+    external_id: "ds_import_1",
+    customers: [{ external_id: "cus_001", name: "Test Customer" }],
+    plans: [{ name: "Gold", external_id: "gold", interval_count: 1, interval_unit: "month" }],
+    invoices: [{ external_id: "inv_001", date: "2023-04-02", currency: "USD", customer_external_id: "cus_001" }],
+    line_items: [{ type: "subscription", amount_in_cents: 1000, invoice_external_id: "inv_001" }],
+    transactions: [{ type: "payment", result: "successful", date: "2023-04-02", invoice_external_id: "inv_001" }],
+    subscription_events: [{ event_type: "subscription_start", event_date: "2023-04-02" }],
+});
+
+// $ExpectType Promise<JsonImportStatus>
+ChartMogul.JsonImport.create(config, "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba", {
+    external_id: "ds_import_2",
+});
+
+// $ExpectType Promise<JsonImportStatus>
+ChartMogul.JsonImport.retrieve(config, "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba", "ds_import_1");
+
 // $ExpectType Promise<Customer>
 ChartMogul.Customer.create(config, {
     data_source_uuid: "",

--- a/types/chartmogul-node/chartmogul-node-tests.ts
+++ b/types/chartmogul-node/chartmogul-node-tests.ts
@@ -1179,6 +1179,9 @@ ChartMogul.Invoice.modify(config, "inv_f466e33d-ff2b-4a11-8f85-417eb02157a7", {
 // $ExpectType Promise<ResourceDestroyed>
 ChartMogul.Invoice.destroy(config, "");
 
+// $ExpectType Promise<ResourceDestroyed>
+ChartMogul.Invoice.destroy_all(config, "ds_uuid", "cus_uuid");
+
 // $ExpectType Promise<UpdateStatusResponse>
 ChartMogul.Invoice.updateStatus(config, "ds_uuid", "INV0001", { status: "voided" });
 

--- a/types/chartmogul-node/common.d.ts
+++ b/types/chartmogul-node/common.d.ts
@@ -2,10 +2,10 @@ export interface Map {
     [key: string]: any;
 }
 export interface CursorParams {
+    cursor?: string;
+    per_page?: number;
     /** @deprecated Use cursor-based pagination instead */
     page?: number;
-    per_page?: number;
-    cursor?: string;
 }
 export type Strings = string[];
 

--- a/types/chartmogul-node/common.d.ts
+++ b/types/chartmogul-node/common.d.ts
@@ -2,6 +2,7 @@ export interface Map {
     [key: string]: any;
 }
 export interface CursorParams {
+    /** @deprecated Use cursor-based pagination instead */
     page?: number;
     per_page?: number;
     cursor?: string;

--- a/types/chartmogul-node/index.d.ts
+++ b/types/chartmogul-node/index.d.ts
@@ -838,7 +838,7 @@ export namespace Invoice {
     function retrieve(config: Config, uuid: string, params?: RetrieveInvoiceParams): Promise<Invoice>;
     function modify(config: Config, uuid: string, data: UpdateInvoice): Promise<Invoice>;
     function destroy(config: Config, uuid: string): Promise<ResourceDestroyed>;
-
+    function destroy_all(config: Config, dataSourceUuid: string, customerUuid: string): Promise<ResourceDestroyed>;
     function all(config: Config, uuid: string, params?: ListInvoicesParams): Promise<Invoices>;
     function all(config: Config, params?: ListInvoicesParams): Promise<Invoices>;
 

--- a/types/chartmogul-node/index.d.ts
+++ b/types/chartmogul-node/index.d.ts
@@ -838,7 +838,7 @@ export namespace Invoice {
     function retrieve(config: Config, uuid: string, params?: RetrieveInvoiceParams): Promise<Invoice>;
     function modify(config: Config, uuid: string, data: UpdateInvoice): Promise<Invoice>;
     function destroy(config: Config, uuid: string): Promise<ResourceDestroyed>;
-    function destroy_all(config: Config, dataSourceUuid: string, customerUuid: string): Promise<ResourceDestroyed>;
+
     function all(config: Config, uuid: string, params?: ListInvoicesParams): Promise<Invoices>;
     function all(config: Config, params?: ListInvoicesParams): Promise<Invoices>;
 

--- a/types/chartmogul-node/index.d.ts
+++ b/types/chartmogul-node/index.d.ts
@@ -119,6 +119,33 @@ export namespace DataSource {
     function all(config: Config, params?: ListDataSourcesParams): Promise<DataSources>;
 }
 
+export namespace JsonImport {
+    interface JsonImportStatus {
+        id: string;
+        data_source_uuid: string;
+        status: "queued" | "processing" | "completed" | "failed" | (string & {});
+        external_id: string;
+        status_details: Record<string, any>;
+        created_at?: string;
+        updated_at?: string;
+    }
+
+    interface NewJsonImport {
+        external_id: string;
+        customers?: Array<Record<string, any>>;
+        plans?: Array<Record<string, any>>;
+        invoices?: Array<Record<string, any>>;
+        line_items?: Array<Record<string, any>>;
+        transactions?: Array<Record<string, any>>;
+        subscription_events?: Array<Record<string, any>>;
+    }
+
+    /** POST /v1/data_sources/{dataSourceUuid}/json_imports — import data in bulk */
+    function create(config: Config, dataSourceUuid: string, data: NewJsonImport): Promise<JsonImportStatus>;
+    /** GET /v1/data_sources/{dataSourceUuid}/json_imports/{importId} — track import status */
+    function retrieve(config: Config, dataSourceUuid: string, importId: string): Promise<JsonImportStatus>;
+}
+
 export namespace Customer {
     interface Customer {
         id?: number;

--- a/types/chartmogul-node/index.d.ts
+++ b/types/chartmogul-node/index.d.ts
@@ -4,6 +4,12 @@ export interface ResourceDestroyed {
     message: string;
 }
 
+/** Query params used to identify a resource by data_source_uuid + external_id */
+export interface ExternalIdParams {
+    data_source_uuid: string;
+    external_id: string;
+}
+
 export class Config {
     VERSION: string;
     API_BASE: string;
@@ -737,6 +743,63 @@ export namespace Invoice {
     function disable(config: Config, uuid: string, data?: object): Promise<Invoice>;
     /** Re-enable a disabled invoice via PATCH /v1/invoices/:uuid/disabled_state */
     function enable(config: Config, uuid: string): Promise<Invoice>;
+
+    /** PATCH /v1/invoices?data_source_uuid&external_id with body — use { qs: {...}, ...body } */
+    function update(config: Config, data: { qs: ExternalIdParams } & UpdateInvoice): Promise<Invoice>;
+    /** DELETE /v1/invoices?data_source_uuid&external_id */
+    function destroyByExternalId(config: Config, data: { qs: ExternalIdParams }): Promise<ResourceDestroyed>;
+    /** Disable by query params: PATCH /v1/invoices/disabled_state?data_source_uuid&external_id */
+    function disableByExternalId(config: Config, params: ExternalIdParams): Promise<Invoice>;
+    /** Enable by query params: PATCH /v1/invoices/disabled_state?data_source_uuid&external_id */
+    function enableByExternalId(config: Config, params: ExternalIdParams): Promise<Invoice>;
+}
+
+export namespace LineItem {
+    interface LineItem {
+        uuid?: string;
+        external_id?: string;
+        type?: string;
+        amount_in_cents?: number;
+        quantity?: number;
+        discount_code?: string;
+        discount_amount_in_cents?: number;
+        tax_amount_in_cents?: number;
+        transaction_fees_in_cents?: number;
+        account_code?: string;
+        plan_uuid?: string;
+        plan_external_id?: string;
+        service_period_start?: string;
+        service_period_end?: string;
+        subscription_uuid?: string;
+        subscription_external_id?: string;
+        subscription_set_external_id?: string;
+        prorated?: boolean;
+        proration_type?: string;
+        description?: string;
+        event_order?: number;
+        balance_transfer?: boolean;
+        transaction_fees_currency?: string | null;
+        discount_description?: string | null;
+        disabled?: boolean;
+        disabled_at?: string | null;
+        disabled_by?: string | null;
+        user_created?: boolean;
+        error?: string | null;
+    }
+    interface LineItems {
+        line_items: LineItem[];
+    }
+
+    /** GET /v1/line_items?data_source_uuid&external_id */
+    function all(config: Config, params: ExternalIdParams): Promise<LineItems>;
+    /** PATCH /v1/line_items?data_source_uuid&external_id with body */
+    function update(config: Config, data: { qs: ExternalIdParams } & Record<string, any>): Promise<LineItem>;
+    /** DELETE /v1/line_items?data_source_uuid&external_id */
+    function destroy(config: Config, data: { qs: ExternalIdParams }): Promise<ResourceDestroyed>;
+    /** Disable: PATCH /v1/line_items/disabled_state?data_source_uuid&external_id */
+    function disable(config: Config, params: ExternalIdParams): Promise<LineItem>;
+    /** Enable: PATCH /v1/line_items/disabled_state?data_source_uuid&external_id */
+    function enable(config: Config, params: ExternalIdParams): Promise<LineItem>;
 }
 
 export namespace Transaction {
@@ -765,7 +828,21 @@ export namespace Transaction {
         transaction_fees_currency?: string;
     }
 
+    interface Transactions {
+        transactions: Transaction[];
+    }
+
     function create(config: Config, invoiceUuid: string, data: NewTransaction): Promise<Transaction>;
+    /** GET /v1/transactions?data_source_uuid&external_id */
+    function all(config: Config, params: ExternalIdParams): Promise<Transactions>;
+    /** PATCH /v1/transactions?data_source_uuid&external_id with body */
+    function update(config: Config, data: { qs: ExternalIdParams } & Record<string, any>): Promise<Transaction>;
+    /** DELETE /v1/transactions?data_source_uuid&external_id */
+    function destroy(config: Config, data: { qs: ExternalIdParams }): Promise<ResourceDestroyed>;
+    /** Disable: PATCH /v1/transactions/disabled_state?data_source_uuid&external_id */
+    function disable(config: Config, params: ExternalIdParams): Promise<Transaction>;
+    /** Enable: PATCH /v1/transactions/disabled_state?data_source_uuid&external_id */
+    function enable(config: Config, params: ExternalIdParams): Promise<Transaction>;
 }
 
 export namespace Subscription {

--- a/types/chartmogul-node/index.d.ts
+++ b/types/chartmogul-node/index.d.ts
@@ -576,6 +576,19 @@ export namespace Invoice {
         date?: string;
         due_date?: string;
         external_id?: string;
+        customer_external_id?: string;
+        collection_method?: "automatic" | "manual" | null;
+        status?: string;
+        disabled?: boolean;
+        disabled_at?: string | null;
+        disabled_by?: string | null;
+        user_created?: boolean;
+        errors?: Record<string, string[]> | null;
+        edit_history_summary?: {
+            values_changed?: Record<string, { original_value: any; edited_value: any }>;
+            latest_edit_author?: string;
+            latest_edit_performed_at?: string;
+        } | null;
         line_items?: LineItem[];
         transactions?: Transaction[];
     }
@@ -598,6 +611,7 @@ export namespace Invoice {
         tax_amount_in_cents?: number;
         transaction_fees_in_cents?: number;
         type?: string;
+        error?: string | null;
     }
     interface Transaction {
         uuid?: string;
@@ -605,6 +619,7 @@ export namespace Invoice {
         external_id?: string;
         result?: string;
         type?: string;
+        error?: string | null;
     }
 
     interface NewLineItemBase {
@@ -703,8 +718,25 @@ export namespace Invoice {
     function retrieve(config: Config, uuid: string, params?: RetrieveInvoiceParams): Promise<Invoice>;
     function modify(config: Config, uuid: string, data: UpdateInvoice): Promise<Invoice>;
     function destroy(config: Config, uuid: string): Promise<ResourceDestroyed>;
+    function destroy_all(config: Config, dataSourceUuid: string, customerUuid: string): Promise<ResourceDestroyed>;
     function all(config: Config, uuid: string, params?: ListInvoicesParams): Promise<Invoices>;
     function all(config: Config, params?: ListInvoicesParams): Promise<Invoices>;
+
+    interface UpdateStatusResponse {
+        message: string;
+        invoice: Invoice;
+    }
+    /** Update invoice status. Expects data_source_uuid and invoice external_id as path params. */
+    function updateStatus(
+        config: Config,
+        dataSourceUuid: string,
+        invoiceExternalId: string,
+        data: { status: "voided" | "written_off" },
+    ): Promise<UpdateStatusResponse>;
+    /** Disable an invoice via PATCH /v1/invoices/:uuid/disabled_state */
+    function disable(config: Config, uuid: string, data?: object): Promise<Invoice>;
+    /** Re-enable a disabled invoice via PATCH /v1/invoices/:uuid/disabled_state */
+    function enable(config: Config, uuid: string): Promise<Invoice>;
 }
 
 export namespace Transaction {
@@ -791,6 +823,11 @@ export namespace SubscriptionEvent {
         tax_amount_in_cents?: number;
         event_order?: number | null;
         retracted_event_id?: string | null;
+        invoice_external_id?: string | null;
+        disabled?: boolean;
+        disabled_at?: string | null;
+        disabled_by?: string | null;
+        user_created?: boolean;
     }
 
     interface NewSubscriptionEvent {
@@ -853,21 +890,28 @@ export namespace SubscriptionEvent {
         id?: number;
     }
 
-    function create(config: Config, data: { subscription_event: NewSubscriptionEvent }): Promise<SubscriptionEvent>;
+    /** Create — accepts flat params (auto-wrapped) or envelope style */
+    function create(config: Config, data: NewSubscriptionEvent | { subscription_event: NewSubscriptionEvent }): Promise<SubscriptionEvent>;
     function all(config: Config, params?: ListSubscriptionEventsParams): Promise<SubscriptionEvents>;
     function modify(config: Config, data: { subscription_event: UpdateSubscriptionEvent }): Promise<SubscriptionEvent>;
+    /** Update — accepts flat params (auto-wrapped) or envelope style */
     function updateWithParams(
         config: Config,
-        data: { subscription_event: UpdateSubscriptionEvent },
+        data: UpdateSubscriptionEvent | { subscription_event: UpdateSubscriptionEvent },
     ): Promise<SubscriptionEvent>;
     function destroy(
         config: Config,
         data: { subscription_event: DestroySubscriptionEvent },
     ): Promise<ResourceDestroyed>;
+    /** Delete — accepts flat params (auto-wrapped) or envelope style */
     function deleteWithParams(
         config: Config,
-        data: { subscription_event: DestroySubscriptionEvent },
+        data: DestroySubscriptionEvent | { subscription_event: DestroySubscriptionEvent },
     ): Promise<ResourceDestroyed>;
+    /** Disable a subscription event via PATCH /v1/subscription_events/:id/disabled_state */
+    function disable(config: Config, id: number): Promise<SubscriptionEvent>;
+    /** Re-enable a disabled subscription event */
+    function enable(config: Config, id: number): Promise<SubscriptionEvent>;
 }
 
 export namespace Tag {

--- a/types/chartmogul-node/index.d.ts
+++ b/types/chartmogul-node/index.d.ts
@@ -121,7 +121,7 @@ export namespace DataSource {
 
 export namespace JsonImport {
     interface JsonImportStatus {
-        id: string;
+        id?: string;
         data_source_uuid: string;
         status: "queued" | "processing" | "completed" | "failed" | (string & {});
         external_id: string;
@@ -130,14 +130,83 @@ export namespace JsonImport {
         updated_at?: string;
     }
 
+    interface BulkCustomer {
+        external_id: string;
+        name?: string;
+        email?: string;
+        company?: string;
+        country?: string;
+        state?: string;
+        city?: string;
+        zip?: string;
+        lead_created_at?: string;
+        free_trial_started_at?: string;
+        [key: string]: any;
+    }
+
+    interface BulkPlan {
+        name: string;
+        interval_count: number;
+        interval_unit: "day" | "month" | "year";
+        external_id?: string;
+        [key: string]: any;
+    }
+
+    interface BulkInvoice {
+        customer_external_id: string;
+        external_id: string;
+        date: string;
+        due_date?: string;
+        currency?: string;
+        collection_method?: "automatic" | "manual";
+        [key: string]: any;
+    }
+
+    interface BulkLineItem {
+        invoice_external_id: string;
+        type: "subscription" | "one_time" | "trial";
+        amount_in_cents: number;
+        external_id?: string;
+        subscription_external_id?: string;
+        plan_external_id?: string;
+        service_period_start?: string;
+        service_period_end?: string;
+        quantity?: number;
+        [key: string]: any;
+    }
+
+    interface BulkTransaction {
+        invoice_external_id: string;
+        type: "payment" | "refund";
+        result: "successful" | "failed";
+        date: string;
+        external_id?: string;
+        amount_in_cents?: number;
+        [key: string]: any;
+    }
+
+    interface BulkSubscriptionEvent {
+        customer_external_id: string;
+        event_type: string;
+        event_date: string;
+        effective_date: string;
+        subscription_external_id: string;
+        plan_external_id?: string;
+        currency?: string;
+        amount_in_cents?: number;
+        quantity?: number;
+        external_id?: string;
+        [key: string]: any;
+    }
+
     interface NewJsonImport {
         external_id: string;
-        customers?: Array<Record<string, any>>;
-        plans?: Array<Record<string, any>>;
-        invoices?: Array<Record<string, any>>;
-        line_items?: Array<Record<string, any>>;
-        transactions?: Array<Record<string, any>>;
-        subscription_events?: Array<Record<string, any>>;
+        customers?: BulkCustomer[];
+        plans?: BulkPlan[];
+        invoices?: BulkInvoice[];
+        line_items?: BulkLineItem[];
+        transactions?: BulkTransaction[];
+        subscription_events?: BulkSubscriptionEvent[];
     }
 
     /** POST /v1/data_sources/{dataSourceUuid}/json_imports — import data in bulk */
@@ -627,23 +696,34 @@ export namespace Invoice {
     }
     interface LineItem {
         uuid?: string;
-        account_code?: string;
-        amount_in_cents?: number;
-        cancelled_at?: string;
-        description?: string;
-        discount_amount_in_cents?: number;
-        discount_code?: string;
         external_id?: string;
-        plan_uuid?: string;
-        prorated?: boolean;
+        type?: string;
+        amount_in_cents?: number;
         quantity?: number;
-        service_period_end?: string;
-        service_period_start?: string;
-        subscription_external_id?: string;
-        subscription_uuid?: string;
+        discount_code?: string;
+        discount_amount_in_cents?: number;
         tax_amount_in_cents?: number;
         transaction_fees_in_cents?: number;
-        type?: string;
+        account_code?: string;
+        plan_uuid?: string;
+        plan_external_id?: string;
+        service_period_start?: string;
+        service_period_end?: string;
+        subscription_uuid?: string;
+        subscription_external_id?: string;
+        subscription_set_external_id?: string;
+        prorated?: boolean;
+        proration_type?: string;
+        description?: string;
+        cancelled_at?: string;
+        event_order?: number;
+        balance_transfer?: boolean;
+        transaction_fees_currency?: string | null;
+        discount_description?: string | null;
+        disabled?: boolean;
+        disabled_at?: string | null;
+        disabled_by?: string | null;
+        user_created?: boolean;
         error?: string | null;
     }
     interface Transaction {
@@ -652,6 +732,13 @@ export namespace Invoice {
         external_id?: string;
         result?: string;
         type?: string;
+        amount_in_cents?: number | null;
+        transaction_fees_in_cents?: number | null;
+        transaction_fees_currency?: string | null;
+        disabled?: boolean;
+        disabled_at?: string | null;
+        disabled_by?: string | null;
+        user_created?: boolean;
         error?: string | null;
     }
 
@@ -757,7 +844,6 @@ export namespace Invoice {
 
     interface UpdateStatusResponse {
         message: string;
-        invoice: Invoice;
     }
     /** Update invoice status. Expects data_source_uuid and invoice external_id as path params. */
     function updateStatus(
@@ -766,8 +852,12 @@ export namespace Invoice {
         invoiceExternalId: string,
         data: { status: "voided" | "written_off" },
     ): Promise<UpdateStatusResponse>;
+    interface DisableInvoiceParams {
+        reason?: string;
+        [key: string]: any;
+    }
     /** Disable an invoice via PATCH /v1/invoices/:uuid/disabled_state */
-    function disable(config: Config, uuid: string, data?: object): Promise<Invoice>;
+    function disable(config: Config, uuid: string, data?: DisableInvoiceParams): Promise<Invoice>;
     /** Re-enable a disabled invoice via PATCH /v1/invoices/:uuid/disabled_state */
     function enable(config: Config, uuid: string): Promise<Invoice>;
 
@@ -816,11 +906,24 @@ export namespace LineItem {
     interface LineItems {
         line_items: LineItem[];
     }
+    interface UpdateLineItem {
+        amount_in_cents?: number;
+        quantity?: number;
+        plan_uuid?: string;
+        service_period_start?: string;
+        service_period_end?: string;
+        description?: string;
+        discount_amount_in_cents?: number;
+        discount_code?: string;
+        tax_amount_in_cents?: number;
+        transaction_fees_in_cents?: number;
+        event_order?: number;
+    }
 
     /** GET /v1/line_items?data_source_uuid&external_id */
     function all(config: Config, params: ExternalIdParams): Promise<LineItems>;
     /** PATCH /v1/line_items?data_source_uuid&external_id with body */
-    function update(config: Config, data: { qs: ExternalIdParams } & Record<string, any>): Promise<LineItem>;
+    function update(config: Config, data: { qs: ExternalIdParams } & UpdateLineItem): Promise<LineItem>;
     /** DELETE /v1/line_items?data_source_uuid&external_id */
     function destroy(config: Config, data: { qs: ExternalIdParams }): Promise<ResourceDestroyed>;
     /** Disable: PATCH /v1/line_items/disabled_state?data_source_uuid&external_id */
@@ -858,12 +961,18 @@ export namespace Transaction {
     interface Transactions {
         transactions: Transaction[];
     }
+    interface UpdateTransaction {
+        type?: "payment" | "refund";
+        date?: string;
+        result?: "successful" | "failed";
+        amount_in_cents?: number;
+    }
 
     function create(config: Config, invoiceUuid: string, data: NewTransaction): Promise<Transaction>;
     /** GET /v1/transactions?data_source_uuid&external_id */
     function all(config: Config, params: ExternalIdParams): Promise<Transactions>;
     /** PATCH /v1/transactions?data_source_uuid&external_id with body */
-    function update(config: Config, data: { qs: ExternalIdParams } & Record<string, any>): Promise<Transaction>;
+    function update(config: Config, data: { qs: ExternalIdParams } & UpdateTransaction): Promise<Transaction>;
     /** DELETE /v1/transactions?data_source_uuid&external_id */
     function destroy(config: Config, data: { qs: ExternalIdParams }): Promise<ResourceDestroyed>;
     /** Disable: PATCH /v1/transactions/disabled_state?data_source_uuid&external_id */
@@ -1016,9 +1125,9 @@ export namespace SubscriptionEvent {
         data: DestroySubscriptionEvent | { subscription_event: DestroySubscriptionEvent },
     ): Promise<ResourceDestroyed>;
     /** Disable a subscription event via PATCH /v1/subscription_events/:id/disabled_state */
-    function disable(config: Config, id: number): Promise<SubscriptionEvent>;
+    function disable(config: Config, id: number | string): Promise<SubscriptionEvent>;
     /** Re-enable a disabled subscription event */
-    function enable(config: Config, id: number): Promise<SubscriptionEvent>;
+    function enable(config: Config, id: number | string): Promise<SubscriptionEvent>;
 }
 
 export namespace Tag {

--- a/types/chartmogul-node/index.d.ts
+++ b/types/chartmogul-node/index.d.ts
@@ -891,7 +891,10 @@ export namespace SubscriptionEvent {
     }
 
     /** Create — accepts flat params (auto-wrapped) or envelope style */
-    function create(config: Config, data: NewSubscriptionEvent | { subscription_event: NewSubscriptionEvent }): Promise<SubscriptionEvent>;
+    function create(
+        config: Config,
+        data: NewSubscriptionEvent | { subscription_event: NewSubscriptionEvent },
+    ): Promise<SubscriptionEvent>;
     function all(config: Config, params?: ListSubscriptionEventsParams): Promise<SubscriptionEvents>;
     function modify(config: Config, data: { subscription_event: UpdateSubscriptionEvent }): Promise<SubscriptionEvent>;
     /** Update — accepts flat params (auto-wrapped) or envelope style */

--- a/types/chartmogul-node/index.d.ts
+++ b/types/chartmogul-node/index.d.ts
@@ -948,6 +948,7 @@ export namespace Transaction {
         disabled_at?: string | null;
         disabled_by?: string | null;
         user_created?: boolean;
+        error?: string | null;
     }
 
     interface NewTransaction {

--- a/types/chartmogul-node/index.d.ts
+++ b/types/chartmogul-node/index.d.ts
@@ -838,6 +838,8 @@ export namespace Invoice {
     function retrieve(config: Config, uuid: string, params?: RetrieveInvoiceParams): Promise<Invoice>;
     function modify(config: Config, uuid: string, data: UpdateInvoice): Promise<Invoice>;
     function destroy(config: Config, uuid: string): Promise<ResourceDestroyed>;
+    function destroyAll(config: Config, dataSourceUuid: string, customerUuid: string): Promise<ResourceDestroyed>;
+    /** @deprecated Use destroyAll instead */
     function destroy_all(config: Config, dataSourceUuid: string, customerUuid: string): Promise<ResourceDestroyed>;
     function all(config: Config, uuid: string, params?: ListInvoicesParams): Promise<Invoices>;
     function all(config: Config, params?: ListInvoicesParams): Promise<Invoices>;

--- a/types/chartmogul-node/index.d.ts
+++ b/types/chartmogul-node/index.d.ts
@@ -988,16 +988,30 @@ export namespace Transaction {
     }
 
     function create(config: Config, invoiceUuid: string, data: NewTransaction): Promise<Transaction>;
+    /** GET /v1/transactions/:transactionUuid */
+    function retrieve(config: Config, transactionUuid: string): Promise<Transaction>;
+    /** PATCH /v1/transactions/:transactionUuid */
+    function modify(config: Config, transactionUuid: string, data: UpdateTransaction): Promise<Transaction>;
     /** GET /v1/transactions?data_source_uuid&external_id */
     function all(config: Config, params: ExternalIdParams): Promise<Transactions>;
     /** PATCH /v1/transactions?data_source_uuid&external_id with body */
     function update(config: Config, data: { qs: ExternalIdParams } & UpdateTransaction): Promise<Transaction>;
+    /** DELETE /v1/transactions/:transactionUuid */
+    function destroy(config: Config, transactionUuid: string): Promise<ResourceDestroyed>;
     /** DELETE /v1/transactions?data_source_uuid&external_id */
-    function destroy(config: Config, data: { qs: ExternalIdParams }): Promise<ResourceDestroyed>;
+    function destroyByExternalId(config: Config, data: { qs: ExternalIdParams }): Promise<ResourceDestroyed>;
+    /** Disable: PATCH /v1/transactions/:transactionUuid/disabled_state */
+    function disable(config: Config, transactionUuid: string): Promise<Transaction>;
     /** Disable: PATCH /v1/transactions/disabled_state?data_source_uuid&external_id */
     function disable(config: Config, params: ExternalIdParams): Promise<Transaction>;
+    /** Enable: PATCH /v1/transactions/:transactionUuid/disabled_state */
+    function enable(config: Config, transactionUuid: string): Promise<Transaction>;
     /** Enable: PATCH /v1/transactions/disabled_state?data_source_uuid&external_id */
     function enable(config: Config, params: ExternalIdParams): Promise<Transaction>;
+    /** Disable by query params: PATCH /v1/transactions/disabled_state?data_source_uuid&external_id */
+    function disableByExternalId(config: Config, params: ExternalIdParams): Promise<Transaction>;
+    /** Enable by query params: PATCH /v1/transactions/disabled_state?data_source_uuid&external_id */
+    function enableByExternalId(config: Config, params: ExternalIdParams): Promise<Transaction>;
 }
 
 export namespace Subscription {

--- a/types/chartmogul-node/index.d.ts
+++ b/types/chartmogul-node/index.d.ts
@@ -922,16 +922,32 @@ export namespace LineItem {
         event_order?: number;
     }
 
+    /** POST /v1/import/invoices/:invoiceUuid/line_items */
+    function create(config: Config, invoiceUuid: string, data: Invoice.NewLineItem): Promise<LineItem>;
+    /** GET /v1/line_items/:lineItemUuid */
+    function retrieve(config: Config, lineItemUuid: string): Promise<LineItem>;
+    /** PATCH /v1/line_items/:lineItemUuid */
+    function modify(config: Config, lineItemUuid: string, data: UpdateLineItem): Promise<LineItem>;
     /** GET /v1/line_items?data_source_uuid&external_id */
     function all(config: Config, params: ExternalIdParams): Promise<LineItems>;
     /** PATCH /v1/line_items?data_source_uuid&external_id with body */
     function update(config: Config, data: { qs: ExternalIdParams } & UpdateLineItem): Promise<LineItem>;
+    /** DELETE /v1/line_items/:lineItemUuid */
+    function destroy(config: Config, lineItemUuid: string): Promise<ResourceDestroyed>;
     /** DELETE /v1/line_items?data_source_uuid&external_id */
-    function destroy(config: Config, data: { qs: ExternalIdParams }): Promise<ResourceDestroyed>;
+    function destroyByExternalId(config: Config, data: { qs: ExternalIdParams }): Promise<ResourceDestroyed>;
+    /** Disable: PATCH /v1/line_items/:lineItemUuid/disabled_state */
+    function disable(config: Config, lineItemUuid: string): Promise<LineItem>;
     /** Disable: PATCH /v1/line_items/disabled_state?data_source_uuid&external_id */
     function disable(config: Config, params: ExternalIdParams): Promise<LineItem>;
+    /** Enable: PATCH /v1/line_items/:lineItemUuid/disabled_state */
+    function enable(config: Config, lineItemUuid: string): Promise<LineItem>;
     /** Enable: PATCH /v1/line_items/disabled_state?data_source_uuid&external_id */
     function enable(config: Config, params: ExternalIdParams): Promise<LineItem>;
+    /** Disable by query params: PATCH /v1/line_items/disabled_state?data_source_uuid&external_id */
+    function disableByExternalId(config: Config, params: ExternalIdParams): Promise<LineItem>;
+    /** Enable by query params: PATCH /v1/line_items/disabled_state?data_source_uuid&external_id */
+    function enableByExternalId(config: Config, params: ExternalIdParams): Promise<LineItem>;
 }
 
 export namespace Transaction {

--- a/types/chartmogul-node/package.json
+++ b/types/chartmogul-node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/chartmogul-node",
-    "version": "3.11.9999",
+    "version": "3.12.9999",
     "projects": [
         "https://github.com/chartmogul/chartmogul-node"
     ],

--- a/types/chartmogul-node/package.json
+++ b/types/chartmogul-node/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/chartmogul-node",
-    "version": "3.9.9999",
+    "version": "3.11.9999",
     "projects": [
         "https://github.com/chartmogul/chartmogul-node"
     ],


### PR DESCRIPTION
Adds types for new Invoice, LineItem, Transaction, and SubscriptionEvent fields and methods introduced in [chartmogul-node#129](https://github.com/chartmogul/chartmogul-node/pull/129).

## Changes

### Invoice
- Add fields: `customer_external_id`, `collection_method`, `status`, `disabled`, `disabled_at`, `disabled_by`, `user_created`, `errors`, `edit_history_summary`
- Add methods: `destroyAll`, `updateStatus`, `disable`, `enable`, `update`, `destroyByExternalId`, `disableByExternalId`, `enableByExternalId`

### Invoice.LineItem / Invoice.Transaction (nested)
- Add `error` field

### LineItem (standalone namespace)
- Add UUID-based methods: `create`, `retrieve`, `modify`, `destroy`, `disable`, `enable`
- Add query-param methods: `all`, `update`, `destroyByExternalId`, `disableByExternalId`, `enableByExternalId`
- `disable` and `enable` accept either a UUID string or `ExternalIdParams` (matching the runtime overload)

### Transaction (standalone namespace)
- Add fields: `disabled`, `disabled_at`, `disabled_by`, `user_created`, `error`
- Add UUID-based methods: `create`, `retrieve`, `modify`, `destroy`, `disable`, `enable`
- Add query-param methods: `all`, `update`, `destroyByExternalId`, `disableByExternalId`, `enableByExternalId`
- `disable` and `enable` accept either a UUID string or `ExternalIdParams` (matching the runtime overload)

### SubscriptionEvent
- Add fields: `invoice_external_id`, `disabled`, `disabled_at`, `disabled_by`, `user_created`
- `create` / `updateWithParams` / `deleteWithParams` now accept flat params (union type with the existing envelope style)
- Add methods: `disable`, `enable`

### Tests
- Add test cases covering all new methods and fields

## Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chartmogul/chartmogul-node/pull/129
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
