### PR TITLE
[react-file-icon] Add missing "android" and "code2" FileIcon Types

### DIFF
--- a/types/react-file-icon/index.d.ts
+++ b/types/react-file-icon/index.d.ts
@@ -3,9 +3,11 @@ import * as React from "react";
 export type IconType =
     | "3d"
     | "acrobat"
+    | "android"
     | "audio"
     | "binary"
     | "code"
+    | "code2"
     | "compressed"
     | "document"
     | "drive"

--- a/types/react-file-icon/react-file-icon-tests.tsx
+++ b/types/react-file-icon/react-file-icon-tests.tsx
@@ -6,3 +6,21 @@ class TestFileIcon extends React.Component {
         return <FileIcon extension={"docx"} labelUppercase={true} {...defaultStyles.docx} />;
     }
 }
+
+class TestFileIconCode extends React.Component {
+    render() {
+        return <FileIcon extension={"docx"} type="code" color="aliceblue" />;
+    }
+}
+
+class TestFileIconCode2 extends React.Component {
+    render() {
+        return <FileIcon extension={"docx"} type="code2" color="aliceblue" />;
+    }
+}
+
+class TestFileIconAndroid extends React.Component {
+    render() {
+        return <FileIcon extension={"docx"} type="android" color="aliceblue" />;
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [See "android" and "code2" on lines 37 and 41 respectively](https://github.com/corygibbons/react-file-icon/blob/master/src/FileIcon.js)

The typings for react-file-icon are incorrect, as code2 is a valid type which should be included.