### PR TITLE
[chrome] update manifest keys

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -9264,36 +9264,37 @@ declare namespace chrome {
 
         export interface ManifestBase {
             // Required
+            /** An integer specifying the version of the manifest file format that your extension uses. */
             manifest_version: number;
+            /** A string that identifies the extension in the Chrome Web Store, the install dialog, and the user's Chrome Extensions page (`chrome://extensions`). The maximum length is 75 characters. */
             name: string;
+            /** A string that identifies the extension's version number. */
             version: string;
 
             // Recommended
+            /** A string that defines the default language of an extension that supports multiple locales. Examples include "en" and "pt_BR". This key is required in localized extensions, and must not be used in extensions that aren't localized. */
             default_locale?: string | undefined;
+            /** A string that describes the extension on both the Chrome Web Store and the user's extension management page. The maximum length is 132 characters. */
             description?: string | undefined;
+            /** One or more icons that represent your extension. */
             icons?: ManifestIcons | undefined;
 
             // Optional
-            author?: {
-                email: string;
-            } | undefined;
-            background_page?: string | undefined;
+            /** @deprecated As of February 2024, the `author` key is no longer supported by Chrome or the Chrome Web Store. If present, it's silently ignored. */
+            author?: { email: string } | undefined;
+            /** Defines overrides for selected Chrome settings.  */
             chrome_settings_overrides?: {
                 homepage?: string | undefined;
                 search_provider?: SearchProvider | undefined;
                 startup_pages?: string[] | undefined;
             } | undefined;
-            chrome_ui_overrides?: {
-                bookmarks_ui?: {
-                    remove_bookmark_shortcut?: boolean | undefined;
-                    remove_button?: boolean | undefined;
-                } | undefined;
-            } | undefined;
+            /** Defines overrides for default Chrome pages. */
             chrome_url_overrides?: {
                 bookmarks?: string | undefined;
                 history?: string | undefined;
                 newtab?: string | undefined;
             } | undefined;
+            /** Defines keyboard shortcuts within the extension. */
             commands?: {
                 [name: string]: {
                     suggested_key?: {
@@ -9311,38 +9312,30 @@ declare namespace chrome {
                 matches?: string[] | undefined;
                 permissions?: string[] | undefined;
             } | undefined;
-            content_scripts?:
-                | Array<{
-                    matches?: string[] | undefined;
-                    exclude_matches?: string[] | undefined;
-                    css?: string[] | undefined;
-                    js?: string[] | undefined;
-                    run_at?: string | undefined;
-                    all_frames?: boolean | undefined;
-                    match_about_blank?: boolean | undefined;
-                    include_globs?: string[] | undefined;
-                    exclude_globs?: string[] | undefined;
-                }>
-                | undefined;
             converted_from_user_script?: boolean | undefined;
+            /** Specifies a value for the Cross-Origin-Embedder-Policy HTTP header, which configures embedding of cross-origin resources in an extension page. */
+            cross_origin_embedder_policy?: { value: string } | undefined;
+            /** Specifies a value for the Cross-Origin-Opener-Policy HTTP header, which lets you ensure that a top-level extension page doesn't share a browsing context group with cross-origin documents. */
+            cross_origin_opener_policy?: { value: string } | undefined;
             current_locale?: string | undefined;
+            /** Defines static rules for the declarativeNetRequest API, which allows blocking and modifying of network requests. */
+            declarative_net_request?: { rule_resources?: declarativeNetRequest.Ruleset[] } | undefined;
+            /** Defines pages that use the DevTools APIs. */
             devtools_page?: string | undefined;
             event_rules?:
                 | Array<{
                     event?: string | undefined;
-                    actions?:
-                        | Array<{
-                            type: string;
-                        }>
-                        | undefined;
+                    actions?: Array<{ type: string }> | undefined;
                     conditions?: chrome.declarativeContent.PageStateMatcherProperties[] | undefined;
                 }>
                 | undefined;
+            /** Specifies what other pages and extensions can connect to your extensions. */
             externally_connectable?: {
                 ids?: string[] | undefined;
                 matches?: string[] | undefined;
                 accepts_tls_channel_id?: boolean | undefined;
             } | undefined;
+            /** Provides access to the fileBrowserHandler API, which lets extensions access the ChromeOS file browser. */
             file_browser_handlers?:
                 | Array<{
                     id?: string | undefined;
@@ -9350,35 +9343,44 @@ declare namespace chrome {
                     file_filters?: string[] | undefined;
                 }>
                 | undefined;
+            /** Allows access to the fileSystemProvider API, which lets extensions create file systems that ChromeOS can use. */
             file_system_provider_capabilities?: {
+                /** Whether configuring via onConfigureRequested is supported. By default: false. */
                 configurable?: boolean | undefined;
+                /** Whether setting watchers and notifying about changes is supported. By default: false. */
                 watchable?: boolean | undefined;
+                /** Whether multiple (more than one) mounted file systems are supported. By default: false. */
                 multiple_mounts?: boolean | undefined;
-                source?: string | undefined;
+                /** Files app uses above information in order to render related UI elements appropriately. For example, if `configurable` is set to true, then a menu item for configuring volumes will be rendered. Similarly, if `multiple_mounts` is set to true, then Files app will allow to add more than one mount points from the UI. If `watchable` is false, then a refresh button will be rendered. Note, that if possible you should add support for watchers, so changes on the file system can be reflected immediately and automatically. */
+                source: "file" | "device" | "network";
             } | undefined;
+            /**  string specifying a URL for the extension's homepage. If this is undefined, the homepage defaults to the extension's Chrome Web Store page. This field is particularly useful if you host the extension on your own site. */
             homepage_url?: string | undefined;
+            /** Allows resources to be imported into the extension. */
             import?:
                 | Array<{
                     id: string;
                     minimum_version?: string | undefined;
                 }>
                 | undefined;
-            export?: {
-                whitelist?: string[] | undefined;
-            } | undefined;
-            incognito?: string | undefined;
+            /** Allows resources to be exported from the extension. */
+            export?: { allowlist?: string[] | undefined } | undefined;
+            /** Defines how the extension behaves in incognito mode. */
+            incognito?: "spanning" | "split" | "not_allowed" | undefined;
+            /** Allows the use of the Input Method Editor API. */
             input_components?:
                 | Array<{
-                    name?: string | undefined;
-                    type?: string | undefined;
+                    name: string;
                     id?: string | undefined;
-                    description?: string | undefined;
                     language?: string[] | string | undefined;
-                    layouts?: string[] | undefined;
-                    indicator?: string | undefined;
+                    layouts?: string[] | string | undefined;
+                    input_view?: string | undefined;
+                    options_page?: string | undefined;
                 }>
                 | undefined;
+            /** Specifies your extension's ID for various development use cases. */
             key?: string | undefined;
+            /** Defines the oldest Chrome version that can install your extension. The value must be a substring of an existing Chrome browser version string, such as "107" or "107.0.5304.87". Users with versions of Chrome older than the minimum version see a "Not compatible" warning in the Chrome Web Store, and are unable to install your extension. If you add this to an existing extension, users whose Chrome version is older won't receive automatic updates to your extension. This includes business users in ephemeral mode. */
             minimum_chrome_version?: string | undefined;
             nacl_modules?:
                 | Array<{
@@ -9386,53 +9388,39 @@ declare namespace chrome {
                     mime_type: string;
                 }>
                 | undefined;
+            /** Allows the use of an OAuth 2.0 security ID. The value of this key must be an object with "client_id" and "scopes" properties. */
             oauth2?: {
                 client_id: string;
                 scopes?: string[] | undefined;
             } | undefined;
             offline_enabled?: boolean | undefined;
-            omnibox?: {
-                keyword: string;
-            } | undefined;
+            /** Allows the extension to register a keyword in Chrome's address bar. */
+            omnibox?: { keyword: string } | undefined;
+            /** Specifies a path to an options.html file for the extension to use as an options page. */
             options_page?: string | undefined;
+            /** Specifies a path to an HTML file that lets a user change extension options from the Chrome Extensions page. */
             options_ui?: {
-                page?: string | undefined;
-                chrome_style?: boolean | undefined;
-                open_in_tab?: boolean | undefined;
+                /** Path to the options page, relative to the extension's root. */
+                page: string;
+                /** Specify as `false` to declare an embedded options page. If `true`, the extension's options page will be opened in a new tab rather than embedded in `chrome://extensions`. */
+                open_in_tab: boolean;
             } | undefined;
-            platforms?:
-                | Array<{
-                    nacl_arch?: string | undefined;
-                    sub_package_path: string;
-                }>
-                | undefined;
-            plugins?:
-                | Array<{
-                    path: string;
-                }>
-                | undefined;
+            /** Lists technologies required to use the extension. */
             requirements?: {
-                "3D"?: {
-                    features?: string[] | undefined;
-                } | undefined;
-                plugins?: {
-                    npapi?: boolean | undefined;
-                } | undefined;
+                "3D"?: { features?: string[] | undefined } | undefined;
+                /** @deprecated NPAPI Plugin support for extensions has been discontinued as of Chrome version 45 */
+                plugins?: { npapi?: boolean | undefined } | undefined;
             } | undefined;
+            /** Defines a set of extension pages that don't have access to extension APIs or direct access to non-sandboxed pages. */
             sandbox?: {
                 pages: string[];
                 content_security_policy?: string | undefined;
             } | undefined;
+            /** A string containing a shortened version of the extension's name to be used when character space is limited. The maximum length is 12 characters. If this is undefined, a truncated version of the "name" key displays instead. */
             short_name?: string | undefined;
-            spellcheck?: {
-                dictionary_language?: string | undefined;
-                dictionary_locale?: string | undefined;
-                dictionary_format?: string | undefined;
-                dictionary_path?: string | undefined;
-            } | undefined;
-            storage?: {
-                managed_schema: string;
-            } | undefined;
+            /** Declares a JSON schema for the managed storage area. */
+            storage?: { managed_schema: string } | undefined;
+            /** Registers the extension as a text to speech engine. */
             tts_engine?: {
                 voices: Array<{
                     voice_name: string;
@@ -9441,13 +9429,14 @@ declare namespace chrome {
                     event_types?: string[] | undefined;
                 }>;
             } | undefined;
+            /** A string containing the URL of the extension's updates page. Use this key if you're hosting your extension outside the Chrome Web Store. */
             update_url?: string | undefined;
+            /** A string describing the extension's version. Examples include "1.0 beta" and "build rc2". If this is unspecified, the "version" value displays on the extension management page instead. */
             version_name?: string | undefined;
             [key: string]: any;
         }
 
         export interface ManifestV2 extends ManifestBase {
-            // Required
             manifest_version: 2;
 
             // Pick one (or none)
@@ -9462,24 +9451,50 @@ declare namespace chrome {
                     persistent?: boolean | undefined;
                 }
                 | undefined;
+            /** Specifies JavaScript or CSS files to be used when the user opens certain web pages. */
+            content_scripts?:
+                | Array<{
+                    matches?: string[] | undefined;
+                    exclude_matches?: string[] | undefined;
+                    css?: string[] | undefined;
+                    js?: string[] | undefined;
+                    run_at?: string | undefined;
+                    all_frames?: boolean | undefined;
+                    match_about_blank?: boolean | undefined;
+                    include_globs?: string[] | undefined;
+                    exclude_globs?: string[] | undefined;
+                }>
+                | undefined;
+            /** Defines restrictions on the scripts, styles, and other resources an extension can use. */
             content_security_policy?: string | undefined;
+            /** Declares optional permissions for your extension. */
             optional_permissions?: (ManifestOptionalPermission | string)[] | undefined;
+            /** Enables use of particular extension APIs. */
             permissions?: (ManifestPermission | string)[] | undefined;
+            platforms?:
+                | Array<{
+                    nacl_arch?: string | undefined;
+                    sub_package_path: string;
+                }>
+                | undefined;
+            /** Defines files within the extension that can be accessed by web pages or other extensions. */
             web_accessible_resources?: string[] | undefined;
         }
 
         export interface ManifestV3 extends ManifestBase {
-            // Required
             manifest_version: 3;
 
             // Optional
+            /** Defines the appearance and behavior of the extension's icon in the Google Toolbar. */
             action?: ManifestAction | undefined;
+            /** Specifies the JavaScript file containing the extension's service worker, which acts as an event handler. */
             background?:
                 | {
                     service_worker: string;
-                    type?: "module"; // If the service worker uses ES modules
+                    type?: "module";
                 }
                 | undefined;
+            /** Specifies JavaScript or CSS files to be used when the user opens certain web pages. */
             content_scripts?:
                 | Array<{
                     matches?: string[] | undefined;
@@ -9494,14 +9509,35 @@ declare namespace chrome {
                     world?: "ISOLATED" | "MAIN" | undefined;
                 }>
                 | undefined;
+            /** Defines restrictions on the scripts, styles, and other resources an extension can use. */
             content_security_policy?: {
                 extension_pages?: string;
                 sandbox?: string;
-            };
+            } | undefined;
+            /** Specifies file types for ChromeOS extensions to handle. */
+            file_handlers?:
+                | Array<{
+                    /** Specifies an HTML file to show when a file is opened. The file must be within your extension. Processing the file, whether it's displayed or used in some other way, is done with JavaScript using appropriate web platform APIs. This code must be in a separate JavaScript file included via a `<script>` tag. */
+                    action: string;
+                    /** A user friendly description of the action. */
+                    name: string;
+                    /** The file types that can be processed by the page specified in "action". The items in the dictionary are a key/value pair where the key is a MIME type and the value is an array of file extensions. Only known MIME types are allowed for the key. Custom file types are allowed but the key for a custom type must be a known MIME type, and the mapping between the MIME type and the custom file type must be supported by the underlying operating system. */
+                    accept: { [mime_type: string]: string[] };
+                    /** Specifies whether multiple files should be opened in a single client or multiple clients. The default value is "single-client". */
+                    launch_type?: "multiple-clients" | "single-client" | undefined;
+                }>
+                | undefined;
+            /** Lists the web pages your extension is allowed to interact with, defined using URL match patterns. User permission for these sites is requested at install time. */
             host_permissions?: string[] | undefined;
+            /** Declares optional permissions for your extension. */
             optional_permissions?: ManifestOptionalPermission[] | undefined;
+            /** Declares optional host permissions for your extension. */
             optional_host_permissions?: string[] | undefined;
+            /** Enables use of particular extension APIs. */
             permissions?: ManifestPermission[] | undefined;
+            /** Identifies an HTML file to display in a sidePanel. */
+            side_panel?: { default_path: string } | undefined;
+            /** Defines files within the extension that can be accessed by web pages or other extensions. */
             web_accessible_resources?:
                 | Array<
                     & {

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -1033,6 +1033,63 @@ function testGetManifest() {
         manifest.author.email; // $ExpectType string
     }
 
+    if (manifest.cross_origin_embedder_policy) {
+        manifest.cross_origin_embedder_policy.value; // $ExpectType string
+    }
+
+    if (manifest.cross_origin_opener_policy) {
+        manifest.cross_origin_opener_policy.value; // $ExpectType string
+    }
+
+    if (manifest.declarative_net_request?.rule_resources) {
+        manifest.declarative_net_request.rule_resources[0].id; // $ExpectType string
+        manifest.declarative_net_request.rule_resources[0].path; // $ExpectType string
+        manifest.declarative_net_request.rule_resources[0].enabled; // $ExpectType boolean
+    }
+
+    if (manifest.file_system_provider_capabilities) {
+        manifest.file_system_provider_capabilities.configurable; // $ExpectType boolean | undefined
+        manifest.file_system_provider_capabilities.watchable; // $ExpectType boolean | undefined
+        manifest.file_system_provider_capabilities.multiple_mounts; // $ExpectType boolean | undefined
+        manifest.file_system_provider_capabilities.source; // $ExpectType "file" | "device" | "network"
+    }
+
+    if (manifest.import) {
+        manifest.import[0].id; // $ExpectType string
+        manifest.import[0].minimum_version; // $ExpectType string | undefined
+    }
+
+    if (manifest.export) {
+        manifest.export.allowlist; // $ExpectType string[] | undefined
+    }
+
+    if (manifest.file_system_provider_capabilities) {
+        manifest.file_system_provider_capabilities.configurable; // $ExpectType boolean | undefined
+        manifest.file_system_provider_capabilities.watchable; // $ExpectType boolean | undefined
+        manifest.file_system_provider_capabilities.source; // $ExpectType "file" | "device" | "network"
+    }
+
+    manifest.incognito; // $ExpectType "spanning" | "split" | "not_allowed" | undefined
+
+    if (manifest.input_components) {
+        manifest.input_components[0].name; // $ExpectType string
+        manifest.input_components[0].id; // $ExpectType string | undefined
+        manifest.input_components[0].language; // $ExpectType string | string[] | undefined
+        manifest.input_components[0].layouts; // $ExpectType string | string[] | undefined
+        manifest.input_components[0].input_view; // $ExpectType string | undefined
+        manifest.input_components[0].options_page; // $ExpectType string | undefined
+    }
+
+    if (manifest.options_ui) {
+        manifest.options_ui.page; // $ExpectType string
+        manifest.options_ui.open_in_tab; // $ExpectType boolean
+    }
+
+    if (manifest.sandbox) {
+        manifest.sandbox.pages; // $ExpectType string[]
+        manifest.sandbox.content_security_policy; // $ExpectType string | undefined
+    }
+
     if (manifest.manifest_version === 2) {
         manifest.browser_action; // $ExpectType ManifestAction | undefined
         manifest.page_action; // $ExpectType ManifestAction | undefined
@@ -1063,6 +1120,17 @@ function testGetManifest() {
         manifest.optional_permissions; // $ExpectType ManifestOptionalPermission[] | undefined
         manifest.optional_host_permissions; // $ExpectType string[] | undefined
         manifest.permissions; // $ExpectType ManifestPermission[] | undefined
+
+        if (manifest.file_handlers) {
+            manifest.file_handlers[0].action; // $ExpectType string
+            manifest.file_handlers[0].name; // $ExpectType string
+            manifest.file_handlers[0].accept; // $ExpectType { [mime_type: string]: string[] }
+            manifest.file_handlers[0].launch_type; // $ExpectType "multiple-clients" | "single-client" | undefined
+        }
+
+        if (manifest.side_panel) {
+            manifest.side_panel.default_path; // $ExpectType string
+        }
 
         manifest.web_accessible_resources = [{
             resources: ["resource.js"],
@@ -1121,6 +1189,12 @@ function testGetManifest() {
                 16: "icon-16.png",
             },
         },
+        content_scripts: [
+            {
+                matches: ["https://github.com/*"],
+                js: ["cs.js"],
+            },
+        ],
         content_security_policy: "default-src 'self'",
         optional_permissions: ["https://*/*"],
         permissions: ["https://*/*"],


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).


If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://developer.chrome.com/docs/extensions/reference/manifest/
  - https://developer.chrome.com/docs/extensions/mv2/manifest/
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

Notes :
- add JSDoc
- deprecated `author` ([doc](https://developer.chrome.com/docs/extensions/reference/manifest/author))
- remove `chrome_ui_overrides` (no documentation)
- add `cross_origin_embedder_policy ` for MV2 and MV3 ([doc](https://developer.chrome.com/docs/extensions/reference/manifest/cross-origin-embedder-policy))
- add `cross_origin_opener_policy`  for MV2 and MV3 ([doc](https://developer.chrome.com/docs/extensions/reference/manifest/cross-origin-opener-policy))
- add `declarative_net_request` for MV2 and MV3 ([doc](https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest#manifest))
- update `file_system_provider_capabilities`: `source` is required and allow some values ([doc](https://developer.chrome.com/docs/extensions/reference/api/fileSystemProvider#availability))
- fix `export`: rename `whitelist` to `allowlist` ([doc](https://developer.chrome.com/docs/extensions/reference/manifest/shared-modules#export))
- update `incognito`: restrict value ([doc](https://developer.chrome.com/docs/extensions/reference/manifest/incognito))
- fix `input_components`: bad keys ([doc](https://developer.chrome.com/docs/extensions/reference/manifest/input-components))
- fix `options_ui`: keys required and `chrome_style` not documented ([doc](https://developer.chrome.com/docs/extensions/develop/ui/options-page#embedded_options))
- update `requirements`: `plugins` is deprecated ([doc](https://developer.chrome.com/docs/extensions/reference/manifest/requirements))
- remove `spellcheck` (no documentation)
- add `file_handlers` for MV3 ([doc](https://developer.chrome.com/docs/extensions/reference/manifest/file-handlers))
- add `side_panel` for MV3 ([doc](https://developer.chrome.com/docs/extensions/reference/api/sidePanel#every-site))

Removed keys of manifest will not trigger TS errors because `ManifestBase` defines `[key: string]: any;`.

Related Issue : https://github.com/DefinitelyTyped/DefinitelyTyped/issues/66809