### PR TITLE
[oracledb] Correct callback style type definition to allow error as null and optional return value for success

### DIFF
--- a/types/oracledb/index.d.ts
+++ b/types/oracledb/index.d.ts
@@ -1305,7 +1305,7 @@ declare namespace OracleDB {
         beginSessionlessTransaction(
             opts: SessionlessTransactionOpts,
         ): Promise<SessionlessTransactionOpts["transactionId"]>;
-        beginSessionlessTransaction(opts: SessionlessTransactionOpts, callback: (error: DBError) => void): void;
+        beginSessionlessTransaction(opts: SessionlessTransactionOpts, callback: (error: DBError | null) => void): void;
         /**
          * Stops the currently running operation on the connection.
          *
@@ -1320,7 +1320,7 @@ declare namespace OracleDB {
          * @see https://node-oracledb.readthedocs.io/en/latest/user_guide/initialization.html#tnsadmin
          */
         break(): Promise<void>;
-        break(callback: (error: DBError) => void): void;
+        break(callback: (error: DBError | null) => void): void;
 
         /**
          * Changes the password of the specified user.
@@ -1339,7 +1339,7 @@ declare namespace OracleDB {
             user: string,
             oldPassword: string,
             newPassword: string,
-            callback: (error: DBError) => void,
+            callback: (error: DBError | null) => void,
         ): void;
 
         /**
@@ -1361,14 +1361,14 @@ declare namespace OracleDB {
          */
         close(options: CloseConnectionOptions): Promise<void>;
         close(): Promise<void>;
-        close(options: CloseConnectionOptions, callback: (error: DBError) => void): void;
-        close(callback: (error: DBError) => void): void;
+        close(options: CloseConnectionOptions, callback: (error: DBError | null) => void): void;
+        close(callback: (error: DBError | null) => void): void;
 
         /**
          * This call commits the current transaction in progress on the connection.
          */
         commit(): Promise<void>;
-        commit(callback: (error: DBError) => void): void;
+        commit(callback: (error: DBError | null) => void): void;
 
         /**
          * Creates a Lob as an Oracle temporary LOB. The LOB is initially empty. Data can be streamed to the LOB,
@@ -1387,7 +1387,7 @@ declare namespace OracleDB {
          * @see https://node-oracledb.readthedocs.io/en/latest/user_guide/bind.html#lobbinds
          */
         createLob(type: DbType): Promise<Lob>;
-        createLob(type: DbType, callback: (error: DBError, lob: Lob) => void): void;
+        createLob(type: DbType, callback: (error: DBError | null, lob?: Lob) => void): void;
         /**
          * This synchronous method decodes an OSON Buffer and returns a Javascript value. This method is useful for fetching BLOB columns that have the check constraint IS JSON FORMAT OSON enabled.
          * The parameters of the connection.decodeOSON() are: buf; Buffer; The OSON buffer that is to be decoded.
@@ -1424,7 +1424,7 @@ declare namespace OracleDB {
             sql: string,
             bindParams: BindParameters,
             options: ExecuteOptions,
-            callback: (error: DBError, result: Result<T>) => void,
+            callback: (error: DBError | null, result?: Result<T>) => void,
         ): void;
 
         /**
@@ -1442,7 +1442,7 @@ declare namespace OracleDB {
         execute<T>(
             sql: string,
             bindParams: BindParameters,
-            callback: (error: DBError, result: Result<T>) => void,
+            callback: (error: DBError | null, result?: Result<T>) => void,
         ): void;
 
         /**
@@ -1454,7 +1454,7 @@ declare namespace OracleDB {
          * @see https://node-oracledb.readthedocs.io/en/latest/api_manual/connection.html#connection.queryStream for an alternative
          */
         execute<T>(sql: string): Promise<Result<T>>;
-        execute<T>(sql: string, callback: (error: DBError, result: Result<T>) => void): void;
+        execute<T>(sql: string, callback: (error: DBError | null, result?: Result<T>) => void): void;
         /**
          * This call executes a single SQL or PL/SQL statement.
          *
@@ -1468,12 +1468,12 @@ declare namespace OracleDB {
          * @see https://github.com/oracle/node-oracledb/issues/1629
          */
         execute<T>(sql: object): Promise<Result<T>>;
-        execute<T>(sql: object, callback: (error: DBError, result: Result<T>) => void): void;
+        execute<T>(sql: object, callback: (error: DBError | null, result?: Result<T>) => void): void;
         execute<T>(sql: object, options: ExecuteOptions): Promise<Result<T>>;
         execute<T>(
             sql: object,
             options: ExecuteOptions,
-            callback: (error: DBError, result: Result<T>) => void,
+            callback: (error: DBError | null, result?: Result<T>) => void,
         ): void;
         /**
          * This method allows sets of data values to be bound to one DML or PL/SQL statement for execution.
@@ -1519,14 +1519,14 @@ declare namespace OracleDB {
             sql: string,
             binds: BindParameters[],
             options: ExecuteManyOptions,
-            callback: (error: DBError, result: Results<T>) => void,
+            callback: (error: DBError | null, result?: Results<T>) => void,
         ): void;
 
         executeMany<T>(sql: string, binds: BindParameters[]): Promise<Results<T>>;
         executeMany<T>(
             sql: string,
             binds: BindParameters[],
-            callback: (error: DBError, result: Results<T>) => void,
+            callback: (error: DBError | null, result?: Results<T>) => void,
         ): void;
 
         /**
@@ -1550,11 +1550,11 @@ declare namespace OracleDB {
             sql: string,
             iterations: number,
             options: ExecuteManyOptions,
-            callback: (error: DBError, result: Results<T>) => void,
+            callback: (error: DBError | null, result?: Results<T>) => void,
         ): void;
 
         executeMany<T>(sql: string, iterations: number): Promise<Results<T>>;
-        executeMany<T>(sql: string, iterations: number, callback: (error: DBError, result: Results<T>) => void): void;
+        executeMany<T>(sql: string, iterations: number, callback: (error: DBError | null, result?: Results<T>) => void): void;
 
         /**
          * Returns a DbObject prototype object representing the named Oracle Database object or collection.
@@ -1570,14 +1570,14 @@ declare namespace OracleDB {
          * @since 4.0
          */
         getDbObjectClass<T>(className: string): Promise<DBObjectClass<T>>;
-        getDbObjectClass<T>(className: string, callback: (error: DBError, dbObject: DBObjectClass<T>) => void): void;
+        getDbObjectClass<T>(className: string, callback: (error: DBError | null, dbObject?: DBObjectClass<T>) => void): void;
 
         getQueue<T>(name: string, options?: GetAdvancedQueueOptions): Promise<AdvancedQueue<T>>;
-        getQueue<T>(name: string, callback: (error: DBError, queue: AdvancedQueue<T>) => void): void;
+        getQueue<T>(name: string, callback: (error: DBError | null, queue?: AdvancedQueue<T>) => void): void;
         getQueue<T>(
             name: string,
             options: GetAdvancedQueueOptions,
-            callback: (error: DBError, queue: AdvancedQueue<T>) => void,
+            callback: (error: DBError | null, queue?: AdvancedQueue<T>) => void,
         ): void;
 
         /**
@@ -1604,7 +1604,7 @@ declare namespace OracleDB {
          * @since 2.2
          */
         getStatementInfo(sql: string): Promise<StatementInfo>;
-        getStatementInfo(sql: string, callback: (error: DBError, info: StatementInfo) => void): void;
+        getStatementInfo(sql: string, callback: (error: DBError | null, info?: StatementInfo) => void): void;
         /**
          * This synchronous function returns a boolean indicating the health status of a connection.
          * Connections may become unusable in several cases, such as if the network socket is broken, if an Oracle error indicates the connection is unusable or after receiving a planned down notification from the database.
@@ -1628,7 +1628,7 @@ declare namespace OracleDB {
          * @since 2.2
          */
         ping(): Promise<void>;
-        ping(callback: (error: DBError) => void): void;
+        ping(callback: (error: DBError | null) => void): void;
 
         /**
          * This function provides query streaming support. The parameters are the same as execute() except
@@ -1671,8 +1671,8 @@ declare namespace OracleDB {
          */
         release(options: CloseConnectionOptions): Promise<void>;
         release(): Promise<void>;
-        release(options: CloseConnectionOptions, callback: (error: DBError) => void): void;
-        release(callback: (error: DBError) => void): void;
+        release(options: CloseConnectionOptions, callback: (error: DBError | null) => void): void;
+        release(callback: (error: DBError | null) => void): void;
 
         /**
          * Resumes an existing sessionless transaction using the specified transaction identifier.
@@ -1684,12 +1684,12 @@ declare namespace OracleDB {
             transactionId: SessionlessTransactionOpts["transactionId"],
             resTxnOpts?: ResumeSessionlessTxnOpts,
         ): Promise<SessionlessTransactionOpts["transactionId"]>;
-        resumeSessionlessTransaction(callback: (error: DBError) => void): void;
+        resumeSessionlessTransaction(callback: (error: DBError | null) => void): void;
         /**
          * Rolls back the current transaction in progress on the connection.
          */
         rollback(): Promise<void>;
-        rollback(callback: (error: DBError) => void): void;
+        rollback(callback: (error: DBError | null) => void): void;
 
         /**
          * Used to shut down a database instance. This is the flexible version of oracledb.shutdown(), allowing more control over behavior.
@@ -1751,7 +1751,7 @@ declare namespace OracleDB {
         subscribe(
             name: string,
             options: SubscribeOptions,
-            callback: (error: DBError, result: Subscription) => void,
+            callback: (error: DBError | null, result?: Subscription) => void,
         ): void;
 
         /**
@@ -1763,7 +1763,7 @@ declare namespace OracleDB {
          * @since 6.9
          */
         suspendSessionlessTransaction(): Promise<void>;
-        suspendSessionlessTransaction(callback: (error: DBError) => void): void;
+        suspendSessionlessTransaction(callback: (error: DBError | null) => void): void;
         /**
          * Unregister a Continuous Query Notification (CQN) subscription previously created with connection.subscribe().
          * No further notifications will be sent. The notification callback does not receive a notification of the
@@ -1778,7 +1778,7 @@ declare namespace OracleDB {
          * @param name Name of the subscription used in connection.subscribe().
          */
         unsubscribe(name: string): Promise<void>;
-        unsubscribe(name: string, callback: (error: DBError) => void): void;
+        unsubscribe(name: string, callback: (error: DBError | null) => void): void;
     }
 
     /**
@@ -2609,7 +2609,7 @@ declare namespace OracleDB {
          * @see https://node-oracledb.readthedocs.io/en/latest/user_guide/lob_data.html#closinglobs
          */
         close(): Promise<void>;
-        close(callback: (error: DBError) => void): void;
+        close(callback: (error: DBError | null) => void): void;
 
         /**
          * Return all the LOB data. CLOBs and NCLOBs will be returned as strings. BLOBs will be returned as a Buffer.
@@ -2629,7 +2629,7 @@ declare namespace OracleDB {
          * @since 4.0
          */
         getData(): Promise<string | Buffer>;
-        getData(callback: (error: DBError, data: string | Buffer) => void): void;
+        getData(callback: (error: DBError | null, data?: string | Buffer) => void): void;
 
         /**
          * Returns a portion (or all) of the data in the LOB object. Note that
@@ -2652,9 +2652,9 @@ declare namespace OracleDB {
          * @param amount The number of bytes(BLOB) or characters(CLOB) returned starting from offset.
          */
         getData(offset: number): Promise<string | Buffer>;
-        getData(offset: number, callback: (error: DBError, data: string | Buffer) => void): void;
+        getData(offset: number, callback: (error: DBError | null, data?: string | Buffer) => void): void;
         getData(offset: number, amount: number): Promise<string | Buffer>;
-        getData(offset: number, amount: number, callback: (error: DBError, data: string | Buffer) => void): void;
+        getData(offset: number, amount: number, callback: (error: DBError | null, data?: string | Buffer) => void): void;
     }
 
     /**
@@ -2871,8 +2871,8 @@ declare namespace OracleDB {
          * @since 1.9
          */
         close(drainTime?: number): Promise<void>;
-        close(drainTime: number, callback: (error: DBError) => void): void;
-        close(callback: (error: DBError) => void): void;
+        close(drainTime: number, callback: (error: DBError | null) => void): void;
+        close(callback: (error: DBError | null) => void): void;
 
         /**
          * This method obtains a connection from the connection pool.
@@ -2912,9 +2912,9 @@ declare namespace OracleDB {
         getConnection(poolAttributes?: GetPooledConnectionOptions): Promise<Connection>;
         getConnection(
             poolAttributes: GetPooledConnectionOptions,
-            callback: (error: DBError, connection: Connection) => void,
+            callback: (error: DBError | null, connection?: Connection) => void,
         ): void;
-        getConnection(callback: (error: DBError, connection: Connection) => void): void;
+        getConnection(callback: (error: DBError | null, connection?: Connection) => void): void;
         /**
          * This call closes connections in the pool and terminates the connection pool.
          *
@@ -2943,8 +2943,8 @@ declare namespace OracleDB {
          * @alias close
          */
         terminate(drainTime?: number): Promise<void>;
-        terminate(drainTime: number, callback: (error: DBError) => void): void;
-        terminate(callback: (error: DBError) => void): void;
+        terminate(drainTime: number, callback: (error: DBError | null) => void): void;
+        terminate(callback: (error: DBError | null) => void): void;
 
         /**
          * If enableStatistics is true, this method can be used to output statistics to the console.
@@ -2965,7 +2965,7 @@ declare namespace OracleDB {
          * If an error such as an invalid value occurs when changing one property, then an error will be thrown but any already changed properties will retain their new values.
          */
         reconfigure(poolAttrs: PoolAttributes): Promise<void>;
-        reconfigure(poolAttrs: PoolAttributes, callback: (error: DBError) => void): void;
+        reconfigure(poolAttrs: PoolAttributes, callback: (error: DBError | null) => void): void;
     }
 
     /**
@@ -3470,14 +3470,14 @@ declare namespace OracleDB {
         deqMany(maxMessages: number): Promise<Array<AdvancedQueueMessage<T>>>;
         deqMany(
             maxMessages: number,
-            callback: (error: DBError, messages: Array<AdvancedQueueMessage<T>>) => void,
+            callback: (error: DBError | null, messages?: Array<AdvancedQueueMessage<T>>) => void,
         ): void;
 
         /**
          * Dequeues a single message. Depending on the dequeue options, the message may also be returned as undefined if no message is available.
          */
         deqOne(): Promise<AdvancedQueueMessage<T> | undefined>;
-        deqOne(callback: (error: DBError, message?: AdvancedQueueMessage<T>) => void): void;
+        deqOne(callback: (error: DBError | null, message?: AdvancedQueueMessage<T>) => void): void;
 
         /**
          * Enqueues multiple messages.
@@ -3492,7 +3492,7 @@ declare namespace OracleDB {
         enqMany(messages: Array<EnqueueMessage<T>>): Promise<AdvancedQueueMessage<T>>;
         enqMany(
             messages: Array<EnqueueMessage<T>>,
-            callback: (error: DBError) => AdvancedQueueMessage<T>,
+            callback: (error: DBError | null) => AdvancedQueueMessage<T>,
         ): AdvancedQueueMessage<T>;
 
         /**
@@ -3505,7 +3505,7 @@ declare namespace OracleDB {
         enqOne(message: EnqueueMessage<T>): Promise<AdvancedQueueMessage<T>>;
         enqOne(
             message: EnqueueMessage<T>,
-            callback: (error: DBError) => AdvancedQueueMessage<T>,
+            callback: (error: DBError | null) => AdvancedQueueMessage<T>,
         ): AdvancedQueueMessage<T>;
     }
 
@@ -3917,7 +3917,7 @@ declare namespace OracleDB {
          * It should also be called if no rows are ever going to be fetched from the ResultSet.
          */
         close(): Promise<void>;
-        close(callback: (error: DBError) => void): void;
+        close(callback: (error: DBError | null) => void): void;
 
         /**
          * This call fetches one row of the ResultSet as an object or an array of column values,
@@ -3929,7 +3929,7 @@ declare namespace OracleDB {
          * the execute() option fetchArraySize.
          */
         getRow(): Promise<T>;
-        getRow(callback: (error: DBError, row: T) => void): void;
+        getRow(callback: (error: DBError | null, row?: T) => void): void;
 
         /**
          * This call fetches numRows rows of the ResultSet as an object or an array of column values,
@@ -3943,8 +3943,8 @@ declare namespace OracleDB {
          * @param numRows The number of rows to fetch
          */
         getRows(numRows?: number): Promise<T[]>;
-        getRows(callback: (error: DBError, rows: T[]) => void): void;
-        getRows(numRows: number, callback: (error: DBError, rows: T[]) => void): void;
+        getRows(callback: (error: DBError | null, rows?: T[]) => void): void;
+        getRows(numRows: number, callback: (error: DBError | null, rows?: T[]) => void): void;
 
         /**
          * This synchronous method converts a ResultSet into a stream.
@@ -4003,9 +4003,9 @@ declare namespace OracleDB {
         createCollection(
             collectionName: string,
             options: SodaCollectionOptions,
-            callback: (error: DBError, collection: SodaCollection) => void,
+            callback: (error: DBError | null, collection?: SodaCollection) => void,
         ): void;
-        createCollection(collectionName: string, callback: (error: DBError, collection: SodaCollection) => void): void;
+        createCollection(collectionName: string, callback: (error: DBError | null, collection?: SodaCollection) => void): void;
 
         /**
          * A synchronous method that constructs a proto SodaDocument object usable for SODA insert and replace methods.
@@ -4032,9 +4032,9 @@ declare namespace OracleDB {
         getCollectionNames(options?: SodaCollectionNamesOptions): string[];
         getCollectionNames(
             options: SodaCollectionNamesOptions,
-            callback: (error: DBError, names: string[]) => void,
+            callback: (error: DBError | null, names?: string[]) => void,
         ): void;
-        getCollectionNames(callback: (error: DBError, names: string[]) => void): void;
+        getCollectionNames(callback: (error: DBError | null, names?: string[]) => void): void;
 
         /**
          * Opens an existing SodaCollection of the given name. The collection can then be used to access documents.
@@ -4050,7 +4050,7 @@ declare namespace OracleDB {
          * @since 3.0
          */
         openCollection(collectionName: string): Promise<SodaCollection | undefined>;
-        openCollection(collectionName: string, callback: (error: DBError, collection?: SodaCollection) => void): void;
+        openCollection(collectionName: string, callback: (error: DBError | null, collection?: SodaCollection) => void): void;
     }
 
     /**
@@ -4114,7 +4114,7 @@ declare namespace OracleDB {
          * @see https://www.oracle.com/pls/topic/lookup?ctx=dblatest&id=GUID-4848E6A0-58A7-44FD-8D6D-A033D0CCF9CB
          */
         createIndex(indexSpec: BTreeIndex | SpatialIndex | SearchIndex): Promise<void>;
-        createIndex(indexSpec: BTreeIndex | SpatialIndex | SearchIndex, callback: (error: DBError) => void): void;
+        createIndex(indexSpec: BTreeIndex | SpatialIndex | SearchIndex, callback: (error: DBError | null) => void): void;
 
         /**
          * Drops the current collection.
@@ -4140,7 +4140,7 @@ declare namespace OracleDB {
          * @since 3.0
          */
         drop(): Promise<DropCollectionResult>;
-        drop(callback: (error: DBError, result: DropCollectionResult) => void): void;
+        drop(callback: (error: DBError | null, result?: DropCollectionResult) => void): void;
 
         /**
          * Drops the specified index.
@@ -4157,7 +4157,7 @@ declare namespace OracleDB {
         dropIndex(
             indexName: string,
             options: DropIndexOptions,
-            callback: (error: DBError, result: DropCollectionResult) => void,
+            callback: (error: DBError | null, result?: DropCollectionResult) => void,
         ): void;
 
         /**
@@ -4187,7 +4187,7 @@ declare namespace OracleDB {
          * @since 3.0
          */
         getDataGuide(): Promise<SodaDocument>;
-        getDataGuide(callback: (error: DBError, document: SodaDocument) => void): void;
+        getDataGuide(callback: (error: DBError | null, document?: SodaDocument) => void): void;
 
         /**
          * Inserts a given document to the collection. The input document can be either a JavaScript object representing
@@ -4206,7 +4206,7 @@ declare namespace OracleDB {
          * @since 3.0
          */
         insertOne(newDocument: SodaDocument | Record<string, any>): Promise<void>;
-        insertOne(newDocument: SodaDocument | Record<string, any>, callback: (error: DBError) => void): void;
+        insertOne(newDocument: SodaDocument | Record<string, any>, callback: (error: DBError | null) => void): void;
 
         /**
          * Similar to sodaCollection.insertOne() but also returns the inserted document so system managed properties,
@@ -4234,7 +4234,7 @@ declare namespace OracleDB {
 
         insertOneAndGet(
             newDocument: SodaDocument | Record<string, any>,
-            callback: (error: DBError, document: SodaDocument) => void,
+            callback: (error: DBError | null, document?: SodaDocument) => void,
             options?: { hint: string },
         ): void;
 
@@ -4253,7 +4253,7 @@ declare namespace OracleDB {
          * @since 4.0
          */
         insertMany(documents: Array<SodaDocument | Record<string, any>>): Promise<void>;
-        insertMany(documents: Array<SodaDocument | Record<string, any>>, callback: (error: DBError) => void): void;
+        insertMany(documents: Array<SodaDocument | Record<string, any>>, callback: (error: DBError | null) => void): void;
 
         /**
          * Similar to sodaCollection.insertMany() but also returns an array of the inserted documents so system managed properties,
@@ -4274,7 +4274,7 @@ declare namespace OracleDB {
         ): Promise<SodaDocument[]>;
         insertManyAndGet(
             documents: Array<SodaDocument | Record<string, any>>,
-            callback: (error: DBError, documents: SodaDocument[]) => void,
+            callback: (error: DBError | null, documents?: SodaDocument[]) => void,
             options?: { hint: string },
         ): void;
 
@@ -4386,7 +4386,7 @@ declare namespace OracleDB {
          * @since 3.0
          */
         close(): Promise<void>;
-        close(callback: (error: DBError) => void): void;
+        close(callback: (error: DBError | null) => void): void;
 
         /**
          * This method returns the next SodaDocument in the cursor returned by a find() terminal method read operation.
@@ -4396,7 +4396,7 @@ declare namespace OracleDB {
          * @since 3.0
          */
         getNext(): Promise<SodaDocument | undefined>;
-        getNext(callback: (error: DBError, document?: SodaDocument) => void): void;
+        getNext(callback: (error: DBError | null, document?: SodaDocument) => void): void;
     }
 
     /**
@@ -4533,7 +4533,7 @@ declare namespace OracleDB {
          * connection is committed.
          */
         count(): Promise<SodaCountResult>;
-        count(callback: (error: DBError, result: SodaCountResult) => void): void;
+        count(callback: (error: DBError | null, result?: SodaCountResult) => void): void;
         /**
          * Returns a SodaDocumentCursor for documents that match the SodaOperation query criteria.
          * The cursor can be iterated over with sodaDocumentCursor.getNext() to access each SodaDocument.
@@ -4547,7 +4547,7 @@ declare namespace OracleDB {
          * @since 3.0
          */
         getCursor(): Promise<SodaDocumentCursor>;
-        getCursor(callback: (error: DBError, cursor: SodaDocumentCursor) => void): void;
+        getCursor(callback: (error: DBError | null, cursor?: SodaDocumentCursor) => void): void;
         /**
          * Gets an array of SodaDocuments matching the SodaOperation query criteria. An empty array will be
          * returned when no documents match.
@@ -4561,7 +4561,7 @@ declare namespace OracleDB {
          * @since 3.0
          */
         getDocuments(): Promise<SodaDocument[]>;
-        getDocuments(callback: (error: DBError, documents: SodaDocument[]) => void): void;
+        getDocuments(callback: (error: DBError | null, documents?: SodaDocument[]) => void): void;
         /**
          * Obtains one document matching the SodaOperation query criteria. If the criteria match more
          * than one document, then only the first is returned.
@@ -4574,7 +4574,7 @@ declare namespace OracleDB {
          * @since 3.0
          */
         getOne(): Promise<SodaDocument | undefined>;
-        getOne(callback: (error: DBError, document?: SodaDocument) => void): void;
+        getOne(callback: (error: DBError | null, document?: SodaDocument) => void): void;
         /**
          * Removes a set of documents matching the SodaOperation query criteria.
          *
@@ -4586,7 +4586,7 @@ declare namespace OracleDB {
          * @since 3.0
          */
         remove(): Promise<SodaRemoveResult>;
-        remove(callback: (error: DBError, result: SodaRemoveResult) => void): void;
+        remove(callback: (error: DBError | null, result?: SodaRemoveResult) => void): void;
         /**
          * Replaces a document in a collection. The input document can be either a JavaScript object representing the
          * data content, or it can be an existing SodaDocument.
@@ -4610,7 +4610,7 @@ declare namespace OracleDB {
          * @since 3.0
          */
         replaceOne(newDocument: SodaDocument): Promise<SodaReplaceOneResult>;
-        replaceOne(newDocument: SodaDocument, callback: (error: DBError, result: SodaReplaceOneResult) => void): void;
+        replaceOne(newDocument: SodaDocument, callback: (error: DBError | null, result?: SodaReplaceOneResult) => void): void;
         /**
          * Replaces a document in a collection. The input document can be either a JavaScript object representing the
          * data content, or it can be an existing SodaDocument.
@@ -4636,7 +4636,7 @@ declare namespace OracleDB {
         replaceOne(newDocumentContent: Record<string, any>): Promise<SodaReplaceOneResult>;
         replaceOne(
             newDocumentContent: Record<string, any>,
-            callback: (error: DBError, result: SodaReplaceOneResult) => void,
+            callback: (error: DBError | null, result?: SodaReplaceOneResult) => void,
         ): void;
         /**
          * Replaces a document in a collection. This is similar to replaceOne(), but also returns the result document,
@@ -4652,7 +4652,7 @@ declare namespace OracleDB {
          * @since 3.0
          */
         replaceOneAndGet(newDocument: SodaDocument): Promise<SodaDocument | undefined>;
-        replaceOneAndGet(newDocument: SodaDocument, callback: (error: DBError, document?: SodaDocument) => void): void;
+        replaceOneAndGet(newDocument: SodaDocument, callback: (error: DBError | null, document?: SodaDocument) => void): void;
         /**
          * Replaces a document in a collection. This is similar to replaceOne(), but also returns the result document,
          * which contains all SodaDocument components (key, version, etc.) except for content.
@@ -4669,7 +4669,7 @@ declare namespace OracleDB {
         replaceOneAndGet(newDocumentContent: Record<string, any>): Promise<SodaDocument>;
         replaceOneAndGet(
             newDocumentContent: Record<string, any>,
-            callback: (error: DBError, document: SodaDocument) => void,
+            callback: (error: DBError | null, document?: SodaDocument) => void,
         ): void;
     }
 
@@ -4981,7 +4981,7 @@ declare namespace OracleDB {
      * @param poolAttributes Provides connection credentials and pool-specific configuration properties, overriding the defualt pooling properties of the Oracledb object.
      */
     function createPool(poolAttributes: PoolAttributes): Promise<Pool>;
-    function createPool(poolAttributes: PoolAttributes, callback: (error: DBError, pool: Pool) => void): void;
+    function createPool(poolAttributes: PoolAttributes, callback: (error: DBError | null, pool?: Pool) => void): void;
 
     /**
      * Obtains a connection from a pool in the connection pool cache.
@@ -4992,7 +4992,7 @@ declare namespace OracleDB {
      * @param poolAlias Specifies which previously created pool in the connection pool cache to use to obtain the connection.
      */
     function getConnection(poolAlias: string): Promise<Connection>;
-    function getConnection(poolAlias: string, callback: (error: DBError, connection: Connection) => void): void;
+    function getConnection(poolAlias: string, callback: (error: DBError | null, connection?: Connection) => void): void;
 
     /**
      * Obtains a connection from the default pool.
@@ -5001,7 +5001,7 @@ declare namespace OracleDB {
      * However, in most cases, Oracle recommends getting connections from a connection pool.
      */
     function getConnection(): Promise<Connection>;
-    function getConnection(callback: (error: DBError, connection: Connection) => void): void;
+    function getConnection(callback: (error: DBError | null, connection?: Connection) => void): void;
 
     /**
      * Creates a new, standalone, non-pooled connection.
@@ -5014,7 +5014,7 @@ declare namespace OracleDB {
     function getConnection(connectionAttributes: ConnectionAttributes): Promise<Connection>;
     function getConnection(
         connectionAttributes: ConnectionAttributes,
-        callback: (error: DBError, connection: Connection) => void,
+        callback: (error: DBError | null, connection?: Connection) => void,
     ): void;
 
     /**

--- a/types/oracledb/index.d.ts
+++ b/types/oracledb/index.d.ts
@@ -1554,7 +1554,11 @@ declare namespace OracleDB {
         ): void;
 
         executeMany<T>(sql: string, iterations: number): Promise<Results<T>>;
-        executeMany<T>(sql: string, iterations: number, callback: (error: DBError | null, result?: Results<T>) => void): void;
+        executeMany<T>(
+            sql: string,
+            iterations: number,
+            callback: (error: DBError | null, result?: Results<T>) => void,
+        ): void;
 
         /**
          * Returns a DbObject prototype object representing the named Oracle Database object or collection.
@@ -1570,7 +1574,10 @@ declare namespace OracleDB {
          * @since 4.0
          */
         getDbObjectClass<T>(className: string): Promise<DBObjectClass<T>>;
-        getDbObjectClass<T>(className: string, callback: (error: DBError | null, dbObject?: DBObjectClass<T>) => void): void;
+        getDbObjectClass<T>(
+            className: string,
+            callback: (error: DBError | null, dbObject?: DBObjectClass<T>) => void,
+        ): void;
 
         getQueue<T>(name: string, options?: GetAdvancedQueueOptions): Promise<AdvancedQueue<T>>;
         getQueue<T>(name: string, callback: (error: DBError | null, queue?: AdvancedQueue<T>) => void): void;
@@ -2654,7 +2661,11 @@ declare namespace OracleDB {
         getData(offset: number): Promise<string | Buffer>;
         getData(offset: number, callback: (error: DBError | null, data?: string | Buffer) => void): void;
         getData(offset: number, amount: number): Promise<string | Buffer>;
-        getData(offset: number, amount: number, callback: (error: DBError | null, data?: string | Buffer) => void): void;
+        getData(
+            offset: number,
+            amount: number,
+            callback: (error: DBError | null, data?: string | Buffer) => void,
+        ): void;
     }
 
     /**
@@ -4005,7 +4016,10 @@ declare namespace OracleDB {
             options: SodaCollectionOptions,
             callback: (error: DBError | null, collection?: SodaCollection) => void,
         ): void;
-        createCollection(collectionName: string, callback: (error: DBError | null, collection?: SodaCollection) => void): void;
+        createCollection(
+            collectionName: string,
+            callback: (error: DBError | null, collection?: SodaCollection) => void,
+        ): void;
 
         /**
          * A synchronous method that constructs a proto SodaDocument object usable for SODA insert and replace methods.
@@ -4050,7 +4064,10 @@ declare namespace OracleDB {
          * @since 3.0
          */
         openCollection(collectionName: string): Promise<SodaCollection | undefined>;
-        openCollection(collectionName: string, callback: (error: DBError | null, collection?: SodaCollection) => void): void;
+        openCollection(
+            collectionName: string,
+            callback: (error: DBError | null, collection?: SodaCollection) => void,
+        ): void;
     }
 
     /**
@@ -4114,7 +4131,10 @@ declare namespace OracleDB {
          * @see https://www.oracle.com/pls/topic/lookup?ctx=dblatest&id=GUID-4848E6A0-58A7-44FD-8D6D-A033D0CCF9CB
          */
         createIndex(indexSpec: BTreeIndex | SpatialIndex | SearchIndex): Promise<void>;
-        createIndex(indexSpec: BTreeIndex | SpatialIndex | SearchIndex, callback: (error: DBError | null) => void): void;
+        createIndex(
+            indexSpec: BTreeIndex | SpatialIndex | SearchIndex,
+            callback: (error: DBError | null) => void,
+        ): void;
 
         /**
          * Drops the current collection.
@@ -4253,7 +4273,10 @@ declare namespace OracleDB {
          * @since 4.0
          */
         insertMany(documents: Array<SodaDocument | Record<string, any>>): Promise<void>;
-        insertMany(documents: Array<SodaDocument | Record<string, any>>, callback: (error: DBError | null) => void): void;
+        insertMany(
+            documents: Array<SodaDocument | Record<string, any>>,
+            callback: (error: DBError | null) => void,
+        ): void;
 
         /**
          * Similar to sodaCollection.insertMany() but also returns an array of the inserted documents so system managed properties,
@@ -4610,7 +4633,10 @@ declare namespace OracleDB {
          * @since 3.0
          */
         replaceOne(newDocument: SodaDocument): Promise<SodaReplaceOneResult>;
-        replaceOne(newDocument: SodaDocument, callback: (error: DBError | null, result?: SodaReplaceOneResult) => void): void;
+        replaceOne(
+            newDocument: SodaDocument,
+            callback: (error: DBError | null, result?: SodaReplaceOneResult) => void,
+        ): void;
         /**
          * Replaces a document in a collection. The input document can be either a JavaScript object representing the
          * data content, or it can be an existing SodaDocument.
@@ -4652,7 +4678,10 @@ declare namespace OracleDB {
          * @since 3.0
          */
         replaceOneAndGet(newDocument: SodaDocument): Promise<SodaDocument | undefined>;
-        replaceOneAndGet(newDocument: SodaDocument, callback: (error: DBError | null, document?: SodaDocument) => void): void;
+        replaceOneAndGet(
+            newDocument: SodaDocument,
+            callback: (error: DBError | null, document?: SodaDocument) => void,
+        ): void;
         /**
          * Replaces a document in a collection. This is similar to replaceOne(), but also returns the result document,
          * which contains all SodaDocument components (key, version, etc.) except for content.

--- a/types/oracledb/index.d.ts
+++ b/types/oracledb/index.d.ts
@@ -1387,7 +1387,7 @@ declare namespace OracleDB {
          * @see https://node-oracledb.readthedocs.io/en/latest/user_guide/bind.html#lobbinds
          */
         createLob(type: DbType): Promise<Lob>;
-        createLob(type: DbType, callback: (error: DBError | null, lob?: Lob) => void): void;
+        createLob(type: DbType, callback: ResultCallback<Lob>): void;
         /**
          * This synchronous method decodes an OSON Buffer and returns a Javascript value. This method is useful for fetching BLOB columns that have the check constraint IS JSON FORMAT OSON enabled.
          * The parameters of the connection.decodeOSON() are: buf; Buffer; The OSON buffer that is to be decoded.
@@ -1424,7 +1424,7 @@ declare namespace OracleDB {
             sql: string,
             bindParams: BindParameters,
             options: ExecuteOptions,
-            callback: (error: DBError | null, result?: Result<T>) => void,
+            callback: ResultCallback<Result<T>>,
         ): void;
 
         /**
@@ -1442,7 +1442,7 @@ declare namespace OracleDB {
         execute<T>(
             sql: string,
             bindParams: BindParameters,
-            callback: (error: DBError | null, result?: Result<T>) => void,
+            callback: ResultCallback<Result<T>>,
         ): void;
 
         /**
@@ -1454,7 +1454,7 @@ declare namespace OracleDB {
          * @see https://node-oracledb.readthedocs.io/en/latest/api_manual/connection.html#connection.queryStream for an alternative
          */
         execute<T>(sql: string): Promise<Result<T>>;
-        execute<T>(sql: string, callback: (error: DBError | null, result?: Result<T>) => void): void;
+        execute<T>(sql: string, callback: ResultCallback<Result<T>>): void;
         /**
          * This call executes a single SQL or PL/SQL statement.
          *
@@ -1468,12 +1468,12 @@ declare namespace OracleDB {
          * @see https://github.com/oracle/node-oracledb/issues/1629
          */
         execute<T>(sql: object): Promise<Result<T>>;
-        execute<T>(sql: object, callback: (error: DBError | null, result?: Result<T>) => void): void;
+        execute<T>(sql: object, callback: ResultCallback<Result<T>>): void;
         execute<T>(sql: object, options: ExecuteOptions): Promise<Result<T>>;
         execute<T>(
             sql: object,
             options: ExecuteOptions,
-            callback: (error: DBError | null, result?: Result<T>) => void,
+            callback: ResultCallback<Result<T>>,
         ): void;
         /**
          * This method allows sets of data values to be bound to one DML or PL/SQL statement for execution.
@@ -1519,14 +1519,14 @@ declare namespace OracleDB {
             sql: string,
             binds: BindParameters[],
             options: ExecuteManyOptions,
-            callback: (error: DBError | null, result?: Results<T>) => void,
+            callback: ResultCallback<Results<T>>,
         ): void;
 
         executeMany<T>(sql: string, binds: BindParameters[]): Promise<Results<T>>;
         executeMany<T>(
             sql: string,
             binds: BindParameters[],
-            callback: (error: DBError | null, result?: Results<T>) => void,
+            callback: ResultCallback<Results<T>>,
         ): void;
 
         /**
@@ -1550,14 +1550,14 @@ declare namespace OracleDB {
             sql: string,
             iterations: number,
             options: ExecuteManyOptions,
-            callback: (error: DBError | null, result?: Results<T>) => void,
+            callback: ResultCallback<Results<T>>,
         ): void;
 
         executeMany<T>(sql: string, iterations: number): Promise<Results<T>>;
         executeMany<T>(
             sql: string,
             iterations: number,
-            callback: (error: DBError | null, result?: Results<T>) => void,
+            callback: ResultCallback<Results<T>>,
         ): void;
 
         /**
@@ -1576,15 +1576,15 @@ declare namespace OracleDB {
         getDbObjectClass<T>(className: string): Promise<DBObjectClass<T>>;
         getDbObjectClass<T>(
             className: string,
-            callback: (error: DBError | null, dbObject?: DBObjectClass<T>) => void,
+            callback: ResultCallback<DBObjectClass<T>>,
         ): void;
 
         getQueue<T>(name: string, options?: GetAdvancedQueueOptions): Promise<AdvancedQueue<T>>;
-        getQueue<T>(name: string, callback: (error: DBError | null, queue?: AdvancedQueue<T>) => void): void;
+        getQueue<T>(name: string, callback: ResultCallback<AdvancedQueue<T>>): void;
         getQueue<T>(
             name: string,
             options: GetAdvancedQueueOptions,
-            callback: (error: DBError | null, queue?: AdvancedQueue<T>) => void,
+            callback: ResultCallback<AdvancedQueue<T>>,
         ): void;
 
         /**
@@ -1611,7 +1611,7 @@ declare namespace OracleDB {
          * @since 2.2
          */
         getStatementInfo(sql: string): Promise<StatementInfo>;
-        getStatementInfo(sql: string, callback: (error: DBError | null, info?: StatementInfo) => void): void;
+        getStatementInfo(sql: string, callback: ResultCallback<StatementInfo>): void;
         /**
          * This synchronous function returns a boolean indicating the health status of a connection.
          * Connections may become unusable in several cases, such as if the network socket is broken, if an Oracle error indicates the connection is unusable or after receiving a planned down notification from the database.
@@ -1758,7 +1758,7 @@ declare namespace OracleDB {
         subscribe(
             name: string,
             options: SubscribeOptions,
-            callback: (error: DBError | null, result?: Subscription) => void,
+            callback: ResultCallback<Subscription>,
         ): void;
 
         /**
@@ -2347,6 +2347,9 @@ declare namespace OracleDB {
         stack?: string;
     }
 
+    // eslint-disable-next-line @definitelytyped/no-single-element-tuple-type
+    type ResultCallback<T> = (...args: [DBError] | [null, T]) => void;
+
     /**
      * Used to control statement execution.
      */
@@ -2636,7 +2639,7 @@ declare namespace OracleDB {
          * @since 4.0
          */
         getData(): Promise<string | Buffer>;
-        getData(callback: (error: DBError | null, data?: string | Buffer) => void): void;
+        getData(callback: ResultCallback<string | Buffer>): void;
 
         /**
          * Returns a portion (or all) of the data in the LOB object. Note that
@@ -2659,12 +2662,12 @@ declare namespace OracleDB {
          * @param amount The number of bytes(BLOB) or characters(CLOB) returned starting from offset.
          */
         getData(offset: number): Promise<string | Buffer>;
-        getData(offset: number, callback: (error: DBError | null, data?: string | Buffer) => void): void;
+        getData(offset: number, callback: ResultCallback<string | Buffer>): void;
         getData(offset: number, amount: number): Promise<string | Buffer>;
         getData(
             offset: number,
             amount: number,
-            callback: (error: DBError | null, data?: string | Buffer) => void,
+            callback: ResultCallback<string | Buffer>,
         ): void;
     }
 
@@ -2923,9 +2926,9 @@ declare namespace OracleDB {
         getConnection(poolAttributes?: GetPooledConnectionOptions): Promise<Connection>;
         getConnection(
             poolAttributes: GetPooledConnectionOptions,
-            callback: (error: DBError | null, connection?: Connection) => void,
+            callback: ResultCallback<Connection>,
         ): void;
-        getConnection(callback: (error: DBError | null, connection?: Connection) => void): void;
+        getConnection(callback: ResultCallback<Connection>): void;
         /**
          * This call closes connections in the pool and terminates the connection pool.
          *
@@ -3481,14 +3484,14 @@ declare namespace OracleDB {
         deqMany(maxMessages: number): Promise<Array<AdvancedQueueMessage<T>>>;
         deqMany(
             maxMessages: number,
-            callback: (error: DBError | null, messages?: Array<AdvancedQueueMessage<T>>) => void,
+            callback: ResultCallback<Array<AdvancedQueueMessage<T>>>,
         ): void;
 
         /**
          * Dequeues a single message. Depending on the dequeue options, the message may also be returned as undefined if no message is available.
          */
         deqOne(): Promise<AdvancedQueueMessage<T> | undefined>;
-        deqOne(callback: (error: DBError | null, message?: AdvancedQueueMessage<T>) => void): void;
+        deqOne(callback: ResultCallback<AdvancedQueueMessage<T> | undefined>): void;
 
         /**
          * Enqueues multiple messages.
@@ -3940,7 +3943,7 @@ declare namespace OracleDB {
          * the execute() option fetchArraySize.
          */
         getRow(): Promise<T>;
-        getRow(callback: (error: DBError | null, row?: T) => void): void;
+        getRow(callback: ResultCallback<T>): void;
 
         /**
          * This call fetches numRows rows of the ResultSet as an object or an array of column values,
@@ -3954,8 +3957,8 @@ declare namespace OracleDB {
          * @param numRows The number of rows to fetch
          */
         getRows(numRows?: number): Promise<T[]>;
-        getRows(callback: (error: DBError | null, rows?: T[]) => void): void;
-        getRows(numRows: number, callback: (error: DBError | null, rows?: T[]) => void): void;
+        getRows(callback: ResultCallback<T[]>): void;
+        getRows(numRows: number, callback: ResultCallback<T[]>): void;
 
         /**
          * This synchronous method converts a ResultSet into a stream.
@@ -4014,11 +4017,11 @@ declare namespace OracleDB {
         createCollection(
             collectionName: string,
             options: SodaCollectionOptions,
-            callback: (error: DBError | null, collection?: SodaCollection) => void,
+            callback: ResultCallback<SodaCollection>,
         ): void;
         createCollection(
             collectionName: string,
-            callback: (error: DBError | null, collection?: SodaCollection) => void,
+            callback: ResultCallback<SodaCollection>,
         ): void;
 
         /**
@@ -4046,9 +4049,9 @@ declare namespace OracleDB {
         getCollectionNames(options?: SodaCollectionNamesOptions): string[];
         getCollectionNames(
             options: SodaCollectionNamesOptions,
-            callback: (error: DBError | null, names?: string[]) => void,
+            callback: ResultCallback<string[]>,
         ): void;
-        getCollectionNames(callback: (error: DBError | null, names?: string[]) => void): void;
+        getCollectionNames(callback: ResultCallback<string[]>): void;
 
         /**
          * Opens an existing SodaCollection of the given name. The collection can then be used to access documents.
@@ -4066,7 +4069,7 @@ declare namespace OracleDB {
         openCollection(collectionName: string): Promise<SodaCollection | undefined>;
         openCollection(
             collectionName: string,
-            callback: (error: DBError | null, collection?: SodaCollection) => void,
+            callback: ResultCallback<SodaCollection | undefined>,
         ): void;
     }
 
@@ -4160,7 +4163,7 @@ declare namespace OracleDB {
          * @since 3.0
          */
         drop(): Promise<DropCollectionResult>;
-        drop(callback: (error: DBError | null, result?: DropCollectionResult) => void): void;
+        drop(callback: ResultCallback<DropCollectionResult>): void;
 
         /**
          * Drops the specified index.
@@ -4177,7 +4180,7 @@ declare namespace OracleDB {
         dropIndex(
             indexName: string,
             options: DropIndexOptions,
-            callback: (error: DBError | null, result?: DropCollectionResult) => void,
+            callback: ResultCallback<DropCollectionResult>,
         ): void;
 
         /**
@@ -4207,7 +4210,7 @@ declare namespace OracleDB {
          * @since 3.0
          */
         getDataGuide(): Promise<SodaDocument>;
-        getDataGuide(callback: (error: DBError | null, document?: SodaDocument) => void): void;
+        getDataGuide(callback: ResultCallback<SodaDocument>): void;
 
         /**
          * Inserts a given document to the collection. The input document can be either a JavaScript object representing
@@ -4254,7 +4257,7 @@ declare namespace OracleDB {
 
         insertOneAndGet(
             newDocument: SodaDocument | Record<string, any>,
-            callback: (error: DBError | null, document?: SodaDocument) => void,
+            callback: ResultCallback<SodaDocument>,
             options?: { hint: string },
         ): void;
 
@@ -4297,7 +4300,7 @@ declare namespace OracleDB {
         ): Promise<SodaDocument[]>;
         insertManyAndGet(
             documents: Array<SodaDocument | Record<string, any>>,
-            callback: (error: DBError | null, documents?: SodaDocument[]) => void,
+            callback: ResultCallback<SodaDocument[]>,
             options?: { hint: string },
         ): void;
 
@@ -4419,7 +4422,7 @@ declare namespace OracleDB {
          * @since 3.0
          */
         getNext(): Promise<SodaDocument | undefined>;
-        getNext(callback: (error: DBError | null, document?: SodaDocument) => void): void;
+        getNext(callback: ResultCallback<SodaDocument | undefined>): void;
     }
 
     /**
@@ -4556,7 +4559,7 @@ declare namespace OracleDB {
          * connection is committed.
          */
         count(): Promise<SodaCountResult>;
-        count(callback: (error: DBError | null, result?: SodaCountResult) => void): void;
+        count(callback: ResultCallback<SodaCountResult>): void;
         /**
          * Returns a SodaDocumentCursor for documents that match the SodaOperation query criteria.
          * The cursor can be iterated over with sodaDocumentCursor.getNext() to access each SodaDocument.
@@ -4570,7 +4573,7 @@ declare namespace OracleDB {
          * @since 3.0
          */
         getCursor(): Promise<SodaDocumentCursor>;
-        getCursor(callback: (error: DBError | null, cursor?: SodaDocumentCursor) => void): void;
+        getCursor(callback: ResultCallback<SodaDocumentCursor>): void;
         /**
          * Gets an array of SodaDocuments matching the SodaOperation query criteria. An empty array will be
          * returned when no documents match.
@@ -4584,7 +4587,7 @@ declare namespace OracleDB {
          * @since 3.0
          */
         getDocuments(): Promise<SodaDocument[]>;
-        getDocuments(callback: (error: DBError | null, documents?: SodaDocument[]) => void): void;
+        getDocuments(callback: ResultCallback<SodaDocument[]>): void;
         /**
          * Obtains one document matching the SodaOperation query criteria. If the criteria match more
          * than one document, then only the first is returned.
@@ -4597,7 +4600,7 @@ declare namespace OracleDB {
          * @since 3.0
          */
         getOne(): Promise<SodaDocument | undefined>;
-        getOne(callback: (error: DBError | null, document?: SodaDocument) => void): void;
+        getOne(callback: ResultCallback<SodaDocument | undefined>): void;
         /**
          * Removes a set of documents matching the SodaOperation query criteria.
          *
@@ -4609,7 +4612,7 @@ declare namespace OracleDB {
          * @since 3.0
          */
         remove(): Promise<SodaRemoveResult>;
-        remove(callback: (error: DBError | null, result?: SodaRemoveResult) => void): void;
+        remove(callback: ResultCallback<SodaRemoveResult>): void;
         /**
          * Replaces a document in a collection. The input document can be either a JavaScript object representing the
          * data content, or it can be an existing SodaDocument.
@@ -4635,7 +4638,7 @@ declare namespace OracleDB {
         replaceOne(newDocument: SodaDocument): Promise<SodaReplaceOneResult>;
         replaceOne(
             newDocument: SodaDocument,
-            callback: (error: DBError | null, result?: SodaReplaceOneResult) => void,
+            callback: ResultCallback<SodaReplaceOneResult>,
         ): void;
         /**
          * Replaces a document in a collection. The input document can be either a JavaScript object representing the
@@ -4662,7 +4665,7 @@ declare namespace OracleDB {
         replaceOne(newDocumentContent: Record<string, any>): Promise<SodaReplaceOneResult>;
         replaceOne(
             newDocumentContent: Record<string, any>,
-            callback: (error: DBError | null, result?: SodaReplaceOneResult) => void,
+            callback: ResultCallback<SodaReplaceOneResult>,
         ): void;
         /**
          * Replaces a document in a collection. This is similar to replaceOne(), but also returns the result document,
@@ -4680,7 +4683,7 @@ declare namespace OracleDB {
         replaceOneAndGet(newDocument: SodaDocument): Promise<SodaDocument | undefined>;
         replaceOneAndGet(
             newDocument: SodaDocument,
-            callback: (error: DBError | null, document?: SodaDocument) => void,
+            callback: ResultCallback<SodaDocument | undefined>,
         ): void;
         /**
          * Replaces a document in a collection. This is similar to replaceOne(), but also returns the result document,
@@ -4698,7 +4701,7 @@ declare namespace OracleDB {
         replaceOneAndGet(newDocumentContent: Record<string, any>): Promise<SodaDocument>;
         replaceOneAndGet(
             newDocumentContent: Record<string, any>,
-            callback: (error: DBError | null, document?: SodaDocument) => void,
+            callback: ResultCallback<SodaDocument>,
         ): void;
     }
 
@@ -5010,7 +5013,7 @@ declare namespace OracleDB {
      * @param poolAttributes Provides connection credentials and pool-specific configuration properties, overriding the defualt pooling properties of the Oracledb object.
      */
     function createPool(poolAttributes: PoolAttributes): Promise<Pool>;
-    function createPool(poolAttributes: PoolAttributes, callback: (error: DBError | null, pool?: Pool) => void): void;
+    function createPool(poolAttributes: PoolAttributes, callback: ResultCallback<Pool>): void;
 
     /**
      * Obtains a connection from a pool in the connection pool cache.
@@ -5021,7 +5024,7 @@ declare namespace OracleDB {
      * @param poolAlias Specifies which previously created pool in the connection pool cache to use to obtain the connection.
      */
     function getConnection(poolAlias: string): Promise<Connection>;
-    function getConnection(poolAlias: string, callback: (error: DBError | null, connection?: Connection) => void): void;
+    function getConnection(poolAlias: string, callback: ResultCallback<Connection>): void;
 
     /**
      * Obtains a connection from the default pool.
@@ -5030,7 +5033,7 @@ declare namespace OracleDB {
      * However, in most cases, Oracle recommends getting connections from a connection pool.
      */
     function getConnection(): Promise<Connection>;
-    function getConnection(callback: (error: DBError | null, connection?: Connection) => void): void;
+    function getConnection(callback: ResultCallback<Connection>): void;
 
     /**
      * Creates a new, standalone, non-pooled connection.
@@ -5043,7 +5046,7 @@ declare namespace OracleDB {
     function getConnection(connectionAttributes: ConnectionAttributes): Promise<Connection>;
     function getConnection(
         connectionAttributes: ConnectionAttributes,
-        callback: (error: DBError | null, connection?: Connection) => void,
+        callback: ResultCallback<Connection>,
     ): void;
 
     /**

--- a/types/oracledb/oracledb-tests.ts
+++ b/types/oracledb/oracledb-tests.ts
@@ -3,6 +3,8 @@ import * as oracledb from "oracledb";
 import assert from "assert";
 import defaultOracledb from "oracledb";
 
+/* eslint-disable @definitelytyped/no-single-element-tuple-type */
+
 const expectType = <T>(value: T): T => value;
 
 /*
@@ -28,19 +30,16 @@ const {
 
 const typeCheckConnection = {} as oracledb.Connection;
 
-oracledb.createPool({} as oracledb.PoolAttributes, (error, pool) => {
-    expectType<oracledb.DBError | null>(error);
-    expectType<oracledb.Pool | undefined>(pool);
+oracledb.createPool({} as oracledb.PoolAttributes, (...args) => {
+    expectType<[oracledb.DBError] | [null, oracledb.Pool]>(args);
 });
 
-typeCheckConnection.createLob(oracledb.CLOB, (error, lob) => {
-    expectType<oracledb.DBError | null>(error);
-    expectType<oracledb.Lob | undefined>(lob);
+typeCheckConnection.createLob(oracledb.CLOB, (...args) => {
+    expectType<[oracledb.DBError] | [null, oracledb.Lob]>(args);
 });
 
-typeCheckConnection.execute("SELECT 1 FROM dual", (error, result) => {
-    expectType<oracledb.DBError | null>(error);
-    expectType<oracledb.Result<unknown> | undefined>(result);
+typeCheckConnection.execute("SELECT 1 FROM dual", (...args) => {
+    expectType<[oracledb.DBError] | [null, oracledb.Result<unknown>]>(args);
 });
 
 typeCheckConnection.commit(error => {
@@ -48,7 +47,13 @@ typeCheckConnection.commit(error => {
 });
 
 const initSession = (connection: oracledb.Connection, requestedTag: string, callback: (e: unknown) => void): void => {
-    connection.execute(`alter session set nls_date_format = 'YYYY-MM-DD' nls_language = AMERICAN`, callback);
+    connection.execute(
+        `alter session set nls_date_format = 'YYYY-MM-DD' nls_language = AMERICAN`,
+        ((...args) => {
+            const [error] = args;
+            callback(error);
+        }) as oracledb.ResultCallback<oracledb.Result<unknown>>,
+    );
 };
 
 const testBreak = (connection: oracledb.Connection): Promise<void> =>
@@ -61,7 +66,10 @@ const testBreak = (connection: oracledb.Connection): Promise<void> =>
                     END;
                 `,
             [2],
-            (error: oracledb.DBError): void => {
+            (error: oracledb.DBError | null, _result?: oracledb.Result<unknown>): void => {
+                if (!error) {
+                    throw new Error("Expected error from dbms_lock.sleep");
+                }
                 // ORA-01013: user requested cancel of current operation
                 assert(error.message.includes("ORA-01013"), "message not defined for DB error");
                 assert(error.errorNum !== undefined, "errorNum not defined for DB error");

--- a/types/oracledb/oracledb-tests.ts
+++ b/types/oracledb/oracledb-tests.ts
@@ -3,6 +3,8 @@ import * as oracledb from "oracledb";
 import assert from "assert";
 import defaultOracledb from "oracledb";
 
+const expectType = <T>(value: T): T => value;
+
 /*
 
 TABLE SETUP FOR TESTING:
@@ -23,6 +25,27 @@ const {
     // DB_POOL_MIN,
     DB_USER,
 } = process.env;
+
+const typeCheckConnection = {} as oracledb.Connection;
+
+oracledb.createPool({} as oracledb.PoolAttributes, (error, pool) => {
+    expectType<oracledb.DBError | null>(error);
+    expectType<oracledb.Pool | undefined>(pool);
+});
+
+typeCheckConnection.createLob(oracledb.CLOB, (error, lob) => {
+    expectType<oracledb.DBError | null>(error);
+    expectType<oracledb.Lob | undefined>(lob);
+});
+
+typeCheckConnection.execute("SELECT 1 FROM dual", (error, result) => {
+    expectType<oracledb.DBError | null>(error);
+    expectType<oracledb.Result<unknown> | undefined>(result);
+});
+
+typeCheckConnection.commit(error => {
+    expectType<oracledb.DBError | null>(error);
+});
 
 const initSession = (connection: oracledb.Connection, requestedTag: string, callback: (e: unknown) => void): void => {
     connection.execute(`alter session set nls_date_format = 'YYYY-MM-DD' nls_language = AMERICAN`, callback);


### PR DESCRIPTION
This fixes the issue reported [here](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/74823) 

It fixes the callback style type definition for all the APIs accepting callbacks.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:

- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

If removing a declaration:

- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
