### PR TITLE
[sinon] Fix `@sinonjs/fake-timers` config import

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -1182,7 +1182,7 @@ declare namespace Sinon {
          * If set to true, the sandbox will have a clock property.
          * You can optionally pass in a configuration object that follows the specification for fake timers, such as { toFake: ["setTimeout", "setInterval"] }.
          */
-        useFakeTimers: boolean | Partial<FakeTimers.FakeTimerInstallOpts>;
+        useFakeTimers: boolean | Partial<Parameters<typeof FakeTimers['install']>[0]>;
         /**
          * The assert options can help limit the amount of output produced by assert.fail
          */
@@ -1332,7 +1332,7 @@ declare namespace Sinon {
          * * Important note: when faking `nextTick`, normal calls to `process.nextTick()` will not execute automatically as they would during normal event-loop phases. You would have to call either `clock.next()`, `clock.tick()`, `clock.runAll()` or `clock.runToLast()` manually (see example below). You can easily work around this using the `config.toFake` option. Please refer to the [`fake-timers`](https://github.com/sinonjs/fake-timers) documentation for more information.
          * @param config
          */
-        useFakeTimers(config?: number | Date | Partial<FakeTimers.FakeTimerInstallOpts>): SinonFakeTimers;
+        useFakeTimers(config?: number | Date | Partial<Parameters<typeof FakeTimers['install']>[0]>): SinonFakeTimers;
         /**
          * Restores all fakes created through sandbox.
          */


### PR DESCRIPTION
`@sinonjs/fake-timers` [renamed][1] the `FakeTimerInstallOpts` type to `Config`, which breaks these types for `@sinonjs/fake-timers@15.3.0`.

This change tries to make these types more robust to this and fixes in a non-breaking way by using `Parameters` to infer the types rather than directly reference them.

[1]: https://github.com/sinonjs/fake-timers/commit/8f096a8b0392dbfe16c76ccedaed3c1a56d8ce54#diff-b417af1ed78243852472c4eb3b4456a4e5336cc15d4d6fac0ea00bb4dcc3355aR108

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
