### PR TITLE
[saml] Update types for v4.0.0

### DIFF
--- a/types/saml/index.d.ts
+++ b/types/saml/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for saml 1.0
+// Type definitions for saml 4.0
 // Project: https://github.com/auth0/node-saml#readme
 // Definitions by: Eric Heikes <https://github.com/eheikes>, Eva Sarafianou <https://github.com/esarafianou>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -6,7 +6,7 @@
 /// <reference types="node" />
 
 export interface SamlAttributes {
-    [key: string]: string;
+    [key: string]: string | ReadonlyArray<string>;
 }
 
 export interface KeyInfoProvider {
@@ -19,6 +19,7 @@ export interface SamlSignedOpts {
     audiences?: string | string[] | undefined;
     cert: Buffer;
     digestAlgorithm?: string | undefined;
+    disallowEncryptionWithInsecureAlgorithm?: boolean | undefined;
     encryptionAlgorithm?: string | undefined;
     encryptionCert?: Buffer | undefined;
     encryptionPublicKey?: Buffer | undefined;
@@ -36,10 +37,12 @@ export interface SamlSignedOpts {
     recipient?: string | undefined;
     sessionIndex?: string | undefined;
     signatureAlgorithm?: string | undefined;
+    signatureIdAttribute?: string | undefined;
     signatureNamespacePrefix?: string | undefined;
     subjectConfirmationMethod?: string | undefined;
     typedAttributes?: boolean | undefined;
     uid?: string | undefined;
+    warnOnInsecureEncryptionAlgorithm?: boolean | undefined;
     xpathToNodeBeforeSignature?: string | undefined;
 }
 
@@ -49,6 +52,7 @@ export interface SamlUnassignedOpts {
     audiences?: string | string[] | undefined;
     cert?: Buffer | undefined;
     digestAlgorithm?: string | undefined;
+    disallowEncryptionWithInsecureAlgorithm?: boolean | undefined;
     encryptionAlgorithm?: string | undefined;
     encryptionCert?: Buffer | undefined;
     encryptionPublicKey?: Buffer | undefined;
@@ -70,6 +74,7 @@ export interface SamlUnassignedOpts {
     subjectConfirmationMethod?: string | undefined;
     typedAttributes?: boolean | undefined;
     uid?: string | undefined;
+    warnOnInsecureEncryptionAlgorithm?: boolean | undefined;
     xpathToNodeBeforeSignature?: string | undefined;
 }
 export namespace Saml11 {

--- a/types/saml/saml-tests.ts
+++ b/types/saml/saml-tests.ts
@@ -81,3 +81,30 @@ Saml20.createUnsignedAssertion(
     },
     () => {}
 );
+
+// v4.0 encryption options
+Saml20.create(
+    {
+        cert: Buffer.from('certificate'),
+        key: Buffer.from('key'),
+        encryptionCert: Buffer.from('encryption-cert'),
+        encryptionAlgorithm: 'http://www.w3.org/2009/xmlenc11#aes256-gcm',
+        keyEncryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p',
+        disallowEncryptionWithInsecureAlgorithm: true,
+        warnOnInsecureEncryptionAlgorithm: false,
+    },
+    () => {}
+);
+
+// v4.0 signatureIdAttribute option
+Saml11.create({
+    cert: Buffer.from('certificate'),
+    key: Buffer.from('key'),
+    signatureIdAttribute: 'ID',
+});
+
+// ReadonlyArray attribute values
+const attrs: SamlAttributes = {
+    email: 'foo@bar.com',
+    groups: ['Group1', 'Group2'] as ReadonlyArray<string>,
+};


### PR DESCRIPTION
## Summary

Updates `@types/saml` type definitions to match the `saml` package v4.0.0 release.

### Changes

**New options added to `SamlSignedOpts` and `SamlUnassignedOpts`:**
- `disallowEncryptionWithInsecureAlgorithm?: boolean` — controls whether insecure encryption algorithms are rejected (defaults to `true` in v4)
- `warnOnInsecureEncryptionAlgorithm?: boolean` — controls whether a warning is emitted for insecure algorithms (defaults to `true` in v4)

**New option added to `SamlSignedOpts` only:**
- `signatureIdAttribute?: string` — allows customizing the ID attribute used for signature references

**`SamlAttributes` index signature widened:**
- `[key: string]: string` → `[key: string]: string | ReadonlyArray<string>` — the runtime has always supported array values, but the types were missing this

### Context

The `saml` package [v4.0.0](https://github.com/auth0/node-saml/blob/master/CHANGELOG.md) bumped `xml-encryption` from 2.x to 4.x, which changed the default encryption algorithm from `aes256-cbc` to `aes256-gcm` and added the `disallowEncryptionWithInsecureAlgorithm` / `warnOnInsecureEncryptionAlgorithm` options. The function signatures and existing options are otherwise unchanged.

Test coverage has been added for all new options.