### PR TITLE
[node] Add webcrypto generateKey types for Ed25519, Ed448, X25519, and X448

### DIFF
--- a/types/node/crypto.d.ts
+++ b/types/node/crypto.d.ts
@@ -3801,6 +3801,12 @@ declare module "node:crypto" {
         interface ContextParams extends Algorithm {
             context?: NodeJS.BufferSource;
         }
+        interface Ed25519KeyGenParams extends Algorithm {
+            name: "Ed25519";
+        }
+        interface Ed448KeyGenParams extends Algorithm {
+            name: "Ed448";
+        }
         interface EcKeyAlgorithm extends KeyAlgorithm {
             namedCurve: NamedCurve;
         }
@@ -3902,6 +3908,12 @@ declare module "node:crypto" {
         interface RsaPssParams extends Algorithm {
             saltLength: number;
         }
+        interface X25519KeyGenParams extends Algorithm {
+            name: "X25519";
+        }
+        interface X448KeyGenParams extends Algorithm {
+            name: "X448";
+        }
         interface Crypto {
             readonly subtle: SubtleCrypto;
             getRandomValues<
@@ -3984,7 +3996,13 @@ declare module "node:crypto" {
             exportKey(format: Exclude<KeyFormat, "jwk">, key: CryptoKey): Promise<ArrayBuffer>;
             exportKey(format: KeyFormat, key: CryptoKey): Promise<ArrayBuffer | JsonWebKey>;
             generateKey(
-                algorithm: RsaHashedKeyGenParams | EcKeyGenParams,
+                algorithm:
+                    | RsaHashedKeyGenParams
+                    | EcKeyGenParams
+                    | Ed25519KeyGenParams
+                    | Ed448KeyGenParams
+                    | X25519KeyGenParams
+                    | X448KeyGenParams,
                 extractable: boolean,
                 keyUsages: KeyUsage[],
             ): Promise<CryptoKeyPair>;

--- a/types/node/node-tests/crypto.ts
+++ b/types/node/node-tests/crypto.ts
@@ -1897,6 +1897,10 @@ import { promisify } from "node:util";
     subtle.encrypt({ name: "AES-CBC", iv: new Uint8Array(16) }, key, new TextEncoder().encode("hello")); // $ExpectType Promise<ArrayBuffer>
     subtle.exportKey("jwk", key); // $ExpectType Promise<JsonWebKey>
     subtle.generateKey({ name: "ECDH", namedCurve: "P-256" }, false, ["deriveKey", "deriveBits"]); // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey({ name: "Ed25519" }, true, ["sign", "verify"]); // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey({ name: "Ed448" }, true, ["sign", "verify"]); // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey({ name: "X25519" }, true, ["deriveKey", "deriveBits"]); // $ExpectType Promise<CryptoKeyPair>
+    subtle.generateKey({ name: "X448" }, true, ["deriveKey", "deriveBits"]); // $ExpectType Promise<CryptoKeyPair>
     subtle.getPublicKey(key, ["sign", "verify", "deriveBits"]); // $ExpectType Promise<CryptoKey>
     subtle.importKey("pkcs8", buf, { name: "RSA-PSS", hash: "SHA-1" }, false, []); // $ExpectType Promise<CryptoKey>
     subtle.sign({ name: "RSA-PSS", saltLength: 64 }, key, buf); // $ExpectType Promise<ArrayBuffer>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/webcrypto.html#subtlegeneratekeyalgorithm-extractable-keyusages
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`. (not needed)