### PR TITLE
[@types/pdfkit] Replace NodeJS.ReadableStream type with stream.Readable

### DIFF
--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="node" />
 
+type PDFKitReadable = import("stream").Readable;
+
 declare namespace PDFKit {
     interface PDFGradient {
         new(document: any): PDFGradient;
@@ -862,7 +864,7 @@ declare namespace PDFKit {
 
     interface PDFDocument
         extends
-            NodeJS.ReadableStream,
+            PDFKitReadable,
             Mixins.PDFMetadata,
             Mixins.PDFAnnotation,
             Mixins.PDFColor,

--- a/types/pdfkit/pdfkit-tests.ts
+++ b/types/pdfkit/pdfkit-tests.ts
@@ -10,6 +10,7 @@ import mtext = require("pdfkit/js/mixins/text");
 
 import PDFDocument = require("pdfkit");
 import PDFDocumentStandalone = require("pdfkit/js/pdfkit.standalone");
+import stream = require("stream");
 
 import font = require("pdfkit/js/mixins/fonts");
 import pdfData = require("pdfkit/js/data");
@@ -33,6 +34,15 @@ var doc: PDFKit.PDFDocument = new PDFDocument({
     font: "Arial",
     fontLayoutCache: true,
 });
+
+const readable: stream.Readable = doc;
+
+// $ExpectType PDFDocument
+doc.destroy();
+// $ExpectType boolean
+doc.destroyed;
+// $ExpectType boolean
+doc.readableEnded;
 
 // $ExpectType PDFDocument
 doc.addPage();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
  - PDFKit's upstream implementation defines `PDFDocument` as a class extending `stream.Readable`:
https://github.com/foliojs/pdfkit/blob/master/lib/document.js
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.
