### PR TITLE
[@types/xrm] Fix ItemCollection.get() overload order to correctly return T | null

### DIFF
--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -1862,14 +1862,14 @@ declare namespace Xrm {
              * @param itemNameOrNumber The item name or item number to get.
              * @returns The T matching the key itemName or the T in the itemNumber-th place.
              */
-            get<TSubType extends T>(itemNameOrNumber: string | number): TSubType;
+            get(itemNameOrNumber: string | number): T | null;
 
             /**
              * Gets the item given by key or index.
              * @param itemNameOrNumber The item name or item number to get.
              * @returns The T matching the key itemName or the T in the itemNumber-th place.
              */
-            get(itemNameOrNumber: string | number): T | null;
+            get<TSubType extends T>(itemNameOrNumber: string | number): TSubType;
 
             /**
              * Gets the item using a delegate matching function or the entire array of T if delegate is not provided.

--- a/types/xrm/xrm-tests.ts
+++ b/types/xrm/xrm-tests.ts
@@ -807,12 +807,12 @@ function testItemCollectionGet(formContext: Xrm.FormContext) {
     formContext.ui.tabs.get(0);
 
     // $ExpectType Tab | null
-    formContext.ui.tabs.get("quickFormName");
+    formContext.ui.tabs.get("tabName");
 
     // With explicit type parameter: returns TSubType (caller asserts item exists)
     // $ExpectType Tab
     formContext.ui.tabs.get<Xrm.Controls.Tab>(0);
 
     // $ExpectType Tab
-    formContext.ui.tabs.get<Xrm.Controls.Tab>("quickFormName");
+    formContext.ui.tabs.get<Xrm.Controls.Tab>("tabName");
 }

--- a/types/xrm/xrm-tests.ts
+++ b/types/xrm/xrm-tests.ts
@@ -630,13 +630,13 @@ function booleanAttributeControls(formContext: Xrm.FormContext) {
     // @ts-expect-error
     const notString: string = booleanAttribute.getValue();
 
-    booleanAttribute = booleanAttribute.controls.get(0).getAttribute();
+    booleanAttribute = booleanAttribute.controls.get<Xrm.Controls.BooleanControl>(0).getAttribute();
 
     booleanAttribute.controls.forEach((c: Xrm.Controls.BooleanControl) => c.setDisabled(true));
 
-    booleanAttribute.controls.get(0).getAttribute().getAttributeType() === "boolean";
+    booleanAttribute.controls.get<Xrm.Controls.BooleanControl>(0).getAttribute().getAttributeType() === "boolean";
     // @ts-expect-error
-    booleanAttribute.controls.get(0).getAttribute().getAttributeType() === "optionset";
+    booleanAttribute.controls.get<Xrm.Controls.OptionSetControl>(0).getAttribute().getAttributeType() === "optionset";
 }
 
 // Demonstrate add and remove methods for formContext.data.process
@@ -799,3 +799,20 @@ const framedControlSetVisible = (formContext: Xrm.FormContext) => {
     // setVisible
     framedControl.setVisible(true);
 };
+
+// Demonstrate ItemCollection.get() overloads
+function testItemCollectionGet(formContext: Xrm.FormContext) {
+    // Without explicit type parameter: returns T | null
+    // $ExpectType Tab | null
+    formContext.ui.tabs.get(0);
+
+    // $ExpectType Tab | null
+    formContext.ui.tabs.get("quickFormName");
+
+    // With explicit type parameter: returns TSubType (caller asserts item exists)
+    // $ExpectType Tab
+    formContext.ui.tabs.get<Xrm.Controls.Tab>(0);
+
+    // $ExpectType Tab
+    formContext.ui.tabs.get<Xrm.Controls.Tab>("quickFormName");
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change.
- [x] Follow the advice from the readme.
- [x] Avoid common mistakes.
- [x] Run `pnpm test xrm`.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.